### PR TITLE
Added LinThesaurusCorpusReader for handling Lin's Thesaurus

### DIFF
--- a/nltk/corpus/reader/__init__.py
+++ b/nltk/corpus/reader/__init__.py
@@ -118,5 +118,5 @@ __all__ = [
     'IPIPANCorpusReader', 'Pl196xCorpusReader',
     'TEICorpusView', 'KNBCorpusReader', 'ChasenCorpusReader',
     'CHILDESCorpusReader', 'AlignedCorpusReader',
-    'TimitTaggedCorpusReader'
+    'TimitTaggedCorpusReader', 'LinThesaurusCorpusReader'
 ]

--- a/nltk/corpus/reader/lin.py
+++ b/nltk/corpus/reader/lin.py
@@ -1,0 +1,139 @@
+# Natural Language Toolkit: Lin's Thesaurus
+#
+# Copyright (C) 2001-2011 NLTK Project
+# Author: Dan Blanchard <dan.blanchard@gmail.com>
+# URL: <http://www.nltk.org/>
+# For license information, see LICEimport re
+import re
+from collections import defaultdict
+
+from nltk.corpus.reader import CorpusReader
+
+
+class LinThesaurusCorpusReader(CorpusReader):
+    """ Wrapper for the LISP-formatted thesauruses distributed by Dekang Lin. """
+
+    # Compiled regular expression for extracting the key from the first line of each
+    # thesaurus entry
+    _key_re = re.compile(r'\("?([^"]+)"? \(desc [0-9.]+\).+')
+
+    @staticmethod
+    def _defaultdict_factory():
+        ''' Factory for creating defaultdict of defaultdict(dict)s '''
+        return defaultdict(dict)
+
+    def __init__(self, root, badscore=0.0):
+        '''
+        Initialize the thesaurus.
+
+        @param root: root directory containing thesaurus LISP files
+        @type root: C{string}
+        @param badscore: the score to give to words which do not appear in each other's synsets
+        @type badscore: C{float}
+        '''
+
+        super(LinThesaurus, self).__init__(root, r'sim[A-Z]\.lsp')
+        self._thesaurus = defaultdict(LinThesaurus._defaultdict_factory)
+        self._badscore = badscore
+        for path, encoding, fileid in self.abspaths(include_encoding=True, include_fileid=True):
+            with open(path) as lin_file:
+                first = True
+                for line in lin_file:
+                    line = line.strip()
+                    # Start of entry
+                    if first:
+                        key = LinThesaurus._key_re.sub(r'\1', line)
+                        first = False
+                        self._thesaurus[fileid][key][key] = 1.0  # thesaurus entries don't contain themselves
+                    # End of entry
+                    elif line == '))':
+                        first = True
+                    # Lines with pairs of ngrams and scores
+                    else:
+                        split_line = line.split('\t')
+                        if len(split_line) == 2:
+                            ngram, score = split_line
+                            self._thesaurus[fileid][key][ngram.strip('"')] = score
+
+    def similarity(self, ngram1, ngram2, fileid=None):
+        '''
+        Returns the similarity score for two ngrams.
+
+        @param ngram1: first ngram to compare
+        @type ngram1: C{string}
+        @param ngram2: second ngram to compare
+        @type ngram2: C{string}
+        @param fileid: thesaurus fileid to search in. If None, search all fileids.
+        @type fileid: C{string}
+        @return: If fileid is specified, just the score for the two ngrams; otherwise,
+                 list of tuples of fileids and scores.
+        '''
+        if fileid:
+            return self._thesaurus[fileid][ngram1][ngram2] if ngram2 in self._thesaurus[fileid][ngram1] else self._badscore
+        else:
+            return [(fid, (self._thesaurus[fid][ngram1][ngram2] if ngram2 in self._thesaurus[fid][ngram1]
+                              else self._badscore)) for fid in self._fileids]
+
+    def scored_synonyms(self, ngram, fileid=None):
+        '''
+        Returns a list of scored synonyms (tuples of synonyms and scores) for the current ngram
+
+        @param ngram: ngram to lookup
+        @type ngram: C{string}
+        @param fileid: thesaurus fileid to search in. If None, search all fileids.
+        @type fileid: C{string}
+        @return: If fileid is specified, list of tuples of scores and synonyms; otherwise,
+                 list of tuples of fileids and lists, where inner lists consist of tuples of
+                 scores and synonyms.
+        '''
+        if fileid:
+            return self._thesaurus[fileid][ngram].items()
+        else:
+            return [(fileid, self._thesaurus[fileid][ngram].items()) for fileid in self._fileids]
+
+    def synonyms(self, ngram, fileid=None):
+        '''
+        Returns a list of synonyms for the current ngram.
+
+        @param ngram: ngram to lookup
+        @type ngram: C{string}
+        @param fileid: thesaurus fileid to search in. If None, search all fileids.
+        @type fileid: C{string}
+        @return: If fileid is specified, list of synonyms; otherwise, list of tuples of fileids and
+                 lists, where inner lists contain synonyms.
+        '''
+        if fileid:
+            return self._thesaurus[fileid][ngram].keys()
+        else:
+            return [(fileid, self._thesaurus[fileid][ngram].keys()) for fileid in self._fileids]
+
+
+######################################################################
+# Demo
+######################################################################
+
+def demo():
+    import nltk
+    print "Loading Lin's Thesaurus...",
+    thes = LinThesaurus(nltk.data.find('corpora/lin_thesaurus'))
+    print "done"
+
+    word1 = "business"
+    word2 = "enterprise"
+    print "Getting synonyms for " + word1
+    print thes.synonyms(word1)
+
+    print "Getting scored synonyms for " + word1
+    print thes.synonyms(word1)
+
+    print "Getting synonyms from simN.lsp (noun subsection) for " + word1
+    print thes.synonyms(word1, fileid="simN.lsp")
+
+    print "Getting synonyms from simN.lsp (noun subsection) for " + word1
+    print thes.synonyms(word1, fileid="simN.lsp")
+
+    print "Similarity score for {} and {}: {}".format(word1, word2, thes.similarity(word1, word2))
+
+
+if __name__ == '__main__':
+    demo()

