### PR TITLE
fixes to align.doctest

### DIFF
--- a/nltk/align/bleu.py
+++ b/nltk/align/bleu.py
@@ -89,8 +89,8 @@ class BLEU(object):
     @staticmethod
     def compute(candidate, references, weights):
 
-        candidate = map(lambda x: x.lower(), candidate) 
-        references = map(lambda x: [c.lower() for c in x], references)
+        candidate = list(map(lambda x: x.lower(), candidate))
+        references = list(map(lambda x: [c.lower() for c in x], references))
 
         n = len(weights)
 
@@ -109,7 +109,7 @@ class BLEU(object):
     @staticmethod
     def modified_precision(candidate, references, n):
 
-        candidate_ngrams = ngrams(candidate, n)
+        candidate_ngrams = list(ngrams(candidate, n))
 
         if len(candidate_ngrams) == 0:
             return 0
@@ -121,7 +121,7 @@ class BLEU(object):
 
             count_max = 0
             for reference in references:
-                reference_ngrams = ngrams(reference, n)
+                reference_ngrams = list(ngrams(reference, n))
 
                 count = reference_ngrams.count(word) + 1
                 if count > count_max:

--- a/nltk/align/ibm1.py
+++ b/nltk/align/ibm1.py
@@ -34,12 +34,12 @@ class IBMModel1(object):
     >>> aligned_sent = ibm.align(bitexts[6])
     >>> aligned_sent.alignment
     Alignment([(0, 0), (1, 1), (2, 2), (3, 7), (4, 7), (5, 8)])
