### PR TITLE
Add support for Google App Engine

### DIFF
--- a/nltk/__init__.py
+++ b/nltk/__init__.py
@@ -97,11 +97,13 @@ except ImportError:
 # Override missing methods on environments where it cannot be used like GAE.
 import subprocess
 if not hasattr(subprocess, 'PIPE'):
-    subprocess.PIPE = lambda *args, **kwargs: print(
-      'subprocess.PIPE is not supported.')
+    def _fake_PIPE(*args, **kwargs):
+      raise NotImplementedError('subprocess.PIPE is not supported.')
+    subprocess.PIPE = _fake_PIPE
 if not hasattr(subprocess, 'Popen'):
-    subprocess.Popen = lambda *args, **kwargs: print(
-      'subprocess.Popen is not supported.')
+    def _fake_Popen(*args, **kwargs):
+      raise NotImplementedError('subprocess.Popen is not supported.')
+    subprocess.Popen = _fake_Popen
 
 ###########################################################
 # TOP-LEVEL MODULES

--- a/nltk/__init__.py
+++ b/nltk/__init__.py
@@ -94,6 +94,15 @@ try:
 except ImportError:
     pass
 
+# Override missing methods on environments where it cannot be used like GAE.
+import subprocess
+if not hasattr(subprocess, 'PIPE'):
+    subprocess.PIPE = lambda *args, **kwargs: print(
+      'subprocess.PIPE is not supported.')
+if not hasattr(subprocess, 'Popen'):
+    subprocess.Popen = lambda *args, **kwargs: print(
+      'subprocess.Popen is not supported.')
+
 ###########################################################
 # TOP-LEVEL MODULES
 ###########################################################

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -73,7 +73,7 @@ path = []
 
 # User-specified locations:
 path += [d for d in os.environ.get('NLTK_DATA', str('')).split(os.pathsep) if d]
-if not os.environ.get('APPENGINE_RUNTIME') and os.path.expanduser('~/') != '~/':
+if 'APPENGINE_RUNTIME' not in os.environ and os.path.expanduser('~/') != '~/':
     path.append(os.path.expanduser(str('~/nltk_data')))
 
 if sys.platform.startswith('win'):

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -73,7 +73,7 @@ path = []
 
 # User-specified locations:
 path += [d for d in os.environ.get('NLTK_DATA', str('')).split(os.pathsep) if d]
-if os.path.expanduser('~/') != '~/':
+if not os.environ.get('APPENGINE_RUNTIME') and os.path.expanduser('~/') != '~/':
     path.append(os.path.expanduser(str('~/nltk_data')))
 
 if sys.platform.startswith('win'):

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -924,6 +924,10 @@ class Downloader(object):
         permission: ``/usr/share/nltk_data``, ``/usr/local/share/nltk_data``,
         ``/usr/lib/nltk_data``, ``/usr/local/lib/nltk_data``, ``~/nltk_data``.
         """
+        # Check if we are on GAE where we cannot write into filesystem.
+        if os.environ.get('APPENGINE_RUNTIME') is not None:
+            return
+
         # Check if we have sufficient permissions to install in a
         # variety of system-wide locations.
         for nltkdir in nltk.data.path:
@@ -2267,4 +2271,3 @@ if __name__ == '__main__':
         downloader.download(download_dir=options.dir,
             quiet=options.quiet, force=options.force,
             halt_on_error=options.halt_on_error)
-

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -925,7 +925,7 @@ class Downloader(object):
         ``/usr/lib/nltk_data``, ``/usr/local/lib/nltk_data``, ``~/nltk_data``.
         """
         # Check if we are on GAE where we cannot write into filesystem.
-        if os.environ.get('APPENGINE_RUNTIME') is not None:
+        if 'APPENGINE_RUNTIME' in os.environ:
             return
 
         # Check if we have sufficient permissions to install in a


### PR DESCRIPTION
We cannot use nor filesystem nor subprocesses under GAE, but by simple
overriding these methods we will allow it to work under GAE.

There's a lot of people who would like to use it under GAE, and with this PL it will be much easier to do.
Without this PL its not even possible to `import nltk` under GAE.

http://stackoverflow.com/questions/1286301/using-the-python-nltk-2-0b5-on-the-google-app-engine
