### PR TITLE
Add warning for when SimpleGoodTuring doesn't work

### DIFF
--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -1272,6 +1272,11 @@ class SimpleGoodTuringProbDist(ProbDistI):
             xy_cov += (x - x_mean) * (y - y_mean)
             x_var += (x - x_mean)**2
         self._slope = (xy_cov / x_var if x_var != 0 else 0.0)
+        if self._slope >= -1:
+            warnings.warn("SimpleGoodTuring did not find a proper best fit "
+                          "line for smoothing probabilities of occurrences. "
+                          "The probabilities are likely to be unreliable "
+                          "estimates.")
         self._intercept = y_mean - self._slope * x_mean
 
     def _switch(self, r, nr):

--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -1217,6 +1217,8 @@ class SimpleGoodTuringProbDist(ProbDistI):
         assert bins is None or bins > freqdist.B(),\
                'bins parameter must not be less than %d=freqdist.B()+1' % (freqdist.B()+1)
         if bins is None:
+            warnings.warn('Bins parameter needs to be passed to '
+                          'SimpleGoodTuringProbDist for accurate estimates.')
             bins = freqdist.B() + 1
         self._freqdist = freqdist
         self._bins = bins
@@ -1273,10 +1275,10 @@ class SimpleGoodTuringProbDist(ProbDistI):
             x_var += (x - x_mean)**2
         self._slope = (xy_cov / x_var if x_var != 0 else 0.0)
         if self._slope >= -1:
-            warnings.warn("SimpleGoodTuring did not find a proper best fit "
-                          "line for smoothing probabilities of occurrences. "
-                          "The probabilities are likely to be unreliable "
-                          "estimates.")
+            warnings.warn('SimpleGoodTuring did not find a proper best fit '
+                          'line for smoothing probabilities of occurrences. '
+                          'The probability estimates are likely to be '
+                          'unreliable.')
         self._intercept = y_mean - self._slope * x_mean
 
     def _switch(self, r, nr):


### PR DESCRIPTION
An attempt to address #602.  I added a warning for when SimpleGoodTuring doesn't find a proper best-fit line.  In order for the Good-Turing estimated frequency to be less than the actual seen frequency, the slope of the best-fit line must be less than -1.

From [Good-Turing Smoothing Without Tears](http://www.d.umn.edu/~tpederse/Courses/CS8761-FALL02/Code/sgt-gale.pdf):
"Thus if the estimate for the slope, b, is greater than -1, the method presented should be regarded as not
applicable."

The warning is triggered for the example in #602, but doesn't appear when there is enough data (for example using a frequency distribution made out of brown.words()).
