### PR TITLE
fixing lemmas() method in wordnet

### DIFF
--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -1204,10 +1204,11 @@ class WordNetCorpusReader(CorpusReader):
         """Return all Lemma objects with a name matching the specified lemma
         name and part of speech tag. Matches any part of speech tag if none is
         specified."""
+        lemma = lemma.lower()
         return [lemma_obj
                 for synset in self.synsets(lemma, pos)
                 for lemma_obj in synset.lemmas
-                if lemma_obj.name == lemma]
+                if lemma_obj.name.lower() == lemma]
 
     def all_lemma_names(self, pos=None):
         """Return all lemma names for all synsets for the given


### PR DESCRIPTION
I had a use case for enumerating all the wordnet lemmas and found that proper noun lemmas like 'english', 'aramaic', 'russia' were enumerated via the all_lemma_names() method but did not return any output when used as the input to the 'lemmas()' method. The reason is that in the lemmas() method, the name matching is not done in a case-insensitive fashion. This doesn't make sense given that the 'synsets()' method lowercases everything.
