### PR TITLE
Escape reserved LaTeX characters in nltk.tree.Tree.pprint_latex_qtree()

### DIFF
--- a/nltk/tree.py
+++ b/nltk/tree.py
@@ -717,7 +717,10 @@ class Tree(list):
         :return: A latex qtree representation of this tree.
         :rtype: str
         """
-        return r'\Tree ' + self.pprint(indent=6, nodesep='', parens=('[.', ' ]'))
+        reserved_chars = re.compile('([#\$%&~_\{\}])')
+
+        pprint = self.pprint(indent=6, nodesep='', parens=('[.', ' ]'))
+        return r'\Tree ' + re.sub(reserved_chars, r'\\\1', pprint)
 
     def _pprint_flat(self, nodesep, parens, quotes):
         childstrs = []


### PR DESCRIPTION
The dollar sign, a reserved character in LaTeX, appears in the possessive pronoun tag from the Penn tagset (PRP$). For example:

``` python
from nltk.tree import Tree

mytree = Tree('''(S
(NP (NP (PRP$ Their) (NN mother)))
(VP (VBZ is) (ADVP (RB inside)) (NP (NP (DT the) (NN house))))
(PP (IN with) (NPPP (DT the) (NN cat)))
(. .))''')
```

If you call `pprint_latex_qtree()`on this Tree, you get

```
>>> print mytree.pprint_latex_qtree()
\Tree [.S
        [.NP [.NP [.PRP$ Their ] [.NN mother ] ] ]
        [.VP
          [.VBZ is ]
          [.ADVP [.RB inside ] ]
          [.NP [.NP [.DT the ] [.NN house ] ] ] ]
        [.PP [.IN with ] [.NPPP [.DT the ] [.NN cat ] ] ]
        [.. . ] ]
```

Because the reserved characters aren't escaped, this won't compile into a QobiTree Tree in a LaTeX document.

This quick fix escapes common LaTeX reserved characters (`#`, `$`, `%`, `&`, `~`, `_`, `{` and `}`):

```
>>> print mytree.pprint_latex_qtree()
\Tree [.S
        [.NP [.NP [.PRP\$ Their ] [.NN mother ] ] ]
        [.VP
          [.VBZ is ]
          [.ADVP [.RB inside ] ]
          [.NP [.NP [.DT the ] [.NN house ] ] ] ]
        [.PP [.IN with ] [.NPPP [.DT the ] [.NN cat ] ] ]
        [.. . ] ]
```
