### PR TITLE
Added function to calculate Corpus-level BLEU and RIBES

### DIFF
--- a/nltk/translate/__init__.py
+++ b/nltk/translate/__init__.py
@@ -19,6 +19,6 @@ from nltk.translate.ibm3 import IBMModel3
 from nltk.translate.ibm4 import IBMModel4
 from nltk.translate.ibm5 import IBMModel5
 from nltk.translate.bleu_score import sentence_bleu as bleu
-from nltk.translate.ribes_score import ribes
+from nltk.translate.ribes_score import sentence_ribes as ribes
 from nltk.translate.metrics import alignment_error_rate
 from nltk.translate.stack_decoder import StackDecoder

--- a/nltk/translate/__init__.py
+++ b/nltk/translate/__init__.py
@@ -18,7 +18,7 @@ from nltk.translate.ibm2 import IBMModel2
 from nltk.translate.ibm3 import IBMModel3
 from nltk.translate.ibm4 import IBMModel4
 from nltk.translate.ibm5 import IBMModel5
-from nltk.translate.sentence_bleu import bleu
+from nltk.translate.bleu_score import sentence_bleu as bleu
 from nltk.translate.ribes_score import ribes
 from nltk.translate.metrics import alignment_error_rate
 from nltk.translate.stack_decoder import StackDecoder

--- a/nltk/translate/__init__.py
+++ b/nltk/translate/__init__.py
@@ -18,7 +18,7 @@ from nltk.translate.ibm2 import IBMModel2
 from nltk.translate.ibm3 import IBMModel3
 from nltk.translate.ibm4 import IBMModel4
 from nltk.translate.ibm5 import IBMModel5
-from nltk.translate.bleu_score import bleu
+from nltk.translate.sentence_bleu import bleu
 from nltk.translate.ribes_score import ribes
 from nltk.translate.metrics import alignment_error_rate
 from nltk.translate.stack_decoder import StackDecoder

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -66,6 +66,8 @@ def sentence_bleu(references, hypothesis, weights=[0.25, 0.25, 0.25, 0.25]):
     :type hypothesis: list(str)
     :param weights: weights for unigrams, bigrams, trigrams and so on
     :type weights: list(float)
+    :return: The sentence-level BLEU score.
+    :rtype: float
     """
     # Calculates the modified precision *p_n* for each order of ngram.
     p_ns = [] 
@@ -137,6 +139,8 @@ def corpus_bleu(list_of_references, hypotheses, weights=[0.25, 0.25, 0.25, 0.25]
     :type hypotheses: list(list(str))
     :param weights: weights for unigrams, bigrams, trigrams and so on
     :type weights: list(float)
+    :return: The corpus-level BLEU score.
+    :rtype: float
     """
     p_numerators = Counter() # Key = ngram order, and value = no. of ngram matches.
     p_denominators = Counter() # Key = ngram order, and value = no. of ngram in ref.
@@ -253,6 +257,8 @@ def _modified_precision(references, hypothesis, n):
     :type hypothesis: list(str)
     :param n: The ngram order.
     :type n: int
