### PR TITLE
moved the import for dispersion_plot out of the else block

### DIFF
--- a/nltk/draw/__init__.py
+++ b/nltk/draw/__init__.py
@@ -18,8 +18,9 @@ else:
     from nltk.draw.cfg import ProductionList, CFGEditor, CFGDemo
     from nltk.draw.tree import (TreeSegmentWidget, tree_to_treesegment,
                       TreeWidget, TreeView, draw_trees)
-    from nltk.draw.dispersion import dispersion_plot
     from nltk.draw.table import Table
+
+from nltk.draw.dispersion import dispersion_plot
 
 # skip doctests from this package
 def setup_module(module):


### PR DESCRIPTION
Moved the import for `dispersion_plot` out of the else block since it does not depend on tkinter.

This addresses issue #1339 where attempting to call `dispersion_plot` on a `Text` object would fail if `tkinter` was not installed.
