### PR TITLE
make nltk.tag.simplify_brown_tag not map -- to the empty string

### DIFF
--- a/nltk/tag/simplify.py
+++ b/nltk/tag/simplify.py
@@ -16,7 +16,8 @@ brown_mapping1 = {
     'h': 'V', 'f': 'FW', 'a': 'DET', 't': 'TO',
     'cc': 'CNJ', 'cs': 'CNJ', 'cd': 'NUM',
     'do': 'V', 'dt': 'DET',
-    'nn': 'N', 'nr': 'N', 'np': 'NP', 'nc': 'N'
+    'nn': 'N', 'nr': 'N', 'np': 'NP', 'nc': 'N',
+    '--': '--'
     }
 brown_mapping2 = {
     'vb': 'V', 'vbd': 'VD', 'vbg': 'VG', 'vbn': 'VN'


### PR DESCRIPTION
There are some tokens in the Brown corpus with the tag `--`, and this tag gets mapped to the empty string by nltk.tag.simplify_brown_tag.

``` python
## currently gives you empty string
nltk.tag.simplify_brown_tag("--")
```

But that shouldn't be! It's getting into the branch where it checks whether there's a dash in the tag. This patch avoids that branch by just adding `--` into the Brown tag map.
