### PR TITLE
Treat 'õ' and 'ã' as vowel+consonant

### DIFF
--- a/nltk/stem/snowball.py
+++ b/nltk/stem/snowball.py
@@ -2429,12 +2429,12 @@ class PortugueseStemmer(_StandardStemmer):
     """
 
     __vowels = "aeiou\xE1\xE9\xED\xF3\xFA\xE2\xEA\xF4"
-    __step1_suffixes = ('amentos', 'imentos', 'uções', 'amento',
+    __step1_suffixes = ('amentos', 'imentos', 'uço~es', 'amento',
                         'imento', 'adoras', 'adores', 'a\xE7o~es',
                         'logias', '\xEAncias', 'amente',
                         'idades', 'an\xE7as', 'ismos', 'istas', 'adora',
                         'a\xE7a~o', 'antes', '\xE2ncia',
-                        'logia', 'ução', '\xEAncia',
+                        'logia', 'uça~o', '\xEAncia',
                         'mente', 'idade', 'an\xE7a', 'ezas', 'icos', 'icas',
                         'ismo', '\xE1vel', '\xEDvel', 'ista',
                         'osos', 'osas', 'ador', 'ante', 'ivas',


### PR DESCRIPTION
The patch will make the code match [the description of the Algorithm](https://github.com/snowballstem/snowball-website/blob/72a7277d8b9df089c7f5c162b41a0f456c2aa1ee/algorithms/portuguese/stemmer.html#L250-L257). This way, "execução" and "execuções" will have the same stem;
Similarly for "revolução" and "revoluções".

Follows up 986d10324d544df1bda41b822e8800ebf3126c1d.
