### PR TITLE
Small improvements to the collocation finders

### DIFF
--- a/nltk/collocations.py
+++ b/nltk/collocations.py
@@ -127,6 +127,7 @@ class BigramCollocationFinder(AbstractCollocationFinder):
     """A tool for the finding and ranking of bigram collocations or other
     association measures. It is often useful to use from_words() rather than
     constructing an instance directly.
+    """
 
     def __init__(self, word_fd, bigram_fd, window_size=2):
         """Construct a TrigramCollocationFinder, given FreqDists for

--- a/nltk/collocations.py
+++ b/nltk/collocations.py
@@ -39,6 +39,7 @@ from nltk.util import ingrams
 from nltk.metrics import ContingencyMeasures, BigramAssocMeasures, TrigramAssocMeasures
 from nltk.metrics.spearman import ranks_from_scores, spearman_correlation
 
+
 class AbstractCollocationFinder(object):
     """
     An abstract base class for collocation finders whose purpose is to
@@ -130,9 +131,8 @@ class BigramCollocationFinder(AbstractCollocationFinder):
     """
 
     def __init__(self, word_fd, bigram_fd, window_size=2):
-        """Construct a TrigramCollocationFinder, given FreqDists for
-        appearances of words, bigrams, two words with any word between them,
-        and trigrams.
+        """Construct a BigramCollocationFinder, given FreqDists for
+        appearances of words and (possibly non-contiguous) bigrams.
         """
         AbstractCollocationFinder.__init__(self, word_fd, bigram_fd)
         self.window_size = window_size
@@ -140,8 +140,8 @@ class BigramCollocationFinder(AbstractCollocationFinder):
     @classmethod
     def from_words(cls, words, window_size=2):
         """Construct a BigramCollocationFinder for all bigrams in the given
-        sequence.  When window_size > 2, count non-contiguous bigrams, in the 
-        style of Church and Hanks's (1990) association ratio. 
+        sequence.  When window_size > 2, count non-contiguous bigrams, in the
+        style of Church and Hanks's (1990) association ratio.
         """
         wfd = FreqDist()
         bfd = FreqDist()
@@ -155,11 +155,12 @@ class BigramCollocationFinder(AbstractCollocationFinder):
             for w2 in window[1:]:
                 if w2 is not None:
                     bfd.inc((w1, w2))
-        return cls(wfd, bfd)
+        return cls(wfd, bfd, window_size=window_size)
 
     def score_ngram(self, score_fn, w1, w2):
         """Returns the score for a given bigram using the given scoring
-        function.
+        function.  Following Church and Hanks (1990), counts are scaled by 
+        a factor of 1/(window_size - 1).
         """
         n_all = self.word_fd.N()
         n_ii = self.ngram_fd[(w1, w2)] / (self.window_size - 1.0)

--- a/nltk/collocations.py
+++ b/nltk/collocations.py
@@ -229,7 +229,7 @@ class TrigramCollocationFinder(AbstractCollocationFinder):
 
 
 def demo(scorer=None, compare_scorer=None):
-    """Finds trigram collocations in the files of the WebText corpus."""
+    """Finds bigram collocations in the files of the WebText corpus."""
     from nltk.metrics import BigramAssocMeasures, spearman_correlation, ranks_from_scores
 
     if scorer is None:

--- a/nltk/metrics/association.py
+++ b/nltk/metrics/association.py
@@ -217,8 +217,8 @@ class BigramAssocMeasures(NgramAssocMeasures):
     @classmethod
     def fisher(cls, *marginals):
         """Scores bigrams using Fisher's Exact Test (Pedersen 1996).  Less
-           sensitive to small counts than PMI or Chi Sq, but also more expensive
-           to compute.
+        sensitive to small counts than PMI or Chi Sq, but also more expensive
+        to compute. Requires scipy.
         """
 
         n_ii, n_io, n_oi, n_oo = cls._contingency(*marginals)

--- a/nltk/metrics/association.py
+++ b/nltk/metrics/association.py
@@ -23,8 +23,8 @@ _SMALL = 1e-20
 try:
     from scipy.stats import fisher_exact
 except ImportError:
-    pass    
-
+    pass
+    
 ### Indices to marginals arguments:
 
 NGRAM = 0
@@ -215,14 +215,15 @@ class BigramAssocMeasures(NgramAssocMeasures):
         return n_xx * cls.phi_sq(n_ii, (n_ix, n_xi), n_xx)
 
     @classmethod
