### PR TITLE
Introduce base IBM model and minimum probability values

### DIFF
--- a/nltk/align/ibm1.py
+++ b/nltk/align/ibm1.py
@@ -95,8 +95,8 @@ class IBMModel1(object):
 
     def __init__(self, sentence_aligned_corpus, iterations):
         """
-        Train on ``sentence_aligned_corpus`` and create
-        a translation model.
+        Train on ``sentence_aligned_corpus`` and create a lexical
+        translation model.
 
         Translation direction is from ``AlignedSent.mots`` to
         ``AlignedSent.words``.

--- a/nltk/align/ibm1.py
+++ b/nltk/align/ibm1.py
@@ -13,31 +13,7 @@
 # For license information, see LICENSE.TXT
 
 """
-The IBM models are a series of generative models that learn lexical
-translation probabilities, p(target language word|source language word),
-given a sentence-aligned parallel corpus.
-
-The models increase in sophistication from model 1 to 5. Typically, the
-output of lower models is used to seed the higher models. All models
-use the Expectation-Maximization (EM) algorithm to learn various
-probability tables.
-
-Words in a sentence are one-indexed. The first word of a sentence has
-position 1, not 0. Index 0 is reserved in the source sentence for the
-NULL token. The concept of position does not apply to NULL, but it is
-indexed at 0 by convention.
-
-Each target word is aligned to exactly one source word or the NULL
-token.
-
-Notations
-i: Position in the source sentence
-    Valid values are 0 (for NULL), 1, 2, ..., length of source sentence
-j: Position in the target sentence
-    Valid values are 1, 2, ..., length of target sentence
-s: A word in the source language
-t: A word in the target language
-
+Lexical translation model that ignores word order.
 
 In IBM Model 1, word order is ignored for simplicity. Thus, the
 following two alignments are equally likely.
@@ -57,6 +33,15 @@ E step - In the training data, count how many times a source language
 
 M step - Estimate the new probability of translation based on the
          counts from the Expectation step.
+
+
+Notations:
+i: Position in the source sentence
+    Valid values are 0 (for NULL), 1, 2, ..., length of source sentence
+j: Position in the target sentence
+    Valid values are 1, 2, ..., length of target sentence
+s: A word in the source language
+t: A word in the target language
 
 
 References:

--- a/nltk/align/ibm1.py
+++ b/nltk/align/ibm1.py
@@ -108,17 +108,15 @@ class IBMModel1(object):
         :type iterations: int
         """
 
-        self.translation_table = self.train(sentence_aligned_corpus, iterations)
+        self.translation_table = defaultdict(lambda: defaultdict(lambda: float))
         """
-        dict(dict(float)): probability(target word | source word). Values
-            accessed with ``translation_table[target_word][source_word].``
+        Probability(target word | source word). Values accessed as
+        ``translation_table[target_word][source_word].``
         """
+
+        self.train(sentence_aligned_corpus, iterations)
 
     def train(self, parallel_corpus, iterations):
-        """
-        :return: A dictionary of translation probabilities
-        """
-
         # Vocabulary of each language
         src_vocab = set()
         trg_vocab = set()
@@ -164,7 +162,7 @@ class IBMModel1(object):
                     translation_table[t][s] = (count_t_given_s[t][s] /
                                                count_any_t_given_s[s])
 
-        return translation_table
+        self.translation_table = translation_table
 
     def align(self, sentence_pair):
         """

--- a/nltk/align/ibm1.py
+++ b/nltk/align/ibm1.py
@@ -132,8 +132,6 @@ class IBMModel1(object):
         translation_table = defaultdict(
             lambda: defaultdict(lambda: initial_prob))
 
-        total_count = defaultdict(lambda: 0.0)
-
         for i in range(0, iterations):
             count_t_given_s = defaultdict(lambda: defaultdict(lambda: 0.0))
             count_any_t_given_s = defaultdict(lambda: 0.0)
