### PR TITLE
Reverting to bleu scores with normalized Fraction

### DIFF
--- a/nltk/test/unit/translate/test_bleu.py
+++ b/nltk/test/unit/translate/test_bleu.py
@@ -79,6 +79,9 @@ class TestBLEU(unittest.TestCase):
         assert (round(hyp1_bigram_precision, 4) == 0.5882)
         assert (round(hyp2_bigram_precision, 4) == 0.0769)
         
+    def test_fringe_cases(self):
+        pass
+        
     def test_brevity_penalty(self):
         pass
     

--- a/nltk/test/unit/translate/test_bleu.py
+++ b/nltk/test/unit/translate/test_bleu.py
@@ -4,10 +4,12 @@ Tests for BLEU translation evaluation metric
 """
 
 import unittest
-from nltk.translate.bleu_score import _modified_precision
+from nltk.translate.bleu_score import modified_precision, brevity_penalty
+from nltk.translate.bleu_score import sentence_bleu, corpus_bleu
+
 
 class TestBLEU(unittest.TestCase):
-    def test__modified_precision(self):
+    def test_modified_precision(self):
         """
         Examples from the original BLEU paper 
         http://www.aclweb.org/anthology/P02-1040.pdf
@@ -22,13 +24,13 @@ class TestBLEU(unittest.TestCase):
         references = [ref1, ref2] 
         
         # Testing modified unigram precision.
-        hyp1_unigram_precision =  float(_modified_precision(references, hyp1, n=1))
+        hyp1_unigram_precision =  float(modified_precision(references, hyp1, n=1))
         assert (round(hyp1_unigram_precision, 4) == 0.2857)
         # With assertAlmostEqual at 4 place precision.
         self.assertAlmostEqual(hyp1_unigram_precision, 0.28571428, places=4)
         
         # Testing modified bigram precision.
-        assert(_modified_precision(references, hyp1, n=2) == 0.0)
+        assert(modified_precision(references, hyp1, n=2) == 0.0)
         
         
         # Example 2: the "of the" example.
@@ -44,10 +46,10 @@ class TestBLEU(unittest.TestCase):
         
         references = [ref1, ref2, ref3] 
         # Testing modified unigram precision.
-        assert (_modified_precision(references, hyp1, n=1) == 1.0)
+        assert (modified_precision(references, hyp1, n=1) == 1.0)
         
         # Testing modified bigram precision.
-        assert(_modified_precision(references, hyp1, n=2) == 1.0)
+        assert(modified_precision(references, hyp1, n=2) == 1.0)
         
 
         # Example 3: Proper MT outputs.
@@ -59,8 +61,8 @@ class TestBLEU(unittest.TestCase):
         references = [ref1, ref2, ref3]
         
         # Unigram precision.
-        hyp1_unigram_precision = float(_modified_precision(references, hyp1, n=1))
-        hyp2_unigram_precision = float(_modified_precision(references, hyp2, n=1))
+        hyp1_unigram_precision = float(modified_precision(references, hyp1, n=1))
+        hyp2_unigram_precision = float(modified_precision(references, hyp2, n=1))
         # Test unigram precision with assertAlmostEqual at 4 place precision.
         self.assertAlmostEqual(hyp1_unigram_precision, 0.94444444, places=4)
         self.assertAlmostEqual(hyp2_unigram_precision, 0.57142857, places=4)
@@ -70,8 +72,8 @@ class TestBLEU(unittest.TestCase):
         
         
         # Bigram precision
-        hyp1_bigram_precision = float(_modified_precision(references, hyp1, n=2))
-        hyp2_bigram_precision = float(_modified_precision(references, hyp2, n=2))
+        hyp1_bigram_precision = float(modified_precision(references, hyp1, n=2))
+        hyp2_bigram_precision = float(modified_precision(references, hyp2, n=2))
         # Test bigram precision with assertAlmostEqual at 4 place precision.
         self.assertAlmostEqual(hyp1_bigram_precision, 0.58823529, places=4)
         self.assertAlmostEqual(hyp2_bigram_precision, 0.07692307, places=4)

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -6,6 +6,7 @@
 # Contributors: Dmitrijs Milajevs, Liling Tan
 # URL: <http://nltk.org/>
 # For license information, see LICENSE.TXT
+
 """BLEU score implementation."""
 from __future__ import division
 
