### PR TITLE
Trees are not lists

### DIFF
--- a/nltk/align.py
+++ b/nltk/align.py
@@ -46,13 +46,9 @@ class AlignedSent(object):
 
     def __init__(self, words = [], mots = [], alignment = '', \
                  encoding = 'latin-1'):
-
-        if not isinstance(alignment, Alignment):
-            alignment = Alignment(alignment)
         self._words = words
         self._mots = mots
-        self._check_align(alignment)
-        self._alignment = alignment
+        self.alignment = alignment
 
     @property
     def words(self):
@@ -66,12 +62,12 @@ class AlignedSent(object):
     def alignment(self):
         return self._alignment
 
-#    @alignment.setter Requires Python 2.6
-#    def alignment(self, alignment):
-#        if not isinstance(alignment, Alignment):
-#            alignment = Alignment(alignment)
-#        self._check_align(alignment)
-#        self._alignment = alignment
+    @alignment.setter
+    def alignment(self, alignment):
+        if not isinstance(alignment, Alignment):
+            alignment = Alignment(alignment)
+        self._check_align(alignment)
+        self._alignment = alignment
 
     def _check_align(self, a):
         """
@@ -220,7 +216,7 @@ class Alignment(frozenset):
         0-0 1-0 2-1 2-2
         >>> a[0]
         [(0, 1), (0, 0)]
-        >>> a.invert()[3]
+        >>> a.invert()[2]
         [(2, 1), (2, 2)]
         >>> b = Alignment([(0, 0), (0, 1)])
         >>> b.issubset(a)

--- a/nltk/ccg/api.py
+++ b/nltk/ccg/api.py
@@ -61,11 +61,11 @@ class CCGVar(AbstractCCGCategory):
         self._id = self.new_id()
         self._prim_only = prim_only
 
-    # A class method allowing generation of unique variable identifiers.
+    @classmethod
     def new_id(cls):
+        """A class method allowing generation of unique variable identifiers."""
         cls._maxID = cls._maxID + 1
         return cls._maxID - 1
-    new_id = classmethod(new_id)
 
     def is_primitive(self):
         return False

--- a/nltk/classify/maxent.py
+++ b/nltk/classify/maxent.py
@@ -674,14 +674,13 @@ class GISEncoding(BinaryMaxentFeatureEncoding):
             self, labels, mapping, unseen_features, alwayson_features)
         if C is None:
             C = len(set([fname for (fname,fval,label) in mapping]))+1
-
         self._C = C
-        """The non-negative constant that all encoded feature vectors
-           will sum to."""
 
-    C = property(lambda self: self._C, doc="""
-        The non-negative constant that all encoded feature vectors
-        will sum to.""")
+    @property
+    def C(self): 
+        """The non-negative constant that all encoded feature vectors
+        will sum to."""
+        return self._C
 
     def encode(self, featureset, label):
         # Get the basic encoding.

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -157,8 +157,10 @@ class FileSystemPathPointer(PathPointer, str):
         # There's no need to call str.__init__(), since it's a no-op;
         # str does all of its setup work in __new__.
 
-    path = property(lambda self: self._path, doc="""
-        The absolute path identified by this path pointer.""")
+    @property
+    def path(self):
+        """The absolute path identified by this path pointer."""
+        return self._path
 
     def open(self, encoding=None):
         stream = open(self._path, 'rb')
@@ -329,12 +331,21 @@ class ZipFilePathPointer(PathPointer):
         self._zipfile = zipfile
         self._entry = entry
 
-    zipfile = property(lambda self: self._zipfile, doc="""
+    @property
+    def zipfile(self): 
+        """
         The zipfile.ZipFile object used to access the zip file
-        containing the entry identified by this path pointer.""")
-    entry = property(lambda self: self._entry, doc="""
+        containing the entry identified by this path pointer.
+        """
+        return self._zipfile
+
+    @property
+    def entry(self):
+        """
         The name of the file within zipfile that this path
-        pointer points to.""")
+        pointer points to.
+        """
+        return self._entry
 
     def open(self, encoding=None):
         data = self._zipfile.read(self._entry)
@@ -933,14 +944,20 @@ class SeekableUnicodeStreamReader(object):
     # Pass-through methods & properties
     #/////////////////////////////////////////////////////////////////
 
-    closed = property(lambda self: self.stream.closed, doc="""
-        True if the underlying stream is closed.""")
+    @property
+    def closed(self):
+        """True if the underlying stream is closed."""
+        return self.stream.closed
 
-    name = property(lambda self: self.stream.name, doc="""
-        The name of the underlying stream.""")
+    @property
+    def name(self):
+        """The name of the underlying stream."""
+        return self.stream.name
 
-    mode = property(lambda self: self.stream.mode, doc="""
-        The mode of the underlying stream.""")
+    @property
+    def mode(self):
+        """The mode of the underlying stream."""
+        return self.stream.mode
 
     def close(self):
         """

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -876,18 +876,23 @@ class Downloader(object):
     # URL & Data Directory
     #/////////////////////////////////////////////////////////////////
 
-    def _set_url(self, url):
-        # If we're unable to contact the given url, then keep the
-        # original url.
+    @property
+    def url(self): 
+        """The URL for the data server's index file."""
+        return self._url
+
+    @url.setter
+    def url(self, url):
+        """
+        Set a new URL for the data server. If we're unable to contact 
+        the given url, then the original url is kept.
+        """
         original_url = self._url
         try:
             self._update_index(url)
         except:
             self._url = original_url
             raise
-
-    url = property(lambda self: self._url, _set_url, doc="""
-        The URL for the data server's index file.""")
 
     def default_download_dir(self):
         """
@@ -925,17 +930,21 @@ class Downloader(object):
         # append "nltk_data" to the home directory
         return os.path.join(homedir, 'nltk_data')
 
-    def _set_download_dir(self, download_dir):
-        self._download_dir = download_dir
-        # Clear the status cache.
-        self._status_cache.clear()
-
-    download_dir = property(lambda self: self._download_dir,
-                            _set_download_dir, doc="""
+    @property
+    def download_dir(self): 
+        """
         The default directory to which packages will be downloaded.
         This defaults to the value returned by ``default_download_dir()``.
         To override this default on a case-by-case basis, use the
-        ``download_dir`` argument when calling ``download()``.""")
+        ``download_dir`` argument when calling ``download()``.
+        """
+        return self._download_dir
+
+    @download_dir.setter
+    def download_dir(self, download_dir):
+        self._download_dir = download_dir
+        # Clear the status cache.
+        self._status_cache.clear()
 
     #/////////////////////////////////////////////////////////////////
     # Interactive Shell

--- a/nltk/draw/table.py
+++ b/nltk/draw/table.py
@@ -200,25 +200,37 @@ class MultiListbox(Frame):
     # Properties
     #/////////////////////////////////////////////////////////////////
 
-    column_names = property(lambda self: self._column_names, doc="""
+    @property
+    def column_names(self): 
+        """
         A tuple containing the names of the columns used by this
-        multi-column listbox.""")
-    
-    column_labels = property(lambda self: tuple(self._labels), doc="""
+        multi-column listbox.
+        """
+        return self._column_names
+
+    @property
+    def column_labels(self): 
+        """
         A tuple containing the ``Tkinter.Label`` widgets used to
         display the label of each column.  If this multi-column
         listbox was created without labels, then this will be an empty
         tuple.  These widgets will all be augmented with a
         ``column_index`` attribute, which can be used to determine
         which column they correspond to.  This can be convenient,
-        e.g., when defining callbacks for bound events.""")
-    
-    listboxes = property(lambda self: tuple(self._listboxes), doc="""
+        e.g., when defining callbacks for bound events.
+        """
+        return tuple(self._labels)
+
+    @property
+    def listboxes(self): 
+        """
         A tuple containing the ``Tkinter.Listbox`` widgets used to
         display individual columns.  These widgets will all be
         augmented with a ``column_index`` attribute, which can be used
         to determine which column they correspond to.  This can be
-        convenient, e.g., when defining callbacks for bound events.""")
+        convenient, e.g., when defining callbacks for bound events.
+        """
+        return tuple(self._listboxes)
 
     #/////////////////////////////////////////////////////////////////
     # Mouse & Keyboard Callback Functions
@@ -822,8 +834,10 @@ class Table(object):
     # Columns
     #/////////////////////////////////////////////////////////////////
 
-    column_names = property(lambda self: self._mlb.column_names, doc="""
-        A list of the names of the columns in this table.""")
+    @property
+    def column_names(self): 
+        """A list of the names of the columns in this table."""
+        return self._mlb.column_names
 
     def column_index(self, i):
         """