@@ -141,12 +139,13 @@ class IBMModel1(object):
             for aligned_sentence in parallel_corpus:
                 trg_sentence = aligned_sentence.words
                 src_sentence = [None] + aligned_sentence.mots
+                total_count = defaultdict(lambda: 0.0)
 
                 # E step (a): Compute normalization factors to weigh counts
                 for t in trg_sentence:
-                    total_count[t] = 0.0
-                    for s in src_sentence:
-                        total_count[t] += translation_table[t][s]
+                    if total_count[t] == 0.0:
+                        for s in src_sentence:
+                            total_count[t] += translation_table[t][s]
 
                 # E step (b): Collect counts
                 for t in trg_sentence:

--- a/nltk/align/ibm2.py
+++ b/nltk/align/ibm2.py
@@ -108,26 +108,23 @@ class IBMModel2(object):
         :type iterations: int
         """
 
-        output = self.train(sentence_aligned_corpus, iterations)
-        self.translation_table = output[0]
+        self.translation_table = defaultdict(lambda: defaultdict(lambda: float))
         """
-        dict(dict(float)): probability(target word | source word). Values
-            accessed with ``translation_table[target_word][source_word].``
+        Probability(target word | source word). Values accessed as
+        ``translation_table[target_word][source_word].``
         """
 
-        self.alignment_table = output[1]
+        self.alignment_table = defaultdict(
+            lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(
+                lambda: float))))
         """
-        dict(dict(dict(dict(float)))): probability(i | j,l,m). Values
-            accessed with ``alignment_table[i][j][m][l].``
+        Probability(i | j,l,m). Values accessed as
+        ``alignment_table[i][j][m][l].``
         """
+
+        self.train(sentence_aligned_corpus, iterations)
 
     def train(self, parallel_corpus, iterations):
-        """
-        :return: A 2-tuple containing a dictionary of translation
-            probabilities and a dictionary of alignment probabilities
-        :rtype: tuple(dict(dict(int)), dict(dict(dict(dict(int)))))
-        """
-
         # Get initial translation probability distribution
         # from a few iterations of Model 1 training.
         ibm1 = IBMModel1(parallel_corpus, 10)
@@ -247,7 +244,8 @@ class IBMModel2(object):
                             alignment_count[i][j][m][l] /
                             alignment_count_for_any_i[j][m][l])
 
-        return translation_table, alignment_table
+        self.translation_table = translation_table
+        self.alignment_table = alignment_table
 
     def align(self, sentence_pair):
         """

--- a/nltk/align/ibm2.py
+++ b/nltk/align/ibm2.py
@@ -146,10 +146,8 @@ class IBMModel2(object):
         # Initialize the distribution of alignment probability,
         # a(i | j,l,m) = 1 / (l+1) for all i, j, l, m
         for aligned_sentence in parallel_corpus:
-            trg_sentence = aligned_sentence.words
-            src_sentence = [None] + aligned_sentence.mots
-            l = len(src_sentence) - 1  # exclude NULL token
-            m = len(trg_sentence)
+            l = len(aligned_sentence.mots)
+            m = len(aligned_sentence.words)
             initial_value = 1 / (l + 1)
             for i in range(0, l + 1):
                 for j in range(1, m + 1):
@@ -170,9 +168,9 @@ class IBMModel2(object):
             total_count = defaultdict(float)
 
             for aligned_sentence in parallel_corpus:
-                trg_sentence = aligned_sentence.words
                 src_sentence = [None] + aligned_sentence.mots
-                l = len(src_sentence) - 1
+                trg_sentence = aligned_sentence.words
+                l = len(aligned_sentence.mots)
                 m = len(trg_sentence)
 
                 # E step (a): Compute normalization factors to weigh counts
@@ -206,10 +204,8 @@ class IBMModel2(object):
             # Perform Laplace smoothing of alignment counts.
             # Note that smoothing is not in the original IBM Model 2 algorithm.
             for aligned_sentence in parallel_corpus:
-                trg_sentence = aligned_sentence.words
-                src_sentence = [None] + aligned_sentence.mots
-                l = len(src_sentence) - 1
-                m = len(trg_sentence)
+                l = len(aligned_sentence.mots)
+                m = len(aligned_sentence.words)
 
                 laplace = 1.0
                 for i in range(0, l + 1):
@@ -234,10 +230,8 @@ class IBMModel2(object):
                                                count_any_t_given_s[s])
 
             for aligned_sentence in parallel_corpus:
-                trg_sentence = aligned_sentence.words
-                src_sentence = [None] + aligned_sentence.mots
-                l = len(src_sentence) - 1
-                m = len(trg_sentence)
+                l = len(aligned_sentence.mots)
+                m = len(aligned_sentence.words)
                 for i in range(0, l + 1):
                     for j in range(1, m + 1):
                         alignment_table[i][j][l][m] = (
@@ -268,8 +262,8 @@ class IBMModel2(object):
 
         alignment = []
 
-        m = len(sentence_pair.words)
         l = len(sentence_pair.mots)
+        m = len(sentence_pair.words)
 
         for j, trg_word in enumerate(sentence_pair.words):
             # Initialize trg_word to align with the NULL token

--- a/nltk/align/ibm2.py
+++ b/nltk/align/ibm2.py
@@ -7,33 +7,7 @@
 # For license information, see LICENSE.TXT
 
 """
-The IBM models are a series of generative models that learn lexical
-translation probabilities, p(target language word|source language word),
-given a sentence-aligned parallel corpus.
-
-The models increase in sophistication from model 1 to 5. Typically, the
-output of lower models is used to seed the higher models. All models
-use the Expectation-Maximization (EM) algorithm to learn various
-probability tables.
-
-Words in a sentence are one-indexed. The first word of a sentence has
-position 1, not 0. Index 0 is reserved in the source sentence for the
-NULL token. The concept of position does not apply to NULL, but it is
-indexed at 0 by convention.
-
-Each target word is aligned to exactly one source word or the NULL
-token.
-
-Notations
-i: Position in the source sentence
-    Valid values are 0 (for NULL), 1, 2, ..., length of source sentence
-j: Position in the target sentence
-    Valid values are 1, 2, ..., length of target sentence
-l: Number of words in the source sentence, excluding NULL
-m: Number of words in the target sentence
-s: A word in the source language
-t: A word in the target language
-
+Lexical translation model that considers word order.
 
 IBM Model 2 improves on Model 1 by accounting for word order.
 An alignment probability is introduced, a(i | j,l,m), which predicts
@@ -49,6 +23,17 @@ E step - In the training data, collect counts, weighted by prior
              sentence
 
 M step - Estimate new probabilities based on the counts from the E step
+
+
+Notations:
+i: Position in the source sentence
+    Valid values are 0 (for NULL), 1, 2, ..., length of source sentence
+j: Position in the target sentence
+    Valid values are 1, 2, ..., length of target sentence
+l: Number of words in the source sentence, excluding NULL
+m: Number of words in the target sentence
+s: A word in the source language
+t: A word in the target language
 
 
 References:

--- a/nltk/align/ibm2.py
+++ b/nltk/align/ibm2.py
@@ -165,13 +165,12 @@ class IBMModel2(object):
                 lambda: defaultdict(lambda: defaultdict(
                     lambda: 0.0)))
 
-            total_count = defaultdict(float)
-
             for aligned_sentence in parallel_corpus:
                 src_sentence = [None] + aligned_sentence.mots
                 trg_sentence = aligned_sentence.words
                 l = len(aligned_sentence.mots)
                 m = len(trg_sentence)
+                total_count = defaultdict(float)
 
                 # E step (a): Compute normalization factors to weigh counts
                 for j in range(1, m + 1):

--- a/nltk/align/ibm2.py
+++ b/nltk/align/ibm2.py
@@ -92,8 +92,8 @@ class IBMModel2(object):
 
     def __init__(self, sentence_aligned_corpus, iterations):
         """
-        Train on ``sentence_aligned_corpus`` and create
-        a translation model and an alignment model.
+        Train on ``sentence_aligned_corpus`` and create a lexical
+        translation model and an alignment model.
 
         Translation direction is from ``AlignedSent.mots`` to
         ``AlignedSent.words``.

--- a/nltk/align/ibm3.py
+++ b/nltk/align/ibm3.py
@@ -219,9 +219,9 @@ class IBMModel3(object):
             fertility_count_for_any_phi = defaultdict(lambda: 0.0)
 
             for aligned_sentence in parallel_corpus:
-                trg_sentence = aligned_sentence.words
                 src_sentence = [None] + aligned_sentence.mots
-                l = len(src_sentence) - 1
+                trg_sentence = aligned_sentence.words
+                l = len(aligned_sentence.mots)
                 m = len(trg_sentence)
 
                 # Sample the alignment space
@@ -293,10 +293,8 @@ class IBMModel3(object):
 
             # Distortion
             for aligned_sentence in parallel_corpus:
-                trg_sentence = aligned_sentence.words
-                src_sentence = [None] + aligned_sentence.mots
-                l = len(src_sentence) - 1
-                m = len(trg_sentence)
+                l = len(aligned_sentence.mots)
+                m = len(aligned_sentence.words)
 
                 for i in range(0, l + 1):
                     for j in range(1, m + 1):
@@ -335,8 +333,8 @@ class IBMModel3(object):
         """
         sampled_alignments = set()
 
+        l = len(src_sentence) - 1 # exclude NULL
         m = len(trg_sentence)
-        l = len(src_sentence) - 1
 
         # Compute Normalization
         for i in range(0, l + 1):
@@ -424,8 +422,8 @@ class IBMModel3(object):
         ``src_sentence``
         """
 
+        l = len(src_sentence) - 1 # exclude NULL
         m = len(trg_sentence)
-        l = len(src_sentence) - 1
         p1 = self.p1
         p0 = 1 - p1
 
@@ -473,8 +471,8 @@ class IBMModel3(object):
 
         neighbors = set()
 
+        l = len(src_sentence) - 1 # exclude NULL
         m = len(trg_sentence)
-        l = len(src_sentence) - 1
 
         for j in range(1, m + 1):
             if j != j_pegged:
@@ -531,8 +529,8 @@ class IBMModel3(object):
 
         alignment = []
 
-        m = len(sentence_pair.words)
         l = len(sentence_pair.mots)
+        m = len(sentence_pair.words)
 
         for j, trg_word in enumerate(sentence_pair.words):
             # Initialize trg_word to align with the NULL token

--- a/nltk/align/ibm3.py
+++ b/nltk/align/ibm3.py
@@ -185,10 +185,10 @@ class IBMModel3(object):
         """
 
         # Initial probability of null insertion
-        self.p0 = 0.5
+        self.p1 = 0.5
         """
-        Probability that a generated word does not require another
-        target word that is aligned to NULL
+        Probability that a generated word requires another target word
+        that is aligned to NULL
         """
 
         # Get the translation and alignment probabilities from IBM model 2
@@ -332,7 +332,7 @@ class IBMModel3(object):
             self.translation_table = translation_table
             self.distortion_table = distortion_table
             self.fertility_table = fertility_table
-            self.p0 = 1 - p1
+            self.p1 = p1
 
     def sample(self, trg_sentence, src_sentence):
         """
@@ -441,13 +441,14 @@ class IBMModel3(object):
 
         m = len(trg_sentence)
         l = len(src_sentence) - 1
-        p1 = 1 - self.p0
+        p1 = self.p1
+        p0 = 1 - p1
 
         probability = 1.0
 
         # Combine NULL insertion probability
         probability *= (pow(p1, fertility_of_i[0]) *
-                        pow(self.p0, m - 2 * fertility_of_i[0]))
+                        pow(p0, m - 2 * fertility_of_i[0]))
         if probability == 0:
             return probability
 