@@ -69,31 +70,7 @@ def sentence_bleu(references, hypothesis, weights=(0.25, 0.25, 0.25, 0.25),
     :return: The sentence-level BLEU score.
     :rtype: float
     """
-    # Calculates the brevity penalty.
-    # *hyp_len* is referred to as *c* in Papineni et. al. (2002)
-    hyp_len = len(hypothesis)
-    # *closest_ref_len* is referred to as *r* variable in Papineni et. al. (2002)
-    closest_ref_len = _closest_ref_length(references, hyp_len)
-    bp = _brevity_penalty(closest_ref_len, hyp_len)
-    
-    # Calculates the modified precision *p_n* for each order of ngram.
-    p_n = [_modified_precision(references, hypothesis, i)
-            for i, _ in enumerate(weights, start=1)]
-
-    # Smoothen the modified precision.
-    # Note: smooth_precision() converts values into float.
-    if smoothing_function:
-        p_n = smoothing_function(p_n, references=references, 
-                                 hypothesis=hypothesis, hyp_len=hyp_len)
-    
-    # Calculates the overall modified precision for all ngrams.
-    # By sum of the product of the weights and the respective *p_n*
-    s = (w * math.log(p_i) if p_i else 0 
-         for w, p_i in zip(weights, p_n))
-    sum_s = math.fsum(s)
-    if sum_s == 0 and all(p_n) == 0:
-        return 0
-    return bp * math.exp(sum_s)
+    return corpus_bleu([references], [hypothesis], weights, smoothing_function)
 
 
 def corpus_bleu(list_of_references, hypotheses, weights=(0.25, 0.25, 0.25, 0.25),
@@ -158,7 +135,7 @@ def corpus_bleu(list_of_references, hypotheses, weights=(0.25, 0.25, 0.25, 0.25)
         # For each order of ngram, calculate the numerator and
         # denominator for the corpus-level modified precision.
         for i, _ in enumerate(weights, start=1): 
-            p_i = _modified_precision(references, hypothesis, i)
+            p_i = modified_precision(references, hypothesis, i)
             p_numerators[i] += p_i.numerator
             p_denominators[i] += p_i.denominator
             
@@ -166,13 +143,13 @@ def corpus_bleu(list_of_references, hypotheses, weights=(0.25, 0.25, 0.25, 0.25)
         # Adds them to the corpus-level hypothesis and reference counts.
         hyp_len =  len(hypothesis)
         hyp_lengths += hyp_len
-        ref_lengths += _closest_ref_length(references, hyp_len)    
+        ref_lengths += closest_ref_length(references, hyp_len)    
         
     # Calculate corpus-level brevity penalty.
-    bp = _brevity_penalty(ref_lengths, hyp_lengths)
+    bp = brevity_penalty(ref_lengths, hyp_lengths)
     
     # Collects the various precision values for the different ngram orders.
-    p_n = [Fraction(p_numerators[i], p_denominators[i], _normalize=False) 
+    p_n = [Fraction(p_numerators[i], p_denominators[i]) 
            for i, _ in enumerate(weights, start=1)]
     
     # Smoothen the modified precision.
@@ -183,13 +160,12 @@ def corpus_bleu(list_of_references, hypotheses, weights=(0.25, 0.25, 0.25, 0.25)
         
     # Calculates the overall modified precision for all ngrams.
     # By sum of the product of the weights and the respective *p_n*
-    s = (w * math.log(p_i) if p_i else 0 
-         for w, p_i in zip(weights, p_n))
+    s = (w * math.log(p_i) if p_i != 0 else 0 for w, p_i in zip(weights, p_n))
         
     return bp * math.exp(math.fsum(s))
 
 
-def _modified_precision(references, hypothesis, n):
+def modified_precision(references, hypothesis, n):
     """
     Calculate modified ngram precision.
 
@@ -209,7 +185,7 @@ def _modified_precision(references, hypothesis, n):
         >>> reference2 = 'there is a cat on the mat'.split()
         >>> hypothesis1 = 'the the the the the the the'.split()
         >>> references = [reference1, reference2]
-        >>> float(_modified_precision(references, hypothesis1, n=1)) # doctest: +ELLIPSIS
+        >>> float(modified_precision(references, hypothesis1, n=1)) # doctest: +ELLIPSIS
         0.2857...
     
     In the modified n-gram precision, a reference word will be considered 
@@ -227,9 +203,9 @@ def _modified_precision(references, hypothesis, n):
         ...               'of', 'the', 'party']
         >>> hypothesis = 'of the'.split()
         >>> references = [reference1, reference2, reference3]
-        >>> float(_modified_precision(references, hypothesis, n=1))
+        >>> float(modified_precision(references, hypothesis, n=1))
         1.0
-        >>> float(_modified_precision(references, hypothesis, n=2))
+        >>> float(modified_precision(references, hypothesis, n=2))
         1.0
         
     An example of a normal machine translation hypothesis:
@@ -255,13 +231,13 @@ def _modified_precision(references, hypothesis, n):
         ...               'army', 'always', 'to', 'heed', 'the', 'directions',
         ...               'of', 'the', 'party']
         >>> references = [reference1, reference2, reference3]
