### PR TITLE
Fix CI issue with Stanford CoreNLP jar 

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -14,6 +14,16 @@ pushd ${HOME}
 pushd 'third'
 
 #download nltk stanford dependencies
+stanford_corenlp_package_zip_name=$(curl -s 'http://nlp.stanford.edu/software/corenlp.shtml' | grep -o 'stanford-corenlp-full-.*\.zip' | head -n1)
+[[ ${stanford_corenlp_package_zip_name} =~ (.+)\.zip ]]
+stanford_corenlp_package_name=${BASH_REMATCH[1]}
+if [[ ! -d ${stanford_corenlp_package_name} ]]; then
+	wget -nv "http://nlp.stanford.edu/software/$stanford_corenlp_package_zip_name"
+	unzip ${stanford_corenlp_package_zip_name}
+	rm ${stanford_corenlp_package_zip_name}
+	ln -s ${stanford_corenlp_package_name} 'stanford-corenlp'
+fi
+
 stanford_parser_package_zip_name=$(curl -s 'http://nlp.stanford.edu/software/lex-parser.shtml' | grep -o 'stanford-parser-full-.*\.zip' | head -n1)
 [[ ${stanford_parser_package_zip_name} =~ (.+)\.zip ]]
 stanford_parser_package_name=${BASH_REMATCH[1]}
@@ -44,6 +54,7 @@ if [[ ! -d $senna_folder_name ]]; then
 fi
 
 # Setup the Enviroment variable 
+export STANFORD_CORENLP=$(pwd)'/stanford-corenlp'
 export STANFORD_PARSER=$(pwd)'/stanford-parser'
 export STANFORD_MODELS=$(pwd)'/stanford-parser'
 export STANFORD_POSTAGGER=$(pwd)'/stanford-postagger'

--- a/nltk/parse/stanford.py
+++ b/nltk/parse/stanford.py
@@ -44,7 +44,7 @@ class GenericStanfordParser(ParserI):
         stanford_jar = max(
             find_jar_iter(
                 self._JAR, path_to_jar,
-                env_vars=('STANFORD_PARSER',),
+                env_vars=('STANFORD_PARSER', 'STANFORD_CORENLP'),
                 searchpath=(), url=_stanford_url,
                 verbose=verbose, is_regex=True
             ),
@@ -54,7 +54,7 @@ class GenericStanfordParser(ParserI):
         model_jar=max(
             find_jar_iter(
                 self._MODEL_JAR_PATTERN, path_to_models_jar,
-                env_vars=('STANFORD_MODELS',),
+                env_vars=('STANFORD_MODELS', 'STANFORD_CORENLP'),
                 searchpath=(), url=_stanford_url,
                 verbose=verbose, is_regex=True
             ),

--- a/nltk/parse/stanford.py
+++ b/nltk/parse/stanford.py
@@ -395,5 +395,6 @@ def setup_module(module):
         StanfordParser(
             model_path='edu/stanford/nlp/models/lexparser/englishPCFG.ser.gz'
         )
+        StanfordNeuralDependencyParser()
     except LookupError:
-        raise SkipTest('doctests from nltk.parse.stanford are skipped because the stanford parser jar doesn\'t exist')
+        raise SkipTest('doctests from nltk.parse.stanford are skipped because one of the stanford parser or CoreNLP jars doesn\'t exist')


### PR DESCRIPTION
Makes Jenkins download both Stanford jars, and skips the Stanford parser doctests if either of the jars is missing.

Fixes the CI issue that cropped up after merging #1163.
