### PR TITLE
changed numpy.stdev = ... to stdev = ... in texttiling algorithm

### DIFF
--- a/nltk/tokenize/texttiling.py
+++ b/nltk/tokenize/texttiling.py
@@ -274,13 +274,13 @@ class TextTilingTokenizer(TokenizerI):
         boundaries = [0 for x in depth_scores]
 
         avg = sum(depth_scores)/len(depth_scores)
-        numpy.stdev = numpy.std(depth_scores)
+        stdev = numpy.std(depth_scores)
 
         #SB: what is the purpose of this conditional?
         if self.cutoff_policy == LC:
-            cutoff = avg-numpy.stdev/2.0
+            cutoff = avg-stdev/2.0
         else:
-            cutoff = avg-numpy.stdev/2.0
+            cutoff = avg-stdev/2.0
 
         depth_tuples = sorted(zip(depth_scores, range(len(depth_scores))))
         depth_tuples.reverse()


### PR DESCRIPTION
no apparent reason to assign the std of the scores to the numpy object
