### PR TITLE
Small fix in chat80 doctest

### DIFF
--- a/nltk/test/chat80.doctest
+++ b/nltk/test/chat80.doctest
@@ -194,7 +194,7 @@ to SQL:
     Det[SEM='SELECT'] -> 'Which' | 'What'
     N[SEM='City FROM city_table'] -> 'cities'
     IV[SEM=''] -> 'are'
-    A -> 'located'
+    A[SEM=''] -> 'located'
     P[SEM=''] -> 'in'
 
 Given this grammar, we can express, and then execute, queries in English.


### PR DESCRIPTION
This fixes the chat80 doctest so it is up to date with 'book_grammars/sql0.fcfg'.
