### PR TITLE
fixed bug: StackDecoder would throw exception if it's unable to finish…

### DIFF
--- a/nltk/translate/stack_decoder.py
+++ b/nltk/translate/stack_decoder.py
@@ -493,3 +493,7 @@ class _Stack(object):
 
     def __contains__(self, hypothesis):
         return hypothesis in self.items
+
+    def __bool__(self):
+        return len(self.items) != 0
+    __nonzero__=__bool__


### PR DESCRIPTION
According to line 182, the decoder is designed to return an empty list if it's unable to translate all words. However, because `stacks[sentence_length]` is a _Stack, `if not stacks[sentence_length]:` will always return false.

I added __bool__ and __nonzero__ to make this line of code work
