### PR TITLE
Carry out word alignment during training of IBM models

### DIFF
--- a/nltk/align/__init__.py
+++ b/nltk/align/__init__.py
@@ -12,9 +12,12 @@ These interfaces are prone to change.
 """
 
 from nltk.align.api import AlignedSent, Alignment
+from nltk.align.ibm_model import IBMModel
 from nltk.align.ibm1 import IBMModel1
 from nltk.align.ibm2 import IBMModel2
 from nltk.align.ibm3 import IBMModel3
+from nltk.align.ibm4 import IBMModel4
+from nltk.align.ibm5 import IBMModel5
 from nltk.align.bleu_score import bleu
 
 

--- a/nltk/align/api.py
+++ b/nltk/align/api.py
@@ -79,7 +79,7 @@ class AlignedSent(object):
         """
         if not all(0 <= p[0] < len(self._words) for p in a):
             raise IndexError("Alignment is outside boundary of words")
-        if not all(0 <= p[1] < len(self._mots) for p in a):
+        if not all(p[1] is None or 0 <= p[1] < len(self._mots) for p in a):
             raise IndexError("Alignment is outside boundary of mots")
         return True
 

--- a/nltk/align/ibm1.py
+++ b/nltk/align/ibm1.py
@@ -110,7 +110,6 @@ class IBMModel1(IBMModel):
         :param iterations: Number of iterations to run training algorithm
         :type iterations: int
         """
-
         super(IBMModel1, self).__init__(sentence_aligned_corpus)
 
         # seed with a uniform distribution
@@ -161,12 +160,11 @@ class IBMModel1(IBMModel):
         Probability of target sentence and an alignment given the
         source sentence
         """
-
         prob = 1.0
 
         for j, i in enumerate(alignment_info.alignment):
             if j == 0:
-                continue # skip the dummy zeroeth element
+                continue  # skip the dummy zeroeth element
             trg_word = alignment_info.trg_sentence[j]
             src_word = alignment_info.src_sentence[i]
             prob *= self.translation_table[trg_word][src_word]
@@ -188,7 +186,6 @@ class IBMModel1(IBMModel):
         :return: ``AlignedSent`` filled in with the best word alignment
         :rtype: AlignedSent
         """
-
         if self.translation_table is None:
             raise ValueError("The model has not been trained.")
 
@@ -201,7 +198,7 @@ class IBMModel1(IBMModel):
             best_alignment = None
             for i, src_word in enumerate(sentence_pair.mots):
                 align_prob = self.translation_table[trg_word][src_word]
-                if align_prob >= best_prob: # prefer newer word in case of tie
+                if align_prob >= best_prob:  # prefer newer word in case of tie
                     best_prob = align_prob
                     best_alignment = i
 

--- a/nltk/align/ibm1.py
+++ b/nltk/align/ibm1.py
@@ -58,7 +58,7 @@ from __future__ import division
 from collections import defaultdict
 from nltk.align import AlignedSent
 from nltk.align import Alignment
-from nltk.align.ibm_model import IBMModel
+from nltk.align import IBMModel
 import warnings
 
 

--- a/nltk/align/ibm1.py
+++ b/nltk/align/ibm1.py
@@ -57,6 +57,7 @@ Translation: Parameter Estimation. Computational Linguistics, 19 (2),
 from __future__ import division
 from collections import defaultdict
 from nltk.align import AlignedSent
+from nltk.align import Alignment
 from nltk.align.ibm_model import IBMModel
 import warnings
 
@@ -89,9 +90,7 @@ class IBMModel1(IBMModel):
     ['das', 'buch', 'ist', 'ja', 'klein']
     >>> test_sentence.mots
     ['the', 'book', 'is', 'small']
-
-    >>> aligned_sentence = ibm1.align(test_sentence)
-    >>> aligned_sentence.alignment
+    >>> test_sentence.alignment
     Alignment([(0, 0), (1, 1), (2, 2), (3, 2), (4, 3)])
 
     """
@@ -123,6 +122,7 @@ class IBMModel1(IBMModel):
                           "Results may be less accurate.")
 
         self.train(sentence_aligned_corpus, iterations)
+        self.__align_all(sentence_aligned_corpus)
 
     def train(self, parallel_corpus, iterations):
         for i in range(0, iterations):
@@ -171,40 +171,40 @@ class IBMModel1(IBMModel):
 
         return max(prob, IBMModel.MIN_PROB)
 
-    def align(self, sentence_pair):
+    def __align_all(self, parallel_corpus):
+        for sentence_pair in parallel_corpus:
+            self.__align(sentence_pair)
+
+    def __align(self, sentence_pair):
         """
         Determines the best word alignment for one sentence pair from
         the corpus that the model was trained on.
 
-        The original sentence pair is not modified. Results are
-        undefined if ``sentence_pair`` is not in the training set.
+        The best alignment will be set in ``sentence_pair`` when the
+        method returns. In contrast with the internal implementation of
+        IBM models, the word indices in the ``Alignment`` are zero-
+        indexed, not one-indexed.
 
         :param sentence_pair: A sentence in the source language and its
             counterpart sentence in the target language
         :type sentence_pair: AlignedSent
-
-        :return: ``AlignedSent`` filled in with the best word alignment
-        :rtype: AlignedSent
         """
-        if self.translation_table is None:
-            raise ValueError("The model has not been trained.")
-
-        alignment = []
+        best_alignment = []
 
         for j, trg_word in enumerate(sentence_pair.words):
             # Initialize trg_word to align with the NULL token
             best_prob = max(self.translation_table[trg_word][None],
                             IBMModel.MIN_PROB)
-            best_alignment = None
+            best_alignment_point = None
             for i, src_word in enumerate(sentence_pair.mots):
                 align_prob = self.translation_table[trg_word][src_word]
                 if align_prob >= best_prob:  # prefer newer word in case of tie
                     best_prob = align_prob
-                    best_alignment = i
+                    best_alignment_point = i
 
             # If trg_word is not aligned to the NULL token,
-            # add it to the viterbi_alignment.
-            if best_alignment is not None:
-                alignment.append((j, best_alignment))
+            # add it to the best_alignment.
+            if best_alignment_point is not None:
+                best_alignment.append((j, best_alignment_point))
 
-        return AlignedSent(sentence_pair.words, sentence_pair.mots, alignment)
+        sentence_pair.alignment = Alignment(best_alignment)

--- a/nltk/align/ibm1.py
+++ b/nltk/align/ibm1.py
@@ -202,9 +202,6 @@ class IBMModel1(IBMModel):
                     best_prob = align_prob
                     best_alignment_point = i
 
-            # If trg_word is not aligned to the NULL token,
-            # add it to the best_alignment.
-            if best_alignment_point is not None:
-                best_alignment.append((j, best_alignment_point))
+            best_alignment.append((j, best_alignment_point))
 
         sentence_pair.alignment = Alignment(best_alignment)

--- a/nltk/align/ibm1.py
+++ b/nltk/align/ibm1.py
@@ -54,9 +54,9 @@ Translation: Parameter Estimation. Computational Linguistics, 19 (2),
 263-311.
 """
 
-from __future__  import division
+from __future__ import division
 from collections import defaultdict
-from nltk.align  import AlignedSent
+from nltk.align import AlignedSent
 from nltk.align.ibm_model import IBMModel
 import warnings
 
@@ -65,19 +65,34 @@ class IBMModel1(IBMModel):
     """
     Lexical translation model that ignores word order
 
-    >>> from nltk.corpus import comtrans
-    >>> bitexts = comtrans.aligned_sents()[:100]
-    >>> ibm = IBMModel1(bitexts, 20)
+    >>> bitext = []
+    >>> bitext.append(AlignedSent(['klein', 'ist', 'das', 'haus'], ['the', 'house', 'is', 'small']))
+    >>> bitext.append(AlignedSent(['das', 'haus', 'ist', 'ja', 'groß'], ['the', 'house', 'is', 'big']))
+    >>> bitext.append(AlignedSent(['das', 'buch', 'ist', 'ja', 'klein'], ['the', 'book', 'is', 'small']))
+    >>> bitext.append(AlignedSent(['das', 'haus'], ['the', 'house']))
+    >>> bitext.append(AlignedSent(['das', 'buch'], ['the', 'book']))
+    >>> bitext.append(AlignedSent(['ein', 'buch'], ['a', 'book']))
 
