### PR TITLE
Adding Basic Ngram Models

### DIFF
--- a/nltk/model/__init__.py
+++ b/nltk/model/__init__.py
@@ -6,5 +6,5 @@
 # URL: <http://nltk.org/
 # For license information, see LICENSE.TXT
 
-from nltk.model.ngram import BaseNgramModel, MLENgramModel
+from nltk.model.ngram import *
 from nltk.model.counter import build_vocabulary, count_ngrams

--- a/nltk/model/__init__.py
+++ b/nltk/model/__init__.py
@@ -6,5 +6,5 @@
 # URL: <http://nltk.org/
 # For license information, see LICENSE.TXT
 
-from nltk.model.ngram import BaseNgramModel
+from nltk.model.ngram import BaseNgramModel, MLENgramModel
 from nltk.model.counter import build_vocabulary, count_ngrams

--- a/nltk/model/ngram.py
+++ b/nltk/model/ngram.py
@@ -105,3 +105,24 @@ class MLENgramModel(BaseNgramModel):
         - context is expected to be something reasonably convertible to a tuple
         """
         return self.ngrams[tuple(context)].freq(word)
+
+
+@compat.python_2_unicode_compatible
+class LidstoneNgramModel(BaseNgramModel):
+    """Provides Lidstone-smoothed scores.
+
+    In addition to initialization arguments from BaseNgramModel also requires
+    a number by which to increase the counts, gamma.
+    """
+
+    def __init__(self, gamma, *args):
+        super(LidstoneNgramModel, self).__init__(*args)
+        self.gamma = gamma
+        # This gets added to the denominator to normalize the effect of gamma
+        self.gamma_norm = len(self.ngram_counter.vocabulary) * gamma
+
+    def score(self, word, context):
+        context_freqdist = self.ngrams[tuple(context)]
+        word_count = context_freqdist[word]
+        ctx_count = context_freqdist.N()
+        return (word_count + self.gamma) / (ctx_count + self.gamma_norm)

--- a/nltk/model/ngram.py
+++ b/nltk/model/ngram.py
@@ -126,3 +126,13 @@ class LidstoneNgramModel(BaseNgramModel):
         word_count = context_freqdist[word]
         ctx_count = context_freqdist.N()
         return (word_count + self.gamma) / (ctx_count + self.gamma_norm)
+
+
+class LaplaceNgramModel(LidstoneNgramModel):
+    """Implements Laplace (add one) smoothing.
+
+    Initialization identical to BaseNgramModel because gamma is always 1.
+    """
+
+    def __init__(self, *args):
+        super(LaplaceNgramModel, self).__init__(1, *args)

--- a/nltk/model/ngram.py
+++ b/nltk/model/ngram.py
@@ -22,13 +22,13 @@ class BaseNgramModel(object):
     when writing their own ngram models.
     """
 
-    def __init__(self, ngram_counts):
+    def __init__(self, ngram_counter):
 
-        self.ngram_counts = ngram_counts
+        self.ngram_counter = ngram_counter
+        # for convenient access save top-most ngram order ConditionalFreqDist
+        self.ngrams = ngram_counter.ngrams[ngram_counter.order]
 
-        self.ngrams = ngram_counts.ngrams[ngram_counts.order]
-
-        self._normalize = self.ngram_counts.check_against_vocab
+        self._normalize = self.ngram_counter.check_against_vocab
 
     def score(self, word, context):
         """
@@ -72,7 +72,7 @@ class BaseNgramModel(object):
         normed_text = (self._normalize(word) for word in text)
         H = 0.0     # entropy is conventionally denoted by "H"
         processed_ngrams = 0
-        for ngram in self.ngram_counts.to_ngrams(normed_text):
+        for ngram in self.ngram_counter.to_ngrams(normed_text):
             context, word = tuple(ngram[:-1]), ngram[-1]
             H += self.logscore(word, context)
             processed_ngrams += 1

--- a/nltk/model/ngram.py
+++ b/nltk/model/ngram.py
@@ -90,6 +90,7 @@ class BaseNgramModel(object):
         return pow(2.0, self.entropy(text))
 
 
+@compat.python_2_unicode_compatible
 class MLENgramModel(BaseNgramModel):
     """Class for providing MLE ngram model scores.
 

