### PR TITLE
A stab at fixing the ngram model

### DIFF
--- a/nltk/model/ngram.py
+++ b/nltk/model/ngram.py
@@ -88,8 +88,6 @@ class NgramModel(ModelI):
         assert(isinstance(pad_right, bool))
 
         self._n = n
-        self._lpad = ('',) * (n - 1) if pad_left else ()
-        self._rpad = ('',) * (n - 1) if pad_right else ()
 
         if estimator is None:
             estimator = _estimator
@@ -105,7 +103,7 @@ class NgramModel(ModelI):
         # we need to keep track of the number of word types we encounter
         words = set()
         for sent in train:
-            for ngram in ngrams(chain(self._lpad, sent, self._rpad), n):
+            for ngram in ngrams(sent, n, pad_left, pad_right, pad_symbol=''):
                 self._ngrams.add(ngram)
                 context = tuple(ngram[:-1])
                 token = ngram[-1]

--- a/nltk/model/ngram.py
+++ b/nltk/model/ngram.py
@@ -10,21 +10,23 @@ from __future__ import unicode_literals
 from itertools import chain
 from math import log
 
-from nltk.probability import (ConditionalProbDist, ConditionalFreqDist,
-                              SimpleGoodTuringProbDist)
+from nltk.probability import (FreqDist,
+    ConditionalProbDist,
+    ConditionalFreqDist,
+    LidstoneProbDist)
 from nltk.util import ngrams
 from nltk.model.api import ModelI
 
 from nltk import compat
 
 
-def _estimator(fdist, bins):
+def _estimator(fdist, *estimator_args, **estimator_kwargs):
     """
     Default estimator function using a SimpleGoodTuringProbDist.
     """
     # can't be an instance method of NgramModel as they
     # can't be pickled either.
-    return SimpleGoodTuringProbDist(fdist)
+    return LidstoneProbDist(fdist, *estimator_args, **estimator_kwargs)
 
 
 @compat.python_2_unicode_compatible

--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -653,7 +653,7 @@ class LidstoneProbDist(ProbDistI):
     likelihood estimate of the resulting frequency distribution.
     """
     SUM_TO_ONE = False
-    def __init__(self, freqdist, gamma, bins=None):
+    def __init__(self, freqdist, gamma, bins=None, override_N=None):
         """
         Use the Lidstone estimate to create a probability distribution
         for the experiment used to generate ``freqdist``.
@@ -687,7 +687,13 @@ class LidstoneProbDist(ProbDistI):
 
         self._freqdist = freqdist
         self._gamma = float(gamma)
-        self._N = self._freqdist.N()
+
+        # if user specifies a number of tokens explicitly, use that number
+        # instead of getting it from the frequency distribution
+        if override_N:
+            self._N = override_N
+        else:
+            self._N = self._freqdist.N()
 
         if bins is None:
             bins = freqdist.B()


### PR DESCRIPTION
The commit messages should give you a good idea of what I've done specifically, so I'm going to give a high-level overview here as well as ask some questions. 
1. The goal of this PR isn't necessarily to fix **everything** wrong with the ngram and probability modules but to get started on that task by enabling basic ngram functionality. 
2. I've implemented @bcroy's take on backoff from #367 and set Lidstone as the default estimator based on the discussion in #602. I suspect  both of these changes have been expected by the community and shouldn't spark much discussion.
3. Here comes the controversial part. I think I've found the cause of the bugs @afourney pointed out in #367. The problem was that nltk's implementation of conditional probability distributions by default breaks up the training sample space into sample spaces for each condition/context. Thus, for every condition/context the denominator is _not_ the **N** of the total number of outcomes _but_ instead the **N** of outcomes observed given a condition/context. This means that as soon as we start summing over outcomes observed during training _but not_ given a certain condition the result will be > 1! I have fixed this by computing an "override_N" value based on the **N** of the whole distribution and then passing that down to the estimator. As of this writing I am certain there's a more natural way to implement this given nltk's class topology. If folks are on board with the concept, I'd be willing to try out some alternative refactorings.
4. @kmike I know we went over this in #326, but I'm still very fuzzy on how testing works. I tried running "tox" from the root of my nltk repo even before I made any of my changes and got 3 to 5 errors right off the bat. I see myself working on the ngram and probability module for a while, so I might as well figure this testing stuff out now with this PR. Who knows, maybe we'll even solve #396!
