### PR TITLE
Added a verification for empty tokens

### DIFF
--- a/nltk/tag/crf.py
+++ b/nltk/tag/crf.py
@@ -111,7 +111,11 @@ class CRFTagger(TaggerI):
         """ 
         token = tokens[idx]
         
-        feature_list = []  
+        feature_list = []
+        
+        if not token:
+            return feature_list
+            
         # Capitalization 
         if token[0].isupper():
             feature_list.append('CAPITALIZATION')


### PR DESCRIPTION
An empty token makes the classifier crash. I've ran into this issue multiple times and this simple if statement fixes that.
