### PR TITLE
fix up AlignedSent._repr_svg_() for Python 3. Python 2 compatible.

### DIFF
--- a/nltk/translate/api.py
+++ b/nltk/translate/api.py
@@ -127,7 +127,7 @@ class AlignedSent(object):
             raise Exception('Cannot find the dot binary from Graphviz package')
         out, err = process.communicate(dot_string)
          
-        return out
+        return out.decode('utf8')
     
     
     def __str__(self):


### PR DESCRIPTION
Plotting is done using the example from the class docstring. Open up IPython notebook and paste:

> > > from nltk.translate import AlignedSent, Alignment
> > > algnsent = AlignedSent(['klein', 'ist', 'das', 'Haus'],
> > > ['the', 'house', 'is', 'small'], Alignment.fromstring('0-2 1-3 2-1 3-0'))
> > > algnsent

This commit fixes the following bug when using Python 3, which represents subprocess output
as bytes instead of str, to draw an AlignedSent in IPython:

/usr/lib/python3.5/site-packages/IPython/core/formatters.py:367: FormatterWarning: image/svg+xml formatter returned invalid type <class 'bytes'> (expected (<class 'str'>,)) for object: AlignedSent(['klein', 'ist', 'das', 'Haus'], ['the', 'house', 'is', 'small'], Alignment([(0, 2), (1, 3), (2, 1), (3, 0)]))
  FormatterWarning
