### PR TITLE
_PY3_DATA_UPDATES uses win path if on win

### DIFF
--- a/nltk/compat.py
+++ b/nltk/compat.py
@@ -358,10 +358,19 @@ except ImportError: # python 2.6
 
 # The following datasets have a /PY3 subdirectory containing
 # a full copy of the data which has been re-encoded or repickled.
-_PY3_DATA_UPDATES = ["chunkers/maxent_ne_chunker",
-                     "help/tagsets",
-                     "taggers/maxent_treebank_pos_tagger",
-                     "tokenizers/punkt"]
+
+_PY3_DATA_UPDATES = []
+
+if sys.platform.startswith('win'):
+    _PY3_DATA_UPDATES = ["chunkers\maxent_ne_chunker",
+                         "help\tagsets",
+                         "taggers\maxent_treebank_pos_tagger",
+                         "tokenizers\punkt"]
+else:
+    _PY3_DATA_UPDATES = ["chunkers/maxent_ne_chunker",
+                        "help/tagsets",
+                        "taggers/maxent_treebank_pos_tagger",
+                        "tokenizers/punkt"]
 
 # for use in adding /PY3 to the second (filename) argument
 # of the file pointers in data.py


### PR DESCRIPTION
py3_data function does not work on windows as the item would never match a value in a windows path.

_PY3_DATA_UPDATES now has a windows version if windows is used

This is only a quick fix as having the list of theses data directories is not perfect.
