### PR TITLE
Fix probability doctest

### DIFF
--- a/nltk/test/probability.doctest
+++ b/nltk/test/probability.doctest
@@ -69,33 +69,33 @@ ConditionalFreqDist
 -------------------
 
     >>> cfd1 = ConditionalFreqDist()
-    >>> cfd1[1] = FreqDist('abbbc')
+    >>> cfd1[1] = FreqDist('abbbb')
     >>> cfd1[2] = FreqDist('xxxxyy')
     >>> cfd1
     <ConditionalFreqDist with 2 conditions>
 
     >>> cfd2 = ConditionalFreqDist()
-    >>> cfd2[1] = FreqDist('bccd')
-    >>> cfd2[2] = FreqDist('xxyyyzz')
+    >>> cfd2[1] = FreqDist('bbccc')
+    >>> cfd2[2] = FreqDist('xxxyyyzz')
     >>> cfd2[3] = FreqDist('m')
     >>> cfd2
     <ConditionalFreqDist with 3 conditions>
 
     >>> r = cfd1 + cfd2
     >>> [(i,r[i]) for i in r.conditions()]
-    [(1, FreqDist({'b': 4, 'c': 3, 'a': 1, 'd': 1})), (2, FreqDist({'x': 6, 'y': 5, 'z': 2})), (3, FreqDist({'m': 1}))]
+    [(1, FreqDist({'b': 6, 'c': 3, 'a': 1})), (2, FreqDist({'x': 7, 'y': 5, 'z': 2})), (3, FreqDist({'m': 1}))]
 
     >>> r = cfd1 - cfd2
     >>> [(i,r[i]) for i in r.conditions()]
-    [(1, FreqDist({'b': 2, 'a': 1})), (2, FreqDist({'x': 2}))]
+    [(1, FreqDist({'b': 2, 'a': 1})), (2, FreqDist({'x': 1}))]
 
     >>> r = cfd1 | cfd2
     >>> [(i,r[i]) for i in r.conditions()]
-    [(1, FreqDist({'b': 3, 'c': 2, 'a': 1, 'd': 1})), (2, FreqDist({'x': 4, 'y': 3, 'z': 2})), (3, FreqDist({'m': 1}))]
+    [(1, FreqDist({'b': 4, 'c': 3, 'a': 1})), (2, FreqDist({'x': 4, 'y': 3, 'z': 2})), (3, FreqDist({'m': 1}))]
 
     >>> r = cfd1 & cfd2
     >>> [(i,r[i]) for i in r.conditions()]
-    [(1, FreqDist({'c': 1, 'b': 1})), (2, FreqDist({'y': 2, 'x': 2}))]
+    [(1, FreqDist({'b': 2})), (2, FreqDist({'x': 3, 'y': 2}))]
 
 Testing some HMM estimators
 ---------------------------

--- a/nltk/tokenize/api.py
+++ b/nltk/tokenize/api.py
@@ -11,7 +11,7 @@ Tokenizer Interface
 """
 
 from abc import ABCMeta, abstractmethod
-from six import add_metaclass
+from nltk.six import add_metaclass
 
 from nltk.internals import overridden
 from nltk.tokenize.util import string_span_tokenize


### PR DESCRIPTION
This PR does two things:
- fixes an import error which was causing some tests to fail (see #1252)
- fixes probability.doctest so it passes

The first thing is unrelated, but I fixed it so I could actually run the unit tests to ensure the second change worked. The problem with the doctests was easy: dictionary order is arbitrary and thus dictionary representations don't work well with doctests.
