### PR TITLE
Remove remaining googlecode URLs

### DIFF
--- a/nltk/corpus/__init__.py
+++ b/nltk/corpus/__init__.py
@@ -5,7 +5,7 @@
 # URL: <http://nltk.org/>
 # For license information, see LICENSE.TXT
 
-# [xx] this docstring isnt' up-to-date!
+# TODO this docstring isn't up-to-date!
 """
 NLTK corpus readers.  The modules in this package provide functions
 that can be used to read corpus files in a variety of formats.  These
@@ -16,8 +16,8 @@ of external corpora.
 Available Corpora
 =================
 
-Please see http://nltk.googlecode.com/svn/trunk/nltk_data/index.xml
-for a complete list.  Install corpora using nltk.download().
+Please see http://www.nltk.org/nltk_data/ for a complete list.
+Install corpora using nltk.download().
 
 Corpus Reader Functions
 =======================

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -54,9 +54,9 @@ NLTK Download Server
 Before downloading any packages, the corpus and module downloader
 contacts the NLTK download server, to retrieve an index file
 describing the available packages.  By default, this index file is
-loaded from ``http://nltk.googlecode.com/svn/trunk/nltk_data/index.xml``.
-If necessary, it is possible to create a new ``Downloader`` object,
-specifying a different URL for the package index file.
+loaded from ``http://www.nltk.org/nltk_data/``.  If necessary, it is
+possible to create a new ``Downloader`` object, specifying a different
+URL for the package index file.
 
 Usage::
 
@@ -377,7 +377,6 @@ class Downloader(object):
        server index will be considered 'stale,' and will be
        re-downloaded."""
 
-    # DEFAULT_URL = 'http://nltk.googlecode.com/svn/trunk/nltk_data/index.xml'
     DEFAULT_URL = 'http://nltk.github.com/nltk_data/'
     """The default URL for the NLTK data server's index.  An
        alternative URL can be specified when creating a new

--- a/nltk/test/align.doctest
+++ b/nltk/test/align.doctest
@@ -162,7 +162,7 @@ Here are some examples:
 
 
 .. _nltk.metrics.scores.precision:
-    http://nltk.googlecode.com/svn/trunk/doc/api/nltk.metrics.scores-module.html#precision
+    http://www.nltk.org/api/nltk.metrics.html#nltk.metrics.scores.precision
 
 
 Recall
@@ -191,7 +191,7 @@ Here are some examples:
 
 
 .. _nltk.metrics.scores.recall:
-    http://nltk.googlecode.com/svn/trunk/doc/api/nltk.metrics.scores-module.html#recall
+    http://www.nltk.org/api/nltk.metrics.html#nltk.metrics.scores.recall
 
 
 Alignment Error Rate (AER)

--- a/nltk/test/ccg.doctest
+++ b/nltk/test/ccg.doctest
@@ -5,9 +5,6 @@
 Combinatory Categorial Grammar
 ==============================
 
-For more information, please see:
-http://nltk.googlecode.com/svn/trunk/doc/contrib/ccg/ccg.pdf
-
 Relative Clauses
 ----------------
 

--- a/nltk/test/corpus.doctest
+++ b/nltk/test/corpus.doctest
@@ -9,7 +9,7 @@ The `nltk.corpus` package defines a collection of *corpus reader*
 classes, which can be used to access the contents of a diverse set of
 corpora.  The list of available corpora is given at:
 
-http://nltk.googlecode.com/svn/trunk/nltk_data/index.xml
+http://www.nltk.org/nltk_data/
 
 Each corpus reader class is specialized to handle a specific
 corpus format.  In addition, the `nltk.corpus` package automatically

--- a/nltk/test/data.doctest
+++ b/nltk/test/data.doctest
@@ -277,13 +277,13 @@ Create a temp dir for tests that write files:
 
 The `retrieve()` function accepts all url types:
 
-    >>> urls = ['http://nltk.googlecode.com/svn/trunk/nltk/nltk/test/toy.cfg',
+    >>> urls = ['https://raw.githubusercontent.com/nltk/nltk/develop/nltk/test/toy.cfg',
     ...         'file:%s' % nltk.data.find('grammars/sample_grammars/toy.cfg'),
     ...         'nltk:grammars/sample_grammars/toy.cfg',
     ...         'grammars/sample_grammars/toy.cfg']
     >>> for i, url in enumerate(urls):
     ...     nltk.data.retrieve(url, 'toy-%d.cfg' % i) # doctest: +ELLIPSIS
-    Retrieving 'http://nltk.googlecode.com/svn/trunk/nltk/nltk/test/toy.cfg', saving to 'toy-0.cfg'
+    Retrieving 'https://raw.githubusercontent.com/nltk/nltk/develop/nltk/test/toy.cfg', saving to 'toy-0.cfg'
     Retrieving 'file:...toy.cfg', saving to 'toy-1.cfg'
     Retrieving 'nltk:grammars/sample_grammars/toy.cfg', saving to 'toy-2.cfg'
     Retrieving 'nltk:grammars/sample_grammars/toy.cfg', saving to 'toy-3.cfg'

--- a/papers/iwcs-08/nltk_iwcs_09.tex
+++ b/papers/iwcs-08/nltk_iwcs_09.tex
@@ -493,6 +493,7 @@ The \NLTK\ module \texttt{sem.glue} implements Glue for
 \footnote{See
   \url{http://nltk.googlecode.com/svn/trunk/doc/contrib/sem/index.html}
 for more details.}
+% sem now at https://github.com/nltk/nltk_contrib/tree/master/doc/sem
 The following example shows how Glue formulas are
 created and combined to derive a logical form for \textit{John walks}:
 


### PR DESCRIPTION
A few URLs from Google Code were remaining. I removed those. This patch is not perfect as I:
- could not find an alternative for the ccg.pdf link
- didn't update nltk/corpus/**init**.py docstring but changed xx to TODO for better visbility.

It's still a step in the right direction as nltk.googlecode.com is no longer accessible.
