### PR TITLE
Add further sphinx docs to read_* methods in nltk.internals

### DIFF
--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -226,6 +226,27 @@ def read_int(s, start_position):
     string, then return a tuple ``(val, end_position)`` containing the
     value of the integer and the position where it ends.  Otherwise,
     raise a ``ReadError``.
+
+    :param s: A string that will be checked to see if within which a 
+        Python integer exists.
+    :type s: str
+    
+    :param start_position: The specified beginning position of the string ``s``
+        to begin regex matching.
+    :type start_position: int
+    
+    :return: A tuple containing the matched integer casted to an int,
+        and the end position of the int in ``s``.
+    :rtype: tuple(int, int)
+
+    :raise ReadError: If the ``_READ_INT_RE`` regex doesn't return a
+        match in ``s`` at ``start_position``.
+
+    :Example:
+    >>> from nltk.internals import read_int
+    >>> read_int('42 is the answer', 0)
+    (42, 2)
+    
     """
     m = _READ_INT_RE.match(s, start_position)
     if not m: raise ReadError('integer', start_position)

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -172,6 +172,31 @@ def read_str(s, start_position):
     given string, then return a tuple ``(val, end_position)``
     containing the value of the string literal and the position where
     it ends.  Otherwise, raise a ``ReadError``.
+
+    :param s: A string that will be checked to see if within which a 
+        Python string literal exists.
+    :type s: str
+    
+    :param start_position: The specified beginning position of the string ``s``
+        to begin regex matching.
+    :type start_position: int
+    
+    :return: A tuple containing the matched string literal evaluated as a 
+        string and the end position of the string literal.
+    :rtype: tuple(str, int)
+
+    :raise ReadError: If the ``_STRING_START_RE`` regex doesn't return a
+        match in ``s`` at ``start_position``, i.e., open quote. If the 
+        ``_STRING_END_RE`` regex doesn't return a match in ``s`` at the 
+        end of the first match, i.e., close quote.
+    :raise ValueError: If an invalid string (i.e., contains an invalid
+        escape sequence) is passed into the ``eval``.
+
+    :Example:
+    >>> from nltk.internals import read_str
+    >>> read_str('"Hello", World!', 0)
+    ('Hello', 7)
+
     """
     # Read the open quote, and any modifiers.
     m = _STRING_START_RE.match(s, start_position)

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -259,6 +259,27 @@ def read_number(s, start_position):
     given string, then return a tuple ``(val, end_position)``
     containing the value of the number and the position where it ends.
     Otherwise, raise a ``ReadError``.
+
+    :param s: A string that will be checked to see if within which a 
+        Python number exists.
+    :type s: str
+    
+    :param start_position: The specified beginning position of the string ``s``
+        to begin regex matching.
+    :type start_position: int
+    
+    :return: A tuple containing the matched number casted to a ``float``,
+        and the end position of the number in ``s``.
+    :rtype: tuple(float, int)
+
+    :raise ReadError: If the ``_READ_NUMBER_VALUE`` regex doesn't return a
+        match in ``s`` at ``start_position``.
+
+    :Example:
+    >>> from nltk.internals import read_number
+    >>> read_number('Pi is 3.14159', 6)
+    (3.14159, 13)
+    
     """
     m = _READ_NUMBER_VALUE.match(s, start_position)
     if not m or not (m.group(1) or m.group(2)):


### PR DESCRIPTION
I was going through nltk/internals.py, specifically `read_str`, `read_int`, and `read_number`, and I saw they didn't have any :Example:'s for `doctest` as well as :param: and :return: (and their corresponding :type:'s), so I added them. I don't believe in this case it is overkill, as explicitly labeling type and providing examples can only help clarify the use.
