### PR TITLE
Implemented span_tokenize() method for PunktWordTokenizer.

### DIFF
--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -101,6 +101,9 @@ leaving all periods attached to words, but separating off other punctuation:
     >>> PunktWordTokenizer().tokenize(s)
     ['Good', 'muffins', 'cost', '$3.88', 'in', 'New', 'York.', 'Please',
     'buy', 'me', 'two', 'of', 'them.', 'Thanks.']
+    >>> PunktWordTokenizer().span_tokenize(s)
+    [(0, 4), (5, 12), (13, 17), (18, 23), (24, 26), (27, 30), (31, 36), (38, 44), 
+    (45, 48), (49, 51), (52, 55), (56, 58), (59, 64), (66, 73)]
 
 The algorithm for this tokenizer is described in::
 

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -315,6 +315,23 @@ class PunktWordTokenizer(TokenizerI):
     def tokenize(self, text):
         return self._lang_vars.word_tokenize(text)
 
+    def span_tokenize(self, text):
+        """
+        Given a text, returns a list of the (start, end) spans of words
+        in the text.
+        """
+        return [(sl.start, sl.stop) for sl in self._slices_from_text(text)]
+
+    def _slices_from_text(self, text):
+        last_break = 0
+        contains_no_words = True
+        for match in self._lang_vars._word_tokenizer_re().finditer(text):
+            contains_no_words = False
+            context = match.group()
+            yield slice(match.start(), match.end())
+        if contains_no_words:
+            yield slice(0, 0) # matches PunktSentenceTokenizer's functionality
+
 #}
 ######################################################################
 


### PR DESCRIPTION
I noticed that the span_tokenize() method was unimplemented in the PunktWordTokenizer class.  I modeled the implementation of this method after the span_tokenize() method in the PunktSentenceTokenizer class.