-    >>> aligned_sent = ibm.align(bitexts[6])
-    >>> aligned_sent.alignment
-    Alignment([(0, 0), (1, 1), (2, 2), (3, 7), (4, 7), (5, 8)])
-    >>> print('{0:.3f}'.format(bitexts[6].precision(aligned_sent)))
-    0.556
-    >>> print('{0:.3f}'.format(bitexts[6].recall(aligned_sent)))
-    0.833
-    >>> print('{0:.3f}'.format(bitexts[6].alignment_error_rate(aligned_sent)))
-    0.333
+    >>> ibm1 = IBMModel1(bitext, 5)
+
+    >>> print('{0:.3f}'.format(ibm1.translation_table['buch']['book']))
+    0.889
+    >>> print('{0:.3f}'.format(ibm1.translation_table['das']['book']))
+    0.062
+    >>> print('{0:.3f}'.format(ibm1.translation_table['buch'][None]))
+    0.113
+    >>> print('{0:.3f}'.format(ibm1.translation_table['ja'][None]))
+    0.073
+
+    >>> test_sentence = bitext[2]
+    >>> test_sentence.words
+    ['das', 'buch', 'ist', 'ja', 'klein']
+    >>> test_sentence.mots
+    ['the', 'book', 'is', 'small']
+
+    >>> aligned_sentence = ibm1.align(test_sentence)
+    >>> aligned_sentence.alignment
+    Alignment([(0, 0), (1, 1), (2, 2), (3, 2), (4, 3)])
 
     """
 

--- a/nltk/align/ibm2.py
+++ b/nltk/align/ibm2.py
@@ -113,7 +113,6 @@ class IBMModel2(IBMModel):
         :param iterations: Number of iterations to run training algorithm
         :type iterations: int
         """
-
         super(IBMModel2, self).__init__(sentence_aligned_corpus)
 
         # Get initial translation probability distribution
@@ -152,7 +151,7 @@ class IBMModel2(IBMModel):
 
             for aligned_sentence in parallel_corpus:
                 src_sentence = [None] + aligned_sentence.mots
-                trg_sentence = ['UNUSED'] + aligned_sentence.words # 1-indexed
+                trg_sentence = ['UNUSED'] + aligned_sentence.words  # 1-indexed
                 l = len(aligned_sentence.mots)
                 m = len(aligned_sentence.words)
                 total_count = defaultdict(float)
@@ -203,14 +202,13 @@ class IBMModel2(IBMModel):
         Probability of target sentence and an alignment given the
         source sentence
         """
-
         prob = 1.0
         l = len(alignment_info.src_sentence) - 1
         m = len(alignment_info.trg_sentence) - 1
 
         for j, i in enumerate(alignment_info.alignment):
             if j == 0:
-                continue # skip the dummy zeroeth element
+                continue  # skip the dummy zeroeth element
             trg_word = alignment_info.trg_sentence[j]
             src_word = alignment_info.src_sentence[i]
             prob *= (self.translation_table[trg_word][src_word] *
@@ -233,7 +231,6 @@ class IBMModel2(IBMModel):
         :return: ``AlignedSent`` filled in with the best word alignment
         :rtype: AlignedSent
         """
-
         if self.translation_table is None or self.alignment_table is None:
             raise ValueError("The model has not been trained.")
 

--- a/nltk/align/ibm2.py
+++ b/nltk/align/ibm2.py
@@ -49,6 +49,7 @@ Translation: Parameter Estimation. Computational Linguistics, 19 (2),
 from __future__ import division
 from collections import defaultdict
 from nltk.align import AlignedSent
+from nltk.align import Alignment
 from nltk.align.ibm_model import IBMModel
 from nltk.align.ibm1 import IBMModel1
 import warnings
@@ -89,9 +90,7 @@ class IBMModel2(IBMModel):
     ['das', 'buch', 'ist', 'ja', 'klein']
     >>> test_sentence.mots
     ['the', 'book', 'is', 'small']
-
-    >>> aligned_sentence = ibm2.align(test_sentence)
-    >>> aligned_sentence.alignment
+    >>> test_sentence.alignment
     Alignment([(0, 0), (1, 1), (2, 2), (3, 2), (4, 3)])
 
     """
@@ -135,6 +134,7 @@ class IBMModel2(IBMModel):
                               " words). Results may be less accurate.")
 
         self.train(sentence_aligned_corpus, iterations)
+        self.__align_all(sentence_aligned_corpus)
 
     def train(self, parallel_corpus, iterations):
         for i in range(0, iterations):
@@ -216,25 +216,25 @@ class IBMModel2(IBMModel):
 
         return max(prob, IBMModel.MIN_PROB)
 
-    def align(self, sentence_pair):
+    def __align_all(self, parallel_corpus):
+        for sentence_pair in parallel_corpus:
+            self.__align(sentence_pair)
+
+    def __align(self, sentence_pair):
         """
         Determines the best word alignment for one sentence pair from
         the corpus that the model was trained on.
 
-        The original sentence pair is not modified. Results are
-        undefined if ``sentence_pair`` is not in the training set.
+        The best alignment will be set in ``sentence_pair`` when the
+        method returns. In contrast with the internal implementation of
+        IBM models, the word indices in the ``Alignment`` are zero-
+        indexed, not one-indexed.
 
         :param sentence_pair: A sentence in the source language and its
             counterpart sentence in the target language
         :type sentence_pair: AlignedSent
-
-        :return: ``AlignedSent`` filled in with the best word alignment
-        :rtype: AlignedSent
         """
-        if self.translation_table is None or self.alignment_table is None:
-            raise ValueError("The model has not been trained.")
-
-        alignment = []
+        best_alignment = []
 
         l = len(sentence_pair.mots)
         m = len(sentence_pair.words)
@@ -244,17 +244,17 @@ class IBMModel2(IBMModel):
             best_prob = (self.translation_table[trg_word][None] *
                          self.alignment_table[0][j + 1][l][m])
             best_prob = max(best_prob, IBMModel.MIN_PROB)
-            best_alignment = None
+            best_alignment_point = None
             for i, src_word in enumerate(sentence_pair.mots):
                 align_prob = (self.translation_table[trg_word][src_word] *
                               self.alignment_table[i + 1][j + 1][l][m])
                 if align_prob >= best_prob:
                     best_prob = align_prob
-                    best_alignment = i
+                    best_alignment_point = i
 
             # If trg_word is not aligned to the NULL token,
-            # add it to the viterbi_alignment.
-            if best_alignment is not None:
-                alignment.append((j, best_alignment))
+            # add it to the best_alignment.
+            if best_alignment_point is not None:
+                best_alignment.append((j, best_alignment_point))
 
-        return AlignedSent(sentence_pair.words, sentence_pair.mots, alignment)
+        sentence_pair.alignment = Alignment(best_alignment)

--- a/nltk/align/ibm2.py
+++ b/nltk/align/ibm2.py
@@ -58,22 +58,41 @@ class IBMModel2(IBMModel):
     """
     Lexical translation model that considers word order
 
