### PR TITLE
Unify implementations of IBM models

### DIFF
--- a/nltk/align/ibm1.py
+++ b/nltk/align/ibm1.py
@@ -110,19 +110,20 @@ class IBMModel1(IBMModel):
         :type iterations: int
         """
         super(IBMModel1, self).__init__(sentence_aligned_corpus)
-
-        # seed with a uniform distribution
-        initial_prob = 1 / len(self.trg_vocab)
-        if initial_prob > IBMModel.MIN_PROB:
-            for t in self.trg_vocab:
-                for s in self.src_vocab:
-                    self.translation_table[t][s] = initial_prob
-        else:
-            warnings.warn("Target language vocabulary is too large. "
-                          "Results may be less accurate.")
+        self.set_uniform_distortion_probabilities(sentence_aligned_corpus)
 
         self.train(sentence_aligned_corpus, iterations)
         self.__align_all(sentence_aligned_corpus)
+
+    def set_uniform_distortion_probabilities(self, sentence_aligned_corpus):
+        initial_prob = 1 / len(self.trg_vocab)
+        if initial_prob < IBMModel.MIN_PROB:
+            warnings.warn("Target language vocabulary is too large (" +
+                          str(len(self.trg_vocab)) + " words). "
+                          "Results may be less accurate.")
+
+        for t in self.trg_vocab:
+            self.translation_table[t] = defaultdict(lambda: initial_prob)
 
     def train(self, parallel_corpus, iterations):
         for i in range(0, iterations):

--- a/nltk/align/ibm1.py
+++ b/nltk/align/ibm1.py
@@ -77,14 +77,14 @@ class IBMModel1(IBMModel):
 
     >>> ibm1 = IBMModel1(bitext, 5)
 
-    >>> print('{0:.3f}'.format(ibm1.translation_table['buch']['book']))
-    0.889
-    >>> print('{0:.3f}'.format(ibm1.translation_table['das']['book']))
-    0.062
-    >>> print('{0:.3f}'.format(ibm1.translation_table['buch'][None]))
-    0.113
-    >>> print('{0:.3f}'.format(ibm1.translation_table['ja'][None]))
-    0.073
+    >>> print(ibm1.translation_table['buch']['book'])
+    0.889...
+    >>> print(ibm1.translation_table['das']['book'])
+    0.061...
+    >>> print(ibm1.translation_table['buch'][None])
+    0.113...
+    >>> print(ibm1.translation_table['ja'][None])
+    0.072...
 
     >>> test_sentence = bitext[2]
     >>> test_sentence.words

--- a/nltk/align/ibm1.py
+++ b/nltk/align/ibm1.py
@@ -178,7 +178,6 @@ class IBMModel1(IBMModel):
         """
         alignment_prob_for_t = defaultdict(lambda: 0.0)
         for t in trg_sentence:
-            alignment_prob_for_t[t] = 0
             for s in src_sentence:
                 alignment_prob_for_t[t] += self.prob_alignment_point(s, t)
         return alignment_prob_for_t

--- a/nltk/align/ibm1.py
+++ b/nltk/align/ibm1.py
@@ -122,7 +122,7 @@ class IBMModel1(IBMModel):
         super(IBMModel1, self).__init__(sentence_aligned_corpus)
 
         if probability_tables is None:
-            self.set_uniform_distortion_probabilities(sentence_aligned_corpus)
+            self.set_uniform_probabilities(sentence_aligned_corpus)
         else:
             # Set user-defined probabilities
             self.translation_table = probability_tables['translation_table']
@@ -132,7 +132,7 @@ class IBMModel1(IBMModel):
 
         self.__align_all(sentence_aligned_corpus)
 
