### PR TITLE
Small fixes for FreqDist and ConditionalFreqDist

### DIFF
--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -292,6 +292,44 @@ class FreqDist(Counter):
         """
         return self.__class__(self)
 
+    # Mathematical operatiors 
+    
+    def __add__(self, other):
+        '''Add counts from two counters.
+
+        >>> FreqDist('abbb') + FreqDist('bcc')
+        FreqDist({'b': 4, 'c': 2, 'a': 1})
+
+        '''
+        return self.__class__(super(FreqDist, self).__add__(other))
+
+    def __sub__(self, other):
+        ''' Subtract count, but keep only results with positive counts.
+
+        >>> FreqDist('abbbc') - FreqDist('bccd')
+        FreqDist({'b': 2, 'a': 1})
+
+        '''
+        return self.__class__(super(FreqDist, self).__sub__(other))
+
+    def __or__(self, other):
+        '''Union is the maximum of value in either of the input counters.
+
+        >>> FreqDist('abbb') | FreqDist('bcc')
+        FreqDist({'b': 3, 'c': 2, 'a': 1})
+
+        '''
+        return self.__class__(super(FreqDist, self).__or__(other))
+
+    def __and__(self, other):
+        ''' Intersection is the minimum of corresponding counts.
+
+        >>> FreqDist('abbb') & FreqDist('bcc')
+        FreqDist({'b': 1})
+
+        '''
+        return self.__class__(super(FreqDist, self).__and__(other))
+
     def __le__(self, other):
         if not isinstance(other, FreqDist):
             raise_unorderable_types("<=", self, other)

--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -265,6 +265,8 @@ class FreqDist(Counter):
 
         :param samples: The samples to plot (default is all samples)
         :type samples: list
+        :param cumulative: A flag to specify whether the freqs are cumulative (default = False)
+        :type title: bool
         """
         if len(args) == 0:
             args = [len(self)]
@@ -277,11 +279,14 @@ class FreqDist(Counter):
             freqs = [self[sample] for sample in samples]
         # percents = [f * 100 for f in freqs]  only in ProbDist?
 
+        width = max(len("%s" % s) for s in samples)
+        width = max(width, max(len("%d" % f) for f in freqs))
+
         for i in range(len(samples)):
-            print("%4s" % samples[i], end=' ')
+            print("%*s" % (width, samples[i]), end=' ')
         print()
         for i in range(len(samples)):
-            print("%4d" % freqs[i], end=' ')
+            print("%*d" % (width, freqs[i]), end=' ')
         print()
 
     def copy(self):
@@ -1827,10 +1832,10 @@ class ConditionalFreqDist(defaultdict):
 
         :param samples: The samples to plot
         :type samples: list
-        :param title: The title for the graph
-        :type title: str
         :param conditions: The conditions to plot (default is all)
         :type conditions: list
+        :param cumulative: A flag to specify whether the freqs are cumulative (default = False)
+        :type title: bool
         """
 
         cumulative = _get_kwarg(kwargs, 'cumulative', False)
@@ -1838,20 +1843,24 @@ class ConditionalFreqDist(defaultdict):
         samples = _get_kwarg(kwargs, 'samples',
                              sorted(set(v for c in conditions for v in self[c])))  # this computation could be wasted
 
+        width = max(len("%s" % s) for s in samples)
+        freqs = dict()
+        for c in conditions:
+            if cumulative:
+                freqs[c] = list(self[c]._cumulative_frequencies(samples))
+            else:
+                freqs[c] = [self[c][sample] for sample in samples]
+            width = max(width, max(len("%d" % f) for f in freqs[c]))
+
         condition_size = max(len("%s" % c) for c in conditions)
         print(' ' * condition_size, end=' ')
         for s in samples:
-            print("%4s" % s, end=' ')
+            print("%*s" % (width, s), end=' ')
         print()
         for c in conditions:
             print("%*s" % (condition_size, c), end=' ')
-            if cumulative:
-                freqs = list(self[c]._cumulative_frequencies(samples))
-            else:
-                freqs = [self[c][sample] for sample in samples]
-
-            for f in freqs:
-                print("%4d" % f, end=' ')
+            for f in freqs[c]:
+                print("%*d" % (width, f), end=' ')
             print()
 
     # Mathematical operators

--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -295,39 +295,43 @@ class FreqDist(Counter):
     # Mathematical operatiors 
     
     def __add__(self, other):
-        '''Add counts from two counters.
+        """
+        Add counts from two counters.
 
         >>> FreqDist('abbb') + FreqDist('bcc')
         FreqDist({'b': 4, 'c': 2, 'a': 1})
 
-        '''
+        """
         return self.__class__(super(FreqDist, self).__add__(other))
 
     def __sub__(self, other):
-        ''' Subtract count, but keep only results with positive counts.
+        """
+        Subtract count, but keep only results with positive counts.
 
         >>> FreqDist('abbbc') - FreqDist('bccd')
         FreqDist({'b': 2, 'a': 1})
 
-        '''
+        """
         return self.__class__(super(FreqDist, self).__sub__(other))
 
     def __or__(self, other):
-        '''Union is the maximum of value in either of the input counters.
+        """
+        Union is the maximum of value in either of the input counters.
 
         >>> FreqDist('abbb') | FreqDist('bcc')
         FreqDist({'b': 3, 'c': 2, 'a': 1})
 
-        '''
+        """
         return self.__class__(super(FreqDist, self).__or__(other))
 
     def __and__(self, other):
-        ''' Intersection is the minimum of corresponding counts.
+        """
+        Intersection is the minimum of corresponding counts.
 
         >>> FreqDist('abbb') & FreqDist('bcc')
         FreqDist({'b': 1})
 