--- a/nltk/draw/util.py
+++ b/nltk/draw/util.py
@@ -837,7 +837,7 @@ class SymbolWidget(TextWidget):
     def __repr__(self):
         return '[Symbol: %r]' % self._symbol
 
-    # A staticmethod that displays all symbols.
+    @staticmethod
     def symbolsheet(size=20):
         """
         Open a new Tkinter window that displays the entire alphabet
@@ -864,7 +864,6 @@ class SymbolWidget(TextWidget):
                 text.insert('end', '%-10d  \t' % i)
             text.insert('end', '[%s]\n' % chr(i), 'symbol')
         top.mainloop()
-    symbolsheet = staticmethod(symbolsheet)
 
 
 class AbstractContainerWidget(CanvasWidget):

--- a/nltk/featstruct.py
+++ b/nltk/featstruct.py
@@ -1785,13 +1785,8 @@ class Feature(object):
         assert display in (None, 'prefix', 'slash')
 
         self._name = name # [xx] rename to .identifier?
-        """The name of this feature."""
-
         self._default = default # [xx] not implemented yet.
-        """Default value for this feature.  Use None for unbound."""
-
         self._display = display
-        """Custom display location: can be prefix, or slash."""
 
         if self._display == 'prefix':
             self._sortkey = (-1, self._name)
@@ -1800,9 +1795,20 @@ class Feature(object):
         else:
             self._sortkey = (0, self._name)
 
-    name = property(lambda self: self._name)
-    default = property(lambda self: self._default)
-    display = property(lambda self: self._display)
+    @property
+    def name(self): 
+        """The name of this feature."""
+        return self._name
+
+    @property
+    def default(self): 
+        """Default value for this feature."""
+        return self._default
+
+    @property
+    def display(self): 
+        """Custom display location: can be prefix, or slash."""
+        return self._display
 
     def __repr__(self):
         return '*%s*' % self.name

--- a/nltk/inference/api.py
+++ b/nltk/inference/api.py
@@ -584,4 +584,5 @@ class TheoremToolThread(threading.Thread):
             print e
             print 'Thread %s completed abnormally' % (self._name)
 
-    result = property(lambda self: self._result)
+    @property
+    def result(self): return self._result

--- a/nltk/inference/mace.py
+++ b/nltk/inference/mace.py
@@ -46,7 +46,8 @@ class MaceCommand(Prover9CommandParent, BaseModelBuilderCommand):
 
         BaseModelBuilderCommand.__init__(self, model_builder, goal, assumptions)
 
-    valuation = property(lambda mbc: mbc.model('valuation'))
+    @property
+    def valuation(mbc): return mbc.model('valuation')
 
     def _convert2val(self, valuation_str):
         """

--- a/nltk/parse/chart.py
+++ b/nltk/parse/chart.py
@@ -251,7 +251,7 @@ class TreeEdge(EdgeI):
         self._span = span
         self._dot = dot
 
-    # [staticmethod]
+    @staticmethod
     def from_production(production, index):
         """
         Return a new ``TreeEdge`` formed from the given production.
@@ -263,7 +263,6 @@ class TreeEdge(EdgeI):
         """
         return TreeEdge(span=(index, index), lhs=production.lhs(),
                         rhs=production.rhs(), dot=0)
-    from_production = staticmethod(from_production)
 
     def move_dot_forward(self, new_end):
         """

--- a/nltk/parse/featurechart.py
+++ b/nltk/parse/featurechart.py
@@ -71,7 +71,7 @@ class FeatureTreeEdge(TreeEdge):
         TreeEdge.__init__(self, span, lhs, rhs, dot)
         self._bindings = bindings
 
-    # [staticmethod]
+    @staticmethod
     def from_production(production, index):
         """
         :return: A new ``TreeEdge`` formed from the given production.
@@ -82,7 +82,6 @@ class FeatureTreeEdge(TreeEdge):
         """
         return FeatureTreeEdge(span=(index, index), lhs=production.lhs(),
                                rhs=production.rhs(), dot=0)
-    from_production = staticmethod(from_production)
 
     def move_dot_forward(self, new_end, bindings=None):
         """

--- a/nltk/parse/pchart.py
+++ b/nltk/parse/pchart.py
@@ -51,14 +51,17 @@ class ProbabilisticTreeEdge(TreeEdge):
     def __init__(self, prob, *args, **kwargs):
         self._prob = prob
         TreeEdge.__init__(self, *args, **kwargs)
+
     def prob(self): return self._prob
+
     def __cmp__(self, other):
         if self._prob != other.prob(): return -1
         return TreeEdge.__cmp__(self, other)
+
+    @staticmethod
     def from_production(production, index, p):
         return ProbabilisticTreeEdge(p, (index, index), production.lhs(),
                                      production.rhs(), 0)
-    from_production = staticmethod(from_production)
 
 # Rules using probabilistic edges
 class ProbabilisticBottomUpInitRule(AbstractChartRule):

--- a/nltk/sem/drt.py
+++ b/nltk/sem/drt.py
@@ -85,10 +85,10 @@ class AbstractDrs(object):
         f2 = other.simplify().fol();
         return f1.equiv(f2, prover)
 
-    def _get_type(self):
+    @property
+    def type(self):
         raise AttributeError("'%s' object has no attribute 'type'" %
                              self.__class__.__name__)
-    type = property(_get_type)
 
     def typecheck(self, signature=None):
         raise NotImplementedError()

--- a/nltk/sem/evaluate.py
+++ b/nltk/sem/evaluate.py
@@ -131,7 +131,9 @@ class Valuation(dict):
     def __str__(self):
         return pformat(self)
 
-    def _getDomain(self):
+    @property
+    def domain(self):
+        """Set-theoretic domain of the value-space of a Valuation."""
         dom = []
         for val in self.values():
             if isinstance(val, str):
@@ -140,14 +142,10 @@ class Valuation(dict):
                 dom.extend([elem for tuple in val for elem in tuple if elem is not None])
         return set(dom)
 
