### PR TITLE
Added `parse` method to malt.py, fixes #682

### DIFF
--- a/nltk/parse/dependencygraph.py
+++ b/nltk/parse/dependencygraph.py
@@ -284,7 +284,7 @@ class DependencyGraph(object):
             elif style == 4:
                 lines.append('%s\t%s\t%s\t%s\n' % (word, tag, head, rel))
             elif style == 10:
-                lines.append('%s\t%s\t%s\t%s\t%s\%s\t%s\t%s\t_\t_\n' % (i+1, word, lemma, ctag, tag, feats, head, rel))
+                lines.append('%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t_\t_\n' % (i+1, word, lemma, ctag, tag, feats, head, rel))
             else:
                 raise ValueError('Number of tab-delimited fields (%d) not supported by CoNLL(10) or Malt-Tab(4) format' % (style))
         return ''.join(lines)

--- a/nltk/parse/malt.py
+++ b/nltk/parse/malt.py
@@ -113,6 +113,18 @@ class MaltParser(ParserI):
         tagged_sentences = [self.tagger.tag(sentence) for sentence in sentences]
         return self.tagged_parse_sents(tagged_sentences, verbose)
 
+    def parse(self, sentence, verbose=False):
+        """
+        Use MaltParser to parse a sentence. Takes a sentence as a list of words.
+        The sentence will be automatically tagged with this MaltParser instance's
+        tagger.
+
+        :param sentence: Input sentence to parse
+        :type sentence: list(str)
+        :return: ``DependencyGraph`` the dependency graph representation of the sentence
+        """
+        return self.parse_sents([sentence], verbose)[0]
+
     def raw_parse(self, sentence, verbose=False):
         """
         Use MaltParser to parse a sentence. Takes a sentence as a string;


### PR DESCRIPTION
A quick fix to #682. Found an error in `.to_conll()` in dependencygraph.py too.

However, this does not make the Maltparser adhere to the API:
- `.parse()` returns a DependencyGraph, not an iterator of DependencyGraph
- similar for `.parse_sents()`, it returns a list of DependencyGraph, not an iterator of iterators
- `.parse_all()` and `.parse_one()` will raise an error

Stanford suffers from similar issues.
