### PR TITLE
Fixed an issue when zipped resources couldn't have been loaded

### DIFF
--- a/nltk/data.py
+++ b/nltk/data.py
@@ -205,6 +205,10 @@ def normalize_resource_name(resource_name, allow_relative=True, relative_path=No
     True
     >>> windows or normalize_resource_name('../dir/file', False, '/') == '/dir/file'
     True
+    >>> not windows or normalize_resource_name('/dir/file', True, '/') == 'dir/file'
+    True
+    >>> windows or normalize_resource_name('/dir/file', True, '/') == '/dir/file'
+    True
     """
     is_dir = bool(re.search(r'[\\/.]$', resource_name)) or resource_name.endswith(os.path.sep)
     if sys.platform.startswith('win'):

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -448,8 +448,8 @@ class ZipFilePathPointer(PathPointer):
         if isinstance(zipfile, string_types):
             zipfile = OpenOnDemandZipFile(os.path.abspath(zipfile))
 
-        # Normalize the entry string, it should be absolute:
-        entry = normalize_resource_name(entry, False, '/').lstrip('/')
+        # Normalize the entry string, it should be relative:
+        entry = normalize_resource_name(entry, True, '/').lstrip('/')
 
         # Check that the entry exists:
         if entry:


### PR DESCRIPTION
`LookupError` is raised when I'm trying to load a zipped corpus (full error message at the bottom).

The zip is there and successfully found — error happens when `ZipFilePathPointer` is accessing a path within the file. Code on line 452

```
# Normalize the entry string, it should be absolute:
entry = normalize_resource_name(entry, False, '/').lstrip('/')
```

returns this:

```
>>> data.normalize_resource_name('/dir/file', allow_relative=False, '/').lstrip('/')
'C:/dir/file'
```

and of course, such an entry cannot be found within a zipfile. In case of a zipfile, `allow_relative` should be set to `True`. This way `os.path.abspath()` function will not be called, and we get a proper path within the archive:

```
>>> data.normalize_resource_name('/dir/file', True, '/').lstrip('/')
'dir/file'
```

---

```
>>> reuters
<CategorizedPlaintextCorpusReader in '.../corpora/reuters' (not loaded yet)>
>>> reuters.fileids()
Traceback (most recent call last):
  File "C:\Python34\lib\site-packages\nltk\corpus\util.py", line 64, in __load
    try: root = nltk.data.find('corpora/%s' % zip_name)
  File "C:\Python34\lib\site-packages\nltk\data.py", line 618, in find
    raise LookupError(resource_not_found)
LookupError:
**********************************************************************
  Resource 'corpora/reuters.zip/reuters/' not found.  Please use
  the NLTK Downloader to obtain the resource:  >>> nltk.download()
  Searched in:
    - 'C:\\Users\\Andrey/nltk_data'
    - 'C:\\nltk_data'
    - 'D:\\nltk_data'
    - 'E:\\nltk_data'
    - 'C:\\Python34\\nltk_data'
    - 'C:\\Python34\\lib\\nltk_data'
    - 'C:\\Users\\Andrey\\AppData\\Roaming\\nltk_data'
**********************************************************************

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Python34\lib\site-packages\nltk\corpus\util.py", line 100, in __getattr__
    self.__load()
  File "C:\Python34\lib\site-packages\nltk\corpus\util.py", line 65, in __load
    except LookupError: raise e
  File "C:\Python34\lib\site-packages\nltk\corpus\util.py", line 62, in __load
    root = nltk.data.find('corpora/%s' % self.__name)
  File "C:\Python34\lib\site-packages\nltk\data.py", line 618, in find
    raise LookupError(resource_not_found)
LookupError:
**********************************************************************
  Resource 'corpora/reuters' not found.  Please use the NLTK
  Downloader to obtain the resource:  >>> nltk.download()
  Searched in:
    - 'C:\\Users\\Andrey/nltk_data'
    - 'C:\\nltk_data'
    - 'D:\\nltk_data'
    - 'E:\\nltk_data'
    - 'C:\\Python34\\nltk_data'
    - 'C:\\Python34\\lib\\nltk_data'
    - 'C:\\Users\\Andrey\\AppData\\Roaming\\nltk_data'
**********************************************************************
```
