### PR TITLE
Fix example for lin scored_synonyms

### DIFF
--- a/nltk/corpus/reader/lin.py
+++ b/nltk/corpus/reader/lin.py
@@ -140,7 +140,7 @@ def demo():
     print(thes.synonyms(word1))
 
     print("Getting scored synonyms for " + word1)
-    print(thes.synonyms(word1))
+    print(thes.scored_synonyms(word1))
 
     print("Getting synonyms from simN.lsp (noun subsection) for " + word1)
     print(thes.synonyms(word1, fileid="simN.lsp"))


### PR DESCRIPTION
- The demo is currently repeating previous example of displaying synonyms without scores.
