### PR TITLE
Add baseform keyword argument to NombankCorpusReader.instances()

### DIFF
--- a/nltk/corpus/reader/nombank.py
+++ b/nltk/corpus/reader/nombank.py
@@ -129,7 +129,7 @@ class NombankCorpusReader(CorpusReader):
                     line, self._parse_fileid_xform,
                     self._parse_corpus)
                 if instance_filter(inst):
-                    block.append()
+                    block.append(inst)
 
         return block
 

--- a/nltk/corpus/reader/nombank.py
+++ b/nltk/corpus/reader/nombank.py
@@ -68,13 +68,16 @@ class NombankCorpusReader(CorpusReader):
         elif isinstance(fileids, basestring): fileids = [fileids]
         return concat([self.open(f).read() for f in fileids])
 
-    def instances(self):
+    def instances(self, baseform=None):
         """
         :return: a corpus view that acts as a list of
         ``NombankInstance`` objects, one for each noun in the corpus.
         """
+        kwargs = {}
+        if baseform is not None:
+            kwargs['instance_filter'] = lambda inst: inst.baseform==baseform
         return StreamBackedCorpusView(self.abspath(self._nomfile),
-                                      self._read_instance_block,
+                                      lambda stream: self._read_instance_block(stream, **kwargs),
                                       encoding=self.encoding(self._nomfile))
 
     def lines(self):
@@ -115,16 +118,18 @@ class NombankCorpusReader(CorpusReader):
                                       read_line_block,
                                       encoding=self.encoding(self._nounsfile))
 
-    def _read_instance_block(self, stream):
+    def _read_instance_block(self, stream, instance_filter=lambda inst: True):
         block = []
 
         # Read 100 at a time.
         for i in range(100):
             line = stream.readline().strip()
             if line:
-                block.append(NombankInstance.parse(
+                inst = NombankInstance.parse(
                     line, self._parse_fileid_xform,
-                    self._parse_corpus))
+                    self._parse_corpus)
+                if instance_filter(inst):
+                    block.append()
 
         return block
 

--- a/nltk/corpus/reader/nombank.py
+++ b/nltk/corpus/reader/nombank.py
@@ -192,7 +192,7 @@ class NombankInstance(object):
 
     def __str__(self):
         s = '%s %s %s %s %s' % (self.fileid, self.sentnum, self.wordnum,
-                                self.basename, self.sensenumber)
+                                self.baseform, self.sensenumber)
         items = self.arguments + ((self.predicate, 'rel'),)
         for (argloc, argid) in sorted(items):
             s += ' %s-%s' % (argloc, argid)


### PR DESCRIPTION
This simplifies searching the corpus by lemma.
