### PR TITLE
Fixes to the align branch

### DIFF
--- a/nltk/align/__init__.py
+++ b/nltk/align/__init__.py
@@ -11,4 +11,4 @@ Experimental functionality for bitext alignment.
 These interfaces are prone to change.
 """
 
-from nltk.align  import AlignedSent, Alignment
+from nltk.align.api  import AlignedSent, Alignment

--- a/nltk/align/api.py
+++ b/nltk/align/api.py
@@ -8,8 +8,6 @@
 # For license information, see LICENSE.TXT
 
 from __future__ import print_function, unicode_literals
-import logging
-from collections import defaultdict
 
 from nltk import compat
 from nltk.metrics import precision, recall

--- a/nltk/align/bleu.py
+++ b/nltk/align/bleu.py
@@ -76,8 +76,8 @@ class BLEU(object):
 
     >>> for candi_raw in candidate_file:
     ...		ref_raw = ref_file.readline()
-    ...		ref_tokens = nltk.word_tokenize(ref_raw)
-    ...		candi_tokens = nltk.word_tokenize(candi_raw)
+    ...		ref_tokens = word_tokenize(ref_raw)
+    ...		candi_tokens = word_tokenize(candi_raw)
     ...		total = BLEU.compute(candi_tokens, [ref_tokens], weights)
     ...		count += 1
 

--- a/nltk/align/bleu.py
+++ b/nltk/align/bleu.py
@@ -135,7 +135,7 @@ class BLEU(object):
 
         lengthes_ref = map(lambda x: abs(len(x) - c), references)
 
-        r = reduce(lambda x, y: min(x,y), lengthes_ref)
+        r = min(*lengthes_ref)
 
         if c > r:
             return 1

--- a/nltk/align/gale_church.py
+++ b/nltk/align/gale_church.py
@@ -16,35 +16,46 @@ http://aclweb.org/anthology/J93-1004.pdf
 
 """
 
-
 from __future__ import division
 import math
 
-infinity = float("inf")
+try:
+    from scipy.stats import norm
+    from norm import logsf as norm_logsf
+except ImportError:
+    def erfcc(x):
+        """Complementary error function."""
+        z = abs(x)
+        t = 1 / (1 + 0.5 * z)
+        r = t * math.exp(-z * z -
+                         1.26551223 + t *
+                         (1.00002368 + t *
+                          (.37409196 + t *
+                           (.09678418 + t *
+                            (-.18628806 + t *
+                             (.27886807 + t *
+                              (-1.13520398 + t *
+                               (1.48851587 + t *
+                                (-.82215223 + t * .17087277)))))))))
+        if x >= 0.:
+            return r
+        else:
+            return 2. - r
 
-def erfcc(x):
-    """Complementary error function."""
-    z = abs(x)
-    t = 1 / (1 + 0.5 * z)
-    r = t * math.exp(-z * z -
-                     1.26551223 + t *
-                     (1.00002368 + t *
-                      (.37409196 + t *
-                       (.09678418 + t *
-                        (-.18628806 + t *
-                         (.27886807 + t *
-                          (-1.13520398 + t *
-                           (1.48851587 + t *
-                            (-.82215223 + t * .17087277)))))))))
-    if x >= 0.:
-        return r
-    else:
-        return 2. - r
+
+    def norm_cdf(x):
+        """Return the area under the normal distribution from M{-∞..x}."""
+        return 1 - 0.5 * erfcc(x / math.sqrt(2))
 
 
-def norm_cdf(x):
-    """Return the area under the normal distribution from M{-∞..x}."""
-    return 1 - 0.5 * erfcc(x / math.sqrt(2))
+    def norm_logsf(x):
+        try:
+            return math.log(1 - norm_cdf(x))
+        except ValueError:
+            return float('-inf')
+
+
+LOG2 = math.log(2)
 
 
 class LanguageIndependent(object):
@@ -67,20 +78,20 @@ class LanguageIndependent(object):
 
 def trace(backlinks, source, target):
     links = []
-    pos = (len(source) - 1, len(target) - 1)
+    pos = (len(source), len(target))
 
-    while pos != (-1, -1):
+    while pos != (0, 0):
         s, t = backlinks[pos]
         for i in range(s):
             for j in range(t):
-                links.append((pos[0] - i, pos[1] - j))
+                links.append((pos[0] - i - 1, pos[1] - j - 1))
         pos = (pos[0] - s, pos[1] - t)
 
     return links[::-1]
 
 
