### PR TITLE
Score in LinThesaurusCorpusReader is now stored as float instead of string.

### DIFF
--- a/nltk/corpus/reader/lin.py
+++ b/nltk/corpus/reader/lin.py
@@ -55,7 +55,7 @@ class LinThesaurusCorpusReader(CorpusReader):
                         split_line = line.split('\t')
                         if len(split_line) == 2:
                             ngram, score = split_line
-                            self._thesaurus[fileid][key][ngram.strip('"')] = score
+                            self._thesaurus[fileid][key][ngram.strip('"')] = float(score)
 
     def similarity(self, ngram1, ngram2, fileid=None):
         '''

--- a/nltk/corpus/reader/lin.py
+++ b/nltk/corpus/reader/lin.py
@@ -1,7 +1,7 @@
 # Natural Language Toolkit: Lin's Thesaurus
 #
 # Copyright (C) 2001-2012 NLTK Project
-# Author: Dan Blanchard <dan.blanchard@gmail.com>
+# Author: Dan Blanchard <dblanchard@ets.org>
 # URL: <http://www.nltk.org/>
 # For license information, see LICENSE.txt
 


### PR DESCRIPTION
I've fixed a bug where the score in the LinThesaurusCorpusReader was being stored as a string instead of a float, and updated my email address to my work address, since I developed this on ETS time (and contributed it with their permission).
