### PR TITLE
Make ConditionalProbDist pickle-able by adding a __missing__ method

### DIFF
--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -2087,15 +2087,11 @@ class ConditionalProbDist(ConditionalProbDistI):
         self._factory_args = factory_args
         self._factory_kw_args = factory_kw_args
 
-        ## factory = lambda: probdist_factory(FreqDist(),
-        ##                                   *factory_args, **factory_kw_args)
-        ## defaultdict.__init__(self, factory)
         for condition in cfdist:
             self[condition] = probdist_factory(cfdist[condition],
                                                *factory_args, **factory_kw_args)
 
     def __missing__(self, key):
-        print("YEEEAAAHHH!")
         self[key] = self._probdist_factory(FreqDist(),
                                            *self._factory_args,
                                            **self._factory_kw_args)

--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -2083,18 +2083,23 @@ class ConditionalProbDist(ConditionalProbDistI):
         :type factory_kw_args: (any)
         :param factory_kw_args: Extra keyword arguments for ``probdist_factory``.
         """
-        # self._probdist_factory = probdist_factory
-        # self._cfdist = cfdist
-        # self._factory_args = factory_args
-        # self._factory_kw_args = factory_kw_args
+        self._probdist_factory = probdist_factory
+        self._factory_args = factory_args
+        self._factory_kw_args = factory_kw_args
 
-        factory = lambda: probdist_factory(FreqDist(),
-                                           *factory_args, **factory_kw_args)
-        defaultdict.__init__(self, factory)
+        ## factory = lambda: probdist_factory(FreqDist(),
+        ##                                   *factory_args, **factory_kw_args)
+        ## defaultdict.__init__(self, factory)
         for condition in cfdist:
             self[condition] = probdist_factory(cfdist[condition],
                                                *factory_args, **factory_kw_args)
 
+    def __missing__(self, key):
+        print("YEEEAAAHHH!")
+        self[key] = self._probdist_factory(FreqDist(),
+                                           *self._factory_args,
+                                           **self._factory_kw_args)
+        return self[key]
 
 class DictionaryConditionalProbDist(ConditionalProbDistI):
     """

--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -1990,7 +1990,7 @@ class ConditionalFreqDist(defaultdict):
 
 
 @compat.python_2_unicode_compatible
-class ConditionalProbDistI(defaultdict):
+class ConditionalProbDistI(dict):
     """
     A collection of probability distributions for a single experiment
     run under different conditions.  Conditional probability
@@ -2109,11 +2109,11 @@ class DictionaryConditionalProbDist(ConditionalProbDistI):
             by the conditions
         :type probdist_dict: dict any -> probdist
         """
-        defaultdict.__init__(self, DictionaryProbDist)
         self.update(probdist_dict)
 
-    def __reduce__(self):
-        return self.__class__, (self.items(),),
+    def __missing__(self, key):
+        self[key] = DictionaryProbDist()
+        return self[key]
 
 ##//////////////////////////////////////////////////////
 ## Adding in log-space.

--- a/nltk/test/probability.doctest
+++ b/nltk/test/probability.doctest
@@ -238,8 +238,8 @@ they don't get smoothed
     >>> p.prob('foobar')
     0.022727272727272728...
 
-``MLEProbDist``, ``DictionaryConditionalProbDist`` and ``ConditionalFreqDist``
-can be pickled:
+``MLEProbDist``, ``ConditionalProbDist'', ``DictionaryConditionalProbDist`` and
+``ConditionalFreqDist`` can be pickled:
 
     >>> import pickle
     >>> pd = MLEProbDist(fd)
@@ -257,6 +257,10 @@ can be pickled:
     >>> cfd['bar'].inc('hello')
     >>> cfd2 = pickle.loads(pickle.dumps(cfd))
     >>> cfd2 == cfd
+    True
+    >>> cpd = ConditionalProbDist(cfd, SimpleGoodTuringProbDist)
+    >>> cpd2 = pickle.loads(pickle.dumps(cpd))
+    >>> cpd['foo'].prob('hello') == cpd2['foo'].prob('hello')
     True
 
 


### PR DESCRIPTION
This should fix #393. Now the ConditionalProbDist objects don't have to hang on to a lambda.
