### PR TITLE
More efficient batch_parse for MaltParser

### DIFF
--- a/nltk/parse/dependencygraph.py
+++ b/nltk/parse/dependencygraph.py
@@ -11,8 +11,7 @@
 """
 Tools for reading and writing dependency trees.
 The input is assumed to be in Malt-TAB format
-(http://w3.msi.vxu.se/~nivre/research/MaltXML.html).
-Currently only reads the first tree in a file.
+(http://stp.lingfil.uu.se/~nivre/research/MaltXML.html).
 """
 from __future__ import print_function, unicode_literals
 
@@ -121,9 +120,11 @@ class DependencyGraph(object):
     def load(file):
         """
         :param file: a file in Malt-TAB format
+        :return: a list of DependencyGraphs
         """
         with open(file) as f:
-            return DependencyGraph(f.read())
+            return [DependencyGraph(tree_str) for tree_str in
+                                                  f.read().split('\n\n')]
 
     @staticmethod
     def _normalize(line):

--- a/nltk/parse/malt.py
+++ b/nltk/parse/malt.py
@@ -97,8 +97,22 @@ class MaltParser(ParserI):
         :type sentence: list(str)
         :return: ``DependencyGraph`` the dependency graph representation of the sentence
         """
-        taggedwords = self.tagger.tag(sentence)
-        return self.tagged_parse(taggedwords, verbose)
+        return self.batch_parse([sentence], verbose)[0]
+
+    def batch_parse(self, sentences, verbose=False):
+        """
+        Use MaltParser to parse multiple sentence. Takes multiple sentences as a
+        list where each sentence is a list of words.
+        Each sentence will be automatically tagged with this MaltParser instance's
+        tagger.
+
+        :param sentences: Input sentences to parse
+        :type sentence: list(list(str))
+        :return: list(``DependencyGraph``) the dependency graph representation
+                 of each sentence
+        """
+        tagged_sentences = [self.tagger.tag(sentence) for sentence in sentences]
+        return self.tagged_batch_parse(tagged_sentences, verbose)
 
     def raw_parse(self, sentence, verbose=False):
         """
@@ -123,6 +137,19 @@ class MaltParser(ParserI):
         :type sentence: list(tuple(str, str))
         :return: ``DependencyGraph`` the dependency graph representation of the sentence
         """
+        return self.tagged_batch_parse([sentence], verbose)[0]
+
+    def tagged_batch_parse(self, sentences, verbose=False):
+        """
+        Use MaltParser to parse multiple sentences. Takes multiple sentences
+        where each sentence is a list of (word, tag) tuples.
+        The sentences must have already been tokenized and tagged.
+
+        :param sentences: Input sentences to parse
+        :type sentence: list(list(tuple(str, str)))
+        :return: list(``DependencyGraph``) the dependency graph representation
+                 of each sentence
+        """
 
         if not self._malt_bin:
             raise Exception("MaltParser location is not configured.  Call config_malt() first.")
@@ -137,13 +164,14 @@ class MaltParser(ParserI):
                                                  delete=False)
 
         try:
-            for (i, (word, tag)) in enumerate(sentence, start=1):
-                input_file.write('%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' %
-                        (i, word, '_', tag, tag, '_', '0', 'a', '_', '_'))
-            input_file.write('\n')
+            for sentence in sentences:
+                for (i, (word, tag)) in enumerate(sentence, start=1):
+                    input_file.write('%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' %
+                            (i, word, '_', tag, tag, '_', '0', 'a', '_', '_'))
+                input_file.write('\n\n')
             input_file.close()
 
-            cmd = ['java'] + self.additional_java_args + ['-jar', self._malt_bin, 
+            cmd = ['java'] + self.additional_java_args + ['-jar', self._malt_bin,
                    '-w', self.working_dir,
                    '-c', self.mco, '-i', input_file.name,
                    '-o', output_file.name, '-m', 'parse']


### PR DESCRIPTION
This commit makes MaltParser parse in batches so the binary doesn't have to be executed and the model doesn't have to be loaded for each sentence.

Tested with the following code:
Results are the same except for the batch_parse time being halved.

``` python
import nltk
import timeit
print timeit.timeit('graph = parser.parse(txt)', 'import nltk; parser = nltk.parse.malt.MaltParser(working_dir="<working_dir>", mco="engmalt.linear-1.7", additional_java_args=["-Xmx512m"]); txt = nltk.tokenize.word_tokenize("This is a test sentence")', number=1)
print timeit.timeit('graph = parser.batch_parse([txt, txt])', 'import nltk; parser = nltk.parse.malt.MaltParser(working_dir="<working_dir>", mco="engmalt.linear-1.7", additional_java_args=["-Xmx512m"]); txt = nltk.tokenize.word_tokenize("This is a test sentence")', number=1)
txt1 = "This is a test sentence."
txt2 = "The cat ate the mouse."
txt1_tok = nltk.tokenize.word_tokenize(txt1)
txt2_tok = nltk.tokenize.word_tokenize(txt2)
parser = nltk.parse.malt.MaltParser(working_dir="<working_dir>", mco="engmalt.linear-1.7", additional_java_args=["-Xmx512m"])
graphs = parser.batch_parse([txt1_tok, txt2_tok])
print graphs[0].tree().pprint()
print graphs[1].tree().pprint()
graph = parser.parse(txt1_tok)
print graph.tree().pprint()
graph = parser.raw_parse(txt1)
print graph.tree().pprint()
```
