### PR TITLE
Fix zero division & log(0) in PunktTrainer._col_log_likelihood

### DIFF
--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -1081,13 +1081,13 @@ class PunktTrainer(PunktBaseClass):
         except ValueError as e:
             summand2 = 0
 
-        if count_a == count_ab or p1 == 0 or p1 == 1:
+        if count_a == count_ab or p1 <= 0 or p1 >= 1:
             summand3 = 0
         else:
             summand3 = (count_ab * math.log(p1) +
                         (count_a - count_ab) * math.log(1.0 - p1))
 
-        if count_b == count_ab or p2 == 0 or p2 == 1:
+        if count_b == count_ab or p2 <= 0 or p2 >= 1:
             summand4 = 0
         else:
             summand4 = ((count_b - count_ab) * math.log(p2) +

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -1080,7 +1080,7 @@ class PunktTrainer(PunktBaseClass):
         if count_a == count_ab:
             summand3 = 0
         else:
-            summand3 = (count_ab * math.log(p1 or 0) +
+            summand3 = (count_ab * math.log(p1 or 1) +
                         (count_a - count_ab) * math.log(1.0 - p1) if p1 < 1 else 0)
 
         if count_b == count_ab:

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -1081,17 +1081,17 @@ class PunktTrainer(PunktBaseClass):
         except ValueError as e:
             summand2 = 0
 
-        if count_a == count_ab:
+        if count_a == count_ab or p1 == 0 or p1 == 1:
             summand3 = 0
         else:
-            summand3 = (count_ab * math.log(p1 or 1) +
-                        (count_a - count_ab) * math.log(1.0 - p1) if p1 < 1 else 0)
+            summand3 = (count_ab * math.log(p1) +
+                        (count_a - count_ab) * math.log(1.0 - p1))
 
-        if count_b == count_ab:
+        if count_b == count_ab or p2 == 0 or p2 == 1:
             summand4 = 0
         else:
-            summand4 = ((count_b - count_ab) * math.log(p2 or 1) +
-                        (N - count_a - count_b + count_ab) * math.log(1.0 - p2) if p2 < 1 else 0)
+            summand4 = ((count_b - count_ab) * math.log(p2) +
+                        (N - count_a - count_b + count_ab) * math.log(1.0 - p2))
 
         likelihood = summand1 + summand2 - summand3 - summand4
 

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -1066,16 +1066,20 @@ class PunktTrainer(PunktBaseClass):
             p2 = (count_b - count_ab) / (N - count_a)
         except ZeroDivisionError as e:
             p2 = 1
-        else:
-            p2 = (count_b - count_ab) / p2_denom
 
         print (p, p1, p2, N, count_a, count_b, count_ab)
 
-        summand1 = (count_ab * math.log(p or 1) +
-                    (count_a - count_ab) * math.log(1.0 - p) if p < 1 else 0)
+        try:
+            summand1 = (count_ab * math.log(p) +
+                        (count_a - count_ab) * math.log(1.0 - p))
+        except ValueError as e:
+            summand1 = 0
 
-        summand2 = ((count_b - count_ab) * math.log(p or 1) +
-                    (N - count_a - count_b + count_ab) * math.log(1.0 - p) if p < 1 else 0)
+        try:
+            summand2 = ((count_b - count_ab) * math.log(p) +
+                        (N - count_a - count_b + count_ab) * math.log(1.0 - p))
+        except ValueError as e:
+            summand2 = 0
 
         if count_a == count_ab:
             summand3 = 0

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -1062,9 +1062,9 @@ class PunktTrainer(PunktBaseClass):
 
         p = count_b / N
         p1 = count_ab / count_a
-
-        p2_denom = N - count_a
-        if p2_denom == 0:
+        try:
+            p2 = (count_b - count_ab) / (N - count_a)
+        except ZeroDivisionError as e:
             p2 = 1
         else:
             p2 = (count_b - count_ab) / p2_denom

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -1062,25 +1062,32 @@ class PunktTrainer(PunktBaseClass):
 
         p = count_b / N
         p1 = count_ab / count_a
-        p2 = (count_b - count_ab) / (N - count_a)
 
-        summand1 = (count_ab * math.log(p) +
-                    (count_a - count_ab) * math.log(1.0 - p))
+        p2_denom = N - count_a
+        if p2_denom == 0:
+            p2 = 1
+        else:
+            p2 = (count_b - count_ab) / p2_denom
 
-        summand2 = ((count_b - count_ab) * math.log(p) +
-                    (N - count_a - count_b + count_ab) * math.log(1.0 - p))
+        print (p, p1, p2, N, count_a, count_b, count_ab)
+
+        summand1 = (count_ab * math.log(p + (p == 0)) +
+                    (count_a - count_ab) * math.log(1.0 - p + (p == 1)))
+
+        summand2 = ((count_b - count_ab) * math.log(p + (p == 0)) +
+                    (N - count_a - count_b + count_ab) * math.log(1.0 - p + (p == 1)))
 
         if count_a == count_ab:
             summand3 = 0
         else:
-            summand3 = (count_ab * math.log(p1) +
-                        (count_a - count_ab) * math.log(1.0 - p1))
+            summand3 = (count_ab * math.log(p1 + (p1 == 0)) +
+                        (count_a - count_ab) * math.log(1.0 - p1 + (p1 == 1)))
 
         if count_b == count_ab:
             summand4 = 0
         else:
-            summand4 = ((count_b - count_ab) * math.log(p2) +
-                        (N - count_a - count_b + count_ab) * math.log(1.0 - p2))
+            summand4 = ((count_b - count_ab) * math.log(p2 + (p2 == 0)) +
+                        (N - count_a - count_b + count_ab) * math.log(1.0 - p2 + (p2 == 1)))
 
         likelihood = summand1 + summand2 - summand3 - summand4
 

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -1071,23 +1071,23 @@ class PunktTrainer(PunktBaseClass):
 
         print (p, p1, p2, N, count_a, count_b, count_ab)
 
-        summand1 = (count_ab * math.log(p + (p == 0)) +
-                    (count_a - count_ab) * math.log(1.0 - p + (p == 1)))
+        summand1 = (count_ab * math.log(p or 1) +
+                    (count_a - count_ab) * math.log(1.0 - p) if p < 1 else 0)
 
-        summand2 = ((count_b - count_ab) * math.log(p + (p == 0)) +
-                    (N - count_a - count_b + count_ab) * math.log(1.0 - p + (p == 1)))
+        summand2 = ((count_b - count_ab) * math.log(p or 1) +
+                    (N - count_a - count_b + count_ab) * math.log(1.0 - p) if p < 1 else 0)
 
         if count_a == count_ab:
             summand3 = 0
         else:
-            summand3 = (count_ab * math.log(p1 + (p1 == 0)) +
-                        (count_a - count_ab) * math.log(1.0 - p1 + (p1 == 1)))
+            summand3 = (count_ab * math.log(p1 or 0) +
+                        (count_a - count_ab) * math.log(1.0 - p1) if p1 < 1 else 0)
 
         if count_b == count_ab:
             summand4 = 0
         else:
-            summand4 = ((count_b - count_ab) * math.log(p2 + (p2 == 0)) +
-                        (N - count_a - count_b + count_ab) * math.log(1.0 - p2 + (p2 == 1)))
+            summand4 = ((count_b - count_ab) * math.log(p2 or 1) +
+                        (N - count_a - count_b + count_ab) * math.log(1.0 - p2) if p2 < 1 else 0)
 
         likelihood = summand1 + summand2 - summand3 - summand4
 


### PR DESCRIPTION
This commit proposes a possible fix for #397.

I followed Dunning's remarks in http://tdunning.blogspot.com/2008/03/surprise-and-coincidence.html to avoid `log(0)`. This includes converting
- `log(p)` to `log(p + (p == 0))`
- `log(1.0 - p)` to `log(1.0 - p + (p == 1))`

Also, for the original error:

```
p2 = (count_b - count_ab) / (N - count_a)
```

I capped it to 1 as in

```
p2_denom = N - count_a
if p2_denom == 0:
    p2 = 1
else:
    p2 = (count_b - count_ab) / p2_denom
```

Let me know what you think, and if this is a valid solution, I will readjust the test cases and add a new one to cover `p2_denom == 0`.
