### PR TITLE
fixes unit testing bugs for https://github.com/nltk/nltk/issues/581

### DIFF
--- a/nltk/test/unit/test_collocations.py
+++ b/nltk/test/unit/test_collocations.py
@@ -29,12 +29,12 @@ class TestBigram(unittest2.TestCase):
 
         #python 2.6 does not have assertItemsEqual
         self.assertItemsEqual(
-            sorted(b.ngram_fd.items()),
-            sorted([(('a', 'a'), 1), (('a', 'test'), 1), (('is', 'a'), 1), (('is', 'is'), 1), (('test', 'test'), 1), (('this', 'is'), 1), (('this', 'this'), 1)])
+            b.ngram_fd.items(),
+            [(('a', 'a'), 1), (('a', 'test'), 1), (('is', 'a'), 1), (('is', 'is'), 1), (('test', 'test'), 1), (('this', 'is'), 1), (('this', 'this'), 1)]
         )
         self.assertItemsEqual(
-            sorted(b.word_fd.items()),
-            sorted([('a', 2), ('is', 2), ('test', 2), ('this', 2)])
+            b.word_fd.items(),
+            [('a', 2), ('is', 2), ('test', 2), ('this', 2)]
         )
         self.assertTrue(len(sent) == sum(b.word_fd.values()) == sum(b.ngram_fd.values()) + 1)
         self.assertTrue(close_enough(
@@ -47,12 +47,12 @@ class TestBigram(unittest2.TestCase):
 
         b = BigramCollocationFinder.from_words(sent, window_size=3)
         self.assertItemsEqual(
-            sorted(b.ngram_fd.items()),
-            sorted([(('a', 'test'), 3), (('is', 'a'), 3), (('this', 'is'), 3), (('a', 'a'), 1), (('is', 'is'), 1), (('test', 'test'), 1), (('this', 'this'), 1)])
+            b.ngram_fd.items(),
+            [(('a', 'test'), 3), (('is', 'a'), 3), (('this', 'is'), 3), (('a', 'a'), 1), (('is', 'is'), 1), (('test', 'test'), 1), (('this', 'this'), 1)]
         )
         self.assertItemsEqual(
-            sorted(b.word_fd.items()),
-            sorted([('a', 2), ('is', 2), ('test', 2), ('this', 2)])
+            b.word_fd.items(),
+            [('a', 2), ('is', 2), ('test', 2), ('this', 2)]
         )
         self.assertTrue(len(sent) == sum(b.word_fd.values()) == (sum(b.ngram_fd.values()) + 2 + 1) / 2.0)
         self.assertTrue(close_enough(
@@ -65,8 +65,8 @@ class TestBigram(unittest2.TestCase):
 
         b = BigramCollocationFinder.from_words(sent, window_size=5)
         self.assertItemsEqual(
-            sorted(b.ngram_fd.items()),
-            sorted([(('a', 'test'), 4), (('is', 'a'), 4), (('this', 'is'), 4), (('is', 'test'), 3), (('this', 'a'), 3), (('a', 'a'), 1), (('is', 'is'), 1), (('test', 'test'), 1), (('this', 'this'), 1)])
+            b.ngram_fd.items(),
+            [(('a', 'test'), 4), (('is', 'a'), 4), (('this', 'is'), 4), (('is', 'test'), 3), (('this', 'a'), 3), (('a', 'a'), 1), (('is', 'is'), 1), (('test', 'test'), 1), (('this', 'this'), 1)]
         )
         self.assertItemsEqual(
             sorted(b.word_fd.items()),

--- a/nltk/test/unit/test_collocations.py
+++ b/nltk/test/unit/test_collocations.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
-import unittest2
+import unittest
 
 from nltk.collocations import BigramCollocationFinder
 from nltk.metrics import BigramAssocMeasures
@@ -21,20 +21,20 @@ def close_enough(x, y):
     return True
 
 
-class TestBigram(unittest2.TestCase):
+class TestBigram(unittest.TestCase):
     def test_bigram2(self):
         sent = 'this this is is a a test test'.split()
 
         b = BigramCollocationFinder.from_words(sent)
 
-        #python 2.6 does not have assertItemsEqual
-        self.assertItemsEqual(
-            b.ngram_fd.items(),
-            [(('a', 'a'), 1), (('a', 'test'), 1), (('is', 'a'), 1), (('is', 'is'), 1), (('test', 'test'), 1), (('this', 'is'), 1), (('this', 'this'), 1)]
+        #python 2.6 does not have assertItemsEqual or assertListEqual
+        self.assertEqual(
+            sorted(b.ngram_fd.items()),
+            sorted([(('a', 'a'), 1), (('a', 'test'), 1), (('is', 'a'), 1), (('is', 'is'), 1), (('test', 'test'), 1), (('this', 'is'), 1), (('this', 'this'), 1)])
         )
-        self.assertItemsEqual(
-            b.word_fd.items(),
-            [('a', 2), ('is', 2), ('test', 2), ('this', 2)]
+        self.assertEqual(
+            sorted(b.word_fd.items()),
+            sorted([('a', 2), ('is', 2), ('test', 2), ('this', 2)])
         )
         self.assertTrue(len(sent) == sum(b.word_fd.values()) == sum(b.ngram_fd.values()) + 1)
         self.assertTrue(close_enough(
@@ -46,13 +46,13 @@ class TestBigram(unittest2.TestCase):
         sent = 'this this is is a a test test'.split()
 
         b = BigramCollocationFinder.from_words(sent, window_size=3)
-        self.assertItemsEqual(
-            b.ngram_fd.items(),
-            [(('a', 'test'), 3), (('is', 'a'), 3), (('this', 'is'), 3), (('a', 'a'), 1), (('is', 'is'), 1), (('test', 'test'), 1), (('this', 'this'), 1)]
+        self.assertEqual(
+            sorted(b.ngram_fd.items()),
+            sorted([(('a', 'test'), 3), (('is', 'a'), 3), (('this', 'is'), 3), (('a', 'a'), 1), (('is', 'is'), 1), (('test', 'test'), 1), (('this', 'this'), 1)])
         )
-        self.assertItemsEqual(
-            b.word_fd.items(),
-            [('a', 2), ('is', 2), ('test', 2), ('this', 2)]
+        self.assertEqual(
+            sorted(b.word_fd.items()),
+            sorted([('a', 2), ('is', 2), ('test', 2), ('this', 2)])
         )
         self.assertTrue(len(sent) == sum(b.word_fd.values()) == (sum(b.ngram_fd.values()) + 2 + 1) / 2.0)
         self.assertTrue(close_enough(
@@ -64,11 +64,11 @@ class TestBigram(unittest2.TestCase):
         sent = 'this this is is a a test test'.split()
 
         b = BigramCollocationFinder.from_words(sent, window_size=5)
-        self.assertItemsEqual(
-            b.ngram_fd.items(),
-            [(('a', 'test'), 4), (('is', 'a'), 4), (('this', 'is'), 4), (('is', 'test'), 3), (('this', 'a'), 3), (('a', 'a'), 1), (('is', 'is'), 1), (('test', 'test'), 1), (('this', 'this'), 1)]
+        self.assertEqual(
+            sorted(b.ngram_fd.items()),
+            sorted([(('a', 'test'), 4), (('is', 'a'), 4), (('this', 'is'), 4), (('is', 'test'), 3), (('this', 'a'), 3), (('a', 'a'), 1), (('is', 'is'), 1), (('test', 'test'), 1), (('this', 'this'), 1)])
         )
-        self.assertItemsEqual(
+        self.assertEqual(
             sorted(b.word_fd.items()),
             sorted([('a', 2), ('is', 2), ('test', 2), ('this', 2)])
         )

--- a/nltk/test/unit/test_collocations.py
+++ b/nltk/test/unit/test_collocations.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
+import unittest2
 
 from nltk.collocations import BigramCollocationFinder
 from nltk.metrics import BigramAssocMeasures
@@ -20,43 +21,59 @@ def close_enough(x, y):
     return True
 
 
-def test_bigram2():
+class TestBigram(unittest2.TestCase):
+    def test_bigram2(self):
+        sent = 'this this is is a a test test'.split()
 
-    sent = 'this this is is a a test test'.split()
+        b = BigramCollocationFinder.from_words(sent)
 
-    b = BigramCollocationFinder.from_words(sent)
-    assert b.ngram_fd.items() == \
-        [(('a', 'a'), 1), (('a', 'test'), 1), (('is', 'a'), 1), (('is', 'is'), 1), (('test', 'test'), 1), (('this', 'is'), 1), (('this', 'this'), 1)]
-    assert b.word_fd.items() == \
-        [('a', 2), ('is', 2), ('test', 2), ('this', 2)]
-    assert len(sent) == sum(b.word_fd.values()) == sum(b.ngram_fd.values()) + 1
-    assert close_enough(b.score_ngrams(BigramAssocMeasures.pmi), \
-        [(('a', 'a'), 1.0), (('a', 'test'), 1.0), (('is', 'a'), 1.0), (('is', 'is'), 1.0), (('test', 'test'), 1.0), (('this', 'is'), 1.0), (('this', 'this'), 1.0)])
+        #python 2.6 does not have assertItemsEqual
+        self.assertItemsEqual(
+            sorted(b.ngram_fd.items()),
+            sorted([(('a', 'a'), 1), (('a', 'test'), 1), (('is', 'a'), 1), (('is', 'is'), 1), (('test', 'test'), 1), (('this', 'is'), 1), (('this', 'this'), 1)])
+        )
+        self.assertItemsEqual(
+            sorted(b.word_fd.items()),
+            sorted([('a', 2), ('is', 2), ('test', 2), ('this', 2)])
+        )
+        self.assertTrue(len(sent) == sum(b.word_fd.values()) == sum(b.ngram_fd.values()) + 1)
+        self.assertTrue(close_enough(
+            sorted(b.score_ngrams(BigramAssocMeasures.pmi)),
+            sorted([(('a', 'a'), 1.0), (('a', 'test'), 1.0), (('is', 'a'), 1.0), (('is', 'is'), 1.0), (('test', 'test'), 1.0), (('this', 'is'), 1.0), (('this', 'this'), 1.0)])
+        ))
 
+    def test_bigram3(self):
+        sent = 'this this is is a a test test'.split()
 
-def test_bigram3():
+        b = BigramCollocationFinder.from_words(sent, window_size=3)
+        self.assertItemsEqual(
+            sorted(b.ngram_fd.items()),
+            sorted([(('a', 'test'), 3), (('is', 'a'), 3), (('this', 'is'), 3), (('a', 'a'), 1), (('is', 'is'), 1), (('test', 'test'), 1), (('this', 'this'), 1)])
+        )
+        self.assertItemsEqual(
+            sorted(b.word_fd.items()),
+            sorted([('a', 2), ('is', 2), ('test', 2), ('this', 2)])
+        )
+        self.assertTrue(len(sent) == sum(b.word_fd.values()) == (sum(b.ngram_fd.values()) + 2 + 1) / 2.0)
+        self.assertTrue(close_enough(
+            sorted(b.score_ngrams(BigramAssocMeasures.pmi)),
+            sorted([(('a', 'test'), 1.584962500721156), (('is', 'a'), 1.584962500721156), (('this', 'is'), 1.584962500721156), (('a', 'a'), 0.0), (('is', 'is'), 0.0), (('test', 'test'), 0.0), (('this', 'this'), 0.0)])
+        ))
 
-    sent = 'this this is is a a test test'.split()
+    def test_bigram5(self):
+        sent = 'this this is is a a test test'.split()
 
-    b = BigramCollocationFinder.from_words(sent, window_size=3)
-    assert b.ngram_fd.items() == \
-        [(('a', 'test'), 3), (('is', 'a'), 3), (('this', 'is'), 3), (('a', 'a'), 1), (('is', 'is'), 1), (('test', 'test'), 1), (('this', 'this'), 1)]
-    assert b.word_fd.items() == \
-        [('a', 2), ('is', 2), ('test', 2), ('this', 2)]
-    assert len(sent) == sum(b.word_fd.values()) == (sum(b.ngram_fd.values()) + 2 + 1) / 2.0
-    assert close_enough(b.score_ngrams(BigramAssocMeasures.pmi),
-        [(('a', 'test'), 1.584962500721156), (('is', 'a'), 1.584962500721156), (('this', 'is'), 1.584962500721156), (('a', 'a'), 0.0), (('is', 'is'), 0.0), (('test', 'test'), 0.0), (('this', 'this'), 0.0)])
-
-
-def test_bigram5():
-
-    sent = 'this this is is a a test test'.split()
-
-    b = BigramCollocationFinder.from_words(sent, window_size=5)
-    assert b.ngram_fd.items() == \
-        [(('a', 'test'), 4), (('is', 'a'), 4), (('this', 'is'), 4), (('is', 'test'), 3), (('this', 'a'), 3), (('a', 'a'), 1), (('is', 'is'), 1), (('test', 'test'), 1), (('this', 'this'), 1)]
-    assert b.word_fd.items() == \
-        [('a', 2), ('is', 2), ('test', 2), ('this', 2)]
-    assert len(sent) == sum(b.word_fd.values()) == (sum(b.ngram_fd.values()) + 4 + 3 + 2 + 1) / 4.0
-    assert close_enough(b.score_ngrams(BigramAssocMeasures.pmi),
-        [(('a', 'test'), 1.0), (('is', 'a'), 1.0), (('this', 'is'), 1.0), (('is', 'test'), 0.5849625007211562), (('this', 'a'), 0.5849625007211562), (('a', 'a'), -1.0), (('is', 'is'), -1.0), (('test', 'test'), -1.0), (('this', 'this'), -1.0)])
+        b = BigramCollocationFinder.from_words(sent, window_size=5)
+        self.assertItemsEqual(
+            sorted(b.ngram_fd.items()),
+            sorted([(('a', 'test'), 4), (('is', 'a'), 4), (('this', 'is'), 4), (('is', 'test'), 3), (('this', 'a'), 3), (('a', 'a'), 1), (('is', 'is'), 1), (('test', 'test'), 1), (('this', 'this'), 1)])
+        )
+        self.assertItemsEqual(
+            sorted(b.word_fd.items()),
+            sorted([('a', 2), ('is', 2), ('test', 2), ('this', 2)])
+        )
+        self.assertTrue(len(sent) == sum(b.word_fd.values()) == (sum(b.ngram_fd.values()) + 4 + 3 + 2 + 1) / 4.0)
+        self.assertTrue(close_enough(
+            sorted(b.score_ngrams(BigramAssocMeasures.pmi)),
+            sorted([(('a', 'test'), 1.0), (('is', 'a'), 1.0), (('this', 'is'), 1.0), (('is', 'test'), 0.5849625007211562), (('this', 'a'), 0.5849625007211562), (('a', 'a'), -1.0), (('is', 'is'), -1.0), (('test', 'test'), -1.0), (('this', 'this'), -1.0)])
+        ))


### PR DESCRIPTION
Fixes unit testing bugs for https://github.com/nltk/nltk/issues/581

I added unittest2 as an import as python 2.6 doesn't have any list comparison asserts, so cleaner code can be used. Unittest2 is also available on python 3 as unittest2py3k.
