### PR TITLE
Complying with the Treebank Tokenization

### DIFF
--- a/nltk/tokenize/treebank.py
+++ b/nltk/tokenize/treebank.py
@@ -49,6 +49,7 @@ class TreebankWordTokenizer(TokenizerI):
     at the end of a line.
     """
     # List of contractions adapted from Robert MacIntyre's tokenizer.
+
     _CONTRACTIONS2 = [re.compile(r"(?i)(.)('ll|'re|'ve|n't|'s|'m|'d)\b"),
                      re.compile(r"(?i)\b(can)(not)\b"),
                      re.compile(r"(?i)\b(D)('ye)\b"),
@@ -71,16 +72,19 @@ class TreebankWordTokenizer(TokenizerI):
             text = regexp.sub(r'\1 \2', text)
         for regexp in self._CONTRACTIONS3:
             text = regexp.sub(r'\1 \2 \3', text)
-
+        
         # Separate most punctuation
         text = re.sub(r"([^\w\.\'\-\/,&])", r' \1 ', text, flags=re.U)
+
+        text = re.sub(r"([A-Z]+)\s+(\$)", r"\1\2", text)
 
         # Separate commas or single quotes if they're followed by space.
         # (E.g., don't separate 2,500)
         text = re.sub(r"([,']\s)", r' \1', text)
 
         # Separate periods that come before newline or end of string.
-        text = re.sub('\. *(\n|$)', ' . ', text)
+        text = re.sub('(?P<s>[^\.])(?P<dot>\.)\s*(?P<closing>[")]?)\s*(?P<end>$|\n)',
+                      '\g<s> \g<dot> \g<closing>', text)
 
         return text.split()
 


### PR DESCRIPTION
I compared the results of tokenizing the first 1000 sentence in Penn Treebank using this module with the standard tokenization that I could retrieve from the Parse Trees.

I found that the module actually does not comply with the treebank tokenization for around 150 sentence. With these modification the number of differences drop to around 25 sentences.

I suggest that before merging those changes, we should take advantage of the portion of PTB that NLTK distributes. I do not think the raw text is part of that till now. However, I see it is under fair use to distribute the raw text that is corresponding to the first two sections.

To get the first 1000 sentence from the raw text of PTB, I split the paragraphs manually. I can send you the paragraphs splitted into sentences that cover the first two sections. This is in general will be a good dataset for unit testing for both tasks, sentence splitting and work tokenization. Not to mention possible classifiers that could be trained using such dataset.