-    >>> from nltk.corpus import comtrans
-    >>> bitexts = comtrans.aligned_sents()[:100]
-    >>> ibm = IBMModel2(bitexts, 5)
-    >>> aligned_sent = ibm.align(bitexts[0])
-    >>> aligned_sent.words
-    ['Wiederaufnahme', 'der', 'Sitzungsperiode']
-    >>> aligned_sent.mots
-    ['Resumption', 'of', 'the', 'session']
-    >>> aligned_sent.alignment
-    Alignment([(0, 0), (1, 2), (2, 3)])
-    >>> bitexts[0].precision(aligned_sent)
-    0.75
-    >>> bitexts[0].recall(aligned_sent)
-    1.0
-    >>> bitexts[0].alignment_error_rate(aligned_sent)
-    0.1428571428571429
+    >>> bitext = []
+    >>> bitext.append(AlignedSent(['klein', 'ist', 'das', 'haus'], ['the', 'house', 'is', 'small']))
+    >>> bitext.append(AlignedSent(['das', 'haus', 'ist', 'ja', 'groß'], ['the', 'house', 'is', 'big']))
+    >>> bitext.append(AlignedSent(['das', 'buch', 'ist', 'ja', 'klein'], ['the', 'book', 'is', 'small']))
+    >>> bitext.append(AlignedSent(['das', 'haus'], ['the', 'house']))
+    >>> bitext.append(AlignedSent(['das', 'buch'], ['the', 'book']))
+    >>> bitext.append(AlignedSent(['ein', 'buch'], ['a', 'book']))
+
+    >>> ibm2 = IBMModel2(bitext, 5)
+
+    >>> print('{0:.3f}'.format(ibm2.translation_table['buch']['book']))
+    1.000
+    >>> print('{0:.3f}'.format(ibm2.translation_table['das']['book']))
+    0.000
+    >>> print('{0:.3f}'.format(ibm2.translation_table['buch'][None]))
+    0.000
+    >>> print('{0:.3f}'.format(ibm2.translation_table['ja'][None]))
+    0.000
+
+    >>> print('{0:.3f}'.format(ibm2.alignment_table[1][1][2][2]))
+    0.939
+    >>> print('{0:.3f}'.format(ibm2.alignment_table[1][2][2][2]))
+    0.000
+    >>> print('{0:.3f}'.format(ibm2.alignment_table[2][2][4][5]))
+    1.000
+
+    >>> test_sentence = bitext[2]
+    >>> test_sentence.words
+    ['das', 'buch', 'ist', 'ja', 'klein']
+    >>> test_sentence.mots
+    ['the', 'book', 'is', 'small']
+
+    >>> aligned_sentence = ibm2.align(test_sentence)
+    >>> aligned_sentence.alignment
+    Alignment([(0, 0), (1, 1), (2, 2), (3, 2), (4, 3)])
 
     """
 

--- a/nltk/align/ibm2.py
+++ b/nltk/align/ibm2.py
@@ -50,8 +50,8 @@ from __future__ import division
 from collections import defaultdict
 from nltk.align import AlignedSent
 from nltk.align import Alignment
-from nltk.align.ibm_model import IBMModel
-from nltk.align.ibm1 import IBMModel1
+from nltk.align import IBMModel
+from nltk.align import IBMModel1
 import warnings
 
 

--- a/nltk/align/ibm2.py
+++ b/nltk/align/ibm2.py
@@ -252,9 +252,6 @@ class IBMModel2(IBMModel):
                     best_prob = align_prob
                     best_alignment_point = i
 
-            # If trg_word is not aligned to the NULL token,
-            # add it to the best_alignment.
-            if best_alignment_point is not None:
-                best_alignment.append((j, best_alignment_point))
+            best_alignment.append((j, best_alignment_point))
 
         sentence_pair.alignment = Alignment(best_alignment)

--- a/nltk/align/ibm3.py
+++ b/nltk/align/ibm3.py
@@ -208,7 +208,7 @@ class IBMModel3(IBMModel):
                 m = len(aligned_sentence.words)
 
                 # Sample the alignment space
-                sampled_alignments = self.sample(src_sentence, trg_sentence)
+                sampled_alignments = self.sample(aligned_sentence)
 
                 total_count = 0.0
 

--- a/nltk/align/ibm3.py
+++ b/nltk/align/ibm3.py
@@ -87,29 +87,49 @@ class IBMModel3(IBMModel):
     Translation model that considers how a word can be aligned to
     multiple words in another language
 
-    >>> align_sents = []
-    >>> align_sents.append(AlignedSent(['klein', 'ist', 'das', 'Haus'], ['the', 'house', 'is', 'small']))
-    >>> align_sents.append(AlignedSent(['das', 'Haus', 'ist', 'ja', 'groß'], ['the', 'house', 'is', 'big']))
-    >>> align_sents.append(AlignedSent(['das', 'Haus'], ['the', 'house']))
-    >>> align_sents.append(AlignedSent(['das', 'Buch'], ['the', 'book']))
-    >>> align_sents.append(AlignedSent(['ein', 'Buch'], ['a', 'book']))
+    >>> bitext = []
+    >>> bitext.append(AlignedSent(['klein', 'ist', 'das', 'haus'], ['the', 'house', 'is', 'small']))
+    >>> bitext.append(AlignedSent(['das', 'haus', 'ist', 'ja', 'groß'], ['the', 'house', 'is', 'big']))
+    >>> bitext.append(AlignedSent(['das', 'buch', 'ist', 'ja', 'klein'], ['the', 'book', 'is', 'small']))
+    >>> bitext.append(AlignedSent(['das', 'haus'], ['the', 'house']))
+    >>> bitext.append(AlignedSent(['das', 'buch'], ['the', 'book']))
+    >>> bitext.append(AlignedSent(['ein', 'buch'], ['a', 'book']))
+    >>> bitext.append(AlignedSent(['ich', 'fasse', 'das', 'buch', 'zusammen'], ['i', 'summarize', 'the', 'book']))
+    >>> bitext.append(AlignedSent(['fasse', 'zusammen'], ['summarize']))
 
-    >>> ibm3 = IBMModel3(align_sents, 5)
+    >>> ibm3 = IBMModel3(bitext, 5)
 
-    >>> print('{0:.1f}'.format(ibm3.translation_table['Buch']['book']))
-    1.0
-    >>> print('{0:.1f}'.format(ibm3.translation_table['das']['book']))
-    0.0
-    >>> print('{0:.1f}'.format(ibm3.translation_table[None]['book']))
-    0.0
+    >>> print('{0:.3f}'.format(ibm3.translation_table['buch']['book']))
+    1.000
+    >>> print('{0:.3f}'.format(ibm3.translation_table['das']['book']))
+    0.000
+    >>> print('{0:.3f}'.format(ibm3.translation_table['ja'][None]))
+    1.000
 
-    >>> aligned_sent = ibm3.align(align_sents[0])
-    >>> aligned_sent.words
-    ['klein', 'ist', 'das', 'Haus']
-    >>> aligned_sent.mots
-    ['the', 'house', 'is', 'small']
-    >>> aligned_sent.alignment
-    Alignment([(0, 3), (1, 2), (2, 0), (3, 1)])
+    >>> print('{0:.3f}'.format(ibm3.distortion_table[1][1][2][2]))
+    1.000
+    >>> print('{0:.3f}'.format(ibm3.distortion_table[1][2][2][2]))
+    0.000
+    >>> print('{0:.3f}'.format(ibm3.distortion_table[2][2][4][5]))
+    0.750
+
+    >>> print('{0:.3f}'.format(ibm3.fertility_table[2]['summarize']))
+    1.000
+    >>> print('{0:.3f}'.format(ibm3.fertility_table[1]['book']))
+    1.000
+
+    >>> print('{0:.3f}'.format(ibm3.p1))
+    0.012
+
+    >>> test_sentence = bitext[2]
+    >>> test_sentence.words
+    ['das', 'buch', 'ist', 'ja', 'klein']
+    >>> test_sentence.mots
+    ['the', 'book', 'is', 'small']
+
+    >>> aligned_sentence = ibm3.align(test_sentence)
+    >>> aligned_sentence.alignment
+    Alignment([(0, 0), (1, 1), (2, 2), (4, 3)])
 
     """
 

--- a/nltk/align/ibm3.py
+++ b/nltk/align/ibm3.py
@@ -151,7 +151,6 @@ class IBMModel3(IBMModel):
         :param iterations: Number of iterations to run training algorithm
         :type iterations: int
         """
-
         super(IBMModel3, self).__init__(sentence_aligned_corpus)
 
         self.distortion_table = defaultdict(
@@ -208,7 +207,7 @@ class IBMModel3(IBMModel):
 
             for aligned_sentence in parallel_corpus:
                 src_sentence = [None] + aligned_sentence.mots
-                trg_sentence = ['UNUSED'] + aligned_sentence.words # 1-indexed
+                trg_sentence = ['UNUSED'] + aligned_sentence.words  # 1-indexed
                 l = len(aligned_sentence.mots)
                 m = len(aligned_sentence.words)
 
@@ -305,10 +304,9 @@ class IBMModel3(IBMModel):
         Probability of target sentence and an alignment given the
         source sentence
         """
-
         src_sentence = alignment_info.src_sentence
         trg_sentence = alignment_info.trg_sentence
-        l = len(src_sentence) - 1 # exclude NULL
+        l = len(src_sentence) - 1  # exclude NULL
         m = len(trg_sentence) - 1
         p1 = self.p1
         p0 = 1 - p1
@@ -368,7 +366,6 @@ class IBMModel3(IBMModel):
         :return: ``AlignedSent`` filled in with the best word alignment
         :rtype: AlignedSent
         """
-
         if self.translation_table is None or self.distortion_table is None:
             raise ValueError("The model has not been trained.")
 

--- a/nltk/align/ibm3.py
+++ b/nltk/align/ibm3.py
@@ -127,10 +127,6 @@ class IBMModel3(IBMModel):
     >>> test_sentence.mots
     ['the', 'book', 'is', 'small']
 
-    >>> aligned_sentence = ibm3.align(test_sentence)
-    >>> aligned_sentence.alignment
-    Alignment([(0, 0), (1, 1), (2, 2), (4, 3)])
-
     """
 
     def __init__(self, sentence_aligned_corpus, iterations):
@@ -347,49 +343,3 @@ class IBMModel3(IBMModel):
                 return MIN_PROB
 
         return probability
