### PR TITLE
make code compatible to NLTK book example.

### DIFF
--- a/nltk/classify/__init__.py
+++ b/nltk/classify/__init__.py
@@ -93,7 +93,7 @@ from nltk.classify.naivebayes import NaiveBayesClassifier
 from nltk.classify.positivenaivebayes import PositiveNaiveBayesClassifier
 from nltk.classify.decisiontree import DecisionTreeClassifier
 from nltk.classify.rte_classify import rte_classifier, rte_features, RTEFeatureExtractor
-from nltk.classify.util import accuracy, log_likelihood
+from nltk.classify.util import accuracy, apply_features, log_likelihood
 
 # Conditional imports
 


### PR DESCRIPTION
A code example in the NLTK book no longer works due to the removal of wildcard imports.
can be fixed either here or in the book (https://github.com/nltk/nltk_book/pull/1).

Of course, only one pull request needs to be accepted (although nothing will break if you accept both).
