### PR TITLE
simplify Twitter.tweets() api and repeat

### DIFF
--- a/nltk/test/twitter.ipynb
+++ b/nltk/test/twitter.ipynb
@@ -336,7 +336,7 @@
    "outputs": [],
    "source": [
     "with open(input_file) as fp:\n",
-    "    json2csv(fp, 'tweets.20150430-223406.tweet.csv.gz',\n",
+    "    json2csv(fp, 'tweets.20150430-223406.tweet.csv',\n",
     "            ['created_at', 'favorite_count', 'id', 'in_reply_to_status_id', \n",
     "            'in_reply_to_user_id', 'retweet_count', 'retweeted', \n",
     "            'text', 'truncated', 'user.id'])"
@@ -346,25 +346,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "where the first 9 elements of the list are attributes of the tweet, while the last one, `user.id`, takes the user object, also for the tweet, and gets the attributes in the list (in this case only the id). The object for the Twitter User is described in this [link](https://dev.twitter.com/overview/api/users).\n",
-    "\n",
-    "Note that, by default, `json2csv` and `json2csv_entities` generate files compressed with gzip. If you want to generate uncompressed files, you may set the parameter `gzip_compress` to `False`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "with open(input_file) as fp:\n",
-    "    json2csv(fp, 'tweets.20150430-223406.tweet.csv',\n",
-    "            ['created_at', 'favorite_count', 'id', 'in_reply_to_status_id', \n",
-    "            'in_reply_to_user_id', 'retweet_count', 'retweeted', \n",
-    "            'text', 'truncated', 'user.id'],\n",
-    "            gzip_compress=False)"
+    "where the first 9 elements of the list are attributes of the tweet, while the last one, `user.id`, takes the user object, also for the tweet, and gets the attributes in the list (in this case only the id). The object for the Twitter User is described in this [link](https://dev.twitter.com/overview/api/users)."
    ]
   },
   {
@@ -376,7 +358,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 23,
    "metadata": {
     "collapsed": false
    },
@@ -384,27 +366,27 @@
    "source": [
     "from nltk.twitter.util import json2csv_entities\n",
     "with open(input_file) as fp:\n",
-    "    json2csv_entities(fp, 'tweets.20150430-223406.hashtags.csv.gz',\n",
+    "    json2csv_entities(fp, 'tweets.20150430-223406.hashtags.csv',\n",
     "                        ['id', 'text'], 'hashtags', ['text'])\n",
     "    \n",
     "with open(input_file) as fp:\n",
-    "    json2csv_entities(fp, 'tweets.20150430-223406.user_mentions.csv.gz',\n",
+    "    json2csv_entities(fp, 'tweets.20150430-223406.user_mentions.csv',\n",
     "                        ['id', 'text'], 'user_mentions', ['id', 'screen_name'])\n",
     "    \n",
     "with open(input_file) as fp:\n",
-    "    json2csv_entities(fp, 'tweets.20150430-223406.media.csv.gz',\n",
+    "    json2csv_entities(fp, 'tweets.20150430-223406.media.csv',\n",
     "                        ['id'], 'media', ['media_url', 'url'])\n",
     "    \n",
     "with open(input_file) as fp:\n",
-    "    json2csv_entities(fp, 'tweets.20150430-223406.urls.csv.gz',\n",
+    "    json2csv_entities(fp, 'tweets.20150430-223406.urls.csv',\n",
     "                        ['id'], 'urls', ['url', 'expanded_url'])\n",
     "    \n",
     "with open(input_file) as fp:\n",
-    "    json2csv_entities(fp, 'tweets.20150430-223406.place.csv.gz',\n",
+    "    json2csv_entities(fp, 'tweets.20150430-223406.place.csv',\n",
     "                        ['id', 'text'], 'place', ['name', 'country'])\n",
     "\n",
     "with open(input_file) as fp:\n",
-    "    json2csv_entities(fp, 'tweets.20150430-223406.place_bounding_box.csv.gz',\n",
+    "    json2csv_entities(fp, 'tweets.20150430-223406.place_bounding_box.csv',\n",
     "                        ['id', 'name'], 'place.bounding_box', ['coordinates'])"
    ]
   },
