### PR TITLE
CHILDESCorpusReader: multiple stems correspond to their source token; keep suffix PoS info

### DIFF
--- a/nltk/corpus/reader/childes.py
+++ b/nltk/corpus/reader/childes.py
@@ -356,9 +356,17 @@ class CHILDESCorpusReader(XMLCorpusReader):
                                                   + "|" + xmlpost_rel.get('relation'))
                         except:
                             pass
+
+                    if suffixStem and not relation and not pos:
+                        word = word + "~" + suffixStem
+                        appendSuffixStem = False
+                    else:
+                        appendSuffixStem = True
+
                     sents.append(word)
-                    if suffixStem:
+                    if appendSuffixStem and suffixStem:
                         sents.append(suffixStem)
+
                 if sent or relation:
                     results.append(sents)
                 else:

--- a/nltk/corpus/reader/childes.py
+++ b/nltk/corpus/reader/childes.py
@@ -270,7 +270,7 @@ class CHILDESCorpusReader(XMLCorpusReader):
             # select speakers
             if speaker == 'ALL' or xmlsent.get('who') in speaker:
                 for xmlword in xmlsent.findall('.//{%s}w' % NS):
-                    infl = None ; suffixStem = None
+                    infl = None ; suffixStem = None; suffixTag = None
                     # getting replaced words
                     if replace and xmlsent.find('.//{%s}w/{%s}replacement'
                                                 % (NS,NS)):
@@ -307,6 +307,8 @@ class CHILDESCorpusReader(XMLCorpusReader):
                             suffixStem = xmlsuffix.text
                         except AttributeError:
                             suffixStem = ""
+                        if suffixStem:
+                            word += "~"+suffixStem
                     # pos
                     if relation or pos:
                         try:
@@ -316,11 +318,22 @@ class CHILDESCorpusReader(XMLCorpusReader):
                                 tag = xmlpos[0].text+":"+xmlpos2[0].text
                             else:
                                 tag = xmlpos[0].text
-                            word = (word,tag)
                         except (AttributeError,IndexError) as e:
-                            word = (word,None)
-                            if suffixStem:
-                                suffixStem = (suffixStem,None)
+                            tag = ""
+                        try:
+                            xmlsuffixpos = xmlword.findall('.//{%s}mor/{%s}mor-post/{%s}mw/{%s}pos/{%s}c'
+                                                     % (NS,NS,NS,NS,NS))
+                            xmlsuffixpos2 = xmlword.findall('.//{%s}mor/{%s}mor-post/{%s}mw/{%s}pos/{%s}s'
+                                                     % (NS,NS,NS,NS,NS))
+                            if xmlsuffixpos2:
+                                suffixTag = xmlsuffixpos[0].text+":"+xmlsuffixpos2[0].text
+                            else:
+                                suffixTag = xmlsuffixpos[0].text
+                        except:
+                            pass
+                        if suffixTag:
+                            tag += "~"+suffixTag
+                        word = (word, tag)
                     # relational
                     # the gold standard is stored in
                     # <mor></mor><mor type="trn"><gra type="grt">
@@ -356,17 +369,7 @@ class CHILDESCorpusReader(XMLCorpusReader):
                                                   + "|" + xmlpost_rel.get('relation'))
                         except:
                             pass
-
-                    if suffixStem and not relation and not pos:
-                        word = word + "~" + suffixStem
-                        appendSuffixStem = False
-                    else:
-                        appendSuffixStem = True
-
                     sents.append(word)
-                    if appendSuffixStem and suffixStem:
-                        sents.append(suffixStem)
-
                 if sent or relation:
                     results.append(sents)
                 else:
@@ -488,3 +491,4 @@ def demo(corpus_root=None):
 
 if __name__ == "__main__":
     demo()
+


### PR DESCRIPTION
## Fixes for `_get_words` in the class `CHILDESCorpusReader`

After some standard code like the following is run:

``` python
>>> import nltk
>>> corpus_root = nltk.data.find('corpora/childes/data-xml/Eng-NA-MOR/')
>>> from nltk.corpus.reader import CHILDESCorpusReader
>>> valian = CHILDESCorpusReader(corpus_root, "Valian/.*.xml")
```

The corpus reader does not seem to handle word tokens with multiple stems properly (note "Lastname's" below):

``` python
>>> valian.words('Valian/01a.xml')[:5]
['at', 'Parent', "Lastname's", 'house', 'with']
>>> valian.words('Valian/01a.xml', stem=True)[:5]
['at', 'Parent', 'Lastname', 's', 'house']
>>> valian.tagged_words('Valian/01a.xml')[:5]
[('at', 'prep'), ('Parent', 'n:prop'), ("Lastname's", 'n:prop'), ('house', 'n'), ('with', 'prep')]
>>> valian.tagged_words('Valian/01a.xml', stem=True)[:5]
[('at', 'prep'), ('Parent', 'n:prop'), ('Lastname', 'n:prop'), 's', ('house', 'n')]
```

Issues:
- When `stem` is `True`, stems are all treated as distinct strings, making it difficult or impossible to align which stems correspond to which words.
- If the stem is treated as a suffix in the XML data, then its PoS tag info is lost.

Results after the fixes are implemented:

``` python
>>> valian.words('Valian/01a.xml')[:5]
['at', 'Parent', "Lastname's", 'house', 'with']
>>> valian.words('Valian/01a.xml', stem=True)[:5]
['at', 'Parent', 'Lastname~s', 'house', 'with']
>>> valian.tagged_words('Valian/01a.xml')[:5]
[('at', 'prep'), ('Parent', 'n:prop'), ("Lastname's", 'n:prop~poss'), ('house', 'n'), ('with', 'prep')]
>>> valian.tagged_words('Valian/01a.xml', stem=True)[:5]
[('at', 'prep'), ('Parent', 'n:prop'), ('Lastname~s', 'n:prop~poss'), ('house', 'n'), ('with', 'prep')]
```

(`~` is used as the separator for multiple "stems" of a word, following the CHILDES convention.)