+    :return: BLEU's modified precision for the nth order ngram.
+    :rtype: Fraction
     """
     counts = Counter(ngrams(hypothesis, n))
 
@@ -283,7 +289,9 @@ def _closest_ref_length(references, hyp_len):
     :param references: A list of reference translations.
     :type references: list(list(str))
     :param hypothesis: The length of the hypothesis.
-    :type hypothesis: int    
+    :type hypothesis: int
+    :return: The length of the reference that's closest to the hypothesis.
+    :rtype: int    
     """
     ref_lens = (len(reference) for reference in references)
     closest_ref_len = min(ref_lens, key=lambda ref_len: 
@@ -371,6 +379,8 @@ def _brevity_penalty(closest_ref_len, hyp_len):
     :param closest_ref_len: The length of the closest reference for a single 
     hypothesis OR the sum of all the closest references for every hypotheses.
     :type closest_reference_len: int    
+    :return: BLEU's brevity penalty.
+    :rtype: float
     """
     if hyp_len > closest_ref_len:
         return 1

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -263,7 +263,7 @@ def _modified_precision(references, hypothesis, n):
     counts = Counter(ngrams(hypothesis, n))
 
     if not counts:
-        return 0
+        return Fraction(0)
 
     max_counts = {}
     for reference in references:
@@ -316,7 +316,6 @@ def _brevity_penalty(closest_ref_len, hyp_len):
         >>> references = [reference1, reference2, reference3]
         >>> hyp_len = len(hypothesis)
         >>> closest_ref_len =  _closest_ref_length(references, hyp_len)
-        >>> hyp_len = len(hypothesis)
         >>> _brevity_penalty(closest_ref_len, hyp_len)
         1.0
 
@@ -352,7 +351,7 @@ def _brevity_penalty(closest_ref_len, hyp_len):
         >>> closest_ref_len =  _closest_ref_length(references, hyp_len)
         >>> bp1 = _brevity_penalty(closest_ref_len, hyp_len)
         >>> hyp_len = len(hypothesis)
-        >>> closest_ref_len =  _closest_ref_length(references, hyp_len)
+        >>> closest_ref_len =  _closest_ref_length(reversed(references), hyp_len)
         >>> bp2 = _brevity_penalty(closest_ref_len, hyp_len)
         >>> bp1 == bp2 == 1
         True

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -116,6 +116,13 @@ def corpus_bleu(list_of_references, hypotheses, weights=[0.25, 0.25, 0.25, 0.25]
     >>> hypotheses = [hyp1, hyp2]
     >>> corpus_bleu(list_of_references, hypotheses)
     0.5920778868801042
+    
+    :param references: a corpus of lists of reference sentences, w.r.t. hypotheses
+    :type references: list(list(list(str)))
+    :param hypothesis: a list of hypothesis sentences
+    :type hypothesis: list(list(str))
+    :param weights: weights for unigrams, bigrams, trigrams and so on
+    :type weights: list(float)
     """
     p_numerators = Counter() # Key = ngram order, and value = no. of ngram matches.
     p_denominators = Counter() # Key = ngram order, and value = no. of ngram in ref.

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -217,11 +217,11 @@ def _brevity_penalty(references, hypothesis):
     :param hypothesis: A hypothesis translation.
     :type hypothesis: list(str)    
     """
-    # *hyp_len* is referred to as *c* in (Papineni et. al. 2002)
+    # *hyp_len* is referred to as *c* in Papineni et. al. (2002)
     hyp_len = len(hypothesis) 
     ref_lens = (len(reference) for reference in references)
     # Find the reference length that's closes to the hypothesis. 
-    # *closest_ref_len* is referred to as *r* in (Papineni et. al. 2002)
+    # *closest_ref_len* is referred to as *r* in Papineni et. al. (2002)
     closest_ref_len = min(ref_lens, key=lambda ref_len: 
                            (abs(ref_len - hyp_len), ref_len))
     return hyp_len, closest_ref_len

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -3,7 +3,7 @@
 #
 # Copyright (C) 2001-2015 NLTK Project
 # Authors: Chin Yee Lee, Hengfeng Li, Ruxin Hou, Calvin Tanujaya Lim
-# Contributors: Dmitrijs Milajevs
+# Contributors: Dmitrijs Milajevs, Liling Tan
 # URL: <http://nltk.org/>
 # For license information, see LICENSE.TXT
 """BLEU score implementation."""
@@ -11,21 +11,19 @@
 from __future__ import division
 
 import math
+from collections import defaultdict
 
-from nltk.tokenize import word_tokenize
 from nltk.compat import Counter
 from nltk.util import ngrams
 
 
-def bleu(references, hypothesis, weights):
+def sentence_bleu(references, hypothesis, weights=[0.25, 0.25, 0.25, 0.25]):
     """
     Calculate BLEU score (Bilingual Evaluation Understudy) from
     Papineni, Kishore, Salim Roukos, Todd Ward, and Wei-Jing Zhu. 2002.
     "BLEU: a method for automatic evaluation of machine translation." 
     In Proceedings of ACL. http://www.aclweb.org/anthology/P02-1040.pdf
 
-
-    >>> weights = [0.25, 0.25, 0.25, 0.25]
     >>> hypothesis1 = ['It', 'is', 'a', 'guide', 'to', 'action', 'which',
     ...               'ensures', 'that', 'the', 'military', 'always',
     ...               'obeys', 'the', 'commands', 'of', 'the', 'party']
@@ -47,12 +45,21 @@ def bleu(references, hypothesis, weights):
     ...               'army', 'always', 'to', 'heed', 'the', 'directions',
     ...               'of', 'the', 'party']
 
-    >>> bleu([reference1, reference2, reference3], hypothesis1, weights)
+    >>> sentence_bleu([reference1, reference2, reference3], hypothesis1)
     0.5045666840058485
 
-    >>> bleu([reference1, reference2, reference3], hypothesis2, weights)
+    >>> sentence_bleu([reference1, reference2, reference3], hypothesis2)
     0
 
