### PR TITLE
Python 3.5 Support. Fix Issue #1106.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -182,3 +182,4 @@
 - wvanlint
 - Álvaro Justen <https://github.com/turicas>
 - bjut-hz
+- Zenohm

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -49,6 +49,10 @@ def compile_regexp_to_noncapturing(pattern, flags=0):
                 raise ValueError('Regular expressions with back-references are not supported: {0}'.format(pattern))
             res_data.append((key, value))
         parsed_pattern.data = res_data
+        try:
+            parsed_pattern.pattern.groups = 1
+        except AttributeError:
+            pass
         parsed_pattern.pattern.groupdict = {}
         return parsed_pattern
 

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -49,7 +49,6 @@ def compile_regexp_to_noncapturing(pattern, flags=0):
                 raise ValueError('Regular expressions with back-references are not supported: {0}'.format(pattern))
             res_data.append((key, value))
         parsed_pattern.data = res_data
-        parsed_pattern.pattern.groups = 1
         parsed_pattern.pattern.groupdict = {}
         return parsed_pattern
 


### PR DESCRIPTION
I was able to fix [this problem](https://github.com/nltk/nltk/issues/1106) by going into the `internals.py` file in the `nltk` directory and ignoring the exception caused by the `parsed_pattern.pattern.groups = 1` line.

My rationale behind this, after doing a bit of code reading, was that the [original version](http://svn.python.org/projects/python/branches/release22-maint/Lib/sre_parse.py) of `sre_parse.py` that NLTK appears to have been designed to work with stored `groups` as an attribute of an instance of the `sre_parse.Pattern` class. The version that comes with Python 3.5 stores `groups` as a property which returns (I'm not too familiar with properties, but this is what I presume it does) the length of a `subpattern` list. [The code I'm talking about is here at about line 75.](https://github.com/python/cpython/blob/master/Lib/sre_parse.py) Since setting the `groups` attribute to 1 was most likely a sort of resetting mechanism or similar (I haven't read that far yet), having the code just work as it does in the newer version with the built in length checker seems to be fine.

This does solve the problem that the OP and I had.

```
In [1]: import nltk

In [2]: nltk.corpus.brown.words()
Out [2]: ['The', 'Fulton', 'County', 'Grand', 'Jury', 'said', ...]

In [3]: 
```

What I don't know is what the long term effects of doing this will be, I came up with this solution just by tracing through the code, I haven't looked at what bugs this may cause in the long run.

Would this cause other problems? If so, is there a better solution?