-    def set_uniform_distortion_probabilities(self, sentence_aligned_corpus):
+    def set_uniform_probabilities(self, sentence_aligned_corpus):
         initial_prob = 1 / len(self.trg_vocab)
         if initial_prob < IBMModel.MIN_PROB:
             warnings.warn("Target language vocabulary is too large (" +

--- a/nltk/align/ibm1.py
+++ b/nltk/align/ibm1.py
@@ -95,7 +95,8 @@ class IBMModel1(IBMModel):
 
     """
 
-    def __init__(self, sentence_aligned_corpus, iterations):
+    def __init__(self, sentence_aligned_corpus, iterations,
+                 probability_tables=None):
         """
         Train on ``sentence_aligned_corpus`` and create a lexical
         translation model.
@@ -108,9 +109,22 @@ class IBMModel1(IBMModel):
 
         :param iterations: Number of iterations to run training algorithm
         :type iterations: int
+
+        :param probability_tables: Optional. Use this to pass in custom
+            probability values. If not specified, probabilities will be
+            set to a uniform distribution, or some other sensible value.
+            If specified, the following entry must be present:
+            ``translation_table``.
+            See ``IBMModel`` for the type and purpose of this table.
+        :type probability_tables: dict[str]: object
         """
         super(IBMModel1, self).__init__(sentence_aligned_corpus)
-        self.set_uniform_distortion_probabilities(sentence_aligned_corpus)
+
+        if probability_tables is None:
+            self.set_uniform_distortion_probabilities(sentence_aligned_corpus)
+        else:
+            # Set user-defined probabilities
+            self.translation_table = probability_tables['translation_table']
 
         for n in range(0, iterations):
             self.train(sentence_aligned_corpus)

--- a/nltk/align/ibm2.py
+++ b/nltk/align/ibm2.py
@@ -127,7 +127,7 @@ class IBMModel2(IBMModel):
             # faster than Model 2
             ibm1 = IBMModel1(sentence_aligned_corpus, 2 * iterations)
             self.translation_table = ibm1.translation_table
-            self.set_uniform_distortion_probabilities(sentence_aligned_corpus)
+            self.set_uniform_probabilities(sentence_aligned_corpus)
         else:
             # Set user-defined probabilities
             self.translation_table = probability_tables['translation_table']
@@ -138,7 +138,7 @@ class IBMModel2(IBMModel):
 
         self.__align_all(sentence_aligned_corpus)
 
-    def set_uniform_distortion_probabilities(self, sentence_aligned_corpus):
+    def set_uniform_probabilities(self, sentence_aligned_corpus):
         # a(i | j,l,m) = 1 / (l+1) for all i, j, l, m
         l_m_combinations = set()
         for aligned_sentence in sentence_aligned_corpus:

--- a/nltk/align/ibm2.py
+++ b/nltk/align/ibm2.py
@@ -210,7 +210,6 @@ class IBMModel2(IBMModel):
         alignment_prob_for_t = defaultdict(lambda: 0.0)
         for j in range(1, len(trg_sentence)):
             t = trg_sentence[j]
-            alignment_prob_for_t[t] = 0
             for i in range(0, len(src_sentence)):
                 alignment_prob_for_t[t] += self.prob_alignment_point(
                     i, j, src_sentence, trg_sentence)

--- a/nltk/align/ibm2.py
+++ b/nltk/align/ibm2.py
@@ -70,21 +70,21 @@ class IBMModel2(IBMModel):
 
     >>> ibm2 = IBMModel2(bitext, 5)
 
-    >>> print('{0:.3f}'.format(ibm2.translation_table['buch']['book']))
-    1.000
-    >>> print('{0:.3f}'.format(ibm2.translation_table['das']['book']))
-    0.000
-    >>> print('{0:.3f}'.format(ibm2.translation_table['buch'][None]))
-    0.000
-    >>> print('{0:.3f}'.format(ibm2.translation_table['ja'][None]))
-    0.000
+    >>> print(round(ibm2.translation_table['buch']['book'], 3))
+    1.0
+    >>> print(round(ibm2.translation_table['das']['book'], 3))
+    0.0
+    >>> print(round(ibm2.translation_table['buch'][None], 3))
+    0.0
+    >>> print(round(ibm2.translation_table['ja'][None], 3))
+    0.0
 
-    >>> print('{0:.3f}'.format(ibm2.alignment_table[1][1][2][2]))
-    0.939
-    >>> print('{0:.3f}'.format(ibm2.alignment_table[1][2][2][2]))
-    0.000
-    >>> print('{0:.3f}'.format(ibm2.alignment_table[2][2][4][5]))
-    1.000
+    >>> print(ibm2.alignment_table[1][1][2][2])
+    0.938...
+    >>> print(round(ibm2.alignment_table[1][2][2][2], 3))
+    0.0
+    >>> print(round(ibm2.alignment_table[2][2][4][5], 3))
+    1.0
 
     >>> test_sentence = bitext[2]
     >>> test_sentence.words

--- a/nltk/align/ibm3.py
+++ b/nltk/align/ibm3.py
@@ -167,7 +167,7 @@ class IBMModel3(IBMModel):
             ibm2 = IBMModel2(sentence_aligned_corpus, iterations)
             self.translation_table = ibm2.translation_table
             self.alignment_table = ibm2.alignment_table
-            self.set_uniform_distortion_probabilities(sentence_aligned_corpus)
+            self.set_uniform_probabilities(sentence_aligned_corpus)
         else:
             # Set user-defined probabilities
             self.translation_table = probability_tables['translation_table']
@@ -189,7 +189,7 @@ class IBMModel3(IBMModel):
         Values accessed as ``distortion_table[j][i][l][m]``.
         """
 
-    def set_uniform_distortion_probabilities(self, sentence_aligned_corpus):
+    def set_uniform_probabilities(self, sentence_aligned_corpus):
         # d(j | i,l,m) = 1 / m for all i, j, l, m
         l_m_combinations = set()
         for aligned_sentence in sentence_aligned_corpus:

--- a/nltk/align/ibm3.py
+++ b/nltk/align/ibm3.py
@@ -91,7 +91,7 @@ class IBMModel3(IBMModel):
 
     >>> bitext = []
     >>> bitext.append(AlignedSent(['klein', 'ist', 'das', 'haus'], ['the', 'house', 'is', 'small']))
-    >>> bitext.append(AlignedSent(['das', 'haus', 'ist', 'ja', 'groß'], ['the', 'house', 'is', 'big']))
+    >>> bitext.append(AlignedSent(['das', 'haus', 'war', 'ja', 'groß'], ['the', 'house', 'was', 'big']))
     >>> bitext.append(AlignedSent(['das', 'buch', 'ist', 'ja', 'klein'], ['the', 'book', 'is', 'small']))
     >>> bitext.append(AlignedSent(['ein', 'haus', 'ist', 'klein'], ['a', 'house', 'is', 'small']))
     >>> bitext.append(AlignedSent(['das', 'haus'], ['the', 'house']))
@@ -102,27 +102,27 @@ class IBMModel3(IBMModel):
 
     >>> ibm3 = IBMModel3(bitext, 5)
 
-    >>> print('{0:.3f}'.format(ibm3.translation_table['buch']['book']))
-    1.000
-    >>> print('{0:.3f}'.format(ibm3.translation_table['das']['book']))
-    0.000
-    >>> print('{0:.3f}'.format(ibm3.translation_table['ja'][None]))
-    1.000
+    >>> print(round(ibm3.translation_table['buch']['book'], 3))
+    1.0
+    >>> print(round(ibm3.translation_table['das']['book'], 3))
+    0.0
+    >>> print(round(ibm3.translation_table['ja'][None], 3))
+    1.0
 
-    >>> print('{0:.3f}'.format(ibm3.distortion_table[1][1][2][2]))
-    1.000
-    >>> print('{0:.3f}'.format(ibm3.distortion_table[1][2][2][2]))
-    0.000
-    >>> print('{0:.3f}'.format(ibm3.distortion_table[2][2][4][5]))
-    0.750
+    >>> print(round(ibm3.distortion_table[1][1][2][2], 3))
+    1.0
+    >>> print(round(ibm3.distortion_table[1][2][2][2], 3))
+    0.0
+    >>> print(round(ibm3.distortion_table[2][2][4][5], 3))
+    0.75
 
-    >>> print('{0:.3f}'.format(ibm3.fertility_table[2]['summarize']))
-    1.000
-    >>> print('{0:.3f}'.format(ibm3.fertility_table[1]['book']))
-    1.000
+    >>> print(round(ibm3.fertility_table[2]['summarize'], 3))
+    1.0
+    >>> print(round(ibm3.fertility_table[1]['book'], 3))
+    1.0
 
-    >>> print('{0:.3f}'.format(ibm3.p1))
-    0.026
+    >>> print(ibm3.p1)
+    0.054...
 
     >>> test_sentence = bitext[2]
     >>> test_sentence.words

--- a/nltk/align/ibm3.py
+++ b/nltk/align/ibm3.py
@@ -205,6 +205,18 @@ class IBMModel3(IBMModel):
                     for i in range(0, l + 1):
                         self.distortion_table[j][i][l][m] = initial_prob
 
+        # simple initialization, taken from GIZA++
+        self.fertility_table[0] = defaultdict(lambda: 0.2)
+        self.fertility_table[1] = defaultdict(lambda: 0.65)
+        self.fertility_table[2] = defaultdict(lambda: 0.1)
+        self.fertility_table[3] = defaultdict(lambda: 0.04)
+        MAX_FERTILITY = 10
+        initial_fert_prob = 0.01 / (MAX_FERTILITY - 4)
+        for phi in range(4, MAX_FERTILITY):
+            self.fertility_table[phi] = defaultdict(lambda: initial_fert_prob)
+
+        self.p1 = 0.5
+
     def train(self, parallel_corpus):
         counts = Model3Counts()
         for aligned_sentence in parallel_corpus:

--- a/nltk/align/ibm4.py
+++ b/nltk/align/ibm4.py
@@ -309,8 +309,7 @@ class IBMModel4(IBMModel):
         # If any probability is less than MIN_PROB, clamp it to MIN_PROB
         existing_alignment_table = self.alignment_table
         self.reset_probabilities()
-        # don't retrain alignment table
-        self.alignment_table = existing_alignment_table
+        self.alignment_table = existing_alignment_table  # don't retrain
 
         self.maximize_lexical_translation_probabilities(counts)
         self.maximize_distortion_probabilities(counts)

--- a/nltk/align/ibm4.py
+++ b/nltk/align/ibm4.py
@@ -176,9 +176,6 @@ class IBMModel4(IBMModel):
         Translation direction is from ``AlignedSent.mots`` to
         ``AlignedSent.words``.
 
-        Runs a few iterations of Model 3 training to initialize
-        model parameters.
-
         :param sentence_aligned_corpus: Sentence-aligned parallel corpus
         :type sentence_aligned_corpus: list(AlignedSent)
 

--- a/nltk/align/ibm4.py
+++ b/nltk/align/ibm4.py
@@ -212,7 +212,7 @@ class IBMModel4(IBMModel):
             self.alignment_table = ibm3.alignment_table
             self.fertility_table = ibm3.fertility_table
             self.p1 = ibm3.p1
-            self.set_uniform_distortion_probabilities(sentence_aligned_corpus)
+            self.set_uniform_probabilities(sentence_aligned_corpus)
         else:
             # Set user-defined probabilities
             self.translation_table = probability_tables['translation_table']
@@ -245,7 +245,7 @@ class IBMModel4(IBMModel):
         Values accessed as ``distortion_table[dj][trg_class]``.
         """
 
-    def set_uniform_distortion_probabilities(self, sentence_aligned_corpus):
+    def set_uniform_probabilities(self, sentence_aligned_corpus):
         """
         Set distortion probabilities uniformly to
         1 / cardinality of displacement values

--- a/nltk/align/ibm4.py
+++ b/nltk/align/ibm4.py
@@ -227,7 +227,7 @@ class IBMModel4(IBMModel):
             self.non_head_distortion_table = probability_tables[
                 'non_head_distortion_table']
 
-        for k in range(0, iterations):
+        for n in range(0, iterations):
             self.train(sentence_aligned_corpus)
 
     def reset_probabilities(self):

--- a/nltk/align/ibm4.py
+++ b/nltk/align/ibm4.py
@@ -277,9 +277,7 @@ class IBMModel4(IBMModel):
                 lambda: initial_prob)
 
     def train(self, parallel_corpus):
