### PR TITLE
Replace None checks in skipgram right padding

### DIFF
--- a/nltk/util.py
+++ b/nltk/util.py
@@ -551,13 +551,14 @@ def skipgrams(sequence, n, k, **kwargs):
         sequence = pad_sequence(sequence, n, **kwargs)
     
     # Note when iterating through the ngrams, the pad_right here is not
-    # the **kwargs padding, it's for the algorithm to detect None on the 
-    # right pad to stop inner loop.
-    for ngram in ngrams(sequence, n + k, pad_right=True):
+    # the **kwargs padding, it's for the algorithm to detect the SENTINEL 
+    # object on the right pad to stop inner loop.
+    SENTINEL = object()
+    for ngram in ngrams(sequence, n + k, pad_right=True, right_pad_symbol=SENTINEL):
         head = ngram[:1]
         tail = ngram[1:]
         for skip_tail in combinations(tail, n - 1):
-            if skip_tail[-1] is None:
+            if skip_tail[-1] is SENTINEL:
                 continue
             yield head + skip_tail
 


### PR DESCRIPTION
From #1070 and #1179, the `None` checks for the end of the inner skipgram loop is replaced with a sentinel object.
