### PR TITLE
Hotfix/fix encoding cess (with test)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -182,3 +182,4 @@
 - wvanlint
 - Álvaro Justen <https://github.com/turicas>
 - bjut-hz
+- Sergio Oller

--- a/nltk/corpus/__init__.py
+++ b/nltk/corpus/__init__.py
@@ -76,10 +76,10 @@ brown = LazyCorpusLoader(
     cat_file='cats.txt', tagset='brown', encoding="ascii")
 cess_cat = LazyCorpusLoader(
     'cess_cat', BracketParseCorpusReader, r'(?!\.).*\.tbf',
-    tagset='unknown', encoding='ISO-8859-2')
+    tagset='unknown', encoding='ISO-8859-15')
 cess_esp = LazyCorpusLoader(
     'cess_esp', BracketParseCorpusReader, r'(?!\.).*\.tbf',
-    tagset='unknown', encoding='ISO-8859-2')
+    tagset='unknown', encoding='ISO-8859-15')
 cmudict = LazyCorpusLoader(
     'cmudict', CMUDictCorpusReader, ['cmudict'])
 comtrans = LazyCorpusLoader(

--- a/nltk/test/unit/test_corpora.py
+++ b/nltk/test/unit/test_corpora.py
@@ -40,11 +40,13 @@ class TestCess(unittest.TestCase):
         words = cess_cat.words()[:15]
         txt = "El Tribunal_Suprem -Fpa- TS -Fpt- ha confirmat la condemna a quatre anys d' inhabilitació especial"
         self.assertEqual(words, txt.split())
+        self.assertEqual(cess_cat.tagged_sents()[0][34][0], "càrrecs")
 
     def test_esp(self):
         words = cess_esp.words()[:15]
         txt = "El grupo estatal Electricité_de_France -Fpa- EDF -Fpt- anunció hoy , jueves , la compra del"
         self.assertEqual(words, txt.split())
+        self.assertEqual(cess_esp.words()[115], "años")
 
 
 class TestFloresta(unittest.TestCase):


### PR DESCRIPTION
This fix amends the encoding of teh cess_cat and cess_esp corpora.

It is split in two commits:

The first commit enhances the TestCess to assert for some words different in ISO-8859-2 and ISO-8859-15 in both corpus. As a result of the test enhancement, after this first commit the: `nosetests nltk.test.unit.test_corpora.TestCess` command fails.

The second commit changes the encoding of both corpora and then the enhanced test passes.
