### PR TITLE
Added java.exe as alternate binary name for Java

### DIFF
--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -438,7 +438,6 @@ def find_file(filename, env_vars=(), searchpath=(),
     :param url: URL presented to user for download help.
     :param verbose: Whether or not to print path when a file is found.
     """
-    if file_names is None: file_names = [filename]
     file_names = [filename] + (file_names or [])
     assert isinstance(filename, compat.string_types)
     assert not isinstance(file_names, compat.string_types)
@@ -448,10 +447,9 @@ def find_file(filename, env_vars=(), searchpath=(),
 
     # File exists, no magic
     for alternative in file_names:
-        # Check if the 'alternative' is a file extension
         path_to_file = os.path.join(filename, alternative)
         if os.path.isfile(path_to_file):
-            if verbose: print('[Found %s: %s]' % (filename, alternative))
+            if verbose: print('[Found %s: %s]' % (filename, path_to_file))
             return path_to_file
         # Check the bare alternatives
         if os.path.isfile(alternative):

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -62,7 +62,8 @@ def convert_regexp_to_nongrouping(pattern):
         \\.           |  # Backslashed character
         \(\?P<[^>]*>  |  # Named group
         \(\?          |  # Extension group
-        \(               # Grouping parenthesis''', subfunc, pattern)
+        \(               # Grouping parenthesis
+        ''', subfunc, pattern)
 
 
 ##########################################################################
@@ -438,6 +439,7 @@ def find_file(filename, env_vars=(), searchpath=(),
     :param verbose: Whether or not to print path when a file is found.
     """
     if file_names is None: file_names = [filename]
+    elif filename not in file_names: file_names.append(filename)
     assert isinstance(filename, compat.string_types)
     assert not isinstance(file_names, compat.string_types)
     assert not isinstance(searchpath, compat.string_types)
@@ -445,39 +447,20 @@ def find_file(filename, env_vars=(), searchpath=(),
         env_vars = env_vars.split()
 
     # File exists, no magic
-    if os.path.isfile(filename):
-        if verbose: print('[Found %s: %s]' % (filename, filename))
-        return filename
     for alternative in file_names:
-        path_to_file = os.path.join(filename, alternative)
-        if os.path.isfile(path_to_file):
-            if verbose: print('[Found %s: %s]' % (alternative, path_to_file))
-            return path_to_file
-        path_to_file = os.path.join(filename, 'file', alternative)
-        if os.path.isfile(path_to_file):
-            if verbose: print('[Found %s: %s]' % (alternative, path_to_file))
-            return path_to_file
+        if os.path.isfile(alternative):
+            if verbose: print('[Found %s: %s]' % (alternative, alternative))
+            return alternative
 
     # Check environment variables
     for env_var in env_vars:
         if env_var in os.environ:
             for env_dir in os.environ[env_var].split(os.pathsep):
-                path_to_file = os.path.join(env_dir, filename)
-                if os.path.isfile(path_to_file):
-                    if verbose: print('[Found %s: %s]' % (filename, env_dir))
-                    return path_to_file
-                else:
-                    for alternative in file_names:
-                        path_to_file = os.path.join(env_dir,
-                                                    alternative)
-                        if os.path.isfile(path_to_file):
-                            if verbose: print('[Found %s: %s]'%(filename, path_to_file))
-                            return path_to_file
-                        path_to_file = os.path.join(env_dir, 'file',
-                                                    alternative)
-                        if os.path.isfile(path_to_file):
-                            if verbose: print('[Found %s: %s]'%(filename, path_to_file))
-                            return path_to_file
+                for alternative in file_names:
+                    path_to_file = os.path.join(env_dir, alternative)
+                    if os.path.isfile(path_to_file):
+                        if verbose: print('[Found %s: %s]'%(alternative, path_to_file))
+                        return path_to_file
 
     # Check the path list.
     for directory in searchpath:
@@ -485,7 +468,6 @@ def find_file(filename, env_vars=(), searchpath=(),
             path_to_file = os.path.join(directory, alternative)
             if os.path.isfile(path_to_file):
                 return path_to_file
-
 
     # If we're on a POSIX system, then try using the 'which' command
     # to find the file.

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -90,7 +90,7 @@ def config_java(bin=None, options=None, verbose=True):
     :type options: list(str)
     """
     global _java_bin, _java_options
-    _java_bin = find_binary('java', bin, env_vars=['JAVAHOME', 'JAVA_HOME'], verbose=verbose)
+    _java_bin = find_binary('java', bin, env_vars=['JAVAHOME', 'JAVA_HOME'], verbose=verbose, binary_names=['java.exe'])
 
     if options is not None:
         if isinstance(options, compat.string_types):

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -475,6 +475,11 @@ def find_file(filename, env_vars=(), searchpath=(),
                     if os.path.isfile(path_to_file):
                         if verbose: print('[Found %s: %s]'%(filename, path_to_file))
                         return path_to_file
+                    # Check if the alternative is inside a 'file' directory
+                    path_to_file = os.path.join(env_dir, 'file', alternative)
+                    if os.path.isfile(path_to_file):
+                        if verbose: print('[Found %s: %s]' % (filename, path_to_file))
+                        return path_to_file
 
     # Check the path list.
     for directory in searchpath:

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -451,32 +451,33 @@ def find_file(filename, env_vars=(), searchpath=(),
     for alternative in file_names:
         path_to_file = os.path.join(filename, alternative)
         if os.path.isfile(path_to_file):
-            if verbose: print('[Found %s: %s]' % (filename, path_to_file))
+            if verbose: print('[Found %s: %s]' % (alternative, path_to_file))
             return path_to_file
         path_to_file = os.path.join(filename, 'file', alternative)
         if os.path.isfile(path_to_file):
-            if verbose: print('[Found %s: %s]' % (filename, path_to_file))
+            if verbose: print('[Found %s: %s]' % (alternative, path_to_file))
             return path_to_file
 
     # Check environment variables
     for env_var in env_vars:
         if env_var in os.environ:
-            path_to_file = os.environ[env_var]
-            if os.path.isfile(path_to_file):
-                if verbose: print('[Found %s: %s]' % (filename, path_to_file))
-                return path_to_file
-            else:
-                for alternative in file_names:
-                    path_to_file = os.path.join(os.environ[env_var],
-                                                alternative)
-                    if os.path.isfile(path_to_file):
-                        if verbose: print('[Found %s: %s]'%(filename, path_to_file))
-                        return path_to_file
-                    path_to_file = os.path.join(os.environ[env_var], 'file',
-                                                alternative)
-                    if os.path.isfile(path_to_file):
-                        if verbose: print('[Found %s: %s]'%(filename, path_to_file))
-                        return path_to_file
+            for env_dir in os.environ[env_var].split(os.pathsep):
+                path_to_file = os.path.join(env_dir, filename)
+                if os.path.isfile(path_to_file):
+                    if verbose: print('[Found %s: %s]' % (filename, env_dir))
+                    return path_to_file
+                else:
+                    for alternative in file_names:
+                        path_to_file = os.path.join(env_dir,
+                                                    alternative)
+                        if os.path.isfile(path_to_file):
+                            if verbose: print('[Found %s: %s]'%(filename, path_to_file))
+                            return path_to_file
+                        path_to_file = os.path.join(env_dir, 'file',
+                                                    alternative)
+                        if os.path.isfile(path_to_file):
+                            if verbose: print('[Found %s: %s]'%(filename, path_to_file))
+                            return path_to_file
 
     # Check the path list.
     for directory in searchpath:


### PR DESCRIPTION
2 Commits:
1) Fix a bug where setting JAVA_HOME and/or JAVAHOME in Windows does not find the java executable (add java.exe as an alternate name for java).
2) environment vars were not split and looped
