### PR TITLE
Adding logging jar to the Stanford CP

### DIFF
--- a/nltk/parse/stanford.py
+++ b/nltk/parse/stanford.py
@@ -17,7 +17,7 @@ from subprocess import PIPE
 from io import StringIO
 
 from nltk import compat
-from nltk.internals import find_jar, find_jar_iter, config_java, java, _java_options
+from nltk.internals import find_jar, find_jar_iter, config_java, java, _java_options, find_jars_within_path
 
 from nltk.parse.api import ParserI
 from nltk.parse.dependencygraph import DependencyGraph
@@ -61,7 +61,11 @@ class GenericStanfordParser(ParserI):
             key=lambda model_name: re.match(self._MODEL_JAR_PATTERN, model_name)
         )
 
-        self._classpath = (stanford_jar, model_jar)
+        #self._classpath = (stanford_jar, model_jar)
+        
+        # Adding logging jar files to classpath 
+        stanford_dir = stanford_jar.rpartition('/')[0]
+        self._classpath = tuple([model_jar] + find_jars_within_path(stanford_dir))
 
         self.model_path = model_path
         self._encoding = encoding

--- a/nltk/tag/stanford.py
+++ b/nltk/tag/stanford.py
@@ -22,7 +22,7 @@ import tempfile
 from subprocess import PIPE
 import warnings
 
-from nltk.internals import find_file, find_jar, config_java, java, _java_options
+from nltk.internals import find_file, find_jar, config_java, java, _java_options, find_jars_within_path
 from nltk.tag.api import TaggerI
 from nltk import compat
 
@@ -54,6 +54,11 @@ class StanfordTagger(TaggerI):
 
         self._stanford_model = find_file(model_filename,
                 env_vars=('STANFORD_MODELS',), verbose=verbose)
+        
+        # Adding logging jar files to classpath 
+        stanford_dir = self._stanford_jar.rpartition('/')[0]
+        self._stanford_jar = tuple(find_jars_within_path(stanford_dir))
+        
         self._encoding = encoding
         self.java_options = java_options
 

--- a/nltk/tokenize/stanford.py
+++ b/nltk/tokenize/stanford.py
@@ -15,7 +15,7 @@ import json
 from subprocess import PIPE
 
 from nltk import compat
-from nltk.internals import find_jar, config_java, java, _java_options
+from nltk.internals import find_jar, config_java, java, _java_options, find_jars_within_path
 
 from nltk.tokenize.api import TokenizerI
 
@@ -43,7 +43,11 @@ class StanfordTokenizer(TokenizerI):
             searchpath=(), url=_stanford_url,
             verbose=verbose
         )
-
+        
+        # Adding logging jar files to classpath 
+        stanford_dir = self._stanford_jar.rpartition('/')[0]
+        self._stanford_jar = tuple(find_jars_within_path(stanford_dir))
+        
         self._encoding = encoding
         self.java_options = java_options
 


### PR DESCRIPTION
Hacking to add logging jar file to the classpath for Stanford POS tagger, parser, tokenizer, NER as discussed in #1237 
