### PR TITLE
Language Model Improvements: Negative Infinity, Unit Test Names

### DIFF
--- a/nltk/model/counter.py
+++ b/nltk/model/counter.py
@@ -100,14 +100,25 @@ class NgramCounter(object):
         }
         # While allowing whatever the user passes to override them
         self.ngrams_kwargs.update(ngrams_kwargs)
+        # Set up the vocabulary
+        self._set_up_vocabulary(vocabulary, unk_cutoff)
 
+        self.ngrams = defaultdict(ConditionalFreqDist)
+        self.unigrams = FreqDist()
+
+    def _set_up_vocabulary(self, vocabulary, unk_cutoff):
         self.vocabulary = copy(vocabulary)  # copy needed to prevent state sharing
         if unk_cutoff is not None:
             # If cutoff value is provided, override vocab's cutoff
             self.vocabulary.cutoff = unk_cutoff
 
-        self.ngrams = defaultdict(ConditionalFreqDist)
-        self.unigrams = FreqDist()
+        if self.ngrams_kwargs['pad_left']:
+            lpad_sym = self.ngrams_kwargs.get("left_pad_symbol")
+            self.vocabulary[lpad_sym] = self.vocabulary.cutoff
+
+        if self.ngrams_kwargs['pad_right']:
+            rpad_sym = self.ngrams_kwargs.get("right_pad_symbol")
+            self.vocabulary[rpad_sym] = self.vocabulary.cutoff
 
     def _enumerate_ngram_orders(self):
         return enumerate(range(self.order, 1, -1))

--- a/nltk/model/ngram.py
+++ b/nltk/model/ngram.py
@@ -11,7 +11,7 @@ from math import log
 from nltk import compat
 
 
-NEG_INF = -1e6
+NEG_INF = float("-inf")
 
 
 @compat.python_2_unicode_compatible

--- a/nltk/model/ngram.py
+++ b/nltk/model/ngram.py
@@ -76,7 +76,7 @@ class BaseNgramModel(object):
             context, word = tuple(ngram[:-1]), ngram[-1]
             H += self.logscore(word, context)
             processed_ngrams += 1
-        return H / processed_ngrams
+        return - (H / processed_ngrams)
 
     def perplexity(self, text):
         """

--- a/nltk/test/model.doctest
+++ b/nltk/test/model.doctest
@@ -324,6 +324,6 @@ Here are examples of these methods:
     >>> base_model.logscore("abc", ("test",))
     -1.0
     >>> base_model.entropy(sents[4])
-    -1.0
+    1.0
     >>> base_model.perplexity(sents[4])
-    0.5
+    2.0

--- a/nltk/test/unit/test_model.py
+++ b/nltk/test/unit/test_model.py
@@ -228,12 +228,18 @@ class LidstoneNgramModelTests(NgramModelBaseTest):
     def setUp(self):
         self.model = LidstoneNgramModel(0.1, self.counter)
 
-    def test_gamma(self):
+    def test_gamma_and_gamma_norm(self):
         self.assertEqual(0.1, self.model.gamma)
-        self.assertEqual(0.5, self.model.gamma_norm)
+        # There are 7 items in the vocabulary, so we expect gamma norm to be 0.7
+        # Due to floating point funkyness in Python, we use float assertion here
+        self.assertAlmostEqual(0.7, self.model.gamma_norm)
 
     def test_score(self):
-        expected_score = 0.7333
+        # count(d | c) = 1
+        # *count(d | c) = 1.1
+        # Count(w | c for w in vocab) = 1
+        # *Count(w | c for w in vocab) = 1.7
+        expected_score = 0.6471
         got_score = self.model.score("d", ["c"])
         self.assertAlmostEqual(expected_score, got_score, places=4)
 
@@ -265,11 +271,16 @@ class LaplaceNgramModelTests(NgramModelBaseTest):
     def test_gamma(self):
         # Make sure the gamma is set to 1
         self.assertEqual(1, self.model.gamma)
-        self.assertEqual(5, self.model.gamma_norm)
+        # Laplace Gamma norm is just the vocabulary size
+        self.assertEqual(7, self.model.gamma_norm)
 
     def test_score(self):
-        # basic sanit-check
-        expected_score = 0.3333
+        # basic sanity-check:
+        # count(d | c) = 1
+        # *count(d | c) = 2
+        # Count(w | c for w in vocab) = 1
+        # *Count(w | c for w in vocab) = 8
+        expected_score = 0.25
         got_score = self.model.score("d", ["c"])
         self.assertAlmostEqual(expected_score, got_score, places=4)
 

--- a/nltk/test/unit/test_model.py
+++ b/nltk/test/unit/test_model.py
@@ -185,7 +185,7 @@ class BaseNgramModelTests(NgramModelBaseTest):
         self.assertEqual(logscore, NEG_INF)
 
 
-class MLENgramModelTest(NgramModelBaseTest):
+class MLENgramModelTests(NgramModelBaseTest):
     """unit tests for MLENgramModel class"""
 
     def setUp(self):
@@ -200,8 +200,8 @@ class MLENgramModelTest(NgramModelBaseTest):
         self.assertEqual(score_ctx_tuple, 0.5)
 
 
-class LidstoneNgramModelTest(NgramModelBaseTest):
-    """unit test for LidstoneNgramModel class"""
+class LidstoneNgramModelTests(NgramModelBaseTest):
+    """unit tests for LidstoneNgramModel class"""
 
     def setUp(self):
         self.model = LidstoneNgramModel(0.1, self.counter)
@@ -216,7 +216,7 @@ class LidstoneNgramModelTest(NgramModelBaseTest):
         self.assertAlmostEqual(expected_score, got_score, places=4)
 
 
-class LaplaceNgramModelTest(NgramModelBaseTest):
+class LaplaceNgramModelTests(NgramModelBaseTest):
     """unit tests for LaplaceNgramModel class"""
 
     def setUp(self):


### PR DESCRIPTION
The most significant change here is that `NEG_INF` which previously was set to an arbitrary "small" number is now using Python's `float("-inf")`. I tried to add some thorough tests for the effect this would have on the different models, including unit tests of entropy/perplexity calculations, please let me know what you think.

Oh and while I was at it, I did some house-keeping in the unit tests :)