--- a/nltk/model/ngram.py
+++ b/nltk/model/ngram.py
@@ -88,3 +88,19 @@ class BaseNgramModel(object):
         """
 
         return pow(2.0, self.entropy(text))
+
+
+class MLENgramModel(BaseNgramModel):
+    """Class for providing MLE ngram model scores.
+
+    Inherits initialization from BaseNgramModel.
+    """
+
+    def score(self, word, context):
+        """Returns the MLE score for a word given a context.
+
+        Args:
+        - word is expcected to be a string
+        - context is expected to be something reasonably convertible to a tuple
+        """
+        return self.ngrams[tuple(context)].freq(word)

--- a/nltk/model/ngram.py
+++ b/nltk/model/ngram.py
@@ -128,6 +128,7 @@ class LidstoneNgramModel(BaseNgramModel):
         return (word_count + self.gamma) / (ctx_count + self.gamma_norm)
 
 
+@compat.python_2_unicode_compatible
 class LaplaceNgramModel(LidstoneNgramModel):
     """Implements Laplace (add one) smoothing.
 

--- a/nltk/test/model.doctest
+++ b/nltk/test/model.doctest
@@ -3,8 +3,6 @@
 
 .. -*- coding: utf-8 -*-
 
-    >>> from pprint import pprint # for dictionary comparison
-
 ===============
 Counting Ngrams
 ===============
@@ -130,16 +128,17 @@ attribute.
 
     >>> print(bigram_counts.unigrams)
     <FreqDist with 9 samples and 117 outcomes>
-    >>> pprint(bigram_counts.unigrams) # doctest: +NORMALIZE_WHITESPACE
-    {'.': 4,
-    '</s>': 4,
-    '<UNK>': 80,
-    'and': 5,
-    'he': 6,
-    'his': 5,
-    'the': 6,
-    'to': 4,
-    'yawned': 3}
+    >>> expected_unigram_counts = {'.': 4,
+    ... '</s>': 4,
+    ... '<UNK>': 80,
+    ... 'and': 5,
+    ... 'he': 6,
+    ... 'his': 5,
+    ... 'the': 6,
+    ... 'to': 4,
+    ... 'yawned': 3}
+    >>> bigram_counts.unigrams == expected_unigram_counts
+    True
 
 Tweaking the unknown label
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -185,11 +184,12 @@ NgramCounter uses nltk's `util.ngrams` function to break a text up into ngrams.
 The behavior of `util.ngrams` is controlled by passing it keyword arguments stored
 in an attribute of NgramCounter.
 
-    >>> pprint(bigram_counts.ngrams_kwargs)  # doctest: +NORMALIZE_WHITESPACE
-    {'left_pad_symbol': '<s>',
-    'pad_left': True,
-    'pad_right': True,
-    'right_pad_symbol': '</s>'}
+    >>> default_kwargs = {'left_pad_symbol': '<s>',
+    ... 'pad_left': True,
+    ... 'pad_right': True,
+    ... 'right_pad_symbol': '</s>'}
+    >>> bigram_counts.ngrams_kwargs == default_kwargs
+    True
 
 The default values of these arguments have been chosen based on what I think are
 the most common practices for ngram splitting. You can easily override the settings
@@ -237,16 +237,18 @@ If you choose to do this, you can call the `train_counts` method with some text
 to populate your counter instance with some numbers.
 
     >>> no_initial_texts.train_counts(sents[3:7])
-    >>> pprint(no_initial_texts.unigrams) # doctest: +NORMALIZE_WHITESPACE
-    {'.': 4,
-    '</s>': 4,
-    '<UNK>': 80,
-    'and': 5,
-    'he': 6,
-    'his': 5,
-    'the': 6,
-    'to': 4,
-    'yawned': 3}
+    >>> expected_unigram_counts = {'.': 4,
+    ... '</s>': 4,
+    ... '<UNK>': 80,
+    ... 'and': 5,
+    ... 'he': 6,
+    ... 'his': 5,
+    ... 'the': 6,
+    ... 'to': 4,
+    ... 'yawned': 3}
+    >>> no_initial_texts.unigrams == expected_unigram_counts
+    True
+
 
 =====================
 From Counts to Scores

--- a/nltk/test/model.doctest
+++ b/nltk/test/model.doctest
@@ -252,31 +252,76 @@ to populate your counter instance with some numbers.
 From Counts to Scores
 =====================
 
-Once we counted up the ngrams it is trivial to turn them into a proper model
-with scores (probabilities): just pass your NgramCounter object to a BaseNgramModel
-class or any of its children.
+Example: MLE
+------------
 