-
-    def align(self, sentence_pair):
-        """
-        Determines the best word alignment for one sentence pair from
-        the corpus that the model was trained on.
-
-        The original sentence pair is not modified. Results are
-        undefined if ``sentence_pair`` is not in the training set.
-
-        Note that the algorithm used is not strictly Model 3, because
-        fertilities and NULL insertion probabilities are ignored.
-
-        :param sentence_pair: A sentence in the source language and its
-            counterpart sentence in the target language
-        :type sentence_pair: AlignedSent
-
-        :return: ``AlignedSent`` filled in with the best word alignment
-        :rtype: AlignedSent
-        """
-        if self.translation_table is None or self.distortion_table is None:
-            raise ValueError("The model has not been trained.")
-
-        alignment = []
-
-        l = len(sentence_pair.mots)
-        m = len(sentence_pair.words)
-
-        for j, trg_word in enumerate(sentence_pair.words):
-            # Initialize trg_word to align with the NULL token
-            best_prob = (self.translation_table[trg_word][None] *
-                         self.distortion_table[j + 1][0][l][m])
-            best_prob = max(best_prob, IBMModel.MIN_PROB)
-            best_alignment = None
-            for i, src_word in enumerate(sentence_pair.mots):
-                align_prob = (self.translation_table[trg_word][src_word] *
-                              self.distortion_table[j + 1][i + 1][l][m])
-                if align_prob >= best_prob:
-                    best_prob = align_prob
-                    best_alignment = i
-
-            # If trg_word is not aligned to the NULL token,
-            # add it to the viterbi_alignment.
-            if best_alignment is not None:
-                alignment.append((j, best_alignment))
-
-        return AlignedSent(sentence_pair.words, sentence_pair.mots, alignment)

--- a/nltk/align/ibm3.py
+++ b/nltk/align/ibm3.py
@@ -76,6 +76,7 @@ Translation: Parameter Estimation. Computational Linguistics, 19 (2),
 from __future__ import division
 from collections import defaultdict
 from nltk.align import AlignedSent
+from nltk.align import Alignment
 from nltk.align.ibm_model import IBMModel
 from nltk.align.ibm2 import IBMModel2
 from math import factorial
@@ -91,6 +92,7 @@ class IBMModel3(IBMModel):
     >>> bitext.append(AlignedSent(['klein', 'ist', 'das', 'haus'], ['the', 'house', 'is', 'small']))
     >>> bitext.append(AlignedSent(['das', 'haus', 'ist', 'ja', 'groß'], ['the', 'house', 'is', 'big']))
     >>> bitext.append(AlignedSent(['das', 'buch', 'ist', 'ja', 'klein'], ['the', 'book', 'is', 'small']))
+    >>> bitext.append(AlignedSent(['ein', 'haus', 'ist', 'klein'], ['a', 'house', 'is', 'small']))
     >>> bitext.append(AlignedSent(['das', 'haus'], ['the', 'house']))
     >>> bitext.append(AlignedSent(['das', 'buch'], ['the', 'book']))
     >>> bitext.append(AlignedSent(['ein', 'buch'], ['a', 'book']))
@@ -119,13 +121,15 @@ class IBMModel3(IBMModel):
     1.000
 
     >>> print('{0:.3f}'.format(ibm3.p1))
-    0.012
+    0.026
 
     >>> test_sentence = bitext[2]
     >>> test_sentence.words
     ['das', 'buch', 'ist', 'ja', 'klein']
     >>> test_sentence.mots
     ['the', 'book', 'is', 'small']
+    >>> test_sentence.alignment
+    Alignment([(0, 0), (1, 1), (2, 2), (3, None), (4, 3)])
 
     """
 
@@ -208,7 +212,11 @@ class IBMModel3(IBMModel):
                 m = len(aligned_sentence.words)
 
                 # Sample the alignment space
-                sampled_alignments = self.sample(aligned_sentence)
+                sampled_alignments, best_alignment = self.sample(
+                    aligned_sentence)
+                # Record the most probable alignment
+                aligned_sentence.alignment = Alignment(
+                    best_alignment.zero_indexed_alignment())
 
                 total_count = 0.0
 

--- a/nltk/align/ibm3.py
+++ b/nltk/align/ibm3.py
@@ -75,11 +75,11 @@ Translation: Parameter Estimation. Computational Linguistics, 19 (2),
 
 from __future__ import division
 from collections import defaultdict
+from math import factorial
 from nltk.align import AlignedSent
 from nltk.align import Alignment
-from nltk.align.ibm_model import IBMModel
-from nltk.align.ibm2 import IBMModel2
-from math import factorial
+from nltk.align import IBMModel
+from nltk.align import IBMModel2
 import warnings
 
 

--- a/nltk/align/ibm4.py
+++ b/nltk/align/ibm4.py
@@ -157,7 +157,7 @@ class IBMModel4(IBMModel):
 
     def __init__(self, sentence_aligned_corpus, iterations,
                  source_word_classes, target_word_classes,
-                 probability_tables = None):
+                 probability_tables=None):
         """
         Train on ``sentence_aligned_corpus`` and create a lexical
         translation model, distortion models, a fertility model, and a
@@ -275,7 +275,7 @@ class IBMModel4(IBMModel):
 
         for aligned_sentence in parallel_corpus:
             src_sentence = [None] + aligned_sentence.mots
-            trg_sentence = ['UNUSED'] + aligned_sentence.words # 1-indexed
+            trg_sentence = ['UNUSED'] + aligned_sentence.words  # 1-indexed
             m = len(aligned_sentence.words)
 
             # Sample the alignment space
@@ -335,7 +335,7 @@ class IBMModel4(IBMModel):
         """
         return IBMModel4.model4_prob_t_a_given_s(alignment_info, self)
 
-    @staticmethod # exposed for Model 5 to use
+    @staticmethod  # exposed for Model 5 to use
     def model4_prob_t_a_given_s(alignment_info, ibm_model):
         probability = 1.0
         MIN_PROB = IBMModel.MIN_PROB

--- a/nltk/align/ibm4.py
+++ b/nltk/align/ibm4.py
@@ -117,23 +117,41 @@ class IBMModel4(IBMModel):
     Translation model that reorders output words based on their type and
     their distance from other related words in the output sentence
 
-    >>> align_sents = []
-    >>> align_sents.append(AlignedSent(['klein', 'ist', 'das', 'Haus'], ['the', 'house', 'is', 'small']))
-    >>> align_sents.append(AlignedSent(['das', 'Haus', 'ist', 'ja', 'groß'], ['the', 'house', 'is', 'big']))
-    >>> align_sents.append(AlignedSent(['das', 'Haus'], ['the', 'house']))
-    >>> align_sents.append(AlignedSent(['das', 'Buch'], ['the', 'book']))
-    >>> align_sents.append(AlignedSent(['ein', 'Buch'], ['a', 'book']))
-    >>> src_classes = {'a': 0, 'big': 1, 'book': 2, 'house': 2, 'is': 3, 'small': 1, 'the': 0 }
-    >>> trg_classes = {'das': 0, 'Buch': 1, 'ein': 0, 'groß': 2, 'Haus': 1, 'ist': 3, 'ja': 4, 'klein': 2 }
+    >>> bitext = []
+    >>> bitext.append(AlignedSent(['klein', 'ist', 'das', 'haus'], ['the', 'house', 'is', 'small']))
+    >>> bitext.append(AlignedSent(['das', 'haus', 'ist', 'ja', 'groß'], ['the', 'house', 'is', 'big']))
+    >>> bitext.append(AlignedSent(['das', 'buch', 'ist', 'ja', 'klein'], ['the', 'book', 'is', 'small']))
+    >>> bitext.append(AlignedSent(['das', 'haus'], ['the', 'house']))
+    >>> bitext.append(AlignedSent(['das', 'buch'], ['the', 'book']))
+    >>> bitext.append(AlignedSent(['ein', 'buch'], ['a', 'book']))
+    >>> bitext.append(AlignedSent(['ich', 'fasse', 'das', 'buch', 'zusammen'], ['i', 'summarize', 'the', 'book']))
+    >>> bitext.append(AlignedSent(['fasse', 'zusammen'], ['summarize']))
+    >>> src_classes = {'the': 0, 'a': 0, 'small': 1, 'big': 1, 'house': 2, 'book': 2, 'is': 3, 'i': 4, 'summarize': 5 }
+    >>> trg_classes = {'das': 0, 'ein': 0, 'haus': 1, 'buch': 1, 'klein': 2, 'groß': 2, 'ist': 3, 'ja': 4, 'ich': 5, 'fasse': 6, 'zusammen': 6 }
 
-    >>> ibm4 = IBMModel4(align_sents, 5, src_classes, trg_classes)
+    >>> ibm4 = IBMModel4(bitext, 5, src_classes, trg_classes)
 
-    >>> print('{0:.1f}'.format(ibm4.translation_table['Buch']['book']))
-    1.0
-    >>> print('{0:.1f}'.format(ibm4.translation_table['das']['book']))
-    0.0
-    >>> print('{0:.1f}'.format(ibm4.translation_table[None]['book']))
-    0.0
+    >>> print('{0:.3f}'.format(ibm4.translation_table['buch']['book']))
+    1.000
+    >>> print('{0:.3f}'.format(ibm4.translation_table['das']['book']))
+    0.000
+    >>> print('{0:.3f}'.format(ibm4.translation_table['ja'][None]))
+    0.971
+
+    >>> print('{0:.3f}'.format(ibm4.head_distortion_table[1][0][1]))
+    1.000
+    >>> print('{0:.3f}'.format(ibm4.head_distortion_table[2][0][1]))
+    0.000
+    >>> print('{0:.3f}'.format(ibm4.non_head_distortion_table[3][6]))
+    0.500
+
+    >>> print('{0:.3f}'.format(ibm4.fertility_table[2]['summarize']))
+    1.000
+    >>> print('{0:.3f}'.format(ibm4.fertility_table[1]['book']))
+    1.000
+
+    >>> print('{0:.3f}'.format(ibm4.p1))
+    0.000
 
     """
 

