### PR TITLE
Triples

### DIFF
--- a/nltk/parse/dependencygraph.py
+++ b/nltk/parse/dependencygraph.py
@@ -221,6 +221,23 @@ class DependencyGraph(object):
         deps = node['deps']
         return Tree(word, [self._tree(i) for i in deps])
 
+    def triples(self, node=None):
+        """
+        Extract dependency triples of the form: 
+        ((head word, head tag), rel, (dep word, dep tag))
+        """
+
+        if not node:
+            node = self.root
+
+        head = (node['word'], node['ctag'])
+        for i in node['deps']:
+            dep = self.get_by_address(i)
+            yield (head, dep['rel'], (dep['word'], dep['ctag']))
+            for triple in self.triples(node=dep):
+                yield triple
+
+
     def _hd(self, i):
         try:
             return self.nodelist[i]['head']

--- a/nltk/parse/dependencygraph.py
+++ b/nltk/parse/dependencygraph.py
@@ -120,14 +120,14 @@ class DependencyGraph(object):
         return "<DependencyGraph with %d nodes>" % len(self.nodelist)
 
     @staticmethod
-    def load(file, zero_based=False):
+    def load(filename, zero_based=False):
         """
-        :param file: a file in Malt-TAB format
-        :param zero_based: nodes in the input file are numbered starting from 0 rather 
+        :param filename: a name of a file in Malt-TAB format
+        :param zero_based: nodes in the input file are numbered starting from 0 rather
             than 1 (as produced by, e.g., zpar)
         :return: a list of DependencyGraphs
         """
-        with open(file) as infile:
+        with open(filename) as infile:
             return [DependencyGraph(tree_str, zero_based=zero_based) for tree_str in
                                                   infile.read().split('\n\n')]
 
@@ -230,7 +230,7 @@ class DependencyGraph(object):
 
     def triples(self, node=None):
         """
-        Extract dependency triples of the form: 
+        Extract dependency triples of the form:
         ((head word, head tag), rel, (dep word, dep tag))
         """
 

--- a/nltk/test/dependency.doctest
+++ b/nltk/test/dependency.doctest
@@ -37,6 +37,24 @@ CoNLL Data
     (will
       (Vinken Pierre , (old (years 61)) ,)
       (join (board the) (as (director a nonexecutive)) (Nov. 29) .))
+    >>> print(list(dg.triples()))
+    [((u'will', u'MD'), u'SUB', (u'Vinken', u'NNP')), 
+     ((u'Vinken', u'NNP'), u'NMOD', (u'Pierre', u'NNP')),
+     ((u'Vinken', u'NNP'), u'P', (u',', u',')),
+     ((u'Vinken', u'NNP'), u'NMOD', (u'old', u'JJ')),
+     ((u'old', u'JJ'), u'AMOD', (u'years', u'NNS')),
+     ((u'years', u'NNS'), u'NMOD', (u'61', u'CD')),
+     ((u'Vinken', u'NNP'), u'P', (u',', u',')),
+     ((u'will', u'MD'), u'VC', (u'join', u'VB')), 
+     ((u'join', u'VB'), u'OBJ', (u'board', u'NN')),
+     ((u'board', u'NN'), u'NMOD', (u'the', u'DT')),
+     ((u'join', u'VB'), u'VMOD', (u'as', u'IN')),
+     ((u'as', u'IN'), u'PMOD', (u'director', u'NN')),
+     ((u'director', u'NN'), u'NMOD', (u'a', u'DT')),
+     ((u'director', u'NN'), u'NMOD', (u'nonexecutive', u'JJ')), 
+     ((u'join', u'VB'), u'VMOD', (u'Nov.', u'NNP')), 
+     ((u'Nov.', u'NNP'), u'NMOD', (u'29', u'CD')), 
+     ((u'join', u'VB'), u'VMOD', (u'.', u'.'))]
 
 Using the dependency-parsed version of the Penn Treebank corpus sample.
 
@@ -61,6 +79,37 @@ Using the dependency-parsed version of the Penn Treebank corpus sample.
     Nov.        NNP     9
     29  CD      16
     .   .       8
+
+Using the output of zpar (like Malt-TAB but with zero-based indexing)
+
+    >>> zpar_data = """
+    ... Pierre	NNP	1	NMOD
+    ... Vinken	NNP	7	SUB
+    ... ,	,	1	P
+    ... 61	CD	4	NMOD
+    ... years	NNS	5	AMOD
+    ... old	JJ	1	NMOD
+    ... ,	,	1	P
+    ... will	MD	-1	ROOT
+    ... join	VB	7	VC
+    ... the	DT	10	NMOD
+    ... board	NN	8	OBJ
+    ... as	IN	8	VMOD
+    ... a	DT	14	NMOD
+    ... nonexecutive	JJ	14	NMOD
+    ... director	NN	11	PMOD
+    ... Nov.	NNP	8	VMOD
+    ... 29	CD	15	NMOD
+    ... .	.	7	P
+    ... """
+    
+    >>> zdg = DependencyGraph(zpar_data, zero_based=True)
+    >>> print(zdg.tree())
+    (will
+      (Vinken Pierre , (old (years 61)) ,)
+      (join (board the) (as (director a nonexecutive)) (Nov. 29))
+      .)
+
 
 Projective Dependency Parsing
 -----------------------------


### PR DESCRIPTION
Two small additions to `DependencyGraph`:
- `zero_based` option to `__init__` and `load`, to allow input with zero-based node numbering. For some reason, [zpar](http://www.sutd.edu.sg/cmsresource/faculty/yuezhang/zpar.html) produces output that is almost in Malt-TAB format except that the first word is number 0 rather than 1.
- `triples()` method returns all the dependency triples in a `DependencyGraph`, where a triple has the form ((_head-word_, _head-ctag_), _relation_, (_dependent-word_, _dependent-ctag_)).
