### PR TITLE
Proposed resolution for issue 395

### DIFF
--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -298,7 +298,6 @@ class Synset(_WordNetObject):
     - root_hypernyms
     - common_hypernyms
     - lowest_common_hypernyms
-    - relative_lowest_common_hypernyms
 
     Note that Synsets do not support the following relations because
     these are defined by WordNet as lexical relations:
@@ -451,11 +450,12 @@ class Synset(_WordNetObject):
                            for other_synset in other_synsets)
         return list(self_synsets.intersection(other_synsets))
 
-    def lowest_common_hypernyms(self, other, simulate_root=False):
+    def lowest_common_hypernyms(self, other, simulate_root=False, use_max_depth=False):
         """Get a list of absolute lowest synset(s) that both synsets have as a hypernym.
 
-        This is calculated by finding the shortest paths for all synsets that are hypernyms
-        of both words, and returning that with the longest path."""
+        By default this is calculated by finding the shortest paths for all synsets that are hypernyms
+        of both words, and returning that with the longest path. By setting use_max_depth=True, lower 
+        hypernyms can be found."""
 
         fake_synset = Synset(None)
         fake_synset.name = '*ROOT*'
@@ -474,40 +474,14 @@ class Synset(_WordNetObject):
         synsets.intersection_update(others)
 
         try:
-            max_depth = max(s.min_depth() for s in synsets)
-            return [s for s in synsets if s.min_depth() == max_depth]
+            if use_max_depth:
+                max_depth = max(s.max_depth() for s in synsets)
+                return [s for s in synsets if s.max_depth() == max_depth]
+            else:
+                max_depth = max(s.min_depth() for s in synsets)
+                return [s for s in synsets if s.min_depth() == max_depth]
         except ValueError:
             return []
-
-    def relative_lowest_common_hypernyms(self, other, simulate_root=False):
-        """Get a list of the lowest synset(s) that both synsets have as a hypernym, relative
-        to the hypernym paths of this synset.
-
-        This compares the hypernym paths of this synset with those of the other word.
-        The lowest hypernym from each path of this word that appears in a hypernym path
-        of the other word is returned."""
-
-        fake_synset = Synset(None)
-        fake_synset.name = '*ROOT*'
-        fake_synset.hypernyms = lambda: []
-        fake_synset.instance_hypernyms = lambda: []
-
-        if simulate_root:
-            self_hypernyms = chain(self.hypernym_paths(), [[fake_synset]])
-            other_hypernyms = chain(other.hypernym_paths(), [[fake_synset]])
-        else:
-            self_hypernyms = self.hypernym_paths()
-            other_hypernyms = other.hypernym_paths()
-
-        results = []
-        for self_path in self_hypernyms:
-            for other_path in other_hypernyms:
-                for s in self_path[::-1]:
-                    if s in other_path:
-                        results.append(s)
-                        break
-
-        return list(set(results))
 
     def hypernym_distances(self, distance=0, simulate_root=False):
         """

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -453,9 +453,29 @@ class Synset(_WordNetObject):
     def lowest_common_hypernyms(self, other, simulate_root=False, use_max_depth=False):
         """Get a list of absolute lowest synset(s) that both synsets have as a hypernym.
 
-        By default this is calculated by finding the shortest paths for all synsets that are hypernyms
-        of both words, and returning that with the longest path. By setting use_max_depth=True, lower 
-        hypernyms can be found."""
+        By default this is calculated by finding the shortest paths for all synsets that 
+        are hypernyms of both words, and returning that with the longest path.
+
+        By setting the use_max_depth flag to True, lower hypernyms can be found by searching for the 
+        longest paths of each hypernym.
+
+        :type other: Synset
+        :param other: other input synset
+        :type simulate_root: bool
+        :param simulate_root: The various verb taxonomies do not
+            share a single root which disallows this metric from working for
+            synsets that are not connected. This flag (False by default)
+            creates a fake root that connects all the taxonomies. Set it
+            to True to enable this behavior. For the noun taxonomy,
+            there is usually a default root except for WordNet version 1.6.
+            If you are using wordnet 1.6, a fake root will need to be added 
+            for nouns as well.
+        :type use_max_depth: bool
+        :param use_max_depth: If True, will use the max_depth function to 
+            calculate the lowest common hypernyms giving results that should
+            be lower in the tree than when using the default settings.
+        :return: The synsets that are the lowest common hypernyms of both synsets
+        """
 
         fake_synset = Synset(None)
         fake_synset.name = '*ROOT*'


### PR DESCRIPTION
See [Issue 395](https://github.com/nltk/nltk/issues/395)

Currently lowest common hypernyms do not return a result based on the
hypernym paths of the 2 synsets. So there may be a "better" result when
taking into account the hypernym paths.

```
>>> from nltk.corpus import wordnet as wn
>>> wn.synset('policeman.n.01').relative_lowest_common_hypernyms(wn.synset('chef.n.01'))
[Synset('person.n.01')]
>>> wn.synset('policeman.n.01').lowest_common_hypernyms(wn.synset('chef.n.01'))
[Synset('organism.n.01')]
```

I'm not sure if this will be considered useful or not, but I thought this approach might make sense. Of course, I'm open to changes and suggestions.
