### PR TITLE
Much faster Vader sentiment tagging

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -197,3 +197,4 @@
 - Tanin Na Nakorn
 - Linghao Zhang
 - Colin Carroll
+- George Berry

--- a/nltk/sentiment/vader.py
+++ b/nltk/sentiment/vader.py
@@ -5,6 +5,7 @@
 # Author: C.J. Hutto <Clayton.Hutto@gtri.gatech.edu>
 #         Ewan Klein <ewan@inf.ed.ac.uk> (modifications)
 #         Pierpaolo Pantone <24alsecondo@gmail.com> (modifications)
+#         George Berry <geb97@cornell.edu> (modifications)
 # URL: <http://nltk.org/>
 # For license information, see LICENSE.TXT
 #
@@ -24,6 +25,7 @@ import codecs
 import math
 import re
 import string
+from itertools import product
 import nltk.data
 
 ##Constants##
@@ -160,44 +162,45 @@ class SentiText(object):
         # adjacent punctuation (keeps emoticons & contractions)
         self.is_cap_diff = allcap_differential(self.words_and_emoticons)
 
-    def _words_only(self):
-        text_mod = REGEX_REMOVE_PUNCTUATION.sub('', self.text)
+    def _words_plus_punc(self):
+        """
+        Returns mapping of form:
+        {
+            'cat,': 'cat',
+            ',cat': 'cat',
+        }
+        """
+        no_punc_text = REGEX_REMOVE_PUNCTUATION.sub('', self.text)
         # removes punctuation (but loses emoticons & contractions)
-        words_only = text_mod.split()
-        # get rid of empty items or single letter "words" like 'a' and 'I'
-        words_only = [word for word in words_only if len(word) > 1]
-        return words_only
+        words_only = no_punc_text.split()
+        # remove singletons
+        words_only = set([w for w in words_only if len(w) > 1])
+        # the product gives ('cat', ',') and (',', 'cat')
+        punc_before = {''.join(p): p[1] for p in product(PUNC_LIST, words_only)}
+        punc_after = {''.join(p): p[0] for p in product(words_only, PUNC_LIST)}
+        words_punc_dict = punc_before
+        words_punc_dict.update(punc_after)
+        return words_punc_dict
 
     def _words_and_emoticons(self):
+        """
+        Removes leading and trailing puncutation
+        Leaves contractions and most emoticons
+            Does not preserve punc-plus-letter emoticons (e.g. :D)
+        """
         wes = self.text.split()
-
-        # get rid of residual empty items or single letter words
+        words_punc_dict = self._words_plus_punc()
         wes = [we for we in wes if len(we) > 1]
-
-        for word in self._words_only():
-            for punct in PUNC_LIST:
-                pword = punct + word
-                x1 = wes.count(pword)
-                while x1 > 0:
-                    i = wes.index(pword)
-                    wes.remove(pword)
-                    wes.insert(i, word)
-                    x1 = wes.count(pword)
-
-                wordp = word + punct
-                x2 = wes.count(wordp)
-                while x2 > 0:
-                    i = wes.index(wordp)
-                    wes.remove(wordp)
-                    wes.insert(i, word)
-                    x2 = wes.count(wordp)
+        for i, we in enumerate(wes):
+            if we in words_punc_dict:
+                wes[i] = words_punc_dict[we]
         return wes
 
 class SentimentIntensityAnalyzer(object):
     """
     Give a sentiment intensity score to sentences.
     """
-    def __init__(self, lexicon_file="sentiment/vader_lexicon.zip/vader_lexicon/vader_lexicon.txt"):
+    def __init__(self, lexicon_file="sentiment/vader_lexicon.txt"):
         self.lexicon_file = nltk.data.load(lexicon_file)
         self.lexicon = self.make_lex_dict()
 

--- a/nltk/sentiment/vader.py
+++ b/nltk/sentiment/vader.py
@@ -200,7 +200,7 @@ class SentimentIntensityAnalyzer(object):
     """
     Give a sentiment intensity score to sentences.
     """
-    def __init__(self, lexicon_file="sentiment/vader_lexicon.txt"):
+    def __init__(self, lexicon_file="sentiment/vader_lexicon.zip/vader_lexicon/vader_lexicon.txt"):
         self.lexicon_file = nltk.data.load(lexicon_file)
         self.lexicon = self.make_lex_dict()
 

--- a/nltk/sentiment/vader.py
+++ b/nltk/sentiment/vader.py
@@ -174,7 +174,7 @@ class SentiText(object):
         # removes punctuation (but loses emoticons & contractions)
         words_only = no_punc_text.split()
         # remove singletons
-        words_only = set([w for w in words_only if len(w) > 1])
+        words_only = set( w for w in words_only if len(w) > 1 )
         # the product gives ('cat', ',') and (',', 'cat')
         punc_before = {''.join(p): p[1] for p in product(PUNC_LIST, words_only)}
         punc_after = {''.join(p): p[0] for p in product(words_only, PUNC_LIST)}

--- a/nltk/test/sentiment.doctest
+++ b/nltk/test/sentiment.doctest
@@ -128,8 +128,8 @@ Vader
     ...    under orders and in the ''least offensive way possible.''"
     ... ]
     >>> sentences.extend(tricky_sentences)
-    >>> sid = SentimentIntensityAnalyzer()
     >>> for sentence in sentences:
+    ...     sid = SentimentIntensityAnalyzer()
     ...     print(sentence)
     ...     ss = sid.polarity_scores(sentence)
     ...     for k in sorted(ss):


### PR DESCRIPTION
Drastic reduction of time complexity for Vader sentiment analysis. Existing `SentiText` code was `O(N^4)`, where `N` is the number of words in the corpus. New `SentiText` class is `O(N)`. On the `scikit-learn` 20 Newsgroups dataset, Vader sentiment tagging from 45 minutes to 30 seconds.
