### PR TITLE
Fixes to #577

### DIFF
--- a/nltk/parse/stanford.py
+++ b/nltk/parse/stanford.py
@@ -27,11 +27,11 @@ class StanfordParser(ParserI):
     Interface to the Stanford Parser
 
     >>> parser=StanfordParser(
-    ...     model_path='edu/stanford/nlp/models/lexparser/englishPCFG.ser.gz'
+    ...     model_path="edu/stanford/nlp/models/lexparser/englishPCFG.ser.gz"
     ... )
     >>> parser.raw_batch_parse((
-    ...     'the quick brown fox jumps over the lazy dog',
-    ...     'the quick grey wolf jumps over the lazy fox'
+    ...     "the quick brown fox jumps over the lazy dog",
+    ...     "the quick grey wolf jumps over the lazy fox"
     ... ))
     [Tree('ROOT', [Tree('NP', [Tree('NP', [Tree('DT', ['the']), Tree('JJ', ['quick']), Tree('JJ', ['brown']),
     Tree('NN', ['fox'])]), Tree('NP', [Tree('NP', [Tree('NNS', ['jumps'])]), Tree('PP', [Tree('IN', ['over']),
@@ -41,8 +41,8 @@ class StanfordParser(ParserI):
     Tree('JJ', ['lazy']), Tree('NN', ['fox'])])])])])])]
 
     >>> parser.batch_parse((
-    ...     'I \'m a dog'.split(),
-    ...     'This is my friends \' cat ( the tabby )'.split(),
+    ...     "I 'm a dog".split(),
+    ...     "This is my friends ' cat ( the tabby )".split(),
     ... ))
     [Tree('ROOT', [Tree('S', [Tree('NP', [Tree('PRP', ['I'])]), Tree('VP', [Tree('VBP', ["'m"]),
     Tree('NP', [Tree('DT', ['a']), Tree('NN', ['dog'])])])])]), Tree('ROOT', [Tree('S', [Tree('NP',
@@ -52,16 +52,16 @@ class StanfordParser(ParserI):
 
     >>> parser.tagged_batch_parse((
     ...     (
-    ...         ('The', 'DT'),
-    ...         ('quick', 'JJ'),
-    ...         ('brown', 'JJ'),
-    ...         ('fox', 'NN'),
-    ...         ('jumped', 'VBD'),
-    ...         ('over', 'IN'),
-    ...         ('the', 'DT'),
-    ...         ('lazy', 'JJ'),
-    ...         ('dog', 'NN'),
-    ...         ('.', '.'),
+    ...         ("The", "DT"),
+    ...         ("quick", "JJ"),
+    ...         ("brown", "JJ"),
+    ...         ("fox", "NN"),
+    ...         ("jumped", "VBD"),
+    ...         ("over", "IN"),
+    ...         ("the", "DT"),
+    ...         ("lazy", "JJ"),
+    ...         ("dog", "NN"),
+    ...         (".", "."),
     ...     ),
     ... ))
     [Tree('ROOT', [Tree('S', [Tree('NP', [Tree('DT', ['The']), Tree('JJ', ['quick']), Tree('JJ', ['brown']),

--- a/nltk/parse/stanford.py
+++ b/nltk/parse/stanford.py
@@ -23,7 +23,7 @@ from nltk.tree import Tree
 _stanford_url = 'http://nlp.stanford.edu/software/lex-parser.shtml'
 
 class StanfordParser(ParserI):
-    '''
+    r"""
     Interface to the Stanford Parser
 
     >>> parser=StanfordParser(
@@ -41,8 +41,8 @@ class StanfordParser(ParserI):
     Tree('JJ', ['lazy']), Tree('NN', ['fox'])])])])])])]
 
     >>> parser.batch_parse((
-    ...     'I \\\'m a dog'.split(),
-    ...     'This is my friends \\\' cat ( the tabby )'.split(),
+    ...     'I \'m a dog'.split(),
+    ...     'This is my friends \' cat ( the tabby )'.split(),
     ... ))
     [Tree('ROOT', [Tree('S', [Tree('NP', [Tree('PRP', ['I'])]), Tree('VP', [Tree('VBP', ["'m"]),
     Tree('NP', [Tree('DT', ['a']), Tree('NN', ['dog'])])])])]), Tree('ROOT', [Tree('S', [Tree('NP',
@@ -67,7 +67,7 @@ class StanfordParser(ParserI):
     [Tree('ROOT', [Tree('S', [Tree('NP', [Tree('DT', ['The']), Tree('JJ', ['quick']), Tree('JJ', ['brown']),
     Tree('NN', ['fox'])]), Tree('VP', [Tree('VBD', ['jumped']), Tree('PP', [Tree('IN', ['over']), Tree('NP',
     [Tree('DT', ['the']), Tree('JJ', ['lazy']), Tree('NN', ['dog'])])])]), Tree('.', ['.'])])])]
-    '''
+    """
     _MODEL_JAR_PATTERN = r'stanford-parser-(\d+)\.(\d+)\.(\d+)-models\.jar'
     _JAR = 'stanford-parser.jar'
 

--- a/nltk/parse/stanford.py
+++ b/nltk/parse/stanford.py
@@ -22,16 +22,6 @@ from nltk.tree import Tree
 
 _stanford_url = 'http://nlp.stanford.edu/software/lex-parser.shtml'
 
-def setup_module(module):
-    from nose import SkipTest
-
-    try:
-        StanfordParser(
-            model_path='edu/stanford/nlp/models/lexparser/englishPCFG.ser.gz'
-        )
-    except LookupError:
-        raise SkipTest('doctests from nltk.parse.stanford are skipped because the stanford parser jar doesn\'t exist')
-
 class StanfordParser(ParserI):
     '''
     Interface to the Stanford Parser
@@ -253,3 +243,13 @@ class StanfordParser(ParserI):
 
         return stdout
 
+
+def setup_module(module):
+    from nose import SkipTest
+
+    try:
+        StanfordParser(
+            model_path='edu/stanford/nlp/models/lexparser/englishPCFG.ser.gz'
+        )
+    except LookupError:
+        raise SkipTest('doctests from nltk.parse.stanford are skipped because the stanford parser jar doesn\'t exist')

--- a/nltk/parse/stanford.py
+++ b/nltk/parse/stanford.py
@@ -30,7 +30,7 @@ def setup_module(module):
             model_path='edu/stanford/nlp/models/lexparser/englishPCFG.ser.gz'
         )
     except LookupError:
-        raise SkipTest('doctests from nltk.parse.stanford are skipped because the stanford parser jar doesn\\\'t exist')
+        raise SkipTest('doctests from nltk.parse.stanford are skipped because the stanford parser jar doesn\'t exist')
 
 class StanfordParser(ParserI):
     '''

--- a/nltk/tokenize/stanford.py
+++ b/nltk/tokenize/stanford.py
@@ -21,14 +21,6 @@ from nltk.tokenize.api import TokenizerI
 
 _stanford_url = 'http://nlp.stanford.edu/software/lex-parser.shtml'
 
-def setup_module(module):
-    from nose import SkipTest
-
-    try:
-        StanfordTokenizer()
-    except LookupError:
-        raise SkipTest('doctests from nltk.tokenize.stanford are skipped because the stanford postagger jar doesn\'t exist')
-
 class StanfordTokenizer(TokenizerI):
     """
     Interface to the Stanford Tokenizer
@@ -104,3 +96,11 @@ class StanfordTokenizer(TokenizerI):
 
         return stdout
 
+
+def setup_module(module):
+    from nose import SkipTest
+
+    try:
+        StanfordTokenizer()
+    except LookupError:
+        raise SkipTest('doctests from nltk.tokenize.stanford are skipped because the stanford postagger jar doesn\'t exist')

--- a/nltk/tokenize/stanford.py
+++ b/nltk/tokenize/stanford.py
@@ -21,20 +21,28 @@ from nltk.tokenize.api import TokenizerI
 
 _stanford_url = 'http://nlp.stanford.edu/software/lex-parser.shtml'
 
+def setup_module(module):
+    from nose import SkipTest
+
+    try:
+        StanfordTokenizer()
+    except LookupError:
+        raise SkipTest('doctests from nltk.tokenize.stanford are skipped because the stanford postagger jar doesn\'t exist')
+
 class StanfordTokenizer(TokenizerI):
     """
     Interface to the Stanford Tokenizer
 
     >>> from nltk.tokenize.stanford import StanfordTokenizer
-    >>> s = 'Good muffins cost $3.88\nin New York.  Please buy me\ntwo of them.\nThanks.'
+    >>> s = 'Good muffins cost $3.88\\nin New York.  Please buy me\\ntwo of them.\\nThanks.'
     >>> StanfordTokenizer().tokenize(s)
     ['Good', 'muffins', 'cost', '$', '3.88', 'in', 'New', 'York', '.', 'Please', 'buy', 'me', 'two', 'of', 'them', '.', 'Thanks', '.']
     >>> s = 'The colour of the wall is blue.'
-    >>> StanfordTokenizer().tokenize(s, options={'americanize': True})
+    >>> StanfordTokenizer(options={'americanize': True}).tokenize(s)
     ['The', 'color', 'of', 'the', 'wall', 'is', 'blue', '.']
     """
 
-    _JAR = 'stanford-parser.jar'
+    _JAR = 'stanford-postagger.jar'
 
     def __init__(self, path_to_jar=None, encoding='UTF-8', options=None, verbose=False, java_options='-mx1000m'):
         self._stanford_jar = find_jar(
@@ -47,7 +55,7 @@ class StanfordTokenizer(TokenizerI):
         self._encoding = encoding
         self.java_options = java_options
         options = {} if options is None else options
-        self._options_cmd = ','.join('{}={}'.format(key, json.dumps(val)) for key, val in options.items())
+        self._options_cmd = ','.join('{0}={1}'.format(key, json.dumps(val)) for key, val in options.items())
 
     @staticmethod
     def _parse_tokenized_output(s):

--- a/nltk/tokenize/stanford.py
+++ b/nltk/tokenize/stanford.py
@@ -22,11 +22,11 @@ from nltk.tokenize.api import TokenizerI
 _stanford_url = 'http://nlp.stanford.edu/software/lex-parser.shtml'
 
 class StanfordTokenizer(TokenizerI):
-    """
+    r"""
     Interface to the Stanford Tokenizer
 
     >>> from nltk.tokenize.stanford import StanfordTokenizer
-    >>> s = 'Good muffins cost $3.88\\nin New York.  Please buy me\\ntwo of them.\\nThanks.'
+    >>> s = 'Good muffins cost $3.88\nin New York.  Please buy me\ntwo of them.\nThanks.'
     >>> StanfordTokenizer().tokenize(s)
     ['Good', 'muffins', 'cost', '$', '3.88', 'in', 'New', 'York', '.', 'Please', 'buy', 'me', 'two', 'of', 'them', '.', 'Thanks', '.']
     >>> s = 'The colour of the wall is blue.'

--- a/nltk/tokenize/stanford.py
+++ b/nltk/tokenize/stanford.py
@@ -26,11 +26,11 @@ class StanfordTokenizer(TokenizerI):
     Interface to the Stanford Tokenizer
 
     >>> from nltk.tokenize.stanford import StanfordTokenizer
-    >>> s = 'Good muffins cost $3.88\nin New York.  Please buy me\ntwo of them.\nThanks.'
+    >>> s = "Good muffins cost $3.88\nin New York.  Please buy me\ntwo of them.\nThanks."
     >>> StanfordTokenizer().tokenize(s)
     ['Good', 'muffins', 'cost', '$', '3.88', 'in', 'New', 'York', '.', 'Please', 'buy', 'me', 'two', 'of', 'them', '.', 'Thanks', '.']
-    >>> s = 'The colour of the wall is blue.'
-    >>> StanfordTokenizer(options={'americanize': True}).tokenize(s)
+    >>> s = "The colour of the wall is blue."
+    >>> StanfordTokenizer(options={"americanize": True}).tokenize(s)
     ['The', 'color', 'of', 'the', 'wall', 'is', 'blue', '.']
     """
 


### PR DESCRIPTION
Fixed bugs in stanford tokenizer doctests.
Added code to skip doctests if the jar doesn't exist.
Tested the doctest for python 2.6 and 3.2, they should hopefully work now.
