### PR TITLE
Quickfix for nltk.classify.maxent: 

### DIFF
--- a/nltk/classify/maxent.py
+++ b/nltk/classify/maxent.py
@@ -183,7 +183,7 @@ class MaxentClassifier(ClassifierI):
                                 reverse=True)
             for (f_id, f_val) in feature_vector:
                 if self._logarithmic: score = self._weights[f_id] * f_val
-                else: score = self._weights[fid] ** f_val
+                else: score = self._weights[f_id] ** f_val
                 descr = self._encoding.describe(f_id)
                 descr = descr.split(' and label is ')[0] # hack
                 descr += ' (%s)' % f_val                 # hack
@@ -293,7 +293,7 @@ class MaxentClassifier(ClassifierI):
         """
         if algorithm is None:
             try:
-                import scipy
+                import scipy.maxentropy
                 algorithm = 'cg'
             except ImportError:
                 algorithm = 'iis'
@@ -423,9 +423,9 @@ class FunctionBackedMaxentFeatureEncoding(MaxentFeatureEncodingI):
         :type func: (callable)
         :param func: A function that takes two arguments, a featureset
              and a label, and returns the sparse joint feature vector
-             that encodes them:
+             that encodes them::
 
-             >>> func(featureset, label) -> feature_vector
+                 func(featureset, label) -> feature_vector
 
              This sparse joint feature vector (``feature_vector``) is a
              list of ``(index,value)`` tuples.
@@ -682,7 +682,7 @@ class GISEncoding(BinaryMaxentFeatureEncoding):
         self._C = C
 
     @property
-    def C(self): 
+    def C(self):
         """The non-negative constant that all encoded feature vectors
         will sum to."""
         return self._C


### PR DESCRIPTION
After this commit MaxentClassifier will use 'cg' algorithm if scipy.maxentropy is not available (instead of raising an exception). This should provide a quick fix for #307.

In the long run we should probably add sklearn.linear_model.LogisticRegression support to MaxentClassifier and make it default.
