### PR TITLE
Remove the path compatibility support in tag/__init__.py

### DIFF
--- a/nltk/parse/transitionparser.py
+++ b/nltk/parse/transitionparser.py
@@ -17,7 +17,7 @@ import numpy as np
 from sklearn.datasets import load_svmlight_file
 from sklearn import svm
 from nltk.parse import DependencyGraph
-from evaluate import DependencyEvaluator
+from nltk.parse.evaluate import DependencyEvaluator
 
 
 class Configuration(object):

--- a/nltk/tag/__init__.py
+++ b/nltk/tag/__init__.py
@@ -77,15 +77,11 @@ from nltk.tag.senna         import SennaTagger, SennaChunkTagger, SennaNERTagger
 from nltk.tag.mapping       import tagset_mapping, map_tag
 
 from nltk.data import load
-from nltk.compat import PY3
 
 
 # Standard treebank POS tagger
 
-if PY3:
-    _POS_TAGGER = 'taggers/maxent_treebank_pos_tagger/PY3/english.pickle'
-else:
-    _POS_TAGGER = 'taggers/maxent_treebank_pos_tagger/english.pickle'
+_POS_TAGGER = 'taggers/maxent_treebank_pos_tagger/english.pickle'
 
 def pos_tag(tokens):
     """


### PR DESCRIPTION
There would be a duplicated "PY3" in the path, since the PY2/PY3 compatibility has been handled by `py3_data` in `nltk.compat`.
