### PR TITLE
Remove unnecessary whitespaces before end of line

### DIFF
--- a/examples/school/categories.py
+++ b/examples/school/categories.py
@@ -70,7 +70,7 @@ def search_contexts(words):
         sorted_hits = sorted(hit_freqs, key=itemgetter(1), reverse=True)
         words = [word for (word, count) in sorted_hits[1:] if count > 1]
         print(join(words))
-        
+
 def lookup(word):
     for category in [N, V, ADJ, ADV]:
         if word in category:
@@ -142,7 +142,7 @@ def train_tagger(corpus):
     t1 = nltk.tag.Unigram(cutoff=0, backoff=t0)
     t2 = nltk.tag.Bigram(cutoff=0, backoff=t1)
     t3 = nltk.tag.Trigram(cutoff=1, backoff=t2)
-    
+
     t1.train(corpus, verbose=True)
     t2.train(corpus, verbose=True)
     t3.train(corpus, verbose=True)

--- a/examples/school/words.py
+++ b/examples/school/words.py
@@ -101,5 +101,5 @@ def generate(model, num=100):
         prev1 = word
     print()
 
-        
+
 

--- a/examples/semantics/syn2sem.py
+++ b/examples/semantics/syn2sem.py
@@ -33,7 +33,7 @@ Parse and evaluate some sentences.
     """
 
     opts = OptionParser(description=description)
-    
+
     opts.set_defaults(evaluate=True, beta=True, syntrace=0,
                       semtrace=0, demo='default', grammar='', sentences='')
 
@@ -57,7 +57,7 @@ Parse and evaluate some sentences.
 
 
     (options, args) = opts.parse_args()
-    
+
     SPACER = '-' * 30
 
 
@@ -70,35 +70,35 @@ Parse and evaluate some sentences.
         import model0 as model
         sentsfile = 'demo_sentences'
         gramfile = 'sem2.cfg'
-        
+
     if options.sentences:
         sentsfile = options.sentences
     if options.grammar:
         gramfile = options.grammar
     if options.model:
         exec "import %s as model" % options.model
-    
+
     sents = read_sents(sentsfile)
-    
+
     # NB. GrammarFile is imported indirectly via nltk.semantics
     gram = GrammarFile.read_file(gramfile)
 
     m = model.m
     g = model.g
 
-    if options.evaluate: 
+    if options.evaluate:
         evaluations = \
             text_evaluate(sents, gram, m, g, semtrace=options.semtrace)
     else:
         semreps = \
             text_interpret(sents, gram, beta_reduce=options.beta, syntrace=options.syntrace)
-        
+
     for sent in sents:
         n = 1
         print('\nSentence: %s' % sent)
         print(SPACER)
-        if options.evaluate: 
-            
+        if options.evaluate:
+
             for (syntree, semrep, value) in evaluations[sent]:
                 if isinstance(value, dict):
                     value = set(value.keys())
@@ -106,11 +106,11 @@ Parse and evaluate some sentences.
                 print(value)
                 n += 1
         else:
-           
+
             for (syntree, semrep) in semreps[sent]:
                 print('%d:  %s' % (n, semrep.infixify()))
                 n += 1
-                
+
 if __name__ == "__main__":
     demo()
 

--- a/nltk/app/collocations_app.py
+++ b/nltk/app/collocations_app.py
@@ -12,7 +12,7 @@ import threading
 import tkinter.font
 if nltk.compat.PY3:
     import queue as q
-else:    
+else:
     import Queue as q
 from tkinter import (Button, END, Frame, IntVar, LEFT, Label, Menu,
                      OptionMenu, SUNKEN, Scrollbar, StringVar,
@@ -171,7 +171,7 @@ class CollocationsView:
     def reset_current_page(self):
         self.current_page = -1
 
-    def _poll(self):   
+    def _poll(self):
         try:
             event = self.queue.get(block=False)
         except q.Empty:

--- a/nltk/app/concordance_app.py
+++ b/nltk/app/concordance_app.py
@@ -11,7 +11,7 @@ import re
 import threading
 if nltk.compat.PY3:
     import queue as q
-else:    
+else:
     import Queue as q
 import tkinter.font
 from tkinter import (Tk, Button, END, Entry, Frame, IntVar, LEFT,
@@ -291,7 +291,7 @@ class ConcordanceSearchView(object):
         self.top.bind(SEARCH_ERROR_EVENT, self.handle_search_error)
         self.top.bind(ERROR_LOADING_CORPUS_EVENT, self.handle_error_loading_corpus)
 
-    def _poll(self):   
+    def _poll(self):
         try:
             event = self.queue.get(block=False)
         except q.Empty:

--- a/nltk/collocations.py
+++ b/nltk/collocations.py
@@ -159,7 +159,7 @@ class BigramCollocationFinder(AbstractCollocationFinder):
 
     def score_ngram(self, score_fn, w1, w2):
         """Returns the score for a given bigram using the given scoring
