### PR TITLE
framenet corpus reader: fes() method to search by frame element name

### DIFF
--- a/nltk/corpus/reader/framenet.py
+++ b/nltk/corpus/reader/framenet.py
@@ -1198,6 +1198,37 @@ class FramenetCorpusReader(XMLCorpusReader):
             self._buildframeindex()
         return dict((fID, finfo.name) for fID,finfo in self._frame_idx.items() if name is None or re.search(name, finfo.name) is not None)
 
+    def fes(self, name=None):
+        '''
+        Lists frame element objects. If 'name' is provided, this is treated as 
+        a case-insensitive regular expression to filter by frame name. 
+        (Case-insensitivity is because casing of frame element names is not always 
+        consistent across frames.)
+        
+        >>> from nltk.corpus import framenet as fn
+        >>> fn.fes('sound')
+        [<fe ID=328 name=Sound>, <fe ID=323 name=Sound_source>, ...]
+        >>> [(fe.frame.name,fe.name) for fe in fn.fes('sound')]
+        [('Make_noise', 'Sound'), ('Make_noise', 'Sound_source'), 
+         ('Cause_to_make_noise', 'Sound_maker'), ('Sounds', 'Sound_source'), 
+         ('Sounds', 'Location_of_sound_source'), ('Sounds', 'Component_sound'), 
+         ('Sound_movement', 'Sound'), ('Sound_movement', 'Sound_source'), 
+         ('Sound_movement', 'Location_of_sound_source'), ('Vocalizations', 'Sound_source'), 
+         ('Vocalizations', 'Location_of_sound_source')]
+        >>> set(fe.name for fe in fn.fes('^sound'))
+        set(['Sound', 'Sound_source', 'Sound_maker'])
+        >>> len(fn.fes('^sound$'))
+        2
+        
+        :param name: A regular expression pattern used to match against
+            frame element names. If 'name' is None, then a list of all
+            frame elements will be returned.
+        :type name: str
+        :return: A list of matching frame elements
+        :rtype: list(AttrDict)
+        '''
+        return PrettyList(fe for f in self.frames() for fename,fe in f.FE.items() if name is None or re.search(name, fename, re.I))
+
     def lus(self, name=None):
         """
         Obtain details for a specific lexical unit.


### PR DESCRIPTION
I have found myself searching FrameNet by FE name a lot; this method will make that more convenient. CC: @wooters
