### PR TITLE
Update nltk/tag/sequential.py

### DIFF
--- a/nltk/tag/sequential.py
+++ b/nltk/tag/sequential.py
@@ -342,7 +342,7 @@ class BigramTagger(NgramTagger):
     """
     yaml_tag = '!nltk.BigramTagger'
 
-    def __init__(self, train, model=None,
+    def __init__(self, train=None, model=None,
                  backoff=None, cutoff=0, verbose=False):
         NgramTagger.__init__(self, 2, train, model,
                              backoff, cutoff, verbose)


### PR DESCRIPTION
Remove need to pass train argument to BigramTagger.**init**() as in other NGramTagger-Classes