-        # Reset all counts
         counts = Model4Counts()
-
         for aligned_sentence in parallel_corpus:
             m = len(aligned_sentence.words)
 
@@ -430,7 +428,7 @@ class IBMModel4(IBMModel):
 class Model4Counts(Counts):
     """
     Data object to store counts of various parameters during training.
-    Include counts for distortion.
+    Includes counts for distortion.
     """
     def __init__(self):
         super(Model4Counts, self).__init__()

--- a/nltk/align/ibm4.py
+++ b/nltk/align/ibm4.py
@@ -120,7 +120,7 @@ class IBMModel4(IBMModel):
 
     >>> bitext = []
     >>> bitext.append(AlignedSent(['klein', 'ist', 'das', 'haus'], ['the', 'house', 'is', 'small']))
-    >>> bitext.append(AlignedSent(['das', 'haus', 'ist', 'ja', 'groß'], ['the', 'house', 'is', 'big']))
+    >>> bitext.append(AlignedSent(['das', 'haus', 'war', 'ja', 'groß'], ['the', 'house', 'was', 'big']))
     >>> bitext.append(AlignedSent(['das', 'buch', 'ist', 'ja', 'klein'], ['the', 'book', 'is', 'small']))
     >>> bitext.append(AlignedSent(['ein', 'haus', 'ist', 'klein'], ['a', 'house', 'is', 'small']))
     >>> bitext.append(AlignedSent(['das', 'haus'], ['the', 'house']))
