### PR TITLE
Fix for decision trees with binary=True

### DIFF
--- a/nltk/classify/decisiontree.py
+++ b/nltk/classify/decisiontree.py
@@ -131,7 +131,7 @@ class DecisionTreeClassifier(ClassifierI):
               support_cutoff=10, binary=False, feature_values=None,
               verbose=False):
         """
-        :param binary: If true, then treat all feature/value pairs a
+        :param binary: If true, then treat all feature/value pairs as
             individual binary features, rather than using a single n-way
             branch for each feature.
         """
@@ -242,8 +242,15 @@ class DecisionTreeClassifier(ClassifierI):
             else:
                 neg_fdist.inc(label)
 
-        decisions = {feature_value: DecisionTreeClassifier(pos_fdist.max())}
-        default = DecisionTreeClassifier(neg_fdist.max())
+
+        decisions = None
+        default = None
+        # But hopefully we have observations!
+        if pos_fdist.values():
+            decisions = {feature_value: DecisionTreeClassifier(pos_fdist.max())}
+        if neg_fdist.values():
+            default = DecisionTreeClassifier(neg_fdist.max())
+
         return DecisionTreeClassifier(label, feature_name, decisions, default)
 
     @staticmethod

--- a/nltk/classify/decisiontree.py
+++ b/nltk/classify/decisiontree.py
@@ -114,7 +114,7 @@ class DecisionTreeClassifier(ClassifierI):
         if self._default is not None:
             if len(self._decisions) == 1:
                 s += '%sif %s != %r: '% (prefix, self._fname,
-                                         self._decisions.keys()[0])
+                                         list(self._decisions.keys())[0])
             else:
                 s += '%selse: ' % (prefix,)
             if self._default._fname is not None and depth>1:
@@ -243,12 +243,12 @@ class DecisionTreeClassifier(ClassifierI):
                 neg_fdist.inc(label)
 
 
-        decisions = None
-        default = None
+        decisions = {}
+        default = label
         # But hopefully we have observations!
-        if pos_fdist.values():
+        if pos_fdist.N() > 0:
             decisions = {feature_value: DecisionTreeClassifier(pos_fdist.max())}
-        if neg_fdist.values():
+        if neg_fdist.N() > 0:
             default = DecisionTreeClassifier(neg_fdist.max())
 
         return DecisionTreeClassifier(label, feature_name, decisions, default)
@@ -268,7 +268,7 @@ class DecisionTreeClassifier(ClassifierI):
                     best_stump = stump
         if best_stump._decisions:
             descr = '%s=%s' % (best_stump._fname,
-                               best_stump._decisions.keys()[0])
+                               list(best_stump._decisions.keys())[0])
         else:
             descr = '(default)'
         if verbose:


### PR DESCRIPTION
Fixes #297 and makes sure that decision stumps work on Python 3 by doing two things:
- In the binary stumps, if we haven't seen any positive (or negative) events, have sensible defaults for when we haven't seen an event of that type, instead of failing when we ask for the most common label on positive/negative events.
- In Python 3, .keys() on a dictionary doesn't return a list, so we can't index into it. Make it a list!