--- a/nltk/corpus/reader/lin.py
+++ b/nltk/corpus/reader/lin.py
@@ -1,9 +1,9 @@
 # Natural Language Toolkit: Lin's Thesaurus
 #
-# Copyright (C) 2001-2011 NLTK Project
+# Copyright (C) 2001-2012 NLTK Project
 # Author: Dan Blanchard <dan.blanchard@gmail.com>
 # URL: <http://www.nltk.org/>
-# For license information, see LICEimport re
+# For license information, see LICENSE.txt
 import re
 from collections import defaultdict
 
@@ -28,12 +28,12 @@ class LinThesaurusCorpusReader(CorpusReader):
 
         @param root: root directory containing thesaurus LISP files
         @type root: C{string}
-        @param badscore: the score to give to words which do not appear in each other's synsets
+        @param badscore: the score to give to words which do not appear in each other's sets of synonyms
         @type badscore: C{float}
         '''
 
-        super(LinThesaurus, self).__init__(root, r'sim[A-Z]\.lsp')
-        self._thesaurus = defaultdict(LinThesaurus._defaultdict_factory)
+        super(LinThesaurusCorpusReader, self).__init__(root, r'sim[A-Z]\.lsp')
+        self._thesaurus = defaultdict(LinThesaurusCorpusReader._defaultdict_factory)
         self._badscore = badscore
         for path, encoding, fileid in self.abspaths(include_encoding=True, include_fileid=True):
             with open(path) as lin_file:
@@ -42,7 +42,7 @@ class LinThesaurusCorpusReader(CorpusReader):
                     line = line.strip()
                     # Start of entry
                     if first:
-                        key = LinThesaurus._key_re.sub(r'\1', line)
+                        key = LinThesaurusCorpusReader._key_re.sub(r'\1', line)
                         first = False
                         self._thesaurus[fileid][key][key] = 1.0  # thesaurus entries don't contain themselves
                     # End of entry
@@ -115,7 +115,7 @@ class LinThesaurusCorpusReader(CorpusReader):
 def demo():
     import nltk
     print "Loading Lin's Thesaurus...",
-    thes = LinThesaurus(nltk.data.find('corpora/lin_thesaurus'))
+    thes = LinThesaurusCorpusReader(nltk.data.find('corpora/lin_thesaurus'))
     print "done"
 
     word1 = "business"


### PR DESCRIPTION
I think this won't quite work until the thesaurus data is added to nltk_data, because I used `nltk.data.find` as part of the demo function.

I only modified `nltk/corpus/reader/__init__.py`, because I wasn't quite sure how to setup the `LazyCorpusReader` in `nltk/corpus/__init__.py`.
