### PR TITLE
cosmetics: get rid of CVS-style $Id$ lines

### DIFF
--- a/MacResources/Portfile24
+++ b/MacResources/Portfile24
@@ -1,5 +1,4 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
-# $Id: Portfile 40109 2008-09-20 21:25:53Z ryandesign  macports.org $
 
 PortSystem 1.0
 PortGroup python24 1.0

--- a/MacResources/Portfile25
+++ b/MacResources/Portfile25
@@ -1,5 +1,4 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
-# $Id: Portfile 40109 2008-09-20 21:25:53Z ryandesign  macports.org $
 
 PortSystem 1.0
 PortGroup python25 1.0

--- a/examples/grammars/book_grammars/background.fol
+++ b/examples/grammars/book_grammars/background.fol
@@ -6,8 +6,6 @@
 ## Author: Ewan Klein <ewan@inf.ed.ac.uk> 
 ## URL: <http://nltk.sourceforge.net>
 ## For license information, see LICENSE.TXT
-##
-## $Id:$
 
 all x. (boxerdog(x) -> dog(x))
 all x. (boxer(x) -> person(x))

--- a/examples/grammars/book_grammars/feat0.fcfg
+++ b/examples/grammars/book_grammars/feat0.fcfg
@@ -7,8 +7,6 @@
 ## Author: Ewan Klein <ewan@inf.ed.ac.uk> 
 ## URL: <http://nltk.sourceforge.net>
 ## For license information, see LICENSE.TXT
-##
-## $Id: feat0.cfg 4674 2007-06-14 08:55:32Z ehk $
 
 % start S
 # ###################

--- a/examples/grammars/book_grammars/feat1.fcfg
+++ b/examples/grammars/book_grammars/feat1.fcfg
@@ -8,8 +8,6 @@
 ## Author: Ewan Klein <ewan@inf.ed.ac.uk> 
 ## URL: <http://nltk.sourceforge.net>
 ## For license information, see LICENSE.TXT
-##
-## $Id: feat1.cfg 4674 2007-06-14 08:55:32Z ehk $
 
 % start S
 # ###################

--- a/examples/grammars/book_grammars/german.fcfg
+++ b/examples/grammars/book_grammars/german.fcfg
@@ -8,8 +8,6 @@
 ##         Ewan Klein <ewan@inf.ed.ac.uk> 
 ##
 ## Plural transitive verbs productions by Jordan Boyd-Graber (ezubaric at users.sourceforge.net)
-##
-## $Id: german.cfg 4916 2007-07-17 16:27:40Z ehk $
 
 % start S
 #####################

--- a/examples/grammars/book_grammars/storage.fcfg
+++ b/examples/grammars/book_grammars/storage.fcfg
@@ -17,8 +17,6 @@
 ##         Ewan Klein <ewan@inf.ed.ac.uk> 
 ## URL: <http://nltk.sourceforge.net>
 ## For license information, see LICENSE.TXT
-##
-## $Id:$
 
 %start S
 

--- a/examples/grammars/sample_grammars/background0.fol
+++ b/examples/grammars/sample_grammars/background0.fol
@@ -6,8 +6,6 @@
 ## Author: Ewan Klein <ewan@inf.ed.ac.uk> 
 ## URL: <http://nltk.sourceforge.net>
 ## For license information, see LICENSE.TXT
-##
-## $Id:$
 
 all x. (boxerdog(x) -> dog(x))
 all x. (boxer(x) -> person(x))

--- a/examples/grammars/sample_grammars/bindop.fcfg
+++ b/examples/grammars/sample_grammars/bindop.fcfg
@@ -16,8 +16,6 @@
 ##         Ewan Klein <ewan@inf.ed.ac.uk> 
 ## URL: <http://nltk.sourceforge.net>
 ## For license information, see LICENSE.TXT
-##
-## $Id: sem0.cfg 4674 2007-06-14 08:55:32Z ehk $
 
 %start S
 ## Grammar summary:

--- a/examples/grammars/sample_grammars/chat80.fcfg
+++ b/examples/grammars/sample_grammars/chat80.fcfg
@@ -6,8 +6,6 @@
 ## Author: Ewan Klein <ewan@inf.ed.ac.uk> 
 ## URL: <http://nltk.sourceforge.net>
 ## For license information, see LICENSE.TXT
-##
-## $Id:$
 
 % start S
 # ###########################

--- a/examples/grammars/sample_grammars/event.fcfg
+++ b/examples/grammars/sample_grammars/event.fcfg
@@ -5,8 +5,6 @@
 ## Author: Ewan Klein <ewan@inf.ed.ac.uk> 
 ## URL: <http://nltk.sourceforge.net>
 ## For license information, see LICENSE.TXT
-##
-## $Id: event.cfg 4674 2007-06-14 08:55:32Z ehk $
 
 % start S
 ############################

--- a/examples/grammars/sample_grammars/sem0.fcfg
+++ b/examples/grammars/sample_grammars/sem0.fcfg
@@ -5,8 +5,6 @@
 ## Author: Ewan Klein <ewan@inf.ed.ac.uk> 
 ## URL: <http://nltk.sourceforge.net>
 ## For license information, see LICENSE.TXT
-##
-## $Id: sem0.cfg 4674 2007-06-14 08:55:32Z ehk $
 
 % start S
 

--- a/examples/grammars/sample_grammars/sem1.fcfg
+++ b/examples/grammars/sample_grammars/sem1.fcfg
@@ -6,8 +6,6 @@
 ## Author: Ewan Klein <ewan@inf.ed.ac.uk> 
 ## URL: <http://nltk.sourceforge.net>
 ## For license information, see LICENSE.TXT
-##
-## $Id: sem1.cfg 4674 2007-06-14 08:55:32Z ehk $
 
 % start S
 

--- a/examples/grammars/sample_grammars/sem2.fcfg
+++ b/examples/grammars/sample_grammars/sem2.fcfg
@@ -8,8 +8,6 @@
 ## Author: Ewan Klein <ewan@inf.ed.ac.uk> 
 ## URL: <http://nltk.sourceforge.net>
 ## For license information, see LICENSE.TXT
-##
-## $Id: sem2.cfg 4674 2007-06-14 08:55:32Z ehk $
 
 % start S
 ############################

--- a/examples/semantics/chat80.cfg
+++ b/examples/semantics/chat80.cfg
@@ -6,8 +6,6 @@
 ## Author: Ewan Klein <ewan@inf.ed.ac.uk> 
 ## URL: <http://nltk.sourceforge.net>
 ## For license information, see LICENSE.TXT
-##
-## $Id:$
 
 % start S
 # ###########################

--- a/nltk/app/__init__.py
+++ b/nltk/app/__init__.py
@@ -5,8 +5,6 @@
 #         Steven Bird <sb@csse.unimelb.edu.au>
 # URL: <http://www.nltk.org/>
 # For license information, see LICENSE.TXT
-#
-# $Id: __init__.py 7460 2009-01-29 01:06:02Z StevenBird1 $
 
 """
 Interactive NLTK Applications:

--- a/nltk/app/concordance_app.py
+++ b/nltk/app/concordance_app.py
@@ -4,8 +4,6 @@
 # Author: Sumukh Ghodke <sghodke@csse.unimelb.edu.au>
 # URL: <http://www.nltk.org/>
 # For license information, see LICENSE.TXT
-#
-# $Id: concordance.py 6121 2008-07-11 02:10:33Z stevenbird $
 
 import re
 import threading

--- a/nltk/classify/decisiontree.py
+++ b/nltk/classify/decisiontree.py
@@ -4,8 +4,6 @@
 # Author: Edward Loper <edloper@gradient.cis.upenn.edu>
 # URL: <http://www.nltk.org/>
 # For license information, see LICENSE.TXT
-#
-# $Id: naivebayes.py 2063 2004-07-17 21:02:24Z edloper $
 
 """
 A classifier model that decides which label to assign to a token on