@@ -128,32 +128,32 @@ class IBMModel4(IBMModel):
     >>> bitext.append(AlignedSent(['ein', 'buch'], ['a', 'book']))
     >>> bitext.append(AlignedSent(['ich', 'fasse', 'das', 'buch', 'zusammen'], ['i', 'summarize', 'the', 'book']))
     >>> bitext.append(AlignedSent(['fasse', 'zusammen'], ['summarize']))
-    >>> src_classes = {'the': 0, 'a': 0, 'small': 1, 'big': 1, 'house': 2, 'book': 2, 'is': 3, 'i': 4, 'summarize': 5 }
-    >>> trg_classes = {'das': 0, 'ein': 0, 'haus': 1, 'buch': 1, 'klein': 2, 'groß': 2, 'ist': 3, 'ja': 4, 'ich': 5, 'fasse': 6, 'zusammen': 6 }
+    >>> src_classes = {'the': 0, 'a': 0, 'small': 1, 'big': 1, 'house': 2, 'book': 2, 'is': 3, 'was': 3, 'i': 4, 'summarize': 5 }
+    >>> trg_classes = {'das': 0, 'ein': 0, 'haus': 1, 'buch': 1, 'klein': 2, 'groß': 2, 'ist': 3, 'war': 3, 'ja': 4, 'ich': 5, 'fasse': 6, 'zusammen': 6 }
 
     >>> ibm4 = IBMModel4(bitext, 5, src_classes, trg_classes)
 
-    >>> print('{0:.3f}'.format(ibm4.translation_table['buch']['book']))
-    1.000
-    >>> print('{0:.3f}'.format(ibm4.translation_table['das']['book']))
-    0.000
-    >>> print('{0:.3f}'.format(ibm4.translation_table['ja'][None]))
-    1.000
+    >>> print(round(ibm4.translation_table['buch']['book'], 3))
+    1.0
+    >>> print(round(ibm4.translation_table['das']['book'], 3))
+    0.0
+    >>> print(round(ibm4.translation_table['ja'][None], 3))
+    1.0
 
-    >>> print('{0:.3f}'.format(ibm4.head_distortion_table[1][0][1]))
-    1.000
-    >>> print('{0:.3f}'.format(ibm4.head_distortion_table[2][0][1]))
-    0.000
-    >>> print('{0:.3f}'.format(ibm4.non_head_distortion_table[3][6]))
-    0.500
+    >>> print(round(ibm4.head_distortion_table[1][0][1], 3))
+    1.0
+    >>> print(round(ibm4.head_distortion_table[2][0][1], 3))
+    0.0
+    >>> print(round(ibm4.non_head_distortion_table[3][6], 3))
+    0.5
 
-    >>> print('{0:.3f}'.format(ibm4.fertility_table[2]['summarize']))
-    1.000
-    >>> print('{0:.3f}'.format(ibm4.fertility_table[1]['book']))
-    1.000
+    >>> print(round(ibm4.fertility_table[2]['summarize'], 3))
+    1.0
+    >>> print(round(ibm4.fertility_table[1]['book'], 3))
+    1.0
 
-    >>> print('{0:.3f}'.format(ibm4.p1))
-    0.033
+    >>> print(ibm4.p1)
+    0.033...
 
     >>> test_sentence = bitext[2]
     >>> test_sentence.words

--- a/nltk/align/ibm5.py
+++ b/nltk/align/ibm5.py
@@ -292,9 +292,7 @@ class IBMModel5(IBMModel):
                     lambda: initial_prob)
 
     def train(self, parallel_corpus):
-        # Reset all counts
         counts = Model5Counts()
-
         for aligned_sentence in parallel_corpus:
             l = len(aligned_sentence.mots)
             m = len(aligned_sentence.words)
@@ -556,7 +554,7 @@ class IBMModel5(IBMModel):
 class Model5Counts(Counts):
     """
     Data object to store counts of various parameters during training.
-    Include counts for vacancies.
+    Includes counts for vacancies.
     """
     def __init__(self):
         super(Model5Counts, self).__init__()

--- a/nltk/align/ibm5.py
+++ b/nltk/align/ibm5.py
@@ -328,8 +328,7 @@ class IBMModel5(IBMModel):
         # If any probability is less than MIN_PROB, clamp it to MIN_PROB
         existing_alignment_table = self.alignment_table
         self.reset_probabilities()