-    domain = property(_getDomain,
-             doc='Set-theoretic domain of the value-space of a Valuation.')
-
-    def _getSymbols(self):
+    @property
+    def symbols(self):
+        """The non-logical constants which the Valuation recognizes."""
         return sorted(self.keys())
-
-    symbols = property(_getSymbols,
-              doc='The non-logical constants which the Valuation recognizes.')
 
 
 class Assignment(dict):

--- a/nltk/sem/logic.py
+++ b/nltk/sem/logic.py
@@ -239,8 +239,11 @@ class AnyType(BasicType, ComplexType):
     def __init__(self):
         pass
 
-    first = property(lambda self: self)
-    second = property(lambda self: self)
+    @property
+    def first(self): return self
+
+    @property
+    def second(self): return self
 
     def __eq__(self, other):
         return isinstance(other, AnyType) or other.__eq__(self)
@@ -643,13 +646,12 @@ class ApplicationExpression(Expression):
         else:
             return self.__class__(function, argument)
 
-    def _get_type(self):
+    @property
+    def type(self):
         if isinstance(self.function.type, ComplexType):
             return self.function.type.second
         else:
             return ANY_TYPE
-
-    type = property(_get_type)
 
     def _set_type(self, other_type=ANY_TYPE, signature=None):
         """:see Expression._set_type()"""
@@ -859,7 +861,11 @@ class IndividualVariableExpression(AbstractVariableExpression):
 
         signature[self.variable.name].append(self)
 
-    type = property(lambda self: ENTITY_TYPE, _set_type)
+    @property
+    def type(self): return ENTITY_TYPE
+
+    @type.setter
+    def type(self, other): self._set_type(other)
 
     def free(self):
         """:see: Expression.free()"""
@@ -1024,9 +1030,10 @@ class VariableBinderExpression(Expression):
 
 
 class LambdaExpression(VariableBinderExpression):
-    type = property(lambda self:
-                    ComplexType(self.term.findtype(self.variable),
-                                self.term.type))
+    @property
+    def type(self):
+        return ComplexType(self.term.findtype(self.variable),
+                           self.term.type)
 
     def _set_type(self, other_type=ANY_TYPE, signature=None):
         """:see Expression._set_type()"""
@@ -1050,7 +1057,8 @@ class LambdaExpression(VariableBinderExpression):
 
 
 class QuantifiedExpression(VariableBinderExpression):
-    type = property(lambda self: TRUTH_TYPE)
+    @property
+    def type(self): return TRUTH_TYPE
 
     def _set_type(self, other_type=ANY_TYPE, signature=None):
         """:see Expression._set_type()"""
@@ -1086,7 +1094,8 @@ class NegatedExpression(Expression):
         assert isinstance(term, Expression), "%s is not an Expression" % term
         self.term = term
 
-    type = property(lambda self: TRUTH_TYPE)
+    @property
+    def type(self): return TRUTH_TYPE
 
     def _set_type(self, other_type=ANY_TYPE, signature=None):
         """:see Expression._set_type()"""
@@ -1125,7 +1134,8 @@ class BinaryExpression(Expression):
         self.first = first
         self.second = second
 
-    type = property(lambda self: TRUTH_TYPE)
+    @property
+    def type(self): return TRUTH_TYPE
 
     def findtype(self, variable):
         """:see Expression.findtype()"""

--- a/nltk/sourcedstring.py
+++ b/nltk/sourcedstring.py
@@ -1325,14 +1325,20 @@ class SourcedStringStream(object):
     # Pass-through methods & properties
     #/////////////////////////////////////////////////////////////////
 
-    closed = property(lambda self: self.stream.closed, doc="""
-        True if the underlying stream is closed.""")
+    @property
+    def closed(self): 
+        """True if the underlying stream is closed."""
+        return self.stream.closed
 
-    name = property(lambda self: self.stream.name, doc="""
-        The name of the underlying stream.""")
+    @property
+    def name(self): 
+        """The name of the underlying stream."""
+        return self.stream.name
 
-    mode = property(lambda self: self.stream.mode, doc="""
-        The mode of the underlying stream.""")
+    @property
+    def mode(self): 
+        """The mode of the underlying stream."""
+        return self.stream.mode
 
     def close(self):
         """Close the underlying stream."""

--- a/nltk/tag/crf.py
+++ b/nltk/tag/crf.py
@@ -83,22 +83,26 @@ class MalletCRF(FeaturesetTaggerI):
     # Convenience accessors (info also available via self.crf_info)
     #/////////////////////////////////////////////////////////////////
 
-    def _get_filename(self):
-        return self.crf_info.model_filename
-    filename = property(_get_filename , doc="""
+    @property
+    def filename(self):
+        """
         The filename of the crf model file that backs this
         MalletCRF.  The crf model file is actually a zip file, and
         it contains one file for the serialized model
         ``crf-model.ser`` and one file for information about the
-        structure of the CRF ``crf-info.xml``).""")
+        structure of the CRF ``crf-info.xml``).
+        """
+        return self.crf_info.model_filename
 
