### PR TITLE
Allow steps in slices for all kinds of Trees

### DIFF
--- a/nltk/test/tree.doctest
+++ b/nltk/test/tree.doctest
@@ -14,14 +14,14 @@ Some trees to run tests on:
     >>> vp = Tree('vp', [Tree('v', ['chased']), dp2])
     >>> tree = Tree('s', [dp1, vp])
     >>> print tree
+    (s (dp (d the) (np dog)) (vp (v chased) (dp (d the) (np cat))))
 
 The node value is stored using the `node` attribute:
 
     >>> dp1.node, dp2.node, vp.node, tree.node
     ('dp', 'dp', 'vp', 's')
 
-
-    >>> print tree[path]
+    >>> print tree[1,1,1,0]
     cat
 
 The `treepositions` method returns a list of the tree positions of
@@ -36,8 +36,8 @@ tree object to one of several standard tree encodings:
 
     >>> print tree.pprint_latex_qtree()
     \Tree [.s
-            [.np [.d THE ] [.np DOG ] ]
-            [.vp [.v CHASED ] [.np [.d THE ] [.np CAT ] ] ] ]
+            [.dp [.d the ] [.np dog ] ]
+            [.vp [.v chased ] [.dp [.d the ] [.np cat ] ] ] ]
 
 Trees can be parsed from treebank strings with the static
 `Tree.parse()` method:
@@ -571,10 +571,9 @@ operations:
     ok! (A (B c) (D e) f)
     >>> del ptree[-100:1]; pcheck(ptree)
     ok! (A (D e) f)
-    >>> del ptree[1:2:3]
-    Traceback (most recent call last):
-      . . .
-    ValueError: slices with steps are not supported by ParentedTree
+    >>> ptree = make_ptree('(A (B c) (D e) f g (H i) j (K l))')
+    >>> del ptree[1:-2:2]; pcheck(ptree)
+    ok! (A (B c) f (H i) j (K l))
 
 **__setitem__()**
 
@@ -619,10 +618,8 @@ operations:
     ok! (A (U v) (X ) (X ) n)
     >>> ptree[-1:] = (make_ptree('(X)') for x in range(3)); pcheck(ptree)
     ok! (A (U v) (X ) (X ) (X ) (X ) (X ))
-    >>> ptree[1:2:3] = ['x']
-    Traceback (most recent call last):
-      . . .
-    ValueError: slices with steps are not supported by ParentedTree
+    >>> ptree[1:-2:2] = ['x', 'y']; pcheck(ptree)
+    ok! (A (U v) x (X ) y (X ) (X ))
 
 **append()**
 
@@ -873,10 +870,9 @@ multiple parents.)
     ok! (A (B c) (D e) f)
     >>> del mptree[-100:1]; mpcheck(mptree)
     ok! (A (D e) f)
-    >>> del mptree[1:2:3]
-    Traceback (most recent call last):
-      . . .
-    ValueError: slices with steps are not supported by MultiParentedTree
+    >>> mptree = make_mptree('(A (B c) (D e) f g (H i) j (K l))')
+    >>> del mptree[1:-2:2]; mpcheck(mptree)
+    ok! (A (B c) f (H i) j (K l))
 
 **__setitem__()**
 
@@ -921,10 +917,8 @@ multiple parents.)
     ok! (A (U v) (X ) (X ) n)
     >>> mptree[-1:] = (make_mptree('(X)') for x in range(3)); mpcheck(mptree)
     ok! (A (U v) (X ) (X ) (X ) (X ) (X ))
-    >>> mptree[1:2:3] = ['x']
-    Traceback (most recent call last):
-      . . .
-    ValueError: slices with steps are not supported by MultiParentedTree
+    >>> mptree[1:-2:2] = ['x', 'y']; mpcheck(mptree)
+    ok! (A (U v) x (X ) y (X ) (X ))
 
 **append()**
 

--- a/nltk/tree.py
+++ b/nltk/tree.py
@@ -878,9 +878,9 @@ class AbstractParentedTree(Tree):
     def __delitem__(self, index):
         # del ptree[start:stop]
         if isinstance(index, slice):
-            start, stop = slice_bounds(self, index)
+            start, stop, step = slice_bounds(self, index, allow_step=True)
             # Clear all the children pointers.
-            for i in xrange(start, stop):
+            for i in xrange(start, stop, step):
                 if isinstance(self[i], Tree):
                     self._delparent(self[i], i)
             # Delete the children from our child list.
@@ -914,7 +914,7 @@ class AbstractParentedTree(Tree):
     def __setitem__(self, index, value):
         # ptree[start:stop] = value
         if isinstance(index, slice):
-            start, stop = slice_bounds(self, index)
+            start, stop, step = slice_bounds(self, index, allow_step=True)
             # make a copy of value, in case it's an iterator
             if not isinstance(value, (list, tuple)):
                 value = list(value)
@@ -922,9 +922,9 @@ class AbstractParentedTree(Tree):
             # up in an inconsistent state if an error does occur.
             for i, child in enumerate(value):
                 if isinstance(child, Tree):
-                    self._setparent(child, start+i, dry_run=True)
+                    self._setparent(child, start + i*step, dry_run=True)
             # clear the child pointers of all parents we're removing
-            for i in xrange(start, stop):
+            for i in xrange(start, stop, step):
                 if isinstance(self[i], Tree):
                     self._delparent(self[i], i)
             # set the child pointers of the new children.  We do this
@@ -932,7 +932,7 @@ class AbstractParentedTree(Tree):
             # reversing the elements in a tree.
             for i, child in enumerate(value):
                 if isinstance(child, Tree):
-                    self._setparent(child, start+i)
+                    self._setparent(child, start + i*step)
             # finally, update the content of the child list itself.
             super(AbstractParentedTree, self).__setitem__(index, value)
 


### PR DESCRIPTION
(Multi)ParentedTree does not allow slices with steps:

```
>>> print ptree
(A (U v) (X ) (X ) (X ) (X ) (X ))
>>> ptree[1:-2:2] = ['a', 'b']
Traceback (most recent call last):
  . . .
ValueError: slices with steps are not supported by ParentedTree
```

But Tree does, and I think there is no good reason why this is not allowed for parented trees. So with this change we get the following:

```
>>> ptree[1:-2:2] = ['a', 'b']
>>> print ptree
(A (U v) a (X ) b (X ) (X ))
```

The tree doctest is changed accordingly
