### PR TITLE
k-means bug len() of map object

### DIFF
--- a/nltk/cluster/kmeans.py
+++ b/nltk/cluster/kmeans.py
@@ -121,8 +121,8 @@ class KMeansClusterer(VectorSpaceClusterer):
                     #print '  mean', i, 'allocated', len(clusters[i]), 'vectors'
 
                 # recalculate cluster means by computing the centroid of each cluster
-                new_means = [self._centroid(cluster,mean) for cluster,mean in zip(clusters, self._means)]
-
+                new_means = list(map(self._centroid, clusters, self._means))
+                
                 # measure the degree of change from the previous step for convergence
                 difference = self._sum_distances(self._means, new_means)
                 if difference < self._max_difference:

--- a/nltk/cluster/kmeans.py
+++ b/nltk/cluster/kmeans.py
@@ -121,7 +121,7 @@ class KMeansClusterer(VectorSpaceClusterer):
                     #print '  mean', i, 'allocated', len(clusters[i]), 'vectors'
 
                 # recalculate cluster means by computing the centroid of each cluster
-                new_means = map(self._centroid, clusters, self._means)
+                new_means = [self._centroid(cluster,mean) for cluster,mean in zip(clusters, self._means)]
 
                 # measure the degree of change from the previous step for convergence
                 difference = self._sum_distances(self._means, new_means)


### PR DESCRIPTION
In python3, map evaluates to a map object instead of a list and you cant do len() on them.

This causes line 138 in kmeans.py to fail since self._means is a map object

``` python
for index in range(len(self._means)):
```

I changed the definition of self._means to a list comprehension in line 124

``` python
# recalculate cluster means by computing the centroid of each cluster
new_means = [self._centroid(cluster,mean) for cluster,mean in zip(clusters, self._means)]
...
self._means = new_means
```