--- a/nltk/classify/mallet.py
+++ b/nltk/classify/mallet.py
@@ -4,8 +4,6 @@
 # Author: Edward Loper <edloper@gradient.cis.upenn.edu>
 # URL: <http://www.nltk.org/>
 # For license information, see LICENSE.TXT
-#
-# $Id: naivebayes.py 2063 2004-07-17 21:02:24Z edloper $
 
 """
 A set of functions used to interface with the external Mallet_ machine learning

--- a/nltk/classify/megam.py
+++ b/nltk/classify/megam.py
@@ -4,8 +4,6 @@
 # Author: Edward Loper <edloper@gradient.cis.upenn.edu>
 # URL: <http://www.nltk.org/>
 # For license information, see LICENSE.TXT
-#
-# $Id: naivebayes.py 2063 2004-07-17 21:02:24Z edloper $
 
 """
 A set of functions used to interface with the external megam_ maxent

--- a/nltk/classify/naivebayes.py
+++ b/nltk/classify/naivebayes.py
@@ -4,8 +4,6 @@
 # Author: Edward Loper <edloper@gradient.cis.upenn.edu>
 # URL: <http://www.nltk.org/>
 # For license information, see LICENSE.TXT
-#
-# $Id: naivebayes.py 2063 2004-07-17 21:02:24Z edloper $
 
 """
 A classifier based on the Naive Bayes algorithm.  In order to find the

--- a/nltk/classify/weka.py
+++ b/nltk/classify/weka.py
@@ -4,8 +4,6 @@
 # Author: Edward Loper <edloper@gradient.cis.upenn.edu>
 # URL: <http://www.nltk.org/>
 # For license information, see LICENSE.TXT
-#
-# $Id: naivebayes.py 2063 2004-07-17 21:02:24Z edloper $
 
 """
 Classifiers that make use of the external 'Weka' package.

--- a/nltk/draw/table.py
+++ b/nltk/draw/table.py
@@ -4,8 +4,6 @@
 # Author: Edward Loper <edloper@gradient.cis.upenn.edu>
 # URL: <http://www.nltk.org/>
 # For license information, see LICENSE.TXT
-#
-# $Id:$
 
 """
 Tkinter widgets for displaying multi-column listboxes and tables.

--- a/nltk/draw/util.py
+++ b/nltk/draw/util.py
@@ -4,8 +4,6 @@
 # Author: Edward Loper <edloper@gradient.cis.upenn.edu>
 # URL: <http://www.nltk.org/>
 # For license information, see LICENSE.TXT
-#
-# $Id: util.py 6339 2008-07-30 01:54:47Z stevenbird $
 
 """
 Tools for graphically displaying and interacting with the objects and

--- a/nltk/parse/earleychart.py
+++ b/nltk/parse/earleychart.py
@@ -9,8 +9,6 @@
 #         Jean Mark Gawron <gawron@mail.sdsu.edu>
 # URL: <http://www.nltk.org/>
 # For license information, see LICENSE.TXT
-#
-# $Id: chart.py 8144 2009-06-01 22:27:39Z edloper $
 
 """
 Data classes and parser implementations for *incremental* chart

--- a/nltk/tag/hunpos.py
+++ b/nltk/tag/hunpos.py
@@ -7,8 +7,6 @@
 #         Attila Zseder <zseder@gmail.com> (modifications)
 # URL: <http://www.nltk.org/>
 # For license information, see LICENSE.TXT
-#
-# $Id: hunpos.py $
 
 """
 A module for interfacing with the HunPos open-source POS-tagger.

--- a/nltk/tag/senna.py
+++ b/nltk/tag/senna.py
@@ -5,8 +5,6 @@
 # Author: Rami Al-Rfou' <ralrfou@cs.stonybrook.edu>
 # URL: <http://www.nltk.org/>
 # For license information, see LICENSE.TXT
