### PR TITLE
Replace incorrect suffix 'ívelmente' by 'ivelmente'

### DIFF
--- a/nltk/stem/snowball.py
+++ b/nltk/stem/snowball.py
@@ -2544,7 +2544,7 @@ class PortugueseStemmer(_StandardStemmer):
                         r2 = r2[:-5]
                         rv = rv[:-5]
 
-                        if r2.endswith(("ante", "avel", "\xEDvel")):
+                        if r2.endswith(("ante", "avel", "ivel")):
                             word = word[:-4]
                             rv = rv[:-4]
 


### PR DESCRIPTION
In Portuguese, adverbs ending in 'mente' are not accented, even if they
are derived from accented adjectives. For example, these are correct:
- 'possivelmente'
- 'visivelmente'

and these are typos:
- 'possívelmente'
- 'visívelmente'

This error is also present in the description of the algorithm on
http://snowball.tartarus.org/algorithms/portuguese/stemmer.html
