### PR TITLE
Model: Important Tests and Fixes

### DIFF
--- a/nltk/model/counter.py
+++ b/nltk/model/counter.py
@@ -132,8 +132,15 @@ class NgramCounter(object):
 
         for sent in training_text:
             checked_sent = (self.check_against_vocab(word) for word in sent)
+            sent_start = True
             for ngram in self.to_ngrams(checked_sent):
                 context, word = tuple(ngram[:-1]), ngram[-1]
+
+                if sent_start:
+                    for context_word in context:
+                        self.unigrams[context_word] += 1
+                    sent_start = False
+
                 for trunc_index, ngram_order in self._enumerate_ngram_orders():
                     trunc_context = context[trunc_index:]
                     # note that above line doesn't affect context on first iteration

--- a/nltk/model/ngram.py
+++ b/nltk/model/ngram.py
@@ -28,7 +28,7 @@ class BaseNgramModel(object):
         # for convenient access save top-most ngram order ConditionalFreqDist
         self.ngrams = ngram_counter.ngrams[ngram_counter.order]
 
-        self._normalize = self.ngram_counter.check_against_vocab
+        self._check_against_vocab = self.ngram_counter.check_against_vocab
 
     def score(self, word, context):
         """
@@ -69,7 +69,7 @@ class BaseNgramModel(object):
         :type text: Iterable[str]
         """
 
-        normed_text = (self._normalize(word) for word in text)
+        normed_text = (self._check_against_vocab(word) for word in text)
         H = 0.0     # entropy is conventionally denoted by "H"
         processed_ngrams = 0
         for ngram in self.ngram_counter.to_ngrams(normed_text):

--- a/nltk/test/model.doctest
+++ b/nltk/test/model.doctest
@@ -127,9 +127,10 @@ preceding contexts. They are namely stored as a simple FreqDist in the `unigrams
 attribute.
 
     >>> print(bigram_counts.unigrams)
-    <FreqDist with 9 samples and 117 outcomes>
+    <FreqDist with 10 samples and 121 outcomes>
     >>> expected_unigram_counts = {'.': 4,
     ... '</s>': 4,
+    ... '<s>': 4,
     ... '<UNK>': 80,
     ... 'and': 5,
     ... 'he': 6,
@@ -239,6 +240,7 @@ to populate your counter instance with some numbers.
     >>> no_initial_texts.train_counts(sents[3:7])
     >>> expected_unigram_counts = {'.': 4,
     ... '</s>': 4,
+    ... '<s>': 4,
     ... '<UNK>': 80,
     ... 'and': 5,
     ... 'he': 6,

--- a/nltk/test/unit/test_model.py
+++ b/nltk/test/unit/test_model.py
@@ -40,6 +40,17 @@ class NgramCounterTests(unittest.TestCase):
         expected_error_msg = "Order of NgramCounter cannot be less than 1. Got: 0"
         self.assertEqual(str(exc_info.exception), expected_error_msg)
 
+    def test_NgramCounter_breaks_given_empty_vocab(self):
+        empty_vocab = NgramModelVocabulary(2, "abc")
+        empty_counter = NgramCounter(2, empty_vocab, pad_left=False, pad_right=False)
+
+        with self.assertRaises(EmptyVocabularyError) as exc_info:
+            empty_counter.train_counts(['ad', 'hominem'])
+
+        self.assertEqual(("Cannot start counting ngrams until "
+                          "vocabulary contains more than one item."),
+                         str(exc_info.exception))
+
     def test_check_against_vocab(self):
         unk_label = "<UNK>"
 

--- a/nltk/test/unit/test_model.py
+++ b/nltk/test/unit/test_model.py
@@ -281,8 +281,12 @@ class LidstoneNgramModelTests(NgramModelBaseTest):
         # Count(w | c for w in vocab) = 1
         # *Count(w | c for w in vocab) = 1.7
         expected_score = 0.6471
-        got_score = self.model.score("d", ["c"])
-        self.assertAlmostEqual(expected_score, got_score, places=4)
+
+        got_score_list = self.model.score("d", ["c"])
+        got_score_tuple = self.model.score("d", ("c",))
+
+        self.assertAlmostEqual(expected_score, got_score_list, places=4)
+        self.assertEqual(got_score_list, got_score_tuple)
 
     def test_scores_sum_to_1(self):
         # Lidstone smoothing can handle contexts unseen during training
@@ -329,8 +333,12 @@ class LaplaceNgramModelTests(NgramModelBaseTest):
         # Count(w | c for w in vocab) = 1
         # *Count(w | c for w in vocab) = 8
         expected_score = 0.25
-        got_score = self.model.score("d", ["c"])
-        self.assertAlmostEqual(expected_score, got_score, places=4)
+
+        got_score_list = self.model.score("d", ["c"])
+        got_score_tuple = self.model.score("d", ("c",))
+
+        self.assertAlmostEqual(expected_score, got_score_list, places=4)
+        self.assertEqual(got_score_list, got_score_tuple)
 
     def test_entropy_perplexity(self):
         # Unlike MLE this should be able to handle completely novel ngrams


### PR DESCRIPTION
We finally have unit tests that make sure our scores/probabilities sum to 1 for a given ngram context. This was a pesky issue with the old implementation, so I'm very happy to say we now have proof this issue has been addressed. Moreover, the tests should warn us if we ever regress on this front :)

While working on this I noticed that I wasn't testing the edge case where an `NgramCounter` is initialized with an empty `NgramVocabulary`, so I fixed that.

I also noticed that when counting ngrams we were not including unigram counts of items in the context of the first ngram of a sentence.
## Update:

In addition to one minor housekeeping change, I've introduced logic that checks some properties of the `context` argument of a model's `score` method. I'd really like feedback on that!