--- a/nltk/align/ibm3.py
+++ b/nltk/align/ibm3.py
@@ -76,6 +76,7 @@ Translation: Parameter Estimation. Computational Linguistics, 19 (2),
 from __future__ import division
 from collections import defaultdict
 from nltk.align import AlignedSent
+from nltk.align.ibm_model import AlignmentInfo
 from nltk.align.ibm2 import IBMModel2
 from math import factorial
 
@@ -549,52 +550,6 @@ class IBMModel3(object):
                 alignment.append((j, best_alignment[1]))
 
         return AlignedSent(sentence_pair.words, sentence_pair.mots, alignment)
-
-
-class AlignmentInfo(object):
-    """
-    Helper data object for IBM Model 3 training
-
-    For a source sentence and its counterpart in the target language,
-    this class holds information about the sentence pair's alignment
-    and fertility.
-    """
-
-    def __init__(self, alignment, src_sentence, trg_sentence, fertility_of_i):
-        if not isinstance(alignment, tuple):
-            raise TypeError("The alignment must be a tuple because it is used "
-                            "to uniquely identify AlignmentInfo objects.")
-
-        self.alignment = alignment
-        """
-        tuple(int): Alignment function. ``alignment[j]`` is the position
-        in the source sentence that is aligned to the position j in the
-        target sentence.
-        """
-
-        self.fertility_of_i = fertility_of_i
-        """
-        tuple(int): Fertility of source word. ``fertility_of_i[i]`` is
-        the number of words in the target sentence that is aligned to
-        the word in position i of the source sentence.
-        """
-
-        self.src_sentence = src_sentence
-        """
-        tuple(str): Source sentence referred to by this object.
-        Should include NULL token (None) in index 0.
-        """
-
-        self.trg_sentence = trg_sentence
-        """
-        tuple(str): Target sentence referred to by this object.
-        """
-
-    def __eq__(self, other):
-        return self.alignment == other.alignment
-
-    def __hash__(self):
-        return hash(self.alignment)
 
 
 # run doctests

