### PR TITLE
Fix implementation error on Method3 Smoothing

### DIFF
--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -491,7 +491,7 @@ class SmoothingFunction:
         incvnt = 1 # From the mteval-v13a.pl, it's referred to as k.
         for i, p_i in enumerate(p_n):
             if p_i == 0:
-                p_n[i] = 1 / 2**incvnt
+                p_n[i] = 1 / (2**incvnt * p_i.denominator)
                 incvnt+=1
         return p_n
     


### PR DESCRIPTION
The smooth should only affect the precision count not the ngram precision itself, so the `p_i.denominator` needs to be considered, i.e.`(1/2**k) / p_i.denominator`. Simplified mathematically to `1/ (2**k * p_i.denominator)`
