### PR TITLE
made codebase sensitive to the current python version

### DIFF
--- a/nltk/test/runtests.py
+++ b/nltk/test/runtests.py
@@ -61,7 +61,7 @@ if __name__ == '__main__':
         #'--debug=nose,nose.importer,nose.inspector,nose.plugins,nose.result,nose.selector',
         '--doctest-extension=.doctest',
         '--doctest-fixtures=_fixt',
-        '--doctest-options=+ELLIPSIS,+NORMALIZE_WHITESPACE,+IGNORE_EXCEPTION_DETAIL,+ALLOW_UNICODE',
+        '--doctest-options=+ELLIPSIS,+NORMALIZE_WHITESPACE,+IGNORE_EXCEPTION_DETAIL,+ALLOW_UNICODE,doctestencoding=utf-8',
         #'--verbosity=3',
     ] + args
 


### PR DESCRIPTION
...ing on the current python version

use http://nltk.github.com/nltk_data/ or http://nltk.github.com/nltk_data_3/ as the download url depending on the current python version
reuse code from nltk.data to get the default download path, if no existing nltk data directories are present
