### PR TITLE
remove `u` because it doesn't work in Python 3.0 to 3.2

### DIFF
--- a/nltk/ccg/chart.py
+++ b/nltk/ccg/chart.py
@@ -335,7 +335,7 @@ def printCCGTree(lwidth,tree):
 
     (token, op) = tree.label()
 
-    if op == u'Leaf':
+    if op == 'Leaf':
         return rwidth
 
     # Pad to the left with spaces, followed by a sequence of '-'


### PR DESCRIPTION
And we don't really need it if it passes the CI. So, how do I get CI to run tests on this PR?

My machine only has python 2.7 and 3.5, and tests are green on both versions.

Here's the current issue with `u`: #1361
