### PR TITLE
Change treebank tokenizer to handle chevron quote brackets.

### DIFF
--- a/nltk/test/tokenize.doctest
+++ b/nltk/test/tokenize.doctest
@@ -39,6 +39,9 @@ Some test strings.
     >>> s10 = "There were 300,000, but that wasn't enough."
     >>> word_tokenize(s10)
     ['There', 'were', '300,000', ',', 'but', 'that', 'was', "n't", 'enough', '.']
+    >>> s11 = "«Now that I can do.»"
+    >>> word_tokenize(s11)
+    ['«', 'Now', 'that', 'I', 'can', 'do', '.', '»']
 
 Sentence tokenization in word_tokenize:
 

--- a/nltk/tokenize/treebank.py
+++ b/nltk/tokenize/treebank.py
@@ -49,6 +49,7 @@ class TreebankWordTokenizer(TokenizerI):
     STARTING_QUOTES = [
         (re.compile(r'^\"'), r'``'),
         (re.compile(r'(``)'), r' \1 '),
+        (re.compile(r'(«)'), r' \1 '),
         (re.compile(r'([ (\[{<])"'), r'\1 `` '),
     ]
 
@@ -58,7 +59,7 @@ class TreebankWordTokenizer(TokenizerI):
         (re.compile(r'([:,])$'), r' \1 '),
         (re.compile(r'\.\.\.'), r' ... '),
         (re.compile(r'[;@#$%&]'), r' \g<0> '),
-        (re.compile(r'([^\.])(\.)([\]\)}>"\']*)\s*$'), r'\1 \2\3 '),
+        (re.compile(r'([^\.])(\.)([\]\)}>"\'»]*)\s*$'), r'\1 \2\3 '),
         (re.compile(r'[?!]'), r' \g<0> '),
 
         (re.compile(r"([^'])' "), r"\1 ' "),
@@ -73,6 +74,7 @@ class TreebankWordTokenizer(TokenizerI):
     #ending quotes
     ENDING_QUOTES = [
         (re.compile(r'"'), " '' "),
+        (re.compile(r'(»)'), r' \1 '),
         (re.compile(r'(\S)(\'\')'), r'\1 \2 '),
 
         (re.compile(r"([^' ])('[sS]|'[mM]|'[dD]|') "), r"\1 \2 "),
@@ -96,7 +98,7 @@ class TreebankWordTokenizer(TokenizerI):
     def tokenize(self, text):
         for regexp, substitution in self.STARTING_QUOTES:
             text = regexp.sub(substitution, text)
-
+            
         for regexp, substitution in self.PUNCTUATION:
             text = regexp.sub(substitution, text)
 


### PR DESCRIPTION
Chevron brackets such as the Guillemet in French weren't being
tokenized.  Tokenizer regexs were changed to recognize the brackets.

See: #1434

However, it seems that the brackets point outward according to other examples,
so I changed the regexs with that in mind, i.e. «text», not »text«
