### PR TITLE
More features for scikit-learn wrapper

### DIFF
--- a/nltk/classify/__init__.py
+++ b/nltk/classify/__init__.py
@@ -97,6 +97,11 @@ from nltk.classify.util import accuracy, log_likelihood
 # Conditional imports
 
 try:
+    from scikitlearn import SklearnClassifier
+except ImportError:
+    pass
+
+try:
     import numpy
     from nltk.classify.maxent import (MaxentClassifier, BinaryMaxentFeatureEncoding,
                                       TypedMaxentFeatureEncoding,

--- a/nltk/classify/scikitlearn.py
+++ b/nltk/classify/scikitlearn.py
@@ -60,6 +60,9 @@ class SklearnClassifier(ClassifierI):
         self._dtype = dtype
         self._sparse = sparse
 
+    def __repr__(self):
+        return "<SklearnClassifier(%r)>" % self._clf
+
     def batch_classify(self, featuresets):
         X = self._featuresets_to_array(featuresets)
         y = self._clf.predict(X)


### PR DESCRIPTION
Ok, here's some more work on the scikit-learn wrapper. The doctests are primitive since the string representation of a scikit-learn estimator depends on the scikit-learn version (new versions often introduce extra parameters). The main thing left to implement is `most_informative_features`, which should not be too hard to implement at least for linear estimators.

The module still does not try to import scikit-learn. That would require

```
try:
    import sklearn
except ImportError:  # scikit-learn < 0.8
    import scikit.learn
```
