### PR TITLE
Speed Improvements in GAAClusterer

### DIFF
--- a/nltk/cluster/gaac.py
+++ b/nltk/cluster/gaac.py
@@ -60,7 +60,7 @@ class GAAClusterer(VectorSpaceClusterer):
                 print("merging %d and %d" % (i, j))
 
             # update similarities for merging i and j
-            self._average_link(dist, cluster_len, i, j)
+            self._merge_similarities(dist, cluster_len, i, j)
 
             # remove j
             dist[:, j] = numpy.inf
@@ -78,7 +78,7 @@ class GAAClusterer(VectorSpaceClusterer):
 
         self.update_clusters(self._num_clusters)
 
-    def _average_link(self, dist, cluster_len, i, j):
+    def _merge_similarities(self, dist, cluster_len, i, j):
         # the new cluster i merged from i and j adopts the average of
         # i and j's similarity to each other cluster, weighted by the
         # number of points in the clusters i and j

--- a/nltk/cluster/gaac.py
+++ b/nltk/cluster/gaac.py
@@ -5,7 +5,6 @@
 # URL: <http://www.nltk.org/>
 # For license information, see LICENSE.TXT
 from __future__ import print_function, unicode_literals
-import copy
 
 try:
     import numpy
@@ -42,35 +41,49 @@ class GAAClusterer(VectorSpaceClusterer):
         return VectorSpaceClusterer.cluster(self, vectors, assign_clusters, trace)
 
     def cluster_vectorspace(self, vectors, trace=False):
-        # create a cluster for each vector
-        clusters = [[vector] for vector in vectors]
+        # variables describing the initial situation
+        N = len(vectors)
+        cluster_len = [1]*N
+        cluster_count = N
+        index_map = range(N)
+        
+        # construct the similarity matrix
+        dims = (N,N)
+        sim = numpy.ones(dims,dtype=numpy.float)*numpy.NINF
+        for i in xrange(N):
+            for j in xrange(i+1,N):
+                sim[ i,j ] = self._average_similarity(vectors[i],1,vectors[j],1)
+        
+        while cluster_count > max(self._num_clusters, 1):
+            i,j = numpy.unravel_index(sim.argmax(),dims)
+            if trace: print("merging %d and %d" % (i,j))
 
-        # the sum vectors
-        vector_sum = copy.copy(vectors)
+            # update similarities
+            cli = cluster_len[i]
+            clj = cluster_len[j]
+            cl = cli+clj
 
-        while len(clusters) > max(self._num_clusters, 1):
-            # find the two best candidate clusters to merge, based on their
-            # S(union c_i, c_j)
-            best = None
-            for i in range(len(clusters)):
-                for j in range(i + 1, len(clusters)):
-                    sim = self._average_similarity(
-                                vector_sum[i], len(clusters[i]),
-                                vector_sum[j], len(clusters[j]))
-                    if not best or sim > best[0]:
-                        best = (sim, i, j)
+            # update for x<i
+            sim[ :i,i ] = (sim[ :i,i ]*cli + sim[ :i, j ]*clj)/cl
+            # update for i<x<j
+            sim[ i,i+1:j ] = (sim[ i,i+1:j ]*cli + sim[ i+1:j, j ]*clj)/cl
+            # update for i<j<x
+            sim[ i,j+1: ] = (sim[ i,j+1: ]*cli + sim[j,j+1:]*clj)/cl
 
-            # merge them and replace in cluster list
-            i, j = best[1:]
-            sum = clusters[i] + clusters[j]
-            if trace: print('merging %d and %d' % (i, j))
+            # remove j
+            sim[ :,j ] = numpy.NINF
+            sim[ j,: ] = numpy.NINF
+                
+            # merge the clusters
+            cluster_len[i] = cl
+            self._dendrogram.merge(index_map[i],index_map[j])
+            cluster_count -= 1
 
-            clusters[i] = sum
-            del clusters[j]
-            vector_sum[i] = vector_sum[i] + vector_sum[j]
-            del vector_sum[j]
-
-            self._dendrogram.merge(i, j)
+            # update the index map to reflect the indexes if we
+            # had removed j
+            for x in xrange(j+1,N):
+                index_map[x] -= 1
+            index_map[j] = -1
 
         self.update_clusters(self._num_clusters)
 

--- a/nltk/cluster/gaac.py
+++ b/nltk/cluster/gaac.py
@@ -46,17 +46,20 @@ class GAAClusterer(VectorSpaceClusterer):
         cluster_len = [1]*N
         cluster_count = N
         index_map = range(N)
-        
+
         # construct the similarity matrix
-        dims = (N,N)
-        sim = numpy.ones(dims,dtype=numpy.float)*numpy.NINF
+        dims = (N, N)
+        sim = numpy.ones(dims, dtype=numpy.float)*numpy.NINF
         for i in xrange(N):
-            for j in xrange(i+1,N):
-                sim[ i,j ] = self._average_similarity(vectors[i],1,vectors[j],1)
-        
+            for j in xrange(i+1, N):
+                sim[i, j] = self._average_similarity(
+                    vectors[i], 1,
+                    vectors[j], 1)
+
         while cluster_count > max(self._num_clusters, 1):
-            i,j = numpy.unravel_index(sim.argmax(),dims)
-            if trace: print("merging %d and %d" % (i,j))
+            i, j = numpy.unravel_index(sim.argmax(), dims)
+            if trace:
+                print("merging %d and %d" % (i, j))
 
             # update similarities
             cli = cluster_len[i]
@@ -64,24 +67,24 @@ class GAAClusterer(VectorSpaceClusterer):
             cl = cli+clj
 
             # update for x<i
-            sim[ :i,i ] = (sim[ :i,i ]*cli + sim[ :i, j ]*clj)/cl
+            sim[:i, i] = (sim[:i, i]*cli + sim[:i, j]*clj)/cl
             # update for i<x<j
-            sim[ i,i+1:j ] = (sim[ i,i+1:j ]*cli + sim[ i+1:j, j ]*clj)/cl
+            sim[i, i+1:j] = (sim[i, i+1:j]*cli + sim[i+1:j, j]*clj)/cl
             # update for i<j<x
-            sim[ i,j+1: ] = (sim[ i,j+1: ]*cli + sim[j,j+1:]*clj)/cl
+            sim[i, j+1:] = (sim[i, j+1:]*cli + sim[j, j+1:]*clj)/cl
 
             # remove j
-            sim[ :,j ] = numpy.NINF
-            sim[ j,: ] = numpy.NINF
-                
+            sim[:, j] = numpy.NINF
+            sim[j, :] = numpy.NINF
+
             # merge the clusters
             cluster_len[i] = cl
-            self._dendrogram.merge(index_map[i],index_map[j])
+            self._dendrogram.merge(index_map[i], index_map[j])
             cluster_count -= 1
 
             # update the index map to reflect the indexes if we
             # had removed j
-            for x in xrange(j+1,N):
+            for x in xrange(j+1, N):
                 index_map[x] -= 1
             index_map[j] = -1
 


### PR DESCRIPTION
I have added a similarity matrix to avoid recomputing the similarities. In addition the matrix update is done in a vectorized fashion to get the maximum NumPy has to offer.

The only thing that has been touched is the function cluster_vectorspace.

The result is more than 100 times faster clustering. It is an improvement (by better utilizing NumPy) from what is [mentioned to the nltk-dev group](https://groups.google.com/d/msg/nltk-dev/7D2ZTePSGFs/A83wLEm3AWIJ) as "First take on the problem".
