### PR TITLE
Define TclError in try block

### DIFF
--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -167,6 +167,7 @@ except:
 try:
     TKINTER = True
     from Tkinter import Tk, Frame, Label, Entry, Button, Canvas, Menu, IntVar
+    from Tkinter import TclError
     from tkMessageBox import showerror
     from nltk.draw.table import Table
     from nltk.draw.util import ShowText


### PR DESCRIPTION
TclError was not defined in the try block when importing from Tkinter, so that when a TclError occurred in the interactive download, it did not run the DownloaderShell; instead, the exception went uncaught.
