### PR TITLE
Fix detect_encoding regex in corpus.reader.xmldocs.XMLCorpusView

### DIFF
--- a/nltk/corpus/reader/xmldocs.py
+++ b/nltk/corpus/reader/xmldocs.py
@@ -170,9 +170,9 @@ class XMLCorpusView(StreamBackedCorpusView):
             return 'utf-32-le'
         if s.startswith(codecs.BOM_UTF8):
             return 'utf-8'
-        m = re.match(br'\s*<?xml\b.*\bencoding="([^"]+)"', s)
+        m = re.match(br'\s*<\?xml\b.*\bencoding="([^"]+)"', s)
         if m: return m.group(1)
-        m = re.match(br"\s*<?xml\b.*\bencoding='([^']+)'", s)
+        m = re.match(br"\s*<\?xml\b.*\bencoding='([^']+)'", s)
         if m: return m.group(1)
         # No encoding found -- what should the default be?
         return 'utf-8'


### PR DESCRIPTION
corpus.reader.xmldocs.XMLCorpusView includes a function to read the file encoding out of the XML declaration on the first line of a corpus file.

Unfortunately, this function relies on regular expressions which contain a simple syntax error.  Instead of searching for r'<?xml' we should look for r'<\?xml' (i.e., the question mark character should be a literal).
