### PR TITLE
Changed URL to account for branch rename

### DIFF
--- a/nltk/test/__init__.py
+++ b/nltk/test/__init__.py
@@ -12,7 +12,7 @@ For instructions, please see:
 
 ../../web/dev/local_testing.rst
 
-https://github.com/nltk/nltk/blob/master/web/dev/local_testing.rst
+https://github.com/nltk/nltk/blob/develop/web/dev/local_testing.rst
 
 
 """


### PR DESCRIPTION
The URL was broken when the "Master" branch was renamed to "Develop." This was pointed out in issue #515