--- a/nltk/align/ibm4.py
+++ b/nltk/align/ibm4.py
@@ -104,6 +104,7 @@ Translation: Parameter Estimation. Computational Linguistics, 19 (2),
 from __future__ import division
 from collections import defaultdict
 from nltk.align import AlignedSent
+from nltk.align import Alignment
 from nltk.align.ibm_model import Counts
 from nltk.align.ibm_model import IBMModel
 from nltk.align.ibm_model import longest_target_sentence_length
@@ -121,6 +122,7 @@ class IBMModel4(IBMModel):
     >>> bitext.append(AlignedSent(['klein', 'ist', 'das', 'haus'], ['the', 'house', 'is', 'small']))
     >>> bitext.append(AlignedSent(['das', 'haus', 'ist', 'ja', 'groß'], ['the', 'house', 'is', 'big']))
     >>> bitext.append(AlignedSent(['das', 'buch', 'ist', 'ja', 'klein'], ['the', 'book', 'is', 'small']))
+    >>> bitext.append(AlignedSent(['ein', 'haus', 'ist', 'klein'], ['a', 'house', 'is', 'small']))
     >>> bitext.append(AlignedSent(['das', 'haus'], ['the', 'house']))
     >>> bitext.append(AlignedSent(['das', 'buch'], ['the', 'book']))
     >>> bitext.append(AlignedSent(['ein', 'buch'], ['a', 'book']))
@@ -136,7 +138,7 @@ class IBMModel4(IBMModel):
     >>> print('{0:.3f}'.format(ibm4.translation_table['das']['book']))
     0.000
     >>> print('{0:.3f}'.format(ibm4.translation_table['ja'][None]))
-    0.971
+    1.000
 
     >>> print('{0:.3f}'.format(ibm4.head_distortion_table[1][0][1]))
     1.000
@@ -151,7 +153,15 @@ class IBMModel4(IBMModel):
     1.000
 
     >>> print('{0:.3f}'.format(ibm4.p1))
-    0.000
+    0.033
+
+    >>> test_sentence = bitext[2]
+    >>> test_sentence.words
+    ['das', 'buch', 'ist', 'ja', 'klein']
+    >>> test_sentence.mots
+    ['the', 'book', 'is', 'small']
+    >>> test_sentence.alignment
+    Alignment([(0, 0), (1, 1), (2, 2), (3, None), (4, 3)])
 
     """
 
@@ -277,7 +287,10 @@ class IBMModel4(IBMModel):
             m = len(aligned_sentence.words)
 
             # Sample the alignment space
-            sampled_alignments = self.sample(aligned_sentence)
+            sampled_alignments, best_alignment = self.sample(aligned_sentence)
+            # Record the most probable alignment
+            aligned_sentence.alignment = Alignment(
+                best_alignment.zero_indexed_alignment())
 
             # E step (a): Compute normalization factors to weigh counts
             total_count = self.prob_of_alignments(sampled_alignments)

--- a/nltk/align/ibm4.py
+++ b/nltk/align/ibm4.py
@@ -103,13 +103,13 @@ Translation: Parameter Estimation. Computational Linguistics, 19 (2),
 
 from __future__ import division
 from collections import defaultdict
+from math import factorial
 from nltk.align import AlignedSent
 from nltk.align import Alignment
+from nltk.align import IBMModel
+from nltk.align import IBMModel3
 from nltk.align.ibm_model import Counts
-from nltk.align.ibm_model import IBMModel
 from nltk.align.ibm_model import longest_target_sentence_length
-from nltk.align.ibm3 import IBMModel3
-from math import factorial
 import warnings
 
 

--- a/nltk/align/ibm4.py
+++ b/nltk/align/ibm4.py
@@ -274,12 +274,10 @@ class IBMModel4(IBMModel):
         counts = Model4Counts()
 
         for aligned_sentence in parallel_corpus:
-            src_sentence = [None] + aligned_sentence.mots
-            trg_sentence = ['UNUSED'] + aligned_sentence.words  # 1-indexed
             m = len(aligned_sentence.words)
 
             # Sample the alignment space
-            sampled_alignments = self.sample(src_sentence, trg_sentence)
+            sampled_alignments = self.sample(aligned_sentence)
 
             # E step (a): Compute normalization factors to weigh counts
             total_count = self.prob_of_alignments(sampled_alignments)

--- a/nltk/align/ibm5.py
+++ b/nltk/align/ibm5.py
@@ -127,23 +127,34 @@ class IBMModel5(IBMModel):
     Translation model that keeps track of vacant positions in the target
     sentence to decide where to place translated words
 
-    >>> align_sents = []
-    >>> align_sents.append(AlignedSent(['klein', 'ist', 'das', 'Haus'], ['the', 'house', 'is', 'small']))
-    >>> align_sents.append(AlignedSent(['das', 'Haus', 'ist', 'ja', 'groß'], ['the', 'house', 'is', 'big']))
-    >>> align_sents.append(AlignedSent(['das', 'Haus'], ['the', 'house']))
-    >>> align_sents.append(AlignedSent(['das', 'Buch'], ['the', 'book']))
-    >>> align_sents.append(AlignedSent(['ein', 'Buch'], ['a', 'book']))
-    >>> src_classes = {'a': 0, 'big': 1, 'book': 2, 'house': 2, 'is': 3, 'small': 1, 'the': 0 }
-    >>> trg_classes = {'das': 0, 'Buch': 1, 'ein': 0, 'groß': 2, 'Haus': 1, 'ist': 3, 'ja': 4, 'klein': 2 }
+    >>> bitext = []
+    >>> bitext.append(AlignedSent(['klein', 'ist', 'das', 'haus'], ['the', 'house', 'is', 'small']))
+    >>> bitext.append(AlignedSent(['das', 'haus', 'ist', 'ja', 'groß'], ['the', 'house', 'is', 'big']))
+    >>> bitext.append(AlignedSent(['das', 'buch', 'ist', 'ja', 'klein'], ['the', 'book', 'is', 'small']))
+    >>> bitext.append(AlignedSent(['das', 'haus'], ['the', 'house']))
+    >>> bitext.append(AlignedSent(['das', 'buch'], ['the', 'book']))
+    >>> bitext.append(AlignedSent(['ein', 'buch'], ['a', 'book']))
+    >>> bitext.append(AlignedSent(['ich', 'fasse', 'das', 'buch', 'zusammen'], ['i', 'summarize', 'the', 'book']))
+    >>> bitext.append(AlignedSent(['fasse', 'zusammen'], ['summarize']))
+    >>> src_classes = {'the': 0, 'a': 0, 'small': 1, 'big': 1, 'house': 2, 'book': 2, 'is': 3, 'i': 4, 'summarize': 5 }
+    >>> trg_classes = {'das': 0, 'ein': 0, 'haus': 1, 'buch': 1, 'klein': 2, 'groß': 2, 'ist': 3, 'ja': 4, 'ich': 5, 'fasse': 6, 'zusammen': 6 }
 
-    >>> ibm5 = IBMModel5(align_sents, 5, src_classes, trg_classes)
+    >>> ibm5 = IBMModel5(bitext, 5, src_classes, trg_classes)
 
-    >>> print('{0:.1f}'.format(ibm5.translation_table['Buch']['book']))
-    1.0
-    >>> print('{0:.1f}'.format(ibm5.translation_table['das']['book']))
-    0.0
-    >>> print('{0:.1f}'.format(ibm5.translation_table[None]['book']))
-    0.0
+    >>> print('{0:.3f}'.format(ibm5.head_vacancy_table[1][1][1]))
+    1.000
+    >>> print('{0:.3f}'.format(ibm5.head_vacancy_table[2][1][1]))
+    0.000
+    >>> print('{0:.3f}'.format(ibm5.non_head_vacancy_table[3][3][6]))
+    1.000
+
+    >>> print('{0:.3f}'.format(ibm5.fertility_table[2]['summarize']))
+    1.000
+    >>> print('{0:.3f}'.format(ibm5.fertility_table[1]['book']))
+    1.000
+
+    >>> print('{0:.3f}'.format(ibm5.p1))
+    0.000
 
     """
     MIN_SCORE_FACTOR = 0.2

