### PR TITLE
Fixed a problem with jar finder

### DIFF
--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -570,9 +570,11 @@ def find_jar_iter(name_pattern, path_to_jar=None, env_vars=(),
     # it's present; otherwise, complain.
     if path_to_jar is not None:
         if os.path.isfile(path_to_jar):
+            yielded = True
             yield path_to_jar
-        raise LookupError('Could not find %s jar file at %s' %
-                         (name_pattern, path_to_jar))
+        else:
+            raise LookupError('Could not find %s jar file at %s' %
+                            (name_pattern, path_to_jar))
 
     # Check environment variables
     for env_var in env_vars:


### PR DESCRIPTION
There's a control flow problem here. As is, if you specify path_to_jar, even if it's correct, the next iteration will raise the lookup exception.
