### PR TITLE
fix interface to megam maxent classifier!

### DIFF
--- a/nltk/classify/maxent.py
+++ b/nltk/classify/maxent.py
@@ -1361,8 +1361,8 @@ def train_maxent_classifier_with_megam(train_toks, trace=3, encoding=None,
 
     # Write a training file for megam.
     try:
-        fd, trainfile_name = tempfile.mkstemp(prefix='nltk-', suffix='.gz')
-        trainfile = gzip.open(trainfile_name, 'wb')
+        fd, trainfile_name = tempfile.mkstemp(prefix='nltk-')
+        trainfile = open(trainfile_name, 'w')
         write_megam_file(train_toks, encoding, trainfile, \
                             explicit=explicit, bernoulli=bernoulli)
         trainfile.close()

--- a/nltk/classify/megam.py
+++ b/nltk/classify/megam.py
@@ -172,5 +172,8 @@ def call_megam(args):
         print(stderr)
         raise OSError('megam command failed!')
 
-    return stdout
+    if isinstance(stdout, compat.string_types):
+        return stdout
+    else:
+        return stdout.decode('utf-8')
 


### PR DESCRIPTION
Small change, but it makes megam work with Pythons 2 and 3.
- Instead of writing a gzipped training file, just write a regular text file. (megam is about to decompress it anyway) -- this avoids the hassle of writing binary files in the gzip library, which doesn't like unicode strings.
- Make sure, when we get the output of megam, that we turn it back into a standard string for the current Python.