-    def fisher(cls,*marginals):
-        """Scores bigrams using Fisher's Exact Test (Pedersen 1996).  Less sensitive to 
-        small counts that PMI or Chi Sq, but also more expensive to compute.    
+    def fisher(cls, *marginals):
+        """Scores bigrams using Fisher's Exact Test (Pedersen 1996).  Less
+           sensitive to small counts than PMI or Chi Sq, but also more expensive
+           to compute.
         """
 
         n_ii, n_io, n_oi, n_oo = cls._contingency(*marginals)
 
-        (odds,pvalue) = fisher_exact([[n_ii,n_io],[n_oi,n_oo]],alternative='less')
+        (odds, pvalue) = fisher_exact([[n_ii, n_io], [n_oi, n_oo]], alternative='less')
         return pvalue
 
     @staticmethod

--- a/nltk/metrics/association.py
+++ b/nltk/metrics/association.py
@@ -20,6 +20,10 @@ _product = lambda s: reduce(lambda x, y: x * y, s)
 
 _SMALL = 1e-20
 
+try:
+    from scipy.stats import fisher_exact
+except ImportError:
+    pass    
 
 ### Indices to marginals arguments:
 
@@ -209,6 +213,17 @@ class BigramAssocMeasures(NgramAssocMeasures):
         """
         (n_ix, n_xi) = n_ix_xi_tuple
         return n_xx * cls.phi_sq(n_ii, (n_ix, n_xi), n_xx)
+
+    @classmethod
+    def fisher(cls,*marginals):
+        """Scores bigrams using Fisher's Exact Test (Pedersen 1996).  Less sensitive to 
+        small counts that PMI or Chi Sq, but also more expensive to compute.    
+        """
+
+        n_ii, n_io, n_oi, n_oo = cls._contingency(*marginals)
+
+        (odds,pvalue) = fisher_exact([[n_ii,n_io],[n_oi,n_oo]],alternative='less')
+        return pvalue
 
     @staticmethod
     def dice(n_ii, n_ix_xi_tuple, n_xx):

