### PR TITLE
Hotfix/bug on internals

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,4 +1,4 @@
-# Natural Language Toolkit (NLTK) Authors
+﻿# Natural Language Toolkit (NLTK) Authors
 
 ## Original Authors
 
@@ -178,3 +178,4 @@
 - pquentin
 - wvanlint
 - Álvaro Justen <https://github.com/turicas>
+- bjut-hz

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -476,7 +476,11 @@ def find_file_iter(filename, env_vars=(), searchpath=(),
                         yielded = True
                         yield path_to_file
                     # Check if the alternative is inside a 'file' directory
-                    path_to_file = os.path.join(env_dir, 'file', alternative)
+                    # path_to_file = os.path.join(env_dir, 'file', alternative)
+
+                    # Check if the alternative is inside a 'file' directory
+                    path_to_file = os.path.join(env_dir, 'bin', alternative)
+
                     if os.path.isfile(path_to_file):
                         if verbose:
                             print('[Found %s: %s]' % (filename, path_to_file))

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -478,7 +478,7 @@ def find_file_iter(filename, env_vars=(), searchpath=(),
                     # Check if the alternative is inside a 'file' directory
                     # path_to_file = os.path.join(env_dir, 'file', alternative)
 
-                    # Check if the alternative is inside a 'file' directory
+                    # Check if the alternative is inside a 'bin' directory
                     path_to_file = os.path.join(env_dir, 'bin', alternative)
 
                     if os.path.isfile(path_to_file):


### PR DESCRIPTION
NLTK will throw a lookuperror exception if we use NLTK to call Stanford NLP written by JAVA. So,  I   modified the search path in  nltk/internals.py  find_file_iter(...).
