### PR TITLE
Use division from python3 for RIBES

### DIFF
--- a/nltk/translate/ribes_score.py
+++ b/nltk/translate/ribes_score.py
@@ -6,7 +6,7 @@
 # URL: <http://nltk.org/>
 # For license information, see LICENSE.TXT
 """ RIBES score implementation """
-
+from __future__ import division
 from itertools import islice
 import math
 


### PR DESCRIPTION
Fixes #1218. Failure from doctests for python2 because code was using python3 division conventions. 
