### PR TITLE
change "Resource not found" msg for easier copy-pasting

### DIFF
--- a/nltk/data.py
+++ b/nltk/data.py
@@ -447,7 +447,7 @@ def find(resource_name):
     # Display a friendly error message if the resource wasn't found:
     msg = textwrap.fill(
         'Resource %r not found.  Please use the NLTK Downloader to '
-        'obtain the resource: >>> nltk.download().' %
+        'obtain the resource:  >>> nltk.download()' %
         (resource_name,), initial_indent='  ', subsequent_indent='  ',
         width=66)
     msg += '\n  Searched in:' + ''.join('\n    - %r' % d for d in path)


### PR DESCRIPTION
Here's a very small change to `nltk/data.py` that allows easier copy-pasting of `nltk.download()` to the Python prompt; something I do on a regular basis.

(Also, novice users might think the full stop is part of the Python expression being displayed.)
