### PR TITLE
using nltk.batch_ne_chunk gives "NameError: global name 'nltk' is not defined"

### DIFF
--- a/nltk/chunk/__init__.py
+++ b/nltk/chunk/__init__.py
@@ -156,6 +156,7 @@ from api import ChunkParserI
 from util import (ChunkScore, accuracy, tagstr2tree, conllstr2tree,
                   tree2conlltags, tree2conllstr, tree2conlltags)
 from regexp import RegexpChunkParser, RegexpParser
+import nltk
 
 # Standard treebank POS tagger
 _BINARY_NE_CHUNKER = 'chunkers/maxent_ne_chunker/english_ace_binary.pickle'


### PR DESCRIPTION
I was almost ready to give up on nltk; then I hacked this file and it started working!

https://gist.github.com/322906

BRIAN-TINGLEs-MacBook-Air:scrub_sample tingle$ python example1.py 
Traceback (most recent call last):
  File "example1.py", line 10, in <module>
    chunked_sentences = nltk.batch_ne_chunk(tagged_sentences, binary=True)
  File "/usr/local/Cellar/python/2.7.2/lib/python2.7/site-packages/nltk-2.0.1rc2_git-py2.7.egg/nltk/chunk/**init**.py", line 185, in batch_ne_chunk
    chunker = nltk.data.load(chunker_pickle)
NameError: global name 'nltk' is not defined
