### PR TITLE
Positive Naive Bayes Classifier

### DIFF
--- a/nltk/classify/__init__.py
+++ b/nltk/classify/__init__.py
@@ -90,6 +90,7 @@ from nltk.classify.mallet import config_mallet, call_mallet
 from nltk.classify.megam import config_megam, call_megam
 from nltk.classify.weka import WekaClassifier, config_weka
 from nltk.classify.naivebayes import NaiveBayesClassifier
+from nltk.classify.positivenaivebayes import PositiveNaiveBayesClassifier
 from nltk.classify.decisiontree import DecisionTreeClassifier
 from nltk.classify.rte_classify import rte_classifier, rte_features, RTEFeatureExtractor
 from nltk.classify.util import accuracy, log_likelihood

--- a/nltk/classify/positivenaivebayes.py
+++ b/nltk/classify/positivenaivebayes.py
@@ -99,6 +99,8 @@ class PositiveNaiveBayesClassifier(NaiveBayesClassifier):
                         - positive_prob_prior *
                         feature_probdist[True, fname].prob(fval)) \
                         / negative_prob_prior
+                # TODO: We need to add some kind of smoothing here, instead of
+                # setting negative probabilities to zero and normalizing.
                 negative_feature_probs[fval] = max(prob, 0.0)
             feature_probdist[False, fname] = DictionaryProbDist(negative_feature_probs,
                                                                 normalize=True)

--- a/nltk/classify/positivenaivebayes.py
+++ b/nltk/classify/positivenaivebayes.py
@@ -103,7 +103,7 @@ class PositiveNaiveBayesClassifier(NaiveBayesClassifier):
                 negative_feature_probs[fval] = max(prob, 0.0)
             feature_probdist[False, fname] = DictionaryProbDist(negative_feature_probs)
 
-        return NaiveBayesClassifier(label_probdist, feature_probdist)
+        return PositiveNaiveBayesClassifier(label_probdist, feature_probdist)
                                                  
 ##//////////////////////////////////////////////////////
 ##  Demo

--- a/nltk/classify/positivenaivebayes.py
+++ b/nltk/classify/positivenaivebayes.py
@@ -1,3 +1,35 @@
+# Natural Language Toolkit: Positive Naive Bayes Classifier
+#
+# Copyright (C) 2012 NLTK Project
+# Author: Alessandro Presta <alessandro.presta@gmail.com>
+# URL: <http://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""
+A variant of the Naive Bayes Classifier that performs binary classification with
+partially-labeled training sets. In other words, assume we want to build a classifier
+that assigns each example to one of two complementary classes (e.g., male names and
+female names).
+If we have a training set with labeled examples for both classes, we can use a
+standard Naive Bayes Classifier. However, consider the case when we only have labeled
+examples for one of the classes, and other, unlabeled, examples.
+Then, assuming a prior distribution on the two labels, we can use the unlabeled set
+to estimate the frequencies of the various features.
+
+Let the two possible labels be 1 and 0, and let's say we only have examples labeled 1
+and unlabeled examples. We are also given an estimate of P(1).
+
+We compute P(feature|1) exactly as in the standard case.
+
+To compute P(feature|0), we first estimate P(feature) from the unlabeled set (we are
+assuming that the unlabeled examples are drawn according to the given prior distribution)
+and then express the conditional probability as:
+
+|                  P(feature) - P(feature|1) * P(1)
+|  P(feature|0) = ----------------------------------
+|                               P(0)
+"""
+
 from collections import defaultdict
 
 from nltk.probability import FreqDist, ConditionalFreqDist, DictionaryProbDist, \
@@ -5,15 +37,22 @@ from nltk.probability import FreqDist, ConditionalFreqDist, DictionaryProbDist, 
 
 from naivebayes import NaiveBayesClassifier
 
-class PositiveNaiveBayesClassifier(NaiveBayesClassifier):
-    """
+##//////////////////////////////////////////////////////
+##  Positive Naive Bayes Classifier
+##//////////////////////////////////////////////////////
 
-    """
+class PositiveNaiveBayesClassifier(NaiveBayesClassifier):
     @staticmethod
     def train(positive_featuresets, unlabeled_featuresets, positive_prob_prior=0.5,
               estimator=ELEProbDist):
         """
+        :param positive_featuresets: A list of featuresets that are known as positive
+            examples (i.e., their label is ``True``).
 
