### PR TITLE
Add the malt parser directory name in the unittest

### DIFF
--- a/nltk/test/gluesemantics_malt_fixt.py
+++ b/nltk/test/gluesemantics_malt_fixt.py
@@ -6,6 +6,6 @@ def setup_module(module):
     from nltk.parse.malt import MaltParser
 
     try:
-        depparser = MaltParser()
+        depparser = MaltParser('maltparser-1.7.2')
     except LookupError:
         raise SkipTest("MaltParser is not available")


### PR DESCRIPTION
Fixes https://nltk.ci.cloudbees.com/job/nltk/TOXENV=py34-jenkins,jdk=jdk8latestOnlineInstall/lastCompletedBuild/testReport/%3Cnose/suite/ContextSuite_context_gluesemantics_malt_fixt__setup/
