### PR TITLE
Fix interface to the Stanford tagger so it works on Python 2 and 3

### DIFF
--- a/nltk/tag/stanford.py
+++ b/nltk/tag/stanford.py
@@ -36,7 +36,7 @@ class StanfordTagger(TaggerI):
     _SEPARATOR = ''
     _JAR = ''
 
-    def __init__(self, path_to_model, path_to_jar=None, encoding=None, verbose=False, java_options='-mx1000m'):
+    def __init__(self, path_to_model, path_to_jar=None, encoding='ascii', verbose=False, java_options='-mx1000m'):
 
         if not self._JAR:
             warnings.warn('The StanfordTagger class is not meant to be '
@@ -48,8 +48,6 @@ class StanfordTagger(TaggerI):
 
         self._stanford_model = find_file(path_to_model,
                 env_vars=('STANFORD_MODELS'), verbose=verbose)
-        if compat.PY3 and not encoding:
-            encoding = "ascii"
         self._encoding = encoding
         self.java_options = java_options
 
@@ -68,8 +66,7 @@ class StanfordTagger(TaggerI):
         # Create a temporary input file
         _input_fh, self._input_file_path = tempfile.mkstemp(text=True)
 
-        if encoding:
-            self._cmd.extend(['-encoding', encoding])
+        self._cmd.extend(['-encoding', encoding])
 
         # Write the actual sentences to the temporary input file
         _input_fh = os.fdopen(_input_fh, 'wb')
@@ -82,8 +79,9 @@ class StanfordTagger(TaggerI):
         # Run the tagger and get the output
         stanpos_output, _stderr = java(self._cmd,classpath=self._stanford_jar, \
                                                        stdout=PIPE, stderr=PIPE)
-        if encoding:
-            stanpos_output = stanpos_output.decode(encoding)
+        stanpos_output = stanpos_output.decode(encoding)
+        if (not compat.PY3) and encoding == 'ascii':
+            stanpos_output = str(stanpos_output)
 
         # Delete the temporary file
         os.unlink(self._input_file_path)

--- a/nltk/tag/stanford.py
+++ b/nltk/tag/stanford.py
@@ -36,7 +36,7 @@ class StanfordTagger(TaggerI):
     _SEPARATOR = ''
     _JAR = ''
 
-    def __init__(self, path_to_model, path_to_jar=None, encoding='ascii', verbose=False, java_options='-mx1000m'):
+    def __init__(self, path_to_model, path_to_jar=None, encoding=None, verbose=False, java_options='-mx1000m'):
 
         if not self._JAR:
             warnings.warn('The StanfordTagger class is not meant to be '
@@ -48,6 +48,8 @@ class StanfordTagger(TaggerI):
 
         self._stanford_model = find_file(path_to_model,
                 env_vars=('STANFORD_MODELS'), verbose=verbose)
+        if compat.PY3 and not encoding:
+            encoding = "ascii"
         self._encoding = encoding
         self.java_options = java_options
 
@@ -66,22 +68,22 @@ class StanfordTagger(TaggerI):
         # Create a temporary input file
         _input_fh, self._input_file_path = tempfile.mkstemp(text=True)
 
-        self._cmd.extend(['-encoding', encoding])
+        if encoding:
+            self._cmd.extend(['-encoding', encoding])
 
         # Write the actual sentences to the temporary input file
         _input_fh = os.fdopen(_input_fh, 'wb')
         _input = '\n'.join((' '.join(x) for x in sentences))
-        _input = _input.encode(encoding)
+        if isinstance(_input, compat.text_type) and encoding:
+            _input = _input.encode(encoding)
         _input_fh.write(_input)
         _input_fh.close()
 
         # Run the tagger and get the output
         stanpos_output, _stderr = java(self._cmd,classpath=self._stanford_jar, \
                                                        stdout=PIPE, stderr=PIPE)
-        stanpos_output = stanpos_output.decode(encoding)
-        # Turn decoded "unicode" string back to str on Python 2.
-        if encoding == 'ascii' and str is bytes:
-            stanpos_output = str(stanpos_output)
+        if encoding:
+            stanpos_output = stanpos_output.decode(encoding)
 
         # Delete the temporary file
         os.unlink(self._input_file_path)


### PR DESCRIPTION
Previously, we would fail with file encoding issues on Python 3.

But now this little program works right for both, assuming you unzipped the Stanford Tagger into the same place that I did.

``` python
from __future__ import print_function
from nltk.tag.stanford import POSTagger

def get_tagger(enc=None):
    taggerhome = '/home/alex/software/stanford-postagger-2012-11-11'
    tagger = taggerhome + '/models/wsj-0-18-bidirectional-distsim.tagger'
    jar = taggerhome + '/stanford-postagger.jar'
    if enc:
        stanford_tagger = POSTagger(tagger, jar, encoding=enc)
    else:
        stanford_tagger = POSTagger(tagger, jar)
    return stanford_tagger

print("DEFAULT")
tagger = get_tagger()
print(tagger.tag("The man saw the dog with the telescope .".split()))
print("*" * 80)
print("UNICODE")
tagger = get_tagger(enc='utf-8')
print(tagger.tag("The man saw the dog with the telescope .".split()))
```
