### PR TITLE
Tgrep module documentation

### DIFF
--- a/nltk/tgrep.py
+++ b/nltk/tgrep.py
@@ -909,3 +909,8 @@ def tgrep_nodes(tree, tgrep_string, search_leaves = True):
     '''
     return [tree[position] for position in tgrep_positions(tree, tgrep_string,
                                                            search_leaves)]
+
+# run module doctests
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod(optionflags=doctest.NORMALIZE_WHITESPACE)


### PR DESCRIPTION
Integrate README information into tgrep module docstring; add doctest.testmod to run module doctests.
