### PR TITLE
made parse.chart deterministic

### DIFF
--- a/nltk/parse/chart.py
+++ b/nltk/parse/chart.py
@@ -43,6 +43,7 @@ import warnings
 
 from nltk.tree import Tree
 from nltk.grammar import WeightedGrammar, is_nonterminal, is_terminal
+from nltk.util import OrderedDict
 
 from nltk.parse.api import ParserI
 
@@ -589,7 +590,7 @@ class Chart(object):
             self._register_with_indexes(edge)
 
         # Get the set of child pointer lists for this edge.
-        cpls = self._edge_to_cpls.setdefault(edge,{})
+        cpls = self._edge_to_cpls.setdefault(edge, OrderedDict())
         chart_was_modified = False
         for child_pointer_list in child_pointer_lists:
             child_pointer_list = tuple(child_pointer_list)

--- a/nltk/test/ccg.doctest
+++ b/nltk/test/ccg.doctest
@@ -17,87 +17,84 @@ Construct a lexicon:
 
     >>> lex = lexicon.parseLexicon('''
     ...     :- S, NP, N, VP
-    ... 
+    ...
     ...     Det :: NP/N
     ...     Pro :: NP
     ...     Modal :: S\\NP/VP
-    ... 
+    ...
     ...     TV :: VP/NP
     ...     DTV :: TV/NP
-    ...     
+    ...
     ...     the => Det
-    ...     
+    ...
     ...     that => Det
     ...     that => NP
-    ... 
+    ...
     ...     I => Pro
     ...     you => Pro
     ...     we => Pro
-    ... 
+    ...
     ...     chef => N
     ...     cake => N
     ...     children => N
     ...     dough => N
-    ... 
+    ...
     ...     will => Modal
     ...     should => Modal
     ...     might => Modal
     ...     must => Modal
-    ... 
+    ...
     ...     and => var\\.,var/.,var
-    ...     
+    ...
     ...     to => VP[to]/VP
-    ...     
+    ...
     ...     without => (VP\\VP)/VP[ing]
-    ... 
+    ...
     ...     be => TV
     ...     cook => TV
     ...     eat => TV
-    ... 
+    ...
     ...     cooking => VP[ing]/NP
-    ... 
+    ...
     ...     give => DTV
-    ... 
+    ...
     ...     is => (S\\NP)/NP
     ...     prefer => (S\\NP)/NP
-    ... 
+    ...
     ...     which => (N\\N)/(S/NP)
-    ... 
+    ...
     ...     persuade => (VP/VP[to])/NP
     ...     ''')
     >>> parser = chart.CCGChartParser(lex, chart.DefaultRuleSet)
     >>> for parse in parser.nbest_parse("you prefer that cake".split(),1):
     ...    chart.printCCGDerivation(parse)
     ...    for parse in parser.nbest_parse("that is the cake which you prefer".split(), 1):
-    ...        chart.printCCGDerivation(parse) # doctest: +NORMALIZE_WHITESPACE
+    ...        chart.printCCGDerivation(parse)
     ...
-     you    prefer      that   cake 
-     NP   ((S\NP)/NP)  (NP/N)   N   
-         --------------------->B
-              ((S\NP)/N)
+     you    prefer      that   cake
+     NP   ((S\NP)/NP)  (NP/N)   N
+                      -------------->
+                            NP
          --------------------------->
                    (S\NP)
     --------------------------------<
                    S
-     that      is        the    cake      which       you    prefer    
-      NP   ((S\NP)/NP)  (NP/N)   N    ((N\N)/(S/NP))  NP   ((S\NP)/NP) 
-          --------------------->B
-               ((S\NP)/N)
-                               ------>T
-                             (N/(N\N))
-          --------------------------->B
-                ((S\NP)/(N\N))
-          ------------------------------------------->B
-                        ((S\NP)/(S/NP))
+     that      is        the    cake      which       you    prefer
+      NP   ((S\NP)/NP)  (NP/N)   N    ((N\N)/(S/NP))  NP   ((S\NP)/NP)
                                                      ----->T
                                                   (S/(S\NP))
                                                      ------------------>B
                                                            (S/NP)
+                                     ---------------------------------->
+                                                   (N\N)
+                               ----------------------------------------<
+                                                  N
+                       ------------------------------------------------>
+                                              NP
           ------------------------------------------------------------->
                                      (S\NP)
     -------------------------------------------------------------------<
                                      S
-
 
 
 Some other sentences to try:
@@ -116,27 +113,25 @@ Without Substitution (no output)
 With Substitution:
 
     >>> for parse in parser.nbest_parse(sent,1):
