### PR TITLE
Updates doctests to use fromstring() method instead of read().

### DIFF
--- a/nltk/app/chartparser_app.py
+++ b/nltk/app/chartparser_app.py
@@ -51,7 +51,7 @@ from nltk.parse.chart import (BottomUpPredictCombineRule, BottomUpPredictRule,
                               SteppingChartParser, TopDownInitRule, TopDownPredictRule,
                               TreeEdge)
 from nltk.tree import Tree
-from nltk.grammar import Nonterminal, parse_cfg
+from nltk.grammar import Nonterminal, ContextFreeGrammar
 from nltk.util import in_idle
 from nltk.draw.util import (CanvasFrame, ColorizedList,
                             EntryDialog, MutableOptionMenu,
@@ -1091,7 +1091,7 @@ class ChartView(object):
 
     def _edge_conflict(self, edge, lvl):
         """
-        Return True if the given edge overlaps with any edge on the given
+        Return 1 if the given edge overlaps with any edge on the given
         level.  This is used by _add_edge to figure out what level a
         new edge should be added to.
         """
@@ -1099,8 +1099,8 @@ class ChartView(object):
         for otheredge in self._edgelevels[lvl]:
             (s2, e2) = otheredge.span()
             if (s1 <= s2 < e1) or (s2 <= s1 < e2) or (s1==s2==e1==e2):
-                return True
-        return False
+                return 1
+        return 0
 
     def _analyze_edge(self, edge):
         """
@@ -2038,7 +2038,7 @@ class ChartParserApp(object):
                     grammar = pickle.load(infile)
             else:
                 with open(filename, 'r') as infile:
-                    grammar = parse_cfg(infile.read())
+                    grammar = ContextFreeGrammar.fromstring(infile.read())
             self.set_grammar(grammar)
         except Exception as e:
             tkinter.messagebox.showerror('Error Loading Grammar',
@@ -2230,7 +2230,7 @@ class ChartParserApp(object):
         self.apply_strategy(self._TD_STRATEGY, TopDownPredictEdgeRule)
 
 def app():
-    grammar = parse_cfg("""
+    grammar = ContextFreeGrammar.fromstring("""
     # Grammatical productions.
         S -> NP VP
         VP -> VP PP | V NP | V

--- a/nltk/app/rdparser_app.py
+++ b/nltk/app/rdparser_app.py
@@ -541,11 +541,11 @@ class RecursiveDescentApp(object):
             index = self._productions.index(rv)
             self._prodlist.selection_set(index)
             self._animate_expand(old_frontier[0])
-            return True
+            return 1
         else:
             self._lastoper1['text'] = 'Expand:'
             self._lastoper2['text'] = '(all expansions tried)'
-            return False
+            return 0
 
     def _match(self, *e):
         if self._animating_lock: return
@@ -555,11 +555,11 @@ class RecursiveDescentApp(object):
             self._lastoper1['text'] = 'Match:'
             self._lastoper2['text'] = rv
             self._animate_match(old_frontier[0])
-            return True
+            return 1
         else:
             self._lastoper1['text'] = 'Match:'
             self._lastoper2['text'] = '(failed)'
-            return False
+            return 0
 
     def _backtrack(self, *e):
         if self._animating_lock: return
@@ -573,12 +573,12 @@ class RecursiveDescentApp(object):
                 self._animate_backtrack(self._parser.frontier()[0])
             else:
                 self._animate_match_backtrack(self._parser.frontier()[0])
-            return True
+            return 1
         else:
             self._autostep = 0
             self._lastoper1['text'] = 'Finished'
             self._lastoper2['text'] = ''
-            return False
+            return 0
 
     def about(self, *e):
         ABOUT = ("NLTK Recursive Descent Parser Application\n"+
@@ -867,8 +867,8 @@ def app():
     Create a recursive descent parser demo, using a simple grammar and
     text.
     """
-    from nltk.grammar import parse_cfg
-    grammar = parse_cfg("""
+    from nltk.grammar import ContextFreeGrammar
+    grammar = ContextFreeGrammar.fromstring("""
     # Grammatical productions.
         S -> NP VP
         NP -> Det N PP | Det N

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -803,13 +803,13 @@ def load(resource_url, format='auto', cache=True, verbose=False,
         if format == 'text':
             resource_val = string_data
         elif format == 'cfg':
-            resource_val = nltk.grammar.ContextFreeGrammar.read(
+            resource_val = nltk.grammar.ContextFreeGrammar.fromstring(
                 string_data, encoding=encoding)
         elif format == 'pcfg':
-            resource_val = nltk.grammar.WeightedGrammar.read(
+            resource_val = nltk.grammar.WeightedGrammar.fromstring(
                 string_data, encoding=encoding)
         elif format == 'fcfg':
-            resource_val = nltk.grammar.FeatureGrammar.read(
+            resource_val = nltk.grammar.FeatureGrammar.fromstring(
                 string_data, logic_parser=logic_parser,
                 fstruct_reader=fstruct_reader, encoding=encoding)
         elif format == 'fol':

--- a/nltk/draw/cfg.py
+++ b/nltk/draw/cfg.py
@@ -702,12 +702,12 @@ def demo2():
 ######################################################################
 
 def demo():
-    from nltk import Nonterminal, parse_cfg
+    from nltk import Nonterminal, ContextFreeGrammar
     nonterminals = 'S VP NP PP P N Name V Det'
     (S, VP, NP, PP, P, N, Name, V, Det) = [Nonterminal(s)
                                            for s in nonterminals.split()]
 
-    grammar = parse_cfg("""
+    grammar = ContextFreeGrammar.fromstring("""
     S -> NP VP
     PP -> P NP
     NP -> Det N

--- a/nltk/parse/featurechart.py
+++ b/nltk/parse/featurechart.py
@@ -507,8 +507,8 @@ class InstantiateVarsChart(FeatureChart):
 #////////////////////////////////////////////////////////////
 
 def demo_grammar():
-    from nltk.grammar import parse_fcfg
-    return parse_fcfg("""
+    from nltk.grammar import FeatureGrammar
+    return FeatureGrammar.fromstring("""
 S  -> NP VP
 PP -> Prep NP
 NP -> NP PP

--- a/nltk/test/dependency.doctest
+++ b/nltk/test/dependency.doctest
@@ -5,7 +5,7 @@
 Dependency Grammars
 ===================
 
-    >>> from nltk.grammar import parse_dependency_grammar
+    >>> from nltk.grammar import DependencyGrammar
     >>> from nltk.parse import *
 
 CoNLL Data
@@ -65,7 +65,7 @@ Using the dependency-parsed version of the Penn Treebank corpus sample.
 Projective Dependency Parsing
 -----------------------------
 
-    >>> grammar = parse_dependency_grammar("""
+    >>> grammar = DependencyGrammar.fromstring("""
     ... 'fell' -> 'price' | 'stock'
     ... 'price' -> 'of' 'the'
     ... 'of' -> 'stock'
@@ -89,7 +89,7 @@ Projective Dependency Parsing
 Non-Projective Dependency Parsing
 ---------------------------------
 
-    >>> grammar = parse_dependency_grammar("""
+    >>> grammar = DependencyGrammar.fromstring("""
     ... 'taught' -> 'play' | 'man'
     ... 'man' -> 'the'
     ... 'play' -> 'golf' | 'dog' | 'to'

--- a/nltk/test/generate.doctest
+++ b/nltk/test/generate.doctest
@@ -8,8 +8,8 @@ Generating sentences from context-free grammars
 An example grammar:
 
     >>> from nltk.parse.generate import generate, demo_grammar
-    >>> from nltk import read_cfg
-    >>> grammar = read_cfg(demo_grammar)
+    >>> from nltk import ContextFreeGrammar
+    >>> grammar = ContextFreeGrammar.fromstring(demo_grammar)
     >>> print(grammar)
     Grammar with 13 productions (start state = S)
         S -> NP VP

--- a/nltk/test/grammar.doctest
+++ b/nltk/test/grammar.doctest
@@ -7,8 +7,8 @@ Grammar Parsing
 
 Grammars can be parsed from strings:
 
-    >>> from nltk import read_cfg
-    >>> grammar = read_cfg("""
+    >>> from nltk import ContextFreeGrammar
+    >>> grammar = ContextFreeGrammar.fromstring("""
     ... S -> NP VP
     ... PP -> P NP
     ... NP -> Det N | NP PP
@@ -29,8 +29,8 @@ Grammars can be parsed from strings:
 
 Probabilistic CFGs:
    
-    >>> from nltk import read_pcfg
-    >>> toy_pcfg1 = read_pcfg("""
+    >>> from nltk import WeightedGrammar
+    >>> toy_pcfg1 = WeightedGrammar.fromstring("""
     ... S -> NP VP [1.0]
     ... NP -> Det N [0.5] | NP PP [0.25] | 'John' [0.1] | 'I' [0.15]
     ... Det -> 'the' [0.8] | 'my' [0.2]
@@ -43,6 +43,6 @@ Probabilistic CFGs:
 
 Chomsky Normal Form grammar (Test for bug 474)
 
-    >>> g = read_cfg("VP^<TOP> -> VBP NP^<VP-TOP>")
+    >>> g = ContextFreeGrammar.fromstring("VP^<TOP> -> VBP NP^<VP-TOP>")
     >>> g.productions()[0].lhs()
     VP^<TOP>

--- a/nltk/test/parse.doctest
+++ b/nltk/test/parse.doctest
@@ -8,7 +8,7 @@
 Unit tests for the Context Free Grammar class
 ---------------------------------------------
 
-    >>> from nltk import Nonterminal, nonterminals, Production, read_cfg, ContextFreeGrammar
+    >>> from nltk import Nonterminal, nonterminals, Production, ContextFreeGrammar
 
     >>> nt1 = Nonterminal('NP')
     >>> nt2 = Nonterminal('VP')
@@ -40,7 +40,7 @@ Unit tests for the Context Free Grammar class
     >>> prod1 == prod2
     False
 
-    >>> grammar = read_cfg("""
+    >>> grammar = ContextFreeGrammar.fromstring("""
     ... S -> NP VP
     ... PP -> P NP
     ... NP -> 'the' N | N PP | 'the' N PP
@@ -529,11 +529,11 @@ Unit tests for the Probabilistic CFG class
 
     >>> from nltk.corpus import treebank
     >>> from itertools import islice
-    >>> from nltk import read_pcfg, induce_pcfg, toy_pcfg1, toy_pcfg2
+    >>> from nltk.grammar import WeightedGrammar, induce_pcfg, toy_pcfg1, toy_pcfg2
 
 Create a set of probabilistic CFG productions.
 
-    >>> grammar = read_pcfg("""
+    >>> grammar = WeightedGrammar.fromstring("""
     ... A -> B B [.3] | C B C [.7]
     ... B -> B D [.5] | C [.5]
     ... C -> 'a' [.1] | 'b' [0.9]
@@ -842,7 +842,7 @@ The demo grammar from before, with an ambiguous sentence.
 This grammar tests that variables in different grammar rules are renamed
 before unification. (The problematic variable is in this case ?X).
 
-    >>> whatwasthat = nltk.read_fcfg('''
+    >>> whatwasthat = nltk.grammar.FeatureGrammar.fromstring('''
     ... S[] -> NP[num=?N] VP[num=?N, slash=?X]
     ... NP[num=?X] -> "what"
     ... NP[num=?X] -> "that"
@@ -854,7 +854,7 @@ before unification. (The problematic variable is in this case ?X).
 This grammar tests that the same rule can be used in different places
 in another rule, and that the variables are properly renamed.
 
-    >>> thislovesthat = nltk.read_fcfg('''
+    >>> thislovesthat = nltk.grammar.FeatureGrammar.fromstring('''
     ... S[] -> NP[case=nom] V[] NP[case=acc]
     ... NP[case=?X] -> Pron[case=?X]
     ... Pron[] -> "this"

--- a/nltk/test/semantics.doctest
+++ b/nltk/test/semantics.doctest
@@ -44,11 +44,11 @@ by ``i`` raises an ``Undefined`` exception; this is caught by
 Batch Processing
 ----------------
 
-The utility functions ``batch_interpret()`` and ``batch_evaluate()`` are intended to
+The utility functions ``interpret_sents()`` and ``evaluate_sents()`` are intended to
 help with processing multiple sentences. Here's an example of the first of these:
 
     >>> sents = ['Mary walks']
-    >>> results = nltk.sem.batch_interpret(sents, 'grammars/sample_grammars/sem2.fcfg')
+    >>> results = nltk.sem.util.interpret_sents(sents, 'grammars/sample_grammars/sem2.fcfg')
     >>> for result in results:
     ...     for (synrep, semrep) in result:
     ...         print(synrep)
@@ -64,17 +64,17 @@ is specified with a lowercase
 ``semkey`` parameter, as shown here:
 
     >>> sents = ['raining']
-    >>> g = nltk.parse_fcfg("""
+    >>> g = nltk.grammar.FeatureGrammar.fromstring("""
     ... % start S
     ... S[sem=<raining>] -> 'raining'
     ... """)
-    >>> results = nltk.sem.batch_interpret(sents, g, semkey='sem')
+    >>> results = nltk.sem.util.interpret_sents(sents, g, semkey='sem')
     >>> for result in results:
     ...     for (synrep, semrep) in result:
     ...         print(semrep)
     raining
 
-The function ``batch_evaluate()`` works in a similar manner, but also needs to be
+The function ``evaluate_sents()`` works in a similar manner, but also needs to be
 passed a ``Model`` against which the semantic representations are evaluated.
 
 Unit Tests
@@ -541,13 +541,14 @@ Tests for mapping from syntax to semantics
 Load a valuation from a file.
 
     >>> import nltk.data
+    >>> from nltk.sem.util import parse_sents
     >>> val = nltk.data.load('grammars/sample_grammars/valuation1.val')
     >>> dom = val.domain
     >>> m = Model(dom, val)
     >>> g = Assignment(dom)
     >>> gramfile = 'grammars/sample_grammars/sem2.fcfg'
     >>> inputs = ['John sees a girl', 'every dog barks']
-    >>> parses = batch_parse(inputs, gramfile)
+    >>> parses = parse_sents(inputs, gramfile)
     >>> for sent, trees in zip(inputs, parses):
     ...     print()
     ...     print("Sentence: %s" % sent)
@@ -580,7 +581,7 @@ Load a valuation from a file.
     Semantics: all x.(dog(x) -> bark(x))
 
     >>> sent = "every dog barks"
-    >>> result = nltk.sem.batch_interpret([sent], gramfile)[0]
+    >>> result = nltk.sem.util.interpret_sents([sent], gramfile)[0]
     >>> for (syntree, semrep) in result:
     ...     print(syntree)
     ...     print()
@@ -595,7 +596,7 @@ Load a valuation from a file.
     <BLANKLINE>
     all x.(dog(x) -> bark(x))
 
-    >>> result = nltk.sem.batch_evaluate([sent], gramfile, m, g)[0]
+    >>> result = nltk.sem.util.evaluate_sents([sent], gramfile, m, g)[0]
     >>> for (syntree, semrel, value) in result:
     ...     print(syntree)
     ...     print()
@@ -615,7 +616,7 @@ Load a valuation from a file.
     True
 
     >>> sents = ['Mary walks', 'John sees a dog']
-    >>> results = nltk.sem.batch_interpret(sents, 'grammars/sample_grammars/sem2.fcfg')
+    >>> results = nltk.sem.util.interpret_sents(sents, 'grammars/sample_grammars/sem2.fcfg')
     >>> for result in results:
     ...     for (synrep, semrep) in result:
     ...         print(synrep)

--- a/nltk/test/simple.doctest
+++ b/nltk/test/simple.doctest
@@ -61,8 +61,9 @@ Feature Structures
 Parsing
 -------
 
-    >>> from nltk.parse.rd import RecursiveDescentParser, parse_cfg
-    >>> grammar = parse_cfg("""
+    >>> from nltk.parse.recursivedescent import RecursiveDescentParser
+    >>> from nltk.grammar import ContextFreeGrammar
+    >>> grammar = ContextFreeGrammar.fromstring("""
     ... S -> NP VP
     ... PP -> P NP
     ... NP -> 'the' N | N PP | 'the' N PP

--- a/nltk/test/tree.doctest
+++ b/nltk/test/tree.doctest
@@ -75,17 +75,17 @@ Trees can be compared for equality:
 Tree Parsing
 ============
 
-The class method `Tree.read()` can be used to parse trees, and it
+The class method `Tree.fromstring()` can be used to parse trees, and it
 provides some additional options.
 
-    >>> tree = Tree.read('(S (NP I) (VP (V enjoyed) (NP my cookie)))')
+    >>> tree = Tree.fromstring('(S (NP I) (VP (V enjoyed) (NP my cookie)))')
     >>> print(tree)
     (S (NP I) (VP (V enjoyed) (NP my cookie)))
 
 When called on a subclass of `Tree`, it will create trees of that
 type:
 
-    >>> tree = ImmutableTree.read('(VP (V enjoyed) (NP my cookie))')
+    >>> tree = ImmutableTree.fromstring('(VP (V enjoyed) (NP my cookie))')
     >>> print(tree)
     (VP (V enjoyed) (NP my cookie))
     >>> print(type(tree))
@@ -102,29 +102,29 @@ type:
 The ``brackets`` parameter can be used to specify two characters that
 should be used as brackets:
 
-    >>> print(Tree.read('[S [NP I] [VP [V enjoyed] [NP my cookie]]]',
+    >>> print(Tree.fromstring('[S [NP I] [VP [V enjoyed] [NP my cookie]]]',
     ...                  brackets='[]'))
     (S (NP I) (VP (V enjoyed) (NP my cookie)))
-    >>> print(Tree.read('<S <NP I> <VP <V enjoyed> <NP my cookie>>>',
+    >>> print(Tree.fromstring('<S <NP I> <VP <V enjoyed> <NP my cookie>>>',
     ...                  brackets='<>'))
     (S (NP I) (VP (V enjoyed) (NP my cookie)))
 
 If ``brackets`` is not a string, or is not exactly two characters,
-then `Tree.read` raises an exception:
+then `Tree.fromstring` raises an exception:
 
-    >>> Tree.read('<VP <V enjoyed> <NP my cookie>>', brackets='')
+    >>> Tree.fromstring('<VP <V enjoyed> <NP my cookie>>', brackets='')
     Traceback (most recent call last):
       . . .
     TypeError: brackets must be a length-2 string
-    >>> Tree.read('<VP <V enjoyed> <NP my cookie>>', brackets='<<>>')
+    >>> Tree.fromstring('<VP <V enjoyed> <NP my cookie>>', brackets='<<>>')
     Traceback (most recent call last):
       . . .
     TypeError: brackets must be a length-2 string
-    >>> Tree.read('<VP <V enjoyed> <NP my cookie>>', brackets=12)
+    >>> Tree.fromstring('<VP <V enjoyed> <NP my cookie>>', brackets=12)
     Traceback (most recent call last):
       . . .
     TypeError: brackets must be a length-2 string
-    >>> Tree.read('<<NP my cookie>>', brackets=('<<','>>'))
+    >>> Tree.fromstring('<<NP my cookie>>', brackets=('<<','>>'))
     Traceback (most recent call last):
       . . .
     TypeError: brackets must be a length-2 string
@@ -134,85 +134,85 @@ which case the ``brackets=('<<','>>')`` example would start working.)
 
 Whitespace brackets are not permitted:
 
-    >>> Tree.read('(NP my cookie\n', brackets='(\n')
+    >>> Tree.fromstring('(NP my cookie\n', brackets='(\n')
     Traceback (most recent call last):
       . . .
     TypeError: whitespace brackets not allowed
 
-If an invalid tree is given to Tree.read, then it raises a
+If an invalid tree is given to Tree.fromstring, then it raises a
 ValueError, with a description of the problem:
 
-    >>> Tree.read('(NP my cookie) (NP my milk)')
+    >>> Tree.fromstring('(NP my cookie) (NP my milk)')
     Traceback (most recent call last):
       . . .
-    ValueError: Tree.read(): expected 'end-of-string' but got '(NP'
+    ValueError: Tree.fromstring(): expected 'end-of-string' but got '(NP'
                 at index 15.
                     "...y cookie) (NP my mil..."
                                   ^
-    >>> Tree.read(')NP my cookie(')
+    >>> Tree.fromstring(')NP my cookie(')
     Traceback (most recent call last):
       . . .
-    ValueError: Tree.read(): expected '(' but got ')'
+    ValueError: Tree.fromstring(): expected '(' but got ')'
                 at index 0.
                     ")NP my coo..."
                      ^
-    >>> Tree.read('(NP my cookie))')
+    >>> Tree.fromstring('(NP my cookie))')
     Traceback (most recent call last):
       . . .
-    ValueError: Tree.read(): expected 'end-of-string' but got ')'
+    ValueError: Tree.fromstring(): expected 'end-of-string' but got ')'
                 at index 14.
                     "...my cookie))"
                                   ^
-    >>> Tree.read('my cookie)')
+    >>> Tree.fromstring('my cookie)')
     Traceback (most recent call last):
       . . .
-    ValueError: Tree.read(): expected '(' but got 'my'
+    ValueError: Tree.fromstring(): expected '(' but got 'my'
                 at index 0.
                     "my cookie)"
                      ^
-    >>> Tree.read('(NP my cookie')
+    >>> Tree.fromstring('(NP my cookie')
     Traceback (most recent call last):
       . . .
-    ValueError: Tree.read(): expected ')' but got 'end-of-string'
+    ValueError: Tree.fromstring(): expected ')' but got 'end-of-string'
                 at index 13.
                     "... my cookie"
                                   ^
-    >>> Tree.read('')
+    >>> Tree.fromstring('')
     Traceback (most recent call last):
       . . .
-    ValueError: Tree.read(): expected '(' but got 'end-of-string'
+    ValueError: Tree.fromstring(): expected '(' but got 'end-of-string'
                 at index 0.
                     ""
                      ^
 
 Trees with no children are supported:
 
-    >>> print(Tree.read('(S)'))
+    >>> print(Tree.fromstring('(S)'))
     (S )
-    >>> print(Tree.read('(X (Y) (Z))'))
+    >>> print(Tree.fromstring('(X (Y) (Z))'))
     (X (Y ) (Z ))
 
 Trees with an empty node label and no children are supported:
 
-    >>> print(Tree.read('()'))
+    >>> print(Tree.fromstring('()'))
     ( )
-    >>> print(Tree.read('(X () ())'))
+    >>> print(Tree.fromstring('(X () ())'))
     (X ( ) ( ))
 
 Trees with an empty node label and children are supported, but only if the
 first child is not a leaf (otherwise, it will be treated as the node label).
 
-    >>> print(Tree.read('((A) (B) (C))'))
+    >>> print(Tree.fromstring('((A) (B) (C))'))
     ( (A ) (B ) (C ))
-    >>> print(Tree.read('((A) leaf)'))
+    >>> print(Tree.fromstring('((A) leaf)'))
     ( (A ) leaf)
-    >>> print(Tree.read('(((())))'))
+    >>> print(Tree.fromstring('(((())))'))
     ( ( ( ( ))))
 
 The optional arguments `read_node` and `read_leaf` may be used to
 transform the string values of nodes or leaves.
 
-    >>> print(Tree.read('(A b (C d e) (F (G h i)))',
+    >>> print(Tree.fromstring('(A b (C d e) (F (G h i)))',
     ...                  read_node=lambda s: '<%s>' % s,
     ...                  read_leaf=lambda s: '"%s"' % s))
     (<A> "b" (<C> "d" "e") (<F> (<G> "h" "i")))
@@ -224,7 +224,7 @@ whitespace, then you must also use the optional `node_pattern` and
 `leaf_pattern` arguments.
 
     >>> from nltk.featstruct import FeatStruct
-    >>> tree = Tree.read('([cat=NP] [lex=the] [lex=dog])',
+    >>> tree = Tree.fromstring('([cat=NP] [lex=the] [lex=dog])',
     ...                   read_node=FeatStruct, read_leaf=FeatStruct)
     >>> tree.set_label(tree.label().unify(FeatStruct('[num=singular]')))
     >>> print(tree)
@@ -233,13 +233,13 @@ whitespace, then you must also use the optional `node_pattern` and
 The optional argument ``remove_empty_top_bracketing`` can be used to
 remove any top-level empty bracketing that occurs.
 
-    >>> print(Tree.read('((S (NP I) (VP (V enjoyed) (NP my cookie))))',
+    >>> print(Tree.fromstring('((S (NP I) (VP (V enjoyed) (NP my cookie))))',
     ...                  remove_empty_top_bracketing=True))
     (S (NP I) (VP (V enjoyed) (NP my cookie)))
 
 It will not remove a top-level empty bracketing with multiple children:
 
-    >>> print(Tree.read('((A a) (B b))'))
+    >>> print(Tree.fromstring('((A a) (B b))'))
     ( (A a) (B b))
 
 Parented Trees
@@ -258,9 +258,9 @@ created directly from a node label and a list of children:
     (VP (VERB saw) (NP (DET the) (NOUN dog)))
 
 Parented trees can be created from strings using the classmethod
-`ParentedTree.read`:
+`ParentedTree.fromstring`:
 
-    >>> ptree = ParentedTree.read('(VP (VERB saw) (NP (DET the) (NOUN dog)))')
+    >>> ptree = ParentedTree.fromstring('(VP (VERB saw) (NP (DET the) (NOUN dog)))')
     >>> print(ptree)
     (VP (VERB saw) (NP (DET the) (NOUN dog)))
     >>> print(type(ptree))
@@ -270,7 +270,7 @@ Parented trees can also be created by using the classmethod
 `ParentedTree.convert` to convert another type of tree to a parented
 tree:
 
-    >>> tree = Tree.read('(VP (VERB saw) (NP (DET the) (NOUN dog)))')
+    >>> tree = Tree.fromstring('(VP (VERB saw) (NP (DET the) (NOUN dog)))')
     >>> ptree = ParentedTree.convert(tree)
     >>> print(ptree)
     (VP (VERB saw) (NP (DET the) (NOUN dog)))
@@ -464,7 +464,7 @@ variable:
 Define a helper funciton to create new parented trees:
 
     >>> def make_ptree(s):
-    ...     ptree = ParentedTree.convert(Tree.read(s))
+    ...     ptree = ParentedTree.convert(Tree.fromstring(s))
     ...     all_ptrees.extend(t for t in ptree.subtrees()
     ...                       if isinstance(t, Tree))
     ...     return ptree
@@ -748,7 +748,7 @@ variable:
 Define a helper funciton to create new parented trees:
 
     >>> def make_mptree(s):
-    ...     mptree = MultiParentedTree.convert(Tree.read(s))
+    ...     mptree = MultiParentedTree.convert(Tree.fromstring(s))
     ...     all_mptrees.extend(t for t in mptree.subtrees()
     ...                       if isinstance(t, Tree))
     ...     return mptree
@@ -1072,7 +1072,7 @@ Squashed Bugs
 
 This used to discard the ``(B b)`` subtree (fixed in svn 6270):
 
-    >>> print(Tree.read('((A a) (B b))'))
+    >>> print(Tree.fromstring('((A a) (B b))'))
     ( (A a) (B b))
 
 


### PR DESCRIPTION
Updates the doctests to reflect the changes made in [#658](https://github.com/nltk/nltk/issues/658). Also,  `semantics.doctest` was updated to account for when the `batch_interpret/evaluate/parse` functions were [renamed here](https://github.com/stevenbird/nltk/commit/1391c620cb86a7c7d8514279c00685eaf82d33a5) and moved into `nltk.sem.util`.
