### PR TITLE
Avoid an IndexError when dealing with empty strings

### DIFF
--- a/nltk/stem/snowball.py
+++ b/nltk/stem/snowball.py
@@ -3551,7 +3551,7 @@ class SpanishStemmer(_StandardStemmer):
                     word = word[:-len(suffix)]
                     rv = rv[:-len(suffix)]
 
-                    if word[-2:] == "gu" and rv[-1:] == "u":
+                    if word[-2:] == "gu" and rv.endswith("u"):
                         word = word[:-1]
                 else:
                     word = word[:-len(suffix)]


### PR DESCRIPTION
Fixes issue #778.