+        :param unlabeled_featuresets: A list of featuresets whose label is unknown.
+
+        :param positive_prob_prior: A prior estimate of the probability of the label
+            ``True`` (default 0.5).
         """
         positive_feature_freqdist = ConditionalFreqDist()
         unlabeled_feature_freqdist = ConditionalFreqDist()
@@ -71,7 +110,7 @@ class PositiveNaiveBayesClassifier(NaiveBayesClassifier):
 ##//////////////////////////////////////////////////////
 
 def demo():
-    from util import pnb_demo#from nltk.classify.util import pnb_demo
+    from nltk.classify.util import pnb_demo
     classifier = pnb_demo(PositiveNaiveBayesClassifier.train)
     classifier.show_most_informative_features()
 

--- a/nltk/classify/positivenaivebayes.py
+++ b/nltk/classify/positivenaivebayes.py
@@ -175,8 +175,3 @@ def demo():
 if __name__ == '__main__':
     import doctest
     doctest.testmod(optionflags=doctest.NORMALIZE_WHITESPACE)
-
-            
-
-
-        

--- a/nltk/classify/positivenaivebayes.py
+++ b/nltk/classify/positivenaivebayes.py
@@ -32,8 +32,7 @@ and then express the conditional probability as:
 
 from collections import defaultdict
 
-from nltk.probability import FreqDist, ConditionalFreqDist, DictionaryProbDist, \
-    ELEProbDist
+from nltk.probability import FreqDist, DictionaryProbDist, ELEProbDist
 
 from naivebayes import NaiveBayesClassifier
 
@@ -54,8 +53,8 @@ class PositiveNaiveBayesClassifier(NaiveBayesClassifier):
         :param positive_prob_prior: A prior estimate of the probability of the label
             ``True`` (default 0.5).
         """
-        positive_feature_freqdist = ConditionalFreqDist()
-        unlabeled_feature_freqdist = ConditionalFreqDist()
+        positive_feature_freqdist = defaultdict(FreqDist)
+        unlabeled_feature_freqdist = defaultdict(FreqDist)
         feature_values = defaultdict(set)
         fnames = set()
         

--- a/nltk/classify/positivenaivebayes.py
+++ b/nltk/classify/positivenaivebayes.py
@@ -100,7 +100,8 @@ class PositiveNaiveBayesClassifier(NaiveBayesClassifier):
                         feature_probdist[True, fname].prob(fval)) \
                         / negative_prob_prior
                 negative_feature_probs[fval] = max(prob, 0.0)
-            feature_probdist[False, fname] = DictionaryProbDist(negative_feature_probs)
+            feature_probdist[False, fname] = DictionaryProbDist(negative_feature_probs,
+                                                                normalize=True)
 
         return PositiveNaiveBayesClassifier(label_probdist, feature_probdist)
                                                  

--- a/nltk/classify/positivenaivebayes.py
+++ b/nltk/classify/positivenaivebayes.py
@@ -1,0 +1,83 @@
+from collections import defaultdict
+
+from nltk.probability import FreqDist, ConditionalFreqDist, DictionaryProbDist, \
+    ELEProbDist
+
+from naivebayes import NaiveBayesClassifier
+
+class PositiveNaiveBayesClassifier(NaiveBayesClassifier):
+    """
+
+    """
+    @staticmethod
+    def train(positive_featuresets, unlabeled_featuresets, positive_prob_prior=0.5,
+              estimator=ELEProbDist):
+        """
+
+        """
+        positive_feature_freqdist = ConditionalFreqDist()
+        unlabeled_feature_freqdist = ConditionalFreqDist()
+        feature_values = defaultdict(set)
+        fnames = set()
+        
+        for featureset in positive_featuresets:
+            for fname, fval in featureset.items():
+                positive_feature_freqdist[fname].inc(fval)
+                feature_values[fname].add(fval)
+                fnames.add(fname)
+                
+        for featureset in unlabeled_featuresets:
+            for fname, fval in featureset.items():
+                unlabeled_feature_freqdist[fname].inc(fval)
+                feature_values[fname].add(fval)
+                fnames.add(fname)
+
+        num_positive_examples = len(positive_featuresets)
+        for fname in fnames:
+            count = positive_feature_freqdist[fname].N()
+            positive_feature_freqdist[fname].inc(None, num_positive_examples-count)
+            feature_values[fname].add(None)
+
+        num_unlabeled_examples = len(unlabeled_featuresets)
+        for fname in fnames:
+            count = unlabeled_feature_freqdist[fname].N()
+            unlabeled_feature_freqdist[fname].inc(None, num_unlabeled_examples-count)
+            feature_values[fname].add(None)
+
+        negative_prob_prior = 1.0 - positive_prob_prior
+        label_probdist = DictionaryProbDist({True: positive_prob_prior,
+                                             False: negative_prob_prior})
+            
+        feature_probdist = {}
+        for fname, freqdist in positive_feature_freqdist.items():
+            probdist = estimator(freqdist, bins=len(feature_values[fname]))
+            feature_probdist[True, fname] = probdist
+
+        for fname, freqdist in unlabeled_feature_freqdist.items():
+            global_probdist = estimator(freqdist, bins=len(feature_values[fname]))
+            negative_feature_probs = {}
+            for fval in feature_values[fname]:
+                prob = (global_probdist.prob(fval)
+                        - positive_prob_prior *
+                        feature_probdist[True, fname].prob(fval)) \
+                        / negative_prob_prior
+                negative_feature_probs[fval] = max(prob, 0.0)
+            feature_probdist[False, fname] = DictionaryProbDist(negative_feature_probs)
+
+        return NaiveBayesClassifier(label_probdist, feature_probdist)
+                                                 
+##//////////////////////////////////////////////////////
+##  Demo
+##//////////////////////////////////////////////////////
+
+def demo():
+    from util import pnb_demo#from nltk.classify.util import pnb_demo
+    classifier = pnb_demo(PositiveNaiveBayesClassifier.train)
+    classifier.show_most_informative_features()
+
+if __name__ == '__main__':
+    demo()
+            
+
+
+        

