### PR TITLE
Fix/bug loading empty files

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -197,3 +197,4 @@
 - Tanin Na Nakorn
 - Linghao Zhang
 - Colin Carroll
+- Tomislav Subic <https://github.com/tsubic>

--- a/nltk/corpus/reader/util.py
+++ b/nltk/corpus/reader/util.py
@@ -760,7 +760,7 @@ def find_corpus_fileids(root, regexp):
         for dirname, subdirs, fileids in os.walk(root.path, **kwargs):
             prefix = ''.join('%s/' % p for p in _path_from(root.path, dirname))
             items += [prefix+fileid for fileid in fileids
-                      if re.match(regexp, prefix+fileid)]
+                      if re.match(regexp, prefix+fileid) and os.path.getsize(root+fileid) > 0]
             # Don't visit svn directories:
             if '.svn' in subdirs: subdirs.remove('.svn')
         return sorted(items)


### PR DESCRIPTION
When creating a corpora by loading a bunch of plain text files it can happen than some text files are empty. They get loaded into the corpus but can cause trouble later on. For example len(reared.words()) won't work; it will give an AssertionError. This is a quick fix to ignore empty files so that it doesn't even include the fileid of the file in the corpus.

Example what happens if there are empty files in the directory all/:

```
>>> reader = CategorizedPlaintextCorpusReader('all/', r'.*\.txt', cat_pattern=r'([^_]*).*\.txt')
>>> len(reader.words())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.4/site-packages/nltk/corpus/reader/util.py", line 372, in __len__
    for tok in self.iterate_from(self._offsets[-1]): pass
  File "/usr/lib/python3.4/site-packages/nltk/corpus/reader/util.py", line 394, in iterate_from
    for tok in piece.iterate_from(max(0, start_tok-offset)):
  File "/usr/lib/python3.4/site-packages/nltk/corpus/reader/util.py", line 336, in iterate_from
    assert self._len is not None
AssertionError
```

With the fix, it works just fine.
