### PR TITLE
improve word_tokenize speed

### DIFF
--- a/nltk/tokenize/treebank.py
+++ b/nltk/tokenize/treebank.py
@@ -83,8 +83,8 @@ class TreebankWordTokenizer(TokenizerI):
         text = re.sub(r'(\S)(\'\')', r'\1 \2 ', text)
 
         text = re.sub(r"([^' ])('[sS]|'[mM]|'[dD]|') ", r"\1 \2 ", text)
-        text = re.sub(r"([^' ])('ll|'re|'ve|n't|) ", r"\1 \2 ", text)
-        text = re.sub(r"([^' ])('LL|'RE|'VE|N'T|) ", r"\1 \2 ", text)
+        text = re.sub(r"([^' ])('ll|'LL|'re|'RE|'ve|'VE|n't|N'T) ", r"\1 \2 ",
+                      text)
 
         for regexp in self.CONTRACTIONS2:
             text = regexp.sub(r' \1 \2 ', text)
@@ -96,14 +96,8 @@ class TreebankWordTokenizer(TokenizerI):
         # for regexp in self.CONTRACTIONS4:
         #     text = regexp.sub(r' \1 \2 \3 ', text)
 
-        text = re.sub(" +", " ", text)
-        text = text.strip()
-
-        #add space at end to match up with MacIntyre's output (for debugging)
-        if text != "":
-            text += " "
-
         return text.split()
+
 
 if __name__ == "__main__":
     import doctest


### PR DESCRIPTION
Runs roughly twice as fast on my test set of 40000 sentences. According to [kernprof](http://pythonhosted.org/line_profiler/), the culprits of the previously bad performance were

```
r"([^' ])('ll|'re|'ve|n't|) "
```

and

```
r"([^' ])('LL|'RE|'VE|N'T|) "
```

which were matching almost all words due to the | at the end.

Also removed some useless whitespace handling that was being undone by the `str.split` just before return.

The contractions handling is now the slowest part @~20% of the time.

Tests pass.
