### PR TITLE
Fix tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,6 @@ nltk/test/tweets*
 nosetests.xml
 nosetests_scrubbed.xml
 pylintoutput
-temp.acreager.model
-temp.arcstd.model
 model.crf.tagger
 coverage.xml
 brown.embedding

--- a/nltk/classify/senna.py
+++ b/nltk/classify/senna.py
@@ -22,17 +22,19 @@ system specific binary should be rebuilt. Otherwise this could introduce
 misalignment errors.
 
 The input is:
-- path to the directory that contains SENNA executables. If the path is incorrect, 
+- path to the directory that contains SENNA executables. If the path is incorrect,
    Senna will automatically search for executable file specified in SENNA environment variable
 - List of the operations needed to be performed.
 - (optionally) the encoding of the input data (default:utf-8)
+
+Note: Unit tests for this module can be found in test/unit/test_senna.py
 
     >>> from __future__ import unicode_literals
     >>> from nltk.classify import Senna
     >>> pipeline = Senna('/usr/share/senna-v3.0', ['pos', 'chk', 'ner'])
     >>> sent = 'Dusseldorf is an international business center'.split()
-    >>> [(token['word'], token['chk'], token['ner'], token['pos']) for token in pipeline.tag(sent)]
-    [('Dusseldorf', 'B-NP', 'B-LOC', 'NNP'), ('is', 'B-VP', 'O', 'VBZ'), ('an', 'B-NP', 'O', 'DT'), 
+    >>> [(token['word'], token['chk'], token['ner'], token['pos']) for token in pipeline.tag(sent)] # doctest: +SKIP
+    [('Dusseldorf', 'B-NP', 'B-LOC', 'NNP'), ('is', 'B-VP', 'O', 'VBZ'), ('an', 'B-NP', 'O', 'DT'),
     ('international', 'I-NP', 'O', 'JJ'), ('business', 'I-NP', 'O', 'NN'), ('center', 'I-NP', 'O', 'NN')]
 """
 
@@ -55,29 +57,29 @@ class Senna(TaggerI):
 
     def __init__(self, senna_path, operations, encoding='utf-8'):
         self._encoding = encoding
-        self._path = path.normpath(senna_path) + sep 
-        
-        # Verifies the existence of the executable on the self._path first    
+        self._path = path.normpath(senna_path) + sep
+
+        # Verifies the existence of the executable on the self._path first
         #senna_binary_file_1 = self.executable(self._path)
         exe_file_1 = self.executable(self._path)
         if not path.isfile(exe_file_1):
-            # Check for the system environment 
+            # Check for the system environment
             if 'SENNA' in environ:
-                #self._path = path.join(environ['SENNA'],'')  
-                self._path = path.normpath(environ['SENNA']) + sep 
+                #self._path = path.join(environ['SENNA'],'')
+                self._path = path.normpath(environ['SENNA']) + sep
                 exe_file_2 = self.executable(self._path)
                 if not path.isfile(exe_file_2):
                     raise OSError("Senna executable expected at %s or %s but not found" % (exe_file_1,exe_file_2))
-        
+
         self.operations = operations
 
-    
+
     def executable(self, base_path):
         """
         The function that determines the system specific binary that should be
         used in the pipeline. In case, the system is not known the default senna binary will
         be used.
-        """ 
+        """
         os_name = system()
         if os_name == 'Linux':
             bits = architecture()[0]
@@ -89,7 +91,7 @@ class Senna(TaggerI):
         if os_name == 'Darwin':
             return path.join(base_path, 'senna-osx')
         return path.join(base_path, 'senna')
-        
+
     def _map(self):
         """
         A method that calculates the order of the columns that SENNA pipeline
@@ -116,11 +118,11 @@ class Senna(TaggerI):
         calculated annotations/tags.
         """
         encoding = self._encoding
-        
+
         if not path.isfile(self.executable(self._path)):
             raise OSError("Senna executable expected at %s but not found" % self.executable(self._path))
-        
-         
+
+
         # Build the senna command to run the tagger
         _senna_cmd = [self.executable(self._path), '-path', self._path, '-usrtokens', '-iobtags']
         _senna_cmd.extend(['-'+op for op in self.operations])

--- a/nltk/metrics/aline.py
+++ b/nltk/metrics/aline.py
@@ -516,7 +516,10 @@ def demo():
     """
     data = [pair.split(',') for pair in cognate_data.split('\n')]
     for pair in data:
-        print(pair[0], "~", pair[1], ":", align(pair[0], pair[1])[0])
+        alignment = align(pair[0], pair[1])[0]
+        alignment = ['({}, {})'.format(a[0], a[1]) for a in alignment]
+        alignment = ' '.join(alignment)
+        print('{} ~ {} : {}'.format(pair[0], pair[1], alignment))
 
 cognate_data = """jo,ʒə
 tu,ty

--- a/nltk/metrics/aline.py
+++ b/nltk/metrics/aline.py
@@ -40,7 +40,10 @@ University of Toronto.
 
 from __future__ import unicode_literals
 
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    np = None
 
 # === Constants ===
 
@@ -380,6 +383,9 @@ def align(str1, str2, epsilon=0):
 
     (Kondrak 2002: 51)
     """
+    if np == None:
+      raise ImportError('You need numpy in order to use the align function')
+
     assert 0.0 <= epsilon <= 1.0, "Epsilon must be between 0.0 and 1.0."
     m = len(str1)
     n = len(str2)

--- a/nltk/metrics/aline.py
+++ b/nltk/metrics/aline.py
@@ -13,17 +13,17 @@ http://webdocs.cs.ualberta.ca/~kondrak/
 Copyright 2002 by Grzegorz Kondrak.
 
 ALINE is an algorithm for aligning phonetic sequences, described in [1].
-This module is a port of Kondrak's (2002) ALINE. It provides functions for 
-phonetic sequence alignment and similarity analysis. These are useful in 
+This module is a port of Kondrak's (2002) ALINE. It provides functions for
+phonetic sequence alignment and similarity analysis. These are useful in
 historical linguistics, sociolinguistics and synchronic phonology.
 
 ALINE has parameters that can be tuned for desired output. These parameters are:
 - C_skip, C_sub, C_exp, C_vwl
 - Salience weights
-- Segmental features 
+- Segmental features
 
-In this implementation, some parameters have been changed from their default 
-values as described in [1], in order to replicate published results. All changes 
+In this implementation, some parameters have been changed from their default
+values as described in [1], in order to replicate published results. All changes
 are noted in comments.
 
 Example usage
@@ -34,24 +34,24 @@ Example usage
 >>> align('θin', 'tenwis')
 [[('θ', 't'), ('i', 'e'), ('n', 'n'), ('-', 'w'), ('-', 'i'), ('-', 's')]]
 
-[1] G. Kondrak. Algorithms for Language Reconstruction. PhD dissertation, 
+[1] G. Kondrak. Algorithms for Language Reconstruction. PhD dissertation,
 University of Toronto.
 """
 import numpy as np
 
 # === Constants ===
- 
-inf = float('inf')
-    
-# Default values for maximum similarity scores (Kondrak 2002: 54) 
-C_skip = 10 # Indels
-C_sub = 35  # Substitutions
-C_exp = 45  # Expansions/compressions
-C_vwl = 5  # Vowel/consonant relative weight (decreased from 10) 
 
-consonants = ['B', 'N', 'R', 'b', 'c', 'd', 'f', 'g', 'h', 'j', 'k', 'l', 'm', 
-              'n', 'p', 'q', 'r', 's', 't', 'v', 'x', 'z', 'ç', 'ð', 'ħ', 
-              'ŋ', 'ɖ', 'ɟ', 'ɢ', 'ɣ', 'ɦ', 'ɬ', 'ɮ', 'ɰ', 'ɱ', 'ɲ', 'ɳ', 'ɴ', 
+inf = float('inf')
+
+# Default values for maximum similarity scores (Kondrak 2002: 54)
+C_skip = 10 # Indels
+C_sub  = 35  # Substitutions
+C_exp  = 45  # Expansions/compressions
+C_vwl  = 5  # Vowel/consonant relative weight (decreased from 10)
+
+consonants = ['B', 'N', 'R', 'b', 'c', 'd', 'f', 'g', 'h', 'j', 'k', 'l', 'm',
+              'n', 'p', 'q', 'r', 's', 't', 'v', 'x', 'z', 'ç', 'ð', 'ħ',
+              'ŋ', 'ɖ', 'ɟ', 'ɢ', 'ɣ', 'ɦ', 'ɬ', 'ɮ', 'ɰ', 'ɱ', 'ɲ', 'ɳ', 'ɴ',
               'ɸ', 'ɹ', 'ɻ', 'ɽ', 'ɾ', 'ʀ', 'ʁ', 'ʂ', 'ʃ', 'ʈ', 'ʋ', 'ʐ ', 'ʒ',
               'ʔ', 'ʕ', 'ʙ', 'ʝ', 'β', 'θ', 'χ', 'ʐ', 'w']
 
@@ -60,48 +60,49 @@ R_c = ['aspirated', 'lateral', 'manner', 'nasal', 'place', 'retroflex',
        'syllabic', 'voice']
 # 'high' taken out of R_v because same as manner
 R_v = ['back', 'lateral', 'long', 'manner', 'nasal', 'place',
-       'retroflex', 'round', 'syllabic', 'voice'] 
+       'retroflex', 'round', 'syllabic', 'voice']
 
 # Flattened feature matrix (Kondrak 2002: 56)
 similarity_matrix = {
-                     #place
-                     'bilabial': 1.0, 'labiodental': 0.95, 'dental': 0.9, 
-                     'alveolar': 0.85, 'retroflex': 0.8, 'palato-alveolar': 0.75,
-                     'palatal': 0.7, 'velar': 0.6, 'uvular': 0.5, 'pharyngeal': 0.3,
-                     'glottal': 0.1, 'labiovelar': 1.0, 'vowel': -1.0, # added 'vowel'
-                     #manner
-                     'stop': 1.0, 'affricate': 0.9, 'fricative': 0.85, # increased fricative from 0.8
-                     'trill': 0.7, 'tap': 0.65, 'approximant': 0.6, 'high vowel': 0.4,
-                     'mid vowel': 0.2, 'low vowel': 0.0, 'vowel2': 0.5, # added vowel
-                     #high
-                     'high': 1.0, 'mid': 0.5, 'low': 0.0,
-                     #back
-                     'front': 1.0, 'central': 0.5, 'back': 0.0,
-                     #binary features
-                     'plus': 1.0, 'minus': 0.0}
+   #place
+   'bilabial': 1.0, 'labiodental': 0.95, 'dental': 0.9,
+   'alveolar': 0.85, 'retroflex': 0.8, 'palato-alveolar': 0.75,
+   'palatal': 0.7, 'velar': 0.6, 'uvular': 0.5, 'pharyngeal': 0.3,
+   'glottal': 0.1, 'labiovelar': 1.0, 'vowel': -1.0, # added 'vowel'
+   #manner
+   'stop': 1.0, 'affricate': 0.9, 'fricative': 0.85, # increased fricative from 0.8
+   'trill': 0.7, 'tap': 0.65, 'approximant': 0.6, 'high vowel': 0.4,
+   'mid vowel': 0.2, 'low vowel': 0.0, 'vowel2': 0.5, # added vowel
+   #high
+   'high': 1.0, 'mid': 0.5, 'low': 0.0,
+   #back
+   'front': 1.0, 'central': 0.5, 'back': 0.0,
+   #binary features
+   'plus': 1.0, 'minus': 0.0
+}
 
