### PR TITLE
Rewrote BFS for correctness and speed

### DIFF
--- a/nltk/test/util.doctest
+++ b/nltk/test/util.doctest
@@ -18,10 +18,9 @@ Utility functions
     >>> tree = Tree(5,
     ...             [Tree(4, [Tree(2, [1, 3])]),
     ...              Tree(8, [Tree(6, [7]), 9])])
-    >>> lst = [x for x in breadth_first(tree)]
-    >>> for l in lst:
-    ...     if type(l) == int: print l
-    ...     else: print l.node
+    >>> for x in breadth_first(tree):
+    ...     if isinstance(x, int): print x
+    ...     else: print x.node
     5
     4
     8
@@ -31,6 +30,15 @@ Utility functions
     1
     3
     7
+    >>> for x in breadth_first(tree, maxdepth=2):
+    ...     if isinstance(x, int): print x
+    ...     else: print x.node
+    5
+    4
+    8
+    2
+    6
+    9
 
     >>> invert_dict({1: 2})
     defaultdict(<type 'list'>, {2: 1})

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -15,7 +15,7 @@ import os
 
 from itertools import islice, chain
 from pprint import pprint
-from collections import defaultdict
+from collections import defaultdict, deque
 
 from nltk.internals import slice_bounds
 
@@ -159,26 +159,21 @@ def filestring(f):
 # Breadth-First Search
 ##########################################################################
 
-def breadth_first(tree, children=iter, depth=-1, queue=None):
+def breadth_first(tree, children=iter, maxdepth=-1):
     """Traverse the nodes of a tree in breadth-first order.
     (No need to check for cycles.)
     The first argument should be the tree root;
     children should be a function taking as argument a tree node
     and returning an iterator of the node's children.
     """
-    if queue is None:
-        queue = []
-    queue.append(tree)
+    queue = deque([(tree, 0)])
 
     while queue:
-        node = queue.pop(0)
+        node, depth = queue.popleft()
         yield node
-        if depth != 0:
-            try:
-                queue += children(node)
-                depth -= 1
-            except:
-                pass
+
+        if depth != maxdepth:
+            queue.extend((c, depth + 1) for c in children(node))
 
 ##########################################################################
 # Guess Character Encoding

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -173,7 +173,10 @@ def breadth_first(tree, children=iter, maxdepth=-1):
         yield node
 
         if depth != maxdepth:
-            queue.extend((c, depth + 1) for c in children(node))
+            try:
+                queue.extend((c, depth + 1) for c in children(node))
+            except TypeError:
+                pass
 
 ##########################################################################
 # Guess Character Encoding


### PR DESCRIPTION
Solves issue #255. In addition:
- renamed the `depth` argument `maxdepth`; it wasn't used as a keyword argument, so this is harmless
- removed the `queue` argument, which wasn't being used in client code
- replaced the `list`-based queue (O(_n_) pop) with a `deque`-based one (O(1) pop)
- replaced a catch-all `except` clause for safety.