-#
-# $Id: senna.py $
 
 """
 A module for interfacing with the SENNA pipeline.

--- a/nltk/tag/stanford.py
+++ b/nltk/tag/stanford.py
@@ -6,8 +6,6 @@
 #         Rami Al-Rfou' <ralrfou@cs.stonybrook.edu>
 # URL: <http://www.nltk.org/>
 # For license information, see LICENSE.TXT
-#
-# $Id: stanford.py $
 
 """
 A module for interfacing with the Stanford taggers.

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -8,8 +8,6 @@
 #         Joel Nothman <jnothman@student.usyd.edu.au> (almost rewrite)
 # URL: <http://www.nltk.org/>
 # For license information, see LICENSE.TXT
-#
-# $Id: probability.py 4865 2007-07-11 22:6:07Z edloper $
 
 r"""
 Punkt Sentence Tokenizer

--- a/papers/acl-02/Makefile
+++ b/papers/acl-02/Makefile
@@ -4,8 +4,6 @@
 # Author: Edward Loper <edloper@gradient.cis.upenn.edu>
 # URL: <http://www.nltk.org/>
 # For license information, see LICENSE.TXT
-#
-# $Id: Makefile,v 1.3 2002/05/14 18:19:54 edloper Exp $
 
 ##############################################
 ##  The name of the report

--- a/papers/acl-02/acl-02.tex
+++ b/papers/acl-02/acl-02.tex
@@ -4,8 +4,6 @@
 % at ACL 2002
 %
 % Authors: Edward Loper and Steven Bird
-% 
-% $Id: acl02.tex,v 1.9 2002/05/15 22:23:35 edloper Exp $
 %
 \documentclass[11pt]{article}
 \usepackage{acl2002,url,alltt,epsfig}

--- a/papers/acl-04/Makefile
+++ b/papers/acl-04/Makefile
@@ -4,8 +4,6 @@
 # Author: Edward Loper <edloper@gradient.cis.upenn.edu>
 # URL: <http://www.nltk.org/>
 # For license information, see LICENSE.TXT
-#
-# $Id: Makefile,v 1.2 2004/04/27 04:26:37 stevenbird Exp $
 
 ##############################################
 ##  The name of the report

--- a/papers/altw-06/altw-06.tex
+++ b/papers/altw-06/altw-06.tex
@@ -1,4 +1,3 @@
-% $Id: pvfs.tex 63 2006-09-08 21:03:07Z ewan $
 \documentclass[11pt]{article}
 \usepackage{colacl06}
 \usepackage{times}

--- a/tools/find_deprecated.py
+++ b/tools/find_deprecated.py
@@ -6,8 +6,6 @@
 # Author: Edward Loper <edloper@gradient.cis.upenn.edu>
 # URL: <http://www.nltk.org/>
 # For license information, see LICENSE.TXT
-#
-# $Id:$
 
 """
 This command-line tool takes a list of python files or directories,

--- a/tools/global_replace.py
+++ b/tools/global_replace.py
@@ -7,8 +7,6 @@
 #         Steven Bird <sb@csse.unimelb.edu.au>
 # URL: <http://www.nltk.org/>
 # For license information, see LICENSE.TXT
-#
-# $Id:$
 
 # NB Should work on all platforms, http://www.python.org/doc/2.5.2/lib/os-file-dir.html
 

--- a/tools/relocate_svn.py
+++ b/tools/relocate_svn.py
@@ -7,8 +7,6 @@
 #         Steven Bird <sb@csse.unimelb.edu.au>
 # URL: <http://www.nltk.org/>
 # For license information, see LICENSE.TXT
-#
-# $Id:$
 
 # NB Should work on all platforms, http://www.python.org/doc/2.5.2/lib/os-file-dir.html
 

--- a/tools/update_checksums.py
+++ b/tools/update_checksums.py
@@ -6,8 +6,6 @@
 # Author: Steven Bird <sb@csse.unimelb.edu.au>
 # URL: <http://www.nltk.org/>
 # For license information, see LICENSE.TXT
-#
-# $Id:$
 
 import re
 import sys


### PR DESCRIPTION
The CVS-style $Id$ lines are pretty much useless with git; and
anyway, using them would require adding proper "ident" directives
to the .gitattributes file -- and we don't have such directives.