--- a/nltk/align/ibm5.py
+++ b/nltk/align/ibm5.py
@@ -113,13 +113,13 @@ Translation: Parameter Estimation. Computational Linguistics, 19 (2),
 
 from __future__ import division
 from collections import defaultdict
+from math import factorial
 from nltk.align import AlignedSent
 from nltk.align import Alignment
+from nltk.align import IBMModel
+from nltk.align import IBMModel4
 from nltk.align.ibm_model import Counts
-from nltk.align.ibm_model import IBMModel
 from nltk.align.ibm_model import longest_target_sentence_length
-from nltk.align.ibm4 import IBMModel4
-from math import factorial
 import warnings
 
 

--- a/nltk/align/ibm5.py
+++ b/nltk/align/ibm5.py
@@ -286,13 +286,11 @@ class IBMModel5(IBMModel):
         counts = Model5Counts()
 
         for aligned_sentence in parallel_corpus:
-            src_sentence = [None] + aligned_sentence.mots
-            trg_sentence = ['UNUSED'] + aligned_sentence.words  # 1-indexed
             l = len(aligned_sentence.mots)
             m = len(aligned_sentence.words)
 
             # Sample the alignment space
-            sampled_alignments = self.sample(src_sentence, trg_sentence)
+            sampled_alignments = self.sample(aligned_sentence)
 
             # E step (a): Compute normalization factors to weigh counts
             total_count = self.prob_of_alignments(sampled_alignments)
@@ -327,7 +325,7 @@ class IBMModel5(IBMModel):
         self.maximize_fertility_probabilities(counts)
         self.maximize_null_generation_probabilities(counts)
 
-    def sample(self, src_sentence, trg_sentence):
+    def sample(self, sentence_pair):
         """
         Sample the most probable alignments from the entire alignment
         space according to Model 4
@@ -343,19 +341,14 @@ class IBMModel5(IBMModel):
         alignment point. Finally, prune alignments that have
         substantially lower Model 4 scores than the best alignment.
 
-        :param src_sentence: 1-indexed source sentence. Zeroeth element
-            should be None.
-        :type src_sentence: list(str)
-
-        :param trg_sentence: 1-indexed target sentence. Zeroeth element
-            will be ignored.
-        :type trg_sentence: list(str)
+        :param sentence_pair: Source and target language sentence pair
+            to generate a sample of alignments from
+        :type sentence_pair: AlignedSent
 
         :return: A set of best alignments represented by their ``AlignmentInfo``
         :rtype: set(AlignmentInfo)
         """
-        sampled_alignments = super(IBMModel5, self).sample(
-            src_sentence, trg_sentence)
+        sampled_alignments = super(IBMModel5, self).sample(sentence_pair)
         return self.prune(sampled_alignments)
 
     def prune(self, alignment_infos):

--- a/nltk/align/ibm5.py
+++ b/nltk/align/ibm5.py
@@ -164,7 +164,7 @@ class IBMModel5(IBMModel):
 
     def __init__(self, sentence_aligned_corpus, iterations,
                  source_word_classes, target_word_classes,
-                 probability_tables = None):
+                 probability_tables=None):
         """
         Train on ``sentence_aligned_corpus`` and create a lexical
         translation model, vacancy models, a fertility model, and a
@@ -287,7 +287,7 @@ class IBMModel5(IBMModel):
 
         for aligned_sentence in parallel_corpus:
             src_sentence = [None] + aligned_sentence.mots
-            trg_sentence = ['UNUSED'] + aligned_sentence.words # 1-indexed
+            trg_sentence = ['UNUSED'] + aligned_sentence.words  # 1-indexed
             l = len(aligned_sentence.mots)
             m = len(aligned_sentence.words)
 
@@ -378,7 +378,7 @@ class IBMModel5(IBMModel):
         alignments = [a[0] for a in alignments if a[1] > threshold]
         return set(alignments)
 
-    def hillclimb(self, alignment_info, j_pegged = None):
+    def hillclimb(self, alignment_info, j_pegged=None):
         """
         Starting from the alignment in ``alignment_info``, look at
         neighboring alignments iteratively for the best one, according
@@ -398,7 +398,7 @@ class IBMModel5(IBMModel):
         :return: The best alignment found from hill climbing
         :rtype: AlignmentInfo
         """
-        alignment = alignment_info # alias with shorter name
+        alignment = alignment_info  # alias with shorter name
         max_probability = IBMModel4.model4_prob_t_a_given_s(alignment, self)
 
         while True:
@@ -477,7 +477,7 @@ class IBMModel5(IBMModel):
             max_v = total_vacancies - tablet_length + 1
             trg_class = self.trg_classes[alignment_info.trg_sentence[j]]
             value *= self.head_vacancy_table[dv][max_v][trg_class]
-            slots.occupy(j) # mark position as occupied
+            slots.occupy(j)  # mark position as occupied
             total_vacancies -= 1
             if value < MIN_PROB:
                 return MIN_PROB
@@ -492,7 +492,7 @@ class IBMModel5(IBMModel):
                          previous_vacancies)
                 trg_class = self.trg_classes[alignment_info.trg_sentence[j]]
                 value *= self.non_head_vacancy_table[dv][max_v][trg_class]
-                slots.occupy(j) # mark position as occupied
+                slots.occupy(j)  # mark position as occupied
                 total_vacancies -= 1
                 if value < MIN_PROB:
                     return MIN_PROB
@@ -576,7 +576,7 @@ class Model5Counts(Counts):
 
         # case 1: NULL aligned words
         if tablet_length == 0:
-            return # ignore zero fertility words
+            return  # ignore zero fertility words
 
         # case 2: head word
         j = tablet[0]
@@ -587,7 +587,7 @@ class Model5Counts(Counts):
         trg_class = trg_classes[alignment_info.trg_sentence[j]]
         self.head_vacancy[dv][max_v][trg_class] += count
         self.head_vacancy_for_any_dv[max_v][trg_class] += count
-        slots.occupy(j) # mark position as occupied
+        slots.occupy(j)  # mark position as occupied
         total_vacancies -= 1
 
         # case 3: non-head words
@@ -601,7 +601,7 @@ class Model5Counts(Counts):
             trg_class = trg_classes[alignment_info.trg_sentence[j]]
             self.non_head_vacancy[dv][max_v][trg_class] += count
             self.non_head_vacancy_for_any_dv[max_v][trg_class] += count
-            slots.occupy(j) # mark position as occupied
+            slots.occupy(j)  # mark position as occupied
             total_vacancies -= 1
 
 
@@ -611,7 +611,7 @@ class Slots(object):
     which slot (position) is occupied.
     """
     def __init__(self, target_sentence_length):
-        self._slots = [False] * (target_sentence_length + 1) # 1-indexed
+        self._slots = [False] * (target_sentence_length + 1)  # 1-indexed
 
     def occupy(self, position):
         """
@@ -630,4 +630,4 @@ class Slots(object):
         return vacancies
 
     def __len__(self):
-        return len(self._slots) - 1 # exclude dummy zeroeth element
+        return len(self._slots) - 1  # exclude dummy zeroeth element

--- a/nltk/align/ibm5.py
+++ b/nltk/align/ibm5.py
@@ -408,6 +408,7 @@ class IBMModel5(IBMModel):
                 # Until there are no better alignments
                 break
 
+        alignment.score = max_probability
         return alignment
 
     def prob_t_a_given_s(self, alignment_info):

--- a/nltk/align/ibm_model.py
+++ b/nltk/align/ibm_model.py
@@ -68,7 +68,7 @@ class IBMModel(object):
     # incorrect, since it may create probabilities that sum to more
     # than 1. In practice, the contribution of probabilities with MIN_PROB
     # is tiny enough that the value of MIN_PROB can be treated as zero.
-    MIN_PROB = 1.0e-12 # GIZA++ is more liberal and uses 1.0e-7
+    MIN_PROB = 1.0e-12  # GIZA++ is more liberal and uses 1.0e-7
 
     def __init__(self, sentence_aligned_corpus):
         self.init_vocab(sentence_aligned_corpus)
@@ -153,7 +153,7 @@ class IBMModel(object):
         """
         sampled_alignments = set()
 
