### PR TITLE
Reverting to old data.py and adding the self._fileRefCnt property

### DIFF
--- a/nltk/corpus/reader/plaintext.py
+++ b/nltk/corpus/reader/plaintext.py
@@ -71,7 +71,12 @@ class PlaintextCorpusReader(CorpusReader):
         """
         if fileids is None: fileids = self._fileids
         elif isinstance(fileids, string_types): fileids = [fileids]
-        return concat([self.open(f).read() for f in fileids])
+        raw_texts = []
+        for f in fileids:
+            _fin = self.open(f)
+            raw_texts.append(_fin.read())
+            _fin.close() 
+        return concat(raw_texts)
 
     def words(self, fileids=None):
         """

--- a/nltk/corpus/reader/util.py
+++ b/nltk/corpus/reader/util.py
@@ -334,6 +334,9 @@ class StreamBackedCorpusView(AbstractLazySequence):
 
         # If we reach this point, then we should know our length.
         assert self._len is not None
+        # Enforce closing of stream once we reached end of file
+        # We should have reached EOF once we're out of the while loop.
+        self.close()
 
     # Use concat for these, so we can use a ConcatenatedCorpusView
     # when possible.

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -978,8 +978,8 @@ class OpenOnDemandZipFile(zipfile.ZipFile):
     def read(self, name):
         assert self.fp is None
         self.fp = open(self.filename, 'rb')
-        with self.open(name, 'r') as zfin:
-          value = zfin.read()
+        value = zipfile.ZipFile.read(self, name)
+        self.close()
         return value
 
     def write(self, *args, **kwargs):

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -974,11 +974,17 @@ class OpenOnDemandZipFile(zipfile.ZipFile):
         zipfile.ZipFile.__init__(self, filename)
         assert self.filename == filename
         self.close()
+        # After closing a ZipFile object, the _fileRefCnt needs to be cleared 
+        # for Python2and3 compatible code.
+        self._fileRefCnt = 0
 
     def read(self, name):
         assert self.fp is None
         self.fp = open(self.filename, 'rb')
         value = zipfile.ZipFile.read(self, name)
+        # Ensure that _fileRefCnt needs to be set for Python2and3 compatible code.
+        # Since we only opened one file here, we add 1.
+        self._fileRefCnt += 1
         self.close()
         return value
 

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -978,7 +978,7 @@ class OpenOnDemandZipFile(zipfile.ZipFile):
     def read(self, name):
         assert self.fp is None
         self.fp = open(self.filename, 'rb')
-        with self.open(name) as zfin:
+        with self.open(name, 'r') as zfin:
           value = zfin.read()
         return value
 


### PR DESCRIPTION
This is tricky, even with the read-mode, after the interpreter ends, the assert pops up when the interpreter gets out of the scope:

``` python
alvas@ubi:~/git/nltk$ python3
Python 3.5.1 (default, Dec 18 2015, 00:00:00) 
[GCC 4.8.4] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from nltk.corpus import comtrans
>>> comtrans.sents()
[['Wiederaufnahme', 'der', 'Sitzungsperiode'], ['Ich', 'erkläre', 'die', 'am', 'Freitag', ',', 'dem', '17.', 'Dezember', 'unterbrochene', 'Sitzungsperiode', 'des', 'Europäischen', 'Parlaments', 'für', 'wiederaufgenommen', ',', 'wünsche', 'Ihnen', 'nochmals', 'alles', 'Gute', 'zum', 'Jahreswechsel', 'und', 'hoffe', ',', 'daß', 'Sie', 'schöne', 'Ferien', 'hatten', '.'], ...]
>>> exit()
Exception ignored in: <bound method ZipFile.__del__ of "OpenOnDemandZipFile('/home/alvas/nltk_data/corpora/comtrans.zip')">
Traceback (most recent call last):
  File "/usr/lib/python3.5/zipfile.py", line 1593, in __del__
  File "/usr/lib/python3.5/zipfile.py", line 1610, in close
  File "/usr/lib/python3.5/zipfile.py", line 1714, in _fpclose
AssertionError: 
```

In Python3.5, the ZipFile reduce the counter everytime it closes: https://github.com/python/cpython/blob/3.5/Lib/zipfile.py#L1717
