### PR TITLE
PunktSentenceTokenizer: accept the realign_boundaries argument in the span_tokenize method

### DIFF
--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -49,7 +49,7 @@ flag.
     >>> text = '''
     ... (How does it deal with this parenthesis?)  "It should be part of the
     ... previous sentence." "(And the same with this one.)" ('And this one!')
-    ... "('(And (this)) '?)" [(and this.)]
+    ... "('(And (this)) '?)" [(and this. )]
     ... '''
     >>> print('\n-----\n'.join(
     ...     sent_detector.tokenize(text.strip())))
@@ -64,7 +64,7 @@ flag.
     -----
     "('(And (this)) '?)"
     -----
-    [(and this.)]
+    [(and this. )]
     >>> print('\n-----\n'.join(
     ...     sent_detector.tokenize(text.strip(), realign_boundaries=False)))
     (How does it deal with this parenthesis?

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -6,6 +6,7 @@
 #         Steven Bird <stevenbird1@gmail.com> (additions)
 #         Edward Loper <edloper@gmail.com> (rewrite)
 #         Joel Nothman <jnothman@student.usyd.edu.au> (almost rewrite)
+#         Arthur Darcet <arthur@darcet.fr> (fixes)
 # URL: <http://nltk.org/>
 # For license information, see LICENSE.TXT
 
@@ -1297,12 +1298,15 @@ class PunktSentenceTokenizer(PunktBaseClass,TokenizerI):
                 break_decision=tokens[0].sentbreak,
             )
 
-    def span_tokenize(self, text):
+    def span_tokenize(self, text, realign_boundaries=True):
         """
         Given a text, returns a list of the (start, end) spans of sentences
         in the text.
         """
-        return [(sl.start, sl.stop) for sl in self._slices_from_text(text)]
+        slices = self._slices_from_text(text)
+        if realign_boundaries:
+            slices = self._realign_boundaries(text, slices)
+        return [(sl.start, sl.stop) for sl in slices]
 
     def sentences_from_text(self, text, realign_boundaries=True):
         """
@@ -1311,10 +1315,7 @@ class PunktSentenceTokenizer(PunktBaseClass,TokenizerI):
         True, includes in the sentence closing punctuation that
         follows the period.
         """
-        sents = [text[sl] for sl in self._slices_from_text(text)]
-        if realign_boundaries:
-            sents = self._realign_boundaries(sents)
-        return sents
+        return [text[s:e] for s, e in self.span_tokenize(text, realign_boundaries)]
 
     def _slices_from_text(self, text):
         last_break = 0
@@ -1330,7 +1331,7 @@ class PunktSentenceTokenizer(PunktBaseClass,TokenizerI):
                     last_break = match.end()
         yield slice(last_break, len(text))
 
-    def _realign_boundaries(self, sents):
+    def _realign_boundaries(self, text, slices):
         """
         Attempts to realign punctuation that falls after the period but
         should otherwise be included in the same sentence.
@@ -1344,21 +1345,21 @@ class PunktSentenceTokenizer(PunktBaseClass,TokenizerI):
             ["(Sent1.)", "Sent2."].
         """
         realign = 0
-        for s1, s2 in _pair_iter(sents):
-            s1 = s1[realign:]
-            if not s2:
-                if s1:
-                    yield s1
+        for sl1, sl2 in _pair_iter(slices):
+            sl1 = slice(sl1.start + realign, sl1.stop)
+            if not sl2:
+                if text[sl1]:
+                    yield sl1
                 continue
 
-            m = self._lang_vars.re_boundary_realignment.match(s2)
+            m = self._lang_vars.re_boundary_realignment.match(text[sl2])
             if m:
-                yield s1 + m.group(0).strip()
+                yield slice(sl1.start, sl2.start + len(m.group(0).rstrip()))
                 realign = m.end()
             else:
                 realign = 0
-                if s1:
-                    yield s1
+                if text[sl1]:
+                    yield sl1
 
     def text_contains_sentbreak(self, text):
         """


### PR DESCRIPTION
Adapt `PunktSentenceTokenizer._realignboundaries` to work with slices instead of using the text directly

This also fix the failing test in the first commit: `"(Sent1. ) Sent2."` should be tokenized `['(Sent1. )', 'Sent2.']`, not `['Sent1.)', 'Sent2.']`.
Without this, the space between the dot and the closing parenthesis is missing in the tokenized sentences.