-def align_probability(i, j, source_sents, target_sents, alignment, params):
-    """Returns the probability of the two sentences C{source_sents[i]}, C{target_sents[j]}
+def align_log_prob(i, j, source_sents, target_sents, alignment, params):
+    """Returns the log probability of the two sentences C{source_sents[i]}, C{target_sents[j]}
     being aligned with a specific C{alignment}.
 
     @param i: The offset of the source sentence.
@@ -90,19 +101,19 @@ def align_probability(i, j, source_sents, target_sents, alignment, params):
     @param alignment: The alignment type, a tuple of two integers.
     @param params: The sentence alignment parameters.
 
-    @returns: The probability of a specific alignment between the two sentences, given the parameters.
+    @returns: The log probability of a specific alignment between the two sentences, given the parameters.
     """
-    l_s = sum(source_sents[i - offset] for offset in range(alignment[0]))
-    l_t = sum(target_sents[j - offset] for offset in range(alignment[1]))
+    l_s = sum(source_sents[i - offset - 1] for offset in range(alignment[0]))
+    l_t = sum(target_sents[j - offset - 1] for offset in range(alignment[1]))
     try:
         # actually, the paper says l_s * params.VARIANCE_CHARACTERS, this is based on the C
         # reference implementation. With l_s in the denominator, insertions are impossible.
         m = (l_s + l_t / params.AVERAGE_CHARACTERS) / 2
-        delta = (l_t - l_s * params.AVERAGE_CHARACTERS) / math.sqrt(m * params.VARIANCE_CHARACTERS)
+        delta = (l_s * params.AVERAGE_CHARACTERS - l_t) / math.sqrt(m * params.VARIANCE_CHARACTERS)
     except ZeroDivisionError:
-        delta = infinity
+        return float('-inf')
 
-    return 2 * (1 - norm_cdf(delta)) * params.PRIORS[alignment]
+    return - (LOG2 + norm_logsf(abs(delta)) + math.log(params.PRIORS[alignment]))
 
 
 def align_blocks(source_sents, target_sents, params = LanguageIndependent):
@@ -126,38 +137,33 @@ def align_blocks(source_sents, target_sents, params = LanguageIndependent):
     alignment_types = list(params.PRIORS.keys())
 
     # there are always three rows in the history (with the last of them being filled)
-    # and the rows are always |target_text| + 2, so that we never have to do
-    # boundary checks
-    D = [(len(target_sents) + 2) * [0] for _ in range(2)]
-
-    # for the first sentence, only substitution, insertion or deletion are
-    # allowed, and they are all equally likely ( == 1)
-
-    D.append([0, 1])
-    D[-2][2] = 1
-    D[-2][1] = 1
+    D = [[]]
 
     backlinks = {}
 
-    for i in range(len(source_sents)):
-        for j in range(len(target_sents)):
-            m = []
+    for i in range(len(source_sents) + 1):
+        for j in range(len(target_sents) + 1):
+            min_dist = float('inf')
+            min_align = None
             for a in alignment_types:
-                k = D[-(1 + a[0])][j + 2 - a[1]]
-                if k > 0:
-                    p = k * align_probability(i, j, source_sents, target_sents, a, params)
-                    m.append((p, a))
+                prev_i = - 1 - a[0]
+                prev_j = j - a[1]
+                if prev_i < -len(D) or prev_j < 0:
+                    continue
+                p = D[prev_i][prev_j] + align_log_prob(i, j, source_sents, target_sents, a, params)
+                if p < min_dist:
+                    min_dist = p
+                    min_align = a
 
-            if len(m) > 0:
-                v = max(m)
-                backlinks[(i, j)] = v[1]
-                D[-1].append(v[0])
-            else:
-                backlinks[(i, j)] = (1, 1)
-                D[-1].append(0)
+            if min_dist == float('inf'):
+                min_dist = 0
 
-        D.pop(0)
-        D.append([0, 0])
+            backlinks[(i, j)] = min_align
+            D[-1].append(min_dist)
+
+        if len(D) > 2:
+            D.pop(0)
+        D.append([])
 
     return trace(backlinks, source_sents, target_sents)
 

--- a/nltk/align/gale_church.py
+++ b/nltk/align/gale_church.py
@@ -20,8 +20,6 @@ http://aclweb.org/anthology/J93-1004.pdf
 from __future__ import division
 import math
 
-from util import *
-
 infinity = float("inf")
 
 def erfcc(x):
@@ -38,7 +36,7 @@ def erfcc(x):
                           (-1.13520398 + t *
                            (1.48851587 + t *
                             (-.82215223 + t * .17087277)))))))))
-    if (x >= 0.):
+    if x >= 0.:
         return r
     else:
         return 2. - r

--- a/nltk/align/ibm1.py
+++ b/nltk/align/ibm1.py
@@ -14,7 +14,7 @@
 
 from __future__  import division
 from collections import defaultdict
-from nltk.align  import AlignedSent, Alignment
+from nltk.align  import AlignedSent
 from nltk.corpus import comtrans
 
 class IBMModel1(object):

--- a/nltk/align/ibm1.py
+++ b/nltk/align/ibm1.py
@@ -42,15 +42,15 @@ class IBMModel1(object):
     0.33333333333333337
     
     """
