### PR TITLE
word_tokenizer / TreebankWordTokenizer rather slow

### DIFF
--- a/nltk/tokenize/treebank.py
+++ b/nltk/tokenize/treebank.py
@@ -42,6 +42,39 @@ class TreebankWordTokenizer(TokenizerI):
         ['They', "'ll", 'save', 'and', 'invest', 'more', '.']
     """
 
+    # compile a sequence of regular expressions to make the overall
+    # processing faster in situations where we are tokenizing many
+    # text instances (e.g. tokenizing each document in the Brown
+    # corpus separately). These data structures have a compiled regex
+    # and the corresponding substitution pattern.
+    SUBSTITUTIONS1 = [
+        #starting quotes
+        (re.compile(r'^\"'), r'``')
+        (re.compile(r'(``)'), r' \1 ')
+        (re.compile(r'([ (\[{<])"'), r'\1 `` ')
+
+        #punctuation
+        (re.compile(r'([:,])([^\d])'), r' \1 \2')
+        (re.compile(r'\.\.\.'), r' ... ')
+        (re.compile(r'[;@#$%&]'), r' \g<0> ')
+        (re.compile(r'([^\.])(\.)([\]\)}>"\']*)\s*$'), r'\1 \2\3 ')
+        (re.compile(r'[?!]'), r' \g<0> ')
+
+        (re.compile(r"([^'])' "), r"\1 ' ")
+
+        #parens, brackets, etc.
+        (re.compile(r'[\]\[\(\)\{\}\<\>]'), r' \g<0> ')
+        (re.compile(r'--'), r' -- ')
+    ]
+    SUBSTITUTIONS2 = [
+        #ending quotes
+        (re.compile(r'"'), " '' ")
+        (re.compile(r'(\S)(\'\')'), r'\1 \2 ')
+
+        (re.compile(r"([^' ])('[sS]|'[mM]|'[dD]|') "), r"\1 \2 ")
+        (re.compile(r"([^' ])('ll|'LL|'re|'RE|'ve|'VE|n't|N'T) "), r"\1 \2 ")
+    ]
+
     # List of contractions adapted from Robert MacIntyre's tokenizer.
     CONTRACTIONS2 = [re.compile(r"(?i)\b(can)(not)\b"),
                      re.compile(r"(?i)\b(d)('ye)\b"),
@@ -57,34 +90,15 @@ class TreebankWordTokenizer(TokenizerI):
                      re.compile(r"(?i)\b(wha)(t)(cha)\b")]
 
     def tokenize(self, text):
-        #starting quotes
-        text = re.sub(r'^\"', r'``', text)
-        text = re.sub(r'(``)', r' \1 ', text)
-        text = re.sub(r'([ (\[{<])"', r'\1 `` ', text)
 
-        #punctuation
-        text = re.sub(r'([:,])([^\d])', r' \1 \2', text)
-        text = re.sub(r'\.\.\.', r' ... ', text)
-        text = re.sub(r'[;@#$%&]', r' \g<0> ', text)
-        text = re.sub(r'([^\.])(\.)([\]\)}>"\']*)\s*$', r'\1 \2\3 ', text)
-        text = re.sub(r'[?!]', r' \g<0> ', text)
-
-        text = re.sub(r"([^'])' ", r"\1 ' ", text)
-
-        #parens, brackets, etc.
-        text = re.sub(r'[\]\[\(\)\{\}\<\>]', r' \g<0> ', text)
-        text = re.sub(r'--', r' -- ', text)
+        for regexp, replacement_str in self.SUBSTITUTIONS1:
+            text = regexp.sub(replacement_str, text)
 
         #add extra space to make things easier
         text = " " + text + " "
 
-        #ending quotes
-        text = re.sub(r'"', " '' ", text)
-        text = re.sub(r'(\S)(\'\')', r'\1 \2 ', text)
-
-        text = re.sub(r"([^' ])('[sS]|'[mM]|'[dD]|') ", r"\1 \2 ", text)
-        text = re.sub(r"([^' ])('ll|'LL|'re|'RE|'ve|'VE|n't|N'T) ", r"\1 \2 ",
-                      text)
+        for regexp, replacement_str in self.SUBSTITUTIONS2:
+            text = regexp.sub(replacement_str, text)
 
         for regexp in self.CONTRACTIONS2:
             text = regexp.sub(r' \1 \2 ', text)


### PR DESCRIPTION
I'm tokenizing several million documents and need to tokenize each of them separately. When tokenizing each of these documents, the repeated calls to re.sub recompiles each of [all these regular expressions on each document](https://github.com/nltk/nltk/blob/master/nltk/tokenize/treebank.py#L61-L87) and is consequently rather slow. Is there a reason that each of these regular expressions aren't pre-compiled as class variables like the [contractions regular expressions](https://github.com/nltk/nltk/blob/master/nltk/tokenize/treebank.py#L46-L57)? 

My understanding is that [pre-compiling is 2-3x faster](http://stackoverflow.com/a/452142/564709).
