### PR TITLE
A fix for git issue 1458:

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -202,3 +202,4 @@
 - George Berry
 - Adam Nelson
 - J Richard Snape
+- Roei Bahumi

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -269,6 +269,9 @@ def modified_precision(references, hypothesis, n):
     # Extracts all ngrams in hypothesis.
     counts = Counter(ngrams(hypothesis, n))
 
+    if not counts:
+        return 0
+
     # Extract a union of references' counts.
     ## max_counts = reduce(or_, [Counter(ngrams(ref, n)) for ref in references])
     max_counts = {}


### PR DESCRIPTION
blue_score:: modified_precision() zero division exception

Added a check for empty counter in modified_precision()

[This is a fix for issue 1458.](https://github.com/nltk/nltk/issues/1458)