-        # don't retrain alignment table
-        self.alignment_table = existing_alignment_table
+        self.alignment_table = existing_alignment_table  # don't retrain
 
         self.maximize_lexical_translation_probabilities(counts)
         self.maximize_vacancy_probabilities(counts)

--- a/nltk/align/ibm5.py
+++ b/nltk/align/ibm5.py
@@ -239,7 +239,7 @@ class IBMModel5(IBMModel):
             self.non_head_vacancy_table = probability_tables[
                 'non_head_vacancy_table']
 
-        for k in range(0, iterations):
+        for n in range(0, iterations):
             self.train(sentence_aligned_corpus)
 
     def reset_probabilities(self):

--- a/nltk/align/ibm5.py
+++ b/nltk/align/ibm5.py
@@ -130,7 +130,7 @@ class IBMModel5(IBMModel):
 
     >>> bitext = []
     >>> bitext.append(AlignedSent(['klein', 'ist', 'das', 'haus'], ['the', 'house', 'is', 'small']))
-    >>> bitext.append(AlignedSent(['das', 'haus', 'ist', 'ja', 'groß'], ['the', 'house', 'is', 'big']))
+    >>> bitext.append(AlignedSent(['das', 'haus', 'war', 'ja', 'groß'], ['the', 'house', 'was', 'big']))
     >>> bitext.append(AlignedSent(['das', 'buch', 'ist', 'ja', 'klein'], ['the', 'book', 'is', 'small']))
     >>> bitext.append(AlignedSent(['ein', 'haus', 'ist', 'klein'], ['a', 'house', 'is', 'small']))
     >>> bitext.append(AlignedSent(['das', 'haus'], ['the', 'house']))
@@ -138,25 +138,25 @@ class IBMModel5(IBMModel):
     >>> bitext.append(AlignedSent(['ein', 'buch'], ['a', 'book']))
     >>> bitext.append(AlignedSent(['ich', 'fasse', 'das', 'buch', 'zusammen'], ['i', 'summarize', 'the', 'book']))
     >>> bitext.append(AlignedSent(['fasse', 'zusammen'], ['summarize']))
-    >>> src_classes = {'the': 0, 'a': 0, 'small': 1, 'big': 1, 'house': 2, 'book': 2, 'is': 3, 'i': 4, 'summarize': 5 }
-    >>> trg_classes = {'das': 0, 'ein': 0, 'haus': 1, 'buch': 1, 'klein': 2, 'groß': 2, 'ist': 3, 'ja': 4, 'ich': 5, 'fasse': 6, 'zusammen': 6 }
+    >>> src_classes = {'the': 0, 'a': 0, 'small': 1, 'big': 1, 'house': 2, 'book': 2, 'is': 3, 'was': 3, 'i': 4, 'summarize': 5 }
+    >>> trg_classes = {'das': 0, 'ein': 0, 'haus': 1, 'buch': 1, 'klein': 2, 'groß': 2, 'ist': 3, 'war': 3, 'ja': 4, 'ich': 5, 'fasse': 6, 'zusammen': 6 }
 
     >>> ibm5 = IBMModel5(bitext, 5, src_classes, trg_classes)
 
-    >>> print('{0:.3f}'.format(ibm5.head_vacancy_table[1][1][1]))
-    1.000
-    >>> print('{0:.3f}'.format(ibm5.head_vacancy_table[2][1][1]))
-    0.000
-    >>> print('{0:.3f}'.format(ibm5.non_head_vacancy_table[3][3][6]))
-    1.000
+    >>> print(round(ibm5.head_vacancy_table[1][1][1], 3))
+    1.0
+    >>> print(round(ibm5.head_vacancy_table[2][1][1], 3))
+    0.0
+    >>> print(round(ibm5.non_head_vacancy_table[3][3][6], 3))
+    1.0
 
-    >>> print('{0:.3f}'.format(ibm5.fertility_table[2]['summarize']))
-    1.000
-    >>> print('{0:.3f}'.format(ibm5.fertility_table[1]['book']))
-    1.000
+    >>> print(round(ibm5.fertility_table[2]['summarize'], 3))
+    1.0
+    >>> print(round(ibm5.fertility_table[1]['book'], 3))
+    1.0
 
-    >>> print('{0:.3f}'.format(ibm5.p1))
-    0.033
+    >>> print(ibm5.p1)
+    0.033...
 
     >>> test_sentence = bitext[2]
     >>> test_sentence.words

--- a/nltk/align/ibm5.py
+++ b/nltk/align/ibm5.py
@@ -223,7 +223,7 @@ class IBMModel5(IBMModel):
             self.p1 = ibm4.p1
             self.head_distortion_table = ibm4.head_distortion_table
             self.non_head_distortion_table = ibm4.non_head_distortion_table
-            self.set_uniform_distortion_probabilities(sentence_aligned_corpus)
+            self.set_uniform_probabilities(sentence_aligned_corpus)
         else:
             # Set user-defined probabilities
             self.translation_table = probability_tables['translation_table']
@@ -260,7 +260,7 @@ class IBMModel5(IBMModel):
         Values accessed as ``non_head_vacancy_table[dv][v_max][trg_class]``.
         """
 
-    def set_uniform_distortion_probabilities(self, sentence_aligned_corpus):
+    def set_uniform_probabilities(self, sentence_aligned_corpus):
         """
         Set vacancy probabilities uniformly to
         1 / cardinality of vacancy difference values

--- a/nltk/align/ibm_model.py
+++ b/nltk/align/ibm_model.py
@@ -105,7 +105,7 @@ class IBMModel(object):
         Used in model 3 and higher.
         """
 
-    def set_uniform_distortion_probabilities(self, sentence_aligned_corpus):
+    def set_uniform_probabilities(self, sentence_aligned_corpus):
         """
         Initialize probability tables to a uniform distribution
 

