### PR TITLE
Fix typo in README.txt

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -13,7 +13,7 @@ Python modules, data sets and tutorials supporting research and
 development in Natural Language Processing.
 
 Documentation: A substantial amount of documentation about how
-to use NLTK, including a textbook and API documention, is
+to use NLTK, including a textbook and API documentation, is
 available from the NLTK website: http://nltk.org/
 
   - The book covers a wide range of introductory topics in NLP, and
@@ -21,7 +21,7 @@ available from the NLTK website: http://nltk.org/
 
   - The toolkit's reference documentation describes every module,
     interface, class, method, function, and variable in the toolkit.
-    This documentation should be useful to both users and developers.  
+    This documentation should be useful to both users and developers.
 
 Mailing Lists: There are several mailing lists associated with NLTK:
 

--- a/nltk/test/bnc.doctest
+++ b/nltk/test/bnc.doctest
@@ -2,7 +2,7 @@
 .. For license information, see LICENSE.TXT
 
     >>> from nltk.corpus.reader import BNCCorpusReader
-    >>> bnc = BNCCorpusReader(root='.', fileids=r'FX8.xml')
+    >>> bnc = BNCCorpusReader(root='./nltk/test/', fileids=r'FX8.xml')
 
 Checking the word access.
 -------------------------

--- a/nltk/test/bnc.doctest
+++ b/nltk/test/bnc.doctest
@@ -2,7 +2,7 @@
 .. For license information, see LICENSE.TXT
 
     >>> from nltk.corpus.reader import BNCCorpusReader
-    >>> bnc = BNCCorpusReader(root='./nltk/test/', fileids=r'FX8.xml')
+    >>> bnc = BNCCorpusReader(root='.', fileids=r'FX8.xml')
 
 Checking the word access.
 -------------------------


### PR DESCRIPTION
I found typo. I removed unnecessary space.
