### PR TITLE
Bugfix for downloader sorting

### DIFF
--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -461,7 +461,7 @@ class Downloader(object):
         for category in categories:
             print('%s:' % category.capitalize())
             lines += 1 # for more_prompt
-            for info in sorted(getattr(self, category)()):
+            for info in sorted(getattr(self, category)(), key=str):
                 status = self.status(info, download_dir)
                 if status == self.INSTALLED and skip_installed: continue
                 if status == self.STALE: stale = True
@@ -1045,7 +1045,7 @@ class DownloaderShell(object):
         while True:
             stale_packages = []
             stale = partial = False
-            for info in sorted(getattr(self._ds, 'packages')()):
+            for info in sorted(getattr(self._ds, 'packages')(), key=str):
                 if self._ds.status(info) == self._ds.STALE:
                     stale_packages.append((info.id, info.name))
 

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -405,7 +405,7 @@ class Deprecated(object):
                                    subsequent_indent='    ')
         warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
         # Do the actual work of __new__.
-        return object.__new__(cls, *args, **kwargs)
+        return object.__new__(cls)
 
 ##########################################################################
 # COUNTER, FOR UNIQUE NAMING


### PR DESCRIPTION
The downloader was crashing due to a call to sorted() whose arguments were not comparable. Using key=str fixed the problem for me and made sense as a way to sort things in the download tree.
