### PR TITLE
Correction on the Pk segmentation metric

### DIFF
--- a/nltk/metrics/segmentation.py
+++ b/nltk/metrics/segmentation.py
@@ -214,33 +214,14 @@ def pk(ref, hyp, k=None, boundary='1'):
 
     if k is None:
         k = int(round(len(ref) / (ref.count(boundary) * 2.)))
-
-    n_considered_seg = len(ref) - k + 1
-    n_same_ref = 0.0
-    n_false_alarm = 0.0
-    n_miss = 0.0
-
-    for i in xrange(n_considered_seg):
-        bsame_ref_seg = False
-        bsame_hyp_seg = False
-
-        if boundary not in ref[(i+1):(i+k)]:
-            n_same_ref += 1.0
-            bsame_ref_seg = True
-        if boundary not in hyp[(i+1):(i+k)]:
-            bsame_hyp_seg = True
-
-        if bsame_hyp_seg and not bsame_ref_seg:
-            n_miss += 1
-        if bsame_ref_seg and not bsame_hyp_seg:
-            n_false_alarm += 1
-
-    prob_same_ref = n_same_ref / n_considered_seg
-    prob_diff_ref = 1 - prob_same_ref
-    prob_miss = n_miss / n_considered_seg
-    prob_false_alarm = n_false_alarm / n_considered_seg
-
-    return prob_miss * prob_diff_ref + prob_false_alarm * prob_same_ref
+    
+    err = 0
+    for i in xrange(len(ref)-k +1):
+        r = ref[i:i+k].count(boundary) > 0
+        h = hyp[i:i+k].count(boundary) > 0
+        if r != h:
+           err += 1
+    return err / (len(ref)-k +1.)
 
 
 # skip doctests if numpy is not installed

--- a/nltk/metrics/segmentation.py
+++ b/nltk/metrics/segmentation.py
@@ -191,15 +191,12 @@ def pk(ref, hyp, k=None, boundary='1'):
     where the specified boundary value is used to mark the edge of a
     segmentation.
 
-    >>> s1 = "00000010000000001000000"
-    >>> s2 = "00000001000000010000000"
-    >>> s3 = "00010000000000000001000"
-    >>> pk(s1, s1, 3)
-    0.0
-    >>> pk(s1, s2, 3)
-    0.095238...
-    >>> pk(s2, s3, 3)
-    0.190476...
+    >>> '%.2f' % pk('0100'*100, '1'*400, 2)
+    '0.50'
+    >>> '%.2f' % pk('0100'*100, '0'*400, 2)
+    '0.50'
+    >>> '%.2f' % pk('0100'*100, '0100'*100, 2)
+    '0.00'
 
     :param ref: the reference segmentation
     :type ref: str or list


### PR DESCRIPTION
The first implementation I did was 100% wrong.

According to [1] Pk should provide a penalty of about 0.5 to all degenerated segmentations (empty, full, randomized), which is not statisfied by my last implementation.
It was corrected using the explantations provided in [2]

Sorry about that

[1] Beeferman D., Berger A., Lafferty J. (1999)
Statistical Models for Text Segmentation
Machine Learning, 34, 177-210

[2] Unbiased discourse segmentation evaluation
John Niekrasz and Johanna D. Moore
Spoken Language Technology Workshop (SLT), 2010 IEEE
Page(s): 43 - 48
