### PR TITLE
Fixed usage of nltk.pos_tag on win platform

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -191,3 +191,4 @@
 - Sergio Oller
 - Will Monroe
 - Elijah Rippeth
+- Emil Manukyan

--- a/nltk/tag/perceptron.py
+++ b/nltk/tag/perceptron.py
@@ -137,7 +137,7 @@ class PerceptronTagger(TaggerI):
         self.tagdict = {}
         self.classes = set()
         if load:
-            AP_MODEL_LOC = str(find('taggers/averaged_perceptron_tagger/'+PICKLE))
+            AP_MODEL_LOC = 'file:'+str(find('taggers/averaged_perceptron_tagger/'+PICKLE))
             self.load(AP_MODEL_LOC)
 
     def tag(self, tokens):


### PR DESCRIPTION
When trying to use nltk.pos_tag in nltk 3.2 which uses **nltk/tag/perceptron** as tagger by default, the call fails because the attempt to load the pickle file using `nltk.data` fails. The reason behind this is that `nltk.data.find` returns full path in Windows format which is invalid format for `nltk.data.normalize_resource_url` function used for loading the resource later. In case of Linux/UNIX this works because path format for them conforms with `nltk.data.normalize_resource_url` function's requirements. Checked this code both with Windows and Linux and it works.
