### PR TITLE
Added comma condition to PunktWordTokeniser

### DIFF
--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -229,7 +229,7 @@ class PunktLanguageVars(object):
     _re_word_start    = r"[^\(\"\`{\[:;&\#\*@\)}\]\-,]"
     """Excludes some characters from starting word tokens"""
 
-    _re_non_word_chars   = r"(?:[?!)\";}\]\*:@\'\({\[])"
+    _re_non_word_chars   = r"(?:[?!)\";}\]\*:@\'\({\[])|,(?=[A-Za-z])"
     """Characters that cannot appear within words"""
 
     _re_multi_char_punct = r"(?:\-{2,}|\.{2,}|(?:\.\s){2,}\.)"


### PR DESCRIPTION
This addition to the word tokeniser splits words that are separated by commas but not numbers. For example the sentence:
    'I have 13,000,000 bottles,in,my,bag'
tokenises as:
    ['I', 'have', '13,000,000', 'bottles', ',', 'in', ',', 'my', ',', 'bag']
rather than the awkward:
    ['I', 'have', '13,000,000', 'bottles,in,my,bag']

This is useful as this occurs quite a lot in blogs and tweets and has caused errors in my processing chain when we had some 1600 words joined in this way - leading to a massive word being created...
