### PR TITLE
Enforcing padding on ngrams

### DIFF
--- a/nltk/util.py
+++ b/nltk/util.py
@@ -451,7 +451,7 @@ def ngrams(sequence, n, pad_left=False, pad_right=False,
     :rtype: sequence or iter
     """
     sequence = pad_sequence(sequence, n, pad_left, pad_right,
-                                left_pad_symbol, right_pad_symbol)
+                            left_pad_symbol, right_pad_symbol)
         
     history = []
     while n > 1:

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -450,9 +450,7 @@ def ngrams(sequence, n, pad_left=False, pad_right=False,
     :type right_pad_symbol: any
     :rtype: sequence or iter
     """
-    
-    if pad_left or pad_right:
-        sequence = pad_sequence(sequence, n, pad_left, pad_right,
+    sequence = pad_sequence(sequence, n, pad_left, pad_right,
                                 left_pad_symbol, right_pad_symbol)
         
     history = []


### PR DESCRIPTION
This is a fix for #1194

Previously, all sequences/iterators were converted into iterables before proceeding with ngram extraction, from https://github.com/nltk/nltk/blob/554a1710ef1011ba65168d442d038763c517e292/nltk/util.py#L411

But after abstracting the `pad_sequence()` away from the ngrams function, the `iterator->iterable` conversion happens [there](https://github.com/alvations/nltk/blob/develop/nltk/util.py#L407) and that would make the checks for pad_left and pad_right within the `ngram()` obsolete because now `pad_sequence()` does the check. 

Sorry for missing this out in the previous merge.
