### PR TITLE
Fix stem.doctest failures

### DIFF
--- a/nltk/test/stem.doctest
+++ b/nltk/test/stem.doctest
@@ -47,17 +47,17 @@ Unit tests for Regexp stemmer
 
     >>> stemmer = RegexpStemmer(patterns, 4)
 
-    >>> stemmer.stem("red")
-    'red'
+    >>> print(stemmer.stem("red"))
+    red
 
-    >>> stemmer.stem("hurried")
-    'hurri'
+    >>> print(stemmer.stem("hurried"))
+    hurri
 
-    >>> stemmer.stem("advisable")
-    'advis'
+    >>> print(stemmer.stem("advisable"))
+    advis
 
-    >>> stemmer.stem("impossible")
-    'impossible'
+    >>> print(stemmer.stem("impossible"))
+    impossible
 
 Unit tests for Snowball stemmer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -67,6 +67,7 @@ Unit tests for Snowball stemmer
 See which languages are supported.
 
     >>> print(" ".join(SnowballStemmer.languages))
+    ... # doctest: +NORMALIZE_WHITESPACE
     danish dutch english finnish french german hungarian italian
     norwegian porter portuguese romanian russian spanish swedish
 


### PR DESCRIPTION
I run doctest for stemmers and got the following failures:

```
$ python -m doctest nltk/test/stem.doctest
**********************************************************************
File "nltk/test/stem.doctest", line 53, in stem.doctest
Failed example:
    stemmer.stem("hurried")
Expected:
    'hurri'
Got:
    u'hurri'
**********************************************************************
File "nltk/test/stem.doctest", line 56, in stem.doctest
Failed example:
    stemmer.stem("advisable")
Expected:
    'advis'
Got:
    u'advis'
**********************************************************************
File "nltk/test/stem.doctest", line 69, in stem.doctest
Failed example:
    print(" ".join(SnowballStemmer.languages))
Expected:
    danish dutch english finnish french german hungarian italian
    norwegian porter portuguese romanian russian spanish swedish
Got:
    danish dutch english finnish french german hungarian italian norwegian porter portuguese romanian russian spanish swedish
**********************************************************************
1 items had failures:
   3 of  23 in stem.doctest
***Test Failed*** 3 failures.
```

The first and second failures were caused because doctest did not expect unicode output. The last failure was caused by missing NORMALIZE_WHITESPACE option.

This pull request resolves these issues and now stemmers can pass all tests.
