### PR TITLE
fix snowball stemmer bug in handling word `y's`

### DIFF
--- a/nltk/stem/snowball.py
+++ b/nltk/stem/snowball.py
@@ -825,7 +825,7 @@ class EnglishStemmer(_StandardStemmer):
                 break
 
         # STEP 1c
-        if word[-1] in u"yY" and word[-2] not in self.__vowels and len(word) > 2:
+        if len(word) > 2 and word[-1] in u"yY" and word[-2] not in self.__vowe:
             word = u"".join((word[:-1], u"i"))
             if len(r1) >= 1:
                 r1 = u"".join((r1[:-1], u"i"))


### PR DESCRIPTION
STEP 1c in line 828 checks `len(word) > 2` as last condition. However, this will cause `string index out of range` error when stem the word `y's` since `word` will be `y` when we come to line 828. Move the condition `len(word)>2` to beginning will solve this issue.
