### PR TITLE
convert twitter additional entities to csv + date_limit for not streaming accesses

### DIFF
--- a/nltk/twitter/api.py
+++ b/nltk/twitter/api.py
@@ -72,4 +72,6 @@ class TweetHandlerI(object):
         (default implementation should be enough in most cases)
         """
         for item in data_chunk:
-            self.handle(item)
+            if self.handle(item) == False:
+                return False
+        return True


### PR DESCRIPTION
1. The function to convert twitter additional entities to csv is now tested for all the possible entities of a tweet (hashtags, user_mentions, urls, media), of a user (urls), and for place (including bounding box)
2. Includes date limit functionality to tweets method for rest api (i.e. not streaming). Api of the method does not change. The param date_limit has different meaning when either streaming or not; in streaming it is a date in the future, if not, it is a date in the past
