### PR TITLE
Use os.path.split to handle file paths in all OS

### DIFF
--- a/nltk/parse/malt.py
+++ b/nltk/parse/malt.py
@@ -66,7 +66,7 @@ def find_maltparser(parser_dirname):
     # Checks that that the found directory contains all the necessary .jar
     malt_dependencies = ['','','']
     _malt_jars = set(find_jars_within_path(_malt_dir))
-    _jars = set(jar.rpartition('/')[2] for jar in _malt_jars)
+    _jars = set(os.path.split(jar)[1] for jar in _malt_jars)
     malt_dependencies = set(['log4j.jar', 'libsvm.jar', 'liblinear-1.8.jar'])
 
     assert malt_dependencies.issubset(_jars)


### PR DESCRIPTION
Currently, `jar.rpartition('/')[2]` only works for linux.
