### PR TITLE
Fixed bug in summation of modified precision in BLEU score

### DIFF
--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -170,7 +170,10 @@ def corpus_bleu(list_of_references, hypotheses, weights=[0.25, 0.25, 0.25, 0.25]
     p_n = []
     for i, w in enumerate(weights, start=1):
         pn = p_numerators[i] / p_denominators[i]
-        p_n.append(w* math.log(pn))
+        try:
+            p_n.append(w* math.log(pn))
+        except ValueError:
+            return 0
         
     return bp * math.exp(math.fsum(p_n))
 


### PR DESCRIPTION
Fixed the bug in summation of modified precision in BLEU score, which previously showed `ValueError` is case of log(0). BLEU score  equals zero if any one of the underlying score is zero. The `try` and `except` block handles this.