+    The default BLEU calculates a score for up to 4grams using uniform
+    weights. To evaluate your translations with higher/lower order ngrams.
+    Use customized weights. E.g. when accounting for up to 6grams with uniform
+    weights:
+
+    >>> weights = [0.1666, 0.1666, 0.1666, 0.1666, 0.1666]
+    >>> sentence_bleu([reference1, reference2, reference3], hypothesis1, weights)
+    0.45838627164939455
+    
     :param references: reference sentences
     :type references: list(list(str))
     :param hypothesis: a hypothesis sentence
@@ -60,19 +67,87 @@ def bleu(references, hypothesis, weights):
     :param weights: weights for unigrams, bigrams, trigrams and so on
     :type weights: list(float)
     """
-    p_ns = (
-        _modified_precision(references, hypothesis, i)
-        for i, _ in enumerate(weights, start=1)
-    )
+    # Calculates the modified precision *p_n* for each order of ngram.
+    p_ns = [] 
+    for i, _ in enumerate(weights, start=1): 
+        p_n = sentence_modified_precision(references, hypothesis, i)
+        p_ns.append(p_n) 
 
     try:
+        # Calculates the overall modified precision for all ngrams.
+        # By taking the product of the weights and the respective *p_n*
         s = math.fsum(w * math.log(p_n) for w, p_n in zip(weights, p_ns))
     except ValueError:
         # some p_ns is 0
         return 0
 
-    bp = _brevity_penalty(references, hypothesis)
+    bp = sentence_brevity_penalty(references, hypothesis)
     return bp * math.exp(s)
+
+
+def corpus_bleu(list_of_references, hypotheses, weights=[0.25, 0.25, 0.25, 0.25]):
+    """
+    Calculate a single corpus-level BLEU score (aka. system-level BLEU) for all 
+    the hypotheses and their respective references.  
+
+    Instead of averaging the sentence level BLEU scores (i.e. marco-average 
+    precision), the original BLEU metric (Papineni et al. 2002) accounts for 
+    the micro-average precision (i.e. summing the numerators and denominators
+    for each hypothesis-reference(s) pairs before the division).
+    
+    >>> hyp1 = ['It', 'is', 'a', 'guide', 'to', 'action', 'which',
+    ...         'ensures', 'that', 'the', 'military', 'always',
+    ...         'obeys', 'the', 'commands', 'of', 'the', 'party']
+    >>> ref1a = ['It', 'is', 'a', 'guide', 'to', 'action', 'that',
+    ...          'ensures', 'that', 'the', 'military', 'will', 'forever',
+    ...          'heed', 'Party', 'commands']
+    >>> ref1b = ['It', 'is', 'the', 'guiding', 'principle', 'which',
+    ...          'guarantees', 'the', 'military', 'forces', 'always',
+    ...          'being', 'under', 'the', 'command', 'of', 'the', 'Party']
+    >>> ref1c = ['It', 'is', 'the', 'practical', 'guide', 'for', 'the',
+    ...          'army', 'always', 'to', 'heed', 'the', 'directions',
+    ...          'of', 'the', 'party']
+    
+    >>> hyp2 = ['he', 'read', 'the', 'book', 'because', 'he', 'was', 
+    ...         'interested', 'in', 'world', 'history']
+    >>> ref2a = ['he', 'was', 'interested', 'in', 'world', 'history', 
+    ...          'because', 'he', 'read', 'the', 'book']
+    
+    >>> list_of_references = [[ref1a, ref1b, ref1c], [ref2a]]
+    >>> hypotheses = [hyp1, hyp2]
+    >>> corpus_bleu(list_of_references, hypotheses)
+    0.5920778868801042
+    """
+    p_numerators = Counter() # Key = ngram order, and value = no. of ngram matches.
+    p_denominators = Counter() # Key = ngram order, and value = no. of ngram in ref.
+    hyp_lengths, ref_lengths = 0, 0
+    
+    # Iterate through each hypothesis and their corresponding references.
+    for references, hypothesis in zip(list_of_references, hypotheses):
+        # For each order of ngram, calculate the modified precision.
+        for i, _ in enumerate(weights, start=1): 
+            numerator, denominator = _modified_precision(references, hypothesis, i)
+            p_numerators[i]+=numerator
+            p_denominators[i]+=denominator
+            
+        # Calculate the hypothesis length and the closest reference length.
+        hyp_len, closest_ref_len = _brevity_penalty(references, hypothesis)    
+        hyp_lengths+=hyp_len
+        ref_lengths+=closest_ref_len
+    
+    # Calcualte corpus-level brevity penalty.
+    if hyp_lengths > ref_lengths:
+        bp = 1
+    else:
+        bp = math.exp(1 - ref_lengths / hyp_lengths)
+    
+    # Calculate corpus-level modified precision.
+    p_n = []
+    for i, w in enumerate(weights, start=1):
+        pn = p_numerators[i] / p_denominators[i]
+        p_n.append(w* math.log(pn))
+        
+    return bp * math.exp(math.fsum(p_n))
 
 
 def _modified_precision(references, hypothesis, n):
@@ -81,7 +156,66 @@ def _modified_precision(references, hypothesis, n):
 
     The normal precision method may lead to some wrong translations with
     high-precision, e.g., the translation, in which a word of reference
-    repeats several times, has very high precision. 
+    repeats several times, has very high precision.     
+
+    This function only returns the numerator and denominator necessary to 
+    calculate the corpus-level precision. To calculate the modified precision
+    for a single pair of hypothesis and references, use or the 
+    sentence_modified_precision() function.
+    
+    :param references: A list of reference translations.
+    :type references: list(list(str))
+    :param hypothesis: A hypothesis translation.
+    :type hypothesis: list(str)
+    :param n: The ngram order.
+    :type n: int
+    """
+    counts = Counter(ngrams(hypothesis, n))
+
+    if not counts:
+        return 0
+
+    max_counts = {}
+    for reference in references:
+        reference_counts = Counter(ngrams(reference, n))
+        for ngram in counts:
+            max_counts[ngram] = max(max_counts.get(ngram, 0), reference_counts[ngram])
+
+    clipped_counts = dict((ngram, min(count, max_counts[ngram])) 
+                          for ngram, count in counts.items())
+    
+    numerator = sum(clipped_counts.values())
+    denominator = sum(counts.values())  
+    
+    return numerator, denominator 
+    
+
+def _brevity_penalty(references, hypothesis):
+    """
+    Calculate brevity penalty.
+
+    As the modified n-gram precision still has the problem from the short
+    length sentence, brevity penalty is used to modify the overall BLEU
+    score according to length.
+
+    :param references: A list of reference translations.
+    :type references: list(list(str))
+    :param hypothesis: A hypothesis translation.
+    :type hypothesis: list(str)    
+    """
+    # *hyp_len* is referred to as *c* in (Papineni et. al. 2002)
+    hyp_len = len(hypothesis) 
+    ref_lens = (len(reference) for reference in references)
+    # Find the reference length that's closes to the hypothesis. 
+    # *closest_ref_len* is referred to as *c* in (Papineni et. al. 2002)
+    closest_ref_len = min(ref_lens, key=lambda ref_len: 
+                           (abs(ref_len - hyp_len), ref_len))
+    return hyp_len, closest_ref_len
+    
+
+def sentence_modified_precision(references, hypothesis, n):
+    """
+    Calculate sentence-level modified ngram precision. 
     
     The famous "the the the ... " example shows that you can get BLEU precision
     by duplicating high frequency words.
@@ -90,7 +224,7 @@ def _modified_precision(references, hypothesis, n):
         >>> reference2 = 'there is a cat on the mat'.split()
         >>> hypothesis1 = 'the the the the the the the'.split()
         >>> references = [reference1, reference2]
-        >>> _modified_precision(references, hypothesis1, n=1)
+        >>> sentence_modified_precision(references, hypothesis1, n=1)
         0.2857142857142857
     
     In the modified n-gram precision, a reference word will be considered 
@@ -108,9 +242,9 @@ def _modified_precision(references, hypothesis, n):
         ...               'of', 'the', 'party']
         >>> hypothesis = 'of the'.split()
         >>> references = [reference1, reference2, reference3]
-        >>> _modified_precision(references, hypothesis, n=1)
+        >>> sentence_modified_precision(references, hypothesis, n=1)
         1.0
-        >>> _modified_precision(references, hypothesis, n=2)
+        >>> sentence_modified_precision(references, hypothesis, n=2)
         1.0
         
     An example of a normal machine translation hypothesis:
@@ -136,15 +270,15 @@ def _modified_precision(references, hypothesis, n):
         ...               'army', 'always', 'to', 'heed', 'the', 'directions',
         ...               'of', 'the', 'party']
         >>> references = [reference1, reference2, reference3]
-        >>> _modified_precision(references, hypothesis1, n=1)
+        >>> sentence_modified_precision(references, hypothesis1, n=1)
         0.9444444444444444
-        >>> _modified_precision(references, hypothesis2, n=1)
+        >>> sentence_modified_precision(references, hypothesis2, n=1)
         0.5714285714285714
-        >>> _modified_precision(references, hypothesis1, n=2)
+        >>> sentence_modified_precision(references, hypothesis1, n=2)
         0.5882352941176471
-        >>> _modified_precision(references, hypothesis2, n=2)
+        >>> sentence_modified_precision(references, hypothesis2, n=2)
         0.07692307692307693
-
+        
     :param references: A list of reference translations.
     :type references: list(list(str))
     :param hypothesis: A hypothesis translation.
@@ -152,29 +286,13 @@ def _modified_precision(references, hypothesis, n):
     :param n: The ngram order.
     :type n: int
     """
