### PR TITLE
fixed issues with coverage and pylint results

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,11 +1,11 @@
 #! /bin/sh
 
-ROOT=`dirname $0`
+cd `dirname $0`
 
-$ROOT/pip-install.py
+./pip-install.py
 coverage erase
-coverage run $ROOT/nltk/test/runtests.py --with-xunit
-coverage xml
+coverage run --source=nltk nltk/test/runtests.py --with-xunit
+coverage xml --omit=nltk/test/*
 iconv -c -f utf-8 -t utf-8 nosetests.xml > nosetests_scrubbed.xml
-pylint -f parseable $ROOT/nltk > pylintoutput
+pylint -f parseable nltk > pylintoutput
 true   # script always succeeds


### PR DESCRIPTION
Fixed a few problems in the coverage and pylint results.
- The file paths were incorrect so Jenkins was not able to find files for per-file highlighted view.
- Reports included files that don't belong to nltk.

After this fix is in place, old coverage and pylint files in the nltk/test directory need to be removed from workspaces on the ShinngPanda executor vm, which I can do.
