### PR TITLE
Added smoothing to BLEU scores

### DIFF
--- a/nltk/test/unit/translate/test_bleu.py
+++ b/nltk/test/unit/translate/test_bleu.py
@@ -22,7 +22,7 @@ class TestBLEU(unittest.TestCase):
         references = [ref1, ref2] 
         
         # Testing modified unigram precision.
-        hyp1_unigram_precision =  _modified_precision(references, hyp1, n=1)
+        hyp1_unigram_precision =  float(_modified_precision(references, hyp1, n=1))
         assert (round(hyp1_unigram_precision, 4) == 0.2857)
         # With assertAlmostEqual at 4 place precision.
         self.assertAlmostEqual(hyp1_unigram_precision, 0.28571428, places=4)
@@ -59,8 +59,8 @@ class TestBLEU(unittest.TestCase):
         references = [ref1, ref2, ref3]
         
         # Unigram precision.
-        hyp1_unigram_precision = _modified_precision(references, hyp1, n=1)
-        hyp2_unigram_precision = _modified_precision(references, hyp2, n=1)
+        hyp1_unigram_precision = float(_modified_precision(references, hyp1, n=1))
+        hyp2_unigram_precision = float(_modified_precision(references, hyp2, n=1))
         # Test unigram precision with assertAlmostEqual at 4 place precision.
         self.assertAlmostEqual(hyp1_unigram_precision, 0.94444444, places=4)
         self.assertAlmostEqual(hyp2_unigram_precision, 0.57142857, places=4)
@@ -70,8 +70,8 @@ class TestBLEU(unittest.TestCase):
         
         
         # Bigram precision
-        hyp1_bigram_precision = _modified_precision(references, hyp1, n=2)
-        hyp2_bigram_precision = _modified_precision(references, hyp2, n=2)
+        hyp1_bigram_precision = float(_modified_precision(references, hyp1, n=2))
+        hyp2_bigram_precision = float(_modified_precision(references, hyp2, n=2))
         # Test bigram precision with assertAlmostEqual at 4 place precision.
         self.assertAlmostEqual(hyp1_bigram_precision, 0.58823529, places=4)
         self.assertAlmostEqual(hyp2_bigram_precision, 0.07692307, places=4)

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -423,32 +423,32 @@ class SmoothingFunction:
         ...               'Party', 'commands']
                 
         >>> chencherry = SmoothingFunction()
-        >>> print (sentence_bleu([reference1], hypothesis1))
-        0.411803763569
+        >>> print (sentence_bleu([reference1], hypothesis1)) # doctest: +ELLIPSIS
+        0.4118...
         >>> chencherry = SmoothingFunction()
-        >>> print (sentence_bleu([reference1], hypothesis1, smoothing_function=chencherry.method0))
-        0.411803763569
+        >>> print (sentence_bleu([reference1], hypothesis1, smoothing_function=chencherry.method0)) # doctest: +ELLIPSIS
+        0.4118...
         >>> chencherry = SmoothingFunction()
-        >>> print (sentence_bleu([reference1], hypothesis1, smoothing_function=chencherry.method1))
-        0.411803763569
+        >>> print (sentence_bleu([reference1], hypothesis1, smoothing_function=chencherry.method1)) # doctest: +ELLIPSIS
+        0.4118...
         >>> chencherry = SmoothingFunction()
-        >>> print (sentence_bleu([reference1], hypothesis1, smoothing_function=chencherry.method2))
-        0.457631898086
+        >>> print (sentence_bleu([reference1], hypothesis1, smoothing_function=chencherry.method2)) # doctest: +ELLIPSIS
+        0.4576...
         >>> chencherry = SmoothingFunction()
-        >>> print (sentence_bleu([reference1], hypothesis1, smoothing_function=chencherry.method3))
-        0.411803763569
+        >>> print (sentence_bleu([reference1], hypothesis1, smoothing_function=chencherry.method3)) # doctest: +ELLIPSIS
+        0.4118...
         >>> chencherry = SmoothingFunction()
