### PR TITLE
Add Dependency Evaluator to compute Labeled Attachment Score and Unlabeled Attachment Score  #805 

### DIFF
--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -644,12 +644,13 @@ def find_jar(name_pattern, path_to_jar=None, env_vars=(),
     return next(find_jar_iter(name_pattern, path_to_jar, env_vars,
                          searchpath, url, verbose, is_regex))
 
-
+# Long Duong : Fix the encoding here 
 def _decode_stdoutdata(stdoutdata):
     """ Convert data read from stdout/stderr to unicode """
     if not isinstance(stdoutdata, bytes):
         return stdoutdata
-    encoding = getattr(sys.stdout, "encoding", locale.getpreferredencoding())
+    
+    encoding = getattr(sys.__stdout__, "encoding", locale.getpreferredencoding())
     if encoding is None:
         return stdoutdata.decode()
     return stdoutdata.decode(encoding)

--- a/nltk/parse/depeval.py
+++ b/nltk/parse/depeval.py
@@ -5,8 +5,7 @@
 # Copyright (C) 2001-2014 NLTK Project
 # URL: <http://nltk.org/>
 # For license information, see LICENSE.TXT
-import string 
-import re 
+import unicodedata
 
 class DependencyEvaluator(object):
     """
@@ -39,11 +38,11 @@ class DependencyEvaluator(object):
 >>> parsed_sent = DependencyGraph(\"""
 ... Pierre  NNP     8       NMOD
 ... Vinken  NNP     1       SUB
-... ,       ,       2       P
+... ,       ,       3       P
 ... 61      CD      6       NMOD
 ... years   NNS     6       AMOD
 ... old     JJ      2       NMOD
-... ,       ,       2       P
+... ,       ,       3       AMOD
 ... will    MD      0       ROOT
 ... join    VB      8       VC
 ... the     DT      11      AMOD
@@ -71,6 +70,15 @@ class DependencyEvaluator(object):
         self._parsed_sents = parsed_sents
         self._gold_sents = gold_sents
     
+    def _remove_punct(self,inStr):
+        """
+        Function to remove punctuation from Unicode string. 
+        :param input: the input string 
+        :return: Unicode string after remove all punctuation  
+        """
+        punc_cat = set(["Pc", "Pd", "Ps", "Pe", "Pi", "Pf", "Po"])
+        return "".join(x for x in inStr  if unicodedata.category(x) not in punc_cat)
+    
     def eval(self):
         """
         Return the Labeled Attachment Score (LAS) and Unlabeled Attachment Score (UAS)  
@@ -87,17 +95,17 @@ class DependencyEvaluator(object):
         for i in range(len(self._parsed_sents)):
             parsed_sent = self._parsed_sents[i].nodelist
             gold_sent = self._gold_sents[i].nodelist
-            if (len(parsed_sent) != len(gold_sent)):
+            if len(parsed_sent) != len(gold_sent):
                 raise ValueError(" Sentence length is not matched. ")
             
             for j in range(len(parsed_sent)):
-                if (parsed_sent[j]["word"] is None): 
+                if parsed_sent[j]["word"] is None: 
                     continue
-                if (parsed_sent[j]["word"] != gold_sent[j]["word"]):
+                if parsed_sent[j]["word"] != gold_sent[j]["word"]:
                     raise ValueError(" Sentence sequence is not matched. ")
                 
-                # Ignore if word is punctuation by default
-                if re.sub(ur"\p{P}+", "", parsed_sent[j]["word"]) == "":  # if this is punctuation the whole string  
+                # by default, ignore if word is punctuation 
+                if  self._remove_punct(parsed_sent[j]["word"]) == "":     
                 #if (parsed_sent[j]["word"] in string.punctuation):
                     continue  
                 

--- a/nltk/parse/depeval.py
+++ b/nltk/parse/depeval.py
@@ -1,0 +1,114 @@
+# Natural Language Toolkit: evaluation of dependency parser
+#
+# Author: Long Duong <longdt219@gmail.com>
+#
+# Copyright (C) 2001-2014 NLTK Project
+# URL: <http://nltk.org/>
+# For license information, see LICENSE.TXT
+import string 
+import re 
+
+class DependencyEvaluator(object):
+    """
+    Class for measuring labelled and unlabelled attachment score for dependency parsing. Note that the evaluation ignore the  punctuation
+        
+>>> from nltk.parse.dependencygraph import DependencyGraph 
+>>> from nltk.parse.depeval import DependencyEvaluator
+
+>>> gold_sent = DependencyGraph(\"""
+... Pierre  NNP     2       NMOD
+... Vinken  NNP     8       SUB
+... ,       ,       2       P
+... 61      CD      5       NMOD
+... years   NNS     6       AMOD
+... old     JJ      2       NMOD
+... ,       ,       2       P
+... will    MD      0       ROOT
+... join    VB      8       VC
+... the     DT      11      NMOD
+... board   NN      9       OBJ
+... as      IN      9       VMOD
+... a       DT      15      NMOD
+... nonexecutive    JJ      15      NMOD
+... director        NN      12      PMOD
+... Nov.    NNP     9       VMOD
+... 29      CD      16      NMOD
+... .       .       9       VMOD
+... \""")
+ 
+>>> parsed_sent = DependencyGraph(\"""
+... Pierre  NNP     8       NMOD
+... Vinken  NNP     1       SUB
+... ,       ,       2       P
+... 61      CD      6       NMOD
+... years   NNS     6       AMOD
+... old     JJ      2       NMOD
+... ,       ,       2       P
+... will    MD      0       ROOT
+... join    VB      8       VC
+... the     DT      11      AMOD
+... board   NN      9       OBJECT
+... as      IN      9       NMOD
+... a       DT      15      NMOD
+... nonexecutive    JJ      15      NMOD
+... director        NN      12      PMOD
+... Nov.    NNP     9       VMOD
+... 29      CD      16      NMOD
+... .       .       9       VMOD
+... \""")
+ 
+>>> de = DependencyEvaluator([parsed_sent],[gold_sent])
+>>> de.eval()
+(0.8, 0.6)
+        
+        
+    """
+    def __init__(self, parsed_sents, gold_sents):
+        """
+        :param parsed_sents: the list of parsed_sents as the output of parser 
+        :type parsed_sents: list(DependencyGraph)
+        """
+        self._parsed_sents = parsed_sents
+        self._gold_sents = gold_sents
+    
+    def eval(self):
+        """
+        Return the Labeled Attachment Score (LAS) and Unlabeled Attachment Score (UAS)  
+        
+        :return : tuple(float,float)
+        """
+        if (len(self._parsed_sents) != len(self._gold_sents)):
+            raise ValueError(" Number of parsed sentence is different with number of gold sentence.")
+        
+        corr = 0 
+        corrL = 0 
+        total = 0 
+        
+        for i in range(len(self._parsed_sents)):
+            parsed_sent = self._parsed_sents[i].nodelist
+            gold_sent = self._gold_sents[i].nodelist
+            if (len(parsed_sent) != len(gold_sent)):
+                raise ValueError(" Sentence length is not matched. ")
+            
+            for j in range(len(parsed_sent)):
+                if (parsed_sent[j]["word"] is None): 
+                    continue
+                if (parsed_sent[j]["word"] != gold_sent[j]["word"]):
+                    raise ValueError(" Sentence sequence is not matched. ")
+                
+                # Ignore if word is punctuation by default
+                if re.sub(ur"\p{P}+", "", parsed_sent[j]["word"]) == "":  # if this is punctuation the whole string  
+                #if (parsed_sent[j]["word"] in string.punctuation):
+                    continue  
+                
+                total += 1 
+                if (parsed_sent[j]["head"] == gold_sent[j]["head"]):
+                    corr += 1 
+                    if (parsed_sent[j]["rel"] == gold_sent[j]["rel"]): 
+                        corrL += 1
+        return (corr / (1.0 * total), corrL/ (1.0 * total))
+             
+if __name__ == '__main__':
+    import doctest
+    doctest.testmod(optionflags=doctest.NORMALIZE_WHITESPACE)
+    

--- a/nltk/tag/senna.py
+++ b/nltk/tag/senna.py
@@ -86,6 +86,8 @@ class SennaTagger(TaggerI):
         used in the pipeline. In case, the system is not known the senna binary will
         be used.
         """
+        
+        # Long Duong : Fix here, should not concatenate the file like this 
         os_name = system()
         if os_name == 'Linux':
             bits = architecture()[0]

--- a/nltk/tag/stanford.py
+++ b/nltk/tag/stanford.py
@@ -40,7 +40,7 @@ class StanfordTagger(TaggerI):
 
         if not self._JAR:
             warnings.warn('The StanfordTagger class is not meant to be '
-                    'instanciated directly. Did you mean POS- or NERTagger?')
+                    'instantiated directly. Did you mean POS- or NERTagger?')
         self._stanford_jar = find_jar(
                 self._JAR, path_to_jar,
                 searchpath=(), url=_stanford_url,
@@ -67,7 +67,7 @@ class StanfordTagger(TaggerI):
         _input_fh, self._input_file_path = tempfile.mkstemp(text=True)
 
         self._cmd.extend(['-encoding', encoding])
-
+        
         # Write the actual sentences to the temporary input file
         _input_fh = os.fdopen(_input_fh, 'wb')
         _input = '\n'.join((' '.join(x) for x in sentences))
@@ -75,18 +75,18 @@ class StanfordTagger(TaggerI):
             _input = _input.encode(encoding)
         _input_fh.write(_input)
         _input_fh.close()
-
+        
         # Run the tagger and get the output
         stanpos_output, _stderr = java(self._cmd,classpath=self._stanford_jar,
                                                        stdout=PIPE, stderr=PIPE)
         stanpos_output = stanpos_output.decode(encoding)
 
         # Delete the temporary file
-        os.unlink(self._input_file_path)
+        os.unlink(self._input_file_path) 
 
         # Return java configurations to their default values
         config_java(options=default_options, verbose=False)
-
+                
         return self.parse_output(stanpos_output)
 
     def parse_output(self, text):
@@ -125,9 +125,10 @@ class POSTagger(StanfordTagger):
 
     @property
     def _cmd(self):
+        # Long Duong : Add -outputFormatOptions option for keeping the empty sentences
         return ['edu.stanford.nlp.tagger.maxent.MaxentTagger',
                 '-model', self._stanford_model, '-textFile',
-                self._input_file_path, '-tokenize', 'false']
+                self._input_file_path, '-tokenize', 'false','-outputFormatOptions', 'keepEmptySentences']
 
 class NERTagger(StanfordTagger):
     """

--- a/nltk/tokenize/stanford.py
+++ b/nltk/tokenize/stanford.py
@@ -46,9 +46,28 @@ class StanfordTokenizer(TokenizerI):
 
         self._encoding = encoding
         self.java_options = java_options
-        options = {} if options is None else options
-        self._options_cmd = ','.join('{0}={1}'.format(key, json.dumps(val)) for key, val in options.items())
-
+        #options = {} if options is None else options
+        
+        # Long Duong : fix bug #735 
+        options_str = options
+        options = {} 
+        if options_str is not None:
+            tokens = options_str.split()
+            if len(tokens) % 2 !=0:
+                    raise ValueError("Must be in set of (argument,value) pair")
+            
+            for i in range(len(tokens)/2):
+                key = tokens[2*i]
+                # Work the case when key might contain -  as in -tokenizeNLs
+                temp = list(key)
+                if temp[0] == '-':
+                    key = "".join(temp[1:])
+                
+                value = tokens[2*i+1]
+                options[key] = value 
+                
+        self._options_cmd = ','.join('{0}={1}'.format(key, val) for key, val in options.items())
+         
     @staticmethod
     def _parse_tokenized_output(s):
         return s.splitlines()

--- a/temp.txt
+++ b/temp.txt
@@ -1,1 +1,0 @@
-This is the temp file 

--- a/temp.txt
+++ b/temp.txt
@@ -1,0 +1,1 @@
+This is the temp file 


### PR DESCRIPTION
Re-implement http://ilk.uvt.nl/conll/software.html for computing LAS and UAS by adding file nltk.parse.depeval

Train MaltParser on english and czech version of conll share tasks and evaluate on the test data (english_ptb_test.conll and czech_pdt_test.conll). Reference implementation and this implementation give the same result. 