-        l = len(src_sentence) - 1 # exclude NULL
+        l = len(src_sentence) - 1  # exclude NULL
         m = len(trg_sentence) - 1
 
         # Start from the best model 2 alignment
@@ -175,7 +175,7 @@ class IBMModel(object):
         return sampled_alignments
 
     def best_model2_alignment(self, src_sentence, trg_sentence,
-                              j_pegged = None, i_pegged = 0):
+                              j_pegged=None, i_pegged=0):
         """
         Finds the best alignment according to IBM Model 2
 
@@ -198,11 +198,11 @@ class IBMModel(object):
         :param i_pegged: Alignment point to j_pegged
         :type i_pegged: int
         """
-        l = len(src_sentence) - 1 # exclude NULL
+        l = len(src_sentence) - 1  # exclude NULL
         m = len(trg_sentence) - 1
 
-        alignment = [0] * (m + 1) # Initialize all alignments to NULL
-        cepts = [[] for i in range((l + 1))] # Initialize all cepts to empty list
+        alignment = [0] * (m + 1)  # init all alignments to NULL
+        cepts = [[] for i in range((l + 1))]  # init all cepts to empty list
 
         for j in range(1, m + 1):
             if j == j_pegged:
@@ -228,7 +228,7 @@ class IBMModel(object):
         return AlignmentInfo(tuple(alignment), tuple(src_sentence),
                              tuple(trg_sentence), cepts)
 
-    def hillclimb(self, alignment_info, j_pegged = None):
+    def hillclimb(self, alignment_info, j_pegged=None):
         """
         Starting from the alignment in ``alignment_info``, look at
         neighboring alignments iteratively for the best one
@@ -244,7 +244,7 @@ class IBMModel(object):
         :return: The best alignment found from hill climbing
         :rtype: AlignmentInfo
         """
-        alignment = alignment_info # alias with shorter name
+        alignment = alignment_info  # alias with shorter name
         max_probability = self.prob_t_a_given_s(alignment)
 
         while True:
@@ -262,7 +262,7 @@ class IBMModel(object):
 
         return alignment
 
-    def neighboring(self, alignment_info, j_pegged = None):
+    def neighboring(self, alignment_info, j_pegged=None):
         """
         Determine the neighbors of ``alignment_info``, obtained by
         moving or swapping one alignment point
@@ -277,7 +277,7 @@ class IBMModel(object):
         """
         neighbors = set()
 
-        l = len(alignment_info.src_sentence) - 1 # exclude NULL
+        l = len(alignment_info.src_sentence) - 1  # exclude NULL
         m = len(alignment_info.trg_sentence) - 1
         original_alignment = alignment_info.alignment
         original_cepts = alignment_info.cepts

--- a/nltk/align/ibm_model.py
+++ b/nltk/align/ibm_model.py
@@ -42,6 +42,7 @@ from bisect import insort_left
 from collections import defaultdict
 from copy import deepcopy
 from math import ceil
+from nltk.align import Alignment
 
 
 def longest_target_sentence_length(sentence_aligned_corpus):
@@ -252,6 +253,7 @@ class IBMModel(object):
                 # Until there are no better alignments
                 break
 
+        alignment.score = max_probability
         return alignment
 
     def neighboring(self, alignment_info, j_pegged=None):
@@ -405,6 +407,12 @@ class AlignmentInfo(object):
         cepts[4] = (2, 3, 7) means that words in positions 2, 3 and 7
         of the target sentence are aligned to the word in position 4 of
         the source sentence
