### PR TITLE
Use proper exceptions in nltk.cluster

### DIFF
--- a/nltk/cluster/api.py
+++ b/nltk/cluster/api.py
@@ -18,14 +18,14 @@ class ClusterI(object):
         Assigns the vectors to clusters, learning the clustering parameters
         from the data. Returns a cluster identifier for each vector.
         """
-        raise AssertionError()
+        raise NotImplementedError()
 
     def classify(self, token):
         """
         Classifies the token into a cluster, setting the token's CLUSTER
         parameter to that cluster identifier.
         """
-        raise AssertionError()
+        raise NotImplementedError()
 
     def likelihood(self, vector, label):
         """
@@ -55,7 +55,7 @@ class ClusterI(object):
         """
         Returns the number of clusters.
         """
-        raise AssertError()
+        raise NotImplementedError()
 
     def cluster_names(self):
         """
@@ -68,4 +68,3 @@ class ClusterI(object):
         Returns the names of the cluster at index.
         """
         return index
-

--- a/nltk/cluster/util.py
+++ b/nltk/cluster/util.py
@@ -59,7 +59,7 @@ class VectorSpaceClusterer(ClusterI):
         """
         Finds the clusters using the given set of vectors.
         """
-        raise AssertionError()
+        raise NotImplementedError()
 
     def classify(self, vector):
         if self._should_normalise:
@@ -73,7 +73,7 @@ class VectorSpaceClusterer(ClusterI):
         """
         Returns the index of the appropriate cluster for the vector.
         """
-        raise AssertionError()
+        raise NotImplementedError()
 
     def likelihood(self, vector, label):
         if self._should_normalise:


### PR DESCRIPTION
The clustering module was raising `AssertionError` (and the non-existing `AssertError`) were it should be raising `NotImplementedError`. Fixed that.