-    >>> from nltk.model import BaseNgramModel
-    >>> bigram_model = BaseNgramModel(bigram_counts)
-    >>> bigram_model.ngram_counts == bigram_counts
+Once we counted up the ngrams it is trivial to turn them into a proper model
+with scores (probabilities): just pass your NgramCounter object to an ngram model class.
+The module currently has classes for only the basic ngram model types:
+MLE, Lidstone, and Laplace.
+Here's an example of how to use an MLE estimator with the counts we've defined.
+
+    >>> from nltk.model import MLENgramModel
+    >>> bigram_model = MLENgramModel(bigram_counts)
+
+We can access the `bigram_counts` object from the `ngram_counter` attribute:
+
+    >>> bigram_model.ngram_counter == bigram_counts
     True
 
-As its name suggests, the BaseNgramModel class is intended first and foremost
-as something folks can base classes for different models. As such BaseNgramModel
-doesn't have an interesting `score` method implementation, it always
-returns 0.5.
+The most important method of all ngram model classes is `score`, which computes
+the score (aka probability) of a word given some preceding context.
+In our example we are working with a bigram model, so the context consists of only
+one word.
 
-    >>> bigram_model.score("test", ('abc',))
+    >>> ex_score = bigram_model.score("yawned", ["he"])
+
+Note that an MLE score is no more than the relative frequency of the word given
+its context (it just looks much nicer!).
+
+    >>> bigram_counts.ngrams[2][('he',)].freq('yawned') == ex_score
+    True
+
+Also note that both lists and tuples are supported as `context` arguments.
+
+    >>> bigram_model.score("yawned", ("he",)) == ex_score
+    True
+
+In addition to `score` all ngram model classes provide the following methods:
+- logscore
+- entropy
+- perplexity
+Their usage is described in the following section.
+
+
+Custom NgramModel Classes
+-------------------------
+
+In case you need an ngram model estimator that's not currently in the module,
+it's quite easy to define your own class for that, you simply subclass the
+`BaseNgramModel` class. The following section describes.
+
+    >>> from nltk.model import BaseNgramModel
+    >>> base_model = BaseNgramModel(bigram_counts)
+
+Since it is intended only as a base class for real estimators, the `BaseNgramModel`
+doesn't have an interesting `score` method, it always returns 0.5.
+
+    >>> base_model.score("test", ('abc',))
     0.5
-    >>> bigram_model.score("abc", ("test",))
+    >>> base_model.score("abc", ("test",))
     0.5
 
-Children classes are expected to override this method and take advantage of methods
-(shown below) whose implementations do not depend on that of `score`.
+Children classes are expected to override this method and provide their own
+logic for how to compute a score.
+The advantage of having a base ngram model class is that there are plenty of methods
+that do not depend of `score` in their implementations which are all defined in
+the `BaseNgramModel` class and which you get "for free" by inheriting from it.
+Here are examples of these methods:
 
-    >>> bigram_model.logscore("abc", ("test",))
+    >>> base_model.logscore("abc", ("test",))
     -1.0
-    >>> bigram_model.entropy(sents[4])
+    >>> base_model.entropy(sents[4])
     -1.0
-    >>> bigram_model.perplexity(sents[4])
+    >>> base_model.perplexity(sents[4])
     0.5

--- a/nltk/test/model.doctest
+++ b/nltk/test/model.doctest
@@ -222,8 +222,8 @@ Just like `build_vocab`, `count_ngrams` can handle multiple source text argument
 
     >>> multiple_texts_counter = count_ngrams(2, vocab, sents[3:6], sents[6:9])
 
-Moreover, it is also possible to specify no texts whatsoever to simply create
-an empty NgramCounter object and train it later.
+Moreover, it is also possible to specify no texts whatsoever, which simply creates
+an empty NgramCounter object so that it can be trained later.
 
     >>> no_initial_texts = count_ngrams(2, vocab)
 
@@ -233,7 +233,7 @@ class directly:
     >>> from nltk.model.counter import NgramCounter
     >>> no_initial_texts = NgramCounter(2, vocab)
 
-If you choose to do this, you can call the `train_counts` method with some text
+If you choose to do this, you can call the `train_counts` method and pass it some text
 to populate your counter instance with some numbers.
 
     >>> no_initial_texts.train_counts(sents[3:7])

