### PR TITLE
Documenting the ptb module (and cousins, propbank_ptb and nombank_ptb)

### DIFF
--- a/nltk/test/corpus.doctest
+++ b/nltk/test/corpus.doctest
@@ -293,12 +293,10 @@ Reading the Penn Treebank (Wall Street Journal sample):
       (. .))
 
 If you have access to a full installation of the Penn Treebank, NLTK 
-can be configured to load it as well. In your ``nltk_data`` directory, 
-create a directory called ``ptb3`` in which the Treebank files will 
-be stored (alternatively, ``ptb3`` can be a symlink to an existing 
-installation). The ``ptb3`` directory should contain the ``BROWN`` and 
-``WSJ`` subdirectories, as well as ``allcats.txt``. Then use the ``ptb`` 
-module instead of ``treebank``:
+can be configured to load it as well. Download the ``ptb3`` package, 
+and in the directory ``nltk_data/corpora/ptb3`` place the ``BROWN`` 
+and ``WSJ`` directories of the Treebank installation (symlinks work 
+as well). Then use the ``ptb`` module instead of ``treebank``:
 
    >>> from nltk.corpus import ptb
    >>> print ptb.fileids() # doctest: +ELLIPSIS

--- a/nltk/test/corpus.doctest
+++ b/nltk/test/corpus.doctest
@@ -273,7 +273,7 @@ The Treebank corpora provide a syntactic parse for each sentence.  The
 NLTK data package includes a 10% sample of the Penn Treebank (in
 ``treebank``), as well as the Sinica Treebank (in ``sinica_treebank``).
 
-Reading the Penn Treebank:
+Reading the Penn Treebank (Wall Street Journal sample):
 
     >>> from nltk.corpus import treebank
     >>> print treebank.fileids() # doctest: +ELLIPSIS
@@ -291,6 +291,38 @@ Reading the Penn Treebank:
       ...
       (VP (VBD reported) (SBAR (-NONE- 0) (S (-NONE- *T*-1))))
       (. .))
+
+If you have access to a full installation of the Penn Treebank, NLTK 
+can be configured to load it as well. In your ``nltk_data`` directory, 
+create a directory called ``ptb3`` in which the Treebank files will 
+be stored (alternatively, ``ptb3`` can be a symlink to an existing 
+installation). The ``ptb3`` directory should contain the ``BROWN`` and 
+``WSJ`` subdirectories, as well as ``allcats.txt``. Then use the ``ptb`` 
+module instead of ``treebank``:
+
+   >>> from nltk.corpus import ptb
+   >>> print ptb.fileids() # doctest: +ELLIPSIS
+   ['BROWN/CF/CF01.MRG', 'BROWN/CF/CF02.MRG', 'BROWN/CF/CF03.MRG', 'BROWN/CF/CF04.MRG', ...]
+   >>> print ptb.words('WSJ/00/WSJ_0003.MRG')
+   ['A', 'form', 'of', 'asbestos', 'once', 'used', '*', ...]
+   >>> print ptb.tagged_words('WSJ/00/WSJ_0003.MRG')
+   [('A', 'DT'), ('form', 'NN'), ('of', 'IN'), ...]
+
+...and so forth, like ``treebank`` but with extended fileids. Categories 
+specified in ``allcats.txt`` can be used to filter by genre; they consist 
+of ``news`` (for WSJ articles) and names of the Brown subcategories 
+(``fiction``, ``humor``, ``romance``, etc.):
+
+   >>> ptb.categories()
+   ['adventure', 'belles_lettres', 'fiction', 'humor', 'lore', 'mystery', 'news', 'romance', 'science_fiction']
+   >>> print ptb.fileids('news') # doctest: +ELLIPSIS
+   ['WSJ/00/WSJ_0001.MRG', 'WSJ/00/WSJ_0002.MRG', 'WSJ/00/WSJ_0003.MRG', ...]
+   >>> print ptb.words(categories=['humor','fiction'])
+   ['Thirty-three', 'Scotty', 'did', 'not', 'go', 'back', ...]
+
+As PropBank and NomBank depend on the (WSJ portion of the) Penn Treebank, 
+the modules ``propbank_ptb`` and ``nombank_ptb`` are provided for access 
+to a full PTB installation.
 
 Reading the Sinica Treebank:
 
@@ -622,7 +654,7 @@ descriptions of the argument roles, along with examples.
     </example>
 
 Note that the standard corpus distribution only contains 10% of the
-treebank, so the parse trees are not availalbe for instances starting
+treebank, so the parse trees are not available for instances starting
 at 9353:
 
     >>> inst = pb_instances[9352]
@@ -644,8 +676,10 @@ at 9353:
     ValueError: Parse tree not avaialable
 
 However, if you supply your own version of the treebank corpus (by
-putting it before the nltk-provided version on `nltk.data.path`),
-then you can access the trees for all instances.
+putting it before the nltk-provided version on `nltk.data.path`, or 
+by creating a `ptb3` directory as described above and using the 
+`propbank_ptb` module), then you can access the trees for all 
+instances.
 
 A list of the verb lemmas contained in propbank is returned by the
 `propbank.verbs()` method:


### PR DESCRIPTION
Here is an attempt to document them in `test/corpus.doctest`. I realized that in order to share the necessary `allcats.txt` file there should be a dedicated `ptb3` package (always stored as a directory rather than a zip file so users can add/symlink the data directories). How should this be accomplished? I'm not familiar with the inner workings of the downloader tool.
