### PR TITLE
Fix for #1025 by reverting to use plain regexes, pre-compiled.

### DIFF
--- a/nltk/tag/sequential.py
+++ b/nltk/tag/sequential.py
@@ -529,34 +529,27 @@ class RegexpTagger(SequentialBackoffTagger):
         """
         """
         SequentialBackoffTagger.__init__(self, backoff)
-        labels = ['g'+str(i) for i in range(len(regexps))]
-        tags = [tag for regex, tag in regexps]
-        self._map = dict(zip(labels, tags))
-        regexps_labels = [(regex, label) for ((regex,tag),label) in zip(regexps,labels)]
-        self._regexs = re.compile('|'.join('(?P<%s>%s)' % (label, regex) for regex,label in regexps_labels))
-        self._size=len(regexps)
+        self._regexs = [(re.compile(regexp), tag,) for regexp, tag in regexps]
 
     def encode_json_obj(self):
-        return self._map, self._regexs.pattern, self._size, self.backoff
+        return [(regexp.patten, tag,) for regexp, tag in self._regexs], self.backoff
 
     @classmethod
     def decode_json_obj(cls, obj):
-        _map, _regexs, _size, backoff = obj
+        regexps, backoff = obj
         self = cls(())
-        self._map = _map
-        self._regexs = re.compile(_regexs)
-        self._size = _size
+        self._regexs = [(re.compile(regexp), tag,) for regexp, tag in regexps]
         SequentialBackoffTagger.__init__(self, backoff)
         return self
 
     def choose_tag(self, tokens, index, history):
-        m = self._regexs.match(tokens[index])
-        if m:
-          return self._map[m.lastgroup]
+        for regexp, tag in self._regexs:
+            if re.match(regexp, tokens[index]):
+                return tag
         return None
 
     def __repr__(self):
-        return '<Regexp Tagger: size=%d>' % self._size
+        return '<Regexp Tagger: size=%d>' % len(self._regexs)
 
 
 @python_2_unicode_compatible

--- a/nltk/test/tag.doctest
+++ b/nltk/test/tag.doctest
@@ -20,3 +20,14 @@ Add tests for:
     backoff tagger if the backoff tagger gets that context correct at
     *all* locations.
 
+
+Regression Testing for issue #1025
+==================================
+
+We want to ensure that a RegexpTagger can be created with more than 100 patterns
+and does not fail with:
+ "AssertionError: sorry, but this version only supports 100 named groups"
+
+    >>> from nltk.tag import RegexpTagger
+    >>> patterns = [(str(i), 'NNP',) for i in range(200)]
+    >>> tagger = RegexpTagger(patterns)


### PR DESCRIPTION
This patch is for #1025 and essentially reverts the changes introduced in https://github.com/nltk/nltk/commit/dd2a827b32900cc6be73b9e45c3b818b7c343e0f#commitcomment-11844004 with a minimal doctest and pre-compilation of the regular expressions for now.
With this fix it is now again possible to create a RegexpTagger with more than 100 patterns.

Signed-off-by: Philippe Ombredanne pombredanne@nexb.com