-    ...     chart.printCCGDerivation(parse)  # doctest: +NORMALIZE_WHITESPACE
+    ...     chart.printCCGDerivation(parse)
      that      is        the    dough      which       you     will        eat          without           cooking
       NP   ((S\NP)/NP)  (NP/N)    N    ((N\N)/(S/NP))  NP   ((S\NP)/VP)  (VP/NP)  ((VP\VP)/VP['ing'])  (VP['ing']/NP)
-          --------------------->B
-               ((S\NP)/N)
-                               ------->T
-                              (N/(N\N))
-          ---------------------------->B
-                 ((S\NP)/(N\N))
-          -------------------------------------------->B
-                        ((S\NP)/(S/NP))
                                                       ----->T
                                                    (S/(S\NP))
-                                                      ------------------>B
-                                                            (S/VP)
                                                                                  ------------------------------------->B
                                                                                              ((VP\VP)/NP)
                                                                         ----------------------------------------------<Sx
                                                                                            (VP/NP)
+                                                           ----------------------------------------------------------->B
+                                                                                   ((S\NP)/NP)
                                                       ---------------------------------------------------------------->B
                                                                                    (S/NP)
+                                      -------------------------------------------------------------------------------->
+                                                                           (N\N)
+                               ---------------------------------------------------------------------------------------<
+                                                                          N
+                       ----------------------------------------------------------------------------------------------->
+                                                                     NP
           ------------------------------------------------------------------------------------------------------------>
                                                              (S\NP)
     ------------------------------------------------------------------------------------------------------------------<
