### PR TITLE
Added missing import for the demo.

### DIFF
--- a/nltk/grammar.py
+++ b/nltk/grammar.py
@@ -1447,6 +1447,8 @@ def sdg_demo():
     A demonstration of how to read a string representation of
     a CoNLL format dependency tree.
     """
+    from nltk.parse import DependencyGraph
+
     dg = DependencyGraph("""
     1   Ze                ze                Pron  Pron  per|3|evofmv|nom                 2   su      _  _
     2   had               heb               V     V     trans|ovt|1of2of3|ev             0   ROOT    _  _


### PR DESCRIPTION
When running nltk.grammar.sdg_demo() with the current git master (and with release 2.0.1), there is a traceback due to a missing import of DependencyGraph.

I initially tried adding the import at the top of the file, but it seems that there are some issues with cyclic imports/dependencies. As such, this change does adds the import in the one place where DependencyGraph is used, at the top of the sdg_demo function.
