### PR TITLE
Use OS specific classpath separator

### DIFF
--- a/nltk/parse/malt.py
+++ b/nltk/parse/malt.py
@@ -2,6 +2,7 @@
 # Natural Language Toolkit: Interface to MaltParser
 #
 # Author: Dan Garrette <dhgarrette@gmail.com>
+# Contributor: Liling Tan, Mustufain, osamamukhtar11
 #
 # Copyright (C) 2001-2015 NLTK Project
 # URL: <http://nltk.org/>

--- a/nltk/parse/malt.py
+++ b/nltk/parse/malt.py
@@ -12,6 +12,7 @@ from __future__ import unicode_literals
 from nltk.six import text_type
 
 import os
+import sys
 import tempfile
 import subprocess
 import inspect
@@ -215,8 +216,10 @@ class MaltParser(ParserI):
         """
 
         cmd = ['java']
-        cmd+= self.additional_java_args # Adds additional java arguments.
-        cmd+= ['-cp', ':'.join(self.malt_jars)] # Adds classpaths for jars
+        cmd+= self.additional_java_args # Adds additional java arguments
+        # Joins classpaths with ";" if on Windows and on Linux/Mac use ":"
+        classpaths_separator = ';' if sys.platform.startswith('win') else ':'
+        cmd+= ['-cp', classpaths_separator.join(self.malt_jars)] # Adds classpaths for jars
         cmd+= ['org.maltparser.Malt'] # Adds the main function.
 
         # Adds the model file.


### PR DESCRIPTION
Windows uses `;` semi-colons to separate Java classpaths and Linux/MacOS uses `:` colons.

(See http://stackoverflow.com/questions/4528438/classpath-does-not-work-under-linux)
