### PR TITLE
Languages list should include English ('eng') by default as it's always there

### DIFF
--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -1084,7 +1084,7 @@ class WordNetCorpusReader(CorpusReader):
     def langs(self):
         ''' return a list of languages supported by Multilingual Wordnet '''
         import os
-        langs = []
+        langs = [ 'eng' ]
         fileids = self._omw_reader.fileids()
         for fileid in fileids:
             file_name, file_extension = os.path.splitext(fileid)


### PR DESCRIPTION
Languages list should include English ('eng') by default as it's always there (Princeton WordNet).