--- a/nltk/test/unit/test_model.py
+++ b/nltk/test/unit/test_model.py
@@ -215,7 +215,7 @@ class ModelFuncsTests(unittest.TestCase):
 
     def test_count_ngrams_multiple_texts(self):
         vocab_text = ("the cow jumped over the blue moon . "
-            "blue river jumped over the rainbow .")
+                      "blue river jumped over the rainbow .")
         vocab = build_vocabulary(2, vocab_text.split())
 
         text1 = ['zabcfdegadbew']
@@ -230,7 +230,7 @@ class ModelFuncsTests(unittest.TestCase):
 
     def test_count_ngrams_kwargs(self):
         vocab_text = ("the cow jumped over the blue moon . "
-            "blue river jumped over the rainbow .")
+                      "blue river jumped over the rainbow .")
         vocab = build_vocabulary(2, vocab_text.split())
 
         text = ["blue moon".split(), "over the rainbow".split()]
@@ -240,7 +240,7 @@ class ModelFuncsTests(unittest.TestCase):
 
     def test_count_grams_bad_kwarg(self):
         vocab_text = ("the cow jumped over the blue moon . "
-            "blue river jumped over the rainbow .")
+                      "blue river jumped over the rainbow .")
         vocab = build_vocabulary(2, vocab_text.split())
 
         text = ["blue moon".split()]

--- a/nltk/test/unit/test_model.py
+++ b/nltk/test/unit/test_model.py
@@ -11,7 +11,7 @@ import unittest
 
 from nltk.model import build_vocabulary, count_ngrams
 from nltk.model.counter import NgramModelVocabulary, EmptyVocabularyError, NgramCounter
-from nltk.model.ngram import BaseNgramModel, NEG_INF
+from nltk.model.ngram import BaseNgramModel, MLENgramModel, NEG_INF
 
 
 class NgramCounterTests(unittest.TestCase):
@@ -179,6 +179,21 @@ class BaseNgramModelTests(NgramModelBaseTest):
         patch_model.score = lambda word, context: 0.0
         logscore = patch_model.logscore("d", ["e"])
         self.assertEqual(logscore, NEG_INF)
+
+
+class MLENgramModelTest(NgramModelBaseTest):
+    """unit tests for MLENgramModel class"""
+
+    def setUp(self):
+        self.base_model = MLENgramModel(self.counter)
+
+    def test_score(self):
+        # simultaneously tests the accuracy of score and whether it can handle
+        # both lists and tuples as context arguments
+        score_ctx_list = self.base_model.score("d", ["c"])
+        score_ctx_tuple = self.base_model.score("b", ("a",))
+        self.assertEqual(score_ctx_list, 1)
+        self.assertEqual(score_ctx_tuple, 0.5)
 
 
 class ModelFuncsTests(unittest.TestCase):

--- a/nltk/test/unit/test_model.py
+++ b/nltk/test/unit/test_model.py
@@ -161,7 +161,7 @@ class BaseNgramModelTests(NgramModelBaseTest):
         self.base_model = BaseNgramModel(self.counter)
 
     def test_score(self):
-        # this should return the relative frequency of the word
+        # should always return 0.5
         score1 = self.base_model.score("b", ["a"])
         score2 = self.base_model.score("c", ["a"])
         score3 = self.base_model.score("c", ["a", "d"])
@@ -174,9 +174,10 @@ class BaseNgramModelTests(NgramModelBaseTest):
         self.assertEqual(logscore, -1.0)
 
     def test_logscore_zero_score(self):
-        model = BaseNgramModel(self.counter)
-        model.score = lambda word, context: 0.0
-        logscore = model.logscore("d", ["e"])
+        patch_model = BaseNgramModel(self.counter)
+        # monkey patched the score method to always return 0, just for this test
+        patch_model.score = lambda word, context: 0.0
+        logscore = patch_model.logscore("d", ["e"])
         self.assertEqual(logscore, NEG_INF)
 
 

--- a/nltk/test/unit/test_model.py
+++ b/nltk/test/unit/test_model.py
@@ -144,15 +144,20 @@ class NgramModelVocabularyTests(unittest.TestCase):
         self.assertEqual(expected_vocab_size, len(self.vocab))
 
 
-class BaseNgramModelTests(unittest.TestCase):
-    """unit tests for BaseNgramModel class"""
+class NgramModelBaseTest(unittest.TestCase):
+    """Base test class for testing ngram model classes"""
 
     @classmethod
     def setUpClass(self):
-        self.vocab = NgramModelVocabulary(2, "abcabc")
+        self.vocab = NgramModelVocabulary(1, "abcd")
         self.counter = NgramCounter(2, self.vocab)
         self.counter.train_counts(['abcd', 'egadbe'])
