### PR TITLE
Fix encoding issue for Stanford taggers

### DIFF
--- a/nltk/tag/stanford.py
+++ b/nltk/tag/stanford.py
@@ -73,7 +73,8 @@ class StanfordTagger(TaggerI):
         # Create a temporary input file
         _input_fh, self._input_file_path = tempfile.mkstemp(text=True)
 
-        self._cmd.extend(['-encoding', encoding])
+        cmd = list(self._cmd)
+        cmd.extend(['-encoding', encoding])
         
         # Write the actual sentences to the temporary input file
         _input_fh = os.fdopen(_input_fh, 'wb')
@@ -84,7 +85,7 @@ class StanfordTagger(TaggerI):
         _input_fh.close()
         
         # Run the tagger and get the output
-        stanpos_output, _stderr = java(self._cmd,classpath=self._stanford_jar,
+        stanpos_output, _stderr = java(cmd, classpath=self._stanford_jar,
                                                        stdout=PIPE, stderr=PIPE)
         stanpos_output = stanpos_output.decode(encoding)
         

--- a/nltk/tag/stanford.py
+++ b/nltk/tag/stanford.py
@@ -114,7 +114,7 @@ class StanfordPOSTagger(StanfordTagger):
      - a model trained on training data
      - (optionally) the path to the stanford tagger jar file. If not specified here,
        then this jar file must be specified in the CLASSPATH envinroment variable.
-     - (optionally) the encoding of the training data (default: ASCII)
+     - (optionally) the encoding of the training data (default: UTF-8)
 
     Example:
 
@@ -143,7 +143,7 @@ class StanfordNERTagger(StanfordTagger):
     - a model trained on training data
     - (optionally) the path to the stanford tagger jar file. If not specified here,
       then this jar file must be specified in the CLASSPATH envinroment variable.
-    - (optionally) the encoding of the training data (default: ASCII)
+    - (optionally) the encoding of the training data (default: UTF-8)
 
     Example:
 


### PR DESCRIPTION
The `_cmd` attribute is implemented as a property in subclasses of `StanfordTagger`, which returns a new list each time `self._cmd` is called. So the `-encoding` option added later is not passed to the Java program.

I've checked that if the `-encoding` option is not specified, the Stanford POS tagger defaults the input and output encoding to UTF-8, while the Stanford NER tagger defaults the input encoding to UTF-8 and the output encoding to the system default. Therefore, on Windows systems whose default encoding is Windows-1252, `StanfordNERTagger` may raise `UnicodeDecodeError` on sentences containing non-ASCII characters, as is shown in the following code snippet. This PR fixes this problem.

``` python
import os
from nltk.tag import StanfordPOSTagger, StanfordNERTagger

# simulate Windows default encoding
os.environ['JAVA_TOOL_OPTIONS'] = '-Dfile.encoding=Cp1252'

pos_tagger = StanfordPOSTagger('english-bidirectional-distsim.tagger')
pos_tagger.tag_sents([[u'caf\xe9']])

ner_tagger = StanfordNERTagger('english.all.3class.distsim.crf.ser.gz')
ner_tagger.tag_sents([[u'caf\xe9']]) # throws `UnicodeDecodeError`
```
