### PR TITLE
Fix 'issues' URL in CONTRIBUTING.md

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -58,6 +58,7 @@
 - Jean Mark Gawron
 - Sumukh Ghodke
 - Yoav Goldberg
+- Michael Wayne Goodman
 - Dougal Graham
 - Brent Gray
 - Simon Greenhill

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ Summary of our git branching model:
   formatting](http://docs.python.org/library/string.html#format-string-syntax)
   (`'{} = {}'.format(a, b)` instead of `'%s = %s' % (a, b)`);
 - All `#TODO` comments should be turned into issues (use our
-  [GitHub issue system](https://github.com/namd/pypln.web/issues));
+  [GitHub issue system](https://github.com/nltk/nltk/issues));
 - Run all tests before pushing (just execute `tox`) so you will know if your
   changes broke something;
 - Try to write both Python 2 and Python3-friendly code so won't be a pain for


### PR DESCRIPTION
The URL for "our GitHub issue system" didn't point to NTLK's issues, but instead to that of the repository that the text was copy-pasted from. That is now fixed.

(I added my name to AUTHORS.md because it said to in CONTRIBUTING.md, but I can remove it if this contribution is too small)
