### PR TITLE
Fixed NLTK Downloader's "About" dialog issue with Python 3.x

### DIFF
--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -1749,7 +1749,11 @@ class DownloaderGUI(object):
             from tkMessageBox import Message
             Message(message=ABOUT, title=TITLE).show()
         except ImportError:
-            ShowText(self._top, TITLE, ABOUT)
+            try:
+                from tkinter.messagebox import Message
+                Message(message=ABOUT, title=TITLE).show()
+            except ImportError:
+                ShowText(self.top, TITLE, ABOUT)
 
     #/////////////////////////////////////////////////////////////////
     # Progress Bar


### PR DESCRIPTION
Attribute name "_top" was misspelled, which resulted in an error when trying to show a fallback ShowText.
tkMessageBox have been renamed to messagebox in Python 3.x. I have added another import to take this into account. From my understanding, the fallback ShowText is not needed now, but I left it just in case.
