### PR TITLE
removes download-cache pip flag from tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ commands =
     ; scipy and scikit-learn requires numpy even to run setup.py so
     ; they can't be installed in one command
 
-    pip install --download-cache={toxworkdir}/_download scipy scikit-learn
+    pip install scipy scikit-learn
     ; python runtests.py --with-coverage --cover-inclusive --cover-package=nltk --cover-html --cover-html-dir={envdir}/docs []
     python runtests.py []
 
@@ -47,7 +47,7 @@ deps =
 commands =
     ; scipy and scikit-learn requires numpy even to run setup.py so
     ; they can't be installed in one command
-    pip install --download-cache={toxworkdir}/_download scipy scikit-learn
+    pip install scipy scikit-learn
 
     ; python runtests.py --with-coverage --cover-inclusive --cover-package=nltk --cover-html --cover-html-dir={envdir}/docs []
     python runtests.py []
@@ -64,7 +64,7 @@ deps =
 commands =
     ; scipy and scikit-learn requires numpy even to run setup.py so
     ; they can't be installed in one command
-    pip install --download-cache={toxworkdir}/_download scipy scikit-learn
+    pip install scipy scikit-learn
 
     ; python runtests.py --with-coverage --cover-inclusive --cover-package=nltk --cover-html --cover-html-dir={envdir}/docs []
     python runtests.py []
@@ -81,7 +81,7 @@ deps =
 commands =
     ; scipy and scikit-learn requires numpy even to run setup.py so
     ; they can't be installed in one command
-    pip install --download-cache={toxworkdir}/_download scipy scikit-learn
+    pip install scipy scikit-learn
 
     ; python runtests.py --with-coverage --cover-inclusive --cover-package=nltk --cover-html --cover-html-dir={envdir}/docs []
     python runtests.py []


### PR DESCRIPTION
This PR removes the `pip` `--download-cache` flag from `tox.ini` config file.

See #1414 
