### PR TITLE
fix lemmatize in rte_classify.py

### DIFF
--- a/nltk/classify/rte_classify.py
+++ b/nltk/classify/rte_classify.py
@@ -36,7 +36,7 @@ def lemmatize(word):
     """
     Use morphy from WordNet to find the base form of verbs.
     """
-    lemma = nltk.corpus.wordnet.morphy(word, pos='verb')
+    lemma = nltk.corpus.wordnet.morphy(word, pos='v')
     if lemma is not None:
         return lemma
     return word


### PR DESCRIPTION
in _nltk.corpus.wordnet.morphy_, _pos='verb'_ argument produces a _KeyError_

constant for verb is _nltk.corpus.wordnet.VERB_, which evaluates to _'v'_