-        >>> float(_modified_precision(references, hypothesis1, n=1)) # doctest: +ELLIPSIS
+        >>> float(modified_precision(references, hypothesis1, n=1)) # doctest: +ELLIPSIS
         0.9444...
-        >>> float(_modified_precision(references, hypothesis2, n=1)) # doctest: +ELLIPSIS
+        >>> float(modified_precision(references, hypothesis2, n=1)) # doctest: +ELLIPSIS
         0.5714...
-        >>> float(_modified_precision(references, hypothesis1, n=2)) # doctest: +ELLIPSIS
+        >>> float(modified_precision(references, hypothesis1, n=2)) # doctest: +ELLIPSIS
         0.5882352941176471
-        >>> float(_modified_precision(references, hypothesis2, n=2)) # doctest: +ELLIPSIS
+        >>> float(modified_precision(references, hypothesis2, n=2)) # doctest: +ELLIPSIS
         0.07692...
      
     
@@ -274,27 +250,29 @@ def _modified_precision(references, hypothesis, n):
     :return: BLEU's modified precision for the nth order ngram.
     :rtype: Fraction
     """
+    # Extracts all ngrams in hypothesis.
     counts = Counter(ngrams(hypothesis, n))
 
-    if not counts:
-        return Fraction(0)
-
+    # Extract a union of references' counts.
+    ## max_counts = reduce(or_, [Counter(ngrams(ref, n)) for ref in references])
     max_counts = {}
     for reference in references:
         reference_counts = Counter(ngrams(reference, n))
         for ngram in counts:
-            max_counts[ngram] = max(max_counts.get(ngram, 0), reference_counts[ngram])
-
-    clipped_counts = dict((ngram, min(count, max_counts[ngram])) 
-                          for ngram, count in counts.items())
+            max_counts[ngram] = max(max_counts.get(ngram, 0), 
+                                    reference_counts[ngram])
     
+    # Assigns the intersection between hypothesis and references' counts.
+    clipped_counts = {ngram: min(count, max_counts[ngram]) 
+                      for ngram, count in counts.items()}
+
     numerator = sum(clipped_counts.values())
-    denominator = sum(counts.values())  
+    denominator = sum(counts.values())
     
-    return Fraction(numerator, denominator, _normalize=False)  
+    return Fraction(numerator, denominator)  
     
 
-def _closest_ref_length(references, hyp_len):
+def closest_ref_length(references, hyp_len):
     """
     This function finds the reference that is the closest length to the 
     hypothesis. The closest reference length is referred to as *r* variable 
@@ -312,7 +290,8 @@ def _closest_ref_length(references, hyp_len):
                           (abs(ref_len - hyp_len), ref_len))
     return closest_ref_len
 
