### PR TITLE
Patch rte

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -39,6 +39,7 @@
 - David Coles
 - Lucas Cooper
 - Robin Cooper
+- Claude Coulombe
 - Chris Crowner
 - James Curran
 - Arthur Darcet

--- a/nltk/classify/rte_classify.py
+++ b/nltk/classify/rte_classify.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 
 import nltk
 from nltk.classify.util import accuracy
+from nltk import word_tokenize
 
 def ne(token):
     """
@@ -58,14 +59,11 @@ class RTEFeatureExtractor(object):
 
         self.negwords = set(['no', 'not', 'never', 'failed', 'rejected',
                              'denied'])
-        # Try to tokenize so that abbreviations like U.S.and monetary amounts
-        # like "$23.00" are kept as tokens.
-        from nltk.tokenize import RegexpTokenizer
-        tokenizer = RegexpTokenizer('([A-Z]\.)+|\w+|\$[\d\.]+')
-
-        #Get the set of word types for text and hypothesis
-        self.text_tokens = tokenizer.tokenize(rtepair.text)
-        self.hyp_tokens = tokenizer.tokenize(rtepair.hyp)
+        # Try to tokenize so that abbreviations like U.S. and number like "23.00" 
+        # are kept as tokens (but '$23.00' will be on two tokens '$' and '23.00')
+        # Get the set of word types for text and hypothesis
+        self.text_tokens = word_tokenize(rtepair.text)
+        self.hyp_tokens = word_tokenize(rtepair.hyp)
         self.text_words = set(self.text_tokens)
         self.hyp_words = set(self.hyp_tokens)
 


### PR DESCRIPTION
I've found a small problem with the nltk.RTEFeatureExtractor, Chapter 6, example 2.2, on Recognizing Textual Entailment : RTE

RTEFeatureExtractor is not working with the actual tokenizer, created from RegexpTokenizer.

In fact if we use the same RegexpTokenizer with the exact text from the extractor, it will produce only empty strings. The goal as commented was probably to keep 'U.S.' and '$23.00' in one token. 

The proposed solution is to replace the tokenizer by nltk.word_tokenize. It preserves 'U.S.' (i.e. included dot) in one token but '$23.00' will be split in two tokes '$' and '23.00'
I could eventually patch the code to keep '$23.00' in one token, but why not euro € or english pounds £ ou yuan? It's very application dependent.

In fact, the «deeper» problem seems to be with RegexpTokenizer since the proposed regular expression '([A-Z].)+|\w+|\$[\d.]+' looks fine. I need to take a look in that code but in the meantime, the proposed patch should work pretty well.
