### PR TITLE
Fix snowball scaping for "ã" and "õ"

### DIFF
--- a/nltk/stem/snowball.py
+++ b/nltk/stem/snowball.py
@@ -2533,7 +2533,7 @@ class PortugueseStemmer(_StandardStemmer):
                         word = suffix_replace(word, suffix, "log")
                         rv = suffix_replace(rv, suffix, "log")
 
-                    elif suffix in ("ução", "uções"):
+                    elif suffix in ("uça~o", "uço~es"):
                         word = suffix_replace(word, suffix, "u")
                         rv = suffix_replace(rv, suffix, "u")
 


### PR DESCRIPTION
Looks like these were needed after all (https://github.com/nltk/nltk/commit/986d10324d544df1bda41b822e8800ebf3126c1d#commitcomment-8185675)
Now "evolução" and "evoluções" are correctly stemmed to "evolu" (matching the stem of "evoluem", "evolui", "evoluir", "evoluirá", etc).
Similarly, "reconstrução" and "reconstruções" are stemmed to "reconstru" (now matching the stem for "reconstruir").

Follows up 986d10324d544df1bda41b822e8800ebf3126c1d and https://github.com/nltk/nltk/issues/754.
