### PR TITLE
installation via puppet

### DIFF
--- a/web/data.rst
+++ b/web/data.rst
@@ -47,3 +47,17 @@ Windows: Use the "Run..." option on the Start menu.  Windows Vista users need to
 Test the installation: Check that the user environment and privileges are set correctly by logging in to a user account,
 starting the Python interpreter, and accessing the Brown Corpus (see the previous section).
 
+.. _puppet_data_installation:
+
+Puppet installation
+-------------------
+
+If you are provisioning many machines with NLTK, it can be convenient
+to use a tool like puppet to download any necessary data on each of
+these machines in a predictable and automated way. The `puppet NLTK
+project <http://forge.puppetlabs.com/DsA/nltk>`_ provides this
+functionality and can be used to install specific corpi (e.g.,
+stopwords) with simple one-liners like::
+
+    puppet::downloader { "stopwords": }
+

--- a/web/install.rst
+++ b/web/install.rst
@@ -38,3 +38,12 @@ Source installation (for 32-bit or 64-bit Windows)
 #. Install PyYAML and NLTK: ``Start>Run... c:\Python27\Scripts\pip install pyyaml nltk``
 #. Test installation: ``Start>All Programs>Python27>IDLE``, then type ``import nltk``
 
+Installation via puppet
+~~~~~~~~~~~~~~~~~~~~~~~
+
+NLTK can also be conveniently `installed via puppet
+<http://forge.puppetlabs.com/DsA/nltk>`_, which has some convenience
+functionality for :ref:`downloading data
+<puppet_data_installation>`. This can be very advantageous when
+installing NLTK on a large number of machines on which you want to
+provision consistent software.


### PR DESCRIPTION
I'm not sure if this is the best place to put this or whether this is even the appropriate forum for it, but I thought that the NLTK user community would like to know about (and contribute to) the [puppet-nltk project](https://github.com/datascopeanalytics/puppet-nltk) that we are working on to make it easy to install nltk on many machines in an automated and reliable way. 

If there is a better place to include this or a better forum for this kind of thing, please let me know and I'm happy to use that alternative channel instead. 
