### PR TITLE
Issue #978: changes in the formula TF

### DIFF
--- a/nltk/text.py
+++ b/nltk/text.py
@@ -544,7 +544,7 @@ class TextCollection(Text):
     Iterating over a TextCollection produces all the tokens of all the
     texts in order.
     """
-    def __init__(self, source, name=None):
+    def __init__(self, source):
         if hasattr(source, 'words'): # bridge to the text corpus reader
             source = [source.words(f) for f in source.fileids()]
 
@@ -552,11 +552,11 @@ class TextCollection(Text):
         Text.__init__(self, LazyConcatenation(source))
         self._idf_cache = {}
 
-    def tf(self, term, text, method=None):
+    def tf(self, term, text):
         """ The frequency of the term in text. """
         return text.count(term) / len(text)
 
-    def idf(self, term, method=None):
+    def idf(self, term):
         """ The number of texts in the corpus divided by the
         number of texts that the term appears in.
         If a term does not appear in the corpus, 0.0 is returned. """

--- a/nltk/text.py
+++ b/nltk/text.py
@@ -554,7 +554,7 @@ class TextCollection(Text):
 
     def tf(self, term, text):
         """ The frequency of the term in text. """
-        return text.count(term) / len(text)
+        return text.count(term)
 
     def idf(self, term):
         """ The number of texts in the corpus divided by the


### PR DESCRIPTION
nltk/nltk/text.py

``` python
def tf(self, term, text, method=None):
    """ The frequency of the term in text. """
    return text.count(term) / len(text)
```

http://en.wikipedia.org/wiki/Tf–idf
Real TF is only the number of occurrences of words in text

And there is also a variation of the "normalization":
1. Boolean "frequencies": tf(t,d) = 1 if t occurs in d and 0 otherwise;
2. Logarithmically scaled frequency: tf(t,d) = 1 + log f(t,d), or zero if f(t, d) is zero;
3. Augmented frequency, to prevent a bias towards longer documents, e.g. raw frequency divided by the maximum raw frequency of any term in the document:
![5cc18acd4dbd9be636047fc2a7a10105](https://cloud.githubusercontent.com/assets/454655/7628683/f5e1a168-fa2e-11e4-9ddd-5791855edcec.png)
4. Normalization of the number of all words
![afcade8c6e040203a292c8ca784fa3f3](https://cloud.githubusercontent.com/assets/454655/7628719/5597925c-fa2f-11e4-812c-c7aeb6d4e48d.png)

Source: wiki, Introduction to information retrieval, ...

But before that code, I have not seen anywhere else the normalization of the length of the text.
