### PR TITLE
Fix a bug on sentiwordnet

### DIFF
--- a/nltk/corpus/reader/sentiwordnet.py
+++ b/nltk/corpus/reader/sentiwordnet.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Natural Language Toolkit: WordNet
+# Natural Language Toolkit: SentiWordNet
 #
 # Copyright (C) 2001-2015 NLTK Project
 # Author: Christopher Potts <cgpotts@stanford.edu>

--- a/nltk/corpus/reader/sentiwordnet.py
+++ b/nltk/corpus/reader/sentiwordnet.py
@@ -70,11 +70,15 @@ class SentiWordNetCorpusReader(CorpusReader):
         if tuple(vals) in self._db:
             pos_score, neg_score = self._db[tuple(vals)]
             pos, offset = vals
+            if pos == 's':
+                pos = 'a'
             synset = wn._synset_from_pos_and_offset(pos, offset)
             return SentiSynset(pos_score, neg_score, synset)
         else:
             synset = wn.synset(vals[0])
             pos = synset.pos()
+            if pos == 's':
+                pos = 'a'
             offset = synset.offset()
             if (pos, offset) in self._db:
                 pos_score, neg_score = self._db[(pos, offset)]


### PR DESCRIPTION
In the current implementation, sentiment synsets of some adjectives
are not found, due to the fact that in SentiWordNet corpus
there exist no 's' tag, which stands for 'adjective satellite.'
This modifies the code to treat 's' tag as 'a', so that it can find
synsets of adjectives correctly.
To see the change, check synsets of the word 'crazy.'
