### PR TITLE
Fix bug in CI related to gluesemantic.doctest

### DIFF
--- a/nltk/sem/glue.py
+++ b/nltk/sem/glue.py
@@ -231,11 +231,13 @@ class GlueDict(dict):
     def to_glueformula_list(self, depgraph, node=None, counter=None, verbose=False):
         if node is None:
             top = depgraph.nodes[0]
-            root = depgraph.nodes[top['deps'][0]]
+            depList = sum(list(top['deps'].values()), [])
+            root = depgraph.nodes[depList[0]]
+            #print (root) 
             return self.to_glueformula_list(depgraph, root, Counter(), verbose)
 
         glueformulas = self.lookup(node, depgraph, counter)
-        for dep_idx in node['deps']:
+        for dep_idx in sum(list(node['deps'].values()), []):
             dep = depgraph.nodes[dep_idx]
             glueformulas.extend(self.to_glueformula_list(depgraph, dep, counter, verbose))
         return glueformulas
@@ -271,12 +273,15 @@ class GlueDict(dict):
         if rel == 'main':
             headnode = depgraph.nodes[node['head']]
             subj = self.lookup_unique('subj', headnode, depgraph)
-            node['deps'].append(subj['address'])
+            relation = subj['rel']
+            node['deps'].setdefault(relation,[])
+            node['deps'][relation].append(subj['address'])
+            #node['deps'].append(subj['address'])
 
     def _lookup_semtype_option(self, semtype, node, depgraph):
         relationships = frozenset(
             depgraph.nodes[dep]['rel'].lower()
-            for dep in node['deps']
+            for dep in sum(list(node['deps'].values()), [])
             if depgraph.nodes[dep]['rel'].lower() not in OPTIONAL_RELATIONSHIPS
         )
 
@@ -409,7 +414,7 @@ class GlueDict(dict):
         """
         deps = [
             depgraph.nodes[dep]
-            for dep in node['deps']
+            for dep in sum(list(node['deps'].values()), [])
             if depgraph.nodes[dep]['rel'].lower() == rel.lower()
         ]
 

--- a/nltk/sem/lfg.py
+++ b/nltk/sem/lfg.py
@@ -46,7 +46,9 @@ class FStructure(dict):
         for address, node in nodes.items():
             for n2 in (n for n in nodes.values() if n['rel'] != 'TOP'):
                 if n2['head'] == address:
-                    node['deps'].append(n2['address'])
+                    relation = n2['rel']
+                    node['deps'].setdefault(relation,[])
+                    node['deps'][relation].append(n2['address'])
 
         depgraph.root = nodes[1]
 
@@ -115,7 +117,7 @@ class FStructure(dict):
             if not fstruct.pred:
                 fstruct.pred = (word, tag)
 
-            children = [depgraph.nodes[idx] for idx in node['deps']]
+            children = [depgraph.nodes[idx] for idx in sum(list(node['deps'].values()), [])]
             for child in children:
                 fstruct.safeappend(child['rel'], FStructure._read_depgraph(child, depgraph, label_counter, fstruct))
 


### PR DESCRIPTION
Hi @stevenbird,

Here is the fix for CI <a href ="https://nltk.ci.cloudbees.com/job/nltk/198/TOXENV=py26-jenkins,jdk=oraclejdk8/testReport/%28root%29/gluesemantics_doctest/gluesemantics_doctest/"> bug  </a> related to gluesemantic.doctest. 

When testing locally, it fixes the problem with the recent dependency graph update, however there are some test case failed mainly because of pprint() (the output is different with expected)