-    counts = Counter(ngrams(hypothesis, n))
-
-    if not counts:
-        return 0
-
-    max_counts = {}
-    for reference in references:
-        reference_counts = Counter(ngrams(reference, n))
-        for ngram in counts:
-            max_counts[ngram] = max(max_counts.get(ngram, 0), reference_counts[ngram])
-
-    clipped_counts = dict((ngram, min(count, max_counts[ngram])) for ngram, count in counts.items())
-
-    return sum(clipped_counts.values()) / sum(counts.values())
+    numerator, denominator = _modified_precision(references, hypothesis, n)
+    return numerator / denominator
 
 
-def _brevity_penalty(references, hypothesis):
+def sentence_brevity_penalty(references, hypothesis):
     """
-    Calculate brevity penalty.
-
-    As the modified n-gram precision still has the problem from the short
-    length sentence, brevity penalty is used to modify the overall BLEU
-    score according to length.
+    Calculate sentence-level brevity penalty.        
 
     An example from the paper. There are three references with length 12, 15
     and 17. And a concise hypothesis of the length 12. The brevity penalty is 1.
@@ -184,7 +302,7 @@ def _brevity_penalty(references, hypothesis):
         >>> reference3 = list('aaaaaaaaaaaaaaaaa') # i.e. ['a'] * 17
         >>> hypothesis = list('aaaaaaaaaaaa')      # i.e. ['a'] * 12
         >>> references = [reference1, reference2, reference3]
-        >>> _brevity_penalty(references, hypothesis)
+        >>> sentence_brevity_penalty(references, hypothesis)
         1.0
 
     In case a hypothesis translation is shorter than the references, penalty is
@@ -192,7 +310,7 @@ def _brevity_penalty(references, hypothesis):
 
         >>> references = [['a'] * 28, ['a'] * 28]
         >>> hypothesis = ['a'] * 12
-        >>> _brevity_penalty(references, hypothesis)
+        >>> sentence_brevity_penalty(references, hypothesis)
         0.2635971381157267
 
     The length of the closest reference is used to compute the penalty. If the
@@ -202,7 +320,7 @@ def _brevity_penalty(references, hypothesis):
 
         >>> references = [['a'] * 13, ['a'] * 2]
         >>> hypothesis = ['a'] * 12
-        >>> _brevity_penalty(references, hypothesis)
+        >>> sentence_brevity_penalty(references, hypothesis)
         0.9200444146293233
 
     The brevity penalty doesn't depend on reference order. More importantly,
@@ -211,8 +329,8 @@ def _brevity_penalty(references, hypothesis):
 
         >>> references = [['a'] * 13, ['a'] * 11]
         >>> hypothesis = ['a'] * 12
-        >>> bp1 = _brevity_penalty(references, hypothesis)  
-        >>> bp2 = _brevity_penalty(reversed(references),hypothesis) 
+        >>> bp1 = sentence_brevity_penalty(references, hypothesis)  
+        >>> bp2 = sentence_brevity_penalty(reversed(references),hypothesis) 
         >>> bp1 == bp2 == 1
         True
 
@@ -220,12 +338,12 @@ def _brevity_penalty(references, hypothesis):
 
         >>> references = [['a'] * 11, ['a'] * 8]
         >>> hypothesis = ['a'] * 7
-        >>> _brevity_penalty(references, hypothesis)
+        >>> sentence_brevity_penalty(references, hypothesis)
         0.8668778997501817
 
         >>> references = [['a'] * 11, ['a'] * 8, ['a'] * 6, ['a'] * 7]
         >>> hypothesis = ['a'] * 7
-        >>> _brevity_penalty(references, hypothesis)
+        >>> sentence_brevity_penalty(references, hypothesis)
         1.0
     
     :param references: A list of reference translations.
@@ -233,12 +351,9 @@ def _brevity_penalty(references, hypothesis):
     :param hypothesis: A hypothesis translation.
     :type hypothesis: list(str)
     """
