### PR TITLE
Minor docstring fix for ProximateTokensRule.extract_property()

### DIFF
--- a/nltk/tag/brill.py
+++ b/nltk/tag/brill.py
@@ -288,7 +288,7 @@ class ProximateTokensRule(BrillRule):
         of ``ProximateTokensTemplate``.
 
         :param token: The token
-        :type token: str
+        :type token: tuple(str, str)
         :return: The property
         :rtype: any
         """


### PR DESCRIPTION
This method's `token` parameter is documented to be `str`, but is actually `tuple(str, str)`.