--- a/nltk/align/ibm3.py
+++ b/nltk/align/ibm3.py
@@ -7,36 +7,8 @@
 # For license information, see LICENSE.TXT
 
 """
-The IBM models are a series of generative models that learn lexical
-translation probabilities, p(target language word|source language word),
-given a sentence-aligned parallel corpus.
-
-The models increase in sophistication from model 1 to 5. Typically, the
-output of lower models is used to seed the higher models. All models
-use the Expectation-Maximization (EM) algorithm to learn various
-probability tables.
-
-Words in a sentence are one-indexed. The first word of a sentence has
-position 1, not 0. Index 0 is reserved in the source sentence for the
-NULL token. The concept of position does not apply to NULL, but it is
-indexed at 0 by convention.
-
-Each target word is aligned to exactly one source word or the NULL
-token.
-
-Notations
-i: Position in the source sentence
-    Valid values are 0 (for NULL), 1, 2, ..., length of source sentence
-j: Position in the target sentence
-    Valid values are 1, 2, ..., length of target sentence
-l: Number of words in the source sentence, excluding NULL
-m: Number of words in the target sentence
-s: A word in the source language
-t: A word in the target language
-phi: Fertility, the number of target words produced by a source word
-p1: Probability that a target word produced by a source word is
-    accompanied by another target word that is aligned to NULL
-p0: 1 - p1
+Translation model that considers how a word can be aligned to
+multiple words in another language.
 
 IBM Model 3 improves on Model 2 by directly modeling the phenomenon
 where a word in one language may be translated into zero or more words
@@ -74,6 +46,21 @@ Because there are too many possible alignments, only the most probable
 ones are considered. First, the best alignment is determined using prior
 probabilities. Then, a hill climbing approach is used to find other good
 candidates.
+
+
+Notations:
+i: Position in the source sentence
+    Valid values are 0 (for NULL), 1, 2, ..., length of source sentence
+j: Position in the target sentence
+    Valid values are 1, 2, ..., length of target sentence
+l: Number of words in the source sentence, excluding NULL
+m: Number of words in the target sentence
+s: A word in the source language
+t: A word in the target language
+phi: Fertility, the number of target words produced by a source word
+p1: Probability that a target word produced by a source word is
+    accompanied by another target word that is aligned to NULL
+p0: 1 - p1
 
 
 References:

--- a/nltk/align/ibm3.py
+++ b/nltk/align/ibm3.py
@@ -125,7 +125,7 @@ class IBMModel3(object):
 
     def __init__(self, sentence_aligned_corpus, iterations):
         """