-        function.  Following Church and Hanks (1990), counts are scaled by 
+        function.  Following Church and Hanks (1990), counts are scaled by
         a factor of 1/(window_size - 1).
         """
         n_all = self.word_fd.N()

--- a/nltk/compat.py
+++ b/nltk/compat.py
@@ -186,7 +186,7 @@ def py3_data(init_func):
                     break
         return init_func(*args, **kwargs)
     return wraps(init_func)(_decorator)
-    
+
 # ======= Compatibility layer for __str__ and __repr__ ==========
 
 import unicodedata

--- a/nltk/corpus/reader/framenet.py
+++ b/nltk/corpus/reader/framenet.py
@@ -1,7 +1,7 @@
 # Natural Language Toolkit: Framenet Corpus Reader
 #
 # Copyright (C) 2001-2013 NLTK Project
-# Authors: Chuck Wooters <wooters@icsi.berkeley.edu>, 
+# Authors: Chuck Wooters <wooters@icsi.berkeley.edu>,
 #          Nathan Schneider <nschneid@cs.cmu.edu>
 # URL: <http://www.nltk.org/>
 # For license information, see LICENSE.TXT
@@ -104,7 +104,7 @@ def _pretty_frame_relation_type(freltyp):
     """
     outstr = "<frame relation type ({0.ID}): {0.superFrameName} -- {0.name} -> {0.subFrameName}>".format(freltyp)
     return outstr
-    
+
 def _pretty_frame_relation(frel):
 
     """
@@ -166,7 +166,7 @@ def _pretty_lu(lu):
     if 'subCorpus' in lukeys:
         subc = [x.name for x in lu.subCorpus]
         outstr += "\n[subCorpus] {0} subcorpora\n".format(len(lu.subCorpus))
-        for line in textwrap.fill(", ".join(sorted(subc)), 60).split('\n'): 
+        for line in textwrap.fill(", ".join(sorted(subc)), 60).split('\n'):
             outstr += "  {0}\n".format(line)
 
     return outstr
@@ -233,7 +233,7 @@ def _pretty_frame(frame):
 
     outstr += "\n[frameRelations] {0} frame relations\n".format(len(frame.frameRelations))
     outstr += '  ' + '\n  '.join(repr(frel) for frel in frame.frameRelations) + '\n'
-    
+
     outstr += "\n[lexUnit] {0} lexical units\n".format(len(frame.lexUnit))
     lustrs = []
     for luName,lu in sorted(frame.lexUnit.items()):
@@ -282,7 +282,7 @@ class AttrDict(dict):
     def __init__(self, *args, **kwargs):
         super(AttrDict, self).__init__(*args, **kwargs)
         #self.__dict__ = self
-    
+
     def __setattr__(self, name, value):
         self[name] = value
     def __getattr__(self, name):
@@ -305,7 +305,7 @@ class AttrDict(dict):
                 return "<{0} name={1}>".format(self['_type'], self['name'])
         else:
             return self.__repr__()
-        
+
     def _str(self):
         outstr = ""
 
@@ -328,13 +328,13 @@ class AttrDict(dict):
         else:
             outstr = _pretty_any(self)
 
-        # ensure result is unicode string prior to applying the 
-        # @python_2_unicode_compatible decorator (because non-ASCII characters 
-        # could in principle occur in the data and would trigger an encoding error when 
+        # ensure result is unicode string prior to applying the
+        # @python_2_unicode_compatible decorator (because non-ASCII characters
+        # could in principle occur in the data and would trigger an encoding error when
         # passed as arguments to str.format()).
         # assert isinstance(outstr, unicode) # not in Python 3.2
         return outstr
-        
+
     def __str__(self):
         return self._str()
     def __repr__(self):
@@ -342,7 +342,7 @@ class AttrDict(dict):
 
 class Future(object):
     """
-    Wraps and acts as a proxy for a value to be loaded lazily (on demand). 
+    Wraps and acts as a proxy for a value to be loaded lazily (on demand).
     Adapted from https://gist.github.com/sergey-miryanov/2935416
     """
     def __init__(self, loader, *args, **kwargs):
@@ -358,19 +358,19 @@ class Future(object):
             self._d = self._loader()
             self._loader = None # the data is now cached
         return self._d
- 
+
     def __nonzero__(self):
         return bool(self._data())
     def __len__(self):
         return len(self._data())
- 
+
     def __setitem__(self, key, value):
         return self._data ().__setitem__(key, value)
     def __getitem__(self, key):
         return self._data ().__getitem__(key)
     def __getattr__(self, key):
         return self._data().__getattr__(key)
- 
+
     def __str__(self):
         return self._data().__str__()
     def __repr__(self):
@@ -381,7 +381,7 @@ class Future(object):
 class PrettyDict(AttrDict):
     """
     Displays an abbreviated repr of values where possible.
-    Inherits from AttrDict, so a callable value will 
+    Inherits from AttrDict, so a callable value will
     be lazily converted to an actual value.
     """
     def __init__(self, *args, **kwargs):
@@ -417,7 +417,7 @@ class PrettyList(list):
         """
         pieces = []
         length = 5
-        
+
         for elt in self:
             pieces.append(elt._short_repr()) # key difference from inherited version: call to _short_repr()
             length += len(pieces[-1]) + 2