-        >>> print (sentence_bleu([reference1], hypothesis1, smoothing_function=chencherry.method4))
-        0.411803763569
+        >>> print (sentence_bleu([reference1], hypothesis1, smoothing_function=chencherry.method4)) # doctest: +ELLIPSIS
+        0.4118...
         >>> chencherry = SmoothingFunction()
-        >>> print (sentence_bleu([reference1], hypothesis1, smoothing_function=chencherry.method5))
-        0.490532813802
+        >>> print (sentence_bleu([reference1], hypothesis1, smoothing_function=chencherry.method5)) # doctest: +ELLIPSIS
+        0.4905...
         >>> chencherry = SmoothingFunction()
-        >>> print (sentence_bleu([reference1], hypothesis1, smoothing_function=chencherry.method6))
-        0.180150787676
+        >>> print (sentence_bleu([reference1], hypothesis1, smoothing_function=chencherry.method6)) # doctest: +ELLIPSIS
+        0.1801...
         >>> chencherry = SmoothingFunction()
-        >>> print (sentence_bleu([reference1], hypothesis1, smoothing_function=chencherry.method7))
-        0.490532813802
+        >>> print (sentence_bleu([reference1], hypothesis1, smoothing_function=chencherry.method7)) # doctest: +ELLIPSIS
+        0.4905...
 
         :param epsilon: the epsilon value use in method 1
         :type epsilon: float

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -45,11 +45,11 @@ def sentence_bleu(references, hypothesis, weights=(0.25, 0.25, 0.25, 0.25),
     ...               'army', 'always', 'to', 'heed', 'the', 'directions',
     ...               'of', 'the', 'party']
 
-    >>> sentence_bleu([reference1, reference2, reference3], hypothesis1)
-    0.5045666840058485
+    >>> sentence_bleu([reference1, reference2, reference3], hypothesis1) # doctest: +ELLIPSIS
+    0.5045...
 
-    >>> sentence_bleu([reference1, reference2, reference3], hypothesis2)
-    0.39692877231857493
+    >>> sentence_bleu([reference1, reference2, reference3], hypothesis2) # doctest: +ELLIPSIS
+    0.3969...
 
     The default BLEU calculates a score for up to 4grams using uniform
     weights. To evaluate your translations with higher/lower order ngrams, 
@@ -126,16 +126,16 @@ def corpus_bleu(list_of_references, hypotheses, weights=(0.25, 0.25, 0.25, 0.25)
     
     >>> list_of_references = [[ref1a, ref1b, ref1c], [ref2a]]
     >>> hypotheses = [hyp1, hyp2]
-    >>> corpus_bleu(list_of_references, hypotheses)
-    0.5520516129306314
+    >>> corpus_bleu(list_of_references, hypotheses) # doctest: +ELLIPSIS
+    0.5520...
     
     The example below show that corpus_bleu() is different from averaging 
     sentence_bleu() for hypotheses 
     
     >>> score1 = sentence_bleu([ref1a, ref1b, ref1c], hyp1)
     >>> score2 = sentence_bleu([ref2a], hyp2)
-    >>> (score1 + score2) / 2
-    0.6223247442490669
+    >>> (score1 + score2) / 2 # doctest: +ELLIPSIS
+    0.6223...
     
     :param references: a corpus of lists of reference sentences, w.r.t. hypotheses
     :type references: list(list(list(str)))
@@ -207,8 +207,8 @@ def _modified_precision(references, hypothesis, n):
         >>> reference2 = 'there is a cat on the mat'.split()
         >>> hypothesis1 = 'the the the the the the the'.split()
         >>> references = [reference1, reference2]
-        >>> float(_modified_precision(references, hypothesis1, n=1))
-        0.2857142857142857
+        >>> float(_modified_precision(references, hypothesis1, n=1)) # doctest: +ELLIPSIS
+        0.2857...
     
     In the modified n-gram precision, a reference word will be considered 
     exhausted after a matching hypothesis word is identified, e.g.
@@ -253,14 +253,14 @@ def _modified_precision(references, hypothesis, n):
         ...               'army', 'always', 'to', 'heed', 'the', 'directions',
         ...               'of', 'the', 'party']
         >>> references = [reference1, reference2, reference3]