-def _brevity_penalty(closest_ref_len, hyp_len):
+
+def brevity_penalty(closest_ref_len, hyp_len):
     """
     Calculate brevity penalty.
 
@@ -329,8 +308,8 @@ def _brevity_penalty(closest_ref_len, hyp_len):
         >>> hypothesis = list('aaaaaaaaaaaa')      # i.e. ['a'] * 12
         >>> references = [reference1, reference2, reference3]
         >>> hyp_len = len(hypothesis)
-        >>> closest_ref_len =  _closest_ref_length(references, hyp_len)
-        >>> _brevity_penalty(closest_ref_len, hyp_len)
+        >>> closest_ref_len =  closest_ref_length(references, hyp_len)
+        >>> brevity_penalty(closest_ref_len, hyp_len)
         1.0
 
     In case a hypothesis translation is shorter than the references, penalty is
@@ -339,8 +318,8 @@ def _brevity_penalty(closest_ref_len, hyp_len):
         >>> references = [['a'] * 28, ['a'] * 28]
         >>> hypothesis = ['a'] * 12
         >>> hyp_len = len(hypothesis)
-        >>> closest_ref_len =  _closest_ref_length(references, hyp_len)
-        >>> _brevity_penalty(closest_ref_len, hyp_len)
+        >>> closest_ref_len =  closest_ref_length(references, hyp_len)
+        >>> brevity_penalty(closest_ref_len, hyp_len)
         0.2635971381157267
 
     The length of the closest reference is used to compute the penalty. If the
@@ -351,8 +330,8 @@ def _brevity_penalty(closest_ref_len, hyp_len):
         >>> references = [['a'] * 13, ['a'] * 2]
         >>> hypothesis = ['a'] * 12
         >>> hyp_len = len(hypothesis)
-        >>> closest_ref_len =  _closest_ref_length(references, hyp_len)
-        >>> _brevity_penalty(closest_ref_len, hyp_len) # doctest: +ELLIPSIS
+        >>> closest_ref_len =  closest_ref_length(references, hyp_len)
+        >>> brevity_penalty(closest_ref_len, hyp_len) # doctest: +ELLIPSIS
         0.9200...
 
     The brevity penalty doesn't depend on reference order. More importantly,
@@ -362,11 +341,11 @@ def _brevity_penalty(closest_ref_len, hyp_len):
         >>> references = [['a'] * 13, ['a'] * 11]
         >>> hypothesis = ['a'] * 12
         >>> hyp_len = len(hypothesis)
-        >>> closest_ref_len =  _closest_ref_length(references, hyp_len)
-        >>> bp1 = _brevity_penalty(closest_ref_len, hyp_len)
+        >>> closest_ref_len =  closest_ref_length(references, hyp_len)
+        >>> bp1 = brevity_penalty(closest_ref_len, hyp_len)
         >>> hyp_len = len(hypothesis)
-        >>> closest_ref_len =  _closest_ref_length(reversed(references), hyp_len)
-        >>> bp2 = _brevity_penalty(closest_ref_len, hyp_len)
+        >>> closest_ref_len =  closest_ref_length(reversed(references), hyp_len)
+        >>> bp2 = brevity_penalty(closest_ref_len, hyp_len)
         >>> bp1 == bp2 == 1
         True
 
@@ -375,15 +354,15 @@ def _brevity_penalty(closest_ref_len, hyp_len):
         >>> references = [['a'] * 11, ['a'] * 8]
         >>> hypothesis = ['a'] * 7
         >>> hyp_len = len(hypothesis)
-        >>> closest_ref_len =  _closest_ref_length(references, hyp_len)
-        >>> _brevity_penalty(closest_ref_len, hyp_len) # doctest: +ELLIPSIS
+        >>> closest_ref_len =  closest_ref_length(references, hyp_len)
+        >>> brevity_penalty(closest_ref_len, hyp_len) # doctest: +ELLIPSIS
         0.8668...
 
         >>> references = [['a'] * 11, ['a'] * 8, ['a'] * 6, ['a'] * 7]
         >>> hypothesis = ['a'] * 7
         >>> hyp_len = len(hypothesis)
-        >>> closest_ref_len =  _closest_ref_length(references, hyp_len)
-        >>> _brevity_penalty(closest_ref_len, hyp_len)
+        >>> closest_ref_len =  closest_ref_length(references, hyp_len)
+        >>> brevity_penalty(closest_ref_len, hyp_len)
         1.0
     
     :param hyp_len: The length of the hypothesis for a single sentence OR the 
@@ -471,7 +450,7 @@ class SmoothingFunction:
         machine translation quality using longest common subsequence and 
         skip-bigram statistics. In ACL04.
         """
-        return [Fraction(p_i.numerator + 1, p_i.denominator + 1, _normalize=False) for p_i in p_n]
+        return [Fraction(p_i.numerator + 1, p_i.denominator + 1) for p_i in p_n]
         
     def method3(self, p_n, *args, **kwargs):
         """
@@ -520,7 +499,7 @@ class SmoothingFunction:
         """
         m = {}
         # Requires an precision value for an addition ngram order.
-        p_n_plus1 = p_n + [_modified_precision(references, hypothesis, 5)]
+        p_n_plus1 = p_n + [modified_precision(references, hypothesis, 5)]
         m[-1] = p_n[0] + 1
         for i, p_i in enumerate(p_n):
             p_n[i] = (m[i-1] + p_i + p_n_plus1[i+1]) / 3

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -152,6 +152,12 @@ def corpus_bleu(list_of_references, hypotheses, weights=(0.25, 0.25, 0.25, 0.25)
     p_n = [Fraction(p_numerators[i], p_denominators[i]) 
            for i, _ in enumerate(weights, start=1)]
     
+    # Sanity check before smoothing, returns 0 if there's no matching n-grams 
+    # We only need to check for p_numerators[1] == 0, since if there's
+    # no unigrams, there won't be any higher order ngrams.
+    if p_numerators[1] == 0:
+        return 0
+    
     # Smoothen the modified precision.
     # Note: smooth_precision() converts values into float.
     if smoothing_function:


### PR DESCRIPTION
This is to revert the changes made in #1319. The `_normalize` parameter in the `Fraction` type will only work in Python>=3.5 and NLTK supports >=2.7. This PR should resolve the doctests and BLEU related issues on CI jenkins. 

Additionally, reduce the `sentence_bleu` to an instance of `corpus_bleu` where there's only one hypothesis and its references. This way, we only need to maintain one function. 

Also refractored the functions starting with underscores since these function are not "temporary" and they will be used by function MT evaluation metrics that are derived from BLEU.

This is the first of several PR to resolve issues with BLEU listed on #1330
