### PR TITLE
Speed improvements and refactor of wordnet `common_hypernyms` functions

### DIFF
--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -551,7 +551,7 @@ class Synset(_WordNetObject):
             fake_synset._name = '*ROOT*'
             fake_synset.hypernyms = lambda: []
             fake_synset.instance_hypernyms = lambda: []
-            synsets.add(fake_synset)
+            synsets.append(fake_synset)
 
         try:
             if use_min_depth:

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -350,6 +350,7 @@ class Synset(_WordNetObject):
         self._definition = None
         self._examples = []
         self._lexname = None # lexicographer name
+        self._allHypernymsSet = None
 
         self._pointers = defaultdict(set)
         self._lemma_pointers = defaultdict(set)
@@ -498,13 +499,15 @@ class Synset(_WordNetObject):
         :param other: other input synset.
         :return: The synsets that are hypernyms of both synsets.
         """
-        self_synsets = set(self_synset
-                           for self_synsets in self._iter_hypernym_lists()
-                           for self_synset in self_synsets)
-        other_synsets = set(other_synset
-                           for other_synsets in other._iter_hypernym_lists()
-                           for other_synset in other_synsets)
-        return list(self_synsets.intersection(other_synsets))
+        if not self._allHypernymsSet:
+            self._allHypernymsSet = set(self_synset
+                                       for self_synsets in self._iter_hypernym_lists()
+                                       for self_synset in self_synsets)
+        if not other._allHypernymsSet:
+            other._allHypernymsSet = set(other_synset
+                                        for other_synsets in other._iter_hypernym_lists()
+                                        for other_synset in other_synsets)
+        return list(self._allHypernymsSet.intersection(other._allHypernymsSet))
 
     def lowest_common_hypernyms(self, other, simulate_root=False, use_min_depth=False):
         """
@@ -542,22 +545,13 @@ class Synset(_WordNetObject):
             (eg: 'chef.n.01', 'fireman.n.01') but is retained for backwards compatibility
         :return: The synsets that are the lowest common hypernyms of both synsets
         """
-
-        fake_synset = Synset(None)
-        fake_synset._name = '*ROOT*'
-        fake_synset.hypernyms = lambda: []
-        fake_synset.instance_hypernyms = lambda: []
-
+        synsets = self.common_hypernyms(self, other)
         if simulate_root:
-            self_hypernyms = chain(self._iter_hypernym_lists(), [[fake_synset]])
-            other_hypernyms = chain(other._iter_hypernym_lists(), [[fake_synset]])
-        else:
-            self_hypernyms = self._iter_hypernym_lists()
-            other_hypernyms = other._iter_hypernym_lists()
-
-        synsets = set(s for synsets in self_hypernyms for s in synsets)
-        others = set(s for synsets in other_hypernyms for s in synsets)
-        synsets.intersection_update(others)
+            fake_synset = Synset(None)
+            fake_synset._name = '*ROOT*'
+            fake_synset.hypernyms = lambda: []
+            fake_synset.instance_hypernyms = lambda: []
+            synsets.add(fake_synset)
 
         try:
             if use_min_depth:

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -545,7 +545,7 @@ class Synset(_WordNetObject):
             (eg: 'chef.n.01', 'fireman.n.01') but is retained for backwards compatibility
         :return: The synsets that are the lowest common hypernyms of both synsets
         """
-        synsets = self.common_hypernyms(self, other)
+        synsets = self.common_hypernyms(other)
         if simulate_root:
             fake_synset = Synset(None)
             fake_synset._name = '*ROOT*'


### PR DESCRIPTION
The changes cause nltk to cache the sets of all hypernyms of a Synset, as its generation is expensive. This causes speed improvements of factor >20 if `common_hypernyms` or `lowest_common_hypernyms` are called repeatedly on combinations of Synsets, for example:

```
from itertools import combinations_with_replacement
from nltk.corpus import wordnet as wn
p = wn.synsets("House")
[x.common_hypernyms(y) for x,y in combinations_with_replacement(p,2)]
```

Comparing speeds using `timeit`, the following results are achieved:
Current develop: 100 loops, best of 3: 4.82 ms per loop
This pull request: 10000 loops, best of 3: 86.6 μs per loop
74x faster.