-        >>> float(_modified_precision(references, hypothesis1, n=1))
-        0.9444444444444444
-        >>> float(_modified_precision(references, hypothesis2, n=1))
-        0.5714285714285714
-        >>> float(_modified_precision(references, hypothesis1, n=2))
+        >>> float(_modified_precision(references, hypothesis1, n=1)) # doctest: +ELLIPSIS
+        0.9444...
+        >>> float(_modified_precision(references, hypothesis2, n=1)) # doctest: +ELLIPSIS
+        0.5714...
+        >>> float(_modified_precision(references, hypothesis1, n=2)) # doctest: +ELLIPSIS
         0.5882352941176471
-        >>> float(_modified_precision(references, hypothesis2, n=2))
-        0.07692307692307693
+        >>> float(_modified_precision(references, hypothesis2, n=2)) # doctest: +ELLIPSIS
+        0.07692...
      
     
     :param references: A list of reference translations.
@@ -350,8 +350,8 @@ def _brevity_penalty(closest_ref_len, hyp_len):
         >>> hypothesis = ['a'] * 12
         >>> hyp_len = len(hypothesis)
         >>> closest_ref_len =  _closest_ref_length(references, hyp_len)
-        >>> _brevity_penalty(closest_ref_len, hyp_len)
-        0.9200444146293233
+        >>> _brevity_penalty(closest_ref_len, hyp_len) # doctest: +ELLIPSIS
+        0.9200...
 
     The brevity penalty doesn't depend on reference order. More importantly,
     when two reference sentences are at the same distance, the shortest
@@ -374,8 +374,8 @@ def _brevity_penalty(closest_ref_len, hyp_len):
         >>> hypothesis = ['a'] * 7
         >>> hyp_len = len(hypothesis)
         >>> closest_ref_len =  _closest_ref_length(references, hyp_len)
-        >>> _brevity_penalty(closest_ref_len, hyp_len)
-        0.8668778997501817
+        >>> _brevity_penalty(closest_ref_len, hyp_len) # doctest: +ELLIPSIS
+        0.8668...
 
         >>> references = [['a'] * 11, ['a'] * 8, ['a'] * 6, ['a'] * 7]
         >>> hypothesis = ['a'] * 7
