### PR TITLE
Populating each DependencyGraph node(aka dictionary) with all the keys

### DIFF
--- a/nltk/parse/dependencygraph.py
+++ b/nltk/parse/dependencygraph.py
@@ -57,6 +57,7 @@ class DependencyGraph(object):
                                            'feats': None,
                                            'head': None,
                                            'deps': defaultdict(list),
+                                           'rel': None,
                                            })
 
         self.nodes[0].update(

--- a/nltk/parse/dependencygraph.py
+++ b/nltk/parse/dependencygraph.py
@@ -18,7 +18,6 @@ from __future__ import print_function, unicode_literals
 from collections import defaultdict
 from itertools import chain
 from pprint import pformat
-from copy import deepcopy
 
 from nltk.tree import Tree
 from nltk.compat import python_2_unicode_compatible, string_types
@@ -34,16 +33,6 @@ class DependencyGraph(object):
     """
     A container for the nodes and labelled edges of a dependency structure.
     """
-    default_node = {
-        'address': None,
-        'word': None,
-        'lemma': None,
-        'ctag': None,
-        'tag': None,
-        'feats': None,
-        'head': None,
-        'deps': defaultdict(list),
-    }
 
     def __init__(self, tree_str=None, cell_extractor=None, zero_based=False, cell_separator=None):
         """Dependency graph.
@@ -60,7 +49,16 @@ class DependencyGraph(object):
         are split by whitespace.
 
         """
-        self.nodes = defaultdict(lambda: deepcopy(DependencyGraph.default_node))
+        self.nodes = defaultdict(lambda:  {'address': None,
+                                           'word': None,
+                                           'lemma': None,
+                                           'ctag': None,
+                                           'tag': None,
+                                           'feats': None,
+                                           'head': None,
+                                           'deps': defaultdict(list),
+                                           })
+
         self.nodes[0].update(
             {
                 'ctag': 'TOP',

--- a/nltk/parse/dependencygraph.py
+++ b/nltk/parse/dependencygraph.py
@@ -18,6 +18,7 @@ from __future__ import print_function, unicode_literals
 from collections import defaultdict
 from itertools import chain
 from pprint import pformat
+from copy import deepcopy
 
 from nltk.tree import Tree
 from nltk.compat import python_2_unicode_compatible, string_types
@@ -33,6 +34,16 @@ class DependencyGraph(object):
     """
     A container for the nodes and labelled edges of a dependency structure.
     """
+    default_node = {
+        'address': None,
+        'word': None,
+        'lemma': None,
+        'ctag': None,
+        'tag': None,
+        'feats': None,
+        'head': None,
+        'deps': defaultdict(list),
+    }
 
     def __init__(self, tree_str=None, cell_extractor=None, zero_based=False, cell_separator=None):
         """Dependency graph.
@@ -49,14 +60,11 @@ class DependencyGraph(object):
         are split by whitespace.
 
         """
-        self.nodes = defaultdict(lambda: {'deps': defaultdict(list)})
+        self.nodes = defaultdict(lambda: deepcopy(DependencyGraph.default_node))
         self.nodes[0].update(
             {
-                'word': None,
-                'lemma': None,
                 'ctag': 'TOP',
                 'tag': 'TOP',
-                'feats': None,
                 'rel': 'TOP',
                 'address': 0,
             }


### PR DESCRIPTION
Hi @dimazest, and @stevenbird,
Some functions in`nltk.parse.dependencygraph.DependencyGraph`
 e.g `nltk.to_conll` expects that all keys exists for each node.
// I think that this is reasonable assumption
However, most of the code does not specify all the keys.
E.g. the dependency graphs generated by `nltk.parse.dependencygraph.ProbabilisticNonprojectiveParser`
contain nodes with missing `lemma` key.

As a solution, I changed the default behaviour for initializing each node
with all the expected keys and corresponding default values.
See the `DependencyGraph.defaultnode` in the PR.

Thanks for your work!
