### PR TITLE
Fix definition of _rv_standard

### DIFF
--- a/nltk/stem/snowball.py
+++ b/nltk/stem/snowball.py
@@ -273,7 +273,7 @@ class _StandardStemmer(_LanguageSpecificStemmer):
                         rv = word[i+1:]
                         break
 
-            elif word[:2] in vowels:
+            elif word[0] in vowels and word[1] in vowels:
                 for i in range(2, len(word)):
                     if word[i] not in vowels:
                         rv = word[i+1:]


### PR DESCRIPTION
The test in the definition of RV is "If the first two letters are vowels"
but this is not what `word[:2] in vowels` tests. In fact, this is `False`:

``` python
'august'[:2] in 'aeiou'
```
