### PR TITLE
Correct tnt.train() initialization (fix #398)

### DIFF
--- a/nltk/tag/tnt.py
+++ b/nltk/tag/tnt.py
@@ -140,7 +140,7 @@ class TnT(TaggerI):
             self._unk.train(data)
 
         for sent in data:
-            history = ['BOS', 'BOS']
+            history = [('BOS',False), ('BOS',False)]
             for w, t in sent:
 
                 # if capitalization is requested,


### PR DESCRIPTION
In train(), history should be a list of string/boolean pairs but it gets initialized to a list of strings.  This was okay (but still not right) in python2, but causes an exception in python3.
