### PR TITLE
fix file descriptor leak when writing to megam training file

### DIFF
--- a/nltk/classify/maxent.py
+++ b/nltk/classify/maxent.py
@@ -1366,6 +1366,7 @@ def train_maxent_classifier_with_megam(train_toks, trace=3, encoding=None,
         write_megam_file(train_toks, encoding, trainfile, \
                             explicit=explicit, bernoulli=bernoulli)
         trainfile.close()
+        os.close(fd)
     except (OSError, IOError, ValueError) as e:
         raise ValueError('Error while creating megam training file: %s' % e)
 


### PR DESCRIPTION
Currently if you train a lot of megam classifiers, you'll eventually run out of file handles!

This is because we weren't closing a file handle when we do a tempfile.mkstemp. This patch fixes that.
