### PR TITLE
Added Python < 3.5 compatible Fraction object with _normalize

### DIFF
--- a/nltk/compat.py
+++ b/nltk/compat.py
@@ -698,7 +698,9 @@ class Fraction(fractions.Fraction):
     """
     def __new__(cls, numerator=0, denominator=None, _normalize=True):
         cls = super(Fraction, cls).__new__(cls, numerator, denominator)
-        if not _normalize:
+        # To emulate fraction.Fraction.from_float across Python >=2.7,
+        # check that numerator is an integer and denominator is not None.
+        if not _normalize and type(numerator) == int and denominator:
             cls._numerator = numerator
             cls._denominator = denominator
         return cls

--- a/nltk/compat.py
+++ b/nltk/compat.py
@@ -11,6 +11,7 @@ import os
 import sys
 import types
 from functools import wraps
+import fractions
 
 # Python 2/3 compatibility layer. Based on six.
 
@@ -678,3 +679,26 @@ def _7bit(method):
 def _was_fixed(method):
     return (getattr(method, "_nltk_compat_7bit", False) or
             getattr(method, "_nltk_compat_transliterated", False))
+
+
+class Fraction(fractions.Fraction):
+    """
+    This is a simplified backwards compatible version of fractions.Fraction from
+    Python >=3.5. It adds the `_normalize` parameter such that it does
+    not normalize the denominator to the Greatest Common Divisor (gcd) when
+    the numerator is 0.
+    
+    This is most probably only used by the nltk.translate.bleu_score.py where
+    numerator and denominator of the different ngram precisions are mutable.
+    But the idea of "mutable" fraction might not be applicable to other usages, 
+    See http://stackoverflow.com/questions/34561265
+    
+    This objects should be deprecated once NLTK stops supporting Python < 3.5
+    See https://github.com/nltk/nltk/issues/1330
+    """
+    def __new__(cls, numerator=0, denominator=None, _normalize=True):
+        cls = super(Fraction, cls).__new__(cls, numerator, denominator)
+        if not _normalize:
+            cls._numerator = numerator
+            cls._denominator = denominator
+        return cls

--- a/nltk/test/unit/test_2x_compat.py
+++ b/nltk/test/unit/test_2x_compat.py
@@ -15,6 +15,16 @@ def setup_module(module):
         raise SkipTest("test_2x_compat is for testing nltk.compat under Python 2.x")
 
 
+class TestTextTransliteration(unittest.TestCase):
+    txt = Text(["São", "Tomé", "and", "Príncipe"])
+
+    def test_repr(self):
+        self.assertEqual(repr(self.txt), br"<Text: S\xe3o Tom\xe9 and Pr\xedncipe...>")
+
+    def test_str(self):
+        self.assertEqual(str(self.txt), b"<Text: Sao Tome and Principe...>")
+
+
 class TestFraction(unittest.TestCase):
     def test_unnoramlize_fraction(self):
         from fractions import Fraction as NativePythonFraction

--- a/nltk/test/unit/test_2x_compat.py
+++ b/nltk/test/unit/test_2x_compat.py
@@ -24,3 +24,33 @@ class TestTextTransliteration(unittest.TestCase):
     def test_str(self):
         self.assertEqual(str(self.txt), b"<Text: Sao Tome and Principe...>")
 
+
+class TestFraction(unittest.TestCase):
+    def test_unnoramlize_fraction(self):
+        from fractions import Fraction as OrginalFraction
+        from nltk.compat import Fraction as NLTKFraction
+        
+        # The orginal fraction should throw a TypeError in Python < 3.5
+        with self.assertRaises(TypeError):
+            OrginalFraction(0, 1000, _normalize=False)
+        
+        # Using nltk.compat.Fraction in Python < 3.5
+        compat_frac = NLTKFraction(0, 1000, _normalize=False)
+        # The numerator and denominator does not change. 
+        assert compat_frac.numerator == 0
+        assert compat_frac.denominator == 1000
+        # The floating point value remains normalized. 
+        assert float(compat_frac) == 0.0
+        
+        # Checks that the division is not divided by 
+        # # by greatest common divisor (gcd).
+        six_twelve = NLTKFraction(6, 12, _normalize=False)
+        assert six_twelve.numerator == 6
+        assert six_twelve.denominator == 12
+        
+        one_two = NLTKFraction(1, 2, _normalize=False)
+        assert one_two.numerator == 1
+        assert one_two.denominator == 2
+        
+        # Checks that rational values of one_two and six_twelve is the same.
+        assert float(one_two) == float(six_twelve)

--- a/nltk/test/unit/test_2x_compat.py
+++ b/nltk/test/unit/test_2x_compat.py
@@ -56,3 +56,8 @@ class TestFraction(unittest.TestCase):
         six_twelve_original = NativePythonFraction(6, 12)
         # Checks that rational values of one_two and six_twelve is the same.
         assert float(one_two) == float(six_twelve) == float(six_twelve_original)
+        
+        # Checks that the fraction does get normalized, even when
+        # _normalize == False when numerator is using native 
+        # fractions.Fraction.from_float 
+        assert NLTKFraction(3.142, _normalize=False) == NativePythonFraction(3.142)

--- a/nltk/test/unit/test_2x_compat.py
+++ b/nltk/test/unit/test_2x_compat.py
@@ -15,24 +15,14 @@ def setup_module(module):
         raise SkipTest("test_2x_compat is for testing nltk.compat under Python 2.x")
 
 
-class TestTextTransliteration(unittest.TestCase):
-    txt = Text(["São", "Tomé", "and", "Príncipe"])
-
-    def test_repr(self):
-        self.assertEqual(repr(self.txt), br"<Text: S\xe3o Tom\xe9 and Pr\xedncipe...>")
-
-    def test_str(self):
-        self.assertEqual(str(self.txt), b"<Text: Sao Tome and Principe...>")
-
-
 class TestFraction(unittest.TestCase):
     def test_unnoramlize_fraction(self):
-        from fractions import Fraction as OrginalFraction
+        from fractions import Fraction as NativePythonFraction
         from nltk.compat import Fraction as NLTKFraction
         
-        # The orginal fraction should throw a TypeError in Python < 3.5
+        # The native fraction should throw a TypeError in Python < 3.5
         with self.assertRaises(TypeError):
-            OrginalFraction(0, 1000, _normalize=False)
+            NativePythonFraction(0, 1000, _normalize=False)
         
         # Using nltk.compat.Fraction in Python < 3.5
         compat_frac = NLTKFraction(0, 1000, _normalize=False)
@@ -52,5 +42,7 @@ class TestFraction(unittest.TestCase):
         assert one_two.numerator == 1
         assert one_two.denominator == 2
         
+        # Checks against the native fraction.
+        six_twelve_original = NativePythonFraction(6, 12)
         # Checks that rational values of one_two and six_twelve is the same.
-        assert float(one_two) == float(six_twelve)
+        assert float(one_two) == float(six_twelve) == float(six_twelve_original)

--- a/nltk/test/unit/translate/test_bleu.py
+++ b/nltk/test/unit/translate/test_bleu.py
@@ -106,7 +106,7 @@ class TestBLEU(unittest.TestCase):
         self.assertAlmostEqual(sentence_bleu(references, hypothesis), 0.4729, places=4)
             
 
-@unittest.skip("Skipping fringe cases for BLEU.")            
+@unittest.skip("Skipping fringe cases for BLEU.")
 class TestBLEUFringeCases(unittest.TestCase):
 
     def test_case_where_n_is_bigger_than_hypothesis_length(self):

--- a/nltk/test/unit/translate/test_bleu.py
+++ b/nltk/test/unit/translate/test_bleu.py
@@ -30,7 +30,7 @@ class TestBLEU(unittest.TestCase):
         self.assertAlmostEqual(hyp1_unigram_precision, 0.28571428, places=4)
         
         # Testing modified bigram precision.
-        assert(modified_precision(references, hyp1, n=2) == 0.0)
+        assert(float(modified_precision(references, hyp1, n=2)) == 0.0)
         
         
         # Example 2: the "of the" example.
@@ -46,10 +46,10 @@ class TestBLEU(unittest.TestCase):
         
         references = [ref1, ref2, ref3] 
         # Testing modified unigram precision.
-        assert (modified_precision(references, hyp1, n=1) == 1.0)
+        assert (float(modified_precision(references, hyp1, n=1)) == 1.0)
         
         # Testing modified bigram precision.
-        assert(modified_precision(references, hyp1, n=2) == 1.0)
+        assert(float(modified_precision(references, hyp1, n=2)) == 1.0)
         
 
         # Example 3: Proper MT outputs.
@@ -70,7 +70,6 @@ class TestBLEU(unittest.TestCase):
         assert (round(hyp1_unigram_precision, 4) == 0.9444)
         assert (round(hyp2_unigram_precision, 4) == 0.5714)
         
-        
         # Bigram precision
         hyp1_bigram_precision = float(modified_precision(references, hyp1, n=2))
         hyp2_bigram_precision = float(modified_precision(references, hyp2, n=2))
@@ -81,8 +80,58 @@ class TestBLEU(unittest.TestCase):
         assert (round(hyp1_bigram_precision, 4) == 0.5882)
         assert (round(hyp2_bigram_precision, 4) == 0.0769)
         
-    def test_fringe_cases(self):
-        pass
+    def test_zero_matches(self):
+        # Test case where there's 0 matches
+        references = ['The candidate has no alignment to any of the references'.split()]
+        hypothesis = 'John loves Mary'.split()
+        
+        # Test BLEU to nth order of n-grams, where n is len(hypothesis). 
+        for n in range(1,len(hypothesis)):
+            weights = [1.0/n] * n # Uniform weights.
+            assert(sentence_bleu(references, hypothesis, weights) == 0)
+    
+    def test_full_matches(self):    
+        # Test case where there's 100% matches
+        references = ['John loves Mary'.split()]
+        hypothesis = 'John loves Mary'.split()
+    
+        # Test BLEU to nth order of n-grams, where n is len(hypothesis). 
+        for n in range(1,len(hypothesis)):
+            weights = [1.0/n] * n # Uniform weights.
+            assert(sentence_bleu(references, hypothesis, weights) == 1.0)
+    
+    def test_partial_matches_hypothesis_longer_than_reference(self):
+        references = ['John loves Mary'.split()]
+        hypothesis = 'John loves Mary who loves Mike'.split()
+        self.assertAlmostEqual(sentence_bleu(references, hypothesis), 0.4729, places=4)
+            
+
+@unittest.skip("Skipping fringe cases for BLEU.")            
+class TestBLEUFringeCases(unittest.TestCase):
+
+    def test_case_where_n_is_bigger_than_hypothesis_length(self):
+        # Test BLEU to nth order of n-grams, where n > len(hypothesis).
+        # TODO: Currently this test breaks the BLEU implementation (13.03.2016)
+        references = ['John loves Mary'.split()]
+        hypothesis = 'John loves Mary'.split()
+        n = len(hypothesis) + 1 # 
+        weights = [1.0/n] * n # Uniform weights.
+        assert(sentence_bleu(references, hypothesis, weights) == 1.0)
+    
+    def test_empty_hypothesis(self):
+        # Test case where there's hypothesis is empty.
+        # TODO: Currently this test breaks the BLEU implementation (13.03.2016)
+        references = ['The candidate has no alignment to any of the references'.split()]
+        hypothesis = []
+        assert(sentence_bleu(references, hypothesis) == 0)
+        
+    def test_empty_references(self):
+        # Test case where there's reference is empty.
+        # TODO: Currently this test breaks the BLEU implementation (13.03.2016)
+        references = [[]]
+        hypothesis = 'John loves Mary'.split()
+        assert(sentence_bleu(references, hypothesis) == 0)
+        
         
     def test_brevity_penalty(self):
         pass

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -16,10 +16,10 @@ from collections import Counter
 
 from nltk.util import ngrams
 
-try:
+try: # If Python's native fraction.Fraction has _normalize param.
     fractions.Fraction(0, 1000, _normalize=False)
     from fractions import Fraction
-except TypeError:
+except TypeError: # Otherwise, use nltk.compat.Fraction.
     from nltk.compat import Fraction
     
 


### PR DESCRIPTION
This is to accommodate the `_normalize` parameter in `fractions.Fraction` from Python >= 3.5 and the compatible Fraction from `nltk.compat.Fraction` allows `_normalize` by overloading the `fraction.Fraction` from Python < 3.5.

This PR:
- Added a new `Fraction` object in `nltk.compat` to use the `_normalize` parameter for Python < 3.5
- Re-added the `_normalize=False` code in `nltk.translate.bleu_score.py` from #1319 
- Added test cases for the new `nltk.compat.Fraction` object and also fringe cases of BLEU scores.
