### PR TITLE
Update stanford_segmenter.py

### DIFF
--- a/nltk/tokenize/stanford_segmenter.py
+++ b/nltk/tokenize/stanford_segmenter.py
@@ -60,7 +60,8 @@ class StanfordSegmenter(TokenizerI):
                 verbose=verbose)
 
         # This is passed to java as the -cp option, the segmenter needs slf4j.
-        self._stanford_jar = ':'.join(
+        sep = ';' if os.name == 'nt' else ':'
+        self._stanford_jar = sep.join(
             [_ for _ in [stanford_segmenter, slf4j] if not _ is None])
 
         self._sihan_corpora_dict = path_to_sihan_corpora_dict


### PR DESCRIPTION
Fixed a separator for the classpath. On Windows, a semi-colon must be used instead of the colon. Otherwise, calling the java process results in _**Could not find or load main class 'edu.stanford.nlp.ie.crf.CRFClassifier'**_.
