### PR TITLE
Fix for bug in internals.is_writable(path)

### DIFF
--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -854,7 +854,7 @@ def is_writable(path):
         elif statdata.st_uid == os.getuid() and (perm & 0200):
             return True
         # are we in a group that can write to it?
-        elif statdata.st_gid == os.getgid() and (perm & 0020):
+        elif statdata.st_gid in os.getgroups() and (perm & 0020):
             return True
         # otherwise, we can't write to it.
         else:

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -854,7 +854,8 @@ def is_writable(path):
         elif statdata.st_uid == os.getuid() and (perm & 0200):
             return True
         # are we in a group that can write to it?
-        elif statdata.st_gid in os.getgroups() and (perm & 0020):
+        elif (statdata.st_gid in [os.getgid()] + os.getgroups()) \
+            and (perm & 0020):
             return True
         # otherwise, we can't write to it.
         else:


### PR DESCRIPTION
The check for whether the path is group writable did not consider all the user's groups.