@@ -165,7 +160,7 @@ Lexicons for the tests:
     ...        the => NP/N
     ...        mushrooms => N
     ...        parsnips => N'''
-    >>> test2_lex = '''        
+    >>> test2_lex = '''
     ...         :- N, S, NP, VP
     ...         articles => N
     ...         the => NP/N
@@ -187,8 +182,8 @@ Note that while the two derivations are different, they are semantically equival
     >>> parser = CCGChartParser(lex, ApplicationRuleSet + CompositionRuleSet + SubstitutionRuleSet)
     >>> for parse in parser.nbest_parse("I will cook and might eat the mushrooms and parsnips".split()):
     ...     printCCGDerivation(parse) # doctest: +NORMALIZE_WHITESPACE
-     I      will       cook               and                might       eat     the    mushrooms             and             parsnips 
-     NP  ((S\NP)/VP)  (VP/NP)  ((_var2\.,_var2)/.,_var2)  ((S\NP)/VP)  (VP/NP)  (NP/N)      N      ((_var2\.,_var2)/.,_var2)     N     
+     I      will       cook               and                might       eat     the    mushrooms             and             parsnips
+     NP  ((S\NP)/VP)  (VP/NP)  ((_var2\.,_var2)/.,_var2)  ((S\NP)/VP)  (VP/NP)  (NP/N)      N      ((_var2\.,_var2)/.,_var2)     N
         ---------------------->B
              ((S\NP)/NP)
                                                          ---------------------->B
@@ -207,8 +202,8 @@ Note that while the two derivations are different, they are semantically equival
                                                                     (S\NP)
     -----------------------------------------------------------------------------------------------------------------------------------<
                                                                      S
-     I      will       cook               and                might       eat     the    mushrooms             and             parsnips 
-     NP  ((S\NP)/VP)  (VP/NP)  ((_var2\.,_var2)/.,_var2)  ((S\NP)/VP)  (VP/NP)  (NP/N)      N      ((_var2\.,_var2)/.,_var2)     N     
+     I      will       cook               and                might       eat     the    mushrooms             and             parsnips
+     NP  ((S\NP)/VP)  (VP/NP)  ((_var2\.,_var2)/.,_var2)  ((S\NP)/VP)  (VP/NP)  (NP/N)      N      ((_var2\.,_var2)/.,_var2)     N
         ---------------------->B
              ((S\NP)/NP)
                                                          ---------------------->B
@@ -236,8 +231,8 @@ Interesting to point that the two parses are clearly semantically different.
     >>> parser = CCGChartParser(lex, ApplicationRuleSet + CompositionRuleSet + SubstitutionRuleSet)
     >>> for parse in parser.nbest_parse("articles which I will file and forget without reading".split()):
     ...     printCCGDerivation(parse)  # doctest: +NORMALIZE_WHITESPACE
-     articles      which       I      will       file               and             forget         without           reading     
-        N      ((N\N)/(S/NP))  NP  ((S/VP)\NP)  (VP/NP)  ((_var3\.,_var3)/.,_var3)  (VP/NP)  ((VP\VP)/VP['ing'])  (VP['ing']/NP) 
+     articles      which       I      will       file               and             forget         without           reading
+        N      ((N\N)/(S/NP))  NP  ((S/VP)\NP)  (VP/NP)  ((_var3\.,_var3)/.,_var3)  (VP/NP)  ((VP\VP)/VP['ing'])  (VP['ing']/NP)
                               -----------------<
                                    (S/VP)
                                                                                             ------------------------------------->B
@@ -254,8 +249,8 @@ Interesting to point that the two parses are clearly semantically different.
                                                                      (N\N)
     -----------------------------------------------------------------------------------------------------------------------------<
                                                                   N
-     articles      which       I      will       file               and             forget         without           reading     
-        N      ((N\N)/(S/NP))  NP  ((S/VP)\NP)  (VP/NP)  ((_var3\.,_var3)/.,_var3)  (VP/NP)  ((VP\VP)/VP['ing'])  (VP['ing']/NP) 
+     articles      which       I      will       file               and             forget         without           reading
+        N      ((N\N)/(S/NP))  NP  ((S/VP)\NP)  (VP/NP)  ((_var3\.,_var3)/.,_var3)  (VP/NP)  ((VP\VP)/VP['ing'])  (VP['ing']/NP)
                               -----------------<
                                    (S/VP)
                                                         ------------------------------------>

--- a/nltk/test/parse.doctest
+++ b/nltk/test/parse.doctest
@@ -187,10 +187,10 @@ Top-down
     Nr edges in chart: 48
     (S
       (NP I)
-      (VP (VP (Verb saw) (NP John)) (PP with (NP (Det a) (Noun dog)))))
+      (VP (Verb saw) (NP (NP John) (PP with (NP (Det a) (Noun dog))))))
     (S
       (NP I)
-      (VP (Verb saw) (NP (NP John) (PP with (NP (Det a) (Noun dog))))))
+      (VP (VP (Verb saw) (NP John)) (PP with (NP (Det a) (Noun dog)))))
     <BLANKLINE>
 
 Bottom-up
@@ -785,15 +785,15 @@ We use the featurechart.demo() function for tracing the Feature Chart Parser.
     (S[]
       (NP[] I)
       (VP[]
+        (VP[] (Verb[] saw) (NP[] John))
+        (PP[] (Prep[] with) (NP[] (Det[-pl] a) (Noun[-pl] dog)))))
+    (S[]
+      (NP[] I)
+      (VP[]
         (Verb[] saw)
         (NP[]
           (NP[] John)
           (PP[] (Prep[] with) (NP[] (Det[-pl] a) (Noun[-pl] dog))))))
-    (S[]
-      (NP[] I)
-      (VP[]
-        (VP[] (Verb[] saw) (NP[] John))
-        (PP[] (Prep[] with) (NP[] (Det[-pl] a) (Noun[-pl] dog)))))
 
 
 Unit tests for the Feature Chart Parser classes


### PR DESCRIPTION
nltk.parse.chart.Chart.parses is currently nondeterministic.

This causes random test failures in ccg.doctest (nltk.ccg.chart.CCGChartParser.nbest_parse may produce different output with the same input).

If I understand the issue correctly, Chart.child_pointer_lists returns dict keys:

```
return self._edge_to_cpls.get(edge, {}).keys()
```

The result is then used in Chart._trees method (which is called by Chart.trees method which is called by Chart.parses method). But dictionaries are unordered in Python and Chart.child_pointer_lists may return different results; this causes nondeterminism for other methods.

So in this pull request the result of Chart.child_pointer_lists is made deterministic (by using nltk.util.OrderedDict instead of dict). This affects parsing results (so tests are updated); ccg.doctest is always passes for me now. 

parse.doctest becomes broken and it is not completely fixed with my commit:

```
======================================================================
FAIL: Doctest: parse.doctest
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/doctest.py", line 2166, in runTest
    raise self.failureException(self.format_failure(new.getvalue()))
AssertionError: Failed doctest test for parse.doctest
  File "/Users/kmike/svn/nltk/nltk/test/parse.doctest", line 0

----------------------------------------------------------------------
File "/Users/kmike/svn/nltk/nltk/test/parse.doctest", line 834, in parse.doctest
Failed example:
    unittest(isawjohn, "I saw John with a dog with my cookie", 5)
Expected nothing
Got:
    Trees differ for parser: FeatureTopDownChartParser

```

Trees differ because the order of results become different for different parsers after this patch. I think they were the same by accident before, and the test should be fixed. 

But I'm not expert in nltk.parse, I haven't used it myself, etc.; it'll be great if somebody with more knowledge will review this pull request because it affects parsing results.
