### PR TITLE
Fixes doctest for python3

### DIFF
--- a/nltk/util.py
+++ b/nltk/util.py
@@ -1332,8 +1332,9 @@ class Trie(defaultdict):
 
         >>> from nltk.util import Trie
         >>> trie = Trie(["abc", "def"])
-        >>> trie.as_dict()
-        {'a': {'b': {'c': {True: None}}}, 'd': {'e': {'f': {True: None}}}}
+        >>> expected = {'a': {'b': {'c': {True: None}}}, 'd': {'e': {'f': {True: None}}}}
+        >>> trie.as_dict() == expected
+        True
 
         """
         def _default_to_regular(d):


### PR DESCRIPTION
Dictionary hash are dynamic in Python3 so the **repr** output will be different all the time. Doctest should check for value equality instead. Monotonic nested defaultdict/dictionary outputs should not be affected though.

Fixes issue on https://nltk.ci.cloudbees.com/job/nltk/TOXENV=py34-jenkins,jdk=jdk8latestOnlineInstall/lastCompletedBuild/testReport/nltk.util/Trie/as_dict/ and https://nltk.ci.cloudbees.com/job/nltk/TOXENV=py33-jenkins,jdk=jdk8latestOnlineInstall/lastCompletedBuild/testReport/ 

(Same issue as https://github.com/nltk/nltk/commit/a488bb6c900c89ea4d2ca154627fa92093626332)

@stevenbird Sorry I pressed the wrong radio button in the previous commit when fixing https://github.com/nltk/nltk/commit/a488bb6c900c89ea4d2ca154627fa92093626332
