### PR TITLE
word_tokenize for languages other than English

### DIFF
--- a/nltk/test/tokenize.doctest
+++ b/nltk/test/tokenize.doctest
@@ -40,6 +40,21 @@ Some test strings.
     >>> word_tokenize(s10)
     ['There', 'were', '300,000', ',', 'but', 'that', 'was', "n't", 'enough', '.']
 
+Sentence tokenization in word_tokenize:
+
+    >>> s11 = "I called Dr. Jones. I called Dr. Jones."
+    >>> word_tokenize(s11)
+    ['I', 'called', 'Dr.', 'Jones', '.', 'I', 'called', 'Dr.', 'Jones', '.']
+    >>> s12 = ("Ich muss unbedingt daran denken, Mehl, usw. fur einen "
+    ...        "Kuchen einzukaufen. Ich muss.")
+    >>> word_tokenize(s12)
+    ['Ich', 'muss', 'unbedingt', 'daran', 'denken', ',', 'Mehl', ',', 'usw',
+     '.', 'fur', 'einen', 'Kuchen', 'einzukaufen', '.', 'Ich', 'muss', '.']
+    >>> word_tokenize(s12, 'german')
+    ['Ich', 'muss', 'unbedingt', 'daran', 'denken', ',', 'Mehl', ',', 'usw.',
+     'fur', 'einen', 'Kuchen', 'einzukaufen', '.', 'Ich', 'muss', '.']
+
+
 Regression Tests: Regexp Tokenizer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/nltk/tokenize/__init__.py
+++ b/nltk/tokenize/__init__.py
@@ -72,25 +72,33 @@ from nltk.tokenize.treebank import TreebankWordTokenizer
 from nltk.tokenize.texttiling import TextTilingTokenizer
 
 # Standard sentence tokenizer.
-def sent_tokenize(text):
+def sent_tokenize(text, language='english'):
     """
     Return a sentence-tokenized copy of *text*,
     using NLTK's recommended sentence tokenizer
-    (currently :class:`.PunktSentenceTokenizer`).
+    (currently :class:`.PunktSentenceTokenizer`
+    for the specified language).
+
+    :param text: text to split into sentences
+    :param language: the model name in the Punkt corpus
     """
-    tokenizer = load('tokenizers/punkt/english.pickle')
+    tokenizer = load('tokenizers/punkt/{0}.pickle'.format(language))
     return tokenizer.tokenize(text)
 
 # Standard word tokenizer.
 _treebank_word_tokenize = TreebankWordTokenizer().tokenize
-def word_tokenize(text):
+def word_tokenize(text, language='english'):
     """
     Return a tokenized copy of *text*,
     using NLTK's recommended word tokenizer
     (currently :class:`.TreebankWordTokenizer`
-    along with :class:`.PunktSentenceTokenizer`).
+    along with :class:`.PunktSentenceTokenizer`
+    for the specified language).
+
+    :param text: text to split into sentences
+    :param language: the model name in the Punkt corpus
     """
-    return [token for sent in sent_tokenize(text)
+    return [token for sent in sent_tokenize(text, language)
             for token in _treebank_word_tokenize(sent)]
 
 if __name__ == "__main__":


### PR DESCRIPTION
This might improve the usability trap @markuskiller fell into in #746, not understanding that `word_tokenize` performed English sentence boundary detection.
