### PR TITLE
Fix undefined variable bugs

### DIFF
--- a/nltk/collections.py
+++ b/nltk/collections.py
@@ -584,11 +584,11 @@ class LazyIteratorList(AbstractLazySequence):
 
     def __add__(self, other):
         """Return a list concatenating self with other."""
-        return type(self)(itertools.chain(self, other))
+        return type(self)(chain(self, other))
 
     def __radd__(self, other):
         """Return a list concatenating other with self."""
-        return type(self)(itertools.chain(other, self))
+        return type(self)(chain(other, self))
 
 ######################################################################
 # Trie Implementation

--- a/nltk/compat.py
+++ b/nltk/compat.py
@@ -241,13 +241,13 @@ else:
                 self._closed = True
                 if _warn:
                     self._warn("Implicitly cleaning up {!r}".format(self),
-                               ResourceWarning)
+                               Warning)
 
         def __exit__(self, exc, value, tb):
             self.cleanup()
 
         def __del__(self):
-            # Issue a ResourceWarning if implicit cleanup needed
+            # Issue a Warning if implicit cleanup needed
             self.cleanup(_warn=True)
 
         # XXX (ncoghlan): The following code attempts to make

--- a/nltk/corpus/reader/crubadan.py
+++ b/nltk/corpus/reader/crubadan.py
@@ -93,7 +93,7 @@ class CrubadanCorpusReader(CorpusReader):
         ngram_file = path.join(self.root, crubadan_code + '-3grams.txt')
 
         if not path.isfile(ngram_file):
-            raise Runtime("No N-gram file found for requested language.")
+            raise RuntimeError("No N-gram file found for requested language.")
 
         counts = FreqDist()
         if PY3:

--- a/nltk/draw/table.py
+++ b/nltk/draw/table.py
@@ -808,7 +808,7 @@ class Table(object):
         """
         Delete the ``row_index``th row from this table.
         """
-        if isinstance(index, slice):
+        if isinstance(row_index, slice):
             raise ValueError('Slicing not supported')
         if isinstance(row_index, tuple) and len(row_index)==2:
             raise ValueError('Cannot delete a single cell!')

--- a/nltk/tokenize/moses.py
+++ b/nltk/tokenize/moses.py
@@ -567,7 +567,7 @@ class MosesDetokenizer(TokenizerI):
                     quote_count[normalized_quo] += 1
             
             elif (self.lang == 'fi' and re.match(r':$', tokens[i-1])
-                  and re.match(FINNISH_REGEX, token)):
+                  and re.match(self.FINNISH_REGEX, token)):
                 # Finnish : without intervening space if followed by case suffix
                 # EU:N EU:n EU:ssa EU:sta EU:hun EU:iin ...
                 detokenized_text += prepend_space + token


### PR DESCRIPTION
This pull request identifies and fixes some undefined variable bugs.

It also (as a side effect) makes trailing whitespace in these files pep8 compliant, mostly because my editor does that automatically. If you prefer I can remove all the whitespace changes and just leave the variable changes.
