### PR TITLE
train_unsupervised modification in initial probability matrix distributions

### DIFF
--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -650,6 +650,7 @@ class RandomProbDist(ProbDistI):
         self._probs = self.unirand(samples)
         self._samples = list(self._probs.keys())
 
+    @classmethod
     def unirand(self, samples):
         """
         The key function that creates a randomized initial distribution 

--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -651,7 +651,7 @@ class RandomProbDist(ProbDistI):
         self._samples = list(self._probs.keys())
 
     @classmethod
-    def unirand(self, samples):
+    def unirand(cls, samples):
         """
         The key function that creates a randomized initial distribution 
         that still sums to 1. Set as a dictionary of prob values so that 

--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -648,7 +648,7 @@ class RandomProbDist(ProbDistI):
             raise ValueError('A probability distribution must '+
                              'have at least one sample.')
         self._probs = self.unirand(samples)
-        self._samples = list(self._sampleset)
+        self._samples = list(self._probs.keys())
 
     def unirand(self, samples):
         """
@@ -662,10 +662,11 @@ class RandomProbDist(ProbDistI):
         for i, x in enumerate(randrow):
             randrow[i] = x/total
 
-        if sum(randrow) != 1:
+        total = sum(randrow)
+        if total != 1:
             #this difference, if present, is so small (near NINF) that it 
             #can be subtracted from any element without risking probs not (0 1)
-            randrow[-1] -= sum(randrow) - 1
+            randrow[-1] -= total - 1
 
         return dict((s, randrow[i]) for i, s in enumerate(samples))
 
@@ -676,7 +677,7 @@ class RandomProbDist(ProbDistI):
         return self._samples
 
     def __repr__(self):
-        return '<RandomUniformProbDist with %d samples>' %len(self._sampleset)
+        return '<RandomUniformProbDist with %d samples>' %len(self._probs)
 
 
 @compat.python_2_unicode_compatible

--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -620,6 +620,7 @@ class UniformProbDist(ProbDistI):
         if len(samples) == 0:
             raise ValueError('A Uniform probability distribution must '+
                              'have at least one sample.')
+        self._sampleset = set(samples)
         self._prob = 1.0/len(self._sampleset)
         self._samples = list(self._sampleset)
 

--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -620,7 +620,6 @@ class UniformProbDist(ProbDistI):
         if len(samples) == 0:
             raise ValueError('A Uniform probability distribution must '+
                              'have at least one sample.')
-        self._sampleset = set(samples)
         self._prob = 1.0/len(self._sampleset)
         self._samples = list(self._sampleset)
 
@@ -647,7 +646,6 @@ class RandomProbDist(ProbDistI):
         if len(samples) == 0: 
             raise ValueError('A probability distribution must '+
                              'have at least one sample.')
-        self._sampleset = set(samples)
         self._probs = self.unirand(samples)
         self._samples = list(self._sampleset)
 
@@ -664,20 +662,14 @@ class RandomProbDist(ProbDistI):
             randrow[i] = x/total
 
         if sum(randrow) != 1:
-            #this difference, if present, is so small (near NINF that it 
-            #can be subtracted from any element without risking negative probs)
+            #this difference, if present, is so small (near NINF) that it 
+            #can be subtracted from any element without risking probs not (0 1)
             randrow[-1] -= sum(randrow) - 1
 
         return dict((s, randrow[i]) for i, s in enumerate(samples))
 
     def prob(self, sample):
-        return (self._probs[sample] if sample in self._sampleset else 0)
-
-    def sum(self):
-        if not self._probs:
-            raise ValueError('no _probs defined, be sure to init using a'+
-                        'set of samples')
-        return sum([v for k, v in self._probs.iteritems()])
+        return self._probs.get(sample, 0)
 
     def samples(self):
         return self._samples

--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -636,6 +636,55 @@ class UniformProbDist(ProbDistI):
     def __repr__(self):
         return '<UniformProbDist with %d samples>' % len(self._sampleset)
 
+@compat.python_2_unicode_compatible
+class RandomProbDist(ProbDistI):
+    """
+    Generates a random probability distribution whereby each sample
+    will be between 0 and 1 with equal probability (uniform random distribution.
+    Also called a continuous uniform distribution).
+    """
+    def __init__(self, samples):
+        if len(samples) == 0: 
+            raise ValueError('A probability distribution must '+
+                             'have at least one sample.')
+        self._sampleset = set(samples)
+        self._probs = self.unirand(samples)
+        self._samples = list(self._sampleset)
+
+    def unirand(self, samples):
+        """
+        The key function that creates a randomized initial distribution 
+        that still sums to 1. Set as a dictionary of prob values so that 
+        it can still be passed to MutableProbDist and called with identical
+        syntax to UniformProbDist
+        """
+        randrow = [random.random() for i in range(len(samples))]
+        total = sum(randrow)
+        for i, x in enumerate(randrow):
+            randrow[i] = x/total
+
+        if sum(randrow) != 1:
+            #this difference, if present, is so small (near NINF that it 
+            #can be subtracted from any element without risking negative probs)
+            randrow[-1] -= sum(randrow) - 1
+
+        return dict((s, randrow[i]) for i, s in enumerate(samples))
+
+    def prob(self, sample):
+        return (self._probs[sample] if sample in self._sampleset else 0)
+
+    def sum(self):
+        if not self._probs:
+            raise ValueError('no _probs defined, be sure to init using a'+
+                        'set of samples')
+        return sum([v for k, v in self._probs.iteritems()])
+
+    def samples(self):
+        return self._samples
+
+    def __repr__(self):
+        return '<RandomUniformProbDist with %d samples>' %len(self._sampleset)
+
 
 @compat.python_2_unicode_compatible
 class DictionaryProbDist(ProbDistI):

--- a/nltk/tag/hmm.py
+++ b/nltk/tag/hmm.py
@@ -83,7 +83,7 @@ from nltk.probability import (FreqDist, ConditionalFreqDist,
                               ConditionalProbDist, DictionaryProbDist,
                               DictionaryConditionalProbDist,
                               LidstoneProbDist, MutableProbDist,
-                              MLEProbDist, RandomProbDist, )
+                              MLEProbDist, RandomProbDist)
 from nltk.metrics import accuracy
 from nltk.util import LazyMap
 from nltk.compat import python_2_unicode_compatible, izip, imap

--- a/nltk/tag/hmm.py
+++ b/nltk/tag/hmm.py
@@ -83,7 +83,7 @@ from nltk.probability import (FreqDist, ConditionalFreqDist,
                               ConditionalProbDist, DictionaryProbDist,
                               DictionaryConditionalProbDist,
                               LidstoneProbDist, MutableProbDist,
-                              MLEProbDist, UniformProbDist)
+                              MLEProbDist, RandomProbDist, )
 from nltk.metrics import accuracy
 from nltk.util import LazyMap
 from nltk.compat import python_2_unicode_compatible, izip, imap
@@ -870,12 +870,12 @@ class HiddenMarkovModelTrainer(object):
         # given an existing model
         model = kwargs.get('model')
         if not model:
-            priors = UniformProbDist(self._states)
+            priors = RandomProbDist(self._states)
             transitions = DictionaryConditionalProbDist(
-                            dict((state, UniformProbDist(self._states))
+                            dict((state, RandomProbDist(self._states))
                                   for state in self._states))
             outputs = DictionaryConditionalProbDist(
-                            dict((state, UniformProbDist(self._symbols))
+                            dict((state, RandomProbDist(self._symbols))
                                   for state in self._states))
             model = HiddenMarkovModelTagger(self._symbols, self._states,
                             transitions, outputs, priors)


### PR DESCRIPTION
In response to issue #373, have created a new probability class in probability.py called RandomProbDist, which initializes a uniform random distribution instead of a flat, equivalent distribution (i.e. all elements in prob matrix are equal). 

With a flat distribution, Baum-Welch algo will not update as it finds itself in a local minimum. With the default distributions now randomized, the algo will perform as expected, optimizing the `_transitions` and `_outputs` matrices and gradually decreasing in total logprob until tolerance is reached. 
