### PR TITLE
Updated docstring of wordnet to clarify new getter methods

### DIFF
--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -197,7 +197,7 @@ class Lemma(_WordNetObject):
     'salt.n.03' has the Lemmas 'salt.n.03.salt', 'salt.n.03.saltiness' and
     'salt.n.03.salinity'.
 
-    Lemma attributes:
+    Lemma attributes, accessible via methods with the same name::
 
     - name: The canonical name of this lemma.
     - synset: The synset that this lemma belongs to.
@@ -205,6 +205,7 @@ class Lemma(_WordNetObject):
       syntactic position relative modified noun. See:
       http://wordnet.princeton.edu/man/wninput.5WN.html#sect10
       For all other parts of speech, this attribute is None.
+    - count: The frequency of this lemma in wordnet.
 
     Lemma methods:
 
@@ -246,21 +247,27 @@ class Lemma(_WordNetObject):
 
         self._key = None # gets set later.
 
+    @property
     def name(self):
         return self._name
 
+    @property
     def syntactic_marker(self):
         return self._syntactic_marker
 
+    @property
     def synset(self):
         return self._synset
 
+    @property
     def frame_strings(self):
         return self._frame_strings
 
+    @property
     def frame_ids(self):
         return self._frame_ids
 
+    @property
     def key(self):
         return self._key
 
@@ -295,7 +302,7 @@ class Synset(_WordNetObject):
     <pos> is one of the module attributes ADJ, ADJ_SAT, ADV, NOUN or VERB
     <number> is the sense number, counting from 0.
 
-    Synset attributes:
+    Synset attributes, accessible via methods with the same name:
 
     - name: The canonical name of this synset, formed using the first lemma
       of this synset. Note that this may be different from the name
@@ -307,7 +314,7 @@ class Synset(_WordNetObject):
     - definition: The definition for this synset.
     - examples: A list of example strings for this synset.
     - offset: The offset in the WordNet dict file of this synset.
-    - #lexname: The name of the lexicographer file containing this synset.
+    - lexname: The name of the lexicographer file containing this synset.
 
     Synset methods:
 
@@ -367,30 +374,39 @@ class Synset(_WordNetObject):
         self._pointers = defaultdict(set)
         self._lemma_pointers = defaultdict(set)
 
+    @property
     def pos(self):
         return self._pos
 
+    @property
     def offset(self):
         return self._offset
 
+    @property
     def name(self):
         return self._name
 
+    @property
     def frame_ids(self):
         return self._frame_ids
 
+    @property
     def lemmas(self):
         return self._lemmas
 
+    @property
     def lemma_names(self):
         return self._lemma_names
 
+    @property
     def definition(self):
         return self._definition
 
+    @property
     def examples(self):
         return self._examples
 
+    @property
     def lexname(self):
         return self._lexname
 

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -247,27 +247,21 @@ class Lemma(_WordNetObject):
 
         self._key = None # gets set later.
 
-    @property
     def name(self):
         return self._name
 
-    @property
     def syntactic_marker(self):
         return self._syntactic_marker
 
-    @property
     def synset(self):
         return self._synset
 
-    @property
     def frame_strings(self):
         return self._frame_strings
 
-    @property
     def frame_ids(self):
         return self._frame_ids
 
-    @property
     def key(self):
         return self._key
 
@@ -374,39 +368,30 @@ class Synset(_WordNetObject):
         self._pointers = defaultdict(set)
         self._lemma_pointers = defaultdict(set)
 
-    @property
     def pos(self):
         return self._pos
 
-    @property
     def offset(self):
         return self._offset
 
-    @property
     def name(self):
         return self._name
 
-    @property
     def frame_ids(self):
         return self._frame_ids
 
-    @property
     def lemmas(self):
         return self._lemmas
 
-    @property
     def lemma_names(self):
         return self._lemma_names
 
-    @property
     def definition(self):
         return self._definition
 
-    @property
     def examples(self):
         return self._examples
 
-    @property
     def lexname(self):
         return self._lexname
 


### PR DESCRIPTION
A small pull request to establish backward compatibility with old code as discussed in #475. Docstring has been updated as to clarify that the classes attributes are now to be accessed via methods.
