### PR TITLE
Handle empty files in a corpus

### DIFF
--- a/nltk/corpus/reader/util.py
+++ b/nltk/corpus/reader/util.py
@@ -280,7 +280,12 @@ class StreamBackedCorpusView(AbstractLazySequence):
         # Open the stream, if it's not open already.
         if self._stream is None:
             self._open()
-
+        
+        # If the file is empty, the while loop will never run.
+        # This *seems* to be all the state we need to set:
+        if self._eofpos == 0:
+            self._len = 0
+            
         # Each iteration through this loop, we read a single block
         # from the stream.
         while filepos < self._eofpos:


### PR DESCRIPTION
This is a solution to issue https://github.com/nltk/nltk/issues/1410. 

I have tested it with various requests on a mini-corpus containing empty files, files with just one space, just one bracket, etc. It seems to behave correctly.

[This pull request](https://github.com/nltk/nltk/pull/1408) addresses the same issue, but is not a good fix in my opinion.
