### PR TITLE
Regexp Tagger speed optimization

### DIFF
--- a/nltk/tag/sequential.py
+++ b/nltk/tag/sequential.py
@@ -458,13 +458,17 @@ class RegexpTagger(SequentialBackoffTagger, yaml.YAMLObject):
     def __init__(self, regexps, backoff=None):
         """
         """
-        self._regexps = regexps
         SequentialBackoffTagger.__init__(self, backoff)
+        labels = ['g'+str(i) for i in range(len(regexps))]
+        tags = [tag for regex, tag in regexps]
+        self._map = dict(zip(tags, labels))
+        self._map_reversed = dict(zip(labels, tags))
+        self._regexs = re.compile('|'.join(['(?P<%s>%s)' % (self._map[tag], regex) for regex,tag in regexps]))
 
     def choose_tag(self, tokens, index, history):
-        for regexp, tag in self._regexps:
-            if re.match(regexp, tokens[index]): # ignore history
-                return tag
+        m = self._regexs.match(tokens[index])
+        if m:
+          return self._map_reversed[m.lastgroup]
         return None
 
     def __repr__(self):

--- a/nltk/tag/sequential.py
+++ b/nltk/tag/sequential.py
@@ -461,14 +461,14 @@ class RegexpTagger(SequentialBackoffTagger, yaml.YAMLObject):
         SequentialBackoffTagger.__init__(self, backoff)
         labels = ['g'+str(i) for i in range(len(regexps))]
         tags = [tag for regex, tag in regexps]
-        self._map = dict(zip(tags, labels))
-        self._map_reversed = dict(zip(labels, tags))
-        self._regexs = re.compile('|'.join(['(?P<%s>%s)' % (self._map[tag], regex) for regex,tag in regexps]))
+        self._map = dict(zip(labels, tags))
+        regexps_labels = [(regex, label) for ((regex,tag),label) in zip(regexps,labels)]
+        self._regexs = re.compile('|'.join(['(?P<%s>%s)' % (label, regex) for regex,label in regexps_labels]))
 
     def choose_tag(self, tokens, index, history):
         m = self._regexs.match(tokens[index])
         if m:
-          return self._map_reversed[m.lastgroup]
+          return self._map[m.lastgroup]
         return None
 
     def __repr__(self):


### PR DESCRIPTION
This patch do the following:
- Compiles all the patterns in the initialization phase of the object construction. This speeds up the execution at least 10x.
- Combines all the patterns supplied by the users in one expression using the OR '|' operator in regex which boosts they performance of the execution up to 2x.

I think regular expressions should be compiled ahead every where in the code, this way we will avoid the expensive process of creating FSMs everytime.
