### PR TITLE
cosmetics: get rid of even more CVS-style $Id$ lines

### DIFF
--- a/emacs/psvn.el
+++ b/emacs/psvn.el
@@ -2,7 +2,6 @@
 ;; Copyright (C) 2002-2008 by Stefan Reichoer
 
 ;; Author: Stefan Reichoer <stefan@xsteve.at>
-;; $Id: psvn.el 32032 2008-07-08 17:21:58Z xsteve $
 
 ;; psvn.el is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/examples/grammars/book_grammars/sql0.fcfg
+++ b/examples/grammars/book_grammars/sql0.fcfg
@@ -6,9 +6,6 @@
 ## Author: Ewan Klein <ewan@inf.ed.ac.uk> 
 ## URL: <http://nltk.sourceforge.net>
 ## For license information, see LICENSE.TXT
-##
-## $Id$
-
 
 % start S
 

--- a/examples/grammars/book_grammars/sql1.fcfg
+++ b/examples/grammars/book_grammars/sql1.fcfg
@@ -6,9 +6,6 @@
 ## Author: Ewan Klein <ewan@inf.ed.ac.uk> 
 ## URL: <http://nltk.sourceforge.net>
 ## For license information, see LICENSE.TXT
-##
-## $Id$
-
 
 % start S
 

--- a/examples/grammars/sample_grammars/sql.fcfg
+++ b/examples/grammars/sample_grammars/sql.fcfg
@@ -6,9 +6,6 @@
 ## Author: Ewan Klein <ewan@inf.ed.ac.uk> 
 ## URL: <http://nltk.sourceforge.net>
 ## For license information, see LICENSE.TXT
-##
-## $Id$
-
 
 % start S
 

--- a/examples/semantics/sem0.cfg
+++ b/examples/semantics/sem0.cfg
@@ -5,8 +5,6 @@
 ## Author: Ewan Klein <ewan@inf.ed.ac.uk> 
 ## URL: <http://nltk.sourceforge.net>
 ## For license information, see LICENSE.TXT
-##
-## $Id$
 
 % start S
 

--- a/examples/semantics/sem1.cfg
+++ b/examples/semantics/sem1.cfg
@@ -6,8 +6,6 @@
 ## Author: Ewan Klein <ewan@inf.ed.ac.uk> 
 ## URL: <http://nltk.sourceforge.net>
 ## For license information, see LICENSE.TXT
-##
-## $Id$
 
 % start S
 

--- a/examples/semantics/sem2.cfg
+++ b/examples/semantics/sem2.cfg
@@ -8,8 +8,6 @@
 ## Author: Ewan Klein <ewan@inf.ed.ac.uk> 
 ## URL: <http://nltk.sourceforge.net>
 ## For license information, see LICENSE.TXT
-##
-## $Id$
 
 % start S
 ############################

--- a/examples/semantics/sem3.cfg
+++ b/examples/semantics/sem3.cfg
@@ -6,9 +6,6 @@
 ## Author: Ewan Klein <ewan@inf.ed.ac.uk> 
 ## URL: <http://nltk.sourceforge.net>
 ## For license information, see LICENSE.TXT
-##
-## $Id$
-
 
 % start S
 

--- a/nltk/draw/__init__.py
+++ b/nltk/draw/__init__.py
@@ -5,8 +5,6 @@
 #         Steven Bird <sb@csse.unimelb.edu.au>
 # URL: <http://www.nltk.org/>
 # For license information, see LICENSE.TXT
-#
-# $Id$
 
 # Import Tkinter-based modules if Tkinter is installed
 try:

--- a/nltk/draw/tree.py
+++ b/nltk/draw/tree.py
@@ -4,8 +4,6 @@
 # Author: Edward Loper <edloper@gradient.cis.upenn.edu>
 # URL: <http://www.nltk.org/>
 # For license information, see LICENSE.TXT
-#
-# $Id$
 
 """
 Graphically display a Tree.

--- a/nltk/inference/discourse.py
+++ b/nltk/inference/discourse.py
@@ -5,7 +5,6 @@
 #
 # URL: <http://www.nltk.org/>
 # For license information, see LICENSE.TXT
-# $Id$
 
 """
 Module for incrementally developing simple discourses, and checking for semantic ambiguity,

--- a/nltk/parse/chart.py
+++ b/nltk/parse/chart.py
@@ -8,8 +8,6 @@
 #         Peter Ljunglöf <peter.ljunglof@heatherleaf.se>
 # URL: <http://www.nltk.org/>
 # For license information, see LICENSE.TXT
-#
-# $Id$
 
 """
 Data classes and parser implementations for "chart parsers", which

--- a/nltk/parse/featurechart.py
+++ b/nltk/parse/featurechart.py
@@ -6,8 +6,6 @@
 #         Peter Ljunglöf <peter.ljunglof@heatherleaf.se>
 # URL: <http://www.nltk.org/>
 # For license information, see LICENSE.TXT
-#
-# $Id$
 
 """
 Extension of chart parsing implementation to handle grammars with

--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -11,8 +11,6 @@
 #
 # URL: <http://www.nltk.org/>
 # For license information, see LICENSE.TXT
-#
-# $Id$
 
 """
 Classes for representing and processing probabilistic information.

--- a/nltk/sem/evaluate.py
+++ b/nltk/sem/evaluate.py
@@ -4,8 +4,6 @@
 # Author: Ewan Klein <ewan@inf.ed.ac.uk>,
 # URL: <http://nltk.sourceforge.net>
 # For license information, see LICENSE.TXT
-#
-# $Id$
 
 #TODO:
     #- fix tracing

--- a/nltk/tag/hmm.py
+++ b/nltk/tag/hmm.py
@@ -8,8 +8,6 @@
 #         Joseph Frazee <jfrazee@mail.utexas.edu> (fixes)
 # URL: <http://www.nltk.org/>
 # For license information, see LICENSE.TXT
-#
-# $Id$
 
 """
 Hidden Markov Models (HMMs) largely used to assign the correct label sequence

--- a/nltk/test/__init__.py
+++ b/nltk/test/__init__.py
@@ -4,8 +4,6 @@
 # Author: Edward Loper <edloper@gradient.cis.upenn.edu>
 # URL: <http://www.nltk.org/>
 # For license information, see LICENSE.TXT
-#
-# $Id$
 
 """
 Unit tests for the NLTK modules.  These tests are intended to ensure


### PR DESCRIPTION
This change removes some occurrences of $Id$ lines that have been
missed by yesterday's commit 44745e29.  Sorry for the confusion.