-        # print(self.counter.ngrams[2])
+
+
+class BaseNgramModelTests(NgramModelBaseTest):
+    """unit tests for BaseNgramModel class"""
+
+    def setUp(self):
         self.base_model = BaseNgramModel(self.counter)
 
     def test_score(self):

--- a/nltk/test/unit/test_model.py
+++ b/nltk/test/unit/test_model.py
@@ -189,13 +189,13 @@ class MLENgramModelTest(NgramModelBaseTest):
     """unit tests for MLENgramModel class"""
 
     def setUp(self):
-        self.base_model = MLENgramModel(self.counter)
+        self.model = MLENgramModel(self.counter)
 
     def test_score(self):
         # simultaneously tests the accuracy of score and whether it can handle
         # both lists and tuples as context arguments
-        score_ctx_list = self.base_model.score("d", ["c"])
-        score_ctx_tuple = self.base_model.score("b", ("a",))
+        score_ctx_list = self.model.score("d", ["c"])
+        score_ctx_tuple = self.model.score("b", ("a",))
         self.assertEqual(score_ctx_list, 1)
         self.assertEqual(score_ctx_tuple, 0.5)
 

--- a/nltk/test/unit/test_model.py
+++ b/nltk/test/unit/test_model.py
@@ -11,7 +11,10 @@ import unittest
 
 from nltk.model import build_vocabulary, count_ngrams
 from nltk.model.counter import NgramModelVocabulary, EmptyVocabularyError, NgramCounter
-from nltk.model.ngram import BaseNgramModel, MLENgramModel, NEG_INF
+from nltk.model.ngram import (BaseNgramModel,
+                              MLENgramModel,
+                              LidstoneNgramModel,
+                              NEG_INF)
 
 
 class NgramCounterTests(unittest.TestCase):
@@ -194,6 +197,22 @@ class MLENgramModelTest(NgramModelBaseTest):
         score_ctx_tuple = self.base_model.score("b", ("a",))
         self.assertEqual(score_ctx_list, 1)
         self.assertEqual(score_ctx_tuple, 0.5)
+
+
+class LidstoneNgramModelTest(NgramModelBaseTest):
+    """unit test for LidstoneNgramModel class"""
+
+    def setUp(self):
+        self.model = LidstoneNgramModel(0.1, self.counter)
+
+    def test_gamma(self):
+        self.assertEqual(0.1, self.model.gamma)
+        self.assertEqual(0.5, self.model.gamma_norm)
+
+    def test_score(self):
+        expected_score = 0.7333
+        got_score = self.model.score("d", ["c"])
+        self.assertAlmostEqual(expected_score, got_score, places=4)
 
 
 class ModelFuncsTests(unittest.TestCase):

--- a/nltk/test/unit/test_model.py
+++ b/nltk/test/unit/test_model.py
@@ -14,6 +14,7 @@ from nltk.model.counter import NgramModelVocabulary, EmptyVocabularyError, Ngram
 from nltk.model.ngram import (BaseNgramModel,
                               MLENgramModel,
                               LidstoneNgramModel,
+                              LaplaceNgramModel,
                               NEG_INF)
 
 
@@ -211,6 +212,24 @@ class LidstoneNgramModelTest(NgramModelBaseTest):
 
     def test_score(self):
         expected_score = 0.7333
+        got_score = self.model.score("d", ["c"])
+        self.assertAlmostEqual(expected_score, got_score, places=4)
+
+
+class LaplaceNgramModelTest(NgramModelBaseTest):
+    """unit tests for LaplaceNgramModel class"""
+
+    def setUp(self):
+        self.model = LaplaceNgramModel(self.counter)
+
+    def test_gamma(self):
+        # Make sure the gamma is set to 1
+        self.assertEqual(1, self.model.gamma)
+        self.assertEqual(5, self.model.gamma_norm)
+
+    def test_score(self):
+        # basic sanit-check
+        expected_score = 0.3333
         got_score = self.model.score("d", ["c"])
         self.assertAlmostEqual(expected_score, got_score, places=4)
 


### PR DESCRIPTION
I've gotten some feedback from folks trying out the `model` branch and they all say it would be nice to have at least some basic ngram model classes already present in the module. I've gotten around to adding a class for MLE estimation as well as Lidstone (and as a consequence Laplace).
I really hope someone finds the time to handle the more "interesting" stuff like SGT and Kneser-Ney.
