### PR TITLE
Fix more nltk.six imports

### DIFF
--- a/nltk/tokenize/moses.py
+++ b/nltk/tokenize/moses.py
@@ -10,7 +10,7 @@
 
 from __future__ import print_function
 import re
-from six import text_type
+from nltk.six import text_type
 
 from nltk.tokenize.api import TokenizerI
 from nltk.tokenize.util import is_cjk

--- a/nltk/tokenize/repp.py
+++ b/nltk/tokenize/repp.py
@@ -9,7 +9,7 @@
 # For license information, see LICENSE.TXT
 
 from __future__ import unicode_literals, print_function
-from six import text_type
+from nltk.six import text_type
 
 import os
 import re

--- a/nltk/tokenize/toktok.py
+++ b/nltk/tokenize/toktok.py
@@ -22,7 +22,7 @@ Model (Doctoral dissertation). Columbus, OH, USA: The Ohio State University.
 """
 
 import re
-from six import text_type
+from nltk.six import text_type
 
 from nltk.tokenize.api import TokenizerI
 


### PR DESCRIPTION
I get ImportErrors when trying to run tox otherwise; as far as I can tell, this case is the same as eebeab6?
