### PR TITLE
Fix bug  Stanford tokenizer -- request to add -outputFormat inlineXML #735 

### DIFF
--- a/nltk/tokenize/stanford.py
+++ b/nltk/tokenize/stanford.py
@@ -46,9 +46,28 @@ class StanfordTokenizer(TokenizerI):
 
         self._encoding = encoding
         self.java_options = java_options
-        options = {} if options is None else options
-        self._options_cmd = ','.join('{0}={1}'.format(key, json.dumps(val)) for key, val in options.items())
-
+        #options = {} if options is None else options
+        
+        # Long Duong : fix bug #735 
+        options_str = options
+        options = {} 
+        if options_str is not None:
+            tokens = options_str.split()
+            if len(tokens) % 2 !=0:
+                    raise ValueError("Must be in set of (argument,value) pair")
+            
+            for i in range(len(tokens)/2):
+                key = tokens[2*i]
+                # Work the case when key might contain -  as in -tokenizeNLs
+                temp = list(key)
+                if temp[0] == '-':
+                    key = "".join(temp[1:])
+                
+                value = tokens[2*i+1]
+                options[key] = value 
+                
+        self._options_cmd = ','.join('{0}={1}'.format(key, val) for key, val in options.items())
+         
     @staticmethod
     def _parse_tokenized_output(s):
         return s.splitlines()

--- a/temp.txt
+++ b/temp.txt
@@ -1,1 +1,0 @@
-This is the temp file 

--- a/temp.txt
+++ b/temp.txt
@@ -1,0 +1,1 @@
+This is the temp file 


### PR DESCRIPTION
The list of valid options for string tokenizer is 
https://github.com/stanfordnlp/CoreNLP/blob/master/src/edu/stanford/nlp/process/PTBTokenizer.java

Thus, for preserving the "newline character" we should use 
==> st = StanfordTokenizer('stanford-postagger.jar', 'utf-8', java_options='-mx300m', options='-tokenizeNLs true')
==> st.tokenize(s)
[u'Good', u'muffins', u'cost', u'$', u'3.88', u'*NL*', u'in', u'New', u'York', u'.', u'Please', u'buy', u'me', u'*NL*', u'two', u'of', u'them', u'.', u'*NL*', u'Thanks', u'.']
The "*NL*" is the new line character. 

Code modified accordingly to resolve this.  
