### PR TITLE
Fix comment in parseLexicon, in CCG

### DIFF
--- a/nltk/ccg/lexicon.py
+++ b/nltk/ccg/lexicon.py
@@ -183,7 +183,7 @@ def parseLexicon(lex_str):
 
         if line.startswith(':-'):
             # A line of primitive categories.
-            # The first line is the target category
+            # The first one is the target category
             # ie, :- S, N, NP, VP
             primitives = primitives + [ prim.strip() for prim in line[2:].strip().split(',') ]
         else:


### PR DESCRIPTION
Regarding to the target category, In [parseLexicon function, in CCG](https://github.com/nltk/nltk/blob/28d7d363769958f3608de574400b20ea3fdc9ad9/nltk/ccg/lexicon.py#L186), shouldn't it be "the first one" (or "the first category", or similar) instead of "the first line"?
