### PR TITLE
Make ConditionalProbDist a subclass of defaultdict

### DIFF
--- a/nltk/tag/hmm.py
+++ b/nltk/tag/hmm.py
@@ -126,9 +126,9 @@ class HiddenMarkovModelTagger(TaggerI):
     :type transform: function or HiddenMarkovModelTaggerTransform
     """
     def __init__(self, symbols, states, transitions, outputs, priors, **kwargs):
-        self._states = states
+        self._symbols = list(set(symbols))
+        self._states = list(set(states))
         self._transitions = transitions
-        self._symbols = symbols
         self._outputs = outputs
         self._priors = priors
         self._cache = None

--- a/nltk/text.py
+++ b/nltk/text.py
@@ -383,18 +383,6 @@ class Text(object):
         text = self._trigram_model.generate(length)
         print tokenwrap(text)
 
-    def search(self, pattern):
-        """
-        Search for instances of the regular expression pattern in the text.
-
-        :seealso: TokenSearcher
-        """
-        if '_token_searcher' not in self.__dict__:
-            print "Loading data..."
-            self._token_searcher = TokenSearcher(self.tokens)
-
-        self._token_searcher.findall(pattern)
-
     def similar(self, word, num=20):
         """
         Distributional similarity: find other words which appear in the


### PR DESCRIPTION
Now ConditionalProbDistI (and its subclasses) is a subclass of deafultdict.
There is no doctest that uses CPD, but I tried to create a HiddenMarkovModelTagger from CPD's and it worked fine.

Also: I removed the .search() method from the Text class: it doesn't work anyway, and there is already a method .findall() that works

Also: I fixed HiddenMarkovModelTagger so that it allows the symbols and states to be sets.
