### PR TITLE
Added VerbNet Corpus Reader Docstring

### DIFF
--- a/nltk/corpus/reader/verbnet.py
+++ b/nltk/corpus/reader/verbnet.py
@@ -34,7 +34,6 @@ class VerbnetCorpusReader(XMLCorpusReader):
     http://verbs.colorado.edu/~mpalmer/projects/verbnet.html
     """
 
-
     # No unicode encoding param, since the data files are all XML.
     def __init__(self, root, fileids, wrap_etree=False):
         XMLCorpusReader.__init__(self, root, fileids, wrap_etree)

--- a/nltk/corpus/reader/verbnet.py
+++ b/nltk/corpus/reader/verbnet.py
@@ -21,6 +21,19 @@ from nltk import compat
 from nltk.corpus.reader.xmldocs import XMLCorpusReader
 
 class VerbnetCorpusReader(XMLCorpusReader):
+    """
+    An NLTK interface to the VerbNet verb lexicon.
+    
+    From the VerbNet site: "VerbNet (VN) (Kipper-Schuler 2006) is the largest 
+    on-line verb lexicon currently available for English. It is a hierarchical 
+    domain-independent, broad-coverage verb lexicon with mappings to other 
+    lexical resources such as WordNet (Miller, 1990; Fellbaum, 1998), Xtag 
+    (XTAG Research Group, 2001), and FrameNet (Baker et al., 1998)."
+
+    For details about VerbNet see:
+    http://verbs.colorado.edu/~mpalmer/projects/verbnet.html
+    """
+
 
     # No unicode encoding param, since the data files are all XML.
     def __init__(self, root, fileids, wrap_etree=False):


### PR DESCRIPTION
I copied the existing docstring into the correct spot so that it would show up in the auto-generated documentation.  I also quoted a couple of descriptive sentences from the existing link that explains what VerbNet is.
