### PR TITLE
Updated Jenkins job config file to get source code from original NLTK repository

### DIFF
--- a/jenkins-job-config.xml
+++ b/jenkins-job-config.xml
@@ -5,7 +5,7 @@
   <keepDependencies>false</keepDependencies>
   <properties>
     <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.4">
-      <projectUrl>https://github.com/hleeldc/nltk/</projectUrl>
+      <projectUrl>https://github.com/nltk/nltk/</projectUrl>
     </com.coravy.hudson.plugins.github.GithubProjectProperty>
   </properties>
   <scm class="hudson.plugins.git.GitSCM" plugin="git@1.1.26">
@@ -14,7 +14,7 @@
       <hudson.plugins.git.UserRemoteConfig>
         <name></name>
         <refspec></refspec>
-        <url>git://github.com/hleeldc/nltk.git</url>
+        <url>git://github.com/nltk/nltk.git</url>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>


### PR DESCRIPTION
The Jenkins job configuration file was set up to pull source code from an NLTK fork. This was updated to pull the source code from the original NLTK repository.
