### PR TITLE
Check the type of start in ContextFreeGrammar.__init__(): fixes #337

### DIFF
--- a/nltk/grammar.py
+++ b/nltk/grammar.py
@@ -439,6 +439,10 @@ class ContextFreeGrammar(object):
             leftcorner relation. In that case, some optimized chart parsers won't work.
         :type calculate_leftcorners: bool
         """
+        if not is_nonterminal(start):
+            raise TypeError("start should be a Nonterminal object,"
+                            " not a %s" % type(start).__name__)
+
         self._start = start
         self._productions = productions
         self._categories = set(prod.lhs() for prod in productions)


### PR DESCRIPTION
As discussed in #337. I've had a look at how argument checking is done in the rest of the code base now, and raising a `TypeError` seems to be in line with how incorrect arguments are usually dealt with.
