### PR TITLE
fixed doctype regex to handle doctype tag w/o square brackets

### DIFF
--- a/nltk/corpus/reader/xmldocs.py
+++ b/nltk/corpus/reader/xmldocs.py
@@ -220,7 +220,7 @@ class XMLCorpusView(StreamBackedCorpusView):
         (?P<COMMENT>        <!--.*?-->                          )|
         (?P<CDATA>          <![CDATA[.*?]]>                     )|
         (?P<PI>             <\?.*?\?>                           )|
-        (?P<DOCTYPE>        <!DOCTYPE\s+[^\[]*(\[[^\]]*])?\s*>  )|
+        (?P<DOCTYPE>        <!DOCTYPE\s+[^\[^>]*(\[[^\]]*])?\s*>)|
         # These are the ones we actually care about:
         (?P<EMPTY_ELT_TAG>  <\s*[^>/\?!\s][^>]*/\s*>            )|
         (?P<START_TAG>      <\s*[^>/\?!\s][^>]*>                )|


### PR DESCRIPTION
If there's no '[' in the DOCTYPE declaration, [^[]\* will match as much of the block as possible, "eating" several start tags that we don't actually want to skip. This breaks [the sense-tagged WordNet corpus](http://wordnet.princeton.edu/glosstag.shtml). 

Since the XML spec doesn't allow ">" in names, this fix shouldn't break anything. Running runtests.py fails, but it fails with the same errors as without this fix, so the errors are (hopefully) not mine. (Should I write tests for this? I've tested it with the WordNet corpus, but I'm not sure if it's worth adding a unit test for this, especially since I'm not adding anything new.)
