### PR TITLE
Fixing bnc.doctest by specifying an absolute root path.

### DIFF
--- a/nltk/test/bnc.doctest
+++ b/nltk/test/bnc.doctest
@@ -1,8 +1,13 @@
 .. Copyright (C) 2001-2015 NLTK Project
 .. For license information, see LICENSE.TXT
 
+    >>> import os.path
+
     >>> from nltk.corpus.reader import BNCCorpusReader
-    >>> bnc = BNCCorpusReader(root='.', fileids=r'FX8.xml')
+    >>> import nltk.test
+
+    >>> root = os.path.dirname(nltk.test.__file__)
+    >>> bnc = BNCCorpusReader(root=root, fileids='FX8.xml')
 
 Checking the word access.
 -------------------------
@@ -40,7 +45,7 @@ Testing access to the sentences.
 A not lazy loader.
 -----------------
 
-    >>> eager = BNCCorpusReader(root='.', fileids=r'FX8.xml', lazy=False)
+    >>> eager = BNCCorpusReader(root=root, fileids=r'FX8.xml', lazy=False)
 
     >>> len(eager.words())
     151


### PR DESCRIPTION
This should fix https://nltk.ci.cloudbees.com/job/nltk/lastCompletedBuild/TOXENV=py26-jenkins,jdk=jdk8latestOnlineInstall/testReport/%28root%29/bnc_doctest/bnc_doctest/
