### PR TITLE
Change string formatting with 'format' specifier

### DIFF
--- a/tools/find_deprecated.py
+++ b/tools/find_deprecated.py
@@ -44,19 +44,19 @@ STRING_PAT = (r'\s*[ur]{0,2}(?:'
               "'''[\s\S]*?'''|"  "'[^'\n]+?'" ")\s*")
 STRING_RE = re.compile(STRING_PAT)
 
-STRINGS_PAT = '%s(?:[+]?%s)*' % (STRING_PAT, STRING_PAT)
+STRINGS_PAT = '{}(?:[+]?{})*'.format(STRING_PAT, STRING_PAT)
 STRINGS_RE = re.compile(STRINGS_PAT)
 
 # Define a regexp to search for deprecated definitions.
 DEPRECATED_DEF_PAT = (
-    r'^\s*@deprecated\s*\(\s*(%s)\s*\)\s*\n+' % STRINGS_PAT +
+    r'^\s*@deprecated\s*\(\s*({})\s*\)\s*\n+'.format(STRINGS_PAT) +
     r'\s*def\s*(\w+).*' +
     r'|' +
     r'^\s*class\s+(\w+)\s*\(.*Deprecated.*\):\s*')
 DEPRECATED_DEF_RE = re.compile(DEPRECATED_DEF_PAT, re.MULTILINE)
 
 CORPUS_READ_METHOD_RE = re.compile(
-    '(%s)\.read\(' % ('|'.join(re.escape(n) for n in dir(nltk.corpus))))
+    '({})\.read\('.format('|'.join(re.escape(n) for n in dir(nltk.corpus))))
 
 CLASS_DEF_RE = re.compile('^\s*class\s+(\w+)\s*[:\(]')
 
@@ -179,9 +179,9 @@ def print_deprecated_uses_in(readline, path, dep_files, dep_names,
         # Ignore all tokens except deprecated names.
         if not (tok in deprecated_classes or
                 (tok in deprecated_funcs and
-                 re.search(r'\b%s\s*\(' % esctok, line)) or
+                 re.search(r'\b{}\s*\('.format(esctok), line)) or
                 (tok in deprecated_methods and
-                 re.search(r'(?!<\bself)[.]\s*%s\s*\(' % esctok, line))):
+                 re.search(r'(?!<\bself)[.]\s*{}\s*\('.format(esctok), line))):
             continue
         # Hack: only complain about read if it's used after a corpus.
         if tok == 'read' and not CORPUS_READ_METHOD_RE.search(line):
@@ -192,7 +192,7 @@ def print_deprecated_uses_in(readline, path, dep_files, dep_names,
         # Print a header for the first use in a file:
         if path not in dep_files:
             print('\n' + term.BOLD + path + term.NORMAL)
-            print('  %slinenum%s' % (term.YELLOW, term.NORMAL))
+            print('  {}linenum{}'.format(term.YELLOW, term.NORMAL))
             dep_files.add(path)
         # Mark the offending token.
         dep_names.add(tok)
@@ -202,9 +202,9 @@ def print_deprecated_uses_in(readline, path, dep_files, dep_names,
             sub = term.BOLD + tok + term.NORMAL
         else:
             sub = '<<' + tok + '>>'
-        line = re.sub(r'\b%s\b' % esctok, sub, line)
+        line = re.sub(r'\b{}\b'.format(esctok), sub, line)
         # Print the offending line.
-        print('  %s[%5d]%s %s' % (term.YELLOW, start[0] + lineno_offset,
+        print('  {}[{:5d}]{} {}'.format(term.YELLOW, start[0] + lineno_offset,
                                   term.NORMAL, line.rstrip()))
 
 

--- a/tools/global_replace.py
+++ b/tools/global_replace.py
@@ -59,4 +59,4 @@ if __name__ == '__main__':
                     print("Updated:", path)
                     count += 1
 
-    print("Updated %d files" % count)
+    print("Updated {} files".format(count))

--- a/tools/nltk_term_index.py
+++ b/tools/nltk_term_index.py
@@ -42,13 +42,13 @@ def find_all_names(stoplist):
                     continue
                 names[key].append(valdoc)
 
-    log.info('Found %s names from %s objects' % (len(names), n))
+    log.info('Found {} names from {} objects'.format(len(names), n))
 
     return names
 
 SCAN_RE1 = "<programlisting>[\s\S]*?</programlisting>"
 SCAN_RE2 = "<literal>[\s\S]*?</literal>"
-SCAN_RE = re.compile("(%s)|(%s)" % (SCAN_RE1, SCAN_RE2))
+SCAN_RE = re.compile("({})|({})".format(SCAN_RE1, SCAN_RE2))
 
 TOKEN_RE = re.compile('[\w\.]+')
 
@@ -67,7 +67,7 @@ def scan_xml(filenames, names):
                 targets = names[token]
                 fdist.inc(token)
                 if len(targets) > 1:
-                    log.warning('%s is ambiguous: %s' % (
+                    log.warning('{} is ambiguous: {}'.format(
                         token, ', '.join(str(v.canonical_name)
                                          for v in names[token])))
                 line += INDEXTERM % token
@@ -78,7 +78,7 @@ def scan_xml(filenames, names):
         return LINE_RE.sub(linesub, match.group())
 
     for filename in filenames:
-        log.info('  %s' % filename)
+        log.info('  {}'.format(filename))
         src = open(filename, 'rb').read()
         src = SCAN_RE.sub(scansub, src)
 #        out = open(filename[:-4]+'.li.xml', 'wb')
@@ -96,7 +96,7 @@ def scan_xml(filenames, names):
 def main():
     log.info('Loading stoplist...')
     stoplist = open(STOPLIST).read().split()
-    log.info('  Stoplist contains %d words' % len(stoplist))
+    log.info('  Stoplist contains {} words'.format(len(stoplist)))
 
     log.info('Running epydoc to build a name index...')
     names = find_all_names(stoplist)

--- a/tools/svnmime.py
+++ b/tools/svnmime.py
@@ -46,7 +46,7 @@ for file in sys.argv[1:]:
     if "." in file:
         extension = file.rsplit('.', 1)[1]
         if extension in types_map:
-            os.system("svn propset svn:mime-type %s %s" %
+            os.system("svn propset svn:mime-type {} {}".format
                       (types_map[extension], file))
         else:
             print("Unrecognized extension", extension)


### PR DESCRIPTION
According to the contributing guidelines, usage of format specifier is recommended. This makes the code clean and also improves the readability.

We can use the format specifier for string interpolation in regex also. This makes the regex more explicit.

Till now, I made changes only to 'tools' directory. If this PR is accepted, I will proceed to fix the entire codebase with the new format specifier.
Thanks!
