### PR TITLE
Handles fringe cases in BLEU

### DIFF
--- a/nltk/test/unit/translate/test_bleu.py
+++ b/nltk/test/unit/translate/test_bleu.py
@@ -106,33 +106,40 @@ class TestBLEU(unittest.TestCase):
         self.assertAlmostEqual(sentence_bleu(references, hypothesis), 0.4729, places=4)
             
 
-@unittest.skip("Skipping fringe cases for BLEU.")
+#@unittest.skip("Skipping fringe cases for BLEU.")
 class TestBLEUFringeCases(unittest.TestCase):
 
     def test_case_where_n_is_bigger_than_hypothesis_length(self):
         # Test BLEU to nth order of n-grams, where n > len(hypothesis).
-        # TODO: Currently this test breaks the BLEU implementation (13.03.2016)
-        references = ['John loves Mary'.split()]
+        references = ['John loves Mary ?'.split()]
         hypothesis = 'John loves Mary'.split()
         n = len(hypothesis) + 1 # 
         weights = [1.0/n] * n # Uniform weights.
+        self.assertAlmostEqual(sentence_bleu(references, hypothesis, weights), 0.7165, places=4)
+        
+        # Test case where n > len(hypothesis) but so is n > len(reference), and
+        # it's a special case where reference == hypothesis.
+        references = ['John loves Mary'.split()]
+        hypothesis = 'John loves Mary'.split()
         assert(sentence_bleu(references, hypothesis, weights) == 1.0)
     
     def test_empty_hypothesis(self):
         # Test case where there's hypothesis is empty.
-        # TODO: Currently this test breaks the BLEU implementation (13.03.2016)
         references = ['The candidate has no alignment to any of the references'.split()]
         hypothesis = []
         assert(sentence_bleu(references, hypothesis) == 0)
         
     def test_empty_references(self):
         # Test case where there's reference is empty.
-        # TODO: Currently this test breaks the BLEU implementation (13.03.2016)
         references = [[]]
         hypothesis = 'John loves Mary'.split()
         assert(sentence_bleu(references, hypothesis) == 0)
         
+    def test_empty_references_and_hypothesis(self):
+        # Test case where both references and hypothesis is empty.
+        references = [[]]
+        hypothesis = []
+        assert(sentence_bleu(references, hypothesis) == 0)
         
     def test_brevity_penalty(self):
         pass
-    

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -292,7 +292,7 @@ def modified_precision(references, hypothesis, n):
 
 def closest_ref_length(references, hyp_len):
     """
-    This function finds the reference that is the closestyu length to the 
+    This function finds the reference that is the closest length to the 
     hypothesis. The closest reference length is referred to as *r* variable 
     from the brevity penalty formula in Papineni et. al. (2002)
     

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -283,7 +283,7 @@ def modified_precision(references, hypothesis, n):
                       for ngram, count in counts.items()}
     
     numerator = sum(clipped_counts.values())
-    # Ensures that denominator is 1 to avoid ZeroDivisionError.
+    # Ensures that denominator is minimum 1 to avoid ZeroDivisionError.
     # Usually this happens when the ngram order is > len(reference).
     denominator = max(1, sum(counts.values()))
     


### PR DESCRIPTION
Previously, `nltk.translate.bleu_score` is brittle and breaks in cases where there're:
- empty hypothesis with non-empty reference
- empty reference(s) with non-empty hypothesis
- ngram order > len(hypothesis) 

To handle these cases, we put in place mathematical solutions that will:
- Returns score of 0 when there's an empty hypothesis, regardless of whether the reference is empty. In the case where hypothesis is empty, we can consider this as "inadequate" translation, thus BLEU = 0.
- Returns score of 0 when there's a non-empty hypothesis in the case of empty reference. Usually this shouldn't happen because of the nature of how MT generates sentence dependent on the source and when source is non-empty but reference is empty, usually `UNK` (unknown) is generated. And in that case, the non-empty hypothesis to an empty reference implies a superfluous translation, thus BLEU = 0

These techniques to handle the fringe cases corresponds to how `multi-bleu.pl` works where it generates BLEU=0 for weird cases. And [`in the recent straw poll`](https://twitter.com/alvations/status/717647857768144896), this behavior would be set as the default and users can easily substitute the `smoothing_function` parameter to emulate other shades of BLEU.

Now we can move on to the last part of the mini-roadmap in #1330 to give an example that emulates `mteval-13a.perl`.
