### PR TITLE
Explicitly mention setuptools 0.6 in install.rst

### DIFF
--- a/web/install.rst
+++ b/web/install.rst
@@ -8,7 +8,7 @@ Mac/Unix
 --------
 
 #. Open ``Finder>Applications>Utilities>Terminal`` and type ``python -V`` to find out what version of Python is installed
-#. Install Setuptools: Download the corresponding version of Setuptools from
+#. Install Setuptools: Download the corresponding version of Setuptools 0.6 from
    http://pypi.python.org/pypi/setuptools (scroll to the bottom, and pick the filename that contains the right version number and which has the extension .egg).  Install it by typing ``sudo sh Downloads/setuptools-...egg``, giving the location of the downloaded file.
 #. Install Pip: run ``sudo easy_install pip``
 #. Install Numpy (optional): run ``sudo pip install -U numpy``


### PR DESCRIPTION
Setuptools merged with Distribute in 0.7. I think setup.py needs to be migrated to 0.7? This should make it clearer for people installing right now: https://github.com/nltk/nltk/issues/424
