### PR TITLE
Add case sensitivity

### DIFF
--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -1099,7 +1099,7 @@ class DownloaderShell(object):
                 self._show_config()
             elif user_input == 'd':
                 new_dl_dir = compat.raw_input('  New Directory> ').strip()
-                if new_dl_dir in ('', 'x', 'q'):
+                if new_dl_dir in ('', 'x', 'q', 'X', 'Q'):
                     print('  Cancelled!')
                 elif os.path.isdir(new_dl_dir):
                     self._ds.download_dir = new_dl_dir
@@ -1108,7 +1108,7 @@ class DownloaderShell(object):
                            new_dl_dir))
             elif user_input == 'u':
                 new_url = compat.raw_input('  New URL> ').strip()
-                if new_url in ('', 'x', 'q'):
+                if new_url in ('', 'x', 'q', 'X', 'Q'):
                     print('  Cancelled!')
                 else:
                     if not new_url.startswith('http://'):

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -1098,7 +1098,7 @@ class DownloaderShell(object):
             if user_input == 's':
                 self._show_config()
             elif user_input == 'd':
-                new_dl_dir = compat.raw_input('  New Directory> ').strip().lower()
+                new_dl_dir = compat.raw_input('  New Directory> ').strip()
                 if new_dl_dir in ('', 'x', 'q'):
                     print('  Cancelled!')
                 elif os.path.isdir(new_dl_dir):

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -1107,7 +1107,7 @@ class DownloaderShell(object):
                     print(('Directory %r not found!  Create it first.' %
                            new_dl_dir))
             elif user_input == 'u':
-                new_url = compat.raw_input('  New URL> ').strip().lower()
+                new_url = compat.raw_input('  New URL> ').strip()
                 if new_url in ('', 'x', 'q'):
                     print('  Cancelled!')
                 else:


### PR DESCRIPTION
Both the `Data dir` path and `Server URL` are `str.lower()`ed.

However, case-sensitivity depends on the file-system, and is handled by python's `os.path`.
Additionally, according to the [W3 spec](http://www.w3.org/TR/WD-html40-970708/htmlweb.html), URLs are case-sensitive as well.
Therefore, `nltk` shouldn't be implicitly lowercasing these strings.
Thoughts?

Note - This affects me, since I store `nltk_data` in `$HOME/Development/data/nltk`.
