### PR TITLE
Don't overwrite sys.meta_path in nltk.compat

### DIFF
--- a/nltk/compat.py
+++ b/nltk/compat.py
@@ -115,7 +115,7 @@ else:
                 sys.modules[name] = mod
             return sys.modules[name]
 
-    sys.meta_path = [TkinterLoader()]
+    sys.meta_path.insert(0, TkinterLoader())
 
 
 def iterkeys(d):


### PR DESCRIPTION
This breaks things for anything else that sets a finder in meta_path, such as pytest.
