### PR TITLE
Add missing nltk.wsd module to documentation

### DIFF
--- a/web/api/nltk.rst
+++ b/web/api/nltk.rst
@@ -115,6 +115,15 @@ nltk Package
     :undoc-members:
     :show-inheritance:
 
+:mod:`wsd` Module
+------------------
+
+.. automodule:: nltk.wsd
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
 Subpackages
 -----------
 


### PR DESCRIPTION
#976 (the correct PR)
