### PR TITLE
Fixing doctests for bleu_score.py (housekeeping)

### DIFF
--- a/nltk/test/bleu.doctest
+++ b/nltk/test/bleu.doctest
@@ -7,8 +7,8 @@ BLEU tests
 If the candidate has no alignment to any of the references, the BLEU score is 0.
 
 >>> bleu(
-...     'John loves Mary'.split(),
 ...     ['The candidate has no alignment to any of the references'.split()],
+...     'John loves Mary'.split(),
 ...     [1],
 ... )
 0

--- a/nltk/test/unit/translate/test_bleu.py
+++ b/nltk/test/unit/translate/test_bleu.py
@@ -7,7 +7,7 @@ import unittest
 from nltk.translate.bleu_score import _modified_precision
 
 class TestBLEU(unittest.TestCase):
-    def test_modified_precision(self):
+    def test__modified_precision(self):
         """
         Examples from the original BLEU paper 
         http://www.aclweb.org/anthology/P02-1040.pdf
@@ -22,10 +22,10 @@ class TestBLEU(unittest.TestCase):
         references = [ref1, ref2] 
         
         # Testing modified unigram precision.
-        assert (modified_precision(references, hyp1, n=1) == 0.28)
+        assert (_modified_precision(references, hyp1, n=1) == 0.28)
         
         # Testing modified bigram precision.
-        assert(modified_precision(references, hyp1, n=2) == 0.0)
+        assert(_modified_precision(references, hyp1, n=2) == 0.0)
         
         
         # Example 2: the "of the" example.
@@ -41,10 +41,10 @@ class TestBLEU(unittest.TestCase):
         
         references = [ref1, ref2, ref3] 
         # Testing modified unigram precision.
-        assert (modified_precision(references, hyp1, n=1) == 1.0)
+        assert (_modified_precision(references, hyp1, n=1) == 1.0)
         
         # Testing modified bigram precision.
-        assert(modified_precision(references, hyp1, n=2) == 1.0)
+        assert(_modified_precision(references, hyp1, n=2) == 1.0)
         
 
         # Example 3: Proper MT outputs.
@@ -56,12 +56,12 @@ class TestBLEU(unittest.TestCase):
         references = [ref1, ref2, ref3]
         
         # Unigram precision.
-        assert (modified_precision(references, hyp1, n=1) == 0.94)
-        assert (modified_precision(references, hyp2, n=1) == 0.57)
+        assert (_modified_precision(references, hyp1, n=1) == 0.94)
+        assert (_modified_precision(references, hyp2, n=1) == 0.57)
         
         # Bigram precision
-        assert (modified_precision(references, hyp1, n=2) == 0.58)
-        assert (modified_precision(references, hyp2, n=2) == 0.07)
+        assert (_modified_precision(references, hyp1, n=2) == 0.58)
+        assert (_modified_precision(references, hyp2, n=2) == 0.07)
 
     def test_brevity_penalty(self):
         pass

--- a/nltk/test/unit/translate/test_bleu.py
+++ b/nltk/test/unit/translate/test_bleu.py
@@ -22,7 +22,7 @@ class TestBLEU(unittest.TestCase):
         references = [ref1, ref2] 
         
         # Testing modified unigram precision.
-        assert (_modified_precision(references, hyp1, n=1) == 0.28)
+        assert (_modified_precision(references, hyp1, n=1) == 0.2857142857142857)
         
         # Testing modified bigram precision.
         assert(_modified_precision(references, hyp1, n=2) == 0.0)
@@ -56,12 +56,12 @@ class TestBLEU(unittest.TestCase):
         references = [ref1, ref2, ref3]
         
         # Unigram precision.
-        assert (_modified_precision(references, hyp1, n=1) == 0.94)
-        assert (_modified_precision(references, hyp2, n=1) == 0.57)
+        assert (_modified_precision(references, hyp1, n=1) == 0.9444444444444444)
+        assert (_modified_precision(references, hyp2, n=1) == 0.5714285714285714)
         
         # Bigram precision
-        assert (_modified_precision(references, hyp1, n=2) == 0.58)
-        assert (_modified_precision(references, hyp2, n=2) == 0.07)
+        assert (_modified_precision(references, hyp1, n=2) == 0.5882352941176471)
+        assert (_modified_precision(references, hyp2, n=2) == 0.07692307692307693)
 
     def test_brevity_penalty(self):
         pass

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -48,7 +48,7 @@ def bleu(references, hypothesis, weights):
     ...               'of', 'the', 'party']
 
     >>> bleu([reference1, reference2, reference3], hypothesis1, weights)
-    0.504...
+    0.5045666840058485
 
     >>> bleu([reference1, reference2, reference3], hypothesis2, weights)
     0
@@ -86,11 +86,12 @@ def _modified_precision(references, hypothesis, n):
     The famous "the the the ... " example shows that you can get BLEU precision
     by duplicating high frequency words.
     
-        >>> ref1 = 'the cat is on the mat'.split()
-        >>> ref2 = 'there is a cat on the mat'.split()
-        >>> hyp1 = 'the the the the the the the'.split()
-        >>> modified_precision(references, hyp1, n=1)
-        0.28
+        >>> reference1 = 'the cat is on the mat'.split()
+        >>> reference2 = 'there is a cat on the mat'.split()
+        >>> hypothesis1 = 'the the the the the the the'.split()
+        >>> references = [reference1, reference2]
+        >>> _modified_precision(references, hypothesis1, n=1)
+        0.2857142857142857
     
     In the modified n-gram precision, a reference word will be considered 
     exhausted after a matching hypothesis word is identified, e.g.
@@ -98,20 +99,18 @@ def _modified_precision(references, hypothesis, n):
         >>> reference1 = ['It', 'is', 'a', 'guide', 'to', 'action', 'that',
         ...               'ensures', 'that', 'the', 'military', 'will', 
         ...               'forever', 'heed', 'Party', 'commands']
-        
         >>> reference2 = ['It', 'is', 'the', 'guiding', 'principle', 'which',
         ...               'guarantees', 'the', 'military', 'forces', 'always',
         ...               'being', 'under', 'the', 'command', 'of', 'the',
         ...               'Party']
-        
         >>> reference3 = ['It', 'is', 'the', 'practical', 'guide', 'for', 'the',
         ...               'army', 'always', 'to', 'heed', 'the', 'directions',
         ...               'of', 'the', 'party']
-        
         >>> hypothesis = 'of the'.split()
-        >>> modified_precision(references, hyp1, n=1)
+        >>> references = [reference1, reference2, reference3]
+        >>> _modified_precision(references, hypothesis, n=1)
         1.0
-        >>> modified_precision(references, hyp1, n=2)
+        >>> _modified_precision(references, hypothesis, n=2)
         1.0
         
     An example of a normal machine translation hypothesis:
@@ -137,14 +136,14 @@ def _modified_precision(references, hypothesis, n):
         ...               'army', 'always', 'to', 'heed', 'the', 'directions',
         ...               'of', 'the', 'party']
         >>> references = [reference1, reference2, reference3]
-        >>> modified_precision(references, hyp1, n=1)
-        0.94
-        >>> modified_precision(references, hyp2, n=1)
-        0.57
-        >>> modified_precision(references, hyp1, n=2
-        0.58
-        >>> modified_precision(references, hyp2, n=2)
-        0.07
+        >>> _modified_precision(references, hypothesis1, n=1)
+        0.9444444444444444
+        >>> _modified_precision(references, hypothesis2, n=1)
+        0.5714285714285714
+        >>> _modified_precision(references, hypothesis1, n=2)
+        0.5882352941176471
+        >>> _modified_precision(references, hypothesis2, n=2)
+        0.07692307692307693
 
     :param references: A list of reference translations.
     :type references: list(list(str))
@@ -184,6 +183,7 @@ def _brevity_penalty(references, hypothesis):
         >>> reference2 = list('aaaaaaaaaaaaaaa')   # i.e. ['a'] * 15
         >>> reference3 = list('aaaaaaaaaaaaaaaaa') # i.e. ['a'] * 17
         >>> hypothesis = list('aaaaaaaaaaaa')      # i.e. ['a'] * 12
+        >>> references = [reference1, reference2, reference3]
         >>> _brevity_penalty(references, hypothesis)
         1.0
 
@@ -193,7 +193,7 @@ def _brevity_penalty(references, hypothesis):
         >>> references = [['a'] * 28, ['a'] * 28]
         >>> hypothesis = ['a'] * 12
         >>> _brevity_penalty(references, hypothesis)
-        0.2635...
+        0.2635971381157267
 
     The length of the closest reference is used to compute the penalty. If the
     length of a hypothesis is 12, and the reference lengths are 13 and 2, the
@@ -203,7 +203,7 @@ def _brevity_penalty(references, hypothesis):
         >>> references = [['a'] * 13, ['a'] * 2]
         >>> hypothesis = ['a'] * 12
         >>> _brevity_penalty(references, hypothesis)
-        0.92...
+        0.9200444146293233
 
     The brevity penalty doesn't depend on reference order. More importantly,
     when two reference sentences are at the same distance, the shortest
@@ -211,8 +211,9 @@ def _brevity_penalty(references, hypothesis):
 
         >>> references = [['a'] * 13, ['a'] * 11]
         >>> hypothesis = ['a'] * 12
-        >>> _brevity_penalty(references, hypothesis) == 
-        ... _brevity_penalty(reversed(references),hypothesis) == 1
+        >>> bp1 = _brevity_penalty(references, hypothesis)  
+        >>> bp2 = _brevity_penalty(reversed(references),hypothesis) 
+        >>> bp1 == bp2 == 1
         True
 
     A test example from mteval-v13a.pl (starting from the line 705):
@@ -220,7 +221,7 @@ def _brevity_penalty(references, hypothesis):
         >>> references = [['a'] * 11, ['a'] * 8]
         >>> hypothesis = ['a'] * 7
         >>> _brevity_penalty(references, hypothesis)
-        0.86...
+        0.8668778997501817
 
         >>> references = [['a'] * 11, ['a'] * 8, ['a'] * 6, ['a'] * 7]
         >>> hypothesis = ['a'] * 7
@@ -240,5 +241,4 @@ def _brevity_penalty(references, hypothesis):
         return 1
     else:
         return math.exp(1 - r / c)
-
 


### PR DESCRIPTION
Fixing these errors in doctest in `bleu_score.py`
- [Doctest results were informally rounded off, changed them to exact floating point numbers](https://nltk.ci.cloudbees.com/job/nltk/lastCompletedBuild/TOXENV=py33-jenkins,jdk=jdk8latestOnlineInstall/testReport/nltk.translate/bleu_score/_brevity_penalty/)
- [Changed order of the from `bleu(hyp, ref)` to `bleu(ref, hyp)`](https://nltk.ci.cloudbees.com/job/nltk/lastCompletedBuild/TOXENV=py33-jenkins,jdk=jdk8latestOnlineInstall/testReport/%28root%29/bleu_doctest/bleu_doctest/)
- [Fixed typo: Missing underscore in function name](https://nltk.ci.cloudbees.com/job/nltk/lastCompletedBuild/TOXENV=py33-jenkins,jdk=jdk8latestOnlineInstall/testReport/nltk.test.unit.translate.test_bleu/TestBLEU/test_modified_precision/)

@stevenbird , sorry, I should have checked the examples in bleu_score.py before changing them into proper doctest. 
