### PR TITLE
Don't swallow OSError when searching for binaries

### DIFF
--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -500,7 +500,7 @@ def find_file_iter(filename, env_vars=(), searchpath=(),
                         print('[Found %s: %s]' % (filename, path))
                     yielded = True
                     yield path
-            except (KeyboardInterrupt, SystemExit):
+            except (KeyboardInterrupt, SystemExit, OSError):
                 raise
             except:
                 pass


### PR DESCRIPTION
Because subprocess.Popen uses fork if the Python process is already using a lot of memory this is likely to cause an out of memory error. The error message that is presented if this exception is swallowed makes it seem like the file cannot be found, even if it would have been found if the process hadn't run out of memory.

I've had a look at the other reasons there could be an OSError and I cannot see any which I think should be swallowed. But if there were then you could check the errno attribute and only re-raise the ones needed.
