### PR TITLE
fix IBM Model 1 comparison of incomparable types

### DIFF
--- a/nltk/align/ibm1.py
+++ b/nltk/align/ibm1.py
@@ -118,6 +118,8 @@ class IBMModel1(object):
             # Initialize the maximum probability with Null token
             max_align_prob = (self.probabilities[en_word][None], None)
             for i, fr_word in enumerate(align_sent.mots):
+                max_align_prob = (max_align_prob[0], max_align_prob[1] if
+                                  max_align_prob[1] else 0)
                 # Find out the maximum probability
                 max_align_prob = max(max_align_prob,
                     (self.probabilities[en_word][fr_word], i))


### PR DESCRIPTION
PS: This produces the same result as on python2 before the fix.  I am reading up on how to verify if this is indeed correct. Will confirm when done. If someone has expertise on text alignment, please do the  needful 
#986
