### PR TITLE
Ptb tokenize with offsets

### DIFF
--- a/nltk/test/tokenize.doctest
+++ b/nltk/test/tokenize.doctest
@@ -115,4 +115,31 @@ Post-hoc alignment of tokens with a source string
     >>> from nltk.tokenize.util import *
     >>> list(align_tokens(word_tokenize(s1), s1))
     [(0, 2), (3, 4), (5, 6), (6, 12), (13, 21), (22, 24), (25, 27), (28, 33), (34, 36), (37, 38), (39, 46), (46, 47), (48, 51), (52, 59), (60, 67), (68, 73), (74, 76), (77, 78), (78, 84), (84, 85)]
-    
+    >>> list(align_tokens([''], ""))
+    [(0, 0)]
+    >>> list(align_tokens([''], " "))
+    [(0, 0)]
+    >>> list(align_tokens([], ""))
+    []
+    >>> list(align_tokens([], " "))
+    []
+    >>> list(align_tokens(['a'], "a"))
+    [(0, 1)]
+    >>> list(align_tokens(['abc', 'def'], "abcdef"))
+    [(0, 3), (3, 6)]
+    >>> list(align_tokens(['abc', 'def'], "abc def"))
+    [(0, 3), (4, 7)]
+    >>> list(align_tokens(['ab', 'cd'], "ab cd ef"))
+    [(0, 2), (3, 5)]
+    >>> list(align_tokens(['ab', 'cd', 'ef'], "ab cd ef"))
+    [(0, 2), (3, 5), (6, 8)]
+    >>> list(align_tokens(['ab', 'cd', 'efg'], "ab cd ef"))
+    Traceback (most recent call last):
+    ....
+    ValueError: ('Sentence ended while scanning for token start', 2)
+    >>> list(align_tokens(['ab', 'cd', 'ef', 'gh'], "ab cd ef"))
+    Traceback (most recent call last):
+    ....
+    ValueError: ('Sentence ended while scanning for token start', 3)
+    >>> list(align_tokens(['The', 'plane', ',', 'bound', 'for', 'St', 'Petersburg', ',', 'crashed', 'in', 'Egypt', "'s", 'Sinai', 'desert', 'just', '23', 'minutes', 'after', 'take-off', 'from', 'Sharm', 'el-Sheikh', 'on', 'Saturday', '.'], "The plane, bound for St Petersburg, crashed in Egypt's Sinai desert just 23 minutes after take-off from Sharm el-Sheikh on Saturday."))
+    [(0, 3), (4, 9), (9, 10), (11, 16), (17, 20), (21, 23), (24, 34), (34, 35), (36, 43), (44, 46), (47, 52), (52, 54), (55, 60), (61, 67), (68, 72), (73, 75), (76, 83), (84, 89), (90, 98), (99, 103), (104, 109), (110, 119), (120, 122), (123, 131), (131, 132)]

--- a/nltk/test/tokenize.doctest
+++ b/nltk/test/tokenize.doctest
@@ -109,3 +109,10 @@ A simple sentence tokenizer '\.(\s+|$)'
     >>> regexp_tokenize(s, pattern=r'\.(?:\s+|$)', gaps=True)
     ['Good muffins cost $3.88\nin New York',
      'Please buy me\ntwo of them', 'Thanks']
+
+Post-hoc alignment of tokens with a source string
+
+    >>> from nltk.tokenize.util import *
+    >>> list(align_tokens(word_tokenize(s1), s1))
+    [(0, 2), (3, 4), (5, 6), (6, 12), (13, 21), (22, 24), (25, 27), (28, 33), (34, 36), (37, 38), (39, 46), (46, 47), (48, 51), (52, 59), (60, 67), (68, 73), (74, 76), (77, 78), (78, 84), (84, 85)]
+    

--- a/nltk/tokenize/util.py
+++ b/nltk/tokenize/util.py
@@ -88,3 +88,32 @@ def spans_to_relative(spans):
         prev = right
 
 
+def align_tokens(tokens, sentence): 
+    r"""
+    Return the offsets of the tokens in *s*, as a sequence of ``(start, end)``
+    tuples, given the tokens and also the source string.
+    
+    :param tokens: the list of strings that are the result of tokenization
+    :type s: list(str)
+    :param sentence: the original string 
+    :rtype: iter(tuple(int,int))
+    """
+    prev = 0
+    token_offset = 0
+
+    while token_offset < len(tokens):
+        token = tokens[token_offset]
+        try:
+            substring = sentence[prev:prev + len(token)]
+        except:
+	        raise ValueError('Sentence ended while scanning for token end', token)
+
+        if substring == token:
+            yield prev, prev + len(token)
+            prev += len(token)
+            token_offset += 1
+        else:
+            prev += 1
+
+        if prev > len(sentence):
+        	raise ValueError('Sentence ended while scanning for token start', token_offset)

--- a/nltk/tokenize/util.py
+++ b/nltk/tokenize/util.py
@@ -92,7 +92,18 @@ def align_tokens(tokens, sentence):
     r"""
     Return the offsets of the tokens in *s*, as a sequence of ``(start, end)``
     tuples, given the tokens and also the source string.
-    
+       
+        >>> from nltk.tokenize import TreebankWordTokenizer
+        >>> from nltk.tokenize.util import align_tokens
+        >>> s = '''The plane, bound for St Petersburg, crashed in Egypt's 
+        ... Sinai desert just 23 minutes after take-off from Sharm el-Sheikh 
+        ... on Saturday.'''
+        >>> list(align_tokens(TreebankWordTokenizer().tokenize(s), s))
+        [(0, 3), (4, 9), (9, 10), (11, 16), (17, 20), (21, 23), (24, 34), 
+        (34, 35), (36, 43), (44, 46), (47, 52), (52, 54), (55, 60), (61, 67), 
+        (68, 72), (73, 75), (76, 83), (84, 89), (90, 98), (99, 103), (104, 109), 
+        (110, 119), (120, 122), (123, 131), (131, 132)]
+
     :param tokens: the list of strings that are the result of tokenization
     :type s: list(str)
     :param sentence: the original string 


### PR DESCRIPTION
The string_span_tokenize() functionality is very useful, critical for anyone working with standoff annotations. This simple function, intended originally for just the PTB tokenizer but actually tokenizer-independent, creates span tuples for any matching token list / source sentence pair.