--- a/nltk/align/ibm_model.py
+++ b/nltk/align/ibm_model.py
@@ -528,6 +528,6 @@ class Counts(object):
     def update_fertility(self, count, alignment_info):
         for i in range(0, len(alignment_info.src_sentence)):
             s = alignment_info.src_sentence[i]
-            phi = len(alignment_info.cepts[i])
+            phi = alignment_info.fertility_of_i(i)
             self.fertility[phi][s] += count
             self.fertility_for_any_phi[s] += count

--- a/nltk/align/ibm_model.py
+++ b/nltk/align/ibm_model.py
@@ -54,8 +54,7 @@ def longest_target_sentence_length(sentence_aligned_corpus):
     max_m = 0
     for aligned_sentence in sentence_aligned_corpus:
         m = len(aligned_sentence.words)
-        if m > max_m:
-            max_m = m
+        max_m = max(m, max_m)
     return max_m
 
 
@@ -105,6 +104,14 @@ class IBMModel(object):
         that is aligned to NULL.
         Used in model 3 and higher.
         """
+
+    def set_uniform_distortion_probabilities(self, sentence_aligned_corpus):
+        """
+        Initialize probability tables to a uniform distribution
+
+        Derived classes should implement this accordingly.
+        """
+        pass
 
     def init_vocab(self, sentence_aligned_corpus):
         src_vocab = set()

--- a/nltk/test/unit/align/test_ibm1.py
+++ b/nltk/test/unit/align/test_ibm1.py
@@ -7,11 +7,44 @@ import unittest
 
 from collections import defaultdict
 from nltk.align import AlignedSent
+from nltk.align import IBMModel
+from nltk.align import IBMModel1
 from nltk.align.ibm_model import AlignmentInfo
-from nltk.align.ibm1 import IBMModel1
 
 
 class TestIBMModel1(unittest.TestCase):
+    def test_set_uniform_translation_probabilities(self):
+        # arrange
+        corpus = [
+            AlignedSent(['ham', 'eggs'], ['schinken', 'schinken', 'eier']),
+            AlignedSent(['spam', 'spam', 'spam', 'spam'], ['spam', 'spam']),
+        ]
+        model1 = IBMModel1(corpus, 0)
+
+        # act
+        model1.set_uniform_probabilities(corpus)
+
+        # assert
+        # expected_prob = 1.0 / (target vocab size + 1)
+        self.assertEqual(model1.translation_table['ham']['eier'], 1.0 / 3)
+        self.assertEqual(model1.translation_table['eggs'][None], 1.0 / 3)
+
+    def test_set_uniform_translation_probabilities_of_non_domain_values(self):
+        # arrange
+        corpus = [
+            AlignedSent(['ham', 'eggs'], ['schinken', 'schinken', 'eier']),
+            AlignedSent(['spam', 'spam', 'spam', 'spam'], ['spam', 'spam']),
+        ]
+        model1 = IBMModel1(corpus, 0)
+
+        # act
+        model1.set_uniform_probabilities(corpus)
+
+        # assert
+        # examine target words that are not in the training data domain
+        self.assertEqual(model1.translation_table['parrot']['eier'],
+                         IBMModel.MIN_PROB)
+
     def test_prob_t_a_given_s(self):
         # arrange
         src_sentence = ["ich", 'esse', 'ja', 'gern', 'räucherschinken']

--- a/nltk/test/unit/align/test_ibm2.py
+++ b/nltk/test/unit/align/test_ibm2.py
@@ -7,11 +7,44 @@ import unittest
 
 from collections import defaultdict
 from nltk.align import AlignedSent
+from nltk.align import IBMModel
+from nltk.align import IBMModel2
 from nltk.align.ibm_model import AlignmentInfo
-from nltk.align.ibm2 import IBMModel2
 
 
 class TestIBMModel2(unittest.TestCase):
+    def test_set_uniform_alignment_probabilities(self):
+        # arrange
+        corpus = [
+            AlignedSent(['ham', 'eggs'], ['schinken', 'schinken', 'eier']),
+            AlignedSent(['spam', 'spam', 'spam', 'spam'], ['spam', 'spam']),
+        ]
+        model2 = IBMModel2(corpus, 0)
+
+        # act
+        model2.set_uniform_probabilities(corpus)
+
+        # assert
+        # expected_prob = 1.0 / (length of source sentence + 1)
+        self.assertEqual(model2.alignment_table[0][1][3][2], 1.0 / 4)
+        self.assertEqual(model2.alignment_table[2][4][2][4], 1.0 / 3)
+
+    def test_set_uniform_alignment_probabilities_of_non_domain_values(self):
+        # arrange
+        corpus = [
+            AlignedSent(['ham', 'eggs'], ['schinken', 'schinken', 'eier']),
+            AlignedSent(['spam', 'spam', 'spam', 'spam'], ['spam', 'spam']),
+        ]
+        model2 = IBMModel2(corpus, 0)
+
+        # act
+        model2.set_uniform_probabilities(corpus)
+
+        # assert
+        # examine i and j values that are not in the training data domain
+        self.assertEqual(model2.alignment_table[99][1][3][2], IBMModel.MIN_PROB)
+        self.assertEqual(model2.alignment_table[2][99][2][4], IBMModel.MIN_PROB)
+
     def test_prob_t_a_given_s(self):
         # arrange
         src_sentence = ["ich", 'esse', 'ja', 'gern', 'räucherschinken']

--- a/nltk/test/unit/align/test_ibm3.py
+++ b/nltk/test/unit/align/test_ibm3.py
@@ -22,7 +22,7 @@ class TestIBMModel3(unittest.TestCase):
         model3 = IBMModel3(corpus, 0)
 
         # act
-        model3.set_uniform_distortion_probabilities(corpus)
+        model3.set_uniform_probabilities(corpus)
 
         # assert
         # expected_prob = 1.0 / length of target sentence
@@ -38,7 +38,7 @@ class TestIBMModel3(unittest.TestCase):
         model3 = IBMModel3(corpus, 0)
 
         # act
-        model3.set_uniform_distortion_probabilities(corpus)
+        model3.set_uniform_probabilities(corpus)
 
         # assert
         # examine i and j values that are not in the training data domain

--- a/nltk/test/unit/align/test_ibm3.py
+++ b/nltk/test/unit/align/test_ibm3.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for IBM Model 3 training methods
+"""
+
+import unittest
+
+from collections import defaultdict
+from nltk.align import AlignedSent
+from nltk.align.ibm_model import AlignmentInfo
+from nltk.align.ibm_model import IBMModel
+from nltk.align.ibm3 import IBMModel3
+
+
+class TestIBMModel3(unittest.TestCase):
+    def test_set_uniform_distortion_probabilities(self):
+        # arrange
+        corpus = [
+            AlignedSent(['ham', 'eggs'], ['schinken', 'schinken', 'eier']),
+            AlignedSent(['spam', 'spam', 'spam', 'spam'], ['spam', 'spam']),
+        ]
+        model3 = IBMModel3(corpus, 0)
+
+        # act
+        model3.set_uniform_distortion_probabilities(corpus)
+
+        # assert
+        # expected_prob = 1.0 / length of target sentence
+        self.assertEqual(model3.distortion_table[1][0][3][2], 1.0 / 2)
+        self.assertEqual(model3.distortion_table[4][2][2][4], 1.0 / 4)
+
+    def test_set_uniform_distortion_probabilities_of_non_domain_values(self):
+        # arrange
+        corpus = [
+            AlignedSent(['ham', 'eggs'], ['schinken', 'schinken', 'eier']),
+            AlignedSent(['spam', 'spam', 'spam', 'spam'], ['spam', 'spam']),
+        ]
+        model3 = IBMModel3(corpus, 0)
+
+        # act
+        model3.set_uniform_distortion_probabilities(corpus)
+
+        # assert
+        # examine i and j values that are not in the training data domain
+        self.assertEqual(model3.distortion_table[0][0][3][2], IBMModel.MIN_PROB)
+        self.assertEqual(model3.distortion_table[9][2][2][4], IBMModel.MIN_PROB)
+        self.assertEqual(model3.distortion_table[2][9][2][4], IBMModel.MIN_PROB)
+
+    def test_prob_t_a_given_s(self):
+        # arrange
+        src_sentence = ["ich", 'esse', 'ja', 'gern', 'räucherschinken']
+        trg_sentence = ['i', 'love', 'to', 'eat', 'smoked', 'ham']
+        corpus = [AlignedSent(trg_sentence, src_sentence)]
+        alignment_info = AlignmentInfo((0, 1, 4, 0, 2, 5, 5),
+                                       [None] + src_sentence,
+                                       ['UNUSED'] + trg_sentence,
+                                       [[3], [1], [4], [], [2], [5, 6]])
+
+        distortion_table = defaultdict(
+            lambda: defaultdict(lambda: defaultdict(
+                lambda: defaultdict(float))))
+        distortion_table[1][1][5][6] = 0.97  # i -> ich
+        distortion_table[2][4][5][6] = 0.97  # love -> gern
+        distortion_table[3][0][5][6] = 0.97  # to -> NULL
+        distortion_table[4][2][5][6] = 0.97  # eat -> esse
+        distortion_table[5][5][5][6] = 0.97  # smoked -> räucherschinken
+        distortion_table[6][5][5][6] = 0.97  # ham -> räucherschinken
+
+        translation_table = defaultdict(lambda: defaultdict(float))
+        translation_table['i']['ich'] = 0.98
+        translation_table['love']['gern'] = 0.98
+        translation_table['to'][None] = 0.98
+        translation_table['eat']['esse'] = 0.98
+        translation_table['smoked']['räucherschinken'] = 0.98
+        translation_table['ham']['räucherschinken'] = 0.98
+
+        fertility_table = defaultdict(lambda: defaultdict(float))
+        fertility_table[1]['ich'] = 0.99
+        fertility_table[1]['esse'] = 0.99
+        fertility_table[0]['ja'] = 0.99
+        fertility_table[1]['gern'] = 0.99
+        fertility_table[2]['räucherschinken'] = 0.999
+        fertility_table[1][None] = 0.99
+
+        probabilities = {
+            'p1': 0.167,
+            'translation_table': translation_table,
+            'distortion_table': distortion_table,
+            'fertility_table': fertility_table,
+            'alignment_table': None
+        }
+
+        model3 = IBMModel3(corpus, 0, probabilities)
+
+        # act
+        probability = model3.prob_t_a_given_s(alignment_info)
+
+        # assert
+        null_generation = 5 * pow(0.167, 1) * pow(0.833, 4)
+        fertility = 1*0.99 * 1*0.99 * 1*0.99 * 1*0.99 * 2*0.999
+        lexical_translation = 0.98 * 0.98 * 0.98 * 0.98 * 0.98 * 0.98
+        distortion = 0.97 * 0.97 * 0.97 * 0.97 * 0.97 * 0.97
+        expected_probability = (null_generation * fertility *
+                                lexical_translation * distortion)
+        self.assertEqual(round(probability, 4), round(expected_probability, 4))

