### PR TITLE
Feature/casual tokenize fix.1158

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -61,6 +61,7 @@
 - Dougal Graham
 - Brent Gray
 - Simon Greenhill
+- Clark Grubb
 - Eduardo Pereira Habkost
 - Masato Hagiwara
 - Lauri Hallila

--- a/nltk/test/tokenize.doctest
+++ b/nltk/test/tokenize.doctest
@@ -160,7 +160,7 @@ The `preserve_case` parameter (default: True) allows to convert uppercase tokens
 
 It should not hang on long sequences of the same punctuation character.
 
-    >>> tknzer = TweetTokenizer()
+    >>> tknzr = TweetTokenizer()
     >>> s10 = "Photo: Aujourd'hui sur http://t.co/0gebOFDUzn Projet... http://t.co/bKfIUbydz2.............................. http://fb.me/3b6uXpz0L"
     >>> tknzr.tokenize(s10)
-    [u'photo', u':', u"aujourd'hui", u'sur', u'http://t.co/0gebOFDUzn', u'projet', u'...', u'http://t.co/bKfIUbydz2', u'...', u'http://fb.me/3b6uXpz0L']
+    [u'Photo', u':', u"Aujourd'hui", u'sur', u'http://t.co/0gebOFDUzn', u'Projet', u'...', u'http://t.co/bKfIUbydz2', u'...', u'http://fb.me/3b6uXpz0L']

--- a/nltk/test/tokenize.doctest
+++ b/nltk/test/tokenize.doctest
@@ -157,3 +157,10 @@ The `preserve_case` parameter (default: True) allows to convert uppercase tokens
     >>> s9 = "@jrmy: I'm REALLY HAPPYYY about that! NICEEEE :D :P"
     >>> tknzr.tokenize(s9)
     ['@jrmy', ':', "i'm", 'really', 'happyyy', 'about', 'that', '!', 'niceeee', ':D', ':P']
+
+It should not hang on long sequences of the same punctuation character.
+
+    >>> tknzer = TweetTokenizer()
+    >>> s10 = "Photo: Aujourd'hui sur http://t.co/0gebOFDUzn Projet... http://t.co/bKfIUbydz2.............................. http://fb.me/3b6uXpz0L"
+    >>> tknzr.tokenize(s10)
+    [u'photo', u':', u"aujourd'hui", u'sur', u'http://t.co/0gebOFDUzn', u'projet', u'...', u'http://t.co/bKfIUbydz2', u'...', u'http://fb.me/3b6uXpz0L']

--- a/nltk/tokenize/casual.py
+++ b/nltk/tokenize/casual.py
@@ -176,6 +176,9 @@ REGEXPS = (
 WORD_RE = re.compile(r"""(%s)""" % "|".join(REGEXPS), re.VERBOSE | re.I
                      | re.UNICODE)
 
+# WORD_RE performs poorly on these patterns:
+HANG_RE = re.compile(r'([^a-zA-Z0-9])\1{3,}')
+
 # The emoticon string gets its own regex so that we can preserve case for
 # them as needed:
 EMOTICON_RE = re.compile(EMOTICONS, re.VERBOSE | re.I | re.UNICODE)
@@ -295,8 +298,10 @@ class TweetTokenizer:
         # Normalize word lengthening
         if self.reduce_len:
             text = reduce_lengthening(text)
+        # Shorten problematic sequences of characters
+        safe_text = HANG_RE.sub(r'\1\1\1', text)
         # Tokenize:
-        words = WORD_RE.findall(text)
+        words = WORD_RE.findall(safe_text)
         # Possibly alter the case, but avoid changing emoticons like :D into :d:
         if not self.preserve_case:
             words = list(map((lambda x : x if EMOTICON_RE.search(x) else


### PR DESCRIPTION
Avoid text which causes nltk.tokenize.casual.casual_tokenize() to hang by shortening long sequences of punctuation (actually, all characters matching [^a-zA-Z0-9]) to a sequence of just three of the same character.

```
>>> import nltk
>>> nltk.tokenize.casual.casual_tokenize("Photo: Aujourd'hui sur http://t.co/0gebOFDUzn Projet... http://t.co/bKfIUbydz2.............................. http://fb.me/3b6uXpz0L")
[u'Photo', u':', u"Aujourd'hui", u'sur', u'http://t.co/0gebOFDUzn', u'Projet', u'...', u'http://t.co/bKfIUbydz2', u'...', u'http://fb.me/3b6uXpz0L']
```

On a sample of 246M tweets, tweets which cause casual_tokenize() to hang were about a 1 in 5M occurrence.  After this change, I was able to process 246M tweets successfully.
