### PR TITLE
add a __reduce__ method to ConditionalFreqDist so that it's pickle-able

### DIFF
--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -1854,6 +1854,13 @@ class ConditionalFreqDist(defaultdict):
             for (cond, sample) in cond_samples:
                 self[cond].inc(sample)
 
+    def __reduce__(self):
+        cond_samples = []
+        for condition in self.conditions():
+            cond_samples.extend([(condition, sample)
+                                 for sample in self[condition].samples()])
+        return (self.__class__, (cond_samples,))
+
     def conditions(self):
         """
         Return a list of the conditions that have been accessed for


### PR DESCRIPTION
At the moment, ConditionalFreqDist isn't pickle-able, but this patch makes it work with pickle.

This little script breaks when trying to unpickle on the current master, but works with the patch.

``` python
import nltk
import pickle

cfd = nltk.probability.ConditionalFreqDist()
cfd['foo'].inc('hello')
with open("cfd.pickle", "wb") as outfile:
    pickle.dump(cfd, outfile)
with open("cfd.pickle", "rb") as infile:
    cfd2 = pickle.load(infile)
```