-# Relative weights of phonetic features (Kondrak 2002: 55)          
+# Relative weights of phonetic features (Kondrak 2002: 55)
 salience = {
-            'syllabic': 5, 
-			'place': 40, 
-			'manner': 50, 
-			'voice': 5, # decreased from 10
-			'nasal': 20, # increased from 10
-			'retroflex': 10, 
-			'lateral': 10, 
-			'aspirated': 5,
-			'long': 0, # decreased from 1 
-			'high': 3, # decreased from 5
-			'back': 2, # decreased from 5
-			'round': 2 # decreased from 5
-			}
-            
-# (Kondrak 2002: 59-60)        
+   'syllabic': 5,
+   'place': 40,
+   'manner': 50,
+   'voice': 5, # decreased from 10
+   'nasal': 20, # increased from 10
+   'retroflex': 10,
+   'lateral': 10,
+   'aspirated': 5,
+   'long': 0, # decreased from 1
+   'high': 3, # decreased from 5
+   'back': 2, # decreased from 5
+   'round': 2 # decreased from 5
+}
+
+# (Kondrak 2002: 59-60)
 feature_matrix = {
 # Consonants
 'p': {'place': 'bilabial', 'manner': 'stop', 'syllabic': 'minus', 'voice': 'minus',
 'nasal': 'minus', 'retroflex': 'minus', 'lateral': 'minus', 'aspirated': 'minus'},
-                  
+
 'b': {'place': 'bilabial', 'manner': 'stop', 'syllabic': 'minus', 'voice': 'plus',
 'nasal': 'minus', 'retroflex': 'minus', 'lateral': 'minus', 'aspirated': 'minus'},
 
@@ -361,30 +362,30 @@ feature_matrix = {
 }
 
 # === Algorithm ===
- 
+
 def align(str1, str2, epsilon=0):
     """
     Compute the alignment of two phonetic strings.
-    
+
     :type str1, str2: str
     :param str1, str2: Two strings to be aligned
     :type epsilon: float (0.0 to 1.0)
     :param epsilon: Adjusts threshold similarity score for near-optimal alignments
-    
+
     :rtpye: list(list(tuple(str, str)))
-    :return: Alignment(s) of str1 and str2 
-     
+    :return: Alignment(s) of str1 and str2
+
     (Kondrak 2002: 51)
     """
     assert 0.0 <= epsilon <= 1.0, "Epsilon must be between 0.0 and 1.0."
     m = len(str1)
     n = len(str2)
     # This includes Kondrak's initialization of row 0 and column 0 to all 0s.
-    S = np.zeros((m+1, n+1), dtype=float) 
+    S = np.zeros((m+1, n+1), dtype=float)
 
     # If i <= 1 or j <= 1, don't allow expansions as it doesn't make sense,
     # and breaks array and string indices. Make sure they never get chosen
-    # by setting them to -inf. 
+    # by setting them to -inf.
     for i in range(1, m+1):
         for j in range(1, n+1):
             edit1 = S[i-1, j] + sigma_skip(str1[i-1])
@@ -397,22 +398,22 @@ def align(str1, str2, epsilon=0):
             if j > 1:
                 edit5 = S[i-1, j-2] + sigma_exp(str1[i-1], str2[j-2:j])
             else:
-                edit5 = -inf   
+                edit5 = -inf
             S[i, j] = max(edit1, edit2, edit3, edit4, edit5, 0)
 
     T = (1-epsilon)*np.amax(S) # Threshold score for near-optimal alignments
-    
+
     alignments = []
     for i in range(1, m+1):
         for j in range(1, n+1):
             if S[i,j] >= T:
                 alignments.append(_retrieve(i, j, 0, S, T, str1, str2, []))
     return alignments
-                                   
+
 def _retrieve(i, j, s, S, T, str1, str2, out):
     """
     Retrieve the path through the similarity matrix S starting at (i, j).
-    
+
     :rtype: list(tuple(str, str))
     :return: Alignment of str1 and str2
     """
@@ -421,7 +422,7 @@ def _retrieve(i, j, s, S, T, str1, str2, out):
     else:
         if j > 1 and S[i-1, j-2] + sigma_exp(str1[i-1], str2[j-2:j]) + s >= T:
             out.insert(0, (str1[i-1], str2[j-2:j]))
-            _retrieve(i-1, j-2, s+sigma_exp(str1[i-1], str2[j-2:j]), S, T, str1, str2, out) 
+            _retrieve(i-1, j-2, s+sigma_exp(str1[i-1], str2[j-2:j]), S, T, str1, str2, out)
         elif i > 1 and S[i-2, j-1] + sigma_exp(str2[j-1], str1[i-2:i]) + s >= T:
             out.insert(0, (str1[i-2:i], str2[j-1]))
             _retrieve(i-2, j-1, s+sigma_exp(str2[j-1], str1[i-2:i]), S, T, str1, str2, out)
@@ -435,37 +436,37 @@ def _retrieve(i, j, s, S, T, str1, str2, out):
             out.insert(0, (str1[i-1], str2[j-1]))
             _retrieve(i-1, j-1, s+sigma_sub(str1[i-1], str2[j-1]), S, T, str1, str2, out)
     return out
-       
+
 def sigma_skip(p):
     """
-    Returns score of an indel of P. 
-    
+    Returns score of an indel of P.
+
     (Kondrak 2002: 54)
     """
     return C_skip
 
 def sigma_sub(p, q):
     """
-    Returns score of a substitution of P with Q. 
-    
+    Returns score of a substitution of P with Q.
+
     (Kondrak 2002: 54)
     """
     return C_sub - delta(p, q) - V(p) - V(q)
-    
+
 def sigma_exp(p, q):
     """
-    Returns score of an expansion/compression. 
-    
+    Returns score of an expansion/compression.
+
     (Kondrak 2002: 54)
     """
     q1 = q[0]
     q2 = q[1]
     return C_exp - delta(p, q1) - delta(p, q2) - V(p) - max(V(q1), V(q2))
-    
+
 def delta(p, q):
     """
     Return weighted sum of difference between P and Q.
-    
+
     (Kondrak 2002: 54)
     """
     features = R(p, q)
@@ -473,20 +474,20 @@ def delta(p, q):
     for f in features:
         total += diff(p, q, f) * salience[f]
     return total
-    
+
 def diff(p, q, f):
     """
     Returns difference between phonetic segments P and Q for feature F.
-    
+
     (Kondrak 2002: 52, 54)
     """
     p_features, q_features = feature_matrix[p], feature_matrix[q]
     return abs(similarity_matrix[p_features[f]] - similarity_matrix[q_features[f]])
-        
+
 def R(p, q):
     """
     Return relevant features for segment comparsion.
-    
+
     (Kondrak 2002: 54)
     """
     if p in consonants or q in consonants:
@@ -496,13 +497,13 @@ def R(p, q):
 def V(p):
     """
     Return vowel weight if P is vowel.
-    
+
     (Kondrak 2002: 54)
     """
     if p in consonants:
         return 0
     return C_vwl
-    
+
 # === Test ===
 
 def demo():

--- a/nltk/metrics/aline.py
+++ b/nltk/metrics/aline.py
@@ -31,12 +31,15 @@ Example usage
 
 # Get optimal alignment of two phonetic sequences
 
->>> align('θin', 'tenwis')
+>>> align('θin', 'tenwis') # doctest: +SKIP
 [[('θ', 't'), ('i', 'e'), ('n', 'n'), ('-', 'w'), ('-', 'i'), ('-', 's')]]
 
 [1] G. Kondrak. Algorithms for Language Reconstruction. PhD dissertation,
 University of Toronto.
 """
+
+from __future__ import unicode_literals
+
 import numpy as np
 
 # === Constants ===

--- a/nltk/parse/transitionparser.py
+++ b/nltk/parse/transitionparser.py
@@ -328,8 +328,8 @@ class TransitionParser(ParserI):
     def _is_projective(self, depgraph):
         arc_list = []
         for key in depgraph.nodes:
-            node = depgraph.nodes[key]           
-            
+            node = depgraph.nodes[key]
+
             if 'head' in node:
                 childIdx = node['address']
                 parentIdx = node['head']
@@ -490,7 +490,7 @@ class TransitionParser(ParserI):
         print(" Number of valid (projective) examples : " + str(countProj))
         return training_seq
 
-    def train(self, depgraphs, modelfile):
+    def train(self, depgraphs, modelfile, verbose=True):
         """
         :param depgraphs : list of DependencyGraph as the training data
         :type depgraphs : DependencyGraph
@@ -522,7 +522,7 @@ class TransitionParser(ParserI):
                 coef0=0,
                 gamma=0.2,
                 C=0.5,
-                verbose=True,
+                verbose=verbose,
                 probability=True)
 
             model.fit(x_train, y_train)
@@ -730,10 +730,9 @@ def demo():
      Number of valid (projective) examples : 1
     SHIFT, LEFTARC:ATT, SHIFT, LEFTARC:SBJ, SHIFT, SHIFT, LEFTARC:ATT, SHIFT, SHIFT, SHIFT, LEFTARC:ATT, RIGHTARC:PC, RIGHTARC:ATT, RIGHTARC:OBJ, SHIFT, RIGHTARC:PU, RIGHTARC:ROOT, SHIFT
 
-    >>> parser_std.train([gold_sent],'temp.arcstd.model')
+    >>> parser_std.train([gold_sent],'temp.arcstd.model', verbose=False)
      Number of training examples : 1
      Number of valid (projective) examples : 1
-    ...
     >>> remove(input_file.name)
 
     B. Check the ARC-EAGER training
@@ -745,10 +744,9 @@ def demo():
      Number of valid (projective) examples : 1
     SHIFT, LEFTARC:ATT, SHIFT, LEFTARC:SBJ, RIGHTARC:ROOT, SHIFT, LEFTARC:ATT, RIGHTARC:OBJ, RIGHTARC:ATT, SHIFT, LEFTARC:ATT, RIGHTARC:PC, REDUCE, REDUCE, REDUCE, RIGHTARC:PU
 
-    >>> parser_eager.train([gold_sent],'temp.arceager.model')
+    >>> parser_eager.train([gold_sent],'temp.arceager.model', verbose=False)
      Number of training examples : 1
      Number of valid (projective) examples : 1
-    ...
 
     >>> remove(input_file.name)
 

--- a/nltk/parse/transitionparser.py
+++ b/nltk/parse/transitionparser.py
@@ -765,6 +765,10 @@ def demo():
     >>> de.eval() >= (0, 0)
     True
 
+    Remove test temporary files
+    >>> remove('temp.arceager.model')
+    >>> remove('temp.arcstd.model')
+
     Note that result is very poor because of only one training example.
     """
 

--- a/nltk/sentiment/util.py
+++ b/nltk/sentiment/util.py
@@ -11,6 +11,8 @@
 Utility methods for Sentiment Analysis.
 """
 
+from __future__ import unicode_literals
+
 from copy import deepcopy
 import codecs
 import csv

--- a/nltk/tag/senna.py
+++ b/nltk/tag/senna.py
@@ -10,29 +10,31 @@
 Senna POS tagger, NER Tagger, Chunk Tagger
 
 The input is:
-- path to the directory that contains SENNA executables. If the path is incorrect, 
-   SennaTagger will automatically search for executable file specified in SENNA environment variable 
+- path to the directory that contains SENNA executables. If the path is incorrect,
+   SennaTagger will automatically search for executable file specified in SENNA environment variable
 - (optionally) the encoding of the input data (default:utf-8)
+
+Note: Unit tests for this module can be found in test/unit/test_senna.py
 
     >>> from nltk.tag import SennaTagger
     >>> tagger = SennaTagger('/usr/share/senna-v3.0')
-    >>> tagger.tag('What is the airspeed of an unladen swallow ?'.split())
+    >>> tagger.tag('What is the airspeed of an unladen swallow ?'.split()) # doctest: +SKIP
     [('What', 'WP'), ('is', 'VBZ'), ('the', 'DT'), ('airspeed', 'NN'),
     ('of', 'IN'), ('an', 'DT'), ('unladen', 'NN'), ('swallow', 'NN'), ('?', '.')]
 
     >>> from nltk.tag import SennaChunkTagger
     >>> chktagger = SennaChunkTagger('/usr/share/senna-v3.0')
-    >>> chktagger.tag('What is the airspeed of an unladen swallow ?'.split())
+    >>> chktagger.tag('What is the airspeed of an unladen swallow ?'.split()) # doctest: +SKIP
     [('What', 'B-NP'), ('is', 'B-VP'), ('the', 'B-NP'), ('airspeed', 'I-NP'),
     ('of', 'B-PP'), ('an', 'B-NP'), ('unladen', 'I-NP'), ('swallow', 'I-NP'),
     ('?', 'O')]
 
     >>> from nltk.tag import SennaNERTagger
     >>> nertagger = SennaNERTagger('/usr/share/senna-v3.0')
-    >>> nertagger.tag('Shakespeare theatre was in London .'.split())
+    >>> nertagger.tag('Shakespeare theatre was in London .'.split()) # doctest: +SKIP
     [('Shakespeare', 'B-PER'), ('theatre', 'O'), ('was', 'O'), ('in', 'O'),
     ('London', 'B-LOC'), ('.', 'O')]
-    >>> nertagger.tag('UN headquarters are in NY , USA .'.split())
+    >>> nertagger.tag('UN headquarters are in NY , USA .'.split()) # doctest: +SKIP
     [('UN', 'B-ORG'), ('headquarters', 'O'), ('are', 'O'), ('in', 'O'),
     ('NY', 'B-LOC'), (',', 'O'), ('USA', 'B-LOC'), ('.', 'O')]
 """
@@ -73,29 +75,29 @@ class SennaChunkTagger(Senna):
                 annotations = tagged_sents[i][j]
                 tagged_sents[i][j] = (annotations['word'], annotations['chk'])
         return tagged_sents
-        
+
     def bio_to_chunks(self, tagged_sent, chunk_type):
         """
         Extracts the chunks in a BIO chunk-tagged sentence.
-        
+
         >>> from nltk.tag import SennaChunkTagger
         >>> chktagger = SennaChunkTagger('/usr/share/senna-v3.0')
         >>> sent = 'What is the airspeed of an unladen swallow ?'.split()
