### PR TITLE
Small tkinter-related fixes

### DIFF
--- a/nltk/__init__.py
+++ b/nltk/__init__.py
@@ -155,7 +155,7 @@ else:
 
 from .downloader import download, download_shell
 try:
-    import Tkinter
+    import tkinter
 except ImportError:
     pass
 else:

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -164,7 +164,7 @@ from hashlib import md5
 
 try:
     TKINTER = True
-    from Tkinter import (Tk, Frame, Label, Entry, Button, Canvas, Menu, IntVar,
+    from tkinter import (Tk, Frame, Label, Entry, Button, Canvas, Menu, IntVar,
                          TclError)
     from tkMessageBox import showerror
     from nltk.draw.table import Table

--- a/nltk/sem/drt.py
+++ b/nltk/sem/drt.py
@@ -22,9 +22,10 @@ from nltk.sem.logic import (APP, AbstractVariableExpression, AllExpression,
 
 # Import Tkinter-based modules if they are available
 try:
-    from Tkinter import Canvas
-    from Tkinter import Tk
-    from tkFont import Font
+    # imports are fixed for Python 2.x by nltk.compat
+    from tkinter import Canvas
+    from tkinter import Tk
+    from tkinter.font import Font
     from nltk.util import in_idle
 
 except ImportError:

--- a/nltk/sem/drt_glue_demo.py
+++ b/nltk/sem/drt_glue_demo.py
@@ -7,9 +7,11 @@
 # URL: <http://www.nltk.org/>
 # For license information, see LICENSE.TXT
 
-from tkFont import Font
+from nltk import compat  # this fixes tkinter imports for Python 2.x
 
-from Tkinter import (Button, Frame, IntVar, Label,
+from tkinter.font import Font
+
+from tkinter import (Button, Frame, IntVar, Label,
                      Listbox, Menu, Scrollbar, Tk)
 
 from nltk.draw.util import CanvasFrame, ShowText
@@ -448,7 +450,7 @@ class DrsWidget(object):
         self.bbox = (0, 0, 0, 0)
 
     def draw(self):
-        (right, bottom) = DrsDrawer(self._drs, canvas=self._canvas).draw();
+        (right, bottom) = DrsDrawer(self._drs, canvas=self._canvas).draw()
         self.bbox = (0, 0, right+1, bottom+1)
 
     def clear(self):


### PR DESCRIPTION
- Use lower-cased tkinter module name (uppercased may fail in Python 3.x on case-sensitive filesystems, and lower-cased tkinter it is fixed by nltk.compat for Python 2.x);
- imports in nltk.sem.drt_glue_demo are fixed (I didn't try the demo, but the code looks OK - I think it should work in 3.x as-is)