@@ -450,7 +450,7 @@ class PrettyLazyMap(LazyMap):
 
 class FramenetCorpusReader(XMLCorpusReader):
     """A corpus reader for the Framenet Corpus.
-    
+
     >>> from nltk.corpus import framenet as fn
     >>> fn.lu(3238).frame.lexUnit['glint.v'] is fn.lu(3238)
     True
@@ -462,9 +462,9 @@ class FramenetCorpusReader(XMLCorpusReader):
 
     _bad_statuses = ['Problem']
     """
-    When loading LUs for a frame, those whose status is in this list will be ignored. 
+    When loading LUs for a frame, those whose status is in this list will be ignored.
     Due to caching, if user code modifies this, it should do so before loading any data.
-    'Problem' should always be listed for FrameNet 1.5, as these LUs are not included 
+    'Problem' should always be listed for FrameNet 1.5, as these LUs are not included
     in the XML index.
     """
 
@@ -494,7 +494,7 @@ class FramenetCorpusReader(XMLCorpusReader):
         # The total number of Frames in Framenet is fairly small (~1200) so
         # this index should not be very large
         if not self._frel_idx:
-            self._buildrelationindex()  # always load frame relations before frames, 
+            self._buildrelationindex()  # always load frame relations before frames,
             # otherwise weird ordering effects might result in incomplete information
         self._frame_idx = {}
         for f in XMLCorpusView(self.abspath("frameIndex.xml"),
@@ -517,7 +517,7 @@ class FramenetCorpusReader(XMLCorpusReader):
         self._lu_idx = {}
         for lu in XMLCorpusView(self.abspath("luIndex.xml"),
                                 'luIndex/lu', self._handle_elt):
-            self._lu_idx[lu['ID']] = lu # populate with LU index entries. if any of these 
+            self._lu_idx[lu['ID']] = lu # populate with LU index entries. if any of these
             # are looked up they will be replaced by full LU objects.
 
     def _buildrelationindex(self):
@@ -529,7 +529,7 @@ class FramenetCorpusReader(XMLCorpusReader):
         self._frel_idx = {}
         self._frel_f_idx = defaultdict(set)
         self._ferel_idx = {}
-        
+
         for freltyp in freltypes:
             self._freltyp_idx[freltyp.ID] = freltyp
             for frel in freltyp.frameRelations:
@@ -598,7 +598,7 @@ class FramenetCorpusReader(XMLCorpusReader):
                     - 'frameID'  : (only if status is 'MANUAL')
                     - 'frameName': (only if status is 'MANUAL')
                     - 'layer' : a list of labels for the layer
-                       - Each item in the layer is a dict containing the 
+                       - Each item in the layer is a dict containing the
                          following keys:
                           - '_type': 'layer'
                           - 'rank'
@@ -700,12 +700,12 @@ class FramenetCorpusReader(XMLCorpusReader):
         Also see the ``frame()`` function for details about what is
         contained in the dict that is returned.
         """
-        
+
         if check_cache and fn_fname in self._cached_frames:
             return self._frame_idx[self._cached_frames[fn_fname]]
         elif not self._frame_idx:
             self._buildframeindex()
-        
+
         # construct the path name for the xml file containing the Frame info
         locpath = os.path.join(
             "{0}".format(self._root), self._frame_dir, fn_fname + ".xml")
@@ -714,23 +714,23 @@ class FramenetCorpusReader(XMLCorpusReader):
         try:
             elt = XMLCorpusView(locpath, 'frame')[0]
         except IOError:
-            raise FramenetError('Unknown frame: {0}'.format(fn_fname)) 
+            raise FramenetError('Unknown frame: {0}'.format(fn_fname))
 
         fentry = self._handle_frame_elt(elt, ignorekeys)
         assert fentry
-        
+
         # INFERENCE RULE: propagate lexical semtypes from the frame to all its LUs
         for st in fentry.semTypes:
             if st.rootType.name=='Lexical_type':
                 for lu in fentry.lexUnit.values():
                     if st not in lu.semTypes:
                         lu.semTypes.append(st)
