### PR TITLE
Twitter tokenizer normalization functions

### DIFF
--- a/nltk/tokenize/casual.py
+++ b/nltk/tokenize/casual.py
@@ -276,14 +276,15 @@ class TweetTokenizer:
 
 def reduce_lengthening(text):
     '''
-    Replace character sequences of length 3 or greater with sequences of length 3.
+    Replace repeated character sequences of length 3 or greater with sequences
+    of length 3.
     '''
     pattern = re.compile(r"(.)\1{2,}")
     return pattern.sub(r"\1\1\1", text)
 
 def remove_handles(text):
     '''
-    Remove twitter username handles from text.
+    Remove Twitter username handles from text.
     '''
     pattern = re.compile(r"(^|(?<=[^\w.-]))@[A-Za-z_]+\w+")
     return pattern.sub('', text)

--- a/nltk/tokenize/casual.py
+++ b/nltk/tokenize/casual.py
@@ -331,25 +331,35 @@ if __name__ == '__main__':
     TWEETS = [s0, s1, s2, s3, s4, s5]
     TOKS = [t0, t1, t2, t3, t4, t5]
 
-    def test(left, right):
+    s6 = '@remy: This is waaaaayyyy too much for you!!!!!!'
+    s7 = '@_willy65: No place for @chuck tonight. Sorry.'
+
+    t6 = [':', 'This', 'is', 'waaayyy', 'too', 'much', 'for', 'you', '!', '!', '!']
+    t7 = [':', 'No', 'place', 'for', 'tonight', '.', 'Sorry', '.']
+
+    NORM_TWEETS = [s6, s7]
+    NORM_TOKS = [t6, t7]
+
+    def test(tokenizer, left, right):
         """
         Compare the tool's tokenization with expected 'gold standard' output.
         """
-        tokenizer = TweetTokenizer()
+        # tokenizer = TweetTokenizer()
         toks = tokenizer.tokenize(left)
         if toks == right:
+            print("Pass")
             return True
         else:
-            return toks
+            print("Expected: {}".format(right))
+            print("Actual: {}".format(toks))
+            return False
 
+    # Test default TweetTokenizer
+    tokenizer = TweetTokenizer()
     for (tweet, tokenized) in zip(TWEETS, TOKS):
-        if test(tweet, tokenized) == True:
-            print("Pass")
-        else:
-            print("Expected: {}".format(tokenized))
-            print("Actual: {}".format(test(tweet, tokenized)))
+        test(tokenizer, tweet, tokenized)
 
-
-
-
-
+    # Test TweetTokenizer with normalization
+    n_tokenizer = TweetTokenizer(strip_handles=True, reduce_len=True)
+    for (tweet, tokenized) in zip(NORM_TWEETS, NORM_TOKS):
+        test(n_tokenizer, tweet, tokenized)

--- a/nltk/tokenize/casual.py
+++ b/nltk/tokenize/casual.py
@@ -285,7 +285,7 @@ def remove_handles(text):
     '''
     Remove twitter username handles from text.
     '''
-    pattern = re.compile(r"(?<=^|(?<=[^a-zA-Z0-9-\.]))@([A-Za-z_]+[A-Za-z0-9_]+)")
+    pattern = re.compile(r"(^|(?<=[^\w.-]))@[A-Za-z_]+\w+")
     return pattern.sub('', text)
 
 ######################################################################
@@ -333,12 +333,14 @@ if __name__ == '__main__':
 
     s6 = '@remy: This is waaaaayyyy too much for you!!!!!!'
     s7 = '@_willy65: No place for @chuck tonight. Sorry.'
+    s8 = '@mar_tin is a great developer. Contact him at mar_tin@email.com'
 
     t6 = [':', 'This', 'is', 'waaayyy', 'too', 'much', 'for', 'you', '!', '!', '!']
     t7 = [':', 'No', 'place', 'for', 'tonight', '.', 'Sorry', '.']
+    t8 = ['is', 'a', 'great', 'developer', '.', 'Contact', 'him', 'at', 'mar_tin', '@email', '.', 'com']
 
-    NORM_TWEETS = [s6, s7]
-    NORM_TOKS = [t6, t7]
+    NORM_TWEETS = [s6, s7, s8]
+    NORM_TOKS = [t6, t7, t8]
 
     def test(tokenizer, left, right):
         """

--- a/nltk/tokenize/casual.py
+++ b/nltk/tokenize/casual.py
@@ -242,9 +242,10 @@ def _replace_html_entities(text, keep=(), remove_illegal=True, encoding='utf-8')
 
 class TweetTokenizer:
     """Tokenize Tweets"""
-    def __init__(self, preserve_case=True, reduce_len=False):
+    def __init__(self, preserve_case=True, reduce_len=False, strip_handles=False):
         self.preserve_case = preserve_case
         self.reduce_len = reduce_len
+        self.strip_handles = strip_handles
 
     def tokenize(self, text):
         """