-    def __init__(self, alignSents, num_iter):
-        self.probabilities = self.train(alignSents, num_iter)
+    def __init__(self, align_sents, num_iter):
+        self.probabilities = self.train(align_sents, num_iter)
 
-    def train(self, alignSents, num_iter):
+    def train(self, align_sents, num_iter):
         """
         Return the translation probability model trained by IBM model 1. 
 
         Arguments:
-        alignSents   -- A list of instances of AlignedSent class, which 
+        align_sents   -- A list of instances of AlignedSent class, which
                         contains sentence pairs. 
         num_iter     -- The number of iterations.
 
@@ -61,7 +61,7 @@ class IBMModel1(object):
         # Vocabulary of each language
         fr_vocab = set()
         en_vocab = set()
-        for alignSent in alignSents:
+        for alignSent in align_sents:
             en_vocab.update(alignSent.words)
             fr_vocab.update(alignSent.mots)
         # Add the Null token
@@ -79,7 +79,7 @@ class IBMModel1(object):
             count_ef = defaultdict(lambda: defaultdict(lambda: 0.0))
             total_f = defaultdict(lambda: 0.0)
 
-            for alignSent in alignSents:
+            for alignSent in align_sents:
                 en_set = alignSent.words
                 fr_set = [None] + alignSent.mots  
 
@@ -103,7 +103,7 @@ class IBMModel1(object):
 
         return t_ef
 
-    def align(self, alignSent):
+    def align(self, align_sent):
         """
         Returns the alignment result for one sentence pair. 
         """
@@ -113,21 +113,21 @@ class IBMModel1(object):
 
         alignment = []
 
-        for j, en_word in enumerate(alignSent.words):
+        for j, en_word in enumerate(align_sent.words):
             
             # Initialize the maximum probability with Null token
-            max_alignProb = (self.probabilities[en_word][None], None)
-            for i, fr_word in enumerate(alignSent.mots):
+            max_align_prob = (self.probabilities[en_word][None], None)
+            for i, fr_word in enumerate(align_sent.mots):
                 # Find out the maximum probability
-                max_alignProb = max(max_alignProb,
+                max_align_prob = max(max_align_prob,
                     (self.probabilities[en_word][fr_word], i))
 
             # If the maximum probability is not Null token,
             # then append it to the alignment. 
-            if max_alignProb[1] is not None:
-                alignment.append((j, max_alignProb[1]))
+            if max_align_prob[1] is not None:
+                alignment.append((j, max_align_prob[1]))
 
-        return AlignedSent(alignSent.words, alignSent.mots, alignment)
+        return AlignedSent(align_sent.words, align_sent.mots, alignment)
 
 # run doctests
 if __name__ == "__main__":

--- a/nltk/align/ibm2.py
+++ b/nltk/align/ibm2.py
@@ -9,9 +9,8 @@
 from __future__  import division
 from collections import defaultdict
 from nltk.align  import AlignedSent
-from nltk.align  import Alignment
 from nltk.corpus import comtrans
-from ibm1 import IBMModel1
+from nltk.align.ibm1 import IBMModel1
 
 class IBMModel2(object):
     """

--- a/nltk/align/ibm2.py
+++ b/nltk/align/ibm2.py
@@ -43,16 +43,16 @@ class IBMModel2(object):
     0.1428571428571429
 
     """
-    def __init__(self, alignSents, num_iter):
-        self.probabilities, self.alignments = self.train(alignSents, num_iter)
+    def __init__(self, align_sents, num_iter):
+        self.probabilities, self.alignments = self.train(align_sents, num_iter)
 
-    def train(self, alignSents, num_iter):
+    def train(self, align_sents, num_iter):
         """
         Return the translation and alignment probability distributions
         trained by the Expectation Maximization algorithm for IBM Model 2. 
 
         Arguments:
-        alignSents   -- A list contains some sentence pairs. 
+        align_sents   -- A list contains some sentence pairs.
         num_iter     -- The number of iterations.
 
         Returns:
@@ -62,13 +62,13 @@ class IBMModel2(object):
 
         # Get initial translation probability distribution
         # from a few iterations of Model 1 training.
-        ibm1 = IBMModel1(alignSents, 10)
+        ibm1 = IBMModel1(align_sents, 10)
         t_ef = ibm1.probabilities
 
         # Vocabulary of each language
         fr_vocab = set()
         en_vocab = set()
