### PR TITLE
Deal gracefully with degenerate cases.

### DIFF
--- a/nltk/metrics/agreement.py
+++ b/nltk/metrics/agreement.py
@@ -311,6 +311,10 @@ class AnnotationTask(object):
         """Krippendorff 1980
 
         """
+        # check for degenerate cases
+        if len(self.K) == 1:
+            return 1
+        
         De = 0.0
 
         label_freqs = FreqDist(x['labels'] for x in self.data)


### PR DESCRIPTION
This edit deals with a degenerate case in Krippendorff's alpha - if there is only one class.

current behaviour throws a ZeroDivisionError, this edit changes that to return complete agreement (since there is only one class)

Happy to discuss alternative behaviours...

How should we deal with no data (ie: len(self.K)==0)? Currently it'll raise a zero division error also, which isn't too informative...