@@ -255,6 +256,10 @@ class TweetTokenizer:
         """
         # Fix HTML character entities:
         text = _replace_html_entities(text)
+        # Remove username handles
+        if self.strip_handles:
+          text = remove_handles(text)
+        # Normalize word lengthening
         if self.reduce_len:
           text = reduce_lengthening(text)
         # Tokenize:
@@ -271,20 +276,28 @@ class TweetTokenizer:
 
 def reduce_lengthening(text):
     '''
-    Replace character sequences of length 3 or greater with sequences of length 3
+    Replace character sequences of length 3 or greater with sequences of length 3.
     '''
     pattern = re.compile(r"(.)\1{2,}")
     return pattern.sub(r"\1\1\1", text)
+
+def remove_handles(text):
+    '''
+    Remove twitter username handles from text.
+    '''
+    pattern = re.compile(r"(?<=^|(?<=[^a-zA-Z0-9-\.]))@([A-Za-z_]+[A-Za-z0-9_]+)")
+    return pattern.sub('', text)
 
 ######################################################################
 # Tokenization Function
 ######################################################################
 
-def casual_tokenize(text, preserve_case=True, reduce_len=False):
+def casual_tokenize(text, preserve_case=True, reduce_len=False, strip_handles=False):
     """
     Convenience function for wrapping the tokenizer.
     """
-    return TweetTokenizer(preserve_case=preserve_case, reduce_len=reduce_len).tokenize(text)
+    return TweetTokenizer(preserve_case=preserve_case, reduce_len=reduce_len,
+      strip_handles=strip_handles).tokenize(text)
 
 ###############################################################################
 

--- a/nltk/tokenize/casual.py
+++ b/nltk/tokenize/casual.py
@@ -248,7 +248,7 @@ class TweetTokenizer:
 
     def tokenize(self, text):
         """
-        :param s: str
+        :param text: str
         :rtype: list(str)
         :return: a tokenized list of strings; concatenating this list returns
         the original string if preserve_case=False

--- a/nltk/tokenize/casual.py
+++ b/nltk/tokenize/casual.py
@@ -241,7 +241,42 @@ def _replace_html_entities(text, keep=(), remove_illegal=True, encoding='utf-8')
 ######################################################################
 
 class TweetTokenizer:
-    """Tokenize Tweets"""
+    r"""
+    Tokenizer for tweets.
+
+    >>> from nltk.tokenize import TweetTokenizer
+    >>> s0 = "This is a cooool #dummysmiley: :-) :-P <3 and some arrows < > -> <--"
+    >>> TweetTokenizer().tokenize(s0)
+    ['This', 'is', 'a', 'cooool', '#dummysmiley', ':', ':-)', ':-P', '<3', 'and', 'some', 'arrows', '<', '>', '->', '<--']
+    >>> s1 = "Naps are a must \ud83d\ude34\ud83d\ude34"
+    >>> TweetTokenizer().tokenize(s1)
+    ['Naps', 'are', 'a', 'must', '\ud83d', '\ude34', '\ud83d', '\ude34']
+    >>> s2 = "Renato fica com muito medo de ouvir meus \u00e1udios perto da gaja dele, pois s\u00f3 falo merda KKK"
+    >>> TweetTokenizer().tokenize(s2)
+    ['Renato', 'fica', 'com', 'muito', 'medo', 'de', 'ouvir', 'meus', 'áudios', 'perto', 'da', 'gaja', 'dele', ',', 'pois', 'só', 'falo', 'merda', 'KKK']
+    >>> s3 = "\u0412\u043b\u0430\u0434\u0435\u043b\u0435\u0446 20th Century Fox \u043d\u0430\u043c\u0435\u0440\u0435\u043d \u043a\u0443\u043f\u0438\u0442\u044c Warner Bros."
+    >>> TweetTokenizer().tokenize(s3)
+    ['Владелец', '20th', 'Century', 'Fox', 'намерен', 'купить', 'Warner', 'Bros', '.']
+    >>> s4 = "RT @facugambande: Ya por arrancar a grabar !!! #TirenTirenTiren vamoo !!"
+    >>> TweetTokenizer().tokenize(s4)
+    ['RT', '@facugambande', ':', 'Ya', 'por', 'arrancar', 'a', 'grabar', '!', '!', '!', '#TirenTirenTiren', 'vamoo', '!', '!']
+    >>> s5 = "http://t.co/7r8d5bVKyA http://t.co/hZpwZe1uKt http://t.co/ZKb7GKWocy Ничто так не сближает людей"
+    >>> TweetTokenizer().tokenize(s5)
+    ['http://t.co/7r8d5bVKyA', 'http://t.co/hZpwZe1uKt', 'http://t.co/ZKb7GKWocy', 'Ничто', 'так', 'не', 'сближает', 'людей']
+
+    Examples using strip_handles and reduce_len parameters:
+    >>> tokenizer = TweetTokenizer(strip_handles=True, reduce_len=True)
+    >>> s6 = '@remy: This is waaaaayyyy too much for you!!!!!!'
+    >>> tokenizer.tokenize(s6)
+    [':', 'This', 'is', 'waaayyy', 'too', 'much', 'for', 'you', '!', '!', '!']
+    >>> s7 = '@_willy65: No place for @chuck tonight. Sorry.'
+    >>> tokenizer.tokenize(s7)
+    [':', 'No', 'place', 'for', 'tonight', '.', 'Sorry', '.']
+    >>> s8 = '@mar_tin is a great developer. Contact him at mar_tin@email.com'
+    >>> tokenizer.tokenize(s8)
+    ['is', 'a', 'great', 'developer', '.', 'Contact', 'him', 'at', 'mar_tin', '@email', '.', 'com']
+    """
+
     def __init__(self, preserve_case=True, reduce_len=False, strip_handles=False):
         self.preserve_case = preserve_case
         self.reduce_len = reduce_len
