### PR TITLE
Fixed "global name 'fileid' is not defined" error when calling CorpusReader.abspath with include_fileid=True 

### DIFF
--- a/nltk/corpus/reader/api.py
+++ b/nltk/corpus/reader/api.py
@@ -169,7 +169,7 @@ class CorpusReader(object):
         if include_encoding and include_fileid:
             return zip(paths, [self.encoding(f) for f in fileids], fileids)
         elif include_fileid:
-            return zip(paths, fileid)
+            return zip(paths, fileids)
         elif include_encoding:
             return zip(paths, [self.encoding(f) for f in fileids])
         else:


### PR DESCRIPTION
Someone wrote "fileid" instead of "fileids", so I fixed that.
