### PR TITLE
Add +NORMALIZE_WHITESPACE in a CCG test

### DIFF
--- a/nltk/test/ccg.doctest
+++ b/nltk/test/ccg.doctest
@@ -345,7 +345,7 @@ Lexicons for the tests:
 
     >>> parser = chart.CCGChartParser(lex, chart.DefaultRuleSet)
     >>> for parse in parser.parse(u"el ministro anunció pero el presidente desmintió la nueva ley".split()):
-    ...     printCCGDerivation(parse)
+    ...     printCCGDerivation(parse) # doctest: +NORMALIZE_WHITESPACE
     ...     break
        el    ministro    anunció              pero              el    presidente   desmintió     la    nueva  ley
      (NP/N)     N      ((S\NP)/NP)  (((S/NP)\(S/NP))/(S/NP))  (NP/N)      N       ((S\NP)/NP)  (NP/N)  (N/N)   N
@@ -393,4 +393,3 @@ Lexicons for the tests:
                                                                  (S/NP)
     -------------------------------------------------------------------------------------------------------------->
                                                           S
-


### PR DESCRIPTION
Otherwise the unicode support test would fail because there are a few white spaces after the first two lines of the result.

I'm not sure why other tests in `ccg.doctest` doesn't need NORMALIZE_WHITESPACE. Weird.

I'd also like to mention that, Python 2.7, it fails because `ó` is printed as a different character (apart from the additional whitespace). In Python 3, the character is printed correctly.
