### PR TITLE
More efficient FreqDist._Nr_cache

### DIFF
--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -211,14 +211,14 @@ class FreqDist(dict):
         if self._Nr_cache is None:
             self._cache_Nr_values()
 
-        return (self._Nr_cache[r] if r < len(self._Nr_cache) else 0)
+        return self._Nr_cache.get(r, 0)
 
     def _cache_Nr_values(self):
-        Nr = [0]
+        Nr = defaultdict(int)
         for sample in self:
             c = self.get(sample, 0)
-            if c >= len(Nr):
-                Nr += [0]*(c+1-len(Nr))
+            if c == 0 and c not in Nr:
+                continue
             Nr[c] += 1
         self._Nr_cache = Nr
 

--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -213,6 +213,14 @@ class FreqDist(dict):
 
         return self._Nr_cache.get(r, 0)
 
+    def _Nr_nonzero(self):
+        """
+        Return (r, Nr(r)) tuples for all r such as Nr(r) > 0 (sorted by r).
+        """
+        if self._Nr_cache is None:
+            self._cache_Nr_values()
+        return sorted(self._Nr_cache.items())
+
     def _cache_Nr_values(self):
         Nr = defaultdict(int)
         for sample in self:
@@ -1449,16 +1457,7 @@ class SimpleGoodTuringProbDist(ProbDistI):
         """
         Split the frequency distribution in two list (r, Nr), where Nr(r) > 0
         """
-        r, nr = [], []
-        b, i = 0, 0
-        while b != self._freqdist.B():
-            nr_i = self._freqdist.Nr(i)
-            if nr_i > 0:
-                b += nr_i
-                r.append(i)
-                nr.append(nr_i)
-            i += 1
-        return (r, nr)
+        return zip(*self._freqdist._Nr_nonzero())
 
     def find_best_fit(self, r, nr):
         """

--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -1457,7 +1457,7 @@ class SimpleGoodTuringProbDist(ProbDistI):
         """
         Split the frequency distribution in two list (r, Nr), where Nr(r) > 0
         """
-        return zip(*self._freqdist._Nr_nonzero())
+        return zip(*self._freqdist._Nr_nonzero()) or ([], [])
 
     def find_best_fit(self, r, nr):
         """


### PR DESCRIPTION
FreqDist._Nr_cache is very sparse in real word. E.g. for Brown corpus there is only 553 non-zero values and 62160 zero values; for bigger corpora issue is worse, e.g. Russian Wikipedia has < 10K non-zero values and > 11M zero values.

Storing numbers in Python list is also quite inefficient: list of integers is an array of pointers to integers (and each integer is a Python object with a pointer to type and a refcount number). 

This change saves me about 100M of memory for FreqDist with unigrams from Russian Wikipedia (and a full _Nr_cache - SimpleGoodTuringProbDist fills it).
