### PR TITLE
Changed encoding for masc_tagged corpus to utf-8

### DIFF
--- a/nltk/corpus/__init__.py
+++ b/nltk/corpus/__init__.py
@@ -142,7 +142,7 @@ machado = LazyCorpusLoader(
     r'(?!\.).*\.txt', cat_pattern=r'([a-z]*)/.*', encoding='latin-1')
 masc_tagged = LazyCorpusLoader(
     'masc_tagged', CategorizedTaggedCorpusReader, r'(spoken|written)/.*\.txt',
-    cat_file='categories.txt', tagset='wsj', encoding="ascii", sep="_")
+    cat_file='categories.txt', tagset='wsj', encoding="utf-8", sep="_")
 movie_reviews = LazyCorpusLoader(
     'movie_reviews', CategorizedPlaintextCorpusReader,
     r'(?!\.).*\.txt', cat_pattern=r'(neg|pos)/.*',


### PR DESCRIPTION
Changed the encoding used by the masc_tagged corpus to address issue #1015 

The actual masc_tagged.zip will come in a separate pull request.
