### PR TITLE
automatic tests failing in Jenkins (relative paths)

### DIFF
--- a/nltk/test/unit/test_json2csv_corpus.py
+++ b/nltk/test/unit/test_json2csv_corpus.py
@@ -48,7 +48,7 @@ class TestJSON2CSV(unittest.TestCase):
             self.infile = [next(infile) for x in range(100)]
         infile.close()
         self.msg = "Test and reference files are not the same"
-        self.subdir = 'files'
+        self.subdir = os.path.join(os.path.dirname(__file__), 'files')
 
     def tearDown(self):
         return

--- a/nltk/test/unit/test_twitter_auth.py
+++ b/nltk/test/unit/test_twitter_auth.py
@@ -15,7 +15,7 @@ class TestCredentials(unittest.TestCase):
     """
 
     def setUp(self):
-        self.subdir = 'files'
+        self.subdir = os.path.join(os.path.dirname(__file__), 'files')
         self.auth = Authenticate()
         os.environ['TWITTER'] = 'twitter-files'
 


### PR DESCRIPTION
automatic test failing in Jenkins since they cannot solve relative paths after PR #1021 

One example of a test that is failing:

> Traceback (most recent call last):
>  File
> "/scratch/jenkins/python/python-3.4.2-x86_64/lib/python3.4/unittest/case
> .py", line 58, in testPartExecutor
>    yield
>  File
> "/scratch/jenkins/python/python-3.4.2-x86_64/lib/python3.4/unittest/case
> .py", line 577, in run
>    testMethod()
>  File
> "/scratch/jenkins/workspace/nltk/TOXENV/py34-jenkins/jdk/jdk8latestOnlin
> eInstall/nltk/test/unit/test_json2csv_corpus.py", line 61, in
> test_textoutput
>    self.assertTrue(are_files_identical(outfn, ref_fn), msg=self.msg)
>  File
> "/scratch/jenkins/workspace/nltk/TOXENV/py34-jenkins/jdk/jdk8latestOnlin
> eInstall/nltk/test/unit/test_json2csv_corpus.py", line 29, in
> are_files_identical
>    with open(filename2, "rb") as fileB:
> FileNotFoundError: [Errno 2] No such file or directory:
> 'files/tweets.20150430-223406.text.csv.ref'

In order to solve `files/tweets.20150430-223406.text.csv.ref`, start
from the path of the test itself.