--- a/nltk/test/unit/align/test_ibm3.py
+++ b/nltk/test/unit/align/test_ibm3.py
@@ -7,9 +7,9 @@ import unittest
 
 from collections import defaultdict
 from nltk.align import AlignedSent
+from nltk.align import IBMModel
+from nltk.align import IBMModel3
 from nltk.align.ibm_model import AlignmentInfo
-from nltk.align.ibm_model import IBMModel
-from nltk.align.ibm3 import IBMModel3
 
 
 class TestIBMModel3(unittest.TestCase):

--- a/nltk/test/unit/align/test_ibm4.py
+++ b/nltk/test/unit/align/test_ibm4.py
@@ -7,9 +7,9 @@ import unittest
 
 from collections import defaultdict
 from nltk.align import AlignedSent
+from nltk.align import IBMModel
+from nltk.align import IBMModel4
 from nltk.align.ibm_model import AlignmentInfo
-from nltk.align.ibm_model import IBMModel
-from nltk.align.ibm4 import IBMModel4
 
 
 class TestIBMModel4(unittest.TestCase):

--- a/nltk/test/unit/align/test_ibm4.py
+++ b/nltk/test/unit/align/test_ibm4.py
@@ -24,7 +24,7 @@ class TestIBMModel4(unittest.TestCase):
         model4 = IBMModel4(corpus, 0, src_classes, trg_classes)
 
         # act
