### PR TITLE
Added checking for zero depth in lch_similarity

### DIFF
--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -659,7 +659,7 @@ class Synset(_WordNetObject):
 
         distance = self.shortest_path_distance(other, simulate_root=simulate_root and need_root)
 
-        if distance is None or distance < 0:
+        if distance is None or distance < 0 or depth == 0:
             return None
         return -math.log((distance + 1) / (2.0 * depth))
 


### PR DESCRIPTION
lch_similarity method raises a ZeroDivisionError when a synset has no hypernyms, since LCH distance is -log(p/2d), so when d == 0, it throws a ZeroDivisionError.

I added checking for when depth == 0 and had the function return None in this case, as LCH similarity is undefined in this instance.
