### PR TITLE
added lesk using sentiwordnet.

### DIFF
--- a/nltk/wsd.py
+++ b/nltk/wsd.py
@@ -7,8 +7,15 @@
 # URL: <http://nltk.org/>
 # For license information, see LICENSE.TXT
 
-from nltk.corpus import wordnet
+try:
+    from nltk.corpus import wordnet
+except ImportError:
+    pass
 
+try:
+    from nltk.corpus import sentiwordnet
+except ImportError:
+    pass
 
 def lesk(context_sentence, ambiguous_word, pos=None, synsets=None):
     """Return a synset for an ambiguous word in a context.
@@ -33,6 +40,34 @@ def lesk(context_sentence, ambiguous_word, pos=None, synsets=None):
     Systems Documentation. ACM, 1986.
     http://dl.acm.org/citation.cfm?id=318728
     """
+    return _lesk(context_sentence, ambiguous_word, pos, synsets, wordnet)
+
+def sentilesk(context_sentence, ambiguous_word, pos=None, synsets=None):
+    """Return a synset for an ambiguous word in a context using sentiwordnet as a source of synsets.
+
+    :param iter context_sentence: The context sentence where the ambiguous word
+    occurs, passed as an iterable of words.
+    :param str ambiguous_word: The ambiguous word that requires WSD.
+    :param str pos: A specified Part-of-Speech (POS).
+    :param iter synsets: Possible synsets of the ambiguous word.
+    :return: ``lesk_sense`` The Synset() object with the highest signature overlaps.
+
+    This function is an implementation of the original Lesk algorithm (1986) [1].
+
+    Usage example::
+
+        >>> lesk(['I', 'went', 'to', 'the', 'bank', 'to', 'deposit', 'money', '.'], 'bank', 'n')
+        SentiSynset('savings_bank.n.02')
+
+    [1] Lesk, Michael. "Automatic sense disambiguation using machine
+    readable dictionaries: how to tell a pine cone from an ice cream
+    cone." Proceedings of the 5th Annual International Conference on
+    Systems Documentation. ACM, 1986.
+    http://dl.acm.org/citation.cfm?id=318728
+    """
+    return _lesk(context_sentence, ambiguous_word, pos, synsets, sentiwordnet)
+
+def _lesk(context_sentence, ambiguous_word, pos=None, synsets=None, wordnet):
 
     context = set(context_sentence)
     if synsets is None:


### PR DESCRIPTION
Added sentiwordnet version of lesk.

This is useful as synsets between wordnet and sentiwordnet are not all the same. Word senses returned from wordnet may not exist in sentiwordnet and so sentiment scores are thus unavailable (an example is "like", an important sentiment indicator). 

imports of both wordnet and sentiwordnet are attempted, but an exception from import problems only occurs when lesk or seltilesk functions are called. Perhaps not ideal - happy for suggestions on a better way.
