### PR TITLE
Fixed installation with recent setuptools. Fixes GH-825 and GH-824.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,13 +29,6 @@ with open(version_file) as fh:
 # setuptools
 from setuptools import setup, find_packages
 
-#
-# Prevent setuptools from trying to add extra files to the source code
-# manifest by scanning the version control system for its contents.
-#
-from setuptools.command import sdist
-del sdist.finders[:]
-
 setup(
     name = "nltk",
     description = "Natural Language Toolkit",


### PR DESCRIPTION
These lines were introduced here: https://github.com/nltk/nltk/commit/1ecbd2edc32db24b4e6c7dd8555d0b89c668f041. It seems they fix an issue with .svn folders. We use git now, there are no .svn folders. See also: http://stackoverflow.com/questions/1129180/how-can-i-make-setuptools-ignore-subversion-inventory.

It should fix https://github.com/nltk/nltk/issues/825 and https://github.com/nltk/nltk/issues/824. 

The fix looks safe to cherry-pick for release branches and for NLTK 2.x. I should have submitted the PR to master branch, but it seems git flow is not followed (master should point to latest NLTK 3.x release which is not the case), so it doesn't matter.
