### PR TITLE
MASC reader

### DIFF
--- a/nltk/corpus/__init__.py
+++ b/nltk/corpus/__init__.py
@@ -69,6 +69,9 @@ from nltk.tag import simplify_brown_tag, simplify_wsj_tag,\
 from util import LazyCorpusLoader
 from reader import *
 
+masc = LazyCorpusLoader(
+    'masc', MascCorpusReader, r'(?!\.).*\.txt', encoding = 'utf-8')
+
 abc = LazyCorpusLoader(
     'abc', PlaintextCorpusReader, r'(?!\.).*\.txt')
 alpino = LazyCorpusLoader(

--- a/nltk/corpus/__init__.py
+++ b/nltk/corpus/__init__.py
@@ -71,7 +71,6 @@ from reader import *
 
 masc = LazyCorpusLoader(
     'masc', MascCorpusReader, r'(?!\.).*\.txt', encoding = 'utf-8')
-
 abc = LazyCorpusLoader(
     'abc', PlaintextCorpusReader, r'(?!\.).*\.txt')
 alpino = LazyCorpusLoader(

--- a/nltk/corpus/reader/__init__.py
+++ b/nltk/corpus/reader/__init__.py
@@ -89,6 +89,7 @@ from nltk.corpus.reader.childes import *
 from nltk.corpus.reader.aligned import *
 from nltk.corpus.reader.lin import *
 from nltk.corpus.reader.semcor import *
+from nltk.corpus.reader.masc import *
 
 # Make sure that nltk.corpus.reader.bracket_parse gives the module, not
 # the function bracket_parse() defined in nltk.tree:
@@ -122,5 +123,5 @@ __all__ = [
     'TEICorpusView', 'KNBCorpusReader', 'ChasenCorpusReader',
     'CHILDESCorpusReader', 'AlignedCorpusReader',
     'TimitTaggedCorpusReader', 'LinThesaurusCorpusReader',
-    'SemcorCorpusReader'
+    'SemcorCorpusReader', 'MascCorpusReader'
 ]

--- a/nltk/corpus/reader/masc.py
+++ b/nltk/corpus/reader/masc.py
@@ -1,0 +1,515 @@
+# Natural Language Toolkit: ISO GrAF Corpus Reader
+#
+# Copyright (C) 2001-2011 NLTK Project
+# Author: Stephen Matysik <smatysik@gmail.com>
+# URL: <http://www.nltk.org/>
+# For License informations, see LICENSE.TXT
+
+"""
+A reader for corpora that consist of documents in
+the ISO GrAF format.
+"""
+import os.path    	
+
+## note - these imports will change once the
+## graf package is placed within the nltk
+from graf.PyGraph import *
+from graf.PyGraphParser import *
+
+from util import *
+from api import *
+
+class MascCorpusReader(CorpusReader):
+    """
+    Reader for corpora that consist of documents from MASC collection.
+    Paragraphs, sentences, words, nouns, verbs, and other annotations 
+    are contained within MASC.
+    """
+    CorpusView = StreamBackedCorpusView
+    """The corpus view class used be this reader"""
+
+    def __init__(self, root, fileids, encoding):
+        """
+        Construct a new MASC corpus reader for a set of documents
+        located at the given root directory.  Example usage:
+    
+            >>> root = '/...path to corpus.../'
+            >>> reader = MascCorpusReader(root, r'(?!\.).*\.txt', 
+                                                      encoding = 'utf-8')
+
+        @param root: The root directory for this corpus.
+        @param fileids: A list of regexp specifying the fileids in 
+                        this corpus.
+        @param encoding: The encoding used for the text files in the corpus.
+        """
+        self._cur_file = ""
+        self._cur_sents_file = ""
+        self._cur_paras_file = ""
+        self._cur_offsets = []
+        self._cur_sents_offsets = []
+        self._cur_paras_offsets = []
+        self._char_to_byte = {}
+        self._byte_to_char = {}
+        self._file_end = 0
+        CorpusReader.__init__(self, root, fileids, encoding)
+
+    def raw(self, fileids=None):
+        """
+        @return: the given file(s) as a single string.
+        @rtype: C{str}
+        """
+        if fileids is None: fileids = self._fileids
+        elif isinstance(fileids, basestring): fileids = [fileids]
+        return concat([self.open(f).read() for f in fileids])
+
+    def words(self, fileids=None):
+        """
+        @return: the given file(s) as a list of words
+            and punctuation symbols.
+        @rtype: C{list} of C{str}
+        """
+        return concat([self.CorpusView(fileid, self._read_word_block,
+                        encoding='utf-8')
+                for fileid in self.abspaths(fileids)])
+
+    def sents(self, fileids=None):
+        """
+        @return: the given file(s) as a list of
+            sentences or utterances, each encoded as a list of word
+            strings
+        @rtype: C{list} of (C{list} of C{str})
+        """
+        return concat([self.CorpusView(fileid, self._read_sent_block, 
+                        encoding='utf-8')
+                for fileid in self.abspaths(fileids)])
+
+    def paras(self, fileids=None):
+        """
+        @return: the given file(s) as a list of
+            paragraphs, each encoded as a list of sentences, which are
+            in turn encoded as lists of word strings.
+        @rtype: C{list} of (C{list} of (C{list} of C{str}))
+        """
+        return concat([self.CorpusView(fileid, self._read_para_block,
+                        encoding='utf-8')
+                for fileid in self.abspaths(fileids)])
+
+    def nouns(self, fileids=None):
+        """
+        @return: the given file(s) as a list of nouns
+        @rtype: C{list} of C{str}
+        """
+        return concat([self.CorpusView(fileid, self._read_noun_block,
+                        encoding = 'utf-8')
+                for fileid in self.abspaths(fileids)])
+
+    def verbs(self, fileids=None):
+        """
+        @return: the given file(s) as a list of verbs
+        @rtype: C{list} of C{str}
+        """
+        return concat([self.CorpusView(fileid, self._read_verb_block,
+                        encoding='utf-8')
+                for fileid in self.abspaths(fileids)])
+
+    def persons(self, fileids=None):
+        """
+        @return: the given file(s) as a list of verbs
+        @rtype: C{list} of C{str}
+        """
+        return concat([self.CorpusView(fileid, self._read_person_block,
+                        encoding='utf-8')
+                for fileid in self.abspaths(fileids)])
+
+    def _get_basename(self, file):
+        """
+        @type file: C{str}
+        @param file: full filename
+        @return: the basename of the specified file
+        @rtype: C{str}
+        """
+        return file[0:len(file)-4]
+
+    def _get_disc(self, stream):
+        """
+        Using the specified file stream, this method creates two
+        discrepency mappings, both as dictionaries:
+            1. self._char_to_byte uses key = character number, 
+                                       entry = byte number
+            2. self._byte_to_char uses key = byte number, 
+                                       entry = character number
+        @type stream: StreamBackedCorpusView
+        @param stream: file stream
+        """
+        self._char_to_byte = {}
+        self._byte_to_char = {}
+        stream.read()
+        file_end = stream.tell()
+        self._file_end = file_end
+        stream.seek(0)
+        for i in range(file_end+1):
+            if i != stream.tell():
+                self._char_to_byte[i] = stream.tell()
+                self._byte_to_char[stream.tell()] = i
+            stream.read(1)
+        stream.seek(0)
+
+    def _get_subset(self, offsets, offsets_start, offsets_end):
+        """
+        @type offsets: C{list} of C{int} pairs
+        @param offsets: List of all offsets
+        @type offsets_start: C{int}
+        @param offsets_start: start of requested set of offsets
+        @type offsets_end: C{int}
+        @param offsets_end: end of requested set of offsets
+        @return: a list of all offsets between offsets_start and offset_end
+        @rtype: C{list} of C{str}
+        """
+        subset = []
+        for i in offsets:
+            if (i[0] >= offsets_start and i[1] <= offsets_end and 
+                i[0] != i[1]):
+                subset.append(i)
+            elif (i[0] >= offsets_start and i[1] > offsets_end and 
+                i[0] != i[1] and i[0] <= offsets_end):
+                subset.append(i)
+        return subset
+
+    def _get_read_size(self, subset, char_to_byte, slimit, offset_end):
+        """
+        @return: the byte size of text that should be read 
+        next from the file stream
+        @rtype: C{int}
+        """
+        if len(subset) != 0:
+            last1 = subset[len(subset)-1]
+            last = last1[1]
+            last = char_to_byte.get(last, last)
+            read_size = last - slimit
+        else:
+            elimit = char_to_byte.get(offset_end, offset_end)
+            read_size = elimit - slimit
+        return read_size
+            
+    def _get_block(self, subset, text, offsets_start):
+        """
+        Retrieve the annotated text, annotations are contained in subset
+        @type subset: C{list}
+        @param subset: list of annotation offset pairs
+        @type text: C{str}
+        @param text: text read from text stream
+        @type offsets_start: C{int}
+        @param offset_start: integer to correct for discrepency 
+                            between offsets and text character number
+        @return: list of annotated text
+        @rtype: C{list} of C{str} 
+        """
+        block = []
+        for s in subset:
+            start = s[0] - offsets_start
+            end = s[1] - offsets_start
+            chunk = text[start:end].encode('utf-8')
+            chunk = self._remove_ws(chunk)
+            block.append(chunk)
+        return block
+
+    def _read_block(self, stream, file_ending, label):
+        """
+        Generic method for retrieving annotated text from a file stream.
+        @type stream: SeekableUnicodeStreamReader
+        @param stream: file stream from StreamBackedCorpusView in 
+                       corpus/reader/util.py
+        @type file_ending: C{str}
+        @param file_ending: xml annotation file containing annotation
+                            offsets
+        @type label: C{str}
+        @param label: label of requested annotation
+        @return: list of annotated text from a block of the file stream
+        @rtype: C{list} of C{str}
+        """
+        file = self._get_basename(stream.name) + file_ending
+        if file != self._cur_file:
+            self._cur_file = file
+            offsets = self._get_annotation(file, label)
+            self._cur_offsets = offsets
+            self._get_disc(stream)
+            char_to_byte = self._char_to_byte
+            byte_to_char = self._byte_to_char
+        else:
+            offsets = self._cur_offsets
+            char_to_byte = self._char_to_byte
+            byte_to_char = self._byte_to_char
+        slimit = stream.tell()
+        offset_slimit = byte_to_char.get(slimit, slimit)
+        offset_elimit = offset_slimit + 500
+
+        subset = self._get_subset(offsets, offset_slimit, offset_elimit)
+
+        read_size = (self._get_read_size(subset, char_to_byte, slimit, 
+                    offset_elimit))
+
+        text = stream.read(read_size)
+
+        block = self._get_block(subset, text, offset_slimit)
+        return block
+
+
+    def _read_person_block(self, stream):
+        """ calls _read_block to retrieve 'person' tagged text """
+        return self._read_block(stream, '-ne.xml', 'person')        
+
+    def _read_verb_block(self, stream):
+        """ calls _read_block to retrieve 'vchunk' (verb chunks) 
+            tagged text """
+        return self._read_block(stream, '-vc.xml', 'vchunk')
+
+    def _read_noun_block(self, stream):
+        """ calls _read_block to retrieve 'nchunk' (noun chunks) 
+            tagged text """
+        return self._read_block(stream, '-nc.xml', 'nchunk')
+
+    def _read_word_block(self, stream):
+        """ calls _read_block to retrieve 'tok' (words) tagged text """
+        return self._read_block(stream, '-ptbtok.xml', 'tok')
+
+    def _read_sent_block(self, stream):
+        """
+        Method for retrieving sentence annotations from text, and 
+        the tok annotations within each sentence.
+        @type stream: SeekableUnicodeStreamReader
+        @param stream: file stream from StreamBackedCorpusView 
+                        in corpus/reader/util.py
+        @return: list of sentences, each of which is a list of words, 
+                        from a block of the file stream
+        @rtype: C{list} of C{str}
+        """
+        file = self._get_basename(stream.name) + '-s.xml'
+        words_file = self._get_basename(stream.name) + '-ptbtok.xml'
+
+        if not file == self._cur_sents_file:
+            self._cur_sents_file = file
+            self._cur_words_file = words_file
+            offsets = self._get_annotation(file, 's')
+            words_offsets = self._get_annotation(words_file, 'tok')
+            self._cur_sents_offsets = offsets
+            self._cur_words_offsets = words_offsets
+            self._get_disc(stream)
+            char_to_byte = self._char_to_byte
+            byte_to_char = self._byte_to_char
+        else:
+            offsets = self._cur_sents_offsets
+            words_offsets = self._cur_words_offsets
+            char_to_byte = self._char_to_byte
+            byte_to_char = self._byte_to_char
+
+        slimit = stream.tell()
+        offset_slimit = byte_to_char.get(slimit, slimit)
+        offset_elimit = offset_slimit + 500
+
+        subset = self._get_subset(offsets, offset_slimit, offset_elimit)
+
+        read_size = self._get_read_size(subset, char_to_byte, 
+                        slimit, offset_elimit)
+        text = stream.read(read_size)
+
+
+        block = []
+        for s in subset:
+            sent = []
+            for w in words_offsets:
+                if w[0] >= s[0] and w[1] <= s[1] and w[0] != w[1]:
+                    start = w[0] - offset_slimit
+                    end = w[1] - offset_slimit
+                    chunk = text[start:end].encode('utf-8')
+                    chunk = self._remove_ws(chunk)
+                    sent.append(chunk)
+            block.append(sent)
+
+        return block
+
+    def _read_para_block(self, stream):
+        """
+        Method for retrieving paragraph annotations from text, 
+        and the sentence and word annotations within each paragraph.
+        @type stream: SeekableUnicodeStreamReader
+        @param stream: file stream from StreamBackedCorpusView 
+                        in corpus/reader/util.py
+        @return: list of paragraphs, each of which is a list of sentences, 
+                        each of which is a list of words, 
+                        from a block of the file stream
+        @rtype: C{list} of C{list} of C{str}
+        """
+        file = self._get_basename(stream.name) + '-logical.xml'
+        sents_file = self._get_basename(stream.name) + '-s.xml'
+        words_file = self._get_basename(stream.name) + '-ptbtok.xml'
+
+        if not file == self._cur_paras_file:
+            self._cur_paras_file = file
+            self._cur_sents_file = sents_file
+            self._cur_words_file = words_file
+            offsets = self._get_annotation(file, 'p')
+            sents_offsets = self._get_annotation(sents_file, 's')
+            words_offsets = self._get_annotation(words_file, 'tok')
+            self._cur_paras_offsets = offsets
+            self._cur_sents_offsets = sents_offsets
+            self._cur_words_offsets = words_offsets
+            self._get_disc(stream)
+            char_to_byte = self._char_to_byte
+            byte_to_char = self._byte_to_char
+        else:
+            offsets = self._cur_paras_offsets
+            sents_offsets = self._cur_sents_offsets
+            words_offsets = self._cur_words_offsets
+            char_to_byte = self._char_to_byte
+            byte_to_char = self._byte_to_char
+
+#        if len(offsets) == 0:
+#            print "No paragraph annotations for file " + file
+            # TODO skip file (advance file stream) if no tokens are found
+
+        slimit = stream.tell()
+        offset_slimit = byte_to_char.get(slimit, slimit)
+        offset_elimit = offset_slimit + 500
+
+        subset = []
+        for i in offsets:
+            if (i[0] >= offset_slimit and i[1] <= offset_elimit 
+                                        and i[0] != i[1]):
+                subset.append(i)
+            if (i[0] >= offset_slimit and i[1] > offset_elimit 
+                                        and i[0] != i[1]):
+                subset.append(i)
+                break
+
+        if len(subset) != 0:
+            last1 = subset[len(subset)-1]
+            last = last1[1]
+            last = char_to_byte.get(last, last)
+            read_size = last - slimit
+            text = stream.read(read_size)
+        else:
+            if offset_elimit < self._file_end:
+                elimit = char_to_byte.get(offset_elimit, offset_elimit)
+                read_size = elimit - slimit
+                text = stream.read(read_size)
+            else:
+                stream.read()
+
+        block = []
+        for p in subset:
+            para = []
+            for s in sents_offsets:
+                if s[0] >= p[0] and s[1] <= p[1] and s[0] != s[1]:
+                    sent = []
+                    for w in words_offsets:
+                        if w[0] >= s[0] and w[1] <= s[1] and w[0] != w[1]:
+                            start = w[0] - offset_slimit
+                            end = w[1] - offset_slimit
+                            chunk = text[start:end].encode('utf-8')
+                            chunk = self._remove_ws(chunk)
+                            sent.append(chunk)
+                    para.append(sent)
+            if len(para) != 0:    # If a paragraph has no internal 
+                                  # sentence tokens, we disregard it
+                block.append(para)
+        return block
+
+    def _get_annotation(self, annfile, label):
+        """
+        Parses the given annfile and returns the offsets of all
+        annotations of type 'label'
+
+        @type annfile: C{str}
+        @param annfile: xml file containing annotation offsets
+        @type label: C{str}
+        @param label: annotation type label
+        @return: list of annotation offsets
+        @rtype: C{list} of C{pairs} of C{int}
+        """
+        parser = PyGraphParser()
+        g = parser.parse(annfile)
+        
+        node_list = g.nodes()
+
+        offsets = []
+        
+        for node in node_list:
+            pair = self._add_annotations(node, label)
+            offsets.extend(pair)
+
+        offsets.sort()
+        return offsets
+
+    def _add_annotations(self, node, label):
+        """
+        Given a node and annotation label, this method calls 
+        _get_offsets for each annotation contained by node, 
+        and adds them to the return list if they are oftype 'label'
+
+        @type node: C{PyNode}
+        @param node: a node in the Graf graph
+        @type label: C{str}
+        @param label: annotation type label 
+        @return: the annotation offsets of type 'label' 
+                 contained by the specified node
+        @rtype: C{list} of C{pairs} of C{int}
+        """
+        node_offsets = []
+        for a in node._annotations:
+            if a._label == label:
+                pair = self._get_offsets(node)
+                if pair is not None:
+                    pair.sort()
+                    node_offsets.append(pair)
+        return node_offsets
+
+    def _get_offsets(self, node):
+        """
+        @type node: C{PyNode}
+        @param node: a node in the Graf graph
+        @return: the offsets contained by a given node
+        @rtype: C{pair} of C{int}, or C{None}
+        """
+        
+        if len(node._links) == 0 and node._outEdgeList != []:
+            offsets = []
+            edge_list = node._outEdgeList
+            edge_list.reverse()
+            for edge in edge_list:
+                temp_offsets = self._get_offsets(edge._toNode)
+                if temp_offsets is not None:
+                    offsets.extend(self._get_offsets(edge._toNode))
+            if len(offsets) == 0:
+                return None
+            offsets.sort()
+            start = offsets[0]
+            end = offsets[len(offsets)-1]
+            return [start, end]
+        elif len(node._links) != 0:
+            offsets = []
+            for link in node._links:
+                for region in link._regions:
+                    for anchor in region._anchors:
+                        offsets.append(int(anchor._offset))
+            offsets.sort()
+            start = offsets[0]
+            end = offsets[len(offsets)-1]
+            return [start, end]
+        else:
+            return None
+            
+    def _remove_ws(self, chunk):
+        """
+        @return: string of text from chunk without end line characters
+        and multiple spaces
+        @rtype: C{str}
+        """
+        chunk = chunk.replace("\n", "")
+        words = chunk.split()
+        new_str = ""
+        for i in words:
+            if i == words[len(words)-1]:
+                new_str += i
+            else:
+                new_str = new_str + i + " "
+        return new_str

--- a/nltk/corpus/reader/masc.py
+++ b/nltk/corpus/reader/masc.py
@@ -11,11 +11,6 @@ the ISO GrAF format.
 """
 import os.path    	
 
-## note - these imports will change once the
-## graf package is placed within the nltk
-from graf.PyGraph import *
-from graf.PyGraphParser import *
-
 from util import *
 from api import *
 
@@ -42,6 +37,13 @@ class MascCorpusReader(CorpusReader):
                         this corpus.
         :param encoding: The encoding used for the text files in the corpus.
         """
+        try: 
+            #from graf.PyGraph import *
+            from graf.PyGraphParser import PyGraphParser
+        except ImportError:
+            print "You need to install the GrAF library in order to use the MASC corpus reader:\nhttp://pypi.python.org/pypi/graf-python\n"
+            return
+ 
         self._cur_file = ""
         self._cur_sents_file = ""
         self._cur_paras_file = ""
@@ -411,6 +413,7 @@ class MascCorpusReader(CorpusReader):
         :return: list of annotation offsets
         :rtype: list(pair(int))
         """
+        from graf.PyGraphParser import PyGraphParser
         parser = PyGraphParser()
         g = parser.parse(annfile)
         

--- a/nltk/corpus/reader/masc.py
+++ b/nltk/corpus/reader/masc.py
@@ -37,10 +37,10 @@ class MascCorpusReader(CorpusReader):
             >>> reader = MascCorpusReader(root, r'(?!\.).*\.txt', 
                                                       encoding = 'utf-8')
 
-        @param root: The root directory for this corpus.
-        @param fileids: A list of regexp specifying the fileids in 
+        :param root: The root directory for this corpus.
+        :param fileids: A list of regexp specifying the fileids in 
                         this corpus.
-        @param encoding: The encoding used for the text files in the corpus.
+        :param encoding: The encoding used for the text files in the corpus.
         """
         self._cur_file = ""
         self._cur_sents_file = ""
@@ -55,8 +55,8 @@ class MascCorpusReader(CorpusReader):
 
     def raw(self, fileids=None):
         """
-        @return: the given file(s) as a single string.
-        @rtype: C{str}
+        :return: the given file(s) as a single string.
+        :rtype: str
         """
         if fileids is None: fileids = self._fileids
         elif isinstance(fileids, basestring): fileids = [fileids]
@@ -64,9 +64,9 @@ class MascCorpusReader(CorpusReader):
 
     def words(self, fileids=None):
         """
-        @return: the given file(s) as a list of words
+        :return: the given file(s) as a list of words
             and punctuation symbols.
-        @rtype: C{list} of C{str}
+        :rtype: list(str)
         """
         return concat([self.CorpusView(fileid, self._read_word_block,
                         encoding='utf-8')
@@ -74,10 +74,10 @@ class MascCorpusReader(CorpusReader):
 
     def sents(self, fileids=None):
         """
-        @return: the given file(s) as a list of
+        :return: the given file(s) as a list of
             sentences or utterances, each encoded as a list of word
             strings
-        @rtype: C{list} of (C{list} of C{str})
+        :rtype: list(list(str))
         """
         return concat([self.CorpusView(fileid, self._read_sent_block, 
                         encoding='utf-8')
@@ -85,10 +85,10 @@ class MascCorpusReader(CorpusReader):
 
     def paras(self, fileids=None):
         """
-        @return: the given file(s) as a list of
+        :return: the given file(s) as a list of
             paragraphs, each encoded as a list of sentences, which are
             in turn encoded as lists of word strings.
-        @rtype: C{list} of (C{list} of (C{list} of C{str}))
+        :rtype: list(list(list(str)))
         """
         return concat([self.CorpusView(fileid, self._read_para_block,
                         encoding='utf-8')
@@ -96,8 +96,8 @@ class MascCorpusReader(CorpusReader):
 
     def nouns(self, fileids=None):
         """
-        @return: the given file(s) as a list of nouns
-        @rtype: C{list} of C{str}
+        :return: the given file(s) as a list of nouns
+        :rtype: list(str)
         """
         return concat([self.CorpusView(fileid, self._read_noun_block,
                         encoding = 'utf-8')
@@ -105,8 +105,8 @@ class MascCorpusReader(CorpusReader):
 
     def verbs(self, fileids=None):
         """
-        @return: the given file(s) as a list of verbs
-        @rtype: C{list} of C{str}
+        :return: the given file(s) as a list of verbs
+        :rtype: list(str)
         """
         return concat([self.CorpusView(fileid, self._read_verb_block,
                         encoding='utf-8')
@@ -114,8 +114,8 @@ class MascCorpusReader(CorpusReader):
 
     def persons(self, fileids=None):
         """
-        @return: the given file(s) as a list of verbs
-        @rtype: C{list} of C{str}
+        :return: the given file(s) as a list of verbs
+        :rtype: list(str)
         """
         return concat([self.CorpusView(fileid, self._read_person_block,
                         encoding='utf-8')
@@ -123,10 +123,9 @@ class MascCorpusReader(CorpusReader):
 
     def _get_basename(self, file):
         """
-        @type file: C{str}
-        @param file: full filename
-        @return: the basename of the specified file
-        @rtype: C{str}
+        :param file: full filename as str
+        :return: the basename of the specified file
+        :rtype: str
         """
         return file[0:len(file)-4]
 
@@ -138,8 +137,7 @@ class MascCorpusReader(CorpusReader):
                                        entry = byte number
             2. self._byte_to_char uses key = byte number, 
                                        entry = character number
-        @type stream: StreamBackedCorpusView
-        @param stream: file stream
+        :param stream: file stream as StreamBackedCorpusView
         """
         self._char_to_byte = {}
         self._byte_to_char = {}
@@ -156,14 +154,11 @@ class MascCorpusReader(CorpusReader):
 
     def _get_subset(self, offsets, offsets_start, offsets_end):
         """
-        @type offsets: C{list} of C{int} pairs
-        @param offsets: List of all offsets
-        @type offsets_start: C{int}
-        @param offsets_start: start of requested set of offsets
-        @type offsets_end: C{int}
-        @param offsets_end: end of requested set of offsets
-        @return: a list of all offsets between offsets_start and offset_end
-        @rtype: C{list} of C{str}
+        :param offsets: List of all offsets
+        :param offsets_start: start of requested set of offsets
+        :param offsets_end: end of requested set of offsets
+        :return: a list of all offsets between offsets_start and offset_end
+        :rtype: list(str)
         """
         subset = []
         for i in offsets:
@@ -177,9 +172,9 @@ class MascCorpusReader(CorpusReader):
 
     def _get_read_size(self, subset, char_to_byte, slimit, offset_end):
         """
-        @return: the byte size of text that should be read 
-        next from the file stream
-        @rtype: C{int}
+        :return: the byte size of text that should be read 
+            next from the file stream
+        :rtype: int
         """
         if len(subset) != 0:
             last1 = subset[len(subset)-1]
@@ -194,15 +189,12 @@ class MascCorpusReader(CorpusReader):
     def _get_block(self, subset, text, offsets_start):
         """
         Retrieve the annotated text, annotations are contained in subset
-        @type subset: C{list}
-        @param subset: list of annotation offset pairs
-        @type text: C{str}
-        @param text: text read from text stream
-        @type offsets_start: C{int}
-        @param offset_start: integer to correct for discrepency 
+        :param subset: list of annotation offset pairs
+        :param text: text read from text stream
+        :param offset_start: integer to correct for discrepency 
                             between offsets and text character number
-        @return: list of annotated text
-        @rtype: C{list} of C{str} 
+        :return: list of annotated text
+        :rtype: list(str)
         """
         block = []
         for s in subset:
@@ -216,16 +208,13 @@ class MascCorpusReader(CorpusReader):
     def _read_block(self, stream, file_ending, label):
         """
         Generic method for retrieving annotated text from a file stream.
-        @type stream: SeekableUnicodeStreamReader
-        @param stream: file stream from StreamBackedCorpusView in 
+        :param stream: file stream from StreamBackedCorpusView in 
                        corpus/reader/util.py
-        @type file_ending: C{str}
-        @param file_ending: xml annotation file containing annotation
+        :param file_ending: xml annotation file containing annotation
                             offsets
-        @type label: C{str}
-        @param label: label of requested annotation
-        @return: list of annotated text from a block of the file stream
-        @rtype: C{list} of C{str}
+        :param label: label of requested annotation
+        :return: list of annotated text from a block of the file stream
+        :rtype: list(str)
         """
         file = self._get_basename(stream.name) + file_ending
         if file != self._cur_file:
@@ -276,12 +265,11 @@ class MascCorpusReader(CorpusReader):
         """
         Method for retrieving sentence annotations from text, and 
         the tok annotations within each sentence.
-        @type stream: SeekableUnicodeStreamReader
-        @param stream: file stream from StreamBackedCorpusView 
-                        in corpus/reader/util.py
-        @return: list of sentences, each of which is a list of words, 
+        :param stream: file stream from StreamBackedCorpusView 
+            as SeekableUnicodeStreamReader in corpus/reader/util.py
+        :return: list of sentences, each of which is a list of words, 
                         from a block of the file stream
-        @rtype: C{list} of C{str}
+        :rtype: list(str)
         """
         file = self._get_basename(stream.name) + '-s.xml'
         words_file = self._get_basename(stream.name) + '-ptbtok.xml'
@@ -331,13 +319,12 @@ class MascCorpusReader(CorpusReader):
         """
         Method for retrieving paragraph annotations from text, 
         and the sentence and word annotations within each paragraph.
-        @type stream: SeekableUnicodeStreamReader
-        @param stream: file stream from StreamBackedCorpusView 
-                        in corpus/reader/util.py
-        @return: list of paragraphs, each of which is a list of sentences, 
-                        each of which is a list of words, 
-                        from a block of the file stream
-        @rtype: C{list} of C{list} of C{str}
+        :param stream: file stream from StreamBackedCorpusView 
+            as SeekableUnicodeStreamReader in corpus/reader/util.py
+        :return: list of paragraphs, each of which is a list of sentences, 
+            each of which is a list of words, 
+            from a block of the file stream
+        :rtype: C{list} of C{list} of C{str}
         """
         file = self._get_basename(stream.name) + '-logical.xml'
         sents_file = self._get_basename(stream.name) + '-s.xml'
@@ -419,12 +406,10 @@ class MascCorpusReader(CorpusReader):
         Parses the given annfile and returns the offsets of all
         annotations of type 'label'
 
-        @type annfile: C{str}
-        @param annfile: xml file containing annotation offsets
-        @type label: C{str}
-        @param label: annotation type label
-        @return: list of annotation offsets
-        @rtype: C{list} of C{pairs} of C{int}
+        :param annfile: xml file containing annotation offsets
+        :param label: annotation type label
+        :return: list of annotation offsets
+        :rtype: list(pair(int))
         """
         parser = PyGraphParser()
         g = parser.parse(annfile)
@@ -446,13 +431,11 @@ class MascCorpusReader(CorpusReader):
         _get_offsets for each annotation contained by node, 
         and adds them to the return list if they are oftype 'label'
 
-        @type node: C{PyNode}
-        @param node: a node in the Graf graph
-        @type label: C{str}
-        @param label: annotation type label 
-        @return: the annotation offsets of type 'label' 
+        :param node: a node in the Graf graph as PyNode
+        :param label: annotation type label 
+        :return: the annotation offsets of type 'label' 
                  contained by the specified node
-        @rtype: C{list} of C{pairs} of C{int}
+        :rtype: list(pair(int))
         """
         node_offsets = []
         for a in node._annotations:
@@ -465,10 +448,9 @@ class MascCorpusReader(CorpusReader):
 
     def _get_offsets(self, node):
         """
-        @type node: C{PyNode}
-        @param node: a node in the Graf graph
-        @return: the offsets contained by a given node
-        @rtype: C{pair} of C{int}, or C{None}
+        :param node: a node in the Graf graph as PyNode
+        :return: the offsets contained by a given node
+        :rtype: pair(int) or None
         """
         
         if len(node._links) == 0 and node._outEdgeList != []:
@@ -500,9 +482,9 @@ class MascCorpusReader(CorpusReader):
             
     def _remove_ws(self, chunk):
         """
-        @return: string of text from chunk without end line characters
-        and multiple spaces
-        @rtype: C{str}
+        :return: string of text from chunk without end line characters
+            and multiple spaces
+        :rtype: str
         """
         chunk = chunk.replace("\n", "")
         words = chunk.split()

--- a/nltk/test/corpus.doctest
+++ b/nltk/test/corpus.doctest
@@ -1124,6 +1124,30 @@ the XML structure directly, as follows:
     >>> [t.attrib['pos'] + "/" + t.attrib['word'] for t in tokens]
     ['RB/now', 'PRP/im', 'VBD/left', 'IN/with', 'DT/this', 'JJ/gay', 'NN/name']
 
+masc
+----
+
+The Manually Annotated Sub-Corpus (MASC) consists of approximately 500,000
+words of contemporary American English written and spoken data drawn from the
+OPEN AMERICAN NATIONAL CORPUS (OANC).
+
+All of MASC includes manually validated annotations for sentence boundaries,
+token, lemma and POS; noun and verb chunks; and named entities (person,
+location, organization, date). Additional manually produced or validated
+annotations have been produced by the MASC project for portions of the
+sub-corpus, including full-text annotation for FrameNet frame elements,
+WordNet sense tags, and Penn Treebank syntactic annotation. Annotations of all
+or portions of the sub-corpus for a wide variety of other linguistic phenomena
+have been contributed by other projects.
+
+    >>> import nltk.corpus
+    >>> print nltk.corpus.masc.words()
+    ['IN', 'THE', 'UNITED', 'STATES', 'DISTRICT', 'COURT', ...]
+    >>> print nltk.corpus.masc.verbs()
+    ['occurred', 'Let', 'go', 'are', 'is', ...]
+    >>> print nltk.corpus.masc.persons()
+    ['TAMMY J. KITZMILLER', 'JOHN E. JONES, III', ...]
+
 
 ---------------------
 Corpus Reader Classes
@@ -1262,7 +1286,7 @@ directory (or in subdirectories of that root directory).  The absolute
 path to the root directory is stored in the ``root`` property:
 
     >>> print nltk.corpus.genesis.root # doctest: +ELLIPSIS
-    ...nltk_data/corpora/genesis...
+    /.../nltk_data/corpora/genesis
 
 Each file within the corpus is identified by a platform-independent
 identifier, which is basically a path string that uses ``/`` as the
@@ -1299,7 +1323,7 @@ The ``abspath()`` method can be used to find the absolute path to a
 corpus file, given its file identifier:
 
     >>> print nltk.corpus.brown.abspath('ce06') # doctest: +ELLIPSIS
-    .../corpora/brown/ce06
+    /.../corpora/brown/ce06
 
 The ``abspaths()`` method can be used to find the absolute paths for
 one corpus file, a list of corpus files, or (if no fileids are specified),

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps =
     numpy
     nose
     svmlight
+    graf-python
 
 
 changedir = nltk/test


### PR DESCRIPTION
Hi,

here is the pull request for the MASC reader.

1) A CorpusReader class parallel to the others. Needs "graf-python" package, which is checked at runtime when the class is used. A message is printed when the package is not in installed.

2) Upate to the corpus.doctest and tox.ini. I added "graf-python" to tox in oder to be able to run the tests.

Hope everything is fine.

The current URL to the corpus files is:

http://www.anc.org/downloads/MASC-2.0.0.zip

Best,
Peter