-        >>> tagged_sent = chktagger.tag(sent)
-        >>> tagged_sent
+        >>> tagged_sent = chktagger.tag(sent) # doctest: +SKIP
+        >>> tagged_sent # doctest: +SKIP
         [('What', 'B-NP'), ('is', 'B-VP'), ('the', 'B-NP'), ('airspeed', 'I-NP'),
         ('of', 'B-PP'), ('an', 'B-NP'), ('unladen', 'I-NP'), ('swallow', 'I-NP'),
         ('?', 'O')]
-        >>> list(chktagger.bio_to_chunks(tagged_sent, chunk_type='NP'))
+        >>> list(chktagger.bio_to_chunks(tagged_sent, chunk_type='NP')) # doctest: +SKIP
         [('What', '0'), ('the airspeed', '2-3'), ('an unladen swallow', '5-6-7')]
-        
+
         :param tagged_sent: A list of tuples of word and BIO chunk tag.
         :type tagged_sent: list(tuple)
         :param tagged_sent: The chunk tag that users want to extract, e.g. 'NP' or 'VP'
         :type tagged_sent: str
-        
+
         :return: An iterable of tuples of chunks that users want to extract
-          and their corresponding indices. 
+          and their corresponding indices.
         :rtype: iter(tuple(str))
         """
         current_chunk = []
@@ -107,14 +109,14 @@ class SennaChunkTagger(Senna):
                 current_chunk_position.append((idx))
             else:
                 if current_chunk: # Flush the full chunk when out of an NP.
-                    _chunk_str = ' '.join(current_chunk) 
+                    _chunk_str = ' '.join(current_chunk)
                     _chunk_pos_str = '-'.join(map(str, current_chunk_position))
-                    yield _chunk_str, _chunk_pos_str 
+                    yield _chunk_str, _chunk_pos_str
                     current_chunk = []
                     current_chunk_position = []
         if current_chunk: # Flush the last chunk.
             yield ' '.join(current_chunk), '-'.join(map(str, current_chunk_position))
-    
+
 
 @python_2_unicode_compatible
 class SennaNERTagger(Senna):

--- a/nltk/test/unit/test_aline.py
+++ b/nltk/test/unit/test_aline.py
@@ -22,39 +22,32 @@ class TestAline(unittest.TestCase):
         
         result = aline.align('jo', 'ʒə')
         expected = [[('j', 'ʒ'), ('o', 'ə')]]
+        
         self.assertEqual(result, expected)
         
         result = aline.align('pematesiweni', 'pematesewen')
         expected = [[('p', 'p'), ('e', 'e'), ('m', 'm'), ('a', 'a'), ('t', 't'), ('e', 'e'), 
                      ('s', 's'), ('i', 'e'), ('w', 'w'), ('e', 'e'), ('n', 'n'), ('i', '-')]]
+        
         self.assertEqual(result, expected)
         
         result = aline.align('tuwθ', 'dentis')
         expected = [[('t', 'd'), ('u', 'e'), ('w', '-'), ('-', 'n'), ('-', 't'), ('-', 'i'), ('θ', 's')]]
+        
+        self.assertEqual(result, expected)
+    
+    def test_aline_delta(self):
+        """
+        Test aline for computing the difference between two segments
+        """
+        result = aline.delta('p', 'q')
+        expected = 20.0
+        
         self.assertEqual(result, expected)
         
-        result = aline.align('wən', 'unus')
-        expected = [[('ə', 'u'), ('n', 'n'), ('-', 'u'), ('-', 's')]]
-        self.assertEqual(result, expected)
+        result = aline.delta('a', 'A')
+        expected = 0.0
         
-        result = aline.align('flow', 'fluere')
-        expected = [[('f', 'f'), ('l', 'l'), ('o', 'u'), ('w', '-'), ('-', 'e'), ('-', 'r'), ('-', 'e')]]
-        self.assertEqual(result, expected)
-        
-        result = aline.align('wat', 'vas')
-        expected = [[('w', 'v'), ('a', 'a'), ('t', 's')]]
-        self.assertEqual(result, expected)
-        
-        result = aline.align('boka', 'buʃ')
-        expected = [[('b', 'b'), ('o', 'u'), ('k', 'ʃ'), ('a', '-')]]
-        self.assertEqual(result, expected)
-        
-        result = aline.align('ombre', 'om')
-        expected = [[('o', 'o'), ('m', 'm'), ('b', '-'), ('r', '-'), ('e', '-')]]
-        self.assertEqual(result, expected)
-        
-        result = aline.align('feðər', 'fEdər')
-        expected = [[('f', 'f'), ('e', 'E'), ('ð', 'd'), ('ə', 'ə'), ('r', 'r')]]
         self.assertEqual(result, expected)
         
         

--- a/nltk/test/unit/test_aline.py
+++ b/nltk/test/unit/test_aline.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests for nltk.metrics.aline
+"""
+
+from __future__ import unicode_literals
+
+import unittest
+
+from nltk.metrics import aline
+
+class TestAline(unittest.TestCase):
+    """
+    Test Aline algorithm for aligning phonetic sequences
+    """
+
+    def test_aline(self):
+        result = aline.align('θin', 'tenwis')
+        expected = [[('θ', 't'), ('i', 'e'), ('n', 'n'), ('-', 'w'), ('-', 'i'), ('-', 's')]]
+
+        self.assertEqual(result, expected)

--- a/nltk/test/unit/test_aline.py
+++ b/nltk/test/unit/test_aline.py
@@ -19,3 +19,44 @@ class TestAline(unittest.TestCase):
         expected = [[('θ', 't'), ('i', 'e'), ('n', 'n'), ('-', 'w'), ('-', 'i'), ('-', 's')]]
 
         self.assertEqual(result, expected)
+        
+        result = aline.align('jo', 'ʒə')
+        expected = [[('j', 'ʒ'), ('o', 'ə')]]
+        self.assertEqual(result, expected)
+        
+        result = aline.align('pematesiweni', 'pematesewen')
+        expected = [[('p', 'p'), ('e', 'e'), ('m', 'm'), ('a', 'a'), ('t', 't'), ('e', 'e'), 
+                     ('s', 's'), ('i', 'e'), ('w', 'w'), ('e', 'e'), ('n', 'n'), ('i', '-')]]
+        self.assertEqual(result, expected)
+        
+        result = aline.align('tuwθ', 'dentis')
+        expected = [[('t', 'd'), ('u', 'e'), ('w', '-'), ('-', 'n'), ('-', 't'), ('-', 'i'), ('θ', 's')]]
+        self.assertEqual(result, expected)
+        
+        result = aline.align('wən', 'unus')
+        expected = [[('ə', 'u'), ('n', 'n'), ('-', 'u'), ('-', 's')]]
+        self.assertEqual(result, expected)
+        
+        result = aline.align('flow', 'fluere')
+        expected = [[('f', 'f'), ('l', 'l'), ('o', 'u'), ('w', '-'), ('-', 'e'), ('-', 'r'), ('-', 'e')]]
+        self.assertEqual(result, expected)
+        
+        result = aline.align('wat', 'vas')
+        expected = [[('w', 'v'), ('a', 'a'), ('t', 's')]]
+        self.assertEqual(result, expected)
+        
+        result = aline.align('boka', 'buʃ')
+        expected = [[('b', 'b'), ('o', 'u'), ('k', 'ʃ'), ('a', '-')]]
+        self.assertEqual(result, expected)
+        
+        result = aline.align('ombre', 'om')
+        expected = [[('o', 'o'), ('m', 'm'), ('b', '-'), ('r', '-'), ('e', '-')]]
+        self.assertEqual(result, expected)
+        
+        result = aline.align('feðər', 'fEdər')
+        expected = [[('f', 'f'), ('e', 'E'), ('ð', 'd'), ('ə', 'ə'), ('r', 'r')]]
+        self.assertEqual(result, expected)
+        
+        
+        
+        

--- a/nltk/test/unit/test_aline.py
+++ b/nltk/test/unit/test_aline.py
@@ -50,6 +50,3 @@ class TestAline(unittest.TestCase):
         
         self.assertEqual(result, expected)
         
-        
-        
-        

--- a/nltk/test/unit/test_senna.py
+++ b/nltk/test/unit/test_senna.py
@@ -18,6 +18,9 @@ if 'SENNA' in environ:
 else:
     SENNA_EXECUTABLE_PATH = '/usr/share/senna-v3.0'
 
+senna_is_installed = path.exists(SENNA_EXECUTABLE_PATH)
+
+@unittest.skipUnless(senna_is_installed, "Requires Senna executable")
 class TestSennaPipeline(unittest.TestCase):
     """Unittest for nltk.classify.senna"""
 
@@ -26,65 +29,46 @@ class TestSennaPipeline(unittest.TestCase):
 
         pipeline = Senna(SENNA_EXECUTABLE_PATH, ['pos', 'chk', 'ner'])
         sent = 'Dusseldorf is an international business center'.split()
+        result = [(token['word'], token['chk'], token['ner'], token['pos']) for token in pipeline.tag(sent)]
+        expected = [('Dusseldorf', 'B-NP', 'B-LOC', 'NNP'), ('is', 'B-VP',
+            'O', 'VBZ'), ('an', 'B-NP', 'O', 'DT'), ('international', 'I-NP',
+            'O', 'JJ'), ('business', 'I-NP', 'O', 'NN'), ('center', 'I-NP',
+            'O', 'NN')]
+        self.assertEqual(result, expected)
 
-        if path.exists(SENNA_EXECUTABLE_PATH):
-            result = [(token['word'], token['chk'], token['ner'], token['pos']) for token in pipeline.tag(sent)]
-            expected = [('Dusseldorf', 'B-NP', 'B-LOC', 'NNP'), ('is', 'B-VP',
-                'O', 'VBZ'), ('an', 'B-NP', 'O', 'DT'), ('international', 'I-NP',
-                'O', 'JJ'), ('business', 'I-NP', 'O', 'NN'), ('center', 'I-NP',
-                'O', 'NN')]
-            self.assertEqual(result, expected)
-        else:
-            # Check that an OSError exception is raised if Senna executable is missing
-            with self.assertRaises(OSError):
-                [(token['word'], token['chk'], token['ner'], token['pos']) for token in pipeline.tag(sent)]
-
+@unittest.skipUnless(senna_is_installed, "Requires Senna executable")
 class TestSennaTagger(unittest.TestCase):
     """Unittest for nltk.tag.senna"""
 
     def test_senna_tagger(self):
         tagger = SennaTagger(SENNA_EXECUTABLE_PATH)
-        if path.exists(SENNA_EXECUTABLE_PATH):
-            result = tagger.tag('What is the airspeed of an unladen swallow ?'.split())
-            expected = [('What', 'WP'), ('is', 'VBZ'), ('the', 'DT'), ('airspeed',
-                'NN'),('of', 'IN'), ('an', 'DT'), ('unladen', 'NN'), ('swallow',
-                'NN'), ('?', '.')]
-            self.assertEqual(result, expected)
-        else:
-            # Check that an OSError exception is raised if Senna executable is missing
-            with self.assertRaises(OSError):
-                tagger.tag('What is the airspeed of an unladen swallow ?'.split())
+        result = tagger.tag('What is the airspeed of an unladen swallow ?'.split())
+        expected = [('What', 'WP'), ('is', 'VBZ'), ('the', 'DT'), ('airspeed',
+            'NN'),('of', 'IN'), ('an', 'DT'), ('unladen', 'NN'), ('swallow',
+            'NN'), ('?', '.')]
+        self.assertEqual(result, expected)
 
     def test_senna_chunk_tagger(self):
         chktagger = SennaChunkTagger(SENNA_EXECUTABLE_PATH)
-        if path.exists(SENNA_EXECUTABLE_PATH):
-            result_1 = chktagger.tag('What is the airspeed of an unladen swallow ?'.split())
-            expected_1 = [('What', 'B-NP'), ('is', 'B-VP'), ('the', 'B-NP'), ('airspeed',
-                'I-NP'), ('of', 'B-PP'), ('an', 'B-NP'), ('unladen', 'I-NP'), ('swallow',
-                'I-NP'), ('?', 'O')]
+        result_1 = chktagger.tag('What is the airspeed of an unladen swallow ?'.split())
+        expected_1 = [('What', 'B-NP'), ('is', 'B-VP'), ('the', 'B-NP'), ('airspeed',
+            'I-NP'), ('of', 'B-PP'), ('an', 'B-NP'), ('unladen', 'I-NP'), ('swallow',
+            'I-NP'), ('?', 'O')]
 
