### PR TITLE
Make Stanford tagger heed class path

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -59,6 +59,7 @@
 - Sumukh Ghodke
 - Yoav Goldberg
 - Michael Wayne Goodman
+- Ian Gow
 - Dougal Graham
 - Brent Gray
 - Simon Greenhill

--- a/nltk/tag/stanford.py
+++ b/nltk/tag/stanford.py
@@ -90,7 +90,11 @@ class StanfordTagger(TaggerI):
         _input_fh.close()
         
         # Run the tagger and get the output
-        stanpos_output, _stderr = java(cmd, classpath=os.environ['CLASSPATH'],
+        if os.environ.get('CLASSPATH'):
+            classpath = self._stanford_jar +  (os.environ.get('CLASSPATH'), )
+        else:
+            classpath = self._stanford_jar
+        stanpos_output, _stderr = java(cmd, classpath=classpath,
                                                        stdout=PIPE, stderr=PIPE)
         stanpos_output = stanpos_output.decode(encoding)
         

--- a/nltk/tag/stanford.py
+++ b/nltk/tag/stanford.py
@@ -90,7 +90,7 @@ class StanfordTagger(TaggerI):
         _input_fh.close()
         
         # Run the tagger and get the output
-        stanpos_output, _stderr = java(cmd, classpath=self._stanford_jar,
+        stanpos_output, _stderr = java(cmd, classpath=os.environ['CLASSPATH'],
                                                        stdout=PIPE, stderr=PIPE)
         stanpos_output = stanpos_output.decode(encoding)
         


### PR DESCRIPTION
NLTK was issuing a command looking a lot like this:

```
/usr/bin/java -mx1000m -cp "stanford-ner-2015-12-09/stanford-ner.jar:stanford-ner-2015-12-09/bin/*" edu.stanford.nlp.ie.crf.CRFClassifier  -loadClassifier stanford-ner-2015-12-09/classifiers/english.muc.7class.distsim.crf.ser.gz -textFile sample.txt -outputFormat slashTags -tokenizerFactory edu.stanford.nlp.process.WhitespaceTokenizer -tokenizerOptions "tokenizeNLs=false"
CRFClassifier invoked on Wed Jun 08 17:03:10 EDT 2016 with arguments:
   -loadClassifier stanford-ner-2015-12-09/classifiers/english.muc.7class.distsim.crf.ser.gz -textFile sample.txt -outputFormat slashTags -tokenizerFactory edu.stanford.nlp.process.WhitespaceTokenizer -tokenizerOptions tokenizeNLs=false
tokenizerFactory=edu.stanford.nlp.process.WhitespaceTokenizer
tokenizerOptions=tokenizeNLs=false
loadClassifier=stanford-ner-2015-12-09/classifiers/english.muc.7class.distsim.crf.ser.gz
textFile=sample.txt
outputFormat=slashTags
Exception in thread "main" java.lang.NoClassDefFoundError: org/slf4j/LoggerFactory
    at edu.stanford.nlp.io.IOUtils.<clinit>(IOUtils.java:42)
    at edu.stanford.nlp.ie.AbstractSequenceClassifier.loadClassifier(AbstractSequenceClassifier.java:1484)
    at edu.stanford.nlp.ie.AbstractSequenceClassifier.loadClassifierNoExceptions(AbstractSequenceClassifier.java:1497)
    at edu.stanford.nlp.ie.crf.CRFClassifier.main(CRFClassifier.java:3015)
Caused by: java.lang.ClassNotFoundException: org.slf4j.LoggerFactory
    at java.net.URLClassLoader$1.run(URLClassLoader.java:372)
    at java.net.URLClassLoader$1.run(URLClassLoader.java:361)
    at java.security.AccessController.doPrivileged(Native Method)
    at java.net.URLClassLoader.findClass(URLClassLoader.java:360)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
    at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:308)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
    ... 4 more
```

However, if I correct what is passed to `-cp` to the following `-cp "stanford-ner-2015-12-09/stanford-ner.jar:stanford-ner-2015-12-09/bin/*"`, it works:

```
/usr/bin/java -mx1000m -cp "stanford-ner-2015-12-09/stanford-ner.jar:stanford-ner-2015-12-09/lib/*" edu.stanford.nlp.ie.crf.CRFClassifier  -loadClassifier stanford-ner-2015-12-09/classifiers/english.muc.7class.distsim.crf.ser.gz -textFile sample.txt -outputFormat slashTags -tokenizerFactory edu.stanford.nlp.process.WhitespaceTokenizer -tokenizerOptions "tokenizeNLs=false"
CRFClassifier invoked on Wed Jun 08 17:12:34 EDT 2016 with arguments:
   -loadClassifier stanford-ner-2015-12-09/classifiers/english.muc.7class.distsim.crf.ser.gz -textFile sample.txt -outputFormat slashTags -tokenizerFactory edu.stanford.nlp.process.WhitespaceTokenizer -tokenizerOptions tokenizeNLs=false
tokenizerFactory=edu.stanford.nlp.process.WhitespaceTokenizer
tokenizerOptions=tokenizeNLs=false
loadClassifier=stanford-ner-2015-12-09/classifiers/english.muc.7class.distsim.crf.ser.gz
textFile=sample.txt
outputFormat=slashTags
Loading classifier from stanford-ner-2015-12-09/classifiers/english.muc.7class.distsim.crf.ser.gz ... done [0.8 sec].
Hello./O Bugs/O Bunny/O is/O a/O wascally/O wabbit./O Elmer/PERSON Fudd/PERSON works/O for/O the/O FBI./O 
CRFClassifier tagged 13 words in 1 documents at 481.48 words per second.
```

where `sample.txt` is created thus `echo "Hello. Bugs Bunny is a wascally wabbit. Elmer Fudd works for the FBI." >> sample.txt`.

But I could not work out how to pass information to the Java command, as it seems that no environment variables are referenced in the appropriate place. I made an edit in one place and all works with appropriate setting of `CLASSPATH`.