-    c = len(hypothesis)
-    ref_lens = (len(reference) for reference in references)
-    r = min(ref_lens, key=lambda ref_len: (abs(ref_len - c), ref_len))
-
-    if c > r:
+    hyp_len, closest_ref_lens = _brevity_penalty(references, hypothesis)
+    if hyp_len > closest_ref_lens:
         return 1
     else:
-        return math.exp(1 - r / c)
+        return math.exp(1 - closest_ref_lens / hyp_len)
 

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -11,9 +11,8 @@
 from __future__ import division
 
 import math
-from collections import defaultdict
+from collections import Counter
 
-from nltk.compat import Counter
 from nltk.util import ngrams
 
 

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -117,6 +117,14 @@ def corpus_bleu(list_of_references, hypotheses, weights=[0.25, 0.25, 0.25, 0.25]
     >>> corpus_bleu(list_of_references, hypotheses)
     0.5920778868801042
     
+    The example below show that corpus_bleu() is different from averaging 
+    sentence_bleu() for hypotheses 
+    
+    >>> score1 = sentence_bleu([ref1a, ref1b, ref1c], hyp1)
+    >>> score2 = sentence_bleu([ref2a], hyp2)
+    >>> (score1 + score2) / 2
+    0.6223247442490669
+    
     :param references: a corpus of lists of reference sentences, w.r.t. hypotheses
     :type references: list(list(list(str)))
     :param hypotheses: a list of hypothesis sentences

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -119,8 +119,8 @@ def corpus_bleu(list_of_references, hypotheses, weights=[0.25, 0.25, 0.25, 0.25]
     
     :param references: a corpus of lists of reference sentences, w.r.t. hypotheses
     :type references: list(list(list(str)))
-    :param hypothesis: a list of hypothesis sentences
-    :type hypothesis: list(list(str))
+    :param hypotheses: a list of hypothesis sentences
+    :type hypotheses: list(list(str))
     :param weights: weights for unigrams, bigrams, trigrams and so on
     :type weights: list(float)
     """

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -207,7 +207,7 @@ def _brevity_penalty(references, hypothesis):
     hyp_len = len(hypothesis) 
     ref_lens = (len(reference) for reference in references)
     # Find the reference length that's closes to the hypothesis. 
-    # *closest_ref_len* is referred to as *c* in (Papineni et. al. 2002)
+    # *closest_ref_len* is referred to as *r* in (Papineni et. al. 2002)
     closest_ref_len = min(ref_lens, key=lambda ref_len: 
                            (abs(ref_len - hyp_len), ref_len))
     return hyp_len, closest_ref_len

--- a/nltk/translate/ribes_score.py
+++ b/nltk/translate/ribes_score.py
@@ -94,7 +94,7 @@ def corpus_ribes(references, hypothesis, alpha=0.25, beta=0.10):
     # Iterate through each hypothesis and their corresponding references.
     for references, hypothesis in zip(list_of_references, hypotheses):
         best_ribes = sentence_ribes(references, hypothesis, alpha, beta)
-    return sum(corpus_best_ribes) / len(corpus_best_ribes)
+    return math.fsum(corpus_best_ribes) / len(corpus_best_ribes)
     
         
 def position_of_ngram(ngram, sentence):

--- a/nltk/translate/ribes_score.py
+++ b/nltk/translate/ribes_score.py
@@ -68,7 +68,7 @@ def sentence_ribes(references, hypothesis, alpha=0.25, beta=0.10):
     return best_ribes
 
 
-def corpus_ribes(references, hypothesis, alpha=0.25, beta=0.10):
+def corpus_ribes(list_of_references, hypothesis, alpha=0.25, beta=0.10):
     """
     This function "calculates RIBES for a system output (hypothesis) with 
     multiple references, and returns "best" score among multi-references and 
@@ -78,6 +78,29 @@ def corpus_ribes(references, hypothesis, alpha=0.25, beta=0.10):
     Different from BLEU's micro-average precision, RIBES calculates the 
     macro-average precision by averaging the best RIBES score for each pair of 
     hypothesis and its corresponding references 
+
+    >>> hyp1 = ['It', 'is', 'a', 'guide', 'to', 'action', 'which',
+    ...         'ensures', 'that', 'the', 'military', 'always',
+    ...         'obeys', 'the', 'commands', 'of', 'the', 'party']
+    >>> ref1a = ['It', 'is', 'a', 'guide', 'to', 'action', 'that',
+    ...          'ensures', 'that', 'the', 'military', 'will', 'forever',
+    ...          'heed', 'Party', 'commands']
+    >>> ref1b = ['It', 'is', 'the', 'guiding', 'principle', 'which',
+    ...          'guarantees', 'the', 'military', 'forces', 'always',
+    ...          'being', 'under', 'the', 'command', 'of', 'the', 'Party']
+    >>> ref1c = ['It', 'is', 'the', 'practical', 'guide', 'for', 'the',
+    ...          'army', 'always', 'to', 'heed', 'the', 'directions',
+    ...          'of', 'the', 'party']
+    
+    >>> hyp2 = ['he', 'read', 'the', 'book', 'because', 'he', 'was', 
+    ...         'interested', 'in', 'world', 'history']
+    >>> ref2a = ['he', 'was', 'interested', 'in', 'world', 'history', 
+    ...          'because', 'he', 'read', 'the', 'book']
+    
+    >>> list_of_references = [[ref1a, ref1b, ref1c], [ref2a]]
+    >>> hypotheses = [hyp1, hyp2]
+    >>> corpus_ribes(list_of_references, hypotheses)
+    0.5920778868801042    
     
     :param references: a corpus of lists of reference sentences, w.r.t. hypotheses
     :type references: list(list(list(str)))

--- a/nltk/translate/ribes_score.py
+++ b/nltk/translate/ribes_score.py
@@ -90,11 +90,11 @@ def corpus_ribes(references, hypothesis, alpha=0.25, beta=0.10):
     :return: The best ribes score from one of the references.
     :rtype: float
     """
-    corpus_best_ribes = []
+    corpus_best_ribes = 0.0
     # Iterate through each hypothesis and their corresponding references.
     for references, hypothesis in zip(list_of_references, hypotheses):
-        best_ribes = sentence_ribes(references, hypothesis, alpha, beta)
-    return math.fsum(corpus_best_ribes) / len(corpus_best_ribes)
+        corpus_best_ribes += sentence_ribes(references, hypothesis, alpha, beta)
+    return corpus_best_ribes / len(hypothesis)
     
         
 def position_of_ngram(ngram, sentence):

--- a/nltk/translate/ribes_score.py
+++ b/nltk/translate/ribes_score.py
@@ -2,7 +2,8 @@
 # Natural Language Toolkit: RIBES Score
 #
 # Copyright (C) 2001-2015 NLTK Project
-# Contributors: Katsuhito Sudoh, Liling Tan, Kasramvd, J.F.Sebastian, Mark Byers, ekhumoro, P. Ortiz
+# Contributors: Katsuhito Sudoh, Liling Tan, Kasramvd, J.F.Sebastian
+#               Mark Byers, ekhumoro, P. Ortiz
 # URL: <http://nltk.org/>
 # For license information, see LICENSE.TXT
 """ RIBES score implementation """
@@ -13,7 +14,7 @@ import math
 from nltk.util import ngrams, choose
 
 
-def ribes(references, hypothesis, alpha=0.25, beta=0.10):
+def sentence_ribes(references, hypothesis, alpha=0.25, beta=0.10):
     """
     The RIBES (Rank-based Intuitive Bilingual Evaluation Score) from 
     Hideki Isozaki, Tsutomu Hirao, Kevin Duh, Katsuhito Sudoh and 
@@ -67,6 +68,35 @@ def ribes(references, hypothesis, alpha=0.25, beta=0.10):
     return best_ribes
 
 
+def corpus_ribes(references, hypothesis, alpha=0.25, beta=0.10):
+    """
+    This function "calculates RIBES for a system output (hypothesis) with 
+    multiple references, and returns "best" score among multi-references and 
+    individual scores. The scores are corpus-wise, i.e., averaged by the number 
+    of sentences." (c.f. RIBES version 1.03.1 code).
+    
+    Different from BLEU's micro-average precision, RIBES calculates the 
+    macro-average precision by averaging the best RIBES score for each pair of 
+    hypothesis and its corresponding references 
+    
+    :param references: a corpus of lists of reference sentences, w.r.t. hypotheses
+    :type references: list(list(list(str)))
+    :param hypotheses: a list of hypothesis sentences
+    :type hypotheses: list(list(str))
+    :param alpha: hyperparameter used as a prior for the unigram precision.
+    :type alpha: float
+    :param beta: hyperparameter used as a prior for the brevity penalty.
+    :type beta: float
+    :return: The best ribes score from one of the references.
+    :rtype: float
+    """
+    corpus_best_ribes = []
+    # Iterate through each hypothesis and their corresponding references.
+    for references, hypothesis in zip(list_of_references, hypotheses):
+        best_ribes = sentence_ribes(references, hypothesis, alpha, beta)
+    return sum(corpus_best_ribes) / len(corpus_best_ribes)
+    
+        
 def position_of_ngram(ngram, sentence):
     """
     This function returns the position of the first instance of the ngram 

--- a/nltk/translate/ribes_score.py
+++ b/nltk/translate/ribes_score.py
@@ -100,7 +100,7 @@ def corpus_ribes(list_of_references, hypotheses, alpha=0.25, beta=0.10):
     >>> list_of_references = [[ref1a, ref1b, ref1c], [ref2a]]
     >>> hypotheses = [hyp1, hyp2]
     >>> corpus_ribes(list_of_references, hypotheses)
-    0.5920778868801042    
+    0.35970295471471503    
     
     :param references: a corpus of lists of reference sentences, w.r.t. hypotheses
     :type references: list(list(list(str)))
@@ -117,7 +117,7 @@ def corpus_ribes(list_of_references, hypotheses, alpha=0.25, beta=0.10):
     # Iterate through each hypothesis and their corresponding references.
     for references, hypothesis in zip(list_of_references, hypotheses):
         corpus_best_ribes += sentence_ribes(references, hypothesis, alpha, beta)
-    return corpus_best_ribes / len(hypothesis)
+    return corpus_best_ribes / len(hypotheses)
     
         
 def position_of_ngram(ngram, sentence):

--- a/nltk/translate/ribes_score.py
+++ b/nltk/translate/ribes_score.py
@@ -68,7 +68,7 @@ def sentence_ribes(references, hypothesis, alpha=0.25, beta=0.10):
     return best_ribes
 
 
-def corpus_ribes(list_of_references, hypothesis, alpha=0.25, beta=0.10):
+def corpus_ribes(list_of_references, hypotheses, alpha=0.25, beta=0.10):
     """
     This function "calculates RIBES for a system output (hypothesis) with 
     multiple references, and returns "best" score among multi-references and 

--- a/nltk/translate/ribes_score.py
+++ b/nltk/translate/ribes_score.py
@@ -99,8 +99,8 @@ def corpus_ribes(list_of_references, hypotheses, alpha=0.25, beta=0.10):
     
     >>> list_of_references = [[ref1a, ref1b, ref1c], [ref2a]]
     >>> hypotheses = [hyp1, hyp2]
-    >>> corpus_ribes(list_of_references, hypotheses)
-    0.35970295471471503    
+    >>> round(corpus_ribes(list_of_references, hypotheses),4)
+    0.3597
     
     :param references: a corpus of lists of reference sentences, w.r.t. hypotheses
     :type references: list(list(list(str)))


### PR DESCRIPTION
In the process of adding functions to calculate corpus-level BLEU and RIBES, the following changes were made:
- **Set the default uniform weights for 4grams when calculating BLEU scores.**
  - The original paper also set default weights and limits to 4grams, thus the default weights were at at `[0.25] * 4`.
- **Added function for corpus-level BLEU by calculating mirco-average precision**
  - The original BLEU paper (Papineni et al. 2002) was meant to calculate micro-average corpus-level score. So the modified precision and brevity penalty scores does return a float but the sum of numerators and denominators. Simply averaging sentence level BLEU (i.e. marco-average) will not be the same as the BLEU as intended in the paper. 
- **Change `_modified_precision()` to return numerator and denominator instead of a single-sentence BLEU score, i.e. `corpus_bleu()`**
  - `sentence_modified_precision()` will return the floating point BLEU score for a single sentence.
  - Also, by disentangling the float return from the precision and penalty functions, smoothing on the precision can be easily extended, now that `_modified_precision()` and `_brevity_penalty()` returns numerators and denominators. E.g. when someone wants  to implement BLEU smoothing from http://acl2014.org/acl2014/W14-33/pdf/W14-3346.pdf. 
- **Change the `nltk.translate` namespaces**
  - To preserve current user's code. the `tranlsate.__init__.py` imports the `sentence_bleu` as the default `nltk.translate.bleu`. So from the user's end, BLEU still works the same way and calculating corpus-level bleu will require importing `from nltk.translate.bleu_score import corpus_bleu`. 
- **Added function for corpus-level RIBES score, i.e. `corpus_ribes()`**
  - Different from BLEU's micro-average precision, RIBES calculates the macro-average precision by averaging the best RIBES score for each pair of hypothesis and its corresponding references. So we can safely sum and divide by `len()`. See line 307 from RIBES v1.03.1 (http://www.kecl.ntt.co.jp/icl/lirg/ribes/)