-        '''
+        """
         return self.__class__(super(FreqDist, self).__and__(other))
 
     def __le__(self, other):
@@ -1849,6 +1853,75 @@ class ConditionalFreqDist(defaultdict):
             for f in freqs:
                 print("%4d" % f, end=' ')
             print()
+
+    # Mathematical operators
+    
+    def __add__(self, other):
+        """
+        Add counts from two ConditionalFreqDists.
+        """
+        if not isinstance(other, ConditionalFreqDist):
+            return NotImplemented
+        result = ConditionalFreqDist()
+        for cond in self.conditions():
+            newfreqdist = self[cond] + other[cond]
+            if newfreqdist:
+                result[cond] = newfreqdist
+        for cond in other.conditions():
+            if cond not in self.conditions():
+                for elem, count in other[cond].items():
+                    if count > 0:
+                        result[cond][elem] = count
+        return result
+
+    def __sub__(self, other):
+        """
+        Subtract count, but keep only results with positive counts.
+        """
+        if not isinstance(other, ConditionalFreqDist):
+            return NotImplemented
+        result = ConditionalFreqDist()
+        for cond in self.conditions():
+            newfreqdist = self[cond] - other[cond]
+            if newfreqdist:
+                result[cond] = newfreqdist
+        for cond in other.conditions():
+            if cond not in self.conditions():
+                for elem, count in other[cond].items():
+                    if count < 0:
+                        result[cond][elem] = 0 - count
+        return result
+
+    def __or__(self, other):
+        """
+        Union is the maximum of value in either of the input counters.
+        """
+        if not isinstance(other, ConditionalFreqDist):
+            return NotImplemented
+        result = ConditionalFreqDist()
+        for cond in self.conditions():
+            newfreqdist = self[cond] | other[cond]
+            if newfreqdist:
+                result[cond] = newfreqdist
+        for cond in other.conditions():
+            if cond not in self.conditions():
+                for elem, count in other[cond].items():
+                    if count > 0:
+                        result[cond][elem] = count
+        return result
+
+    def __and__(self, other):
+        """ 
+        Intersection is the minimum of corresponding counts.
+        """
+        if not isinstance(other, ConditionalFreqDist):
+            return NotImplemented
+        result = ConditionalFreqDist()
+        for cond in self.conditions():
+            newfreqdist = self[cond] & other[cond]
+            if newfreqdist:
+                result[cond] = newfreqdist
+        return result
 
     # @total_ordering doesn't work here, since the class inherits from a builtin class
     def __le__(self, other):

--- a/nltk/test/probability.doctest
+++ b/nltk/test/probability.doctest
@@ -54,6 +54,17 @@ Note that items are sorted in order of decreasing frequency; two items of the sa
     >>> fd1 == pickle.loads(pickled)
     True
 
+Mathematical operations:
+
+    >>> FreqDist('abbb') + FreqDist('bcc')
+    FreqDist({'b': 4, 'c': 2, 'a': 1})
+    >>> FreqDist('abbbc') - FreqDist('bccd')
+    FreqDist({'b': 2, 'a': 1})
+    >>> FreqDist('abbb') | FreqDist('bcc')
+    FreqDist({'b': 3, 'c': 2, 'a': 1})
+    >>> FreqDist('abbb') & FreqDist('bcc')
+    FreqDist({'b': 1})
+
 Testing some HMM estimators
 ---------------------------
 

--- a/nltk/test/probability.doctest
+++ b/nltk/test/probability.doctest
@@ -65,6 +65,38 @@ Mathematical operations:
     >>> FreqDist('abbb') & FreqDist('bcc')
     FreqDist({'b': 1})
 
+ConditionalFreqDist
+-------------------
+
+    >>> cfd1 = ConditionalFreqDist()
+    >>> cfd1[1] = FreqDist('abbbc')
+    >>> cfd1[2] = FreqDist('xxxxyy')
+    >>> cfd1
+    <ConditionalFreqDist with 2 conditions>
+
+    >>> cfd2 = ConditionalFreqDist()
+    >>> cfd2[1] = FreqDist('bccd')
+    >>> cfd2[2] = FreqDist('xxyyyzz')
+    >>> cfd2[3] = FreqDist('m')
+    >>> cfd2
+    <ConditionalFreqDist with 3 conditions>
+
+    >>> r = cfd1 + cfd2
+    >>> [(i,r[i]) for i in r.conditions()]
+    [(1, FreqDist({'b': 4, 'c': 3, 'a': 1, 'd': 1})), (2, FreqDist({'x': 6, 'y': 5, 'z': 2})), (3, FreqDist({'m': 1}))]
+
+    >>> r = cfd1 - cfd2
+    >>> [(i,r[i]) for i in r.conditions()]
+    [(1, FreqDist({'b': 2, 'a': 1})), (2, FreqDist({'x': 2}))]
+
+    >>> r = cfd1 | cfd2
+    >>> [(i,r[i]) for i in r.conditions()]
+    [(1, FreqDist({'b': 3, 'c': 2, 'a': 1, 'd': 1})), (2, FreqDist({'x': 4, 'y': 3, 'z': 2})), (3, FreqDist({'m': 1}))]
+
+    >>> r = cfd1 & cfd2
+    >>> [(i,r[i]) for i in r.conditions()]
+    [(1, FreqDist({'c': 1, 'b': 1})), (2, FreqDist({'y': 2, 'x': 2}))]
+
 Testing some HMM estimators
 ---------------------------
 


### PR DESCRIPTION
Fixes for some minor annoyances with FreqDists that came up in class this semester:
- Adjust tabulate column widths so that samples and counts line up.
- Add mathematical operators to FreqDist.  They're inherited from Counter and, since that is a built-in type, they returned Counter objects rather than FreqDists.  That's now fixed.
-  Add mathematical operators to ConditionalFreqDist. 
