### PR TITLE
HMM improvements

### DIFF
--- a/nltk/tag/hmm.py
+++ b/nltk/tag/hmm.py
@@ -280,7 +280,7 @@ class HiddenMarkovModelTagger(TaggerI):
 
     def _tag(self, unlabeled_sequence):
         path = self._best_path(unlabeled_sequence)
-        return list(zip(unlabeled_sequence, path))
+        return list(izip(unlabeled_sequence, path))
 
     def _output_logprob(self, state, symbol):
         """
@@ -315,9 +315,9 @@ class HiddenMarkovModelTagger(TaggerI):
         if not self._cache:
             N = len(self._states)
             M = len(self._symbols)
-            P = zeros(N, float32)
-            X = zeros((N, N), float32)
-            O = zeros((N, M), float32)
+            P = np.zeros(N, np.float32)
+            X = np.zeros((N, N), np.float32)
+            O = np.zeros((N, M), np.float32)
             for i in range(N):
                 si = self._states[i]
                 P[i] = self._priors.logprob(si)
@@ -357,6 +357,9 @@ class HiddenMarkovModelTagger(TaggerI):
                 for k in range(Q, M):
                     S[self._symbols[k]] = k
                 self._cache = (P, O, X, S)
+
+    def reset_cache(self):
+        self._cache = None
 
     def best_path(self, unlabeled_sequence):
         """
@@ -893,6 +896,8 @@ class HiddenMarkovModelTrainer(object):
         model._outputs = DictionaryConditionalProbDist(
             dict((s, MutableProbDist(model._outputs[s], self._symbols))
                  for s in self._states))
+
+        model.reset_cache()
 
         # iterate until convergence
         converged = False

--- a/nltk/tag/hmm.py
+++ b/nltk/tag/hmm.py
@@ -977,14 +977,29 @@ class HiddenMarkovModelTrainer(object):
             # use the calculated values to update the transition and output
             # probability values
             for i in range(N):
+                logprob_Ai = A_numer[i] - A_denom[i]
+                logprob_Bi = B_numer[i] - B_denom[i]
+
+                # We should normalize all probabilities (see p.391 Huang et al)
+                # Let sum(P) be K.
+                # We can divide each Pi by K to make sum(P) == 1.
+                #   Pi' = Pi/K
+                #   log2(Pi') = log2(Pi) - log2(K)
+                logprob_Ai -= _log_add(*logprob_Ai)
+                logprob_Bi -= _log_add(*logprob_Bi)
+
+                # print(logprob_Ai, logprob_Bi, _log_add(*logprob_Ai), _log_add(*logprob_Bi))
+
+                # update output and transition probabilities
                 si = self._states[i]
+
                 for j in range(N):
                     sj = self._states[j]
-                    model._transitions[si].update(sj, A_numer[i,j] -
-                                                  A_denom[i])
+                    model._transitions[si].update(sj, logprob_Ai[j])
+
                 for k in range(M):
                     ok = self._symbols[k]
-                    model._outputs[si].update(ok, B_numer[i,k] - B_denom[i])
+                    model._outputs[si].update(ok, logprob_Bi[k])
                 # Rabiner says the priors don't need to be updated. I don't
                 # believe him. FIXME
 

--- a/nltk/tag/hmm.py
+++ b/nltk/tag/hmm.py
@@ -889,7 +889,7 @@ class HiddenMarkovModelTrainer(object):
 
         N = len(self._states)
         M = len(self._symbols)
-        symbol_dict = dict((self._symbols[i], i) for i in range(M))
+        symbol_dict = dict((sym, i) for i, sym in enumerate(self._symbols))
 
         # update model prob dists so that they can be modified
         model._priors = MutableProbDist(model._priors, self._states)

--- a/nltk/tag/hmm.py
+++ b/nltk/tag/hmm.py
@@ -888,6 +888,14 @@ class HiddenMarkovModelTrainer(object):
             model = HiddenMarkovModelTagger(self._symbols, self._states,
                             transitions, outputs, priors)
 