-        Train on ``sentence_aligned_corpus`` and create a
+        Train on ``sentence_aligned_corpus`` and create a lexical
         translation model, a distortion model, a fertility model, and a
         model for generating NULL-aligned words.
 

--- a/nltk/align/ibm3.py
+++ b/nltk/align/ibm3.py
@@ -93,21 +93,6 @@ from nltk.align.ibm2 import IBMModel2
 from math import factorial
 
 
-class HashableDict(dict):
-    """
-    Hashable dictionary which can be put into a set.
-    """
-
-    def __key(self):
-        return tuple((k, self[k]) for k in sorted(self))
-
-    def __hash__(self):
-        return hash(self.__key())
-
-    def __eq__(self, other):
-        return self.__key() == other.__key()
-
-
 class IBMModel3(object):
     """
     Translation model that considers how a word can be aligned to
@@ -356,8 +341,8 @@ class IBMModel3(object):
         # Compute Normalization
         for i in range(0, l + 1):
             for j in range(1, m + 1):
-                alignment = HashableDict()
-                fertility_of_i = HashableDict()
+                alignment = list(range(m + 1))
+                fertility_of_i = list(range(l + 1))
 
                 # Initialize all fertility to zero
                 for ii in range(0, l + 1):
@@ -483,7 +468,7 @@ class IBMModel3(object):
         """
         :return: Neighbors of ``alignment`` obtained by moving or
             swapping one alignment point, with the corresponding fertility
-        :rtype: set(tuple(HashableDict(int), int))
+        :rtype: set(tuple(tuple(int), int))
         """
 
         neighbors = set()
@@ -495,28 +480,30 @@ class IBMModel3(object):
             if j != j_pegged:
                 # Add alignments that differ by one alignment point
                 for i in range(0, l + 1):
-                    new_alignment = HashableDict(alignment)
+                    new_alignment = list(alignment)
                     new_alignment[j] = i
 
                     new_fertility = fertility_of_i
                     if new_fertility[alignment[j]] > 0:
-                        new_fertility = HashableDict(fertility_of_i)
+                        new_fertility = list(fertility_of_i)
                         new_fertility[alignment[j]] -= 1
                         new_fertility[i] += 1
 
-                    neighbors.update([(new_alignment, new_fertility)])
+                    # convert list to tuple because set members must be immutable
+                    neighbors.add((tuple(new_alignment), tuple(new_fertility)))
 
         for j in range(1, m + 1):
             if j != j_pegged:
                 # Add alignments that have two alignment points swapped
                 for other_j in range(1, m + 1):
                     if other_j != j_pegged and other_j != j:
-                        new_alignment = HashableDict(alignment)
+                        new_alignment = list(alignment)
                         new_fertility = fertility_of_i
                         new_alignment[j] = alignment[other_j]
                         new_alignment[other_j] = alignment[j]
 
-                        neighbors.update([(new_alignment, new_fertility)])
+                        neighbors.add((tuple(new_alignment),
+                                       tuple(new_fertility)))
 
         return neighbors
 

--- a/nltk/align/ibm3.py
+++ b/nltk/align/ibm3.py
@@ -174,7 +174,7 @@ class IBMModel3(object):
                 lambda: self.PROB_SMOOTH))))
         """
         Probability(j | i,l,m). Values accessed as
