### PR TITLE
Add support for unicode terms to nltk.chunk.named_entity.shape()

### DIFF
--- a/nltk/chunk/named_entity.py
+++ b/nltk/chunk/named_entity.py
@@ -167,16 +167,17 @@ class NEChunkParser(ChunkParserI):
         return toks
 
 def shape(word):
-    if re.match('[0-9]+(\.[0-9]*)?|[0-9]*\.[0-9]+$', word):
+    if re.match('[0-9]+(\.[0-9]*)?|[0-9]*\.[0-9]+$', word, re.UNICODE):
         return 'number'
-    elif re.match('\W+$', word):
+    elif re.match('\W+$', word, re.UNICODE):
         return 'punct'
-    elif re.match('[A-Z][a-z]+$', word):
-        return 'upcase'
-    elif re.match('[a-z]+$', word):
-        return 'downcase'
-    elif re.match('\w+$', word):
-        return 'mixedcase'
+    elif re.match('\w+$', word, re.UNICODE):
+        if word.istitle():
+            return 'upcase'
+        elif word.islower():
+            return 'downcase'
+        else:
+            return 'mixedcase'
     else:
         return 'other'
 


### PR DESCRIPTION
Currently, shape(u'Monáe') returns 'other'. This patch fixes it to handle unicode terms better, causing it to return 'mixedcase'. This in turn causes NEChunkParserTagger to correctly tag tokens that have unicode characters in them.