@@ -414,22 +414,22 @@ def smooth_precision(references, hypothesis, p_n, hyp_len,
         >>> reference1 = ['It', 'is', 'a', 'guide', 'to', 'action', 'that',
         ... 'ensures', 'that', 'the', 'military', 'will', 'forever',
         ... 'heed', 'Party', 'commands']
-        >>> print (sentence_bleu([reference1], hypothesis1, smoothing_method=0))
-        0.411803763569
-        >>> print (sentence_bleu([reference1], hypothesis1, smoothing_method=1))
-        0.411803763569
-        >>> print (sentence_bleu([reference1], hypothesis1, smoothing_method=2))
-        0.457631898086
-        >>> print (sentence_bleu([reference1], hypothesis1, smoothing_method=3))
-        0.411803763569
-        >>> print (sentence_bleu([reference1], hypothesis1, smoothing_method=4))
-        0.411803763569
-        >>> print (sentence_bleu([reference1], hypothesis1, smoothing_method=5))
-        0.490532813802
-        >>> print (sentence_bleu([reference1], hypothesis1, smoothing_method=6))
-        0.180150787676
-        >>> print (sentence_bleu([reference1], hypothesis1, smoothing_method=7))
-        0.490532813802
+        >>> print (sentence_bleu([reference1], hypothesis1, smoothing_method=0)) # doctest: +ELLIPSIS
+        0.4118...
+        >>> print (sentence_bleu([reference1], hypothesis1, smoothing_method=1)) # doctest: +ELLIPSIS
+        0.4118...
+        >>> print (sentence_bleu([reference1], hypothesis1, smoothing_method=2)) # doctest: +ELLIPSIS
+        0.4576...
+        >>> print (sentence_bleu([reference1], hypothesis1, smoothing_method=3)) # doctest: +ELLIPSIS
+        0.4118...
+        >>> print (sentence_bleu([reference1], hypothesis1, smoothing_method=4)) # doctest: +ELLIPSIS
+        0.4118...
+        >>> print (sentence_bleu([reference1], hypothesis1, smoothing_method=5)) # doctest: +ELLIPSIS
+        0.4905...
+        >>> print (sentence_bleu([reference1], hypothesis1, smoothing_method=6)) # doctest: +ELLIPSIS
+        0.1801...
+        >>> print (sentence_bleu([reference1], hypothesis1, smoothing_method=7)) # doctest: +ELLIPSIS
+        0.4905...
     
     :param references: reference sentences
     :type references: list(list(str))

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -485,7 +485,7 @@ def smooth_precision(references, hypothesis, p_n, hyp_len,
     # Shorter translations may have inflated precision values due to having 
     # smaller denominators; therefore, we give them proportionally
     # smaller smoothed counts. Instead of scaling to 1/(2^k), Chen and Cherry 
-    # suggests dividing by 1/ln(len(T), where T is the length of the translation.
+    # suggests dividing by 1/ln(len(T)), where T is the length of the translation.
     if method == 4:
         incvnt = 1 
         for i, p_i in enumerate(p_n):

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -89,8 +89,10 @@ def sentence_bleu(references, hypothesis, weights=(0.25, 0.25, 0.25, 0.25),
     # By sum of the product of the weights and the respective *p_n*
     s = (w * math.log(p_i) if p_i else 0 
          for w, p_i in zip(weights, p_n))
-    
-    return bp * math.exp(math.fsum(s))
+    sum_s = math.fsum(s)
+    if sum_s == 0:
+        return 0
+    return bp * math.exp(sum_s)
 
 
 def corpus_bleu(list_of_references, hypotheses, weights=(0.25, 0.25, 0.25, 0.25),

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -447,7 +447,7 @@ def smooth_precision(references, hypothesis, p_n, hyp_len,
     :type alpha: int
     :param k: the k value use in method 4
     :type k: int
-    :return: a list of smoothen modified precisions
+    :return: a list of smoothed modified precisions
     :rtype: list(float)
     """
     # No smoothing.

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -491,7 +491,7 @@ def smooth_precision(references, hypothesis, p_n, hyp_len,
     elif method == 4:
         incvnt = 1 
         for i, p_i in enumerate(p_n):
-            if p_i == 0:
+            if p_i == 0 and hyp_len != 0:
                 p_n[i] = incvnt * k / math.log(hyp_len) # Note that this K is different from the K from NIST.
                 incvnt+=1
         return p_n

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -454,14 +454,14 @@ def smooth_precision(references, hypothesis, p_n, hyp_len,
     if method == 0:
         return p_n
     # Smoothing method 1: Add *epsilon* counts to precision with 0 counts.
-    if method == 1:
+    elif method == 1:
         return [(p_i.numerator + epsilon)/ p_i.denominator 
                 if p_i.numerator == 0 else p_i for p_i in p_n]
     # Smoothing method 2: Add 1 to both numerator and denominator from 
     # Chin-Yew Lin and Franz Josef Och (2004) Automatic evaluation of 
     # machine translation quality using longest common subsequence and 
     # skip-bigram statistics. In ACL04.
-    if method == 2:
+    elif method == 2:
         return [Fraction(p_i.numerator + 1, p_i.denominator + 1)
                 for p_i in p_n]
     # Smoothing method 3: NIST geometric sequence smoothing 
@@ -476,7 +476,7 @@ def smooth_precision(references, hypothesis, p_n, hyp_len,
     #   - n=2  =>  prec_count = 1     (one bigram)
     #   - n=3  =>  prec_count = 1/2   (no trigram,  taking 'smoothed' value of 1 / ( 2^k ), with k=1)
     #   - n=4  =>  prec_count = 1/4   (no fourgram, taking 'smoothed' value of 1 / ( 2^k ), with k=2)
-    if method == 3:
+    elif method == 3:
         incvnt = 1 # From the mteval-v13a.pl, it's referred to as k.
         for i, p_i in enumerate(p_n):
             if p_i == 0:
@@ -488,7 +488,7 @@ def smooth_precision(references, hypothesis, p_n, hyp_len,
     # smaller denominators; therefore, we give them proportionally
     # smaller smoothed counts. Instead of scaling to 1/(2^k), Chen and Cherry 
     # suggests dividing by 1/ln(len(T)), where T is the length of the translation.
-    if method == 4:
+    elif method == 4:
         incvnt = 1 
         for i, p_i in enumerate(p_n):
             if p_i == 0:
@@ -499,7 +499,7 @@ def smooth_precision(references, hypothesis, p_n, hyp_len,
     # The matched counts for similar values of n should be similar. To a 
     # calculate the n-gram matched count, it averages the n−1, n and n+1 gram 
     # matched counts.
-    if method == 5:
+    elif method == 5:
         m = {}
         # Requires an precision value for an addition ngram order.
         p_n_plus5 = p_n + [_modified_precision(references, hypothesis, 5)]
@@ -512,7 +512,7 @@ def smooth_precision(references, hypothesis, p_n, hyp_len,
     # Interpolates the maximum likelihood estimate of the precision *p_n* with 
     # a prior estimate *pi0*. The prior is estimated by assuming that the ratio 
     # between pn and pn−1 will be the same as that between pn−1 and pn−2.
-    if method == 6:
+    elif method == 6:
         for i, p_i in enumerate(p_n):
             if i in [1,2]: # Skips the first 2 orders of ngrams.
                 continue
@@ -523,7 +523,7 @@ def smooth_precision(references, hypothesis, p_n, hyp_len,
                 p_n[i] = (p_i + alpha * pi0) / (l + alpha)
         return p_n
     # Smoothing method
-    if method == 7:
+    elif method == 7:
         p_n = smooth_precision(references, hypothesis, p_n, hyp_len, method=4)
         p_n = smooth_precision(references, hypothesis, p_n, hyp_len, method=5)
         return p_n

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -447,6 +447,8 @@ def smooth_precision(references, hypothesis, p_n, hyp_len,
     :type alpha: int
     :param k: the k value use in method 4
     :type k: int
+    :return: a list of smoothen modified precisions
+    :rtype: list(float)
     """
     # No smoothing.
     if method == 0:

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -425,28 +425,20 @@ class SmoothingFunction:
         >>> chencherry = SmoothingFunction()
         >>> print (sentence_bleu([reference1], hypothesis1)) # doctest: +ELLIPSIS
         0.4118...
-        >>> chencherry = SmoothingFunction()
         >>> print (sentence_bleu([reference1], hypothesis1, smoothing_function=chencherry.method0)) # doctest: +ELLIPSIS
         0.4118...
-        >>> chencherry = SmoothingFunction()
         >>> print (sentence_bleu([reference1], hypothesis1, smoothing_function=chencherry.method1)) # doctest: +ELLIPSIS
         0.4118...
-        >>> chencherry = SmoothingFunction()
         >>> print (sentence_bleu([reference1], hypothesis1, smoothing_function=chencherry.method2)) # doctest: +ELLIPSIS
         0.4576...
-        >>> chencherry = SmoothingFunction()
         >>> print (sentence_bleu([reference1], hypothesis1, smoothing_function=chencherry.method3)) # doctest: +ELLIPSIS
         0.4118...
-        >>> chencherry = SmoothingFunction()
         >>> print (sentence_bleu([reference1], hypothesis1, smoothing_function=chencherry.method4)) # doctest: +ELLIPSIS
         0.4118...
-        >>> chencherry = SmoothingFunction()
         >>> print (sentence_bleu([reference1], hypothesis1, smoothing_function=chencherry.method5)) # doctest: +ELLIPSIS
         0.4905...
-        >>> chencherry = SmoothingFunction()
         >>> print (sentence_bleu([reference1], hypothesis1, smoothing_function=chencherry.method6)) # doctest: +ELLIPSIS
         0.1801...
-        >>> chencherry = SmoothingFunction()
         >>> print (sentence_bleu([reference1], hypothesis1, smoothing_function=chencherry.method7)) # doctest: +ELLIPSIS
         0.4905...
 
@@ -461,35 +453,41 @@ class SmoothingFunction:
         self.alpha = alpha
         self.k = k
         
-    def method0(self, p_n, **kwargs):
-        # No smoothing.
+    def method0(self, p_n, *args, **kwargs):
+        """ No smoothing. """
         return p_n
         
-    def method1(self, p_n, **kwargs):
-        # Smoothing method 1: Add *epsilon* counts to precision with 0 counts.
+    def method1(self, p_n, *args, **kwargs):
+        """ 
+        Smoothing method 1: Add *epsilon* counts to precision with 0 counts.
+        """ 
         return [(p_i.numerator + self.epsilon)/ p_i.denominator 
                 if p_i.numerator == 0 else p_i for p_i in p_n]
         
-    def method2(self, p_n, **kwargs):
-        # Smoothing method 2: Add 1 to both numerator and denominator from 
-        # Chin-Yew Lin and Franz Josef Och (2004) Automatic evaluation of 
-        # machine translation quality using longest common subsequence and 
-        # skip-bigram statistics. In ACL04.
+    def method2(self, p_n, *args, **kwargs):
+        """
+        Smoothing method 2: Add 1 to both numerator and denominator from 
+        Chin-Yew Lin and Franz Josef Och (2004) Automatic evaluation of 
+        machine translation quality using longest common subsequence and 
+        skip-bigram statistics. In ACL04.
+        """
         return [Fraction(p_i.numerator + 1, p_i.denominator + 1) for p_i in p_n]
         
-    def method3(self, p_n, **kwargs):
-        # Smoothing method 3: NIST geometric sequence smoothing 
-        # The smoothing is computed by taking 1 / ( 2^k ), instead of 0, for each 
-        # precision score whose matching n-gram count is null.
-        # k is 1 for the first 'n' value for which the n-gram match count is null/
-        # For example, if the text contains:
-        #   - one 2-gram match
-        #   - and (consequently) two 1-gram matches
-        # the n-gram count for each individual precision score would be:
-        #   - n=1  =>  prec_count = 2     (two unigrams)
-        #   - n=2  =>  prec_count = 1     (one bigram)
-        #   - n=3  =>  prec_count = 1/2   (no trigram,  taking 'smoothed' value of 1 / ( 2^k ), with k=1)
-        #   - n=4  =>  prec_count = 1/4   (no fourgram, taking 'smoothed' value of 1 / ( 2^k ), with k=2)
+    def method3(self, p_n, *args, **kwargs):
+        """
+        Smoothing method 3: NIST geometric sequence smoothing 
+        The smoothing is computed by taking 1 / ( 2^k ), instead of 0, for each 
+        precision score whose matching n-gram count is null.
+        k is 1 for the first 'n' value for which the n-gram match count is null/
+        For example, if the text contains:
+         - one 2-gram match
+         - and (consequently) two 1-gram matches
+        the n-gram count for each individual precision score would be:
+         - n=1  =>  prec_count = 2     (two unigrams)
+         - n=2  =>  prec_count = 1     (one bigram)
+         - n=3  =>  prec_count = 1/2   (no trigram,  taking 'smoothed' value of 1 / ( 2^k ), with k=1)
+         - n=4  =>  prec_count = 1/4   (no fourgram, taking 'smoothed' value of 1 / ( 2^k ), with k=2)
+        """
         incvnt = 1 # From the mteval-v13a.pl, it's referred to as k.
         for i, p_i in enumerate(p_n):
             if p_i == 0:
@@ -498,11 +496,13 @@ class SmoothingFunction:
         return p_n
     
     def method4(self, p_n, references, hypothesis, hyp_len):
-        # Smoothing method 4: 
-        # Shorter translations may have inflated precision values due to having 
-        # smaller denominators; therefore, we give them proportionally
-        # smaller smoothed counts. Instead of scaling to 1/(2^k), Chen and Cherry 
-        # suggests dividing by 1/ln(len(T)), where T is the length of the translation.
+        """
+        Smoothing method 4: 
+        Shorter translations may have inflated precision values due to having 
+        smaller denominators; therefore, we give them proportionally
+        smaller smoothed counts. Instead of scaling to 1/(2^k), Chen and Cherry 
+        suggests dividing by 1/ln(len(T)), where T is the length of the translation.
+        """
         incvnt = 1 
         for i, p_i in enumerate(p_n):
             if p_i == 0 and hyp_len != 0:
@@ -512,10 +512,12 @@ class SmoothingFunction:
 
 
     def method5(self, p_n, references, hypothesis, hyp_len):
-        # Smoothing method 5:
-        # The matched counts for similar values of n should be similar. To a 
-        # calculate the n-gram matched count, it averages the n−1, n and n+1 gram 
-        # matched counts.
+        """
+        Smoothing method 5:
+        The matched counts for similar values of n should be similar. To a 
+        calculate the n-gram matched count, it averages the n−1, n and n+1 gram 
+        matched counts.
+        """
         m = {}
         # Requires an precision value for an addition ngram order.
         p_n_plus1 = p_n + [_modified_precision(references, hypothesis, 5)]
@@ -526,10 +528,12 @@ class SmoothingFunction:
         return p_n
         
     def method6(self, p_n, references, hypothesis, hyp_len):
-        # Smoothing method 6:
-        # Interpolates the maximum likelihood estimate of the precision *p_n* with 
-        # a prior estimate *pi0*. The prior is estimated by assuming that the ratio 
-        # between pn and pn−1 will be the same as that between pn−1 and pn−2.
+        """
+        Smoothing method 6:
+        Interpolates the maximum likelihood estimate of the precision *p_n* with 
+        a prior estimate *pi0*. The prior is estimated by assuming that the ratio 
+        between pn and pn−1 will be the same as that between pn−1 and pn−2.
+        """
         for i, p_i in enumerate(p_n):
             if i in [1,2]: # Skips the first 2 orders of ngrams.
                 continue
@@ -541,6 +545,12 @@ class SmoothingFunction:
         return p_n
     
     def method7(self, p_n, references, hypothesis, hyp_len):
+        """
+        Smoothing method 6:
+        Interpolates the maximum likelihood estimate of the precision *p_n* with 
+        a prior estimate *pi0*. The prior is estimated by assuming that the ratio 
+        between pn and pn−1 will be the same as that between pn−1 and pn−2.
+        """
         p_n = self.method4(p_n, references, hypothesis, hyp_len)
         p_n = self.method5(p_n, references, hypothesis, hyp_len)
         return p_n


### PR DESCRIPTION
- Added Chen and Cherry (2014) smoothing methods for BLEU. 
- Note that the `p_n` now needs to be materialized as opposed to how it was previously stored in a generator. It's because the `p_n` needs to be modified by the `smooth_bleu()` function. 

---

Additionally, fix related test failures from `bleu_score.py`:
- https://nltk.ci.cloudbees.com/job/nltk/TOXENV=py34-jenkins,jdk=jdk8latestOnlineInstall/lastCompletedBuild/testReport/nltk.test.unit.translate.test_bleu/TestBLEU/test__modified_precision/ 
- https://nltk.ci.cloudbees.com/job/nltk/TOXENV=py34-jenkins,jdk=jdk8latestOnlineInstall/lastCompletedBuild/testReport/(root)/bleu_doctest/bleu_doctest/
