### PR TITLE
Call gs directly in nltk.tree._repr_png_, no shell

### DIFF
--- a/nltk/tree.py
+++ b/nltk/tree.py
@@ -715,8 +715,7 @@ class Tree(list):
             _canvas_frame.destroy_widget(widget)
             subprocess.call([find_binary('gs', binary_names=['gswin32c.exe', 'gswin64c.exe'], env_vars=['PATH'], verbose=False)] +
                             '-q -dEPSCrop -sDEVICE=png16m -r90 -dTextAlphaBits=4 -dGraphicsAlphaBits=4 -dSAFER -dBATCH -dNOPAUSE -sOutputFile={0:} {1:}'
-                            .format(out_path, in_path).split(),
-                            shell=True)
+                            .format(out_path, in_path).split())
             with open(out_path, 'rb') as sr:
                 res = sr.read()
             os.remove(in_path)


### PR DESCRIPTION
shell=True causes ghostscript to stick around with a prompt on
MacOS X (and apparently Linux too, as reported by another user)

```
GPL Ghostscript 9.06 (2012-08-08)
Copyright (C) 2012 Artifex Software, Inc.  All rights reserved.
This software comes with NO WARRANTY: see the file PUBLIC for details.
GS>
```

Note that the shell=True was deliberately introduced in 0cc3d8a
to avoid a console window from popping up, possibly
related to Windows? If so, this patch may undo that change, but
maybe we can have the best of both worlds by setting the
STARTUPINFO.wShowWindow flag instead.

http://stackoverflow.com/questions/3172470/actual-meaning-of-shell-true-in-subprocess