+        """
+
+        self.score = None
+        """
+        float: Optional. Probability of alignment, as defined by the
+        IBM model that assesses this alignment
         """
 
     def fertility_of_i(self, i):

--- a/nltk/test/unit/align/test_ibm2.py
+++ b/nltk/test/unit/align/test_ibm2.py
@@ -33,12 +33,12 @@ class TestIBMModel2(unittest.TestCase):
         alignment_table = defaultdict(
             lambda: defaultdict(lambda: defaultdict(
                 lambda: defaultdict(float))))
-        alignment_table[0][3][5][6] = 0.97 # None -> to
-        alignment_table[1][1][5][6] = 0.97 # ich -> i
-        alignment_table[2][4][5][6] = 0.97 # esse -> eat
-        alignment_table[4][2][5][6] = 0.97 # gern -> love
-        alignment_table[5][5][5][6] = 0.96 # räucherschinken -> smoked
-        alignment_table[5][6][5][6] = 0.96 # räucherschinken -> ham
+        alignment_table[0][3][5][6] = 0.97  # None -> to
+        alignment_table[1][1][5][6] = 0.97  # ich -> i
+        alignment_table[2][4][5][6] = 0.97  # esse -> eat
+        alignment_table[4][2][5][6] = 0.97  # gern -> love
+        alignment_table[5][5][5][6] = 0.96  # räucherschinken -> smoked
+        alignment_table[5][6][5][6] = 0.96  # räucherschinken -> ham
 
         model2 = IBMModel2(corpus, 0)
         model2.translation_table = translation_table

--- a/nltk/test/unit/align/test_ibm4.py
+++ b/nltk/test/unit/align/test_ibm4.py
@@ -77,13 +77,13 @@ class TestIBMModel4(unittest.TestCase):
 
         head_distortion_table = defaultdict(
             lambda: defaultdict(lambda: defaultdict(float)))
-        head_distortion_table[1][None][3] = 0.97 # None, i
-        head_distortion_table[3][2][4] = 0.97 # ich, eat
-        head_distortion_table[-2][3][4] = 0.97 # esse, love
-        head_distortion_table[3][4][1] = 0.97 # gern, smoked
+        head_distortion_table[1][None][3] = 0.97  # None, i
+        head_distortion_table[3][2][4] = 0.97  # ich, eat
+        head_distortion_table[-2][3][4] = 0.97  # esse, love
+        head_distortion_table[3][4][1] = 0.97  # gern, smoked
 
         non_head_distortion_table = defaultdict(lambda: defaultdict(float))
-        non_head_distortion_table[1][0] = 0.96 # ham
+        non_head_distortion_table[1][0] = 0.96  # ham
 
         translation_table = defaultdict(lambda: defaultdict(float))
         translation_table['i']['ich'] = 0.98

--- a/nltk/test/unit/align/test_ibm5.py
+++ b/nltk/test/unit/align/test_ibm5.py
@@ -80,14 +80,14 @@ class TestIBMModel5(unittest.TestCase):
 
         head_vacancy_table = defaultdict(
             lambda: defaultdict(lambda: defaultdict(float)))
-        head_vacancy_table[1 - 0][6][3] = 0.97 # ich -> i
-        head_vacancy_table[3 - 0][5][4] = 0.97 # esse -> eat
-        head_vacancy_table[1 - 2][4][4] = 0.97 # gern -> love
-        head_vacancy_table[2 - 0][2][1] = 0.97 # räucherschinken -> smoked
+        head_vacancy_table[1 - 0][6][3] = 0.97  # ich -> i
+        head_vacancy_table[3 - 0][5][4] = 0.97  # esse -> eat
+        head_vacancy_table[1 - 2][4][4] = 0.97  # gern -> love
+        head_vacancy_table[2 - 0][2][1] = 0.97  # räucherschinken -> smoked
 
         non_head_vacancy_table = defaultdict(
             lambda: defaultdict(lambda: defaultdict(float)))
-        non_head_vacancy_table[1 - 0][1][0] = 0.96 # räucherschinken -> ham
+        non_head_vacancy_table[1 - 0][1][0] = 0.96  # räucherschinken -> ham
 
         translation_table = defaultdict(lambda: defaultdict(float))
         translation_table['i']['ich'] = 0.98
@@ -149,7 +149,7 @@ class TestIBMModel5(unittest.TestCase):
             (2, 2): min_factor * best_score * 0.5,  # low score
             (0, 0): min(min_factor * 1.1, 1) * 1.2  # above threshold
         }
-        corpus = [AlignedSent(['a'],['b'])]
+        corpus = [AlignedSent(['a'], ['b'])]
         original_prob_function = IBMModel4.model4_prob_t_a_given_s
         # mock static method
         IBMModel4.model4_prob_t_a_given_s = staticmethod(

--- a/nltk/test/unit/align/test_ibm_model.py
+++ b/nltk/test/unit/align/test_ibm_model.py
@@ -12,8 +12,8 @@ from nltk.align.ibm_model import IBMModel
 
 
 class TestIBMModel(unittest.TestCase):
-    __TEST_SRC_SENTENCE = (None, "j'", 'aime', 'bien', 'jambon')
-    __TEST_TRG_SENTENCE = ('UNUSED', 'i', 'love', 'ham')
+    __TEST_SRC_SENTENCE = ["j'", 'aime', 'bien', 'jambon']
+    __TEST_TRG_SENTENCE = ['i', 'love', 'ham']
 
     def test_vocabularies_are_initialized(self):
         parallel_corpora = [
@@ -36,8 +36,9 @@ class TestIBMModel(unittest.TestCase):
 
     def test_best_model2_alignment(self):
         # arrange
-        src_sentence = TestIBMModel.__TEST_SRC_SENTENCE
-        trg_sentence = TestIBMModel.__TEST_TRG_SENTENCE
+        sentence_pair = AlignedSent(
+            TestIBMModel.__TEST_TRG_SENTENCE,
+            TestIBMModel.__TEST_SRC_SENTENCE)
         # None and 'bien' have zero fertility
         translation_table = {
             'i': {"j'": 0.9, 'aime': 0.05, 'bien': 0.02, 'jambon': 0.03,
@@ -56,7 +57,7 @@ class TestIBMModel(unittest.TestCase):
         ibm_model.alignment_table = alignment_table
 
         # act
-        a_info = ibm_model.best_model2_alignment(src_sentence, trg_sentence)
+        a_info = ibm_model.best_model2_alignment(sentence_pair)
 
         # assert
         self.assertEqual(a_info.alignment[1:], (1, 2, 4))  # 0th element unused
@@ -64,8 +65,9 @@ class TestIBMModel(unittest.TestCase):
 
     def test_best_model2_alignment_does_not_change_pegged_alignment(self):
         # arrange
-        src_sentence = TestIBMModel.__TEST_SRC_SENTENCE
-        trg_sentence = TestIBMModel.__TEST_TRG_SENTENCE
+        sentence_pair = AlignedSent(
+            TestIBMModel.__TEST_TRG_SENTENCE,
+            TestIBMModel.__TEST_SRC_SENTENCE)
         translation_table = {
             'i': {"j'": 0.9, 'aime': 0.05, 'bien': 0.02, 'jambon': 0.03,
                   None: 0},
@@ -82,16 +84,16 @@ class TestIBMModel(unittest.TestCase):
         ibm_model.alignment_table = alignment_table
 
         # act: force 'love' to be pegged to 'jambon'
-        a_info = ibm_model.best_model2_alignment(src_sentence, trg_sentence,
-                                                 2, 4)
+        a_info = ibm_model.best_model2_alignment(sentence_pair, 2, 4)
         # assert
         self.assertEqual(a_info.alignment[1:], (1, 4, 4))
         self.assertEqual(a_info.cepts, [[], [1], [], [], [2, 3]])
 
     def test_best_model2_alignment_handles_fertile_words(self):
         # arrange
-        src_sentence = TestIBMModel.__TEST_SRC_SENTENCE
-        trg_sentence = ['UNUSED', 'i', 'really', ',', 'really', 'love', 'ham']
+        sentence_pair = AlignedSent(
+            ['i', 'really', ',', 'really', 'love', 'ham'],
+            TestIBMModel.__TEST_SRC_SENTENCE)
         # 'bien' produces 2 target words: 'really' and another 'really'
         translation_table = {
             'i': {"j'": 0.9, 'aime': 0.05, 'bien': 0.02, 'jambon': 0.03, None: 0},
@@ -109,7 +111,7 @@ class TestIBMModel(unittest.TestCase):
         ibm_model.alignment_table = alignment_table
 
         # act
-        a_info = ibm_model.best_model2_alignment(src_sentence, trg_sentence)
+        a_info = ibm_model.best_model2_alignment(sentence_pair)
 
         # assert
         self.assertEqual(a_info.alignment[1:], (1, 3, 0, 3, 2, 4))
@@ -117,12 +119,11 @@ class TestIBMModel(unittest.TestCase):
 
     def test_best_model2_alignment_handles_empty_src_sentence(self):
         # arrange
-        src_sentence = [None]
-        trg_sentence = TestIBMModel.__TEST_TRG_SENTENCE
+        sentence_pair = AlignedSent(TestIBMModel.__TEST_TRG_SENTENCE, [])
         ibm_model = IBMModel([])
 
         # act
-        a_info = ibm_model.best_model2_alignment(src_sentence, trg_sentence)
+        a_info = ibm_model.best_model2_alignment(sentence_pair)
 
         # assert
         self.assertEqual(a_info.alignment[1:], (0, 0, 0))
@@ -130,12 +131,11 @@ class TestIBMModel(unittest.TestCase):
 
     def test_best_model2_alignment_handles_empty_trg_sentence(self):
         # arrange
-        src_sentence = TestIBMModel.__TEST_SRC_SENTENCE
-        trg_sentence = ['UNUSED']
+        sentence_pair = AlignedSent([], TestIBMModel.__TEST_SRC_SENTENCE)
         ibm_model = IBMModel([])
 
         # act
-        a_info = ibm_model.best_model2_alignment(src_sentence, trg_sentence)
+        a_info = ibm_model.best_model2_alignment(sentence_pair)
 
         # assert
         self.assertEqual(a_info.alignment[1:], ())
@@ -257,12 +257,14 @@ class TestIBMModel(unittest.TestCase):
 
     def test_sample(self):
         # arrange
+        sentence_pair = AlignedSent(
+            TestIBMModel.__TEST_TRG_SENTENCE,
+            TestIBMModel.__TEST_SRC_SENTENCE)
         ibm_model = IBMModel([])
         ibm_model.prob_t_a_given_s = lambda x: 0.001
 
         # act
-        samples = ibm_model.sample(TestIBMModel.__TEST_SRC_SENTENCE,
-                                   TestIBMModel.__TEST_TRG_SENTENCE)
+        samples = ibm_model.sample(sentence_pair)
 
         # assert
         self.assertEqual(len(samples), 61)

--- a/nltk/test/unit/align/test_ibm_model.py
+++ b/nltk/test/unit/align/test_ibm_model.py
@@ -17,7 +17,8 @@ class TestIBMModel(unittest.TestCase):
 
     def test_vocabularies_are_initialized(self):
         parallel_corpora = [
-            AlignedSent(['one', 'two', 'three', 'four'], ['un', 'deux', 'trois']),
+            AlignedSent(['one', 'two', 'three', 'four'],
+                        ['un', 'deux', 'trois']),
             AlignedSent(['five', 'one', 'six'], ['quatre', 'cinq', 'six']),
             AlignedSent([], ['sept'])
         ]
@@ -30,7 +31,7 @@ class TestIBMModel(unittest.TestCase):
         parallel_corpora = []
 
         ibm_model = IBMModel(parallel_corpora)
-        self.assertEqual(len(ibm_model.src_vocab), 1) # addition of NULL token
+        self.assertEqual(len(ibm_model.src_vocab), 1)  # addition of NULL token
         self.assertEqual(len(ibm_model.trg_vocab), 0)
 
     def test_best_model2_alignment(self):
@@ -58,7 +59,7 @@ class TestIBMModel(unittest.TestCase):
         a_info = ibm_model.best_model2_alignment(src_sentence, trg_sentence)
 
         # assert
-        self.assertEqual(a_info.alignment[1:], (1, 2, 4)) # 0th element unused
+        self.assertEqual(a_info.alignment[1:], (1, 2, 4))  # 0th element unused
         self.assertEqual(a_info.cepts, [[], [1], [2], [], [3]])
 
     def test_best_model2_alignment_does_not_change_pegged_alignment(self):

--- a/nltk/test/unit/align/test_ibm_model.py
+++ b/nltk/test/unit/align/test_ibm_model.py
@@ -264,7 +264,7 @@ class TestIBMModel(unittest.TestCase):
         ibm_model.prob_t_a_given_s = lambda x: 0.001
 
         # act
-        samples = ibm_model.sample(sentence_pair)
+        samples, best_alignment = ibm_model.sample(sentence_pair)
 
         # assert
         self.assertEqual(len(samples), 61)


### PR DESCRIPTION
This is really the main use of the IBM models. Breaking changes include:
- Removal of align method in models 1 to 3. Every sentence pair in the corpus is aligned during training.
- Overwrite the existing alignments (if any) in the training corpus. If the alignments were known in advance, there will be no need to use the IBM models at all.
- Allow alignment to NULL
