### PR TITLE
decode path byte string

### DIFF
--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -495,7 +495,7 @@ def find_file(filename, env_vars=(), searchpath=(),
             try:
                 p = subprocess.Popen(['which', alternative], stdout=subprocess.PIPE)
                 stdout, stderr = p.communicate()
-                path = stdout.strip()
+                path = stdout.strip().decode()
                 if path.endswith(alternative) and os.path.exists(path):
                     if verbose: print('[Found %s: %s]' % (filename, path))
                     return path


### PR DESCRIPTION
without decode(), path.endswith(alternative) will throw an exception, making the which lookup fail
decode() on python2 returns unicode from ascii
decode() on python3 returns string from bytes