@@ -303,66 +338,5 @@ def casual_tokenize(text, preserve_case=True, reduce_len=False, strip_handles=Fa
 ###############################################################################
 
 if __name__ == '__main__':
-    s0 = "This is a cooool #dummysmiley: :-) :-P <3 and some arrows < > -> <--"
-    s1 = "Naps are a must \ud83d\ude34\ud83d\ude34"
-    s2 = "Renato fica com muito medo de ouvir meus \u00e1udios perto da gaja\
-    dele, pois s\u00f3 falo merda KKK"
-    s3 = "\u0412\u043b\u0430\u0434\u0435\u043b\u0435\u0446 20th Century Fox\
-    \u043d\u0430\u043c\u0435\u0440\u0435\u043d\
-    \u043a\u0443\u043f\u0438\u0442\u044c Warner Bros."
-    s4 = "RT @facugambande: Ya por arrancar a grabar !!! #TirenTirenTiren vamoo !!"
-    s5 = "http://t.co/7r8d5bVKyA http://t.co/hZpwZe1uKt\
-    http://t.co/ZKb7GKWocy Ничто так не сближает\
-    людей"
-
-    t0 = ['This', 'is', 'a', 'cooool', '#dummysmiley', ':', ':-)', ':-P',\
-          '<3', 'and', 'some', 'arrows', '<', '>', '->', '<--']
-    t1 = ['Naps', 'are', 'a', 'must', '\ud83d', '\ude34', '\ud83d', '\ude34']
-    t2 = ['Renato', 'fica', 'com', 'muito', 'medo', 'de', 'ouvir', 'meus',
-          'áudios', 'perto', 'da', 'gaja', 'dele', ',', 'pois', 'só', 'falo',
-          'merda', 'KKK']
-    t3 = ['Владелец', '20th', 'Century', 'Fox', 'намерен',
-          'купить', 'Warner', 'Bros', '.']
-    t4 = ['RT', '@facugambande', ':', 'Ya', 'por', 'arrancar', 'a', 'grabar',
-          '!', '!', '!', '#TirenTirenTiren', 'vamoo', '!', '!']
-    t5 = ['http://t.co/7r8d5bVKyA', 'http://t.co/hZpwZe1uKt',
-          'http://t.co/ZKb7GKWocy', 'Ничто', 'так', 'не',
-          'сближает', 'людей']
-
-    TWEETS = [s0, s1, s2, s3, s4, s5]
-    TOKS = [t0, t1, t2, t3, t4, t5]
-
-    s6 = '@remy: This is waaaaayyyy too much for you!!!!!!'
-    s7 = '@_willy65: No place for @chuck tonight. Sorry.'
-    s8 = '@mar_tin is a great developer. Contact him at mar_tin@email.com'
-
-    t6 = [':', 'This', 'is', 'waaayyy', 'too', 'much', 'for', 'you', '!', '!', '!']
-    t7 = [':', 'No', 'place', 'for', 'tonight', '.', 'Sorry', '.']
-    t8 = ['is', 'a', 'great', 'developer', '.', 'Contact', 'him', 'at', 'mar_tin', '@email', '.', 'com']
-
-    NORM_TWEETS = [s6, s7, s8]
-    NORM_TOKS = [t6, t7, t8]
-
-    def test(tokenizer, left, right):
-        """
-        Compare the tool's tokenization with expected 'gold standard' output.
-        """
-        # tokenizer = TweetTokenizer()
-        toks = tokenizer.tokenize(left)
-        if toks == right:
-            print("Pass")
-            return True
-        else:
-            print("Expected: {}".format(right))
-            print("Actual: {}".format(toks))
-            return False
-
-    # Test default TweetTokenizer
-    tokenizer = TweetTokenizer()
-    for (tweet, tokenized) in zip(TWEETS, TOKS):
-        test(tokenizer, tweet, tokenized)
-
-    # Test TweetTokenizer with normalization
-    n_tokenizer = TweetTokenizer(strip_handles=True, reduce_len=True)
-    for (tweet, tokenized) in zip(NORM_TWEETS, NORM_TOKS):
-        test(n_tokenizer, tweet, tokenized)
+    import doctest
+    doctest.testmod(optionflags=doctest.NORMALIZE_WHITESPACE)

--- a/nltk/tokenize/casual.py
+++ b/nltk/tokenize/casual.py
@@ -242,9 +242,9 @@ def _replace_html_entities(text, keep=(), remove_illegal=True, encoding='utf-8')
 
 class TweetTokenizer:
     """Tokenize Tweets"""
-    def __init__(self, preserve_case=True, normalize=True):
+    def __init__(self, preserve_case=True, reduce_len=False):
         self.preserve_case = preserve_case
-        self.normalize = normalize
+        self.reduce_len = reduce_len
 
     def tokenize(self, text):
         """
@@ -255,8 +255,8 @@ class TweetTokenizer:
         """
         # Fix HTML character entities:
         text = _replace_html_entities(text)
-        if self.normalize:
-          text = normalize(text)
+        if self.reduce_len:
+          text = reduce_lengthening(text)
         # Tokenize:
         words = WORD_RE.findall(text)
         # Possibly alter the case, but avoid changing emoticons like :D into :d:
@@ -269,12 +269,7 @@ class TweetTokenizer:
 # Normalization Functions
 ######################################################################
 
-def normalize(text, reduce_length=True):
-    if reduce_length:
-      text = _reduce_length(text)
-    return text
-
-def _reduce_length(text):
+def reduce_lengthening(text):
     '''
     Replace character sequences of length 3 or greater with sequences of length 3
     '''
@@ -285,11 +280,11 @@ def _reduce_length(text):
 # Tokenization Function
 ######################################################################
 
-def casual_tokenize(text, preserve_case=True, normalize=True):
+def casual_tokenize(text, preserve_case=True, reduce_len=False):
     """
     Convenience function for wrapping the tokenizer.
     """
-    return TweetTokenizer(preserve_case=preserve_case, normalize=normalize).tokenize(text)
+    return TweetTokenizer(preserve_case=preserve_case, reduce_len=reduce_len).tokenize(text)
 
 ###############################################################################
 
@@ -305,7 +300,6 @@ if __name__ == '__main__':
     s5 = "http://t.co/7r8d5bVKyA http://t.co/hZpwZe1uKt\
     http://t.co/ZKb7GKWocy Ничто так не сближает\
     людей"
-    s6 = "These words are waaaaay toooo loooooong for a tokenizer! :P"
 
     t0 = ['This', 'is', 'a', 'cooool', '#dummysmiley', ':', ':-)', ':-P',\
           '<3', 'and', 'some', 'arrows', '<', '>', '->', '<--']
@@ -320,11 +314,9 @@ if __name__ == '__main__':
     t5 = ['http://t.co/7r8d5bVKyA', 'http://t.co/hZpwZe1uKt',
           'http://t.co/ZKb7GKWocy', 'Ничто', 'так', 'не',
           'сближает', 'людей']
-    t6 = ['These', 'words', 'are', 'waaay', 'tooo', 'looong', 'for', 'a',
-          'tokenizer', '!', ':P']
 
-    TWEETS = [s0, s1, s2, s3, s4, s5, s6]
-    TOKS = [t0, t1, t2, t3, t4, t5, t6]
+    TWEETS = [s0, s1, s2, s3, s4, s5]
+    TOKS = [t0, t1, t2, t3, t4, t5]
 
     def test(left, right):
         """
@@ -338,7 +330,7 @@ if __name__ == '__main__':
             return toks
 
     for (tweet, tokenized) in zip(TWEETS, TOKS):
-        if test(tweet, tokenized):
+        if test(tweet, tokenized) == True:
             print("Pass")
         else:
             print("Expected: {}".format(tokenized))

--- a/nltk/tokenize/casual.py
+++ b/nltk/tokenize/casual.py
@@ -242,7 +242,7 @@ def _replace_html_entities(text, keep=(), remove_illegal=True, encoding='utf-8')
 
 class TweetTokenizer:
     """Tokenize Tweets"""
-    def __init__(self, preserve_case=True, normalize=False):
+    def __init__(self, preserve_case=True, normalize=True):
         self.preserve_case = preserve_case
         self.normalize = normalize
 


### PR DESCRIPTION
Add options to normalize tweets:
- reduce character sequences of length 3 (or more) to sequences of length 3
- strip Twitter handles for usernames
