### PR TITLE
Fixing the ZipFile issue in Python3.5

### DIFF
--- a/nltk/data.py
+++ b/nltk/data.py
@@ -978,8 +978,8 @@ class OpenOnDemandZipFile(zipfile.ZipFile):
     def read(self, name):
         assert self.fp is None
         self.fp = open(self.filename, 'rb')
-        value = zipfile.ZipFile.read(self, name)
-        self.close()
+        with self.open(name) as zfin:
+          value = zfin.read()
         return value
 
     def write(self, *args, **kwargs):


### PR DESCRIPTION
Fixing the assert issue when ZipFile object closes in Python3.5 from #1204 and #1299 

I tried to emulate `zipfile.ZipFile.read(self, name)` without the setting the mode but maybe we should add `mode=r` (but i think that's just a personal preference for explicit over implicit)