-    >>> bitexts[6].precision(aligned_sent)
-    0.5555555555555556
-    >>> bitexts[6].recall(aligned_sent)
-    0.8333333333333334
-    >>> bitexts[6].alignment_error_rate(aligned_sent)
-    0.33333333333333337
+    >>> round(bitexts[6].precision(aligned_sent), 3)
+    0.556
+    >>> round(bitexts[6].recall(aligned_sent), 3)
+    0.833
+    >>> round(bitexts[6].alignment_error_rate(aligned_sent), 3)
+    0.333
     
     """
     def __init__(self, align_sents, num_iter):

--- a/nltk/align/ibm3.py
+++ b/nltk/align/ibm3.py
@@ -384,7 +384,7 @@ class IBMModel3(object):
         for j, en_word in enumerate(align_sent.words):
             
             # Initialize the maximum probability with Null token
-            max_align_prob = (self.probabilities[en_word][None]*self.distortion[j+1][0][l_e][l_f], None)
+            max_align_prob = (self.probabilities[en_word][None]*self.distortion[j+1][0][l_e][l_f], 0)
             for i, fr_word in enumerate(align_sent.mots):
                 # Find out the maximum probability
                 max_align_prob = max(max_align_prob,

--- a/nltk/align/ibm3.py
+++ b/nltk/align/ibm3.py
@@ -50,11 +50,11 @@ class IBMModel3(object):
 
     >>> ibm3 = IBMModel3(align_sents, 5)
 
-    >>> print "%.1f" % ibm3.probabilities['Buch']['book']
+    >>> round(ibm3.probabilities['Buch']['book'], 1)
     1.0
-    >>> print "%.1f" % ibm3.probabilities['das']['book']
+    >>> round(ibm3.probabilities['das']['book'], 1)
     0.0
-    >>> print "%.1f" % ibm3.probabilities[None]['book']
+    >>> round(ibm3.probabilities[None]['book'], 1)
     0.0
 
     >>> aligned_sent = ibm3.align(align_sents[0])

--- a/nltk/test/align.doctest
+++ b/nltk/test/align.doctest
@@ -76,54 +76,44 @@ Alignment Algorithms
 EM for IBM Model 1
 ~~~~~~~~~~~~~~~~~~
 
-Here is an example from Kohn, 2010:
+Here is an example from Koehn, 2010:
 
-    >>> from nltk.align import IBMModel1
+    >>> from nltk.align.ibm1 import IBMModel1
     >>> corpus = [AlignedSent(['the', 'house'], ['das', 'Haus']),
     ...           AlignedSent(['the', 'book'], ['das', 'Buch']),
     ...           AlignedSent(['a', 'book'], ['ein', 'Buch'])]
-    >>> em_ibm1 = IBMModel1(corpus, 1e-3)
-    >>> print(round(em_ibm1.probabilities['the', 'das'], 1))
+    >>> em_ibm1 = IBMModel1(corpus, 20)
+    >>> print(round(em_ibm1.probabilities['the']['das'], 1))
     1.0
-    >>> print(round(em_ibm1.probabilities['book', 'das'], 1))
+    >>> print(round(em_ibm1.probabilities['book']['das'], 1))
     0.0
-    >>> print(round(em_ibm1.probabilities['house', 'das'], 1))
+    >>> print(round(em_ibm1.probabilities['house']['das'], 1))
     0.0
-    >>> print(round(em_ibm1.probabilities['the', 'Buch'], 1))
+    >>> print(round(em_ibm1.probabilities['the']['Buch'], 1))
     0.0
-    >>> print(round(em_ibm1.probabilities['book', 'Buch'], 1))
+    >>> print(round(em_ibm1.probabilities['book']['Buch'], 1))
     1.0
-    >>> print(round(em_ibm1.probabilities['a', 'Buch'], 1))
+    >>> print(round(em_ibm1.probabilities['a']['Buch'], 1))
     0.0
-    >>> print(round(em_ibm1.probabilities['book', 'ein'], 1))
+    >>> print(round(em_ibm1.probabilities['book']['ein'], 1))
     0.0
-    >>> print(round(em_ibm1.probabilities['a', 'ein'], 1))
+    >>> print(round(em_ibm1.probabilities['a']['ein'], 1))
     1.0
-    >>> print(round(em_ibm1.probabilities['the', 'Haus'], 1))
+    >>> print(round(em_ibm1.probabilities['the']['Haus'], 1))
     0.0
-    >>> print(round(em_ibm1.probabilities['house', 'Haus'], 1))
+    >>> print(round(em_ibm1.probabilities['house']['Haus'], 1))
     1.0
-    >>> print(round(em_ibm1.probabilities['book', None], 1))
+    >>> print(round(em_ibm1.probabilities['book'][None], 1))
     0.5
 
 And using an NLTK corpus. We train on only 10 sentences, since it is so incredibly slow:
 
     >>> from nltk.corpus import comtrans
-    >>> com_ibm1 = IBMModel1(comtrans.aligned_sents() [:10])
-    >>> print(round(com_ibm1.probabilities['bitte', 'Please'], 1))
+    >>> com_ibm1 = IBMModel1(comtrans.aligned_sents()[:10], 20)
+    >>> print(round(com_ibm1.probabilities['bitte']['Please'], 1))
     0.2
-    >>> print(round(com_ibm1.probabilities['Sitzungsperiode', 'session'], 1))
+    >>> print(round(com_ibm1.probabilities['Sitzungsperiode']['session'], 1))
     1.0
-
-Get the alignments:
-
-    >>> em_ibm1.aligned() # doctest: +NORMALIZE_WHITESPACE
-    [AlignedSent(['the', 'house'], ['das', 'Haus'],
-            Alignment([(0, 0), (1, 1)])),
-     AlignedSent(['the', 'book'], ['das', 'Buch'],
-            Alignment([(0, 0), (1, 1)])),
-     AlignedSent(['a', 'book'], ['ein', 'Buch'],
-            Alignment([(0, 0), (1, 1)]))]
 
 
 Evaluation


### PR DESCRIPTION
fixes to align.doctest, got rid of aligned() as it doesn't seem to exist anymore in `nltk.align.ibm1`.