-        ``distortion_table[j][i][m][l].``
+        ``distortion_table[j][i][l][m].``
         """
 
         self.fertility_table = defaultdict(
@@ -267,8 +267,8 @@ class IBMModel3(object):
                         count_any_t_given_s[s] += normalized_count
 
                         # Distortion
-                        distortion_count[j][i][m][l] += normalized_count
-                        distortion_count_for_any_j[i][m][l] += normalized_count
+                        distortion_count[j][i][l][m] += normalized_count
+                        distortion_count_for_any_j[i][l][m] += normalized_count
 
                         if i == 0:
                             null_count += 1
@@ -315,9 +315,9 @@ class IBMModel3(object):
 
                 for i in range(0, l + 1):
                     for j in range(1, m + 1):
-                        distortion_table[j][i][m][l] = (
-                            distortion_count[j][i][m][l] /
-                            distortion_count_for_any_j[i][m][l])
+                        distortion_table[j][i][l][m] = (
+                            distortion_count[j][i][l][m] /
+                            distortion_count_for_any_j[i][l][m])
 
             # Fertility
             for fertility in range(0, max_fertility + 1):
@@ -377,7 +377,7 @@ class IBMModel3(object):
                             s = src_sentence[ii]
                             t = trg_sentence[jj - 1]
                             alignment_prob = (self.translation_table[t][s] *
-                                         self.__alignment_table[ii][jj][m][l])
+                                         self.__alignment_table[ii][jj][l][m])
                             if alignment_prob > max_alignment_prob:
                                 max_alignment_prob = alignment_prob
                                 best_i = ii
@@ -471,7 +471,7 @@ class IBMModel3(object):
             s = src_sentence[i]
 
             probability *= self.translation_table[t][s]
-            probability *= self.distortion_table[j][i][m][l]
+            probability *= self.distortion_table[j][i][l][m]
             if probability == 0:
                 return probability
 
@@ -549,10 +549,10 @@ class IBMModel3(object):
         for j, trg_word in enumerate(sentence_pair.words):
             # Initialize trg_word to align with the NULL token
             best_alignment = (self.translation_table[trg_word][None] *
-                              self.distortion_table[j + 1][0][m][l], 0)
+                              self.distortion_table[j + 1][0][l][m], 0)
             for i, src_word in enumerate(sentence_pair.mots):
                 align_prob = (self.translation_table[trg_word][src_word] *
-                              self.distortion_table[j + 1][i + 1][m][l])
+                              self.distortion_table[j + 1][i + 1][l][m])
                 best_alignment = max(best_alignment, (align_prob, i))
 
             # If trg_word is not aligned to the NULL token,

--- a/nltk/align/ibm3.py
+++ b/nltk/align/ibm3.py
@@ -100,6 +100,7 @@ class IBMModel3(object):
 
     >>> align_sents = []
     >>> align_sents.append(AlignedSent(['klein', 'ist', 'das', 'Haus'], ['the', 'house', 'is', 'small']))
+    >>> align_sents.append(AlignedSent(['das', 'Haus', 'ist', 'groß'], ['the', 'house', 'is', 'big']))
     >>> align_sents.append(AlignedSent(['das', 'Haus'], ['the', 'house']))
     >>> align_sents.append(AlignedSent(['das', 'Buch'], ['the', 'book']))
     >>> align_sents.append(AlignedSent(['ein', 'Buch'], ['a', 'book']))
@@ -119,7 +120,7 @@ class IBMModel3(object):
     >>> aligned_sent.mots
     ['the', 'house', 'is', 'small']
     >>> aligned_sent.alignment
-    Alignment([(0, 2), (1, 3), (2, 0), (3, 1)])
+    Alignment([(0, 3), (1, 2), (2, 0), (3, 1)])
 
     """
 

