### PR TITLE
ConditionalFreqDist should remember how many times each sample happened, not just that it happened

### DIFF
--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -1855,11 +1855,8 @@ class ConditionalFreqDist(defaultdict):
                 self[cond].inc(sample)
 
     def __reduce__(self):
-        cond_samples = []
-        for condition in self.conditions():
-            cond_samples.extend([(condition, sample)
-                                 for sample in self[condition].samples()])
-        return (self.__class__, (cond_samples,))
+        kv_pairs = [(cond, self[cond]) for cond in self.conditions()]
+        return (self.__class__, (), None, None, iter(kv_pairs))
 
     def conditions(self):
         """

--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -1855,8 +1855,8 @@ class ConditionalFreqDist(defaultdict):
                 self[cond].inc(sample)
 
     def __reduce__(self):
-        kv_pairs = [(cond, self[cond]) for cond in self.conditions()]
-        return (self.__class__, (), None, None, iter(kv_pairs))
+        kv_pairs = ((cond, self[cond]) for cond in self.conditions())
+        return (self.__class__, (), None, None, kv_pairs)
 
     def conditions(self):
         """

--- a/nltk/test/probability.doctest
+++ b/nltk/test/probability.doctest
@@ -253,6 +253,8 @@ can be pickled:
     True
     >>> cfd = nltk.probability.ConditionalFreqDist()
     >>> cfd['foo'].inc('hello')
+    >>> cfd['foo'].inc('hello')
+    >>> cfd['bar'].inc('hello')
     >>> cfd2 = pickle.loads(pickle.dumps(cfd))
     >>> cfd2 == cfd
     True


### PR DESCRIPTION
Sorry, #389 I only stored each condition and each sample that happened with it. But we should have been storing the FreqDist objects themselves, because they store the _count_ of the individual samples.

(the `__init__` method on ConditionalFreqDist isn't all that useful...) 
