### PR TITLE
Bigram fixer

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -49,6 +49,7 @@
 - Nikhil Dinesh
 - Liang Dong
 - David Doukhan
+- Melvyn Drag
 - Rebecca Dridan
 - Pablo Duboue
 - Long Duong

--- a/nltk/collocations.py
+++ b/nltk/collocations.py
@@ -176,12 +176,14 @@ class BigramCollocationFinder(AbstractCollocationFinder):
         function.  Following Church and Hanks (1990), counts are scaled by
         a factor of 1/(window_size - 1).
         """
-        n_all = self.N
-        n_ii = self.ngram_fd[(w1, w2)] / (self.window_size - 1.0)
+        n_all = self.ngram_fd.N()
+        n_ii = self.ngram_fd[(w1, w2)]/(self.window_size - 1.0)
         if not n_ii:
             return
-        n_ix = self.word_fd[w1]
-        n_xi = self.word_fd[w2]
+        nix_list = [tup for tup in self.ngram_fd if tup[0] == w1]
+        nxi_list = [tup for tup in self.ngram_fd if tup[1] == w2] 
+        n_ix = sum([self.ngram_fd[tup] for tup in nix_list])
+        n_xi = sum([self.ngram_fd[tup] for tup in nxi_list])
         return score_fn(n_ii, (n_ix, n_xi), n_all)
 
 


### PR DESCRIPTION
I have made a simple change which is to make bigram scoring depend on the FreqDist of bigrams, and not on the frequency of words, and added myself to the AUTHORS file. 

Ive run the tox for py34 and py27 and get a number of errors, but I get the same errors for both the code with my changes and the code without my changes. 

Also I wrote this simple test to make sure frequency distributions are calculated correctly:

```
from nltk.collocations import BigramCollocationFinder
from nltk.metrics.association import NgramAssocMeasures
import unittest
"""
Bigrams: 
    (Dogs, are)
    (are, animals)
    (animals, Giraffes)
    (Giraffes, are)
    (are, animals)
    (animals, too)
 """
class BigramTest(unittest.TestCase):
    def test_freq_dist1(self):
        text = 'Dogs are animals Giraffes are animals too'.split()
        bcf = BigramCollocationFinder.from_words(text)
        scorefn = NgramAssocMeasures.raw_freq
        tol = 1e-10
        val = bcf.score_ngram(scorefn, 'are', 'animals')
        desired_val = 1.0 / 3.0
        diff = abs(val - desired_val)
        self.assertTrue(diff < tol)
    def test_freq_dist2(self):
        text = 'Dogs are animals Giraffes are animals too'.split()
        bcf = BigramCollocationFinder.from_words(text)
        scorefn = NgramAssocMeasures.raw_freq
        tol = 1e-10
        val = bcf.score_ngram(scorefn, 'Dogs', 'are')
        desired_val = 1.0 / 6.0
        diff = abs(val - desired_val)
        self.assertTrue(diff < tol)

unittest.main()
```
