### PR TITLE
Fix bug #963 finding jar files

### DIFF
--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -592,6 +592,23 @@ def find_jar_iter(name_pattern, path_to_jar=None, env_vars=(),
                                 print('[Found %s: %s]' % (name_pattern, cp))
                             yielded = True
                             yield cp
+                    # The case where user put directory containing the jar file in the classpath 
+                    if os.path.isdir(cp):
+                        if not is_regex:
+                            if os.path.isfile(os.path.join(cp,name_pattern)):
+                                if verbose:
+                                    print('[Found %s: %s]' % (name_pattern, cp))
+                                yielded = True
+                                yield os.path.join(cp,name_pattern)
+                        else:
+                            # Look for file using regular expression 
+                            for file_name in os.listdir(cp):
+                                if re.match(name_pattern,file_name):
+                                    if verbose:
+                                        print('[Found %s: %s]' % (name_pattern, os.path.join(cp,file_name)))
+                                    yielded = True
+                                    yield os.path.join(cp,file_name)
+                                
             else:
                 jar_env = os.environ[env_var]
                 jar_iter = ((os.path.join(jar_env, path_to_jar) for path_to_jar in os.listdir(jar_env))


### PR DESCRIPTION
Hi @stevenbird, 
Here's the simple bug fix for #963. I also modified the <a href = 'https://github.com/nltk/nltk/wiki/Installing-Third-Party-Software' > wiki </a> for 3rd party software installation so that all Stanford packages use the consensus global environment. 