-            result_2 = list(chktagger.bio_to_chunks(result_1, chunk_type='NP'))
-            expected_2 = [('What', '0'), ('the airspeed', '2-3'), ('an unladen swallow',
-                '5-6-7')]
-            self.assertEqual(result_1, expected_1)
-            self.assertEqual(result_2, expected_2)
-        else:
-            with self.assertRaises(OSError):
-                chktagger.tag('What is the airspeed of an unladen swallow ?'.split())
+        result_2 = list(chktagger.bio_to_chunks(result_1, chunk_type='NP'))
+        expected_2 = [('What', '0'), ('the airspeed', '2-3'), ('an unladen swallow',
+            '5-6-7')]
+        self.assertEqual(result_1, expected_1)
+        self.assertEqual(result_2, expected_2)
 
     def test_senna_ner_tagger(self):
         nertagger = SennaNERTagger(SENNA_EXECUTABLE_PATH)
-        if path.exists(SENNA_EXECUTABLE_PATH):
-            result_1 = nertagger.tag('Shakespeare theatre was in London .'.split())
-            expected_1 = [('Shakespeare', 'B-PER'), ('theatre', 'O'), ('was', 'O'),
-                    ('in', 'O'), ('London', 'B-LOC'), ('.', 'O')]
+        result_1 = nertagger.tag('Shakespeare theatre was in London .'.split())
+        expected_1 = [('Shakespeare', 'B-PER'), ('theatre', 'O'), ('was', 'O'),
+                ('in', 'O'), ('London', 'B-LOC'), ('.', 'O')]
 
-            result_2 = nertagger.tag('UN headquarters are in NY , USA .'.split())
-            expected_2 = [('UN', 'B-ORG'), ('headquarters', 'O'), ('are', 'O'),
-            ('in', 'O'), ('NY', 'B-LOC'), (',', 'O'), ('USA', 'B-LOC'), ('.', 'O')]
-            self.assertEqual(result_1, expected_1)
-            self.assertEqual(result_2, expected_2)
-        else:
-            with self.assertRaises(OSError):
-                nertagger.tag('Shakespeare theatre was in London .'.split())
-                nertagger.tag('UN headquarters are in NY , USA .'.split())
+        result_2 = nertagger.tag('UN headquarters are in NY , USA .'.split())
+        expected_2 = [('UN', 'B-ORG'), ('headquarters', 'O'), ('are', 'O'),
+        ('in', 'O'), ('NY', 'B-LOC'), (',', 'O'), ('USA', 'B-LOC'), ('.', 'O')]
+        self.assertEqual(result_1, expected_1)
+        self.assertEqual(result_2, expected_2)

--- a/nltk/test/unit/test_senna.py
+++ b/nltk/test/unit/test_senna.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests for Senna
+"""
+
+from __future__ import unicode_literals
+from os import environ, path, sep
+
+import logging
+import unittest
+
+from nltk.classify import Senna
+from nltk.tag import SennaTagger, SennaChunkTagger, SennaNERTagger
+
+# Set Senna executable path for tests if it is not specified as an environment variable
+if 'SENNA' in environ:
+    SENNA_EXECUTABLE_PATH = path.normpath(environ['SENNA']) + sep
+else:
+    SENNA_EXECUTABLE_PATH = '/usr/share/senna-v3.0'
+
+class TestSennaPipeline(unittest.TestCase):
+    """Unittest for nltk.classify.senna"""
+
+    def test_senna_pipeline(self):
+        """Senna pipeline interface"""
+
+        pipeline = Senna(SENNA_EXECUTABLE_PATH, ['pos', 'chk', 'ner'])
+        sent = 'Dusseldorf is an international business center'.split()
+
+        if path.exists(SENNA_EXECUTABLE_PATH):
+            result = [(token['word'], token['chk'], token['ner'], token['pos']) for token in pipeline.tag(sent)]
+            expected = [('Dusseldorf', 'B-NP', 'B-LOC', 'NNP'), ('is', 'B-VP',
+                'O', 'VBZ'), ('an', 'B-NP', 'O', 'DT'), ('international', 'I-NP',
+                'O', 'JJ'), ('business', 'I-NP', 'O', 'NN'), ('center', 'I-NP',
+                'O', 'NN')]
+            self.assertEqual(result, expected)
+        else:
+            # Check that an OSError exception is raised if Senna executable is missing
+            with self.assertRaises(OSError):
+                [(token['word'], token['chk'], token['ner'], token['pos']) for token in pipeline.tag(sent)]
+
+class TestSennaTagger(unittest.TestCase):
+    """Unittest for nltk.tag.senna"""
+
+    def test_senna_tagger(self):
+        tagger = SennaTagger(SENNA_EXECUTABLE_PATH)
+        if path.exists(SENNA_EXECUTABLE_PATH):
+            result = tagger.tag('What is the airspeed of an unladen swallow ?'.split())
+            expected = [('What', 'WP'), ('is', 'VBZ'), ('the', 'DT'), ('airspeed',
+                'NN'),('of', 'IN'), ('an', 'DT'), ('unladen', 'NN'), ('swallow',
+                'NN'), ('?', '.')]
+            self.assertEqual(result, expected)
+        else:
+            # Check that an OSError exception is raised if Senna executable is missing
+            with self.assertRaises(OSError):
+                tagger.tag('What is the airspeed of an unladen swallow ?'.split())
+
+    def test_senna_chunk_tagger(self):
+        chktagger = SennaChunkTagger(SENNA_EXECUTABLE_PATH)
+        if path.exists(SENNA_EXECUTABLE_PATH):
+            result_1 = chktagger.tag('What is the airspeed of an unladen swallow ?'.split())
+            expected_1 = [('What', 'B-NP'), ('is', 'B-VP'), ('the', 'B-NP'), ('airspeed',
+                'I-NP'), ('of', 'B-PP'), ('an', 'B-NP'), ('unladen', 'I-NP'), ('swallow',
+                'I-NP'), ('?', 'O')]
+
+            result_2 = list(chktagger.bio_to_chunks(result_1, chunk_type='NP'))
+            expected_2 = [('What', '0'), ('the airspeed', '2-3'), ('an unladen swallow',
+                '5-6-7')]
+            self.assertEqual(result_1, expected_1)
+            self.assertEqual(result_2, expected_2)
+        else:
+            with self.assertRaises(OSError):
+                chktagger.tag('What is the airspeed of an unladen swallow ?'.split())
+
+    def test_senna_ner_tagger(self):
+        nertagger = SennaNERTagger(SENNA_EXECUTABLE_PATH)
+        if path.exists(SENNA_EXECUTABLE_PATH):
+            result_1 = nertagger.tag('Shakespeare theatre was in London .'.split())
+            expected_1 = [('Shakespeare', 'B-PER'), ('theatre', 'O'), ('was', 'O'),
+                    ('in', 'O'), ('London', 'B-LOC'), ('.', 'O')]
+
+            result_2 = nertagger.tag('UN headquarters are in NY , USA .'.split())
+            expected_2 = [('UN', 'B-ORG'), ('headquarters', 'O'), ('are', 'O'),
+            ('in', 'O'), ('NY', 'B-LOC'), (',', 'O'), ('USA', 'B-LOC'), ('.', 'O')]
+            self.assertEqual(result_1, expected_1)
+            self.assertEqual(result_2, expected_2)
+        else:
+            print("OKKK")
+            print("OKKK")
+            print("OKKK")
+            print("OKKK")
+            with self.assertRaises(OSError):
+                nertagger.tag('Shakespeare theatre was in London .'.split())
+                nertagger.tag('UN headquarters are in NY , USA .'.split())

--- a/nltk/test/unit/test_senna.py
+++ b/nltk/test/unit/test_senna.py
@@ -85,10 +85,6 @@ class TestSennaTagger(unittest.TestCase):
             self.assertEqual(result_1, expected_1)
             self.assertEqual(result_2, expected_2)
         else:
-            print("OKKK")
-            print("OKKK")
-            print("OKKK")
-            print("OKKK")
             with self.assertRaises(OSError):
                 nertagger.tag('Shakespeare theatre was in London .'.split())
                 nertagger.tag('UN headquarters are in NY , USA .'.split())

--- a/nltk/tokenize/moses.py
+++ b/nltk/tokenize/moses.py
@@ -10,7 +10,7 @@
 
 from __future__ import print_function
 import re
-from six import text_type
+from nltk.six import text_type
 
 from nltk.tokenize.api import TokenizerI
 from nltk.tokenize.util import is_cjk

--- a/nltk/tokenize/moses.py
+++ b/nltk/tokenize/moses.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Natural Language Toolkit: 
+# Natural Language Toolkit:
 #
 # Copyright (C) 2001-2015 NLTK Project
 # Author: Pidong Wang, Josh Schroeder, Ondrej Bojar, based on code by Philipp Koehn
@@ -10,8 +10,8 @@
 
 from __future__ import print_function
 import re
-from nltk.six import text_type
 
+from nltk.six import text_type
 from nltk.tokenize.api import TokenizerI
 from nltk.tokenize.util import is_cjk
 from nltk.corpus import perluniprops, nonbreaking_prefixes
@@ -19,9 +19,9 @@ from nltk.corpus import perluniprops, nonbreaking_prefixes
 
 class MosesTokenizer(TokenizerI):
     """
-    This is a Python port of the Moses Tokenizer from 
+    This is a Python port of the Moses Tokenizer from
     https://github.com/moses-smt/mosesdecoder/blob/master/scripts/tokenizer/tokenizer.perl
-    
+
     >>> tokenizer = MosesTokenizer()
     >>> text = u'This, is a sentence with weird\xbb symbols\u2026 appearing everywhere\xbf'
     >>> expected_tokenized = u'This , is a sentence with weird \xbb symbols \u2026 appearing everywhere \xbf'
@@ -31,7 +31,7 @@ class MosesTokenizer(TokenizerI):
     >>> tokenizer.tokenize(text) == [u'This', u',', u'is', u'a', u'sentence', u'with', u'weird', u'\xbb', u'symbols', u'\u2026', u'appearing', u'everywhere', u'\xbf']
     True
     """
-    
+
     # Perl Unicode Properties character sets.
     IsN = text_type(''.join(perluniprops.chars('IsN')))
     IsAlnum = text_type(''.join(perluniprops.chars('IsAlnum')))
@@ -39,29 +39,29 @@ class MosesTokenizer(TokenizerI):
     IsSo = text_type(''.join(perluniprops.chars('IsSo')))
     IsAlpha = text_type(''.join(perluniprops.chars('IsAlpha')))
     IsLower = text_type(''.join(perluniprops.chars('IsLower')))
-    
+
     # Remove ASCII junk.
     DEDUPLICATE_SPACE = r'\s+', r' '
     ASCII_JUNK = r'[\000-\037]', r''
-    
+
     # Neurotic Perl heading space, multi-space and trailing space chomp.
     # These regexes are kept for reference purposes and shouldn't be used!!
     MID_STRIP = r" +", r" "     # Use DEDUPLICATE_SPACE instead.
     LEFT_STRIP = r"^ ", r""     # Uses text.lstrip() instead.
     RIGHT_STRIP = r" $", r""    # Uses text.rstrip() instead.
-    
+
     # Pad all "other" special characters not in IsAlnum.
     PAD_NOT_ISALNUM = u'([^{}\s\.\'\`\,\-])'.format(IsAlnum), r' \1 '
-    
+
     # Splits all hypens (regardless of circumstances), e.g.
     # 'foo -- bar' -> 'foo @-@ @-@ bar' , 'foo-bar' -> 'foo @-@ bar'
     AGGRESSIVE_HYPHEN_SPLIT = u'([{alphanum}])\-(?=[{alphanum}])'.format(alphanum=IsAlnum), r'\1 \@-\@ '
-    
+
     # Make multi-dots stay together.
     REPLACE_DOT_WITH_LITERALSTRING_1 = r'\.([\.]+)', ' DOTMULTI\1'
     REPLACE_DOT_WITH_LITERALSTRING_2 = r'DOTMULTI\.([^\.])', 'DOTDOTMULTI \1'
     REPLACE_DOT_WITH_LITERALSTRING_3 = r'DOTMULTI\.', 'DOTDOTMULTI'
-  
+
     # Separate out "," except if within numbers (5,300)
     # e.g.  A,B,C,D,E > A , B,C , D,E
     # First application uses up B so rule can't see B,C
@@ -69,7 +69,7 @@ class MosesTokenizer(TokenizerI):
     # will also space digit,letter or letter,digit forms (redundant with next section)
     COMMA_SEPARATE_1 = u'([^{}])[,]'.format(IsN), r'\1 , '
     COMMA_SEPARATE_2 = u'[,]([^{}])'.format(IsN), r' , \1'
-    
+
     # Attempt to get correct directional quotes.
     DIRECTIONAL_QUOTE_1 = r'^``',               r'`` '
     DIRECTIONAL_QUOTE_2 = r'^"',                r'`` '
@@ -79,31 +79,31 @@ class MosesTokenizer(TokenizerI):
     DIRECTIONAL_QUOTE_6 = r'([ ([{<])``',       r'\1 `` '
     DIRECTIONAL_QUOTE_7 = r'([ ([{<])`([^`])',  r'\1 ` \2'
     DIRECTIONAL_QUOTE_8 = r"([ ([{<])'",        r'\1 ` '
-    
+
     # Replace ... with _ELLIPSIS_
     REPLACE_ELLIPSIS = r'\.\.\.',       r' _ELLIPSIS_ '
     # Restore _ELLIPSIS_ with ...
     RESTORE_ELLIPSIS = r'_ELLIPSIS_',   r'\.\.\.'
-    
+
     # Pad , with tailing space except if within numbers, e.g. 5,300
     # These are used in nltk.tokenize.moses.penn_tokenize()
     COMMA_1 = u'([^{numbers})[,]([^{numbers}])'.format(numbers=IsN), r'\1 , \2'
     COMMA_2 = u'([{numbers}])[,]([^{numbers}])'.format(numbers=IsN), r'\1 , \2'
     COMMA_3 = u'([^{numbers}])[,]([{numbers}])'.format(numbers=IsN), r'\1 , \2'
-    
+
     # Pad unicode symbols with spaces.
     SYMBOLS = u'([;:@#\$%&{}{}])'.format(IsSc, IsSo), r' \1 '
-    
+
     # Separate out intra-token slashes.  PTB tokenization doesn't do this, so
     # the tokens should be merged prior to parsing with a PTB-trained parser.
     # e.g. "and/or" -> "and @/@ or"
     INTRATOKEN_SLASHES = u'([{alphanum}])\/([{alphanum}])'.format(alphanum=IsAlnum), r'$1 \@\/\@ $2'
-    
+
     # Splits final period at end of string.
     FINAL_PERIOD = r"""([^.])([.])([\]\)}>"']*) ?$""", r'\1 \2\3'
     # Pad all question marks and exclamation marks with spaces.
     PAD_QUESTION_EXCLAMATION_MARK = r'([?!])', r' \1 '
