### PR TITLE
Remove unnecessary conditional imports

### DIFF
--- a/nltk/classify/__init__.py
+++ b/nltk/classify/__init__.py
@@ -91,24 +91,8 @@ from nltk.classify.positivenaivebayes import PositiveNaiveBayesClassifier
 from nltk.classify.decisiontree import DecisionTreeClassifier
 from nltk.classify.rte_classify import rte_classifier, rte_features, RTEFeatureExtractor
 from nltk.classify.util import accuracy, apply_features, log_likelihood
-
-# Conditional imports
-
-try:
-    from .scikitlearn import SklearnClassifier
-except ImportError:
-    pass
-
-try:
-    import numpy
-    from nltk.classify.maxent import (MaxentClassifier, BinaryMaxentFeatureEncoding,
-                                      TypedMaxentFeatureEncoding,
-                                      ConditionalExponentialClassifier)
-except ImportError:
-    pass
-
-try:
-    import svmlight
-    from nltk.classify.svm import SvmClassifier
-except ImportError:
-    pass
+from nltk.classify.scikitlearn import SklearnClassifier
+from nltk.classify.maxent import (MaxentClassifier, BinaryMaxentFeatureEncoding,
+                                  TypedMaxentFeatureEncoding,
+                                  ConditionalExponentialClassifier)
+from nltk.classify.svm import SvmClassifier

--- a/nltk/tag/__init__.py
+++ b/nltk/tag/__init__.py
@@ -74,15 +74,10 @@ from nltk.tag.tnt        import TnT
 from nltk.tag.hunpos     import HunposTagger
 from nltk.tag.stanford   import StanfordTagger
 from nltk.tag.crf        import MalletCRF
+from nltk.tag.hmm        import HiddenMarkovModelTagger, HiddenMarkovModelTrainer
 
-from nltk.data      import load
+from nltk.data import load
 
-# Import hmm module if numpy is installed
-try:
-    import numpy
-    from nltk.tag.hmm import HiddenMarkovModelTagger, HiddenMarkovModelTrainer
-except ImportError:
-    pass
 
 # Standard treebank POS tagger
 _POS_TAGGER = 'taggers/maxent_treebank_pos_tagger/english.pickle'

--- a/nltk/tokenize/__init__.py
+++ b/nltk/tokenize/__init__.py
@@ -57,13 +57,7 @@ from nltk.tokenize.regexp   import (RegexpTokenizer, WhitespaceTokenizer,
 from nltk.tokenize.punkt    import PunktSentenceTokenizer, PunktWordTokenizer
 from nltk.tokenize.sexpr    import SExprTokenizer, sexpr_tokenize
 from nltk.tokenize.treebank import TreebankWordTokenizer
-
-try:
-    import numpy
-except ImportError:
-    pass
-else:
-    from nltk.tokenize.texttiling import TextTilingTokenizer
+from nltk.tokenize.texttiling import TextTilingTokenizer
 
 # Standard sentence tokenizer.
 def sent_tokenize(text):


### PR DESCRIPTION
In this pull requests some conditional imports are removed. They are no longer necessary (as numpy imports are protected by try/except since https://github.com/nltk/nltk/commit/73906dcce7e1552de277dcfdcca30e358f433319). 

This should make exception messages more informative and prevent issues like http://stackoverflow.com/questions/15320894/python-importerror-maxentclassifier/15321784.

This change doesn't break any tests for me (including tests in environments without numpy & friends).