-        for alignSent in alignSents:
+        for alignSent in align_sents:
             en_vocab.update(alignSent.words)
             fr_vocab.update(alignSent.mots)
         fr_vocab.add(None)
@@ -77,7 +77,7 @@ class IBMModel2(object):
 
         # Initialize the distribution of alignment probability,
         # a(i|j,l_e, l_f) = 1/(l_f + 1)
-        for alignSent in alignSents:
+        for alignSent in align_sents:
             en_set = alignSent.words
             fr_set = [None] + alignSent.mots
             l_f = len(fr_set) - 1
@@ -97,7 +97,7 @@ class IBMModel2(object):
 
             total_e = defaultdict(float)
 
-            for alignSent in alignSents:
+            for alignSent in align_sents:
                 en_set = alignSent.words
                 fr_set = [None] + alignSent.mots
                 l_f = len(fr_set) - 1
@@ -126,7 +126,7 @@ class IBMModel2(object):
             align = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: 0.0))))
 
             # Smoothing the counts for alignments
-            for alignSent in alignSents:
+            for alignSent in align_sents:
                 en_set = alignSent.words
                 fr_set = [None] + alignSent.mots
                 l_f = len(fr_set) - 1
@@ -136,7 +136,7 @@ class IBMModel2(object):
                 for i in range(0, l_f+1):
                     for j in range(1, l_e+1):
                         value = count_align[i][j][l_e][l_f]
-                        if value > 0 and value < laplace:
+                        if 0 < value < laplace:
                             laplace = value
 
                 laplace *= 0.5 
@@ -154,7 +154,7 @@ class IBMModel2(object):
                     t_ef[e][f] = count_ef[e][f] / total_f[f]
 
             # Estimate the new alignment probabilities
-            for alignSent in alignSents:
+            for alignSent in align_sents:
                 en_set = alignSent.words
                 fr_set = [None] + alignSent.mots
                 l_f = len(fr_set) - 1
@@ -165,7 +165,7 @@ class IBMModel2(object):
 
         return t_ef, align
 
-    def align(self, alignSent):
+    def align(self, align_sent):
         """
         Returns the alignment result for one sentence pair. 
         """
@@ -175,24 +175,24 @@ class IBMModel2(object):
 
         alignment = []
 
-        l_e = len(alignSent.words);
-        l_f = len(alignSent.mots);
+        l_e = len(align_sent.words)
+        l_f = len(align_sent.mots)
 
-        for j, en_word in enumerate(alignSent.words):
+        for j, en_word in enumerate(align_sent.words):
             
             # Initialize the maximum probability with Null token
-            max_alignProb = (self.probabilities[en_word][None]*self.alignments[0][j+1][l_e][l_f], None)
-            for i, fr_word in enumerate(alignSent.mots):
+            max_align_prob = (self.probabilities[en_word][None]*self.alignments[0][j+1][l_e][l_f], None)
+            for i, fr_word in enumerate(align_sent.mots):
                 # Find out the maximum probability
-                max_alignProb = max(max_alignProb,
+                max_align_prob = max(max_align_prob,
                     (self.probabilities[en_word][fr_word]*self.alignments[i+1][j+1][l_e][l_f], i))
 
             # If the maximum probability is not Null token,
             # then append it to the alignment. 
-            if max_alignProb[1] is not None:
-                alignment.append((j, max_alignProb[1]))
+            if max_align_prob[1] is not None:
+                alignment.append((j, max_align_prob[1]))
 
-        return AlignedSent(alignSent.words, alignSent.mots, alignment)
+        return AlignedSent(align_sent.words, align_sent.mots, alignment)
 
 # run doctests
 if __name__ == "__main__":

--- a/nltk/align/ibm3.py
+++ b/nltk/align/ibm3.py
@@ -8,9 +8,8 @@
 
 from __future__  import division
 from collections import defaultdict
-from nltk.align  import AlignedSent, Alignment
-from nltk.corpus import comtrans
-from ibm2 import IBMModel2
+from nltk.align  import AlignedSent
+from nltk.align.ibm2 import IBMModel2
 from math import factorial
 
 class hashabledict(dict):


### PR DESCRIPTION
Some small bug fixes for the align branch and changed variable names to PEP-8 style variable names.

Fixed the gale church implementation so the included doctests pass & used log probabilities in the distance function. 
The implementation details has changed somewhat from @tmarek's original implementation as I couldn't get the same distance scores as the ones from the reference implementation in the the Gale-Church Aligner paper.

cf https://github.com/nltk/nltk/issues/559
