### PR TITLE
Add optional stream argument for tree pretty printing

### DIFF
--- a/nltk/tree.py
+++ b/nltk/tree.py
@@ -685,15 +685,16 @@ class Tree(list):
         from nltk.draw.tree import draw_trees
         draw_trees(self)
 
-    def pprint(self, sentence=None, highlight=(), **viz_args):
+    def pprint(self, stream=None, sentence=None, highlight=(), **viz_args):
         """
         Pretty-print this tree as ASCII or Unicode art.
         For explanation of the arguments, see the documentation for
         `nltk.treeprettyprinter.TreePrettyPrinter`.
         """
         from nltk.treeprettyprinter import TreePrettyPrinter
-        print(TreePrettyPrinter(self, sentence, highlight).text(**viz_args))
-        
+        print(TreePrettyPrinter(self, sentence, highlight).text(**viz_args),
+              stream=stream)
+
     def __repr__(self):
         childstr = ", ".join(unicode_repr(c) for c in self)
         return '%s(%s, [%s])' % (type(self).__name__, unicode_repr(self._label), childstr)


### PR DESCRIPTION
Hi,
This tries to fix https://github.com/nltk/nltk/issues/859
This seemed a easy beginner issue, so I made a attempt at adding optional stream argument for tree modules' pprint method. 
Please let me know if this was what was intended(or not). If yes, I will help in making other pprint methods consistent, otherwise let me know what I should do. 

Thanks.
