### PR TITLE
search_tweets with pagination & rate limits

### DIFF
--- a/nltk/twitter/api.py
+++ b/nltk/twitter/api.py
@@ -65,3 +65,11 @@ class TweetHandlerI(object):
         Deal appropriately with data returned by the Twitter API
         """
         raise NotImplementedError
+
+    def handle_chunk(self, data_chunk):
+        """
+        Deal appropriately with a list of elements returned by the Twitter API
+        (default implementation should be enough in most cases)
+        """
+        for item in data_chunk:
+            self.handle(item)


### PR DESCRIPTION
Handles requests to the rest api for count bigger than 100 tweets:
- successive requests using pagination
- wait for 15 minutes when rate limit is reached