-        
-        
+
+
         self._frame_idx[fentry.ID] = fentry
         self._cached_frames[fentry.name] = fentry.ID
         '''
-        # now set up callables to resolve the LU pointers lazily. 
+        # now set up callables to resolve the LU pointers lazily.
         # (could also do this here--caching avoids infinite recursion.)
         for luName,luinfo in fentry.lexUnit.items():
             fentry.lexUnit[luName] = (lambda luID: Future(lambda: self.lu(luID)))(luinfo.ID)
@@ -767,8 +767,8 @@ class FramenetCorpusReader(XMLCorpusReader):
               - 'ID'   : can be used with the semtype() function
 
         - 'lexUnit'    : a dict containing all of the LUs for this frame.
-                         The keys in this dict are the names of the LUs and 
-                         the value for each key is itself a dict containing 
+                         The keys in this dict are the names of the LUs and
+                         the value for each key is itself a dict containing
                          info about the LU (see the lu() function for more info.)
 
         - 'FE' : a dict containing the Frame Elements that are part of this frame
@@ -781,7 +781,7 @@ class FramenetCorpusReader(XMLCorpusReader):
               - 'abbrev'     : Abbreviation e.g. 'bod'
               - 'coreType'   : one of "Core", "Peripheral", or "Extra-Thematic"
               - 'semType'    : if not None, a dict with the following two keys:
-                 - 'name' : name of the semantic type. can be used with 
+                 - 'name' : name of the semantic type. can be used with
                             the semtype() function
                  - 'ID'   : id number of the semantic type. can be used with
                             the semtype() function
@@ -900,10 +900,10 @@ class FramenetCorpusReader(XMLCorpusReader):
                  - 'annotated': number of sentences annotated with this LU
                  - 'total'    : total number of sentences with this LU
 
-        - 'lexemes'  : a list of dicts describing the lemma of this LU. 
+        - 'lexemes'  : a list of dicts describing the lemma of this LU.
            Each dict in the list contains these keys:
            - 'POS'     : part of speech e.g. 'N'
-           - 'name'    : either single-lexeme e.g. 'merger' or 
+           - 'name'    : either single-lexeme e.g. 'merger' or
                          multi-lexeme e.g. 'a little'
            - 'order': the order of the lexeme in the lemma (starting from 1)
            - 'headword': a boolean ('true' or 'false')
@@ -942,10 +942,10 @@ class FramenetCorpusReader(XMLCorpusReader):
                                       - 'end': end pos of label in sentence 'text' (0-based)
                                       - 'name': name of label (e.g. 'NN1')
 
-        Under the hood, this implementation looks up the lexical unit information 
-        in the *frame* definition file. That file does not contain 
-        corpus annotations, so the LU files will be accessed on demand if those are 
-        needed. In principle, valence patterns could be loaded here too, 
+        Under the hood, this implementation looks up the lexical unit information
+        in the *frame* definition file. That file does not contain
+        corpus annotations, so the LU files will be accessed on demand if those are
+        needed. In principle, valence patterns could be loaded here too,
         though these are not currently supported.
 
         :param fn_luid: The id number of the lexical unit
@@ -971,7 +971,7 @@ class FramenetCorpusReader(XMLCorpusReader):
 
     def _lu_file(self, lu, ignorekeys=[]):
         """
-        Augment the LU information that was loaded from the frame file 
+        Augment the LU information that was loaded from the frame file
         with additional information from the LU file.
         """
         fn_luid = lu.ID
@@ -981,7 +981,7 @@ class FramenetCorpusReader(XMLCorpusReader):
         #print(locpath, file=sys.stderr)
         if not self._lu_idx:
             self._buildluindex()
-        
+
         try:
             elt = XMLCorpusView(locpath, 'lexUnit')[0]
         except IOError:
@@ -989,7 +989,7 @@ class FramenetCorpusReader(XMLCorpusReader):
 
         lu2 = self._handle_lexunit_elt(elt, ignorekeys)
         lu.subCorpus = lu2.subCorpus
-        
+
         return lu.subCorpus
 
     def _loadsemtypes(self):
@@ -1027,12 +1027,12 @@ class FramenetCorpusReader(XMLCorpusReader):
 
     def propagate_semtypes(self):
         """
-        Apply inference rules to distribute semtypes over relations between FEs. 
+        Apply inference rules to distribute semtypes over relations between FEs.
         For FrameNet 1.5, this results in 1011 semtypes being propagated.
-        (Not done by default because it requires loading all frame files, 
-        which takes several seconds. If this needed to be fast, it could be rewritten 
+        (Not done by default because it requires loading all frame files,
+        which takes several seconds. If this needed to be fast, it could be rewritten
         to traverse the neighboring relations on demand for each FE semtype.)
-        
+
         >>> from nltk.corpus import framenet as fn
         >>> sum(1 for f in fn.frames() for fe in f.FE.values() if fe.semType)
         4241
@@ -1106,7 +1106,7 @@ class FramenetCorpusReader(XMLCorpusReader):
             st = self._semtypes[stid]
 
         return st
-        
+
     def semtype_inherits(self, st, superST):
         if not isinstance(st, dict):
             st = self.semtype(st)
@@ -1183,7 +1183,7 @@ class FramenetCorpusReader(XMLCorpusReader):
         except AttributeError:
             self._buildframeindex()
             fIDs = list(self._frame_idx.keys())
-        
+
         if name is not None:
             return PrettyList(self.frame(fID) for fID,finfo in self.frame_ids_and_names(name).items())
         else:
@@ -1191,7 +1191,7 @@ class FramenetCorpusReader(XMLCorpusReader):
 
     def frame_ids_and_names(self, name=None):
         """
-        Uses the frame index, which is much faster than looking up each frame definition 
+        Uses the frame index, which is much faster than looking up each frame definition
         if only the names and IDs are needed.
         """
         if not self._frame_idx:
@@ -1303,7 +1303,7 @@ class FramenetCorpusReader(XMLCorpusReader):
         except AttributeError:
             self._buildluindex()
             luIDs = list(self._lu_idx.keys())
-        
+
         if name is not None:
             return PrettyList(self.lu(luID) for luID,luName in self.lu_ids_and_names(name).items())
         else:
@@ -1311,7 +1311,7 @@ class FramenetCorpusReader(XMLCorpusReader):
 
     def lu_ids_and_names(self, name=None):
         """
-        Uses the LU index, which is much faster than looking up each LU definition 
+        Uses the LU index, which is much faster than looking up each LU definition
         if only the names and IDs are needed.
         """
         if not self._lu_idx:
@@ -1390,9 +1390,9 @@ class FramenetCorpusReader(XMLCorpusReader):
 
     def frame_relations(self, frame=None, frame2=None, type=None):
         """
-        :param frame: (optional) frame object, name, or ID; only relations involving 
+        :param frame: (optional) frame object, name, or ID; only relations involving
         this frame will be returned
-        :param frame2: (optional; 'frame' must be a different frame) only show relations 
+        :param frame2: (optional; 'frame' must be a different frame) only show relations
         between the two specified frames, in either direction
         :param type: (optional) frame relation type (name or object); show only relations
         of this type
@@ -1426,14 +1426,14 @@ class FramenetCorpusReader(XMLCorpusReader):
 
         if not self._frel_idx:
             self._buildrelationindex()
-        
+
         rels = None
-        
+
         if relation_type is not None:
             if not isinstance(relation_type, dict):
                 type = [rt for rt in self.frame_relation_types() if rt.name==type][0]
                 assert isinstance(type,dict)
-        
+
         # lookup by 'frame'
         if frame is not None:
             if isinstance(frame,dict) and 'frameRelations' in frame:
@@ -1445,7 +1445,7 @@ class FramenetCorpusReader(XMLCorpusReader):
                     else:
                         frame = self.frame_by_name(frame).ID
                 rels = [self._frel_idx[frelID] for frelID in self._frel_f_idx[frame]]
-        
+
             # filter by 'type'
             if type is not None:
                 rels = [rel for rel in rels if rel.type is type]
@@ -1454,7 +1454,7 @@ class FramenetCorpusReader(XMLCorpusReader):
             rels = type.frameRelations
         else:
             rels = self._frel_idx.values()
-        
+
         # filter by 'frame2'
         if frame2 is not None:
             if frame is None:
@@ -1467,10 +1467,10 @@ class FramenetCorpusReader(XMLCorpusReader):
             if frame==frame2:
                 raise FramenetError("The two frame arguments to frame_relations() must be different frames")
             rels = [rel for rel in rels if rel.superFrame.ID==frame2 or rel.subFrame.ID==frame2]
-        
-        return PrettyList(sorted(rels, 
+
+        return PrettyList(sorted(rels,
                 key=lambda frel: (frel.type.ID, frel.superFrameName, frel.subFrameName)))
-        
+
     def fe_relations(self):
         """
         Obtain a list of frame element relations.
@@ -1500,8 +1500,8 @@ class FramenetCorpusReader(XMLCorpusReader):
         """
         if not self._ferel_idx:
             self._buildrelationindex()
-        return PrettyList(sorted(self._ferel_idx.values(), 
-                key=lambda ferel: (ferel.type.ID, ferel.frameRelation.superFrameName, 
+        return PrettyList(sorted(self._ferel_idx.values(),
+                key=lambda ferel: (ferel.type.ID, ferel.frameRelation.superFrameName,
                     ferel.superFEName, ferel.frameRelation.subFrameName, ferel.subFEName)))
 
     def semtypes(self):
@@ -1673,7 +1673,7 @@ class FramenetCorpusReader(XMLCorpusReader):
                 frinfo['semTypes'].append(self.semtype(semtypeinfo.ID))
 
         frinfo['frameRelations'] = self.frame_relations(frame=frinfo)
-        
+
         # resolve 'requires' and 'excludes' links between FEs of this frame
         for fe in frinfo.FE.values():
             if fe.requiresFE:
@@ -1684,7 +1684,7 @@ class FramenetCorpusReader(XMLCorpusReader):
                 name, ID = fe.excludesFE.name, fe.excludesFE.ID
                 fe.excludesFE = frinfo.FE[name]
                 assert fe.excludesFE.ID==ID
-        
+
         return frinfo
 
     def _handle_fecoreset_elt(self, elt):
@@ -1701,7 +1701,7 @@ class FramenetCorpusReader(XMLCorpusReader):
         info = self._load_xml_attributes(AttrDict(), elt)
         info['_type'] = 'framerelationtype'
         info['frameRelations'] = PrettyList()
-        
+
         for sub in elt:
             if sub.tag.endswith('frameRelation'):
                 frel = self._handle_framerelation_elt(sub)
@@ -1711,7 +1711,7 @@ class FramenetCorpusReader(XMLCorpusReader):
                 info['frameRelations'].append(frel)
 
         return info
-    
+
     def _handle_framerelation_elt(self, elt):
         """Load frame-relation element and its child fe-relation elements from frRelation.xml."""
         info = self._load_xml_attributes(AttrDict(), elt)
@@ -1818,8 +1818,8 @@ class FramenetCorpusReader(XMLCorpusReader):
 
     def _handle_lexunit_elt(self, elt, ignorekeys):
         """
-        Load full info for a lexical unit from its xml file. 
-        This should only be called when accessing corpus annotations 
+        Load full info for a lexical unit from its xml file.
+        This should only be called when accessing corpus annotations
         (which are not included in frame files).
         """
         luinfo = self._load_xml_attributes(AttrDict(), elt)

--- a/nltk/inference/discourse.py
+++ b/nltk/inference/discourse.py
@@ -86,11 +86,11 @@ class ReadingCommand(object):
         :rtype: Expression
         """
         raise NotImplementedError()
-    
+
     def to_fol(self, expression):
         """
         Convert this expression into a First-Order Logic expression.
-        
+
         :param expression: an expression
         :type expression: Expression
         :return: a FOL version of the input expression
@@ -118,7 +118,7 @@ class CfgReadingCommand(ReadingCommand):
     def combine_readings(self, readings):
         """:see: ReadingCommand.combine_readings()"""
         return reduce(and_, readings)
-    
+
     def to_fol(self, expression):
         """:see: ReadingCommand.to_fol()"""
         return expression
@@ -153,7 +153,7 @@ class DrtGlueReadingCommand(ReadingCommand):
         """:see: ReadingCommand.combine_readings()"""
         thread_reading = reduce(add, readings)
         return resolve_anaphora(thread_reading.simplify())
-    
+
     def to_fol(self, expression):
         """:see: ReadingCommand.to_fol()"""
         return expression.fol()

--- a/nltk/inference/prover9.py
+++ b/nltk/inference/prover9.py
@@ -189,7 +189,7 @@ class Prover9Parent(object):
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                              stderr=subprocess.STDOUT,
                              stdin=subprocess.PIPE)
-        (stdout, stderr) = p.communicate(input=input_str) 
+        (stdout, stderr) = p.communicate(input=input_str)
 
         if verbose:
             print('Return code:', p.returncode)

--- a/nltk/metrics/association.py
+++ b/nltk/metrics/association.py
@@ -24,7 +24,7 @@ try:
     from scipy.stats import fisher_exact
 except ImportError:
     pass
-    
+
 ### Indices to marginals arguments:
 
 NGRAM = 0

--- a/nltk/metrics/segmentation.py
+++ b/nltk/metrics/segmentation.py
@@ -211,7 +211,7 @@ def pk(ref, hyp, k=None, boundary='1'):
 
     if k is None:
         k = int(round(len(ref) / (ref.count(boundary) * 2.)))
-    
+
     err = 0
     for i in xrange(len(ref)-k +1):
         r = ref[i:i+k].count(boundary) > 0

--- a/nltk/parse/generate.py
+++ b/nltk/parse/generate.py
@@ -54,7 +54,7 @@ def _generate_one(grammar, item, depth):
             yield [item]
 
 demo_grammar = """
-  S -> NP VP 
+  S -> NP VP
   NP -> Det N
   PP -> P NP
   VP -> 'slept' | 'saw' NP | 'walked' PP

--- a/nltk/parse/util.py
+++ b/nltk/parse/util.py
@@ -141,7 +141,7 @@ def extract_test_sentences(string, comment_chars="#%;", encoding=None):
         and a result is None, or bool, or int
 
     :param comment_chars: ``str`` of possible comment characters.
-    :param encoding: the encoding of the string, if it is binary 
+    :param encoding: the encoding of the string, if it is binary
     """
     if encoding is not None:
         string = string.decode(encoding)
@@ -163,6 +163,6 @@ def extract_test_sentences(string, comment_chars="#%;", encoding=None):
             continue
         sentences += [(tokens, result)]
     return sentences
-    
+
 # nose thinks it is a test
 extract_test_sentences.__test__ = False

--- a/nltk/sem/boxer.py
+++ b/nltk/sem/boxer.py
@@ -238,20 +238,20 @@ class Boxer(object):
                 line = lines[i]
                 assert line.startswith('sem(%s,' % drs_id)
                 assert line.endswith(').')
-                
+
                 search_start = len('sem(%s,[' % drs_id)
                 brace_count = 1
                 drs_start = -1
                 for j,c in enumerate(line[search_start:]):
-                    if(c == '['): 
+                    if(c == '['):
                         brace_count += 1
-                    if(c == ']'): 
+                    if(c == ']'):
                         brace_count -= 1
-                        if(brace_count == 0): 
+                        if(brace_count == 0):
                             drs_start = search_start + j + 2
                             break
                 assert drs_start > -1
-                    
+
                 drs_input = line[drs_start:-2].strip()
                 parsed = self._parse_drs(drs_input, discourse_id, use_disc_id)
                 drs_dict[discourse_id] = self._boxer_drs_interpreter.interpret(parsed)

--- a/nltk/stem/porter.py
+++ b/nltk/stem/porter.py
@@ -159,7 +159,7 @@ class PorterStemmer(StemmerI):
         for key in irregular_forms:
             for val in irregular_forms[key]:
                 self.pool[val] = key
-                
+
         self.vowels = frozenset(['a', 'e', 'i', 'o', 'u'])
 
     def _cons(self, word, i):
@@ -297,15 +297,15 @@ class PorterStemmer(StemmerI):
         elif word.endswith("eed"):
             if self._m(word, len(word)-4) > 0:
                 word = word[:-1]
-        
-        
+
+
         elif word.endswith("ed") and self._vowelinstem(word[:-2]):
             word = word[:-2]
             ed_or_ing_trimmed = True
         elif word.endswith("ing") and self._vowelinstem(word[:-3]):
             word = word[:-3]
             ed_or_ing_trimmed = True
-        
+
         if ed_or_ing_trimmed:
             if word.endswith("at") or word.endswith("bl") or word.endswith("iz"):
                 word += 'e'
@@ -314,7 +314,7 @@ class PorterStemmer(StemmerI):
                     word = word[:-1]
             elif (self._m(word, len(word)-1) == 1 and self._cvc(word, len(word)-1)):
                 word += 'e'
-                
+
         return word
 
     def _step1c(self, word):
@@ -346,11 +346,11 @@ class PorterStemmer(StemmerI):
         so -ization ( = -ize plus -ation) maps to -ize etc. note that the
         string before the suffix must give m() > 0.
         """
-        if len(word) <= 1: # Only possible at this stage given unusual inputs to stem_word like 'oed'       
+        if len(word) <= 1: # Only possible at this stage given unusual inputs to stem_word like 'oed'
             return word
-        
+
         ch = word[-2]
-        
+
         if ch == 'a':
             if word.endswith("ational"):
                 return word[:-7] + "ate" if self._m(word, len(word)-8) > 0 else word
@@ -369,7 +369,7 @@ class PorterStemmer(StemmerI):
             if word.endswith("izer"):
                 return word[:-1] if self._m(word, len(word)-5) > 0 else word
             else:
-                return word                
+                return word
         elif ch == 'l':
             if word.endswith("bli"):
                 return word[:-3] + "ble" if self._m(word, len(word)-4) > 0 else word # --DEPARTURE--
@@ -390,7 +390,7 @@ class PorterStemmer(StemmerI):
             elif word.endswith("ousli"):
                 return word[:-2] if self._m(word, len(word)-6) else word
             else:
-                return word                
+                return word
         elif ch == 'o':
             if word.endswith("ization"):
                 return word[:-7] + "ize" if self._m(word, len(word)-8) else word
@@ -399,7 +399,7 @@ class PorterStemmer(StemmerI):
             elif word.endswith("ator"):
                 return word[:-4] + "ate" if self._m(word, len(word)-5) else word
             else:
-                return word                
+                return word
         elif ch == 's':
             if word.endswith("alism"):
                 return word[:-3] if self._m(word, len(word)-6) else word
@@ -413,7 +413,7 @@ class PorterStemmer(StemmerI):
                 else:
                     return word
             else:
-                return word                    
+                return word
         elif ch == 't':
             if word.endswith("aliti"):
                 return word[:-3] if self._m(word, len(word)-6) else word
@@ -422,22 +422,22 @@ class PorterStemmer(StemmerI):
             elif word.endswith("biliti"):
                 return word[:-6] + "ble" if self._m(word, len(word)-7) else word
             else:
-                return word                
+                return word
         elif ch == 'g': # --DEPARTURE--
             if word.endswith("logi"):
                 return word[:-1] if self._m(word, len(word) - 4) else word # --NEW-- (Barry Wilkins)
             # To match the published algorithm, pass len(word)-5 to _m instead of len(word)-4
             else:
-                return word            
-        
+                return word
+
         else:
             return word
 
     def _step3(self, word):
         """step3() deals with -ic-, -full, -ness etc. similar strategy to step2."""
-        
+
         ch = word[-1]
-        
+
         if ch == 'e':
             if word.endswith("icate"):
                 return word[:-3] if self._m(word, len(word)-6) else word
@@ -451,31 +451,31 @@ class PorterStemmer(StemmerI):
             if word.endswith("iciti"):
                 return word[:-3] if self._m(word, len(word)-6) else word
             else:
-                return word                
+                return word
         elif ch == 'l':
             if word.endswith("ical"):
                 return word[:-2] if self._m(word, len(word)-5) else word
             elif word.endswith("ful"):
                 return word[:-3] if self._m(word, len(word)-4) else word
             else:
-                return word                
+                return word
         elif ch == 's':
             if word.endswith("ness"):
                 return word[:-4] if self._m(word, len(word)-5) else word
             else:
-                return word                
-                
+                return word
+
         else:
             return word
 
     def _step4(self, word):
         """step4() takes off -ant, -ence etc., in context <c>vcvc<v>."""
-        
-        if len(word) <= 1: # Only possible at this stage given unusual inputs to stem_word like 'oed'       
+
+        if len(word) <= 1: # Only possible at this stage given unusual inputs to stem_word like 'oed'
             return word
-        
+
         ch = word[-2]
-        
+
         if ch == 'a':
             if word.endswith("al"):
                 return word[:-2] if self._m(word, len(word)-3) > 1 else word
@@ -563,7 +563,7 @@ class PorterStemmer(StemmerI):
                 word = word[:-1]
         if word.endswith('ll') and self._m(word, len(word)-1) > 1:
             word = word[:-1]
-            
+
         return word
 
     def stem_word(self, p, i=0, j=None):
@@ -587,7 +587,7 @@ class PorterStemmer(StemmerI):
         # stemming process, although no mention is made of this in the
         # published algorithm. Remove the line to match the published
         # algorithm.
-        
+
         word = self._step1ab(word)
         word = self._step1c(word)
         word = self._step2(word)
@@ -595,7 +595,7 @@ class PorterStemmer(StemmerI):
         word = self._step4(word)
         word = self._step5(word)
         return word
-        
+
     def _adjust_case(self, word, stem):
         lower = word.lower()
 

--- a/nltk/tag/mapping.py
+++ b/nltk/tag/mapping.py
@@ -7,14 +7,14 @@
 # For license information, see LICENSE.TXT
 
 """
-Interface for converting POS tags from various treebanks 
+Interface for converting POS tags from various treebanks
 to the universal tagset of Petrov, Das, & McDonald.
 
 The tagset consists of the following 12 coarse tags:
 
 VERB - verbs (all tenses and modes)
 NOUN - nouns (common and proper)
-PRON - pronouns 
+PRON - pronouns
 ADJ - adjectives
 ADV - adverbs
 ADP - adpositions (prepositions and postpositions)
@@ -55,11 +55,11 @@ def _load_universal_map(fileid):
 
         _MAPPINGS[fileid]['universal'][fine] = coarse
 
-            
+
 def tagset_mapping(source, target):
     """
     Retrieve the mapping dictionary between tagsets.
-    
+
     >>> tagset_mapping('ru-rnc', 'universal') == {'!': '.', 'A': 'ADJ', 'C': 'CONJ', 'AD': 'ADV',\
             'NN': 'NOUN', 'VG': 'VERB', 'COMP': 'CONJ', 'NC': 'NUM', 'VP': 'VERB', 'P': 'ADP',\
             'IJ': 'X', 'V': 'VERB', 'Z': 'X', 'VI': 'VERB', 'YES_NO_SENT': 'X', 'PTCL': 'PRT'}
@@ -74,7 +74,7 @@ def tagset_mapping(source, target):
 def map_tag(source, target, source_tag):
     """
     Maps the tag from the source tagset to the target tagset.
-    
+
     >>> map_tag('en-ptb', 'universal', 'VBZ')
     'VERB'
     >>> map_tag('en-ptb', 'universal', 'VBP')

--- a/nltk/tokenize/treebank.py
+++ b/nltk/tokenize/treebank.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2001-2013 NLTK Project
 # Author: Edward Loper <edloper@gradient.cis.upenn.edu>
 #         Michael Heilman <mheilman@cmu.edu> (re-port from http://www.cis.upenn.edu/~treebank/tokenizer.sed)
-#         
+#
 # URL: <http://nltk.sourceforge.net>
 # For license information, see LICENSE.TXT
 

--- a/pip-install.py
+++ b/pip-install.py
@@ -3,7 +3,7 @@
 # Read pip-req.txt file, which is a pip requirements file, and then install the
 # modules one by one using pip. The installation process stops if there's an
 # installation error before reaching the bottom of the list.
-# 
+#
 
 import sys
 import os

--- a/setup.py
+++ b/setup.py
@@ -12,15 +12,15 @@
 # python2.5 compatibility
 from __future__ import with_statement
 
-# Work around mbcs bug in distutils. 
+# Work around mbcs bug in distutils.
 # http://bugs.python.org/issue10945
-import codecs 
-try: 
-    codecs.lookup('mbcs') 
-except LookupError: 
-    ascii = codecs.lookup('ascii') 
-    func = lambda name, enc=ascii: {True: enc}.get(name=='mbcs') 
-    codecs.register(func) 
+import codecs
+try:
+    codecs.lookup('mbcs')
+except LookupError:
+    ascii = codecs.lookup('ascii')
+    func = lambda name, enc=ascii: {True: enc}.get(name=='mbcs')
+    codecs.register(func)
 
 import os
 


### PR DESCRIPTION
Some python codes contained unnecessary whitespaces before end of line. I think it should be removed to avoid any further conflict. This pull request does not change any logic.

I removed these whitespaces from the following files:

```
./examples/school/categories.py
./examples/school/words.py
./examples/semantics/syn2sem.py
./nltk/app/collocations_app.py
./nltk/app/concordance_app.py
./nltk/collocations.py
./nltk/compat.py
./nltk/corpus/reader/framenet.py
./nltk/inference/discourse.py
./nltk/inference/prover9.py
./nltk/metrics/association.py
./nltk/metrics/segmentation.py
./nltk/parse/generate.py
./nltk/parse/util.py
./nltk/sem/boxer.py
./nltk/stem/porter.py
./nltk/tag/mapping.py
./nltk/tokenize/treebank.py
./pip-install.py
./setup.py
```
