### PR TITLE
Adding _repr_svg_ for Ipython notebook

### DIFF
--- a/nltk/parse/dependencygraph.py
+++ b/nltk/parse/dependencygraph.py
@@ -129,7 +129,7 @@ class DependencyGraph(object):
         """
         return node_address in self.nodes
 
-    def draw_dot(self):
+    def to_dot(self):
         """
         Returns a dot representation suitable for using with Graphviz
         @rtype C{String}
@@ -139,13 +139,14 @@ class DependencyGraph(object):
         s += 'edge [dir=forward]\n'
         s += 'node [shape=plaintext]\n'
         # Draw the remaining nodes
-        for head, h_node in self.nodes.iteritems():
-            s += '\n%s [label="%s (%s)"]' % (h_node['address'], h_node['address'], h_node['word'])
-            if head != 0:  # not TOP
-                if h_node['rel'] != '_':
-                    s += '\n%s -> %s [label="%s"]' % (h_node['head'], h_node['address'], h_node['rel'])
-                else:
-                    s += '\n%s -> %s ' % (h_node['head'], h_node['address'])
+        for node in sorted(self.nodes.values()):
+            s += '\n%s [label="%s (%s)"]' % (node['address'], node['address'], node['word'])
+            for rel, deps in node['deps'].iteritems():
+                for dep in deps:
+                    if rel != None:
+                        s += '\n%s -> %s [label="%s"]' % (node['address'], dep, rel)
+                    else:
+                        s += '\n%s -> %s ' % (node['address'], dep)
         s += "\n}"
         return s
 

--- a/nltk/parse/dependencygraph.py
+++ b/nltk/parse/dependencygraph.py
@@ -132,7 +132,6 @@ class DependencyGraph(object):
     def draw_dot(self):
         """
         Returns a dot representation suitable for using with Graphviz
-        @type t:L{nltk.parse.dependencygraph.DependencyGraph}
         @rtype C{String}
         """
         # Start the digraph specification

--- a/nltk/parse/dependencygraph.py
+++ b/nltk/parse/dependencygraph.py
@@ -18,6 +18,7 @@ from __future__ import print_function, unicode_literals
 from collections import defaultdict
 from itertools import chain
 from pprint import pformat
+import subprocess
 
 from nltk.tree import Tree
 from nltk.compat import python_2_unicode_compatible, string_types
@@ -99,7 +100,7 @@ class DependencyGraph(object):
         node specified by the mod address.
         """
         relation = self.nodes[mod_address]['rel']
-        self.nodes[head_address]['deps'].setdefault(relation,[])
+        self.nodes[head_address]['deps'].setdefault(relation, [])
         self.nodes[head_address]['deps'][relation].append(mod_address)
         #self.nodes[head_address]['deps'].append(mod_address)
 
@@ -127,6 +128,41 @@ class DependencyGraph(object):
         address, false otherwise.
         """
         return node_address in self.nodes
+
+    def draw_dot(self):
+        """
+        Returns a dot representation suitable for using with Graphviz
+        @type t:L{nltk.parse.dependencygraph.DependencyGraph}
+        @rtype C{String}
+        """
+        # Start the digraph specification
+        s = 'digraph G{\n'
+        s += 'edge [dir=forward]\n'
+        s += 'node [shape=plaintext]\n'
+        # Draw the remaining nodes
+        for head, h_node in self.nodes.iteritems():
+            s += '\n%s [label="%s (%s)"]' % (h_node['address'], h_node['address'], h_node['word'])
+            if head != 0:  # not TOP
+                if h_node['rel'] != '_':
+                    s += '\n%s -> %s [label="%s"]' % (h_node['head'], h_node['address'], h_node['rel'])
+                else:
+                    s += '\n%s -> %s ' % (h_node['head'], h_node['address'])
+        s += "\n}"
+        return s
+
+    def _repr_svg_(self):
+        """Ipython magic: show SVG representation of the transducer"""
+        dot_string = self.draw_dot()
+        format = 'svg'
+        try:
+            process = subprocess.Popen(['dot', '-T%s' % format], stdin=subprocess.PIPE,
+                                       stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        except OSError:
+            raise Exception('Cannot find the dot binary from Graphviz package')
+        out, err = process.communicate(dot_string)
+        if err:
+            raise Exception('Cannot create %s representation by running dot from string\n:%s' % (format, dot_string))
+        return out
 
     def __str__(self):
         return pformat(self.nodes)


### PR DESCRIPTION
The _repr_svg is implemented using dot and graphviz.
Usage in IPython notebook:

from IPython.display import display
import nltk.parse.dependencygraph as depgraph
dg = depgraph.DependencyGraph(depgraph.conll_data1)
display(dg)

Should draw the dependency graph for the sentence

draw_dot is based on @gmonce code https://github.com/pln-fing-udelar/pln_inco/blob/master/syntax_trees.py#L52
