### PR TITLE
address of free software foundation updated

### DIFF
--- a/nltk/stem/porter.py
+++ b/nltk/stem/porter.py
@@ -12,7 +12,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301
 # USA
 #
 # This software is maintained by Vivake (vivakeATomniscia.org) and is available at:


### PR DESCRIPTION
Address is now 51 Franklin St, Boston, MA 02110-1301. Please update
