### PR TITLE
tgrep: tgrep_positions and tgrep_nodes can take lists of trees

### DIFF
--- a/nltk/tgrep.py
+++ b/nltk/tgrep.py
@@ -120,6 +120,7 @@ except ImportError:
     print('Warning: nltk.tgrep will not work without the `pyparsing` package')
     print('installed.')
 import re
+import types
 
 class TgrepException(Exception):
     '''Tgrep exception type.'''
@@ -894,7 +895,8 @@ def tgrep_positions(tree, tgrep_string, search_leaves = True):
     # compile tgrep_string if needed
     if isinstance(tgrep_string, (binary_type, text_type)):
         tgrep_string = tgrep_compile(tgrep_string)
-    if not _istree(tree) and isinstance(tree, (list, tuple)):
+    if not _istree(tree) and isinstance(tree,
+                                        (list, tuple, types.GeneratorType)):
         return [tgrep_positions(t, tgrep_string, search_leaves) for t in tree]
     else:
         try:
@@ -922,7 +924,8 @@ def tgrep_nodes(tree, tgrep_string, search_leaves = True):
     # compile tgrep_string if needed
     if isinstance(tgrep_string, (binary_type, text_type)):
         tgrep_string = tgrep_compile(tgrep_string)
-    if not _istree(tree) and isinstance(tree, (list, tuple)):
+    if not _istree(tree) and isinstance(tree,
+                                        (list, tuple, types.GeneratorType)):
         return [tgrep_nodes(t, tgrep_string, search_leaves) for t in tree]
     else:
         return [tree[position] for position in

--- a/nltk/tgrep.py
+++ b/nltk/tgrep.py
@@ -905,6 +905,7 @@ def tgrep_positions(tree, tgrep_string, search_leaves = True):
         return [tgrep_positions(t, tgrep_string, search_leaves)
                 for t in tree_iter]
     else:
+        # tree is not an iterable but a single tree
         try:
             if search_leaves:
                 search_positions = tree.treepositions()
@@ -940,6 +941,7 @@ def tgrep_nodes(tree, tgrep_string, search_leaves = True):
     if tree_iter is not None:
         return [tgrep_nodes(t, tgrep_string, search_leaves) for t in tree_iter]
     else:
+        # tree is not an iterable but a single tree
         return [tree[position] for position in
                 tgrep_positions(tree, tgrep_string, search_leaves)]
 

--- a/nltk/tgrep.py
+++ b/nltk/tgrep.py
@@ -120,7 +120,6 @@ except ImportError:
     print('Warning: nltk.tgrep will not work without the `pyparsing` package')
     print('installed.')
 import re
-import types
 
 class TgrepException(Exception):
     '''Tgrep exception type.'''
@@ -886,7 +885,7 @@ def tgrep_positions(tree, tgrep_string, search_leaves = True):
     `tgrep_string`.
 
     Arguments:
-    - `tree`: a NLTK tree (usually a ParentedTree), or a list of trees
+    - `tree`: a NLTK tree (usually a ParentedTree), or an iterable over trees
     - `tgrep_string`: a tgrep search query, either as a string value,
       or compiled into a lambda function with `tgrep_compile`
     - `search_leaves`: Boolean flag; if this is False, the method will
@@ -895,9 +894,16 @@ def tgrep_positions(tree, tgrep_string, search_leaves = True):
     # compile tgrep_string if needed
     if isinstance(tgrep_string, (binary_type, text_type)):
         tgrep_string = tgrep_compile(tgrep_string)
-    if not _istree(tree) and isinstance(tree,
-                                        (list, tuple, types.GeneratorType)):
-        return [tgrep_positions(t, tgrep_string, search_leaves) for t in tree]
+    # check if tree is iterable
+    tree_iter = None
+    if not _istree(tree):
+        try:
+            tree_iter = iter(tree)
+        except TypeError:
+            pass
+    if tree_iter is not None:
+        return [tgrep_positions(t, tgrep_string, search_leaves)
+                for t in tree_iter]
     else:
         try:
             if search_leaves:
@@ -915,7 +921,7 @@ def tgrep_nodes(tree, tgrep_string, search_leaves = True):
     `tgrep_ string`.
 
     Arguments:
-    - `tree`: a NLTK tree (usually a ParentedTree), or a list of trees
+    - `tree`: a NLTK tree (usually a ParentedTree), or an iterable over trees
     - `tgrep_string`: a tgrep search query, either as a string value,
       or compiled into a lambda function with `tgrep_compile`
     - `search_leaves`: Boolean flag; if this is False, the method will
@@ -924,9 +930,15 @@ def tgrep_nodes(tree, tgrep_string, search_leaves = True):
     # compile tgrep_string if needed
     if isinstance(tgrep_string, (binary_type, text_type)):
         tgrep_string = tgrep_compile(tgrep_string)
-    if not _istree(tree) and isinstance(tree,
-                                        (list, tuple, types.GeneratorType)):
-        return [tgrep_nodes(t, tgrep_string, search_leaves) for t in tree]
+    # check if tree is iterable
+    tree_iter = None
+    if not _istree(tree):
+        try:
+            tree_iter = iter(tree)
+        except TypeError:
+            pass
+    if tree_iter is not None:
+        return [tgrep_nodes(t, tgrep_string, search_leaves) for t in tree_iter]
     else:
         return [tree[position] for position in
                 tgrep_positions(tree, tgrep_string, search_leaves)]

--- a/nltk/tgrep.py
+++ b/nltk/tgrep.py
@@ -894,7 +894,7 @@ def tgrep_positions(tree, tgrep_string, search_leaves = True):
     # compile tgrep_string if needed
     if isinstance(tgrep_string, (binary_type, text_type)):
         tgrep_string = tgrep_compile(tgrep_string)
-    if isinstance(tree, (list, tuple)):
+    if not _istree(tree) and isinstance(tree, (list, tuple)):
         return [tgrep_positions(t, tgrep_string, search_leaves) for t in tree]
     else:
         try:
@@ -922,7 +922,7 @@ def tgrep_nodes(tree, tgrep_string, search_leaves = True):
     # compile tgrep_string if needed
     if isinstance(tgrep_string, (binary_type, text_type)):
         tgrep_string = tgrep_compile(tgrep_string)
-    if isinstance(tree, (list, tuple)):
+    if not _istree(tree) and isinstance(tree, (list, tuple)):
         return [tgrep_nodes(t, tgrep_string, search_leaves) for t in tree]
     else:
         return [tree[position] for position in

--- a/nltk/tgrep.py
+++ b/nltk/tgrep.py
@@ -884,31 +884,49 @@ def tgrep_positions(tree, tgrep_string, search_leaves = True):
     Return all tree positions in the given tree which match the given
     `tgrep_string`.
 
-    If `search_leaves` is False, the method will not return any
-    results in leaf positions.
+    Arguments:
+    - `tree`: a NLTK tree (usually a ParentedTree), or a list of trees
+    - `tgrep_string`: a tgrep search query, either as a string value,
+      or compiled into a lambda function with `tgrep_compile`
+    - `search_leaves`: Boolean flag; if this is False, the method will
+      not return any positions which are leaf nodes of the given tree(s)
     '''
-    try:
-        if search_leaves:
-            search_positions = tree.treepositions()
-        else:
-            search_positions = treepositions_no_leaves(tree)
-    except AttributeError:
-        return []
+    # compile tgrep_string if needed
     if isinstance(tgrep_string, (binary_type, text_type)):
         tgrep_string = tgrep_compile(tgrep_string)
-    return [position for position in search_positions
-            if tgrep_string(tree[position])]
+    if isinstance(tree, (list, tuple)):
+        return [tgrep_positions(t, tgrep_string, search_leaves) for t in tree]
+    else:
+        try:
+            if search_leaves:
+                search_positions = tree.treepositions()
+            else:
+                search_positions = treepositions_no_leaves(tree)
+        except AttributeError:
+            return []
+        return [position for position in search_positions
+                if tgrep_string(tree[position])]
 
 def tgrep_nodes(tree, tgrep_string, search_leaves = True):
     '''
     Return all tree nodes in the given tree which match the given
     `tgrep_ string`.
 
-    If `search_leaves` is False, the method will not return any
-    results in leaf positions.
+    Arguments:
+    - `tree`: a NLTK tree (usually a ParentedTree), or a list of trees
+    - `tgrep_string`: a tgrep search query, either as a string value,
+      or compiled into a lambda function with `tgrep_compile`
+    - `search_leaves`: Boolean flag; if this is False, the method will
+      not return any leaf nodes of the given tree(s)
     '''
-    return [tree[position] for position in tgrep_positions(tree, tgrep_string,
-                                                           search_leaves)]
+    # compile tgrep_string if needed
+    if isinstance(tgrep_string, (binary_type, text_type)):
+        tgrep_string = tgrep_compile(tgrep_string)
+    if isinstance(tree, (list, tuple)):
+        return [tgrep_nodes(t, tgrep_string, search_leaves) for t in tree]
+    else:
+        return [tree[position] for position in
+                tgrep_positions(tree, tgrep_string, search_leaves)]
 
 # run module doctests
 if __name__ == "__main__":


### PR DESCRIPTION
Change `tgrep_positions` and `tgrep_nodes` to be able to take a list of trees.  Update the docstrings for the functions to document this.

Mentioned in #931 
