### PR TITLE
modified pos_tag and pos_tag_sents for russian pos-tagging

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -202,6 +202,7 @@
 - George Berry
 - Adam Nelson
 - J Richard Snape
+- Tsolak Ghukasyan
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 ### Contributors to the Porter Stemmer

--- a/nltk/tag/__init__.py
+++ b/nltk/tag/__init__.py
@@ -76,7 +76,22 @@ from nltk.tag.mapping       import tagset_mapping, map_tag
 from nltk.tag.crf           import CRFTagger
 from nltk.tag.perceptron    import PerceptronTagger
 
-from nltk.data import load
+from nltk.data import load, find
+
+RUS_PICKLE = 'taggers/averaged_perceptron_tagger_ru/averaged_perceptron_tagger_ru.pickle'
+
+
+def _get_tagger(language=None):
+    if language == 'russian':
+        tagger = PerceptronTagger(False)
+        ap_russian_model_loc = 'file:' + str(find(RUS_PICKLE))
+        tagger.load(ap_russian_model_loc)
+    elif language == 'english':
+        tagger = PerceptronTagger()
+    else:
+        tagger = PerceptronTagger()
+    return tagger
+
 
 def _pos_tag(tokens, tagset, tagger):
     tagged_tokens = tagger.tag(tokens)
@@ -84,7 +99,8 @@ def _pos_tag(tokens, tagset, tagger):
         tagged_tokens = [(token, map_tag('en-ptb', tagset, tag)) for (token, tag) in tagged_tokens]
     return tagged_tokens
 
-def pos_tag(tokens, tagset=None):
+
+def pos_tag(tokens, tagset=None, language='english'):
     """
     Use NLTK's currently recommended part of speech tagger to
     tag the given list of tokens.
@@ -107,11 +123,11 @@ def pos_tag(tokens, tagset=None):
     :return: The tagged tokens
     :rtype: list(tuple(str, str))
     """
-    tagger = PerceptronTagger()
+    tagger = _get_tagger(language)
     return _pos_tag(tokens, tagset, tagger)    
 
 
-def pos_tag_sents(sentences, tagset=None):
+def pos_tag_sents(sentences, tagset=None, language='english'):
     """
     Use NLTK's currently recommended part of speech tagger to tag the
     given list of sentences, each consisting of a list of tokens.
@@ -123,5 +139,5 @@ def pos_tag_sents(sentences, tagset=None):
     :return: The list of tagged sentences
     :rtype: list(list(tuple(str, str)))
     """
-    tagger = PerceptronTagger()
+    tagger = _get_tagger(language)
     return [_pos_tag(sent, tagset, tagger) for sent in sentences]

--- a/nltk/tag/__init__.py
+++ b/nltk/tag/__init__.py
@@ -120,6 +120,8 @@ def pos_tag(tokens, tagset=None, lang='eng'):
     :type tokens: list(str)
     :param tagset: the tagset to be used, e.g. universal, wsj, brown
     :type tagset: str
+    :param lang: the ISO 639 code of the language, e.g. 'eng' for English, 'rus' for Russian
+    :type lang: str
     :return: The tagged tokens
     :rtype: list(tuple(str, str))
     """
@@ -136,6 +138,8 @@ def pos_tag_sents(sentences, tagset=None, lang='eng'):
     :type tokens: list(list(str))
     :param tagset: the tagset to be used, e.g. universal, wsj, brown
     :type tagset: str
+    :param lang: the ISO 639 code of the language, e.g. 'eng' for English, 'rus' for Russian
+    :type lang: str
     :return: The list of tagged sentences
     :rtype: list(list(tuple(str, str)))
     """

--- a/nltk/tag/__init__.py
+++ b/nltk/tag/__init__.py
@@ -81,12 +81,12 @@ from nltk.data import load, find
 RUS_PICKLE = 'taggers/averaged_perceptron_tagger_ru/averaged_perceptron_tagger_ru.pickle'
 
 
-def _get_tagger(language=None):
-    if language == 'russian':
+def _get_tagger(lang=None):
+    if lang == 'rus':
         tagger = PerceptronTagger(False)
         ap_russian_model_loc = 'file:' + str(find(RUS_PICKLE))
         tagger.load(ap_russian_model_loc)
-    elif language == 'english':
+    elif lang == 'eng':
         tagger = PerceptronTagger()
     else:
         tagger = PerceptronTagger()
@@ -100,7 +100,7 @@ def _pos_tag(tokens, tagset, tagger):
     return tagged_tokens
 
 
-def pos_tag(tokens, tagset=None, language='english'):
+def pos_tag(tokens, tagset=None, lang='eng'):
     """
     Use NLTK's currently recommended part of speech tagger to
     tag the given list of tokens.
@@ -123,11 +123,11 @@ def pos_tag(tokens, tagset=None, language='english'):
     :return: The tagged tokens
     :rtype: list(tuple(str, str))
     """
-    tagger = _get_tagger(language)
+    tagger = _get_tagger(lang)
     return _pos_tag(tokens, tagset, tagger)    
 
 
-def pos_tag_sents(sentences, tagset=None, language='english'):
+def pos_tag_sents(sentences, tagset=None, lang='eng'):
     """
     Use NLTK's currently recommended part of speech tagger to tag the
     given list of sentences, each consisting of a list of tokens.
@@ -139,5 +139,5 @@ def pos_tag_sents(sentences, tagset=None, language='english'):
     :return: The list of tagged sentences
     :rtype: list(list(tuple(str, str)))
     """
-    tagger = _get_tagger(language)
+    tagger = _get_tagger(lang)
     return [_pos_tag(sent, tagset, tagger) for sent in sentences]

--- a/nltk/tag/perceptron.py
+++ b/nltk/tag/perceptron.py
@@ -197,7 +197,7 @@ class PerceptronTagger(TaggerI):
         # Pickle as a binary file
         if save_loc is not None:
             with open(save_loc, 'wb') as fout:
-                pickle.dump((self.model.weights, self.tagdict, self.classes), fout, -1)
+                pickle.dump((self.model.weights, self.tagdict, self.classes), fout, 2)
         
 
     def load(self, loc):

--- a/nltk/tag/perceptron.py
+++ b/nltk/tag/perceptron.py
@@ -197,6 +197,7 @@ class PerceptronTagger(TaggerI):
         # Pickle as a binary file
         if save_loc is not None:
             with open(save_loc, 'wb') as fout:
+                # changed protocol from -1 to 2 to make pickling Python 2 compatible
                 pickle.dump((self.model.weights, self.tagdict, self.classes), fout, 2)
         
 


### PR DESCRIPTION
I have modified pos_tag and pos_tag_sents methods from tag module so that they work not only for English texts but also for Russian. An additional parameter 'language' was added. The parameter's default value is 'english', thus the methods behave the same way as before when 'language' is not specified. For Russian pos-tagging, the parameter needs to be set to 'russian'.

I trained an averaged perceptron model for part-of-speech tagging of Russian texts. For training I used Russian National Corpus (consists of 94240 tagged sentences with over 1 million tagged tokens): http://ruscorpora.ru/en/index.html
Methods of PerceptronTagger class from tag module were used for training and storing the model file.

The average accuracy of the model is 99% (measured by 10-fold cross-validation).
