### PR TITLE
Regex remove groups bug

### DIFF
--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -49,6 +49,8 @@ def compile_regexp_to_nongrouping(pattern, flags=0):
                 value = (None, convert_regexp_to_nongrouping_parsed(subpattern))
             res_data.append((key, value))
         parsed_pattern.data = res_data
+        parsed_pattern.pattern.groups = 1
+        parsed_pattern.pattern.groupdict = {}
         return parsed_pattern
 
     return sre_compile.compile(convert_regexp_to_nongrouping_parsed(sre_parse.parse(pattern)))

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -29,13 +29,13 @@ from nltk import compat
 # Regular Expression Processing
 ######################################################################
 
-def convert_regexp_to_nongrouping(pattern):
+def compile_regexp_to_nongrouping(pattern, flags=0):
     """
     Convert all grouping parentheses in the given regexp pattern to
     non-grouping parentheses, and return the result.  E.g.:
 
-        >>> from nltk.internals import convert_regexp_to_nongrouping
-        >>> convert_regexp_to_nongrouping('ab(c(x+)(z*))?d')
+        >>> from nltk.internals import compile_regexp_to_nongrouping
+        >>> compile_regexp_to_nongrouping('ab(c(x+)(z*))?d')
         'ab(?:c(?:x+)(?:z*))?d'
 
     :type pattern: str

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -47,6 +47,8 @@ def compile_regexp_to_nongrouping(pattern, flags=0):
             if key == sre_constants.SUBPATTERN:
                 index, subpattern = value
                 value = (None, convert_regexp_to_nongrouping_parsed(subpattern))
+            elif key == sre_constants.GROUPREF:
+                raise ValueError('Regular expressions with back-references are not supported: {0}'.format(pattern))
             res_data.append((key, value))
         parsed_pattern.data = res_data
         parsed_pattern.pattern.groups = 1

--- a/nltk/tokenize/regexp.py
+++ b/nltk/tokenize/regexp.py
@@ -70,7 +70,7 @@ from __future__ import unicode_literals
 import re
 import sre_constants
 
-from nltk.internals import convert_regexp_to_nongrouping
+from nltk.internals import compile_regexp_to_nongrouping
 from nltk.tokenize.api import TokenizerI
 from nltk.tokenize.util import regexp_span_tokenize
 from nltk.compat import python_2_unicode_compatible
@@ -115,10 +115,8 @@ class RegexpTokenizer(TokenizerI):
         # Remove grouping parentheses -- if the regexp contains any
         # grouping parentheses, then the behavior of re.findall and
         # re.split will change.
-        nongrouping_pattern = convert_regexp_to_nongrouping(pattern)
-
         try:
-            self._regexp = re.compile(nongrouping_pattern, flags)
+            self._regexp = compile_regexp_to_nongrouping(pattern, flags)
         except re.error as e:
             raise ValueError('Error in regular expression %r: %s' %
                              (pattern, e))


### PR DESCRIPTION
Fix to nltk#545, by using the python's sre module to parse regexes so all corner cases are covered.
