### PR TITLE
Fixes 2.6 compatibility of numerous utility/example files

### DIFF
--- a/emacs/pycomplete.py
+++ b/emacs/pycomplete.py
@@ -1,4 +1,4 @@
-from __future__ import print_statement
+from __future__ import print_function
 
 """
 Python dot expression completion using Pymacs.

--- a/examples/school/categories.py
+++ b/examples/school/categories.py
@@ -1,4 +1,4 @@
-from __future__ import print_statement
+from __future__ import print_function
 
 from words import *
 from nltk.wordnet import *

--- a/examples/school/parser.py
+++ b/examples/school/parser.py
@@ -1,4 +1,4 @@
-from __future__ import print_statement
+from __future__ import print_function
 
 import nltk
 

--- a/examples/school/words.py
+++ b/examples/school/words.py
@@ -1,4 +1,4 @@
-from __future__ import print_statement
+from __future__ import print_function
 
 import re, random
 

--- a/examples/semantics/syn2sem.py
+++ b/examples/semantics/syn2sem.py
@@ -4,7 +4,7 @@
 # URL: <http://nltk.org/>
 # For license information, see LICENSE.TXT
 
-from __future__ import print_statement
+from __future__ import print_function
 
 """
 Demo of how to combine the output of parsing with evaluation in a model.

--- a/tools/find_deprecated.py
+++ b/tools/find_deprecated.py
@@ -7,7 +7,7 @@
 # URL: <http://nltk.org/>
 # For license information, see LICENSE.TXT
 
-from __future__ import print_statement
+from __future__ import print_function
 
 """
 This command-line tool takes a list of python files or directories,
@@ -214,10 +214,10 @@ def main():
                 deprecated_classes[name]).union(
                 deprecated_methods[name])
             for msg, prefix, suffix in msgs:
-                print(textwrap.fill(term.RED+prefix+name+suffix+)
+                print(textwrap.fill(term.RED+prefix+name+suffix+
                                     term.NORMAL+': '+msg,
                                     width=75, initial_indent=' '*2,
-                                    subsequent_indent=' '*6)
+                                    subsequent_indent=' '*6))
 
 
 

--- a/tools/nltk_term_index.py
+++ b/tools/nltk_term_index.py
@@ -1,4 +1,4 @@
-from __future__ import print_statement
+from __future__ import print_function
 
 import re, sys
 import nltk

--- a/tools/svnmime.py
+++ b/tools/svnmime.py
@@ -4,7 +4,7 @@
 # configured to automatically set mime types
 # http://code.google.com/p/support/wiki/FAQ
 
-from __future__ import print_statement
+from __future__ import print_function
 
 import os
 import sys


### PR DESCRIPTION
Many pieces of example code or other utility modules were trying to
import print_statement from future, which does not exist. What the
developers probably meant was print_function (in common use elsewhere in
the repository).

This branch makes it so that compileall succeeds on all .py files in the
repo.