-    
+
     # Handles parentheses, brackets and converts them to PTB symbols.
     PAD_PARENTHESIS = r'([\]\[\(\){}<>])', r' \1 '
     CONVERT_PARENTHESIS_1 = r'\(', '-LRB-'
@@ -112,22 +112,22 @@ class MosesTokenizer(TokenizerI):
     CONVERT_PARENTHESIS_4 = r'\]', '-RSB-'
     CONVERT_PARENTHESIS_5 = r'\{', '-LCB-'
     CONVERT_PARENTHESIS_6 = r'\}', '-RCB-'
-    
+
     # Pads double dashes with spaces.
     PAD_DOUBLE_DASHES = r'--', ' -- '
-    
+
     # Adds spaces to start and end of string to simplify further regexps.
     PAD_START_OF_STR = r'^', ' '
-    PAD_END_OF_STR = r'$', ' ' 
-    
+    PAD_END_OF_STR = r'$', ' '
+
     # Converts double quotes to two single quotes and pad with spaces.
     CONVERT_DOUBLE_TO_SINGLE_QUOTES = r'"', " '' "
     # Handles single quote in possessives or close-single-quote.
     HANDLES_SINGLE_QUOTES = r"([^'])' ", r"\1 ' "
-    
+
     # Pad apostrophe in possessive or close-single-quote.
     APOSTROPHE = r"([^'])'", r"\1 ' "
-    
+
     # Prepend space on contraction apostrophe.
     CONTRACTION_1 = r"'([sSmMdD]) ", r" '\1 "
     CONTRACTION_2 = r"'ll ", r" 'll "
@@ -138,9 +138,9 @@ class MosesTokenizer(TokenizerI):
     CONTRACTION_7 = r"'RE ", r" 'RE "
     CONTRACTION_8 = r"'VE ", r" 'VE "
     CONTRACTION_9 = r"N'T ", r" N'T "
-    
+
     # Informal Contractions.
-    CONTRACTION_10 = r" ([Cc])annot ",  r" \1an not " 
+    CONTRACTION_10 = r" ([Cc])annot ",  r" \1an not "
     CONTRACTION_11 = r" ([Dd])'ye ",    r" \1' ye "
     CONTRACTION_12 = r" ([Gg])imme ",   r" \1im me "
     CONTRACTION_13 = r" ([Gg])onna ",   r" \1on na "
@@ -150,12 +150,12 @@ class MosesTokenizer(TokenizerI):
     CONTRACTION_17 = r" '([Tt])is ",    r" '\1 is "
     CONTRACTION_18 = r" '([Tt])was ",   r" '\1 was "
     CONTRACTION_19 = r" ([Ww])anna ",   r" \1an na "
-    
+
     # Clean out extra spaces
     CLEAN_EXTRA_SPACE_1 = r'  *', r' '
     CLEAN_EXTRA_SPACE_2 = r'^ *', r''
     CLEAN_EXTRA_SPACE_3 = r' *$', r''
-    
+
     # Escape special characters.
     ESCAPE_AMPERSAND = r'\&', r'\&amp;'
     ESCAPE_PIPE = r'\|', r'\&#124;'
@@ -165,72 +165,72 @@ class MosesTokenizer(TokenizerI):
     ESCAPE_DOUBLE_QUOTE = r'\"', r'\&quot;'
     ESCAPE_LEFT_SQUARE_BRACKET = r"\[", r"\&#91;"
     ESCAPE_RIGHT_SQUARE_BRACKET = r"\]", r"\&#93;"
-    
+
     EN_SPECIFIC_1 = u"([^{alpha}])[']([^{alpha}])".format(alpha=IsAlpha), r"\1 ' \2"
-    EN_SPECIFIC_2 = u"([^{alpha}{isn}])[']([{alpha}])".format(alpha=IsAlpha, isn=IsN), r"\1 ' \2" 
+    EN_SPECIFIC_2 = u"([^{alpha}{isn}])[']([{alpha}])".format(alpha=IsAlpha, isn=IsN), r"\1 ' \2"
     EN_SPECIFIC_3 = u"([{alpha}])[']([^{alpha}])".format(alpha=IsAlpha), r"\1 ' \2"
     EN_SPECIFIC_4 = u"([{alpha}])[']([{alpha}])".format(alpha=IsAlpha), r"\1 ' \2"
     EN_SPECIFIC_5 = u"([{isn}])[']([s])".format(isn=IsN), r"\1 '\2"
