### PR TITLE
Memory improvements

### DIFF
--- a/nltk/corpus/__init__.py
+++ b/nltk/corpus/__init__.py
@@ -277,3 +277,12 @@ if __name__ == '__main__':
     #demo()
     pass
 
+# ** this is for nose **
+# unload all corpus after tests
+def teardown_module(module):
+    import nltk.corpus
+    for name in dir(nltk.corpus):
+        obj = getattr(nltk.corpus, name)
+        if isinstance(obj, CorpusReader):
+            if hasattr(obj, '_unload'):
+                obj._unload()

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -1687,6 +1687,12 @@ def _get_pos(field):
         raise ValueError(msg)
 
 
+# unload corpus after tests
+def teardown_module(module):
+    from nltk.corpus import wordnet
+    wordnet._unload()
+
+
 ######################################################################
 # Demo
 ######################################################################
@@ -1777,6 +1783,7 @@ def demo():
     print(S('code.n.03').topic_domains())
     print(S('pukka.a.01').region_domains())
     print(S('freaky.a.01').usage_domains())
+
 
 if __name__ == '__main__':
     demo()

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -209,6 +209,10 @@ class Lemma(_WordNetObject):
     - pertainyms
     """
 
+    __slots__ = ['_wordnet_corpus_reader', 'name', 'syntactic_marker',
+                 'synset', 'frame_strings', 'frame_ids',
+                 '_lexname_index', '_lex_id', 'key']
+
     # formerly _from_synset_info
     def __init__(self, wordnet_corpus_reader, synset, name,
                  lexname_index, lex_id, syntactic_marker):
@@ -300,6 +304,12 @@ class Synset(_WordNetObject):
     - pertainyms
     """
 
+    __slots__ = ['pos', 'offset', 'name', 'frame_ids',
+                 'lemmas', 'lemma_names',
+                 'definition', 'examples', 'lexname',
+                 '_pointers', '_lemma_pointers', '_max_depth',
+                 '_min_depth', ]
+
     def __init__(self, wordnet_corpus_reader):
         self._wordnet_corpus_reader = wordnet_corpus_reader
         # All of these attributes get initialized by
@@ -311,7 +321,6 @@ class Synset(_WordNetObject):
         self.frame_ids = []
         self.lemmas = []
         self.lemma_names = []
-        self.lemma_infos = []  # never used?
         self.definition = None
         self.examples = []
         self.lexname = None # lexicographer name

--- a/nltk/model/ngram.py
+++ b/nltk/model/ngram.py
@@ -90,8 +90,8 @@ class NgramModel(ModelI):
 
         cfd = ConditionalFreqDist()
         self._ngrams = set()
-        
-            
+
+
         # If given a list of strings instead of a list of lists, create enclosing list
         if (train is not None) and isinstance(train[0], basestring):
             train = [train]
@@ -222,6 +222,10 @@ class NgramModel(ModelI):
     def __repr__(self):
         return '<NgramModel with %d %d-grams>' % (len(self._ngrams), self._n)
 
+
+def teardown_module(module):
+    from nltk.corpus import brown
+    brown._unload()
 
 if __name__ == "__main__":
     import doctest

--- a/nltk/stem/wordnet.py
+++ b/nltk/stem/wordnet.py
@@ -41,6 +41,11 @@ class WordNetLemmatizer(object):
         return '<WordNetLemmatizer>'
 
 
+# unload wordnet
+def teardown_module(module):
+    from nltk.corpus import wordnet
+    wordnet._unload()
+
 if __name__ == "__main__":
     import doctest
     doctest.testmod(optionflags=doctest.NORMALIZE_WHITESPACE)

--- a/nltk/test/align_fixt.py
+++ b/nltk/test/align_fixt.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+from nltk.corpus import teardown_module

--- a/nltk/test/corpus_fixt.py
+++ b/nltk/test/corpus_fixt.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+from nltk.corpus import teardown_module

--- a/nltk/test/portuguese_en_fixt.py
+++ b/nltk/test/portuguese_en_fixt.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from nltk.corpus import teardown_module

--- a/nltk/test/unit/test_corpora.py
+++ b/nltk/test/unit/test_corpora.py
@@ -158,3 +158,6 @@ class TestPTB(unittest.TestCase):
             ptb.words(categories=['humor','fiction'])[:6],
             ['Thirty-three', 'Scotty', 'did', 'not', 'go', 'back']
         )
+
+# unload corpora
+from nltk.corpus import teardown_module

--- a/nltk/test/unit/test_seekable_unicode_stream_reader.py
+++ b/nltk/test/unit/test_seekable_unicode_stream_reader.py
@@ -104,13 +104,21 @@ than 72 characters.  It's got lots of repetition.  Here's \
 some unicode chars: \xee \u0123 \uffe3 \ueeee \u2345
 
 How fun!  Let's repeat it twenty times.
-"""*20
+"""*10
 
 def test_reader_on_large_string():
     for encoding in ENCODINGS:
         try:
             # skip strings that can't be encoded with the current encoding
             LARGE_STRING.encode(encoding)
-            yield functools.partial(check_reader, LARGE_STRING), encoding
+            def _check(encoding, n=1000):
+                check_reader(LARGE_STRING, encoding, n)
+
+            yield _check, encoding
+
         except UnicodeEncodeError:
             pass
+
+def teardown_module(module):
+    import gc
+    gc.collect()

--- a/nltk/test/wordnet_fixt.py
+++ b/nltk/test/wordnet_fixt.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+def teardown_module(module):
+    from nltk.corpus import wordnet
+    wordnet._unload()


### PR DESCRIPTION
- _unload hack;
- wordnet.Lemma and wordnet.Synset got `__slots__`

This should reduce average test memory usage for 100-200M and peak test memory usage for about 300-400M. 

It should also improve general wordnet memory usage. But this is a breaking change because wordnet.Lemma and wordnet.Synset become non-monkey-patchable with `__slots__` - it is no longer possible to assign custom attributes to Lemma and Synset. I think the resulting memory gains worth it.