--- a/nltk/metrics/association.py
+++ b/nltk/metrics/association.py
@@ -143,7 +143,7 @@ class NgramAssocMeasures(object):
 
 class BigramAssocMeasures(NgramAssocMeasures):
     """
-    A collection of trigram association measures. Each association measure
+    A collection of bigram association measures. Each association measure
     is provided as a function with three arguments::
 
         bigram_score_fn(n_ii, (n_ix, n_xi), n_xx)

--- a/nltk/test/unit/test_collocations.py
+++ b/nltk/test/unit/test_collocations.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
+
+from nltk.collocations import BigramCollocationFinder
+
+def test_bigram2():
+
+    sent = 'this this is is a a test test'.split()
+
+    b = BigramCollocationFinder.from_words(sent)
+    assert b.ngram_fd.items() == \
+        [(('a', 'a'), 1), (('a', 'test'), 1), (('is', 'a'), 1), (('is', 'is'), 1), (('test', 'test'), 1), (('this', 'is'), 1), (('this', 'this'), 1)]
+    assert b.word_fd.items() == \
+        [('a', 2), ('is', 2), ('test', 2), ('this', 2)]
+    assert len(sent) == sum(b.word_fd.values()) == sum(b.ngram_fd.values()) + 1
+
+def test_bigram3():
+
+    sent = 'this this is is a a test test'.split()
+
+    b = BigramCollocationFinder.from_words(sent,window_size=3)
+    assert b.ngram_fd.items() == \
+        [(('a', 'test'), 3), (('is', 'a'), 3), (('this', 'is'), 3), (('a', 'a'), 1), (('is', 'is'), 1), (('test', 'test'), 1), (('this', 'this'), 1)]
+    assert b.word_fd.items() == \
+        [('a', 2), ('is', 2), ('test', 2), ('this', 2)]
+    assert len(sent) == sum(b.word_fd.values()) == (sum(b.ngram_fd.values()) + 2 + 1) / 2.0
+
+def test_bigram5():
+
+    sent = 'this this is is a a test test'.split()
+
+    b = BigramCollocationFinder.from_words(sent,window_size=5)
+    assert b.ngram_fd.items() == \
+        [(('a', 'test'), 4), (('is', 'a'), 4), (('this', 'is'), 4), (('is', 'test'), 3), (('this', 'a'), 3), (('a', 'a'), 1), (('is', 'is'), 1), (('test', 'test'), 1), (('this', 'this'), 1)]
+    assert b.word_fd.items() == \
+        [('a', 2), ('is', 2), ('test', 2), ('this', 2)]
+    assert len(sent) == sum(b.word_fd.values()) == (sum(b.ngram_fd.values()) + 4 + 3 + 2 + 1) / 4.0
+

--- a/nltk/test/unit/test_collocations.py
+++ b/nltk/test/unit/test_collocations.py
@@ -2,6 +2,23 @@
 from __future__ import absolute_import, unicode_literals
 
 from nltk.collocations import BigramCollocationFinder
+from nltk.metrics import BigramAssocMeasures
+
+## Test bigram counters with discontinuous bigrams and repeated words
+
+_EPSILON = 1e-8
+
+
+def close_enough(x, y):
+    """Verify that two sequences of n-gram association values are within
+       _EPSILON of each other.
+    """
+
+    for (x1, y1) in zip(x, y):
+        if x1[0] != y1[0] or abs(x1[1] - y1[1]) > _EPSILON:
+            return False
+    return True
+
 
 def test_bigram2():
 
@@ -13,26 +30,33 @@ def test_bigram2():
     assert b.word_fd.items() == \
         [('a', 2), ('is', 2), ('test', 2), ('this', 2)]
     assert len(sent) == sum(b.word_fd.values()) == sum(b.ngram_fd.values()) + 1
+    assert close_enough(b.score_ngrams(BigramAssocMeasures.pmi), \
+        [(('a', 'a'), 1.0), (('a', 'test'), 1.0), (('is', 'a'), 1.0), (('is', 'is'), 1.0), (('test', 'test'), 1.0), (('this', 'is'), 1.0), (('this', 'this'), 1.0)])
+
 
 def test_bigram3():
 
     sent = 'this this is is a a test test'.split()
 
-    b = BigramCollocationFinder.from_words(sent,window_size=3)
+    b = BigramCollocationFinder.from_words(sent, window_size=3)
     assert b.ngram_fd.items() == \
         [(('a', 'test'), 3), (('is', 'a'), 3), (('this', 'is'), 3), (('a', 'a'), 1), (('is', 'is'), 1), (('test', 'test'), 1), (('this', 'this'), 1)]
     assert b.word_fd.items() == \
         [('a', 2), ('is', 2), ('test', 2), ('this', 2)]
     assert len(sent) == sum(b.word_fd.values()) == (sum(b.ngram_fd.values()) + 2 + 1) / 2.0
+    assert close_enough(b.score_ngrams(BigramAssocMeasures.pmi),
+        [(('a', 'test'), 1.584962500721156), (('is', 'a'), 1.584962500721156), (('this', 'is'), 1.584962500721156), (('a', 'a'), 0.0), (('is', 'is'), 0.0), (('test', 'test'), 0.0), (('this', 'this'), 0.0)])
+
 
 def test_bigram5():
 
     sent = 'this this is is a a test test'.split()
 
-    b = BigramCollocationFinder.from_words(sent,window_size=5)
+    b = BigramCollocationFinder.from_words(sent, window_size=5)
     assert b.ngram_fd.items() == \
         [(('a', 'test'), 4), (('is', 'a'), 4), (('this', 'is'), 4), (('is', 'test'), 3), (('this', 'a'), 3), (('a', 'a'), 1), (('is', 'is'), 1), (('test', 'test'), 1), (('this', 'this'), 1)]
     assert b.word_fd.items() == \
         [('a', 2), ('is', 2), ('test', 2), ('this', 2)]
     assert len(sent) == sum(b.word_fd.values()) == (sum(b.ngram_fd.values()) + 4 + 3 + 2 + 1) / 4.0
-
+    assert close_enough(b.score_ngrams(BigramAssocMeasures.pmi),
+        [(('a', 'test'), 1.0), (('is', 'a'), 1.0), (('this', 'is'), 1.0), (('is', 'test'), 0.5849625007211562), (('this', 'a'), 0.5849625007211562), (('a', 'a'), -1.0), (('is', 'is'), -1.0), (('test', 'test'), -1.0), (('this', 'this'), -1.0)])


### PR DESCRIPTION
Correct some typos, add Fisher's exact test to the set of association metrics, and improve handling of non-contiguous bigrams (see #403).
