### PR TITLE
compatibility with python 2.7

### DIFF
--- a/nltk/compat.py
+++ b/nltk/compat.py
@@ -54,6 +54,9 @@ if PY3:
 
     from collections import Counter
 
+    from datetime import timezone
+    UTC = timezone.utc
+
 else:
     def b(s):
         return s
@@ -120,6 +123,9 @@ else:
             return sys.modules[name]
 
     sys.meta_path.insert(0, TkinterLoader())
+
+    import pytz
+    UTC = pytz.utc
 
     import csv, codecs, cStringIO
     class UnicodeWriter:

--- a/nltk/twitter/api.py
+++ b/nltk/twitter/api.py
@@ -10,15 +10,8 @@
 """
 Provides an interface for TweetHandlers.
 """
-from nltk import compat
 import datetime
-
-if compat.PY26:
-    import pytz
-    UTC = pytz.utc
-else:
-    from datetime import timezone
-    UTC = timezone.utc
+from nltk.compat import UTC
 
 class TweetHandlerI(object):
     """

--- a/nltk/twitter/api.py
+++ b/nltk/twitter/api.py
@@ -10,8 +10,29 @@
 """
 Provides an interface for TweetHandlers.
 """
-import datetime
-from nltk.compat import UTC
+
+'''
+The following is not a general purpose object for dealing with the local timezone
+- It assumes that the date passed has been created using datetime(..., tzinfo=Local),
+  where Local is an instance of the object LocalTimezoneOffsetWithUTC
+- For such un object, it returns the offset with UTC, used for date comparations
+
+Reference: https://docs.python.org/3/library/datetime.html
+'''
+import time as _time
+from datetime import tzinfo, timedelta, datetime
+
+class LocalTimezoneOffsetWithUTC(tzinfo):
+    STDOFFSET = timedelta(seconds = -_time.timezone)
+    if _time.daylight:
+        DSTOFFSET = timedelta(seconds = -_time.altzone)
+    else:
+        DSTOFFSET = STDOFFSET
+
+    def utcoffset(self, dt):
+        return self.DSTOFFSET
+
+Local = LocalTimezoneOffsetWithUTC()
 
 class TweetHandlerI(object):
     """
@@ -32,7 +53,7 @@ class TweetHandlerI(object):
         self.limit = limit
         self.date_limit = date_limit
         if date_limit is not None:
-            self.date_limit = datetime.datetime(*date_limit, tzinfo=UTC)
+            self.date_limit = datetime(*date_limit, tzinfo=Local)
 
         self.startingup = True
         """A flag to indicate whether this is the first data

--- a/nltk/twitter/twitterclient.py
+++ b/nltk/twitter/twitterclient.py
@@ -24,14 +24,7 @@ import itertools
 import json
 import os
 import requests
-from nltk import compat
-
-if compat.PY26:
-    import pytz
-    UTC = pytz.utc
-else:
-    from datetime import timezone
-    UTC = timezone.utc
+from nltk.compat import UTC
 
 
 try:


### PR DESCRIPTION
use pytz to obtain UTC timezone in python <> 3, standard datetime in python 3
