### PR TITLE
Faster Baum-Welch

### DIFF
--- a/nltk/tag/hmm.py
+++ b/nltk/tag/hmm.py
@@ -793,10 +793,10 @@ class HiddenMarkovModelTagger(TaggerI):
                     ' '.join('%s/%s' % (token, tag)
                               for (token, tag) in predicted_sent))
                 print()
-                # print('Entropy:',
-                #     self.entropy([(token, None) for
-                #                   (token, tag) in predicted_sent]))
-                # print()
+                print('Entropy:',
+                    self.entropy([(token, None) for
+                                  (token, tag) in predicted_sent]))
+                print()
                 print('-' * 60)
 
         test_tags = flatten(imap(tags, test_sequence))

--- a/nltk/tag/hmm.py
+++ b/nltk/tag/hmm.py
@@ -1218,7 +1218,7 @@ def _untag(sentences):
         unlabeled.append([(token[_TEXT], None) for token in sentence])
     return unlabeled
 
-def demo_pos_bw(test=10, supervised=200, unsupervised=10, verbose=True,
+def demo_pos_bw(test=10, supervised=20, unsupervised=10, verbose=True,
                 max_iterations=5):
     # demonstrates the Baum-Welch algorithm in POS tagging
 
@@ -1226,7 +1226,7 @@ def demo_pos_bw(test=10, supervised=200, unsupervised=10, verbose=True,
     print("Baum-Welch demo for POS tagging")
     print()
 
-    print('Training HMM (supervised)...')
+    print('Training HMM (supervised, %d sentences)...' % supervised)
 
     sentences, tag_set, symbols = load_pos(test + supervised + unsupervised)
 
@@ -1239,9 +1239,9 @@ def demo_pos_bw(test=10, supervised=200, unsupervised=10, verbose=True,
     hmm = trainer.train_supervised(sentences[test:test+supervised],
                     estimator=lambda fd, bins: LidstoneProbDist(fd, 0.1, bins))
 
-    # hmm.test(sentences[:test], verbose=verbose)
+    hmm.test(sentences[:test], verbose=verbose)
 
-    print('Training (unsupervised)...')
+    print('Training (unsupervised, %d sentences)...' % unsupervised)
     # it's rather slow - so only use 10 samples by default
     unlabeled = _untag(sentences[test+supervised:])
     hmm = trainer.train_unsupervised(unlabeled, model=hmm,

--- a/nltk/tag/hmm.py
+++ b/nltk/tag/hmm.py
@@ -607,10 +607,10 @@ class HiddenMarkovModelTagger(TaggerI):
 
         log_probs = []
         for labelling in labellings:
-            labelled_sequence = unlabeled_sequence[:]
+            labeled_sequence = unlabeled_sequence[:]
             for t, label in enumerate(labelling):
-                labelled_sequence[t] = (labelled_sequence[t][_TEXT], label)
-            lp = self.log_probability(labelled_sequence)
+                labeled_sequence[t] = (labeled_sequence[t][_TEXT], label)
+            lp = self.log_probability(labeled_sequence)
             log_probs.append(lp)
         normalisation = _log_add(*log_probs)
 
@@ -810,7 +810,7 @@ class HiddenMarkovModelTrainer(object):
         self._states = (states if states else [])
         self._symbols = (symbols if symbols else [])
 
-    def train(self, labelled_sequences=None, unlabeled_sequences=None,
+    def train(self, labeled_sequences=None, unlabeled_sequences=None,
               **kwargs):
         """
         Trains the HMM using both (or either of) supervised and unsupervised
@@ -826,10 +826,10 @@ class HiddenMarkovModelTrainer(object):
         :type unlabeled_sequences: list
         :param kwargs: additional arguments to pass to the training methods
         """
-        assert labelled_sequences or unlabeled_sequences
+        assert labeled_sequences or unlabeled_sequences
         model = None
-        if labelled_sequences:
-            model = self.train_supervised(labelled_sequences, **kwargs)
+        if labeled_sequences:
+            model = self.train_supervised(labeled_sequences, **kwargs)
         if unlabeled_sequences:
             if model: kwargs['model'] = model
             model = self.train_unsupervised(unlabeled_sequences, **kwargs)

--- a/nltk/tag/hmm.py
+++ b/nltk/tag/hmm.py
@@ -74,7 +74,6 @@ import itertools
 
 try:
     import numpy as np
-    from numpy import zeros, ones, float32, float64, log2, hstack, array, argmax
 except ImportError:
     pass
 
@@ -337,7 +336,7 @@ class HiddenMarkovModelTagger(TaggerI):
                 Q = O.shape[1]
                 # add new columns to the output probability table without
                 # destroying the old probabilities
-                O = hstack([O, zeros((N, M - Q), float32)])
+                O = np.hstack([O, np.zeros((N, M - Q), np.float32)])
                 for i in range(N):
                     si = self._states[i]
                     # only calculate probabilities for new symbols
@@ -379,11 +378,11 @@ class HiddenMarkovModelTagger(TaggerI):
         for t in range(1, T):
             for j in range(N):
                 vs = V[t-1, :] + X[:, j]
-                best = argmax(vs)
+                best = np.argmax(vs)
                 V[t, j] = vs[best] + O[j, S[unlabeled_sequence[t]]]
                 B[t, j] = best
 
-        current = argmax(V[T-1,:])
+        current = np.argmax(V[T-1,:])
         sequence = [current]
         for t in range(T-1, 0, -1):
             last = B[t, current]
@@ -581,8 +580,8 @@ class HiddenMarkovModelTagger(TaggerI):
         beta = self._backward_probability(unlabeled_sequence)
         normalisation = _log_add(*alpha[T-1, :])
 
-        entropies = zeros(T, float64)
-        probs = zeros(N, float64)
+        entropies = np.zeros(T, np.float64)
+        probs = np.zeros(N, np.float64)
         for t in range(T):
             for s in range(N):
                 probs[s] = alpha[t, s] + beta[t, s] - normalisation
@@ -663,7 +662,7 @@ class HiddenMarkovModelTagger(TaggerI):
                 index = self._states.index(label)
                 probabilities[t, index] = _log_add(probabilities[t, index], lp)
 
-        entropies = zeros(T, float64)
+        entropies = np.zeros(T, np.float64)
         for t in range(T):
             for s in range(N):
                 entropies[t] -= 2**(probabilities[t, s]) * probabilities[t, s]
@@ -723,7 +722,7 @@ class HiddenMarkovModelTagger(TaggerI):
         beta = np.zeros((T, N), np.float64)
 
         # initialise the backward values
-        beta[T-1, :] = log2(1)
+        beta[T-1, :] = np.log2(1)
 
         # inductively calculate remaining backward values
         for t in range(T-2, -1, -1):
@@ -1082,7 +1081,7 @@ def _log_add(*values):
         sum_diffs = 0
         for value in values:
             sum_diffs += 2**(value - x)
-        return x + log2(sum_diffs)
+        return x + np.log2(sum_diffs)
     else:
         return x
 

--- a/nltk/tag/hmm.py
+++ b/nltk/tag/hmm.py
@@ -258,7 +258,7 @@ class HiddenMarkovModelTagger(TaggerI):
             return p
         else:
             alpha = self._forward_probability(sequence)
-            p = _log_add(*alpha[T-1, :])
+            p = logsumexp2(alpha[T-1])
             return p
 
     def tag(self, unlabeled_sequence):
@@ -541,7 +541,7 @@ class HiddenMarkovModelTagger(TaggerI):
 
         alpha = self._forward_probability(unlabeled_sequence)
         beta = self._backward_probability(unlabeled_sequence)
-        normalisation = _log_add(*alpha[T-1, :])
+        normalisation = logsumexp2(alpha[T-1])
 
         entropy = normalisation
 
@@ -585,7 +585,7 @@ class HiddenMarkovModelTagger(TaggerI):
 
         alpha = self._forward_probability(unlabeled_sequence)
         beta = self._backward_probability(unlabeled_sequence)
-        normalisation = _log_add(*alpha[T-1, :])
+        normalisation = logsumexp2(alpha[T-1])
 
         entropies = np.zeros(T, np.float64)
         probs = np.zeros(N, np.float64)
@@ -1008,10 +1008,8 @@ class HiddenMarkovModelTrainer(object):
                 # We can divide each Pi by K to make sum(P) == 1.
                 #   Pi' = Pi/K
                 #   log2(Pi') = log2(Pi) - log2(K)
-                logprob_Ai -= _log_add(*logprob_Ai)
-                logprob_Bi -= _log_add(*logprob_Bi)
-
-                # print(logprob_Ai, logprob_Bi, _log_add(*logprob_Ai), _log_add(*logprob_Bi))
+                logprob_Ai -= logsumexp2(logprob_Ai)
+                logprob_Bi -= logsumexp2(logprob_Bi)
 
                 # update output and transition probabilities
                 si = self._states[i]

--- a/nltk/tag/hmm.py
+++ b/nltk/tag/hmm.py
@@ -94,13 +94,6 @@ _TAG = 1   # index of tag in a tuple
 def _identity(labeled_symbols):
     return labeled_symbols
 
-try:
-    from nltk_speed.math import logsumexp2
-except ImportError:
-    def logsumexp2(arr):
-        max_ = arr.max()
-        return np.log2(np.sum(2**(arr - max_))) + max_
-
 
 @python_2_unicode_compatible
 class HiddenMarkovModelTagger(TaggerI):
@@ -1104,22 +1097,23 @@ def _ninf_array(shape):
     return res
 
 
-try:
-    from nltk_speed.math import log_add as _log_add
-    # raise ImportError()
-except ImportError:
-    def _log_add(*values):
-        """
-        Adds the logged values, returning the logarithm of the addition.
-        """
-        x = max(values)
-        if x > -np.inf:
-            sum_diffs = 0
-            for value in values:
-                sum_diffs += 2**(value - x)
-            return x + np.log2(sum_diffs)
-        else:
-            return x
+def logsumexp2(arr):
+    max_ = arr.max()
+    return np.log2(np.sum(2**(arr - max_))) + max_
+
+
+def _log_add(*values):
+    """
+    Adds the logged values, returning the logarithm of the addition.
+    """
+    x = max(values)
+    if x > -np.inf:
+        sum_diffs = 0
+        for value in values:
+            sum_diffs += 2**(value - x)
+        return x + np.log2(sum_diffs)
+    else:
+        return x
 
 
 def _create_hmm_tagger(states, symbols, A, B, pi):


### PR DESCRIPTION
In this pull request most calculations required for HiddenMarkovModelTrainer.train_unsupervised are vectorized; this makes train_unsupervised about 30x faster (number is for demo_pos_bw example).