@@ -417,14 +399,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 24,
    "metadata": {
     "collapsed": false
    },
    "outputs": [],
    "source": [
     "with open(input_file) as fp:\n",
-    "    json2csv_entities(fp, 'tweets.20150430-223406.original_tweets.csv.gz',\n",
+    "    json2csv_entities(fp, 'tweets.20150430-223406.original_tweets.csv',\n",
     "                        ['id'], 'retweeted_status', ['created_at', 'favorite_count', \n",
     "                        'id', 'in_reply_to_status_id', 'in_reply_to_user_id', 'retweet_count',\n",
     "                        'text', 'truncated', 'user.id'])"
@@ -441,7 +423,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 25,
    "metadata": {
     "collapsed": false
    },
@@ -449,8 +431,7 @@
    "source": [
     "import pandas as pd\n",
     "\n",
-    "tweets = pd.read_csv('tweets.20150430-223406.tweet.csv.gz', index_col=2, header=0, encoding=\"utf8\",\n",
-    "                    compression='gzip')"
+    "tweets = pd.read_csv('tweets.20150430-223406.tweet.csv', index_col=2, header=0, encoding=\"utf8\")"
    ]
   },
   {
@@ -462,7 +443,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 26,
    "metadata": {
     "collapsed": false
    },
@@ -476,7 +457,7 @@
        "Name: text, dtype: object"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/nltk/twitter/twitterclient.py
+++ b/nltk/twitter/twitterclient.py
@@ -227,7 +227,10 @@ class Query(Twython):
         if not max_id:
             results = self.search(q=keywords, count=min(100, limit), lang=lang,
                                   result_type='recent')
-            count = results['search_metadata']['count']
+            count = len(results['statuses'])
+            if count == 0:
+                print("No Tweets available through rest api for those keywords")
+                return                
             count_from_query = count
             max_id = results['statuses'][count - 1]['id'] - 1
 
@@ -256,7 +259,7 @@ class Query(Twython):
                     raise e
                 retries += 1
                 
-            count = results['search_metadata']['count']
+            count = len(results['statuses'])
             if count == 0:
                 print("No more Tweets available through rest api")
                 return
@@ -420,6 +423,7 @@ class TweetWriter(TweetHandlerI):
         self.repeat = repeat
         # max_id stores the id of the older tweet fetched
         self.max_id = None
+        self.output = None
         TweetHandlerI.__init__(self, limit, date_limit)
 
 
@@ -483,7 +487,8 @@ class TweetWriter(TweetHandlerI):
         
     def on_finish(self):
         print('Written {0} Tweets'.format(self.counter))
-        self.output.close()
+        if self.output:
+            self.output.close()
         
     def do_continue(self):
         if self.repeat == False:

--- a/nltk/twitter/util.py
+++ b/nltk/twitter/util.py
@@ -85,7 +85,7 @@ def _get_entity_recursive(json, entity):
         return None
 
 def json2csv(fp, outfile, fields, encoding='utf8', errors='replace',
-             gzip_compress=True):
+             gzip_compress=False):
     """
     Extract selected fields from a file of line-separated JSON tweets and
     write to a file in CSV format.
@@ -127,7 +127,7 @@ def json2csv(fp, outfile, fields, encoding='utf8', errors='replace',
         writer.writerow(row)
     outf.close()
 
-def outf_writer_compat(outfile, encoding, errors, gzip_compress=True):
+def outf_writer_compat(outfile, encoding, errors, gzip_compress=False):
     """
     Identify appropriate CSV writer given the Python version
     """
@@ -149,7 +149,7 @@ def outf_writer_compat(outfile, encoding, errors, gzip_compress=True):
 
 
 def json2csv_entities(fp, outfile, main_fields, entity_type, entity_fields,
-                      encoding='utf8', errors='replace', gzip_compress=True):
+                      encoding='utf8', errors='replace', gzip_compress=False):
     """
     Extract selected fields from a file of line-separated JSON tweets and
     write to a file in CSV format.


### PR DESCRIPTION
comments to PR #1021 
- remove `retries` and `locations` from Twitter.tweets() api, in order to keep it simple
- recover `repeat`
- by default no compression in json2csv functions

tested for 2.7 and 3