-    def _get_feature_detector(self):
-        return self.crf_info.model_feature_detector
-    feature_detector = property(_get_feature_detector , doc="""
+    @property
+    def feature_detector(self):
+        """
         The feature detector function that is used to convert tokens
         to featuresets.  This function has the signature::
 
-            feature_detector(tokens, index) -> featureset""")
+        feature_detector(tokens, index) -> featureset
+        """
+        return self.crf_info.model_feature_detector
 
     #/////////////////////////////////////////////////////////////////
     # Tagging

--- a/nltk/tag/senna.py
+++ b/nltk/tag/senna.py
@@ -31,26 +31,26 @@ class SennaTagger(TaggerI):
 
     @property
     def executable(self):
-      os_name = system()
-      if os_name == 'Linux':
-        bits = architecture()[0]
-        if bits == '64bit':
-          return os.path.join(self._path, 'senna-linux64')
-        return os.path.join(self._path, 'senna-linux32')
-      if os_name == 'Windows':
-          return os.path.join(self._path, 'senna-win32.exe')
-      if os_name == 'Darwin':
-          return os.path.join(self._path, 'senna-osx')
-      return os.path.join(self._path, 'senna')
+        os_name = system()
+        if os_name == 'Linux':
+            bits = architecture()[0]
+            if bits == '64bit':
+                return os.path.join(self._path, 'senna-linux64')
+            return os.path.join(self._path, 'senna-linux32')
+        if os_name == 'Windows':
+            return os.path.join(self._path, 'senna-win32.exe')
+        if os_name == 'Darwin':
+            return os.path.join(self._path, 'senna-osx')
+        return os.path.join(self._path, 'senna')
 
     def _map(self):
-      _map = {'word':0}
-      i = 1
-      for operation in SennaTagger.__OPS:
-          if operation in self.operations:
-              _map[operation] = i
-              i+= 1
-      return _map
+        _map = {'word':0}
+        i = 1
+        for operation in SennaTagger.__OPS:
+            if operation in self.operations:
+                _map[operation] = i
+                i+= 1
+        return _map
 
     def tag(self, tokens):
         return self.batch_tag([tokens])[0]
@@ -61,7 +61,6 @@ class SennaTagger(TaggerI):
         # Build the senna command to run the tagger
         _senna_cmd = [self.executable, '-path', self._path, '-usrtokens', '-iobtags']
         _senna_cmd.extend(['-'+op for op in self.operations])
-
 
         # Write the actual sentences to the temporary input file
         _input = '\n'.join((' '.join(x) for x in sentences))+'\n'
@@ -111,40 +110,40 @@ class POSTagger(SennaTagger):
         [('What', 'WP'), ('is', 'VBZ'), ('the', 'DT'), ('airspeed', 'NN'),
         ('of', 'IN'), ('an', 'DT'), ('unladen', 'JJ'), ('swallow', 'VB'), ('?', '.')]
     """
-  def __init__(self, path, encoding=None, verbose=False):
-    super(POSTagger, self).__init__(path, {'pos'}, encoding, verbose)
+    def __init__(self, path, encoding=None, verbose=False):
+        super(POSTagger, self).__init__(path, ['pos'], encoding, verbose)
 
-  def batch_tag(self, sentences):
-    tagged_sents = super(POSTagger, self).batch_tag(sentences)
-    for i in range(len(tagged_sents)):
-      for j in range(len(tagged_sents[i])):
-        tagged_sents[i][j] = (sentences[i][j], tagged_sents[i][j]['pos'])
-    return tagged_sents
+    def batch_tag(self, sentences):
+        tagged_sents = super(POSTagger, self).batch_tag(sentences)
+        for i in range(len(tagged_sents)):
+            for j in range(len(tagged_sents[i])):
+                tagged_sents[i][j] = (sentences[i][j], tagged_sents[i][j]['pos'])
+        return tagged_sents
 
 
 class NERTagger(SennaTagger):
-  def __init__(self, path, encoding=None, verbose=False):
-    super(NERTagger, self).__init__(path, {'ner'}, encoding, verbose)
+    def __init__(self, path, encoding=None, verbose=False):
+        super(NERTagger, self).__init__(path, ['ner'], encoding, verbose)
 
-  def batch_tag(self, sentences):
-    tagged_sents = super(NERTagger, self).batch_tag(sentences)
-    for i in range(len(tagged_sents)):
-      for j in range(len(tagged_sents[i])):
-        try:
-          tagged_sents[i][j] = (sentences[i][j], tagged_sents[i][j]['ner'])
-        except:
-          import pdb
-          pdb.set_trace()
-    return tagged_sents
+    def batch_tag(self, sentences):
+        tagged_sents = super(NERTagger, self).batch_tag(sentences)
+        for i in range(len(tagged_sents)):
+            for j in range(len(tagged_sents[i])):
+                try:
+                    tagged_sents[i][j] = (sentences[i][j], tagged_sents[i][j]['ner'])
+                except:
+                    import pdb
+                    pdb.set_trace()
+        return tagged_sents
 
 
 class CHKTagger(SennaTagger):
-  def __init__(self, path, encoding=None, verbose=False):
-    super(CHKTagger, self).__init__(path, {'chk'}, encoding, verbose)
+    def __init__(self, path, encoding=None, verbose=False):
+        super(CHKTagger, self).__init__(path, ['chk'], encoding, verbose)
 
-  def batch_tag(self, sentences):
-    tagged_sents = super(CHKTagger, self).batch_tag(sentences)
-    for i in range(len(tagged_sents)):
-      for j in range(len(tagged_sents[i])):
-        tagged_sents[i][j] = (sentences[i][j], tagged_sents[i][j]['chk'])
-    return tagged_sents
+    def batch_tag(self, sentences):
+        tagged_sents = super(CHKTagger, self).batch_tag(sentences)
+        for i in range(len(tagged_sents)):
+            for j in range(len(tagged_sents[i])):
+                tagged_sents[i][j] = (sentences[i][j], tagged_sents[i][j]['chk'])
+        return tagged_sents

--- a/nltk/tag/sequential.py
+++ b/nltk/tag/sequential.py
@@ -45,11 +45,11 @@ class SequentialBackoffTagger(TaggerI):
         else:
             self._taggers = [self] + backoff._taggers
 
-    def _get_backoff(self):
+    @property
+    def backoff(self):
+        """The backoff tagger for this tagger."""
         if len(self._taggers) < 2: return None
         else: return self._taggers[1]
-    backoff = property(_get_backoff, doc='''
-        The backoff tagger for this tagger.''')
 
     def tag(self, tokens):
         # docs inherited from TaggerI

--- a/nltk/test/tree.doctest
+++ b/nltk/test/tree.doctest
@@ -302,24 +302,24 @@ incorrect parent pointers and in `TypeError` exceptions:
     >>> # inserting a ParentedTree in a Tree gives incorrect parent pointers:
     >>> broken_tree = Tree('NP', [
     ...     ParentedTree('DET', ['the']), ParentedTree('NOUN', ['dog'])])
-    >>> print broken_tree[0].parent
+    >>> print broken_tree[0].parent()
     None
 
-Parented Tree Properties
+Parented Tree Methods
 ------------------------
 In addition to all the methods defined by the `Tree` class, the
-`ParentedTree` class adds six new properties whose values are
-automatically updated whenver a parented tree is modified: `parent`,
-`parent_index`, `left_sibling`, `right_sibling`, `root`, and
-`treeposition`.
+`ParentedTree` class adds six new methods whose values are
+automatically updated whenver a parented tree is modified: `parent()`,
+`parent_index()`, `left_sibling()`, `right_sibling()`, `root()`, and
+`treeposition()`.
 
-The `parent` property contains a `ParentedTree`\ 's parent, if it has
+The `parent()` method contains a `ParentedTree`\ 's parent, if it has
 one; and ``None`` otherwise.  `ParentedTree`\ s that do not have
 parents are known as "root trees."
 
     >>> for subtree in ptree.subtrees():
     ...     print subtree
-    ...     print '  Parent = %s' % subtree.parent
+    ...     print '  Parent = %s' % subtree.parent()
     (VP (VERB saw) (NP (DET the) (NOUN dog)))
       Parent = None
     (VERB saw)
@@ -331,15 +331,15 @@ parents are known as "root trees."
     (NOUN dog)
       Parent = (NP (DET the) (NOUN dog))
 
-The `parent_index` property stores the index of a tree in its parent's
+The `parent_index()` method stores the index of a tree in its parent's
 child list.  If a tree does not have a parent, then its `parent_index`
 is ``None``.
 
     >>> for subtree in ptree.subtrees():
     ...     print subtree
-    ...     print '  Parent Index = %s' % subtree.parent_index
-    ...     assert (subtree.parent is None or
-    ...             subtree.parent[subtree.parent_index] is subtree)
+    ...     print '  Parent Index = %s' % subtree.parent_index()
+    ...     assert (subtree.parent() is None or
+    ...             subtree.parent()[subtree.parent_index()] is subtree)
     (VP (VERB saw) (NP (DET the) (NOUN dog)))
       Parent Index = None
     (VERB saw)
@@ -351,9 +351,9 @@ is ``None``.
     (NOUN dog)
       Parent Index = 1
 
-Note that ``ptree.parent.index(ptree)`` is *not* equivalent to
-``ptree.parent_index``.  In particular, ``ptree.parent.index(ptree)``
-will return the index of the first child of ``ptree.parent`` that is
+Note that ``ptree.parent().index(ptree)`` is *not* equivalent to
+``ptree.parent_index()``.  In particular, ``ptree.parent().index(ptree)``
+will return the index of the first child of ``ptree.parent()`` that is
 equal to ``ptree`` (using ``==``); and that child may not be
 ``ptree``:
 
@@ -362,19 +362,19 @@ equal to ``ptree`` (using ``==``); and that child may not be
     ...     ParentedTree('COJN', ['and']),
     ...     ParentedTree('PREP', ['on'])])
     >>> second_on = on_and_on[2]
-    >>> print second_on.parent_index
+    >>> print second_on.parent_index()
     2
-    >>> print second_on.parent.index(second_on)
+    >>> print second_on.parent().index(second_on)
     0
 
-The properties `left_sibling` and `right_sibling` can be used to get a
+The methods `left_sibling()` and `right_sibling()` can be used to get a
 parented tree's siblings.  If a tree does not have a left or right
-sibling, then the corresponding property's value is ``None``:
+sibling, then the corresponding method's value is ``None``:
 
     >>> for subtree in ptree.subtrees():
     ...     print subtree
-    ...     print '  Left Sibling  = %s' % subtree.left_sibling
-    ...     print '  Right Sibling = %s' % subtree.right_sibling
+    ...     print '  Left Sibling  = %s' % subtree.left_sibling()
+    ...     print '  Right Sibling = %s' % subtree.right_sibling()
     (VP (VERB saw) (NP (DET the) (NOUN dog)))
       Left Sibling  = None
       Right Sibling = None
@@ -391,14 +391,14 @@ sibling, then the corresponding property's value is ``None``:
       Left Sibling  = (DET the)
       Right Sibling = None
 
-A parented tree's root tree can be accessed using the `root`
-property.  This property follows the tree's parent pointers until it
+A parented tree's root tree can be accessed using the `root()`
+method.  This method follows the tree's parent pointers until it
 finds a tree without a parent.  If a tree does not have a parent, then
 it is its own root:
 
     >>> for subtree in ptree.subtrees():
     ...     print subtree
-    ...     print '  Root = %s' % subtree.root
+    ...     print '  Root = %s' % subtree.root()
     (VP (VERB saw) (NP (DET the) (NOUN dog)))
       Root = (VP (VERB saw) (NP (DET the) (NOUN dog)))
     (VERB saw)
@@ -410,13 +410,13 @@ it is its own root:
     (NOUN dog)
       Root = (VP (VERB saw) (NP (DET the) (NOUN dog)))
 
-The `treeposition` property can be used to find a tree's treeposition
+The `treeposition()` method can be used to find a tree's treeposition
 relative to its root:
 
     >>> for subtree in ptree.subtrees():
     ...     print subtree
-    ...     print '  Tree Position = %s' % (subtree.treeposition,)
-    ...     assert subtree.root[subtree.treeposition] is subtree
+    ...     print '  Tree Position = %s' % (subtree.treeposition(),)
+    ...     assert subtree.root()[subtree.treeposition()] is subtree
     (VP (VERB saw) (NP (DET the) (NOUN dog)))
       Tree Position = ()
     (VERB saw)
@@ -428,11 +428,11 @@ relative to its root:
     (NOUN dog)
       Tree Position = (1, 1)
 
-Whenever a parented tree is modified, all of the properties described
-above (`parent`, `parent_index`, `left_sibling`, `right_sibling`,
-`root`, and `treeposition`) are automatically updated.  For example,
+Whenever a parented tree is modified, all of the methods described
+above (`parent()`, `parent_index()`, `left_sibling()`, `right_sibling()`,
+`root()`, and `treeposition()`) are automatically updated.  For example,
 if we replace ``ptree``\ 's subtree for the word "dog" with a new
-subtree for "cat," the properties for both the "dog" subtree and the
+subtree for "cat," the method values for both the "dog" subtree and the
 "cat" subtree get automatically updated:
 
     >>> # Replace the dog with a cat
@@ -441,24 +441,24 @@ subtree for "cat," the properties for both the "dog" subtree and the
     >>> ptree[1,1] = cat
 
     >>> # the noun phrase is no longer the dog's parent:
-    >>> print dog.parent, dog.parent_index, dog.left_sibling
+    >>> print dog.parent(), dog.parent_index(), dog.left_sibling()
     None None None
     >>> # dog is now its own root.
-    >>> print dog.root
+    >>> print dog.root()
     (NOUN dog)
-    >>> print dog.treeposition
+    >>> print dog.treeposition()
     ()
 
     >>> # the cat's parent is now the noun phrase:
-    >>> print cat.parent
+    >>> print cat.parent()
     (NP (DET the) (NOUN cat))
-    >>> print cat.parent_index
+    >>> print cat.parent_index()
     1
-    >>> print cat.left_sibling
+    >>> print cat.left_sibling()
     (DET the)
-    >>> print cat.root
+    >>> print cat.root()
     (VP (VERB saw) (NP (DET the) (NOUN cat)))
-    >>> print cat.treeposition
+    >>> print cat.treeposition()
     (1, 1)
 
 ParentedTree Regression Tests
@@ -477,47 +477,47 @@ Define a helper funciton to create new parented trees:
     ...     return ptree
 
 Define a test function that examines every subtree in all_ptrees; and
-checks that all six of its properties are defined correctly.  If any
+checks that all six of its methods are defined correctly.  If any
 ptrees are passed as arguments, then they are printed.
 
     >>> def pcheck(*print_ptrees):
     ...     for ptree in all_ptrees:
-    ...         # Check ptree's properties.
-    ...         if ptree.parent is not None:
-    ...             i = ptree.parent_index
-    ...             assert ptree.parent[i] is ptree
+    ...         # Check ptree's methods.
+    ...         if ptree.parent() is not None:
+    ...             i = ptree.parent_index()
+    ...             assert ptree.parent()[i] is ptree
     ...             if i > 0:
-    ...                 assert ptree.left_sibling is ptree.parent[i-1]
-    ...             if i < (len(ptree.parent)-1):
-    ...                 assert ptree.right_sibling is ptree.parent[i+1]
-    ...             assert len(ptree.treeposition) > 0
-    ...             assert (ptree.treeposition ==
-    ...                     ptree.parent.treeposition + (ptree.parent_index,))
-    ...             assert ptree.root is not ptree
-    ...             assert ptree.root is not None
-    ...             assert ptree.root is ptree.parent.root
-    ...             assert ptree.root[ptree.treeposition] is ptree
+    ...                 assert ptree.left_sibling() is ptree.parent()[i-1]
+    ...             if i < (len(ptree.parent())-1):
+    ...                 assert ptree.right_sibling() is ptree.parent()[i+1]
+    ...             assert len(ptree.treeposition()) > 0
+    ...             assert (ptree.treeposition() ==
+    ...                     ptree.parent().treeposition() + (ptree.parent_index(),))
+    ...             assert ptree.root() is not ptree
+    ...             assert ptree.root() is not None
+    ...             assert ptree.root() is ptree.parent().root()
+    ...             assert ptree.root()[ptree.treeposition()] is ptree
     ...         else:
-    ...             assert ptree.parent_index is None
-    ...             assert ptree.left_sibling is None
-    ...             assert ptree.right_sibling is None
-    ...             assert ptree.root is ptree
-    ...             assert ptree.treeposition == ()
-    ...         # Check ptree's children's properties:
+    ...             assert ptree.parent_index() is None
+    ...             assert ptree.left_sibling() is None
+    ...             assert ptree.right_sibling() is None
+    ...             assert ptree.root() is ptree
+    ...             assert ptree.treeposition() == ()
+    ...         # Check ptree's children's methods:
     ...         for i, child in enumerate(ptree):
     ...             if isinstance(child, Tree):
-    ...                 # pcheck parent & parent_index properties
-    ...                 assert child.parent is ptree
-    ...                 assert child.parent_index == i
-    ...                 # pcheck sibling properties
+    ...                 # pcheck parent() & parent_index() methods
+    ...                 assert child.parent() is ptree
+    ...                 assert child.parent_index() == i
+    ...                 # pcheck sibling methods
     ...                 if i == 0:
-    ...                     assert child.left_sibling is None
+    ...                     assert child.left_sibling() is None
     ...                 else:
-    ...                     assert child.left_sibling is ptree[i-1]
+    ...                     assert child.left_sibling() is ptree[i-1]
     ...                 if i == len(ptree)-1:
-    ...                     assert child.right_sibling is None
+    ...                     assert child.right_sibling() is None
     ...                 else:
-    ...                     assert child.right_sibling is ptree[i+1]
+    ...                     assert child.right_sibling() is ptree[i+1]
     ...     if print_ptrees:
     ...         print 'ok!',
     ...         for ptree in print_ptrees: print ptree
@@ -710,10 +710,10 @@ operations:
     >>> x1, y, x2 = ptree
     >>> ptree.remove(ptree[-1]); pcheck(ptree)
     ok! (A (Y y) (X x))
-    >>> print x1.parent; pcheck(x1)
+    >>> print x1.parent(); pcheck(x1)
     None
     ok! (X x)
-    >>> print x2.parent
+    >>> print x2.parent()
     (A (Y y) (X x))
 
 Test that a tree can not be given multiple parents:
@@ -761,7 +761,7 @@ Define a helper funciton to create new parented trees:
     ...     return mptree
 
 Define a test function that examines every subtree in all_mptrees; and
-checks that all six of its properties are defined correctly.  If any
+checks that all six of its methods are defined correctly.  If any
 mptrees are passed as arguments, then they are printed.
 
     >>> def mpcheck(*print_mptrees):
@@ -770,20 +770,20 @@ mptrees are passed as arguments, then they are printed.
     ...             if item is val: return True
     ...         return False
     ...     for mptree in all_mptrees:
-    ...         # Check mptree's properties.
-    ...         if len(mptree.parents) == 0:
-    ...             assert len(mptree.left_siblings) == 0
-    ...             assert len(mptree.right_siblings) == 0
-    ...             assert len(mptree.roots) == 1
-    ...             assert mptree.roots[0] is mptree
+    ...         # Check mptree's methods.
+    ...         if len(mptree.parents()) == 0:
+    ...             assert len(mptree.left_siblings()) == 0
+    ...             assert len(mptree.right_siblings()) == 0
+    ...             assert len(mptree.roots()) == 1
+    ...             assert mptree.roots()[0] is mptree
     ...             assert mptree.treepositions(mptree) == [()]
     ...             left_siblings = right_siblings = ()
     ...             roots = {id(mptree): 1}
     ...         else:
-    ...             roots = dict((id(r), 0) for r in mptree.roots)
-    ...             left_siblings = mptree.left_siblings
-    ...             right_siblings = mptree.right_siblings
-    ...         for parent in mptree.parents:
+    ...             roots = dict((id(r), 0) for r in mptree.roots())
+    ...             left_siblings = mptree.left_siblings()
+    ...             right_siblings = mptree.right_siblings()
+    ...         for parent in mptree.parents():
     ...             for i in mptree.parent_indices(parent):
     ...                 assert parent[i] is mptree
     ...                 # check left siblings
@@ -803,7 +803,7 @@ mptrees are passed as arguments, then they are printed.
     ...                     else:
     ...                         assert 0, 'sibling not found!'
     ...             # check roots
-    ...             for root in parent.roots:
+    ...             for root in parent.roots():
     ...                 assert id(root) in roots, 'missing root'
     ...                 roots[id(root)] += 1
     ...         # check that we don't have any unexplained values
@@ -811,20 +811,20 @@ mptrees are passed as arguments, then they are printed.
     ...         assert len(right_siblings)==0, 'unexpected sibling'
     ...         for v in roots.values(): assert v>0, roots #'unexpected root'
     ...         # check treepositions
-    ...         for root in mptree.roots:
+    ...         for root in mptree.roots():
     ...             for treepos in mptree.treepositions(root):
     ...                 assert root[treepos] is mptree
-    ...         # Check mptree's children's properties:
+    ...         # Check mptree's children's methods:
     ...         for i, child in enumerate(mptree):
     ...             if isinstance(child, Tree):
-    ...                 # mpcheck parent & parent_index properties
-    ...                 assert has(child.parents, mptree)
+    ...                 # mpcheck parent() & parent_index() methods
+    ...                 assert has(child.parents(), mptree)
     ...                 assert i in child.parent_indices(mptree)
-    ...                 # mpcheck sibling properties
+    ...                 # mpcheck sibling methods
     ...                 if i > 0:
-    ...                     assert has(child.left_siblings, mptree[i-1])
+    ...                     assert has(child.left_siblings(), mptree[i-1])
     ...                 if i < len(mptree)-1:
-    ...                     assert has(child.right_siblings, mptree[i+1])
+    ...                     assert has(child.right_siblings(), mptree[i+1])
     ...     if print_mptrees:
     ...         print 'ok!',
     ...         for mptree in print_mptrees: print mptree
@@ -1025,9 +1025,9 @@ multiple parents.)
     >>> x1, y, x2 = mptree
     >>> mptree.remove(mptree[-1]); mpcheck(mptree)
     ok! (A (Y y) (X x))
-    >>> print [str(p) for p in x1.parents]
+    >>> print [str(p) for p in x1.parents()]
     []
-    >>> print [str(p) for p in x2.parents]
+    >>> print [str(p) for p in x2.parents()]
     ['(A (Y y) (X x))']
 
 

--- a/nltk/test/tree.doctest
+++ b/nltk/test/tree.doctest
@@ -683,7 +683,7 @@ operations:
     >>> ptree.pop(-100)
     Traceback (most recent call last):
       . . .
-    IndexError: index out of range
+    IndexError: list index out of range
 
 **remove()**
 
@@ -697,13 +697,13 @@ operations:
     >>> ptree[0,0].remove(make_ptree('(Q p)'))
     Traceback (most recent call last):
       . . .
-    ValueError: list.index(x): x not in list
+    ValueError
     >>> ptree.remove('h'); pcheck(ptree)
     ok! (A (B (C (D )) g))
     >>> ptree.remove('h');
     Traceback (most recent call last):
       . . .
-    ValueError: list.index(x): x not in list
+    ValueError
     >>> # remove() removes the first subtree that is equal (==) to the
     >>> # given tree, which may not be the identical tree we give it:
     >>> ptree = make_ptree('(A (X x) (Y y) (X x))')
@@ -998,7 +998,7 @@ multiple parents.)
     >>> mptree.pop(-100)
     Traceback (most recent call last):
       . . .
-    IndexError: index out of range
+    IndexError: list index out of range
 
 **remove()**
 
@@ -1012,13 +1012,13 @@ multiple parents.)
     >>> mptree[0,0].remove(make_mptree('(Q p)'))
     Traceback (most recent call last):
       . . .
-    ValueError: list.index(x): x not in list
+    ValueError
     >>> mptree.remove('h'); mpcheck(mptree)
     ok! (A (B (C (D )) g))
     >>> mptree.remove('h');
     Traceback (most recent call last):
       . . .
-    ValueError: list.index(x): x not in list
+    ValueError
     >>> # remove() removes the first subtree that is equal (==) to the
     >>> # given tree, which may not be the identical tree we give it:
     >>> mptree = make_mptree('(A (X x) (Y y) (X x))')

--- a/nltk/tree.py
+++ b/nltk/tree.py
@@ -18,6 +18,7 @@ syntax trees and morphological trees.
 
 import re
 import string
+from collections import MutableSequence
 
 from nltk.grammar import Production, Nonterminal
 from nltk.probability import ProbabilisticMixIn
@@ -27,7 +28,7 @@ from nltk.util import slice_bounds
 ## Trees
 ######################################################################
 
-class Tree(list):
+class Tree(MutableSequence):
     """
     A Tree represents a hierarchical grouping of leaves and subtrees.
     For example, each constituent in a syntax tree is represented by a single Tree.
@@ -97,13 +98,13 @@ class Tree(list):
                 raise TypeError("%s: Expected a node value and child list "
                                 "or a single string" % type(self).__name__)
             tree = type(self).parse(node_or_str)
-            list.__init__(self, tree)
+            self.children = tree.children
             self.node = tree.node
         elif isinstance(children, basestring):
             raise TypeError("%s() argument 2 should be a list, not a "
                             "string" % type(self).__name__)
         else:
-            list.__init__(self, children)
+            self.children = list(children)
             self.node = node_or_str
 
     #////////////////////////////////////////////////////////////
@@ -112,42 +113,29 @@ class Tree(list):
 
     def __eq__(self, other):
         if not isinstance(other, Tree): return False
-        return self.node == other.node and list.__eq__(self, other)
+        return self.node == other.node and self.children == other.children
     def __ne__(self, other):
         return not (self == other)
     def __lt__(self, other):
         if not isinstance(other, Tree): return False
-        return self.node < other.node or list.__lt__(self, other)
+        return self.node < other.node or self.children < other.children
     def __le__(self, other):
         if not isinstance(other, Tree): return False
-        return self.node <= other.node or list.__le__(self, other)
+        return self.node <= other.node or self.children <= other.children
     def __gt__(self, other):
         if not isinstance(other, Tree): return True
-        return self.node > other.node or list.__gt__(self, other)
+        return self.node > other.node or self.children > other.children
     def __ge__(self, other):
         if not isinstance(other, Tree): return False
-        return self.node >= other.node or list.__ge__(self, other)
+        return self.node >= other.node or self.children >= other.children
 
     #////////////////////////////////////////////////////////////
-    # Disabled list operations
-    #////////////////////////////////////////////////////////////
-
-    def __mul__(self, v):
-        raise TypeError('Tree does not support multiplication')
-    def __rmul__(self, v):
-        raise TypeError('Tree does not support multiplication')
-    def __add__(self, v):
-        raise TypeError('Tree does not support addition')
-    def __radd__(self, v):
-        raise TypeError('Tree does not support addition')
-
-    #////////////////////////////////////////////////////////////
-    # Indexing (with support for tree positions)
+    # Required MutableSequence methods
     #////////////////////////////////////////////////////////////
 
     def __getitem__(self, index):
         if isinstance(index, (int, slice)):
-            return list.__getitem__(self, index)
+            return self.children[index]
         elif isinstance(index, (list, tuple)):
             if len(index) == 0:
                 return self
@@ -161,7 +149,7 @@ class Tree(list):
 
     def __setitem__(self, index, value):
         if isinstance(index, (int, slice)):
-            return list.__setitem__(self, index, value)
+            self.children[index] = value
         elif isinstance(index, (list, tuple)):
             if len(index) == 0:
                 raise IndexError('The tree position () may not be '
@@ -176,7 +164,7 @@ class Tree(list):
 
     def __delitem__(self, index):
         if isinstance(index, (int, slice)):
-            return list.__delitem__(self, index)
+            del self.children[index]
         elif isinstance(index, (list, tuple)):
             if len(index) == 0:
                 raise IndexError('The tree position () may not be deleted.')
@@ -187,6 +175,18 @@ class Tree(list):
         else:
             raise TypeError("%s indices must be integers, not %s" %
                             (type(self).__name__, type(index).__name__))
+
+    def __contains__(self, child):
+        return child in self.children
+
+    def __len__(self):
+        return len(self.children)
+
+    def __iter__(self):
+        return iter(self.children)
+
+    def insert(self, index, child):
+        self.children.insert(index, child)
 
     #////////////////////////////////////////////////////////////
     # Basic tree operations
@@ -482,7 +482,7 @@ class Tree(list):
             return tree
 
     def copy(self, deep=False):
-        if not deep: return type(self)(self.node, self)
+        if not deep: return type(self)(self.node, self.children[:])
         else: return type(self).convert(self)
 
     def _frozen_class(self): return ImmutableTree
@@ -738,7 +738,7 @@ class ImmutableTree(Tree):
         # Precompute our hash value.  This ensures that we're really
         # immutable.  It also means we only have to calculate it once.
         try:
-            self._hash = hash( (self.node, tuple(self)) )
+            self._hash = hash( (self.node, self.children) )
         except (TypeError, ValueError):
             raise ValueError("%s: node value and children "
                              "must be immutable" % type(self).__name__)
@@ -772,7 +772,7 @@ class ImmutableTree(Tree):
 
     @property
     def node(self):
-        """Get the node value"""
+        """Get the node value."""
         return self._node
 
     @node.setter
@@ -785,6 +785,20 @@ class ImmutableTree(Tree):
             raise ValueError('%s may not be modified' % type(self).__name__)
         self._node = value
 
+    @property
+    def children(self):
+        """Get the list of children."""
+        return self._children
+
+    @children.setter
+    def children(self, children):
+        """
+        Set the children.  This will only succeed the first time the 
+        children are set, which should occur in ImmutableTree.__init__().
+        """
+        if hasattr(self, 'children'):
+            raise ValueError('%s may not be modified' % type(self).__name__)
+        self._children = tuple(children)
 
 ######################################################################
 ## Parented trees
@@ -963,17 +977,6 @@ class AbstractParentedTree(Tree):
             raise TypeError("%s indices must be integers, not %s" %
                             (type(self).__name__, type(index).__name__))
 
-    def append(self, child):
-        if isinstance(child, Tree):
-            self._setparent(child, len(self))
-        super(AbstractParentedTree, self).append(child)
-
-    def extend(self, children):
-        for child in children:
-            if isinstance(child, Tree):
-                self._setparent(child, len(self))
-            super(AbstractParentedTree, self).append(child)
-
     def insert(self, index, child):
         # Handle negative indexes.  Note that if index < -len(self),
         # we do *not* raise an IndexError, unlike __getitem__.  This
@@ -985,34 +988,6 @@ class AbstractParentedTree(Tree):
             self._setparent(child, index)
         super(AbstractParentedTree, self).insert(index, child)
 
-    def pop(self, index=-1):
-        if index < 0: index += len(self)
-        if index < 0: raise IndexError('index out of range')
-        if isinstance(self[index], Tree):
-            self._delparent(self[index], index)
-        return super(AbstractParentedTree, self).pop(index)
-
-    # n.b.: like `list`, this is done by equality, not identity!
-    # To remove a specific child, use del ptree[i].
-    def remove(self, child):
-        index = self.index(child)
-        if isinstance(self[index], Tree):
-            self._delparent(self[index], index)
-        super(AbstractParentedTree, self).remove(child)
-
-    # We need to implement __getslice__ and friends, even though
-    # they're deprecated, because otherwise list.__getslice__ will get
-    # called (since we're subclassing from list).  Just delegate to
-    # __getitem__ etc., but use max(0, start) and max(0, stop) because
-    # because negative indices are already handled *before*
-    # __getslice__ is called; and we don't want to double-count them.
-    if hasattr(list, '__getslice__'):
-        def __getslice__(self, start, stop):
-            return self.__getitem__(slice(max(0, start), max(0, stop)))
-        def __delslice__(self, start, stop):
-            return self.__delitem__(slice(max(0, start), max(0, stop)))
-        def __setslice__(self, start, stop, value):
-            return self.__setitem__(slice(max(0, start), max(0, stop)), value)
 
 class ParentedTree(AbstractParentedTree):
     """

--- a/nltk/tree.py
+++ b/nltk/tree.py
@@ -1017,10 +1017,9 @@ class AbstractParentedTree(Tree):
 class ParentedTree(AbstractParentedTree):
     """
     A ``Tree`` that automatically maintains parent pointers for
-    single-parented trees.  The following read-only property values
-    are automatically updated whenever the structure of a parented
-    tree is modified: ``parent``, ``parent_index``, ``left_sibling``,
-    ``right_sibling``, ``root``, ``treeposition``.
+    single-parented trees.  The following are methods for querying 
+    the structure of a parented tree: ``parent``, ``parent_index``, 
+    ``left_sibling``, ``right_sibling``, ``root``, ``treeposition``.
 
     Each ``ParentedTree`` may have at most one parent.  In
     particular, subtrees may not be shared.  Any attempt to reuse a
@@ -1040,20 +1039,18 @@ class ParentedTree(AbstractParentedTree):
     def _frozen_class(self): return ImmutableParentedTree
 
     #/////////////////////////////////////////////////////////////////
-    # Properties
+    # Methods
     #/////////////////////////////////////////////////////////////////
 
-    @property
     def parent(self):
         """The parent of this tree, or None if it has no parent."""
         return self._parent
 
-    @property
     def parent_index(self):
         """
         The index of this tree in its parent.  I.e.,
-        ``ptree.parent[ptree.parent_index] is ptree``.  Note that
-        ``ptree.parent_index`` is not necessarily equal to
+        ``ptree.parent()[ptree.parent_index()] is ptree``.  Note that
+        ``ptree.parent_index()`` is not necessarily equal to
         ``ptree.parent.index(ptree)``, since the ``index()`` method
         returns the first child that is equal to its argument.
         """
@@ -1062,42 +1059,38 @@ class ParentedTree(AbstractParentedTree):
             if child is self: return i
         assert False, 'expected to find self in self._parent!'
 
-    @property
     def left_sibling(self):
         """The left sibling of this tree, or None if it has none."""
-        parent_index = self.parent_index
+        parent_index = self.parent_index()
         if self._parent and parent_index > 0:
             return self._parent[parent_index-1]
         return None # no left sibling
 
-    @property
     def right_sibling(self):
         """The right sibling of this tree, or None if it has none."""
-        parent_index = self.parent_index
+        parent_index = self.parent_index()
         if self._parent and parent_index < (len(self._parent)-1):
             return self._parent[parent_index+1]
         return None # no right sibling
 
-    @property
     def root(self):
         """
         The root of this tree.  I.e., the unique ancestor of this tree
-        whose parent is None.  If ``ptree.parent`` is None, then
+        whose parent is None.  If ``ptree.parent()`` is None, then
         ``ptree`` is its own root.
         """
         root = self
-        while root.parent is not None:
-            root = root.parent
+        while root.parent() is not None:
+            root = root.parent()
         return root
 
-    @property
     def treeposition(self):
         """
         The tree position of this tree, relative to the root of the
         tree.  I.e., ``ptree.root[ptree.treeposition] is ptree``.
         """
-        if self.parent is None: return ()
-        else: return self.parent.treeposition + (self.parent_index,)
+        if self.parent() is None: return ()
+        else: return self.parent().treeposition() + (self.parent_index(),)
 
 
     #/////////////////////////////////////////////////////////////////
@@ -1132,16 +1125,15 @@ class ParentedTree(AbstractParentedTree):
 class MultiParentedTree(AbstractParentedTree):
     """
     A ``Tree`` that automatically maintains parent pointers for
-    multi-parented trees.  The following read-only property values are
-    automatically updated whenever the structure of a multi-parented
-    tree is modified: ``parents``, ``parent_indices``, ``left_siblings``,
-    ``right_siblings``, ``roots``, ``treepositions``.
+    multi-parented trees.  The following are methods for querying the 
+    structure of a multi-parented tree: ``parents()``, ``parent_indices()``, 
+    ``left_siblings()``, ``right_siblings()``, ``roots``, ``treepositions``.
 
     Each ``MultiParentedTree`` may have zero or more parents.  In
     particular, subtrees may be shared.  If a single
     ``MultiParentedTree`` is used as multiple children of the same
     parent, then that parent will appear multiple times in its
-    ``parents`` property.
+    ``parents()`` method.
 
     ``MultiParentedTrees`` should never be used in the same tree as
     ``Trees`` or ``ParentedTrees``.  Mixing tree implementations may
@@ -1157,22 +1149,20 @@ class MultiParentedTree(AbstractParentedTree):
     def _frozen_class(self): return ImmutableMultiParentedTree
 
     #/////////////////////////////////////////////////////////////////
-    # Properties
+    # Methods
     #/////////////////////////////////////////////////////////////////
 
-    @property
     def parents(self):
         """
         The set of parents of this tree.  If this tree has no parents,
         then ``parents`` is the empty set.  To check if a tree is used
         as multiple children of the same parent, use the
-        ``parent_indices`` property.
+        ``parent_indices()`` method.
 
         :type: list(MultiParentedTree)
         """
         return list(self._parents)
 
-    @property
     def left_siblings(self):
         """
         A list of all left siblings of this tree, in any of its parent
@@ -1187,7 +1177,6 @@ class MultiParentedTree(AbstractParentedTree):
                 for (parent, index) in self._get_parent_indices()
                 if index > 0]
 
-    @property
     def right_siblings(self):
         """
         A list of all right siblings of this tree, in any of its parent
@@ -1208,7 +1197,6 @@ class MultiParentedTree(AbstractParentedTree):
                 for index, child in enumerate(parent)
                 if child is self]
 
-    @property
     def roots(self):
         """
         The set of all roots of this tree.  This set is formed by


### PR DESCRIPTION
This pull reqeust is silghtly more experimental than the others.

Since trees do not work like lists, I think it's better to make trees a subclass of a generic Sequence class. Instead of `list` I chose `collections.MutableSequence` as superclass of Tree.  The tree children are now stored in the property `.children`, but the standard sequence methods and selectors work directly on the tree, just as before.

I hope no existing code will break, and that the new code is more intuitive than before.  The doctests pass without problems. 

This only changes the files tree.py and tree.doctest -- the other changes are the same as my previous pull request:
https://github.com/nltk/nltk/pull/207
