### PR TITLE
Adding os.path.split() for finding the jar folder

### DIFF
--- a/nltk/parse/stanford.py
+++ b/nltk/parse/stanford.py
@@ -64,7 +64,7 @@ class GenericStanfordParser(ParserI):
         #self._classpath = (stanford_jar, model_jar)
         
         # Adding logging jar files to classpath 
-        stanford_dir = stanford_jar.rpartition('/')[0]
+        stanford_dir = os.path.split(stanford_jar)[0]
         self._classpath = tuple([model_jar] + find_jars_within_path(stanford_dir))
 
         self.model_path = model_path

--- a/nltk/tag/stanford.py
+++ b/nltk/tag/stanford.py
@@ -56,7 +56,7 @@ class StanfordTagger(TaggerI):
                 env_vars=('STANFORD_MODELS',), verbose=verbose)
         
         # Adding logging jar files to classpath 
-        stanford_dir = self._stanford_jar.rpartition('/')[0]
+        stanford_dir = os.path.split(self._stanford_jar)[0]
         self._stanford_jar = tuple(find_jars_within_path(stanford_dir))
         
         self._encoding = encoding

--- a/nltk/tokenize/stanford.py
+++ b/nltk/tokenize/stanford.py
@@ -45,7 +45,7 @@ class StanfordTokenizer(TokenizerI):
         )
         
         # Adding logging jar files to classpath 
-        stanford_dir = self._stanford_jar.rpartition('/')[0]
+        stanford_dir = os.path.split(self._stanford_jar)[0]
         self._stanford_jar = tuple(find_jars_within_path(stanford_dir))
         
         self._encoding = encoding


### PR DESCRIPTION
Regarding PR #1280, using os.path.split() instead of rpartition 