-        model4.set_uniform_distortion_probabilities(corpus)
+        model4.set_uniform_probabilities(corpus)
 
         # assert
         # number of displacement values =
@@ -48,7 +48,7 @@ class TestIBMModel4(unittest.TestCase):
         model4 = IBMModel4(corpus, 0, src_classes, trg_classes)
 
         # act
-        model4.set_uniform_distortion_probabilities(corpus)
+        model4.set_uniform_probabilities(corpus)
 
         # assert
         # examine displacement values that are not in the training data domain

--- a/nltk/test/unit/align/test_ibm5.py
+++ b/nltk/test/unit/align/test_ibm5.py
@@ -14,7 +14,7 @@ from nltk.align.ibm5 import IBMModel5
 
 
 class TestIBMModel5(unittest.TestCase):
-    def test_set_uniform_distortion_probabilities_of_max_displacements(self):
+    def test_set_uniform_vacancy_probabilities_of_max_displacements(self):
         # arrange
         src_classes = {'schinken': 0, 'eier': 0, 'spam': 1}
         trg_classes = {'ham': 0, 'eggs': 1, 'spam': 2}
@@ -25,7 +25,7 @@ class TestIBMModel5(unittest.TestCase):
         model5 = IBMModel5(corpus, 0, src_classes, trg_classes)
 
         # act
-        model5.set_uniform_distortion_probabilities(corpus)
+        model5.set_uniform_probabilities(corpus)
 
         # assert
         # number of vacancy difference values =
@@ -38,7 +38,7 @@ class TestIBMModel5(unittest.TestCase):
         self.assertEqual(model5.non_head_vacancy_table[4][4][0], expected_prob)
         self.assertEqual(model5.non_head_vacancy_table[-3][1][2], expected_prob)
 
-    def test_set_uniform_distortion_probabilities_of_non_domain_values(self):
+    def test_set_uniform_vacancy_probabilities_of_non_domain_values(self):
         # arrange
         src_classes = {'schinken': 0, 'eier': 0, 'spam': 1}
         trg_classes = {'ham': 0, 'eggs': 1, 'spam': 2}
@@ -49,7 +49,7 @@ class TestIBMModel5(unittest.TestCase):
         model5 = IBMModel5(corpus, 0, src_classes, trg_classes)
 
         # act
-        model5.set_uniform_distortion_probabilities(corpus)
+        model5.set_uniform_probabilities(corpus)
 
         # assert
         # examine dv and max_v values that are not in the training data domain

--- a/nltk/test/unit/align/test_ibm5.py
+++ b/nltk/test/unit/align/test_ibm5.py
@@ -7,10 +7,10 @@ import unittest
 
 from collections import defaultdict
 from nltk.align import AlignedSent
+from nltk.align import IBMModel
+from nltk.align import IBMModel4
+from nltk.align import IBMModel5
 from nltk.align.ibm_model import AlignmentInfo
-from nltk.align.ibm_model import IBMModel
-from nltk.align.ibm4 import IBMModel4
-from nltk.align.ibm5 import IBMModel5
 
 
 class TestIBMModel5(unittest.TestCase):

--- a/nltk/test/unit/align/test_ibm_model.py
+++ b/nltk/test/unit/align/test_ibm_model.py
@@ -7,8 +7,8 @@ import unittest
 
 from collections import defaultdict
 from nltk.align import AlignedSent
+from nltk.align import IBMModel
 from nltk.align.ibm_model import AlignmentInfo
-from nltk.align.ibm_model import IBMModel
 
 
 class TestIBMModel(unittest.TestCase):


### PR DESCRIPTION
Make the algorithm structure consistent across IBM models, so it is easier to see how one model builds from the preceding one.

Other minor refactorings and fixes:
- In Models 1 and 2, don't reset counts if a target word occurs more than once in a sentence
- In Model 3, set fertility distribution to default values
- Less specific import paths
- Use ellipsis in doctests where appropriate, to compare floats

This will be the final major edits to the IBM models from me for a while.