--- a/nltk/align/ibm_model.py
+++ b/nltk/align/ibm_model.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# Natural Language Toolkit: IBM Model Core
+#
+# Copyright (C) 2001-2015 NLTK Project
+# Author: Tah Wei Hoon <hoon.tw@gmail.com>
+# URL: <http://nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""
+Common methods and classes for all IBM models. See ``IBMModel1``,
+``IBMModel2``, and ``IBMModel3`` for specific implementations.
+
+The IBM models are a series of generative models that learn lexical
+translation probabilities, p(target language word|source language word),
+given a sentence-aligned parallel corpus.
+
+The models increase in sophistication from model 1 to 5. Typically, the
+output of lower models is used to seed the higher models. All models
+use the Expectation-Maximization (EM) algorithm to learn various
+probability tables.
+
+Words in a sentence are one-indexed. The first word of a sentence has
+position 1, not 0. Index 0 is reserved in the source sentence for the
+NULL token. The concept of position does not apply to NULL, but it is
+indexed at 0 by convention.
+
+Each target word is aligned to exactly one source word or the NULL
+token.
+
+References:
+Philipp Koehn. 2010. Statistical Machine Translation.
+Cambridge University Press, New York.
+
+Peter E Brown, Stephen A. Della Pietra, Vincent J. Della Pietra, and
+Robert L. Mercer. 1993. The Mathematics of Statistical Machine
+Translation: Parameter Estimation. Computational Linguistics, 19 (2),
+263-311.
+"""

--- a/nltk/align/ibm_model.py
+++ b/nltk/align/ibm_model.py
@@ -36,3 +36,49 @@ Robert L. Mercer. 1993. The Mathematics of Statistical Machine
 Translation: Parameter Estimation. Computational Linguistics, 19 (2),
 263-311.
 """
+
+
+class AlignmentInfo(object):
+    """
+    Helper data object for training IBM Model 3
+
+    Read-only. For a source sentence and its counterpart in the target
+    language, this class holds information about the sentence pair's
+    alignment and fertility.
+    """
+
+    def __init__(self, alignment, src_sentence, trg_sentence, fertility_of_i):
+        if not isinstance(alignment, tuple):
+            raise TypeError("The alignment must be a tuple because it is used "
+                            "to uniquely identify AlignmentInfo objects.")
+
+        self.alignment = alignment
+        """
+        tuple(int): Alignment function. ``alignment[j]`` is the position
+        in the source sentence that is aligned to the position j in the
+        target sentence.
+        """
+
+        self.fertility_of_i = fertility_of_i
+        """
+        tuple(int): Fertility of source word. ``fertility_of_i[i]`` is
+        the number of words in the target sentence that is aligned to
+        the word in position i of the source sentence.
+        """
+
+        self.src_sentence = src_sentence
+        """
+        tuple(str): Source sentence referred to by this object.
+        Should include NULL token (None) in index 0.
+        """
+
+        self.trg_sentence = trg_sentence
+        """
+        tuple(str): Target sentence referred to by this object.
+        """
+
+    def __eq__(self, other):
+        return self.alignment == other.alignment
+
+    def __hash__(self):
+        return hash(self.alignment)

--- a/nltk/align/ibm_model.py
+++ b/nltk/align/ibm_model.py
@@ -37,13 +37,12 @@ Translation: Parameter Estimation. Computational Linguistics, 19 (2),
 263-311.
 """
 
-from abc import ABCMeta
 from collections import defaultdict
 
 
-class IBMModel(metaclass=ABCMeta):
+class IBMModel(object):
     """
-    Base class for all IBM models
+    Abstract base class for all IBM models
     """
 
     # Avoid division by zero and precision errors by imposing a minimum


### PR DESCRIPTION
Move shared code and documentation to a new module, `ibm_model`.
Ensure a minimum value for probabilities in order to avoid underflow, singularities, and precision errors. In practical terms, the minimum value is small enough to be regarded as zero.

Other smaller changes for Model 3:
- Expose `p1` instead of `p0`.
- Swap order of `l` and `m` in `alignment_table` and `distortion_table`.
- Fix bug in updating fertilities when looking for neighboring alignments. Fertility tables were shared among some alignments, instead of each alignment having its own table.
- Add additional training data to doctest, so that the correct alignments can be converged. The original expected result was incorrect.
