### PR TITLE
Exclude common 'nltk.' prefix from module index.

### DIFF
--- a/web/conf.py
+++ b/web/conf.py
@@ -87,7 +87,7 @@ exclude_patterns = ['_build']
 pygments_style = 'sphinx'
 
 # A list of ignored prefixes for module index sorting.
-#modindex_common_prefix = []
+modindex_common_prefix = ['nltk.']
 
 
 # -- Options for HTML output ---------------------------------------------------


### PR DESCRIPTION
(resubmission of #227)
This is a minor tweak to improve the usability of Sphinx's generated [Module Index](http://nltk.github.com/py-modindex.html), by not just sorting everything under a single "nltk" entry.
