### PR TITLE
Remove 'SVN Revision' from the downloader GUI

### DIFF
--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -1133,7 +1133,7 @@ class DownloaderGUI(object):
     COLUMNS = ['', 'Identifier', 'Name', 'Size', 'Status',
                'Unzipped Size',
                'Copyright', 'Contact', 'License', 'Author',
-               'SVN Revision', 'Subdir', 'Checksum']
+               'Subdir', 'Checksum']
     """A list of the names of columns.  This controls the order in
        which the columns will appear.  If this is edited, then
        ``_package_to_columns()`` may need to be edited to match."""


### PR DESCRIPTION
... we might want to add a similar field later, but right now "SVN Revision" can never be set!

Tested this out: when this is removed from the list, "SVN Revision" simply doesn't appear in the dropdown of possible fields to display.
