### PR TITLE
Allow corenlp_options argument for StanfordParser to be a list

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -189,3 +189,4 @@
 - Sergio Oller
 - Will Monroe
 - Elijah Rippeth
+- Alexander Mathews

--- a/nltk/parse/stanford.py
+++ b/nltk/parse/stanford.py
@@ -186,7 +186,10 @@ class GenericStanfordParser(ParserI):
         encoding = self._encoding
         cmd.extend(['-encoding', encoding])
         if self.corenlp_options:
-            cmd.append(self.corenlp_options)
+            if type(self.corenlp_options) is list:
+                cmd.extend(self.corenlp_options)
+            else:
+                cmd.append(self.corenlp_options)
 
         default_options = ' '.join(_java_options)
 


### PR DESCRIPTION
I have made a very small change to allow the corenlp_options argument to the StanfordParser initializer to be a list.

When adding corenlp arguments you might want to have arguments like '-nthreads 4'. Adding the arguments as a string doesn't work because when Popen is called to start the java process it interprets the whole string '-nthreads 4' as an argument which is unrecognised. Allowing corenlp_options to be a list allows the arguments to be added as ['-nthreads', '4'].
