### PR TITLE
Improvement to BLEU scores

### DIFF
--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -81,6 +81,7 @@ def sentence_bleu(references, hypothesis, weights=(0.25, 0.25, 0.25, 0.25)):
             s.append(w * math.log(p_n))
         except ValueError: # some p_ns is 0
             s.append(0)
+    s = math.fsum(s)
 
     # Calculates the brevity penalty.
     # *hyp_len* is referred to as *c* in Papineni et. al. (2002)

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -161,7 +161,7 @@ def corpus_bleu(list_of_references, hypotheses, weights=(0.25, 0.25, 0.25, 0.25)
     bp = _brevity_penalty(ref_lengths, hyp_lengths)
     
     # Calculate sum of corpus-level modified precisions.
-    s = (0 if p_numerators[i] == 0 else
+    s = (0 if (p_numerators[i] | p_denominators[i]) == 0 else
          (w* math.log(p_numerators[i] / p_denominators[i]))
          for i, w in enumerate(weights, start=1))
         

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -70,17 +70,14 @@ def sentence_bleu(references, hypothesis, weights=(0.25, 0.25, 0.25, 0.25)):
     :rtype: float
     """
     # Calculates the modified precision *p_n* for each order of ngram.
-    p_ns = [float(_modified_precision(references, hypothesis, i))
+    p_n = [float(_modified_precision(references, hypothesis, i))
             for i, _ in enumerate(weights, start=1)]
 
     # Calculates the overall modified precision for all ngrams.
     # By sum of the product of the weights and the respective *p_n*
     s = []
-    for w, p_n in zip(weights, p_ns):
-        try:
-            s.append(w * math.log(p_n))
-        except ValueError: # some p_ns is 0
-            s.append(0)
+    for w, p_i in zip(weights, p_n):
+        p_i = 0 if p_i == 0 else w * math.log(p_i)
     s = math.fsum(s)
 
     # Calculates the brevity penalty.
@@ -169,11 +166,9 @@ def corpus_bleu(list_of_references, hypotheses, weights=(0.25, 0.25, 0.25, 0.25)
     # Calculate corpus-level modified precision.
     p_n = []
     for i, w in enumerate(weights, start=1):
-        pn = p_numerators[i] / p_denominators[i]
-        try:
-            p_n.append(w* math.log(pn))
-        except ValueError:
-            p_n.append(0)
+        p_i = p_numerators[i] / p_denominators[i]
+        p_i = 0 if p_i == 0 else w * math.log(p_i) 
+        p_n.append(p_i)
         
     return bp * math.exp(math.fsum(p_n))
 

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -74,7 +74,7 @@ def sentence_bleu(references, hypothesis, weights=(0.25, 0.25, 0.25, 0.25)):
 
     # Calculates the overall modified precision for all ngrams.
     # By sum of the product of the weights and the respective *p_n*
-    s = (0 if p_i == 0 else (w * math.log(p_i)) 
+    s = (w * math.log(p_i) if p_i else 0 
          for w, p_i in zip(weights, p_n))
     
     # Calculates the brevity penalty.
@@ -161,8 +161,8 @@ def corpus_bleu(list_of_references, hypotheses, weights=(0.25, 0.25, 0.25, 0.25)
     bp = _brevity_penalty(ref_lengths, hyp_lengths)
     
     # Calculate sum of corpus-level modified precisions.
-    s = (0 if (p_numerators[i] | p_denominators[i]) == 0 else
-         (w * math.log(p_numerators[i] / p_denominators[i]))
+    s = (0 if not(p_numerators[i] and p_denominators[i]) else
+         w * math.log(p_numerators[i] / p_denominators[i])
          for i, w in enumerate(weights, start=1))
         
     return bp * math.exp(math.fsum(s))

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -7,7 +7,6 @@
 # URL: <http://nltk.org/>
 # For license information, see LICENSE.TXT
 """BLEU score implementation."""
-
 from __future__ import division
 
 import math
@@ -70,16 +69,13 @@ def sentence_bleu(references, hypothesis, weights=(0.25, 0.25, 0.25, 0.25)):
     :rtype: float
     """
     # Calculates the modified precision *p_n* for each order of ngram.
-    p_n = [float(_modified_precision(references, hypothesis, i))
-            for i, _ in enumerate(weights, start=1)]
+    p_n = (float(_modified_precision(references, hypothesis, i))
+            for i, _ in enumerate(weights, start=1))
 
     # Calculates the overall modified precision for all ngrams.
     # By sum of the product of the weights and the respective *p_n*
-    s = []
-    for w, p_i in zip(weights, p_n):
-        p_i = 0 if p_i == 0 else (w * math.log(p_i))
-        s.append(p_i)
-
+    s = (p_i if p_i == 0 else (w * math.log(p_i)) for w, p_i in zip(weights, p_n))
+    
     # Calculates the brevity penalty.
     # *hyp_len* is referred to as *c* in Papineni et. al. (2002)
     hyp_len = len(hypothesis)
@@ -164,11 +160,9 @@ def corpus_bleu(list_of_references, hypotheses, weights=(0.25, 0.25, 0.25, 0.25)
     bp = _brevity_penalty(ref_lengths, hyp_lengths)
     
     # Calculate sum of corpus-level modified precisions.
-    s = []
-    for i, w in enumerate(weights, start=1):
-        p_i = p_numerators[i] / p_denominators[i]
-        p_i = 0 if p_i == 0 else (w* math.log(p_i))
-        s.append(p_i)
+    s = (p_i if p_numerators[i] == 0 else
+         (w* math.log(p_numerators[i] / p_denominators[i]))
+         for i, w in enumerate(weights, start=1))
         
     return bp * math.exp(math.fsum(s))
 

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -162,7 +162,7 @@ def corpus_bleu(list_of_references, hypotheses, weights=(0.25, 0.25, 0.25, 0.25)
     
     # Calculate sum of corpus-level modified precisions.
     s = (0 if (p_numerators[i] | p_denominators[i]) == 0 else
-         (w* math.log(p_numerators[i] / p_denominators[i]))
+         (w * math.log(p_numerators[i] / p_denominators[i]))
          for i, w in enumerate(weights, start=1))
         
     return bp * math.exp(math.fsum(s))

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -70,10 +70,8 @@ def sentence_bleu(references, hypothesis, weights=(0.25, 0.25, 0.25, 0.25)):
     :rtype: float
     """
     # Calculates the modified precision *p_n* for each order of ngram.
-    p_ns = [] 
-    for i, _ in enumerate(weights, start=1): 
-        p_n = float(_modified_precision(references, hypothesis, i))
-        p_ns.append(p_n) 
+    p_ns = [float(_modified_precision(references, hypothesis, i))
+            for i, _ in enumerate(weights, start=1)]
 
     try:
         # Calculates the overall modified precision for all ngrams.

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -74,7 +74,8 @@ def sentence_bleu(references, hypothesis, weights=(0.25, 0.25, 0.25, 0.25)):
 
     # Calculates the overall modified precision for all ngrams.
     # By sum of the product of the weights and the respective *p_n*
-    s = (p_i if p_i == 0 else (w * math.log(p_i)) for w, p_i in zip(weights, p_n))
+    s = (0 if p_i == 0 else (w * math.log(p_i)) 
+         for w, p_i in zip(weights, p_n))
     
     # Calculates the brevity penalty.
     # *hyp_len* is referred to as *c* in Papineni et. al. (2002)
@@ -160,7 +161,7 @@ def corpus_bleu(list_of_references, hypotheses, weights=(0.25, 0.25, 0.25, 0.25)
     bp = _brevity_penalty(ref_lengths, hyp_lengths)
     
     # Calculate sum of corpus-level modified precisions.
-    s = (p_i if p_numerators[i] == 0 else
+    s = (0 if p_numerators[i] == 0 else
          (w* math.log(p_numerators[i] / p_denominators[i]))
          for i, w in enumerate(weights, start=1))
         

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -170,7 +170,10 @@ def corpus_bleu(list_of_references, hypotheses, weights=(0.25, 0.25, 0.25, 0.25)
     p_n = []
     for i, w in enumerate(weights, start=1):
         pn = p_numerators[i] / p_denominators[i]
-        p_n.append(w* math.log(pn))
+        try:
+            p_n.append(w* math.log(pn))
+        except ValueError:
+            p_n.append(0)
         
     return bp * math.exp(math.fsum(p_n))
 

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -73,13 +73,14 @@ def sentence_bleu(references, hypothesis, weights=(0.25, 0.25, 0.25, 0.25)):
     p_ns = [float(_modified_precision(references, hypothesis, i))
             for i, _ in enumerate(weights, start=1)]
 
-    try:
-        # Calculates the overall modified precision for all ngrams.
-        # By taking the product of the weights and the respective *p_n*
-        s = math.fsum(w * math.log(p_n) for w, p_n in zip(weights, p_ns))
-    except ValueError:
-        # some p_ns is 0
-        return 0
+    # Calculates the overall modified precision for all ngrams.
+    # By sum of the product of the weights and the respective *p_n*
+    s = []
+    for w, p_n in zip(weights, p_ns):
+        try:
+            s.append(w * math.log(p_n))
+        except ValueError: # some p_ns is 0
+            s.append(0)
 
     # Calculates the brevity penalty.
     # *hyp_len* is referred to as *c* in Papineni et. al. (2002)

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -164,14 +164,14 @@ def corpus_bleu(list_of_references, hypotheses, weights=(0.25, 0.25, 0.25, 0.25)
     # Calculate corpus-level brevity penalty.
     bp = _brevity_penalty(ref_lengths, hyp_lengths)
     
-    # Calculate corpus-level modified precision.
+    # Calculate sum of corpus-level modified precisions.
     s = []
     for i, w in enumerate(weights, start=1):
         p_i = p_numerators[i] / p_denominators[i]
-        p_i = 0 if p_i == 0 else (w* math.log(pn))
+        p_i = 0 if p_i == 0 else (w* math.log(p_i))
         s.append(p_i)
         
-    return bp * math.exp(math.fsum(p_n))
+    return bp * math.exp(math.fsum(s))
 
 
 def _modified_precision(references, hypothesis, n):

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -17,7 +17,7 @@ from collections import Counter
 from nltk.util import ngrams
 
 
-def sentence_bleu(references, hypothesis, weights=[0.25, 0.25, 0.25, 0.25]):
+def sentence_bleu(references, hypothesis, weights=(0.25, 0.25, 0.25, 0.25)):
     """
     Calculate BLEU score (Bilingual Evaluation Understudy) from
     Papineni, Kishore, Salim Roukos, Todd Ward, and Wei-Jing Zhu. 2002.

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -164,13 +164,13 @@ def corpus_bleu(list_of_references, hypotheses, weights=(0.25, 0.25, 0.25, 0.25)
     bp = _brevity_penalty(ref_lengths, hyp_lengths)
     
     # Calculate corpus-level modified precision.
-    p_n = []
+    s = []
     for i, w in enumerate(weights, start=1):
         p_i = p_numerators[i] / p_denominators[i]
         p_i = 0 if p_i == 0 else w * math.log(p_i) 
-        p_n.append(p_i)
+        s.append(p_i)
         
-    return bp * math.exp(math.fsum(p_n))
+    return bp * math.exp(math.fsum(s))
 
 
 def _modified_precision(references, hypothesis, n):

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -56,7 +56,7 @@ def sentence_bleu(references, hypothesis, weights=(0.25, 0.25, 0.25, 0.25)):
     use customized weights. E.g. when accounting for up to 6grams with uniform
     weights:
 
-    >>> weights = [0.1666, 0.1666, 0.1666, 0.1666, 0.1666]
+    >>> weights = (0.1666, 0.1666, 0.1666, 0.1666, 0.1666)
     >>> sentence_bleu([reference1, reference2, reference3], hypothesis1, weights)
     0.45838627164939455
     
@@ -90,7 +90,7 @@ def sentence_bleu(references, hypothesis, weights=(0.25, 0.25, 0.25, 0.25)):
     return bp * math.exp(s)
 
 
-def corpus_bleu(list_of_references, hypotheses, weights=[0.25, 0.25, 0.25, 0.25]):
+def corpus_bleu(list_of_references, hypotheses, weights=(0.25, 0.25, 0.25, 0.25)):
     """
     Calculate a single corpus-level BLEU score (aka. system-level BLEU) for all 
     the hypotheses and their respective references.  

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -77,7 +77,8 @@ def sentence_bleu(references, hypothesis, weights=(0.25, 0.25, 0.25, 0.25)):
     # By sum of the product of the weights and the respective *p_n*
     s = []
     for w, p_i in zip(weights, p_n):
-        p_i = 0 if p_i == 0 else w * math.log(p_i)
+        p_i = 0 if p_i == 0 else (w * math.log(p_i))
+        s.append(p_i)
     s = math.fsum(s)
 
     # Calculates the brevity penalty.
@@ -167,10 +168,10 @@ def corpus_bleu(list_of_references, hypotheses, weights=(0.25, 0.25, 0.25, 0.25)
     s = []
     for i, w in enumerate(weights, start=1):
         p_i = p_numerators[i] / p_denominators[i]
-        p_i = 0 if p_i == 0 else w * math.log(p_i) 
+        p_i = 0 if p_i == 0 else (w* math.log(pn))
         s.append(p_i)
         
-    return bp * math.exp(math.fsum(s))
+    return bp * math.exp(math.fsum(p_n))
 
 
 def _modified_precision(references, hypothesis, n):

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -79,7 +79,6 @@ def sentence_bleu(references, hypothesis, weights=(0.25, 0.25, 0.25, 0.25)):
     for w, p_i in zip(weights, p_n):
         p_i = 0 if p_i == 0 else (w * math.log(p_i))
         s.append(p_i)
-    s = math.fsum(s)
 
     # Calculates the brevity penalty.
     # *hyp_len* is referred to as *c* in Papineni et. al. (2002)
@@ -87,7 +86,7 @@ def sentence_bleu(references, hypothesis, weights=(0.25, 0.25, 0.25, 0.25)):
     # *closest_ref_len* is referred to as *r* variable in Papineni et. al. (2002)
     closest_ref_len = _closest_ref_length(references, hyp_len)
     bp = _brevity_penalty(closest_ref_len, hyp_len)
-    return bp * math.exp(s)
+    return bp * math.exp(math.fsum(s))
 
 
 def corpus_bleu(list_of_references, hypotheses, weights=(0.25, 0.25, 0.25, 0.25)):

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -49,7 +49,7 @@ def sentence_bleu(references, hypothesis, weights=(0.25, 0.25, 0.25, 0.25)):
     0.5045666840058485
 
     >>> sentence_bleu([reference1, reference2, reference3], hypothesis2)
-    0
+    0.39692877231857493
 
     The default BLEU calculates a score for up to 4grams using uniform
     weights. To evaluate your translations with higher/lower order ngrams, 


### PR DESCRIPTION
Spillover improvements from #1229 
- Use tuple instead of list in `sentence_bleu` default parameter
- Use list comprehension to get modified precision for n orders of ngrams.