--- a/nltk/classify/positivenaivebayes.py
+++ b/nltk/classify/positivenaivebayes.py
@@ -110,8 +110,8 @@ class PositiveNaiveBayesClassifier(NaiveBayesClassifier):
 ##//////////////////////////////////////////////////////
 
 def demo():
-    from nltk.classify.util import pnb_demo
-    classifier = pnb_demo(PositiveNaiveBayesClassifier.train)
+    from nltk.classify.util import partial_names_demo
+    classifier = partial_names_demo(PositiveNaiveBayesClassifier.train)
     classifier.show_most_informative_features()
 
 if __name__ == '__main__':

--- a/nltk/classify/util.py
+++ b/nltk/classify/util.py
@@ -208,6 +208,53 @@ def names_demo(trainer, features=names_demo_features):
     # Return the classifier
     return classifier
 
+def pnb_demo(trainer, features=names_demo_features):
+    from nltk.corpus import names
+    import random
+
+    male_names = names.words('male.txt')
+    female_names = names.words('female.txt')
+
+    random.seed(654321)
+    random.shuffle(male_names)
+    random.shuffle(female_names)
+    positive = map(features, male_names[:2000])
+    unlabeled = map(features, male_names[2000:2500] + female_names[:500])
+    test = [(name, True) for name in male_names[2500:2750]] \
+        + [(name, False) for name in female_names[500:750]]
+    random.shuffle(test)
+
+    # Train up a classifier.
+    print 'Training classifier...'
+    classifier = trainer(positive, unlabeled)
+
+    # Run the classifier on the test data.
+    print 'Testing classifier...'
+    acc = accuracy(classifier, [(features(n),m) for (n,m) in test])
+    print 'Accuracy: %6.4f' % acc
+
+    # For classifiers that can find probabilities, show the log
+    # likelihood and some sample probability distributions.
+    try:
+        test_featuresets = [features(n) for (n,m) in test]
+        pdists = classifier.batch_prob_classify(test_featuresets)
+        ll = [pdist.logprob(gold)
+              for ((name, gold), pdist) in zip(test, pdists)]
+        print 'Avg. log likelihood: %6.4f' % (sum(ll)/len(test))
+        print
+        print 'Unseen Names      P(Male)  P(Female)\n'+'-'*40
+        for ((name, is_male), pdist) in zip(test, pdists)[:5]:
+            if is_male == True:
+                fmt = '  %-15s *%6.4f   %6.4f'
+            else:
+                fmt = '  %-15s  %6.4f  *%6.4f'
+            print fmt % (name, pdist.prob(True), pdist.prob(False))
+    except NotImplementedError:
+        pass
+
+    # Return the classifier
+    return classifier
+
 _inst_cache = {}
 def wsd_demo(trainer, word, features, n=1000):
     from nltk.corpus import senseval

--- a/nltk/classify/util.py
+++ b/nltk/classify/util.py
@@ -208,7 +208,7 @@ def names_demo(trainer, features=names_demo_features):
     # Return the classifier
     return classifier
 
-def pnb_demo(trainer, features=names_demo_features):
+def partial_names_demo(trainer, features=names_demo_features):
     from nltk.corpus import names
     import random
 
@@ -218,10 +218,17 @@ def pnb_demo(trainer, features=names_demo_features):
     random.seed(654321)
     random.shuffle(male_names)
     random.shuffle(female_names)
+
+    # Create a list of male names to be used as positive-labeled examples for training
     positive = map(features, male_names[:2000])
+
+    # Create a list of male and female names to be used as unlabeled examples
     unlabeled = map(features, male_names[2000:2500] + female_names[:500])
+
+    # Create a test set with correctly-labeled male and female names
     test = [(name, True) for name in male_names[2500:2750]] \
         + [(name, False) for name in female_names[500:750]]
+
     random.shuffle(test)
 
     # Train up a classifier.


### PR DESCRIPTION
An implementation of a "Positive Naive Bayes Classifier", introduced in

"Text Classification from Positive and Unlabeled Examples"
François Denis, Rémi Gilleron, Marc Tommasi (2002)
http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.8.5291

The source contains a simple explanation. 

An example application is the following: we want to highlight interesting articles for a user by looking at his click history. Clearly, a clicked article represents a positive example. However, an article that hasn't been clicked yet isn't necessarily a negative example. Still, the information that unlabeled examples give, together with positive-labeled ones, can help us build a naive bayes classifier for the task.
The only additional requirement is a prior distribution on the two labels (e.g., an estimate of how likely it is for an article to be interesting).