+        else:
+            self._states = model._states
+            self._symbols = model._symbols
+
+        N = len(self._states)
+        M = len(self._symbols)
+        symbol_dict = dict((self._symbols[i], i) for i in range(M))
+
         # update model prob dists so that they can be modified
         model._priors = MutableProbDist(model._priors, self._states)
         model._transitions = DictionaryConditionalProbDist(

--- a/nltk/tag/hmm.py
+++ b/nltk/tag/hmm.py
@@ -89,10 +89,6 @@ from nltk.util import LazyMap
 from nltk.compat import python_2_unicode_compatible, izip, imap
 from nltk.tag.api import TaggerI, HiddenMarkovModelTaggerTransformI
 
-# won't work on Windows under Python 2.5, but we require Python 2.6
-# see http://bugs.python.org/issue1635
-_NINF = float('-inf')
-
 
 _TEXT = 0  # index of text in a tuple
 _TAG = 1   # index of tag in a tuple
@@ -665,8 +661,8 @@ class HiddenMarkovModelTagger(TaggerI):
 
         normalisation = _log_add(*log_probs)
 
-        probabilities = zeros((T, N), float64)
-        probabilities[:] = _NINF
+        probabilities = _ninf_array((T,N))
+
         for labelling, lp in zip(labellings, log_probs):
             lp -= normalisation
             for t, label in enumerate(labelling):
@@ -739,7 +735,7 @@ class HiddenMarkovModelTagger(TaggerI):
         for t in range(T-2, -1, -1):
             symbol = unlabeled_sequence[t+1][_TEXT]
             for i, si in enumerate(self._states):
-                beta[t, i] = _NINF
+                beta[t, i] = -np.inf
                 for j, sj in enumerate(self._states):
                     beta[t, i] = _log_add(beta[t, i],
                                           self._transitions[si].logprob(sj) +
@@ -1079,7 +1075,7 @@ class HiddenMarkovModelTrainer(object):
 
 def _ninf_array(shape):
     res = np.empty(shape, np.float64)
-    res.fill(_NINF)
+    res.fill(-np.inf)
     return res
 
 
@@ -1123,7 +1119,7 @@ def _log_add(*values):
     Adds the logged values, returning the logarithm of the addition.
     """
     x = max(values)
-    if x > _NINF:
+    if x > -np.inf:
         sum_diffs = 0
         for value in values:
             sum_diffs += 2**(value - x)

--- a/nltk/tag/hmm.py
+++ b/nltk/tag/hmm.py
@@ -870,10 +870,6 @@ class HiddenMarkovModelTrainer(object):
             allow convergence
         """
 
-        N = len(self._states)
-        M = len(self._symbols)
-        symbol_dict = dict((self._symbols[i], i) for i in range(M))
-
         # create a uniform HMM, which will be iteratively refined, unless
         # given an existing model
         model = kwargs.get('model')
@@ -888,9 +884,8 @@ class HiddenMarkovModelTrainer(object):
             model = HiddenMarkovModelTagger(self._symbols, self._states,
                             transitions, outputs, priors)
 
-        else:
-            self._states = model._states
-            self._symbols = model._symbols
+        self._states = model._states
+        self._symbols = model._symbols
 
         N = len(self._states)
         M = len(self._symbols)

--- a/nltk/test/unit/test_hmm.py
+++ b/nltk/test/unit/test_hmm.py
@@ -1,25 +1,85 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
-
 from nltk import hmm
 
+def _wikipedia_example_hmm():
+    # Example from wikipedia
+    # (http://en.wikipedia.org/wiki/Forward%E2%80%93backward_algorithm)
+
+    states = ['rain', 'no rain']
+    symbols = ['umbrella', 'no umbrella']
+
+    A = [[0.7, 0.3], [0.3, 0.7]]  # transition probabilities
+    B = [[0.9, 0.1], [0.2, 0.8]]  # emission probabilities
+    pi = [0.5, 0.5]  # initial probabilities
+
+    seq = ['umbrella', 'umbrella', 'no umbrella', 'umbrella', 'umbrella']
+    seq = list(zip(seq, [None]*len(seq)))
+
+    model = hmm._create_hmm_tagger(states, symbols, A, B, pi)
+    return model, states, symbols, seq
+
+
 def test_forward_probability():
-    import numpy as np
     from numpy.testing import assert_array_almost_equal
-    model, states, symbols = hmm._market_hmm_example()
 
     # example from p. 385, Huang et al
+    model, states, symbols = hmm._market_hmm_example()
     seq = [('up', None), ('up', None)]
-    expected = np.array([
+    expected = [
         [0.09, 0.02, 0.35],
         [0.0357, 0.0085, 0.1792]
-    ], np.float64)
+    ]
 
-    log_prob_matrix = model._forward_probability(seq)
-    prob_matrix = 2**log_prob_matrix
+    fp = 2**model._forward_probability(seq)
 
-    assert_array_almost_equal(prob_matrix, expected)
+    assert_array_almost_equal(fp, expected)
 
+
+def test_forward_probability2():
+    from numpy.testing import assert_array_almost_equal
+
+    model, states, symbols, seq = _wikipedia_example_hmm()
+    fp = 2**model._forward_probability(seq)
+
+    # examples in wikipedia are normalized
+    fp = (fp.T / fp.sum(axis=1)).T
+
+    # results are swapped to match our states order
+    # FIXME: is it possible to make order stable?
+    wikipedia_results = [
+        [0.1818, 0.8182],
+        [0.1166, 0.8834],
+        [0.8093, 0.1907],
+        [0.2692, 0.7308],
+        [0.1327, 0.8673],
+    ]
+
+    assert_array_almost_equal(wikipedia_results, fp, 4)
+
+
+def test_backward_probability():
+    from numpy.testing import assert_array_almost_equal
+
+    model, states, symbols, seq = _wikipedia_example_hmm()
+
+    bp = 2**model._backward_probability(seq)
+    # examples in wikipedia are normalized
+
+    bp = (bp.T / bp.sum(axis=1)).T
+
+    wikipedia_results = [
+        # Forward-backward algorithm doesn't need b0_5,
+        # so .backward_probability doesn't compute it.
+        # [0.3531, 0.6469],
+        [0.4077, 0.5923],
+        [0.6237, 0.3763],
+        [0.3467, 0.6533],
+        [0.3727, 0.6273],
+        [0.5, 0.5],
+    ]
+
+    assert_array_almost_equal(wikipedia_results, bp, 4)
 
 
 def setup_module(module):

--- a/nltk/test/unit/test_hmm.py
+++ b/nltk/test/unit/test_hmm.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
+
+from nltk import hmm
+
+def test_forward_probability():
+    import numpy as np
+    from numpy.testing import assert_array_almost_equal
+    model, states, symbols = hmm._market_hmm_example()
+
+    # example from p. 385, Huang et al
+    seq = [('up', None), ('up', None)]
+    expected = np.array([
+        [0.09, 0.02, 0.35],
+        [0.0357, 0.0085, 0.1792]
+    ], np.float64)
+
+    log_prob_matrix = model._forward_probability(seq)
+    prob_matrix = 2**log_prob_matrix
+
+    assert_array_almost_equal(prob_matrix, expected)
+
+
+
+def setup_module(module):
+    from nose import SkipTest
+    try:
+        import numpy
+    except ImportError:
+        raise SkipTest("numpy is required for nltk.test.test_hmm")


### PR DESCRIPTION
1. Faster HiddenMarkovModelTrainer.train_supervised (30-40x faster in demo_pos() example): HiddenMarkovModelTrainer._states and HiddenMarkovModelTrainer._symbols are lists so `if state not in self._states` and `if symbol not in self._symbols` are O(N). This is fixed by maintaining `known_symbols` and `known_states` sets.
2. more tests for HiddenMarkovModelTagger are added;
3. I think that probability calculations were incorrect for multiple observation sequences (they were not normalized);
4. when an initial model was passed to train_unsupervised the calculations were totally off because states and symbols of trainer and model was not the same - this is fixed; also, train_unsupervised didn't affect .tag if a model was used before (because of caching issues) - this is also fixed.