-    
-    ENGLISH_SPECIFIC_APOSTROPHE = [EN_SPECIFIC_1, EN_SPECIFIC_2, EN_SPECIFIC_3, 
+
+    ENGLISH_SPECIFIC_APOSTROPHE = [EN_SPECIFIC_1, EN_SPECIFIC_2, EN_SPECIFIC_3,
                                    EN_SPECIFIC_4, EN_SPECIFIC_5]
-    
+
     FR_IT_SPECIFIC_1 = u"([^{alpha}])[']([^{alpha}])".format(alpha=IsAlpha), r"\1 ' \2"
     FR_IT_SPECIFIC_2 = u"([^{alpha}])[']([{alpha}])".format(alpha=IsAlpha), r"\1 ' \2"
     FR_IT_SPECIFIC_3 = u"([{alpha}])[']([^{alpha}])".format(alpha=IsAlpha), r"\1 ' \2"
     FR_IT_SPECIFIC_4 = u"([{alpha}])[']([{alpha}])".format(alpha=IsAlpha), r"\1' \2"
-    
-    FR_IT_SPECIFIC_APOSTROPHE = [FR_IT_SPECIFIC_1, FR_IT_SPECIFIC_2, 
+
+    FR_IT_SPECIFIC_APOSTROPHE = [FR_IT_SPECIFIC_1, FR_IT_SPECIFIC_2,
                                  FR_IT_SPECIFIC_3, FR_IT_SPECIFIC_4]
-    
-    NON_SPECIFIC_APOSTROPHE = r"\'", r" \' " 
-    
+
+    NON_SPECIFIC_APOSTROPHE = r"\'", r" \' "
+
     MOSES_PENN_REGEXES_1 = [DEDUPLICATE_SPACE, ASCII_JUNK, DIRECTIONAL_QUOTE_1,
-                              DIRECTIONAL_QUOTE_2, DIRECTIONAL_QUOTE_3, 
+                              DIRECTIONAL_QUOTE_2, DIRECTIONAL_QUOTE_3,
                               DIRECTIONAL_QUOTE_4, DIRECTIONAL_QUOTE_5,
                               DIRECTIONAL_QUOTE_6, DIRECTIONAL_QUOTE_7,
-                              DIRECTIONAL_QUOTE_8, REPLACE_ELLIPSIS, COMMA_1, 
-                              COMMA_2, COMMA_3, SYMBOLS, INTRATOKEN_SLASHES, 
-                              FINAL_PERIOD, PAD_QUESTION_EXCLAMATION_MARK, 
-                              PAD_PARENTHESIS, CONVERT_PARENTHESIS_1, 
-                              CONVERT_PARENTHESIS_2, CONVERT_PARENTHESIS_3, 
-                              CONVERT_PARENTHESIS_4, CONVERT_PARENTHESIS_5, 
-                              CONVERT_PARENTHESIS_6, PAD_DOUBLE_DASHES, 
-                              PAD_START_OF_STR, PAD_END_OF_STR, 
-                              CONVERT_DOUBLE_TO_SINGLE_QUOTES, 
-                              HANDLES_SINGLE_QUOTES, APOSTROPHE, CONTRACTION_1, 
-                              CONTRACTION_2, CONTRACTION_3, CONTRACTION_4, 
-                              CONTRACTION_5, CONTRACTION_6, CONTRACTION_7, 
-                              CONTRACTION_8, CONTRACTION_9, CONTRACTION_10, 
-                              CONTRACTION_11, CONTRACTION_12, CONTRACTION_13, 
-                              CONTRACTION_14, CONTRACTION_15, CONTRACTION_16, 
+                              DIRECTIONAL_QUOTE_8, REPLACE_ELLIPSIS, COMMA_1,
+                              COMMA_2, COMMA_3, SYMBOLS, INTRATOKEN_SLASHES,
+                              FINAL_PERIOD, PAD_QUESTION_EXCLAMATION_MARK,
+                              PAD_PARENTHESIS, CONVERT_PARENTHESIS_1,
+                              CONVERT_PARENTHESIS_2, CONVERT_PARENTHESIS_3,
+                              CONVERT_PARENTHESIS_4, CONVERT_PARENTHESIS_5,
+                              CONVERT_PARENTHESIS_6, PAD_DOUBLE_DASHES,
+                              PAD_START_OF_STR, PAD_END_OF_STR,
+                              CONVERT_DOUBLE_TO_SINGLE_QUOTES,
+                              HANDLES_SINGLE_QUOTES, APOSTROPHE, CONTRACTION_1,
+                              CONTRACTION_2, CONTRACTION_3, CONTRACTION_4,
+                              CONTRACTION_5, CONTRACTION_6, CONTRACTION_7,
+                              CONTRACTION_8, CONTRACTION_9, CONTRACTION_10,
+                              CONTRACTION_11, CONTRACTION_12, CONTRACTION_13,
+                              CONTRACTION_14, CONTRACTION_15, CONTRACTION_16,
                               CONTRACTION_17, CONTRACTION_18, CONTRACTION_19]
-        
-    MOSES_PENN_REGEXES_2 = [RESTORE_ELLIPSIS, CLEAN_EXTRA_SPACE_1, 
-                        CLEAN_EXTRA_SPACE_2, CLEAN_EXTRA_SPACE_3, 
-                        ESCAPE_AMPERSAND, ESCAPE_PIPE, 
-                        ESCAPE_LEFT_ANGLE_BRACKET, ESCAPE_RIGHT_ANGLE_BRACKET, 
-                        ESCAPE_SINGLE_QUOTE, ESCAPE_DOUBLE_QUOTE]    
 
-    MOSES_ESCAPE_XML_REGEXES = [ESCAPE_AMPERSAND, ESCAPE_PIPE, 
-                                ESCAPE_LEFT_ANGLE_BRACKET, 
-                                ESCAPE_RIGHT_ANGLE_BRACKET, 
-                                ESCAPE_SINGLE_QUOTE, ESCAPE_DOUBLE_QUOTE, 
-                                ESCAPE_LEFT_SQUARE_BRACKET, 
+    MOSES_PENN_REGEXES_2 = [RESTORE_ELLIPSIS, CLEAN_EXTRA_SPACE_1,
+                        CLEAN_EXTRA_SPACE_2, CLEAN_EXTRA_SPACE_3,
+                        ESCAPE_AMPERSAND, ESCAPE_PIPE,
+                        ESCAPE_LEFT_ANGLE_BRACKET, ESCAPE_RIGHT_ANGLE_BRACKET,
+                        ESCAPE_SINGLE_QUOTE, ESCAPE_DOUBLE_QUOTE]
+
+    MOSES_ESCAPE_XML_REGEXES = [ESCAPE_AMPERSAND, ESCAPE_PIPE,
+                                ESCAPE_LEFT_ANGLE_BRACKET,
+                                ESCAPE_RIGHT_ANGLE_BRACKET,
+                                ESCAPE_SINGLE_QUOTE, ESCAPE_DOUBLE_QUOTE,
+                                ESCAPE_LEFT_SQUARE_BRACKET,
                                 ESCAPE_RIGHT_SQUARE_BRACKET]
-    
+
     def __init__(self, lang='en'):
         # Initialize the object.
         super(MosesTokenizer, self).__init__()
         self.lang = lang
         # Initialize the language specific nonbreaking prefixes.
         self.NONBREAKING_PREFIXES = nonbreaking_prefixes.words(lang)
-        self.NUMERIC_ONLY_PREFIXES = [w.rpartition(' ')[0] for w in 
-                                      self.NONBREAKING_PREFIXES if 
+        self.NUMERIC_ONLY_PREFIXES = [w.rpartition(' ')[0] for w in
+                                      self.NONBREAKING_PREFIXES if
                                       self.has_numeric_only(w)]
-        
-        
-    
+
+
+
     def replace_multidots(self, text):
         text = re.sub(r'\.([\.]+)', r' DOTMULTI\1', text)
         while re.search(r'DOTMULTI\.', text):
@@ -242,16 +242,16 @@ class MosesTokenizer(TokenizerI):
         while re.search(r'DOTDOTMULTI', text):
             text = re.sub(r'DOTDOTMULTI', r'DOTMULTI.', text)
         return re.sub(r'DOTMULTI', r'.', text)
-    
+
     def islower(self, text):
         return not set(text).difference(set(IsLower))
-    
+
     def isalpha(self, text):
         return not set(text).difference(set(IsAlpha))
-    
+
     def has_numeric_only(self, text):
         return bool(re.match(r'(.*)[\s]+(\#NUMERIC_ONLY\#)', text))
-    
+
     def handles_nonbreaking_prefixes(self, text):
         # Splits the text into toknes to check for nonbreaking prefixes.
         tokens = text.split()
@@ -265,10 +265,10 @@ class MosesTokenizer(TokenizerI):
                 # i.   the prefix is a token made up of chars within the IsAlpha
                 # ii.  the prefix is in the list of nonbreaking prefixes and
                 #      does not contain #NUMERIC_ONLY#
-                # iii. the token is not the last token and that the 
-                #      next token contains all lowercase. 
+                # iii. the token is not the last token and that the
+                #      next token contains all lowercase.
                 if ( (prefix and self.isalpha(prefix)) or
-                     (prefix in self.NONBREAKING_PREFIXES and 
+                     (prefix in self.NONBREAKING_PREFIXES and
                       prefix not in self.NUMERIC_ONLY_PREFIXES) or
                      (i != num_tokens-1 and self.islower(tokens[i+1])) ):
                     pass # No change to the token.
@@ -280,20 +280,20 @@ class MosesTokenizer(TokenizerI):
                 else: # Otherwise, adds a space after the tokens before a dot.
                     tokens[i] = prefix + ' .'
         return " ".join(tokens) # Stitch the tokens back.
-    
+
     def escape_xml(self, text):
         for regexp, subsitution in self.MOSES_ESCAPE_XML_REGEXES:
             text = re.sub(regexp, subsitution, text)
         return text
-    
+
     def penn_tokenize(self, text, return_str=False):
         """
         This is a Python port of the Penn treebank tokenizer adapted by the Moses
-        machine translation community. It's a little different from the 
+        machine translation community. It's a little different from the
         version in nltk.tokenize.treebank.
         """
         # Converts input string into unicode.
-        text = text_type(text) 
+        text = text_type(text)
         # Perform a chain of regex substituitions using MOSES_PENN_REGEXES_1
         for regexp, subsitution in self.MOSES_PENN_REGEXES_1:
             text = re.sub(regexp, subsitution, text)
@@ -301,13 +301,13 @@ class MosesTokenizer(TokenizerI):
         text = handles_nonbreaking_prefixes(text)
         # Restore ellipsis, clean extra spaces, escape XML symbols.
         for regexp, subsitution in self.MOSES_PENN_REGEXES_2:
-            text = re.sub(regexp, subsitution, text)        
+            text = re.sub(regexp, subsitution, text)
         return text if return_str else text.split()
-    
+
     def tokenize(self, text, agressive_dash_splits=False, return_str=False):
         """
-        Python port of the Moses tokenizer. 
-        
+        Python port of the Moses tokenizer.
+
         >>> mtokenizer = MosesTokenizer()
         >>> text = u'Is 9.5 or 525,600 my favorite number?'
         >>> print (mtokenizer.tokenize(text, return_str=True))
@@ -318,15 +318,15 @@ class MosesTokenizer(TokenizerI):
         >>> text = u'This, is a sentence with weird\xbb symbols\u2026 appearing everywhere\xbf'
         >>> expected = u'This , is a sentence with weird \xbb symbols \u2026 appearing everywhere \xbf'
         >>> assert mtokenizer.tokenize(text, return_str=True) == expected
-        
+
         :param tokens: A single string, i.e. sentence text.
         :type tokens: str
         :param agressive_dash_splits: Option to trigger dash split rules .
         :type agressive_dash_splits: bool
         """
         # Converts input string into unicode.
-        text = text_type(text) 
-        
+        text = text_type(text)
+
         # De-duplicate spaces and clean ASCII junk
         for regexp, subsitution in [self.DEDUPLICATE_SPACE, self.ASCII_JUNK]:
             text = re.sub(regexp, subsitution, text)
@@ -344,7 +344,7 @@ class MosesTokenizer(TokenizerI):
         # Separate out "," except if within numbers e.g. 5,300
         for regexp, subsitution in [self.COMMA_SEPARATE_1, self.COMMA_SEPARATE_2]:
             text = re.sub(regexp, subsitution, text)
-        
+
         # (Language-specific) apostrophe tokenization.
         if self.lang == 'en':
             for regexp, subsitution in self.ENGLISH_SPECIFIC_APOSTROPHE:
@@ -355,7 +355,7 @@ class MosesTokenizer(TokenizerI):
         else:
             regexp, subsitution = self.NON_SPECIFIC_APOSTROPHE
             text = re.sub(regexp, subsitution, text)
-        
+
         # Handles nonbreaking prefixes.
         text = self.handles_nonbreaking_prefixes(text)
         # Cleans up extraneous spaces.
@@ -365,15 +365,15 @@ class MosesTokenizer(TokenizerI):
         text = self.restore_multidots(text)
         # Escape XML symbols.
         text = self.escape_xml(text)
-        
+
         return text if return_str else text.split()
 
 
 class MosesDetokenizer(TokenizerI):
     """
-    This is a Python port of the Moses Detokenizer from 
+    This is a Python port of the Moses Detokenizer from
     https://github.com/moses-smt/mosesdecoder/blob/master/scripts/tokenizer/detokenizer.perl
-    
+
     >>> tokenizer = MosesTokenizer()
     >>> text = u'This, is a sentence with weird\xbb symbols\u2026 appearing everywhere\xbf'
     >>> expected_tokenized = u'This , is a sentence with weird \xbb symbols \u2026 appearing everywhere \xbf'
@@ -396,7 +396,7 @@ class MosesDetokenizer(TokenizerI):
     # Merge multiple spaces.
     ONE_SPACE = re.compile(r' {2,}'), ' '
 
-    # Unescape special characters. 
+    # Unescape special characters.
     UNESCAPE_FACTOR_SEPARATOR = r'\&#124;', r'\|'
     UNESCAPE_LEFT_ANGLE_BRACKET = r'\&lt;', r'\<'
     UNESCAPE_RIGHT_ANGLE_BRACKET = r'\&gt;', r'\>'
@@ -406,40 +406,40 @@ class MosesDetokenizer(TokenizerI):
     UNESCAPE_SYNTAX_NONTERMINAL_RIGHT = r'\&#93;', r'\]'
     UNESCAPE_AMPERSAND = r'\&amp;', r'\&'
     # The legacy regexes are used to support outputs from older Moses versions.
-    UNESCAPE_FACTOR_SEPARATOR_LEGACY = r'\&bar;', r'\|' 
+    UNESCAPE_FACTOR_SEPARATOR_LEGACY = r'\&bar;', r'\|'
     UNESCAPE_SYNTAX_NONTERMINAL_LEFT_LEGACY = r'\&bra;', r'\['
     UNESCAPE_SYNTAX_NONTERMINAL_RIGHT_LEGACY = r'\&ket;', r'\]'
-    
-    
-    MOSES_UNESCAPE_XML_REGEXES = [UNESCAPE_FACTOR_SEPARATOR_LEGACY, 
-                        UNESCAPE_FACTOR_SEPARATOR, UNESCAPE_LEFT_ANGLE_BRACKET, 
-                        UNESCAPE_RIGHT_ANGLE_BRACKET, 
-                        UNESCAPE_SYNTAX_NONTERMINAL_LEFT_LEGACY, 
-                        UNESCAPE_SYNTAX_NONTERMINAL_RIGHT_LEGACY, 
-                        UNESCAPE_DOUBLE_QUOTE, UNESCAPE_SINGLE_QUOTE, 
-                        UNESCAPE_SYNTAX_NONTERMINAL_LEFT, 
+
+
+    MOSES_UNESCAPE_XML_REGEXES = [UNESCAPE_FACTOR_SEPARATOR_LEGACY,
+                        UNESCAPE_FACTOR_SEPARATOR, UNESCAPE_LEFT_ANGLE_BRACKET,
+                        UNESCAPE_RIGHT_ANGLE_BRACKET,
+                        UNESCAPE_SYNTAX_NONTERMINAL_LEFT_LEGACY,
+                        UNESCAPE_SYNTAX_NONTERMINAL_RIGHT_LEGACY,
+                        UNESCAPE_DOUBLE_QUOTE, UNESCAPE_SINGLE_QUOTE,
+                        UNESCAPE_SYNTAX_NONTERMINAL_LEFT,
                         UNESCAPE_SYNTAX_NONTERMINAL_RIGHT, UNESCAPE_AMPERSAND]
 
-    FINNISH_MORPHSET_1 = [u'N', u'n', u'A', u'a', u'\xc4', u'\xe4', u'ssa', 
-                         u'Ssa', u'ss\xe4', u'Ss\xe4', u'sta', u'st\xe4', 
-                         u'Sta', u'St\xe4', u'hun', u'Hun', u'hyn', u'Hyn', 
-                         u'han', u'Han', u'h\xe4n', u'H\xe4n', u'h\xf6n', 
-                         u'H\xf6n', u'un', u'Un', u'yn', u'Yn', u'an', u'An', 
-                         u'\xe4n', u'\xc4n', u'\xf6n', u'\xd6n', u'seen', 
-                         u'Seen', u'lla', u'Lla', u'll\xe4', u'Ll\xe4', u'lta', 
-                         u'Lta', u'lt\xe4', u'Lt\xe4', u'lle', u'Lle', u'ksi', 
+    FINNISH_MORPHSET_1 = [u'N', u'n', u'A', u'a', u'\xc4', u'\xe4', u'ssa',
+                         u'Ssa', u'ss\xe4', u'Ss\xe4', u'sta', u'st\xe4',
+                         u'Sta', u'St\xe4', u'hun', u'Hun', u'hyn', u'Hyn',
+                         u'han', u'Han', u'h\xe4n', u'H\xe4n', u'h\xf6n',
+                         u'H\xf6n', u'un', u'Un', u'yn', u'Yn', u'an', u'An',
+                         u'\xe4n', u'\xc4n', u'\xf6n', u'\xd6n', u'seen',
+                         u'Seen', u'lla', u'Lla', u'll\xe4', u'Ll\xe4', u'lta',
+                         u'Lta', u'lt\xe4', u'Lt\xe4', u'lle', u'Lle', u'ksi',
                          u'Ksi', u'kse', u'Kse', u'tta', u'Tta', u'ine', u'Ine']
-    
+
     FINNISH_MORPHSET_2 = [u'ni', u'si', u'mme', u'nne', u'nsa']
-    
-    FINNISH_MORPHSET_3 = [u'ko', u'k\xf6', u'han', u'h\xe4n', u'pa', u'p\xe4', 
+
+    FINNISH_MORPHSET_3 = [u'ko', u'k\xf6', u'han', u'h\xe4n', u'pa', u'p\xe4',
                          u'kaan', u'k\xe4\xe4n', u'kin']
-    
-    FINNISH_REGEX = u'^({})({})?({})$'.format(text_type('|'.join(FINNISH_MORPHSET_1)), 
-                                               text_type('|'.join(FINNISH_MORPHSET_2)), 
+
+    FINNISH_REGEX = u'^({})({})?({})$'.format(text_type('|'.join(FINNISH_MORPHSET_1)),
+                                               text_type('|'.join(FINNISH_MORPHSET_2)),
                                                text_type('|'.join(FINNISH_MORPHSET_3)))
 
-    
+
     def __init__(self, lang='en'):
         super(MosesDetokenizer, self).__init__()
         self.lang = lang
@@ -449,12 +449,12 @@ class MosesDetokenizer(TokenizerI):
         for regexp, subsitution in self.MOSES_UNESCAPE_XML_REGEXES:
             text = re.sub(regexp, subsitution, text)
         return text
-    
+
 
     def tokenize(self, tokens, return_str=False):
         """
         Python port of the Moses detokenizer.
-        
+
         :param tokens: A list of strings, i.e. tokenized text.
         :type tokens: list(str)
         :return: str
@@ -470,13 +470,13 @@ class MosesDetokenizer(TokenizerI):
         text = self.unescape_xml(text)
         # Keep track of no. of quotation marks.
         quote_counts = {u"'":0 , u'"':0}
-        
-        # The *prepend_space* variable is used to control the "effects" of 
+
+        # The *prepend_space* variable is used to control the "effects" of
         # detokenization as the function loops through the list of tokens and
-        # changes the *prepend_space* accordingly as it sequentially checks 
-        # through the language specific and language independent conditions. 
-        prepend_space = " " 
-        detokenized_text = "" 
+        # changes the *prepend_space* accordingly as it sequentially checks
+        # through the language specific and language independent conditions.
+        prepend_space = " "
+        detokenized_text = ""
         tokens = text.split()
         # Iterate through every token and apply language specific detokenization rule(s).
         for i, token in enumerate(iter(tokens)):
@@ -488,8 +488,8 @@ class MosesDetokenizer(TokenizerI):
                 # But do nothing special if this is a CJK word that doesn't follow a CJK word
                 else:
                     detokenized_text += prepend_space + token
-                prepend_space = " " 
-                
+                prepend_space = " "
+
             # If it's a currency symbol.
             elif token in self.IsSc:
                 # Perform right shift on currency and other random punctuation items
@@ -502,15 +502,15 @@ class MosesDetokenizer(TokenizerI):
                     detokenized_text += " "
                 # Perform left shift on punctuation items.
                 detokenized_text += token
-                prepend_space = " " 
-               
-            elif (self.lang == 'en' and i > 0 
+                prepend_space = " "
+
+            elif (self.lang == 'en' and i > 0
                   and re.match(u'^[\'][{}]'.format(self.IsAlpha), token)
                   and re.match(u'[{}]'.format(self.IsAlnum), token)):
                 # For English, left-shift the contraction.
                 detokenized_text += token
                 prepend_space = " "
-                
+
             elif (self.lang == 'cs' and i > 1
                   and re.match(r'^[0-9]+$', tokens[-2]) # If the previous previous token is a number.
                   and re.match(r'^[.,]$', tokens[-1]) # If previous token is a dot.
@@ -518,14 +518,14 @@ class MosesDetokenizer(TokenizerI):
                 # In Czech, left-shift floats that are decimal numbers.
                 detokenized_text += token
                 prepend_space = " "
-            
+
             elif (self.lang in ['fr', 'it'] and i <= len(tokens)-2
                   and re.match(u'[{}][\']$'.format(self.IsAlpha), token)
                   and re.match(u'^[{}]$'.format(self.IsAlpha), tokens[i+1])): # If the next token is alpha.
                 # For French and Italian, right-shift the contraction.
                 detokenized_text += prepend_space + token
                 prepend_space = ""
-            
+
             elif (self.lang == 'cs' and i <= len(tokens)-3
                   and re.match(u'[{}][\']$'.format(self.IsAlpha), token)
                   and re.match(u'^[-–]$', tokens[i+1])
@@ -534,25 +534,25 @@ class MosesDetokenizer(TokenizerI):
                 detokenized_text += prepend_space + token + tokens[i+1]
                 next(tokens, None) # Advance over the dash
                 prepend_space = ""
-                
+
             # Combine punctuation smartly.
             elif re.match(r'''^[\'\"„“`]+$''', token):
                 normalized_quo = token
                 if re.match(r'^[„“”]+$', token):
                     normalized_quo = '"'
                 quote_count.get(normalized_quo, 0)
-                
+
                 if self.lang == 'cs' and token == u"„":
                     quote_count[normalized_quo] = 0
                 if self.lang == 'cs' and token == u"“":
                     quote_count[normalized_quo] = 1
-            
-            
+
+
                 if quote_count[normalized_quo] % 2 == 0:
-                    if (self.lang == 'en' and token == u"'" and i > 0 
+                    if (self.lang == 'en' and token == u"'" and i > 0
                         and re.match(r'[s]$', tokens[i-1]) ):
                         # Left shift on single quote for possessives ending
-                        # in "s", e.g. "The Jones' house" 
+                        # in "s", e.g. "The Jones' house"
                         detokenized_text += token
                         prepend_space = " "
                     else:
@@ -565,27 +565,26 @@ class MosesDetokenizer(TokenizerI):
                     text += token
                     prepend_space = " "
                     quote_count[normalized_quo] += 1
-            
+
             elif (self.lang == 'fi' and re.match(r':$', tokens[i-1])
                   and re.match(self.FINNISH_REGEX, token)):
                 # Finnish : without intervening space if followed by case suffix
                 # EU:N EU:n EU:ssa EU:sta EU:hun EU:iin ...
                 detokenized_text += prepend_space + token
                 prepend_space = " "
-            
+
             else:
                 detokenized_text += prepend_space + token
                 prepend_space = " "
-                
+
         # Merge multiple spaces.
         regexp, subsitution = self.ONE_SPACE
         detokenized_text = re.sub(regexp, subsitution, detokenized_text)
         # Removes heading and trailing spaces.
         detokenized_text = detokenized_text.strip()
-    
+
         return detokenized_text if return_str else detokenized_text.split()
-    
+
     def detokenize(self, tokens, return_str=False):
         """ Duck-typing the abstract *tokenize()*."""
         return self.tokenize(tokens, return_str)
-    

--- a/nltk/tokenize/repp.py
+++ b/nltk/tokenize/repp.py
@@ -9,7 +9,6 @@
 # For license information, see LICENSE.TXT
 
 from __future__ import unicode_literals, print_function
-from nltk.six import text_type
 
 import os
 import re
@@ -17,17 +16,16 @@ import sys
 import subprocess
 import tempfile
 
-
 from nltk.data import ZipFilePathPointer
 from nltk.internals import find_dir
-
+from nltk.six import text_type
 from nltk.tokenize.api import TokenizerI
 
 class ReppTokenizer(TokenizerI):
     """
     A class for word tokenization using the REPP parser described in
-    Rebecca Dridan and Stephan Oepen (2012) Tokenization: Returning to a 
-    Long Solved Problem - A Survey, Contrastive  Experiment, Recommendations, 
+    Rebecca Dridan and Stephan Oepen (2012) Tokenization: Returning to a
+    Long Solved Problem - A Survey, Contrastive  Experiment, Recommendations,
     and Toolkit. In ACL. http://anthology.aclweb.org/P/P12/P12-2.pdf#page=406
 
     >>> sents = ['Tokenization is widely regarded as a solved problem due to the high accuracy that rulebased tokenizers achieve.' ,
@@ -37,58 +35,58 @@ class ReppTokenizer(TokenizerI):
     >>> tokenizer = ReppTokenizer('/home/alvas/repp/') # doctest: +SKIP
     >>> for sent in sents:                             # doctest: +SKIP
     ...     tokenizer.tokenize(sent)                   # doctest: +SKIP
-    ... 
+    ...
     (u'Tokenization', u'is', u'widely', u'regarded', u'as', u'a', u'solved', u'problem', u'due', u'to', u'the', u'high', u'accuracy', u'that', u'rulebased', u'tokenizers', u'achieve', u'.')
     (u'But', u'rule-based', u'tokenizers', u'are', u'hard', u'to', u'maintain', u'and', u'their', u'rules', u'language', u'specific', u'.')
     (u'We', u'evaluated', u'our', u'method', u'on', u'three', u'languages', u'and', u'obtained', u'error', u'rates', u'of', u'0.27', u'%', u'(', u'English', u')', u',', u'0.35', u'%', u'(', u'Dutch', u')', u'and', u'0.76', u'%', u'(', u'Italian', u')', u'for', u'our', u'best', u'models', u'.')
 
     >>> for sent in tokenizer.tokenize_sents(sents): # doctest: +SKIP
     ...     print sent                               # doctest: +SKIP
-    ... 
+    ...
     (u'Tokenization', u'is', u'widely', u'regarded', u'as', u'a', u'solved', u'problem', u'due', u'to', u'the', u'high', u'accuracy', u'that', u'rulebased', u'tokenizers', u'achieve', u'.')
     (u'But', u'rule-based', u'tokenizers', u'are', u'hard', u'to', u'maintain', u'and', u'their', u'rules', u'language', u'specific', u'.')
     (u'We', u'evaluated', u'our', u'method', u'on', u'three', u'languages', u'and', u'obtained', u'error', u'rates', u'of', u'0.27', u'%', u'(', u'English', u')', u',', u'0.35', u'%', u'(', u'Dutch', u')', u'and', u'0.76', u'%', u'(', u'Italian', u')', u'for', u'our', u'best', u'models', u'.')
     >>> for sent in tokenizer.tokenize_sents(sents, keep_token_positions=True): # doctest: +SKIP
     ...     print sent                                                          # doctest: +SKIP
-    ... 
+    ...
     [(u'Tokenization', 0, 12), (u'is', 13, 15), (u'widely', 16, 22), (u'regarded', 23, 31), (u'as', 32, 34), (u'a', 35, 36), (u'solved', 37, 43), (u'problem', 44, 51), (u'due', 52, 55), (u'to', 56, 58), (u'the', 59, 62), (u'high', 63, 67), (u'accuracy', 68, 76), (u'that', 77, 81), (u'rulebased', 82, 91), (u'tokenizers', 92, 102), (u'achieve', 103, 110), (u'.', 110, 111)]
     [(u'But', 0, 3), (u'rule-based', 4, 14), (u'tokenizers', 15, 25), (u'are', 26, 29), (u'hard', 30, 34), (u'to', 35, 37), (u'maintain', 38, 46), (u'and', 47, 50), (u'their', 51, 56), (u'rules', 57, 62), (u'language', 63, 71), (u'specific', 72, 80), (u'.', 80, 81)]
     [(u'We', 0, 2), (u'evaluated', 3, 12), (u'our', 13, 16), (u'method', 17, 23), (u'on', 24, 26), (u'three', 27, 32), (u'languages', 33, 42), (u'and', 43, 46), (u'obtained', 47, 55), (u'error', 56, 61), (u'rates', 62, 67), (u'of', 68, 70), (u'0.27', 71, 75), (u'%', 75, 76), (u'(', 77, 78), (u'English', 78, 85), (u')', 85, 86), (u',', 86, 87), (u'0.35', 88, 92), (u'%', 92, 93), (u'(', 94, 95), (u'Dutch', 95, 100), (u')', 100, 101), (u'and', 102, 105), (u'0.76', 106, 110), (u'%', 110, 111), (u'(', 112, 113), (u'Italian', 113, 120), (u')', 120, 121), (u'for', 122, 125), (u'our', 126, 129), (u'best', 130, 134), (u'models', 135, 141), (u'.', 141, 142)]
     """
     def __init__(self, repp_dir, encoding='utf8'):
         self.repp_dir = self.find_repptokenizer(repp_dir)
-        # Set a directory to store the temporary files. 
+        # Set a directory to store the temporary files.
         self.working_dir = tempfile.gettempdir()
         # Set an encoding for the input strings.
         self.encoding = encoding
-        
+
     def tokenize(self, sentence):
         """
-        Use Repp to tokenize a single sentence.  
-        
+        Use Repp to tokenize a single sentence.
+
         :param sentence: A single sentence string.
         :type sentence: str
-        :return: A tuple of tokens. 
+        :return: A tuple of tokens.
         :rtype: tuple(str)
         """
         return next(self.tokenize_sents([sentence]))
-    
+
     def tokenize_sents(self, sentences, keep_token_positions=False):
         """
         Tokenize multiple sentences using Repp.
-                
+
         :param sentences: A list of sentence strings.
         :type sentences: list(str)
         :return: A list of tuples of tokens
         :rtype: iter(tuple(str))
         """
-        with tempfile.NamedTemporaryFile(prefix='repp_input.', 
+        with tempfile.NamedTemporaryFile(prefix='repp_input.',
             dir=self.working_dir, mode='w', delete=False) as input_file:
             # Write sentences to temporary input file.
             for sent in sentences:
                 input_file.write(text_type(sent) + '\n')
             input_file.close()
-            # Generate command to run REPP. 
+            # Generate command to run REPP.
             cmd =self.generate_repp_command(input_file.name)
             # Decode the stdout and strips the ending newline.
             repp_output = self._execute(cmd).decode(self.encoding).strip()
@@ -96,12 +94,12 @@ class ReppTokenizer(TokenizerI):
                 if not keep_token_positions:
                     # Removes token position information.
                     tokenized_sent, starts, ends = zip(*tokenized_sent)
-                yield tokenized_sent      
-        
+                yield tokenized_sent
+
     def generate_repp_command(self, inputfilename):
         """
         This module generates the REPP command to be used at the terminal.
-        
+
         :param inputfilename: path to the input file
         :type inputfilename: str
         """
@@ -109,21 +107,21 @@ class ReppTokenizer(TokenizerI):
         cmd+= ['-c', self.repp_dir + '/erg/repp.set']
         cmd+= ['--format', 'triple']
         cmd+= [inputfilename]
-        return cmd  
+        return cmd
 
     @staticmethod
     def _execute(cmd):
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = p.communicate()
         return stdout
-    
-    @staticmethod    
+
+    @staticmethod
     def parse_repp_outputs(repp_output):
         """
         This module parses the tri-tuple format that REPP outputs using the
         "--format triple" option and returns an generator with tuple of string
         tokens.
-        
+
         :param repp_output:
         :type repp_output: type
         :return: an iterable of the tokenized sentences as tuples of strings
@@ -132,11 +130,11 @@ class ReppTokenizer(TokenizerI):
         line_regex = re.compile('^\((\d+), (\d+), (.+)\)$', re.MULTILINE)
         for section in repp_output.split('\n\n'):
             words_with_positions = [(token, int(start), int(end))
-                                    for start, end, token in 
+                                    for start, end, token in
                                     line_regex.findall(section)]
             words = tuple(t[2] for t in words_with_positions)
             yield words_with_positions
-    
+
     def find_repptokenizer(self, repp_dirname):
         """
         A module to find REPP tokenizer binary and its *repp.set* config file.

--- a/nltk/tokenize/repp.py
+++ b/nltk/tokenize/repp.py
@@ -9,7 +9,7 @@
 # For license information, see LICENSE.TXT
 
 from __future__ import unicode_literals, print_function
-from six import text_type
+from nltk.six import text_type
 
 import os
 import re

--- a/nltk/tokenize/toktok.py
+++ b/nltk/tokenize/toktok.py
@@ -9,28 +9,28 @@
 # For license information, see LICENSE.TXT
 
 """
-The tok-tok tokenizer is a simple, general tokenizer, where the input has one 
+The tok-tok tokenizer is a simple, general tokenizer, where the input has one
 sentence per line; thus only final period is tokenized.
 
-Tok-tok has been tested on, and gives reasonably good results for English, 
-Persian, Russian, Czech, French, German, Vietnamese, Tajik, and a few others. 
+Tok-tok has been tested on, and gives reasonably good results for English,
+Persian, Russian, Czech, French, German, Vietnamese, Tajik, and a few others.
 The input should be in UTF-8 encoding.
 
 Reference:
-Jon Dehdari. 2014. A Neurophysiologically-Inspired Statistical Language 
-Model (Doctoral dissertation). Columbus, OH, USA: The Ohio State University. 
+Jon Dehdari. 2014. A Neurophysiologically-Inspired Statistical Language
+Model (Doctoral dissertation). Columbus, OH, USA: The Ohio State University.
 """
 
 import re
-from nltk.six import text_type
 
+from nltk.six import text_type
 from nltk.tokenize.api import TokenizerI
 
 class ToktokTokenizer(TokenizerI):
     """
     This is a Python port of the tok-tok.pl from
     https://github.com/jonsafari/tok-tok/blob/master/tok-tok.pl
-    
+
     >>> toktok = ToktokTokenizer()
     >>> text = u'Is 9.5 or 525,600 my favorite number?'
     >>> print (toktok.tokenize(text, return_str=True))
@@ -46,34 +46,34 @@ class ToktokTokenizer(TokenizerI):
     """
     # Replace non-breaking spaces with normal spaces.
     NON_BREAKING = re.compile(u"\u00A0"), " "
-    
+
     # Pad some funky punctuation.
     FUNKY_PUNCT_1 = re.compile(u'([،;؛¿!"\])}»›”؟%٪°±©®।॥…])'), r" \1 "
     # Pad more funky punctuation.
     FUNKY_PUNCT_2 = re.compile(u'([({\[“‘„‚«‹「『])'), r" \1 "
     # Pad En dash and em dash
     EN_EM_DASHES = re.compile(u'([–—])'), r" \1 "
-    
+
     # Replace problematic character with numeric character reference.
     AMPERCENT = re.compile('& '), '&amp; '
     TAB = re.compile('\t'), ' &#9; '
     PIPE = re.compile('\|'), ' &#124; '
-    
-    # Pad numbers with commas to keep them from further tokenization. 
+
+    # Pad numbers with commas to keep them from further tokenization.
     COMMA_IN_NUM = re.compile(r'(?<!,)([,،])(?![,\d])'), r' \1 '
-    
+
     # Just pad problematic (often neurotic) hyphen/single quote, etc.
     PROB_SINGLE_QUOTES = re.compile(r"(['’`])"), r' \1 '
     # Group ` ` stupid quotes ' ' into a single token.
     STUPID_QUOTES_1 = re.compile(r" ` ` "), r" `` "
     STUPID_QUOTES_2 = re.compile(r" ' ' "), r" '' "
-    
-    # Don't tokenize period unless it ends the line and that it isn't 
-    # preceded by another period, e.g.  
-    # "something ..." -> "something ..." 
-    # "something." -> "something ." 
+
+    # Don't tokenize period unless it ends the line and that it isn't
+    # preceded by another period, e.g.
+    # "something ..." -> "something ..."
+    # "something." -> "something ."
     FINAL_PERIOD_1 = re.compile(r"(?<!\.)\.$"), r" ."
-    # Don't tokenize period unless it ends the line eg. 
+    # Don't tokenize period unless it ends the line eg.
     # " ... stuff." ->  "... stuff ."
     FINAL_PERIOD_2 = re.compile(r"""(?<!\.)\.\s*(["'’»›”]) *$"""), r" . \1"
 
@@ -112,44 +112,44 @@ class ToktokTokenizer(TokenizerI):
                              u'\u20ac\u20ad\u20ae\u20af\u20b0\u20b1\u20b2\u20b3'
                              u'\u20b4\u20b5\u20b6\u20b7\u20b8\u20b9\u20ba\ua838'
                              u'\ufdfc\ufe69\uff04\uffe0\uffe1\uffe5\uffe6')
-    
+
     # Pad spaces after opening punctuations.
     OPEN_PUNCT_RE = re.compile(u'([{}])'.format(OPEN_PUNCT)), r'\1 '
     # Pad spaces before closing punctuations.
     CLOSE_PUNCT_RE = re.compile(u'([{}])'.format(CLOSE_PUNCT)), r'\1 '
     # Pad spaces after currency symbols.
     CURRENCY_SYM_RE = re.compile(u'([{}])'.format(CURRENCY_SYM)), r'\1 '
-    
+
     # Use for tokenizing URL-unfriendly characters: [:/?#]
     URL_FOE_1 = re.compile(r':(?!//)'), r' : ' # in perl s{:(?!//)}{ : }g;
     URL_FOE_2 = re.compile(r'\?(?!\S)'), r' ? ' # in perl s{\?(?!\S)}{ ? }g;
     # in perl: m{://} or m{\S+\.\S+/\S+} or s{/}{ / }g;
     URL_FOE_3 = re.compile(r'(:\/\/)[\S+\.\S+\/\S+][\/]'), ' / '
     URL_FOE_4 = re.compile(r' /'), r' / ' # s{ /}{ / }g;
-    
+
     # Left/Right strip, i.e. remove heading/trailing spaces.
     # These strip regexes should NOT be used,
-    # instead use str.lstrip(), str.rstrip() or str.strip() 
-    # (They are kept for reference purposes to the original toktok.pl code)  
+    # instead use str.lstrip(), str.rstrip() or str.strip()
+    # (They are kept for reference purposes to the original toktok.pl code)
     LSTRIP = re.compile(r'^ +'), ''
-    RSTRIP = re.compile(r'\s+$'),'\n' 
+    RSTRIP = re.compile(r'\s+$'),'\n'
     # Merge multiple spaces.
     ONE_SPACE = re.compile(r' {2,}'), ' '
-    
-    TOKTOK_REGEXES = [NON_BREAKING, FUNKY_PUNCT_1, 
+
+    TOKTOK_REGEXES = [NON_BREAKING, FUNKY_PUNCT_1,
                       URL_FOE_1, URL_FOE_2, URL_FOE_3, URL_FOE_4,
                       AMPERCENT, TAB, PIPE,
-                      OPEN_PUNCT_RE, CLOSE_PUNCT_RE, 
+                      OPEN_PUNCT_RE, CLOSE_PUNCT_RE,
                       MULTI_COMMAS, COMMA_IN_NUM, FINAL_PERIOD_2,
                       PROB_SINGLE_QUOTES, STUPID_QUOTES_1, STUPID_QUOTES_2,
                       CURRENCY_SYM_RE, EN_EM_DASHES, MULTI_DASHES, MULTI_DOTS,
                       FINAL_PERIOD_1, FINAL_PERIOD_2, ONE_SPACE]
-    
+
     def tokenize(self, text, return_str=False):
         text = text_type(text) # Converts input string into unicode.
         for regexp, subsitution in self.TOKTOK_REGEXES:
             text = regexp.sub(subsitution, text)
         # Finally, strips heading and trailing spaces
         # and converts output string into unicode.
-        text = text_type(text.strip()) 
+        text = text_type(text.strip())
         return text if return_str else text.split()

--- a/nltk/tokenize/toktok.py
+++ b/nltk/tokenize/toktok.py
@@ -22,7 +22,7 @@ Model (Doctoral dissertation). Columbus, OH, USA: The Ohio State University.
 """
 
 import re
-from six import text_type
+from nltk.six import text_type
 
 from nltk.tokenize.api import TokenizerI
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps =
     coverage
     text-unidecode
     twython
+    pyparsing
 ;    six
 
 changedir = nltk/test
@@ -41,6 +42,7 @@ deps =
     coverage
     text-unidecode
     twython
+    pyparsing
 ;    six
 
 commands =
@@ -58,6 +60,7 @@ deps =
     coverage
     text-unidecode
     twython
+    pyparsing
 ;    six
 
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,9 @@ setenv =
     LAPACK=
     ATLAS=None
 
+; Copy all environment variables to the tox test environment
+passenv = *
+
 deps =
     numpy
     nose >= 1.2.1

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ deps =
     text-unidecode
     twython
     pyparsing
+    python-crfsuite
 ;    six
 
 changedir = nltk/test
@@ -43,6 +44,7 @@ deps =
     text-unidecode
     twython
     pyparsing
+    python-crfsuite
 ;    six
 
 commands =
@@ -61,6 +63,7 @@ deps =
     text-unidecode
     twython
     pyparsing
+    python-crfsuite
 ;    six
 
 commands =


### PR DESCRIPTION
Please review this PR so that I can eventually merge it.

This PR currently solves several test failures. Following are the main changes:
- merge PR by @ExplodingCabbage to fix `six` imports (#1467)
- refactor `six` imports so that they are correctly grouped following NLTK guidelines (see: [Package Structure](https://github.com/nltk/nltk/wiki/Package-Structure))
- add `pyparsing` and `python-crfsuite` packages to `tox` dependencies.
  
  This fixes the following test failures: 
  
  ```
  NameError: name 'pyparsing' is not defined
  NameError: name 'pycrfsuite' is not defined
  ```
- make `tox` aware of environment variables.
  
  This is needed, for example, to run tests in a system where custom environment variables (like `NLTK_DATA` or `SENNA`) have been set. See [Installing NLTK data](http://www.nltk.org/data.html) and [Installing Third Party Software](https://github.com/nltk/nltk/wiki/Installing-Third-Party-Software) for more info.
- replace Senna doctests with unit tests.
  
  Doctests were failing on systems that did not have a `Senna` executable in `/usr/share/senna-v3.0`. New tests check if a different location is set using the `SENNA` environment variable. If the executable folder cannot be found we expect that a `OSError` exception is raised. If this happens, tests are considered successful. **NOTE:** I suppose this behaviour can be debatable.
- Fix `aline.py` tests (see #1418)
  
  Doctests were failing with `python2.7` because of encoding problems. We now use unittest and add `from __future__ import unicode_literals` in the module. Thanks @geoffbacon for your help on the module.

Related issues:
- Better document how to run the tests (#1466) 
# NOTE

Some tests are still failing. Please submit other PR in order to fix them.
- Fix Gluesemantic tests (see #1050)
- Fix `ipipan` and `nkjp` corpora (see #1484)

@stevenbird @kmike @dimazest I would be grateful if you could please give me your opinion about this PR :)
