### PR TITLE
Doctest fixes for renaming in d566f23 and more read() -> fromstring() changes

### DIFF
--- a/nltk/test/featgram.doctest
+++ b/nltk/test/featgram.doctest
@@ -26,7 +26,7 @@ Grammars can be parsed from strings.
     ... N[AGR=[NUM='sg']] -> 'student'
     ... N[AGR=[NUM='pl']] -> 'students'
     ... """
-    >>> grammar = grammar.read_fcfg(g)
+    >>> grammar = grammar.FeatureGrammar.fromstring(g)
     >>> tokens = 'these girls'.split()
     >>> parser = parse.FeatureEarleyChartParser(grammar)
     >>> trees = parser.parse(tokens)

--- a/nltk/test/featstruct.doctest
+++ b/nltk/test/featstruct.doctest
@@ -699,9 +699,9 @@ Playing with ranges:
     >>> from nltk.featstruct import RangeFeature, FeatStructReader
     >>> width = RangeFeature('width')
     >>> reader = FeatStructReader([width])
-    >>> fs1 = reader.read('[*width*=-5:12]')
-    >>> fs2 = reader.read('[*width*=2:123]')
-    >>> fs3 = reader.read('[*width*=-7:-2]')
+    >>> fs1 = reader.fromstring('[*width*=-5:12]')
+    >>> fs2 = reader.fromstring('[*width*=2:123]')
+    >>> fs3 = reader.fromstring('[*width*=-7:-2]')
     >>> fs1.unify(fs2)
     [*width*=(2, 12)]
     >>> fs1.unify(fs3)

--- a/nltk/test/relextract.doctest
+++ b/nltk/test/relextract.doctest
@@ -94,12 +94,12 @@ recognize pairs *(o, l)* of these kinds of entities such that *o* is
 located in *l*.
 
 The `sem.relextract` module provides some tools to help carry out a
-simple version of this task. The `mk_pairs()` function splits a chunk
+simple version of this task. The `_tree2semi_rel()` function splits a chunk
 document into a list of two-member lists, each of which consists of a
 (possibly empty) string followed by a `Tree` (i.e., a Named Entity):
 
     >>> from nltk.sem import relextract
-    >>> pairs = relextract.mk_pairs(tree)
+    >>> pairs = relextract._tree2semi_rel(tree)
     >>> for s, tree in pairs[18:22]:
     ...     print('("...%s", %s)' % (" ".join(s[-5:]),tree))
     ("...about first-level questions,'' said Ms.", (PERSON Cohn))
@@ -107,14 +107,14 @@ document into a list of two-member lists, each of which consists of a
     ("...firm in", (LOCATION San Mateo))
     ("...,", (LOCATION Calif.))
 
-The function `mk_reldicts()` processes triples of these pairs, i.e.,
+The function `semi_rel2reldict()` processes triples of these pairs, i.e.,
 pairs of the form ``((string1, Tree1), (string2, Tree2), (string3,
 Tree3))`` and outputs a dictionary (a `reldict`) in which ``Tree1`` is
 the subject of the relation, ``string2`` is the filler
 and ``Tree3`` is the object of the relation. ``string1`` and ``string3`` are
 stored as left and right context respectively.
 
-    >>> reldicts = relextract.mk_reldicts(pairs)
+    >>> reldicts = relextract.semi_rel2reldict(pairs)
     >>> for k, v in sorted(reldicts[0].items()):
     ...     print(k, '=>', v) # doctest: +ELLIPSIS
     filler => of messages to their own ``Cyberia'' ...
@@ -126,6 +126,7 @@ stored as left and right context respectively.
     subjclass => CARDINAL
     subjsym => hundreds
     subjtext => hundreds
+    untagged_filler => of messages to their own ``Cyberia'' ...
 
 The next example shows some of the values for two `reldict`\ s
 corresponding to the ``'NYT_19980315'`` text extract shown earlier.
@@ -156,7 +157,7 @@ signature <ORG, LOC>.
     >>> for fileid in ieer.fileids():
     ...     for doc in ieer.parsed_docs(fileid):
     ...         for rel in relextract.extract_rels('ORG', 'LOC', doc, corpus='ieer', pattern = IN):
-    ...             print(relextract.show_raw_rtuple(rel))  # doctest: +ELLIPSIS
+    ...             print(relextract.rtuple(rel))  # doctest: +ELLIPSIS
     [ORG: 'Christian Democrats'] ', the leading political forces in' [LOC: 'Italy']
     [ORG: 'AP'] ') _ Lebanese guerrillas attacked Israeli forces in southern' [LOC: 'Lebanon']
     [ORG: 'Security Council'] 'adopted Resolution 425. Huge yellow banners hung across intersections in' [LOC: 'Beirut']
@@ -208,7 +209,7 @@ of roles that a PERSON can occupy in an ORGANIZATION.
     >>> for fileid in ieer.fileids():
     ...     for doc in ieer.parsed_docs(fileid):
     ...         for rel in relextract.extract_rels('PER', 'ORG', doc, corpus='ieer', pattern=ROLES):
-    ...             print(relextract.show_raw_rtuple(rel)) # doctest: +ELLIPSIS
+    ...             print(relextract.rtuple(rel)) # doctest: +ELLIPSIS
     [PER: 'Kivutha Kibwana'] ', of the' [ORG: 'National Convention Assembly']
     [PER: 'Boban Boskovic'] ', chief executive of the' [ORG: 'Plastika']
     [PER: 'Annan'] ', the first sub-Saharan African to head the' [ORG: 'United Nations']
@@ -232,7 +233,7 @@ presented as something that looks more like a clause in a logical language.
     >>> rels = [rel for doc in conll2002.chunked_sents('esp.train')
     ...         for rel in relextract.extract_rels('ORG', 'LOC', doc, corpus='conll2002', pattern = DE)]
     >>> for r in rels[:10]:
-    ...     print(relextract.show_clause(r, relsym='DE'))    # doctest: +NORMALIZE_WHITESPACE
+    ...     print(relextract.clause(r, relsym='DE'))    # doctest: +NORMALIZE_WHITESPACE
     DE(u'tribunal_supremo', u'victoria')
     DE(u'museo_de_arte', u'alcorc\xf3n')
     DE(u'museo_de_bellas_artes', u'a_coru\xf1a')
@@ -256,7 +257,7 @@ presented as something that looks more like a clause in a logical language.
     >>> VAN = re.compile(vnv, re.VERBOSE)
     >>> for doc in conll2002.chunked_sents('ned.train'):
     ...     for r in relextract.extract_rels('PER', 'ORG', doc, corpus='conll2002', pattern=VAN):
-    ...         print(relextract.show_clause(r, relsym="VAN"))
+    ...         print(relextract.clause(r, relsym="VAN"))
     VAN(u"cornet_d'elzius", u'buitenlandse_handel')
     VAN(u'johan_rottiers', u'kardinaal_van_roey_instituut')
     VAN(u'annie_lennox', u'eurythmics')


### PR DESCRIPTION
Missed a few `read() -> fromstring()` changes in my previous commit 227c157.

The tests `featgram.doctest,  featstruct.doctest, relextract.doctest` all pass now.

For the renaming of  `mk_pairs() -> _tree2semi_rel()` in d566f23, does it make sense for the doctest to test an underscored method?
