### PR TITLE
Final tests and tweaks to fix BLEU

### DIFF
--- a/nltk/test/unit/translate/test_bleu.py
+++ b/nltk/test/unit/translate/test_bleu.py
@@ -188,24 +188,3 @@ class TestBLEUvsMteval13a(unittest.TestCase):
                     #       +/- 1.0 BLEU might be "statistically significant",
                     #       the actual translation quality might not be.
                     assert abs(mteval_bleu - nltk_bleu) < 0.5
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-            #

--- a/nltk/test/unit/translate/test_bleu.py
+++ b/nltk/test/unit/translate/test_bleu.py
@@ -3,15 +3,18 @@
 Tests for BLEU translation evaluation metric
 """
 
+import io
 import unittest
-from nltk.translate.bleu_score import modified_precision, brevity_penalty
+
+from nltk.data import find, load
+from nltk.translate.bleu_score import modified_precision, brevity_penalty, closest_ref_length
 from nltk.translate.bleu_score import sentence_bleu, corpus_bleu
 
 
 class TestBLEU(unittest.TestCase):
     def test_modified_precision(self):
         """
-        Examples from the original BLEU paper 
+        Examples from the original BLEU paper
         http://www.aclweb.org/anthology/P02-1040.pdf
         """
         # Example 1: the "the*" example.
@@ -20,19 +23,19 @@ class TestBLEU(unittest.TestCase):
         ref2 = 'there is a cat on the mat'.split()
         # Hypothesis sentence(s).
         hyp1 = 'the the the the the the the'.split()
-        
-        references = [ref1, ref2] 
-        
+
+        references = [ref1, ref2]
+
         # Testing modified unigram precision.
         hyp1_unigram_precision =  float(modified_precision(references, hyp1, n=1))
         assert (round(hyp1_unigram_precision, 4) == 0.2857)
         # With assertAlmostEqual at 4 place precision.
         self.assertAlmostEqual(hyp1_unigram_precision, 0.28571428, places=4)
-        
+
         # Testing modified bigram precision.
         assert(float(modified_precision(references, hyp1, n=2)) == 0.0)
-        
-        
+
+
         # Example 2: the "of the" example.
         # Reference sentences
         ref1 = str('It is a guide to action that ensures that the military '
@@ -43,23 +46,23 @@ class TestBLEU(unittest.TestCase):
                    'the directions of the party').split()
         # Hypothesis sentence(s).
         hyp1 = 'of the'.split()
-        
-        references = [ref1, ref2, ref3] 
+
+        references = [ref1, ref2, ref3]
         # Testing modified unigram precision.
         assert (float(modified_precision(references, hyp1, n=1)) == 1.0)
-        
+
         # Testing modified bigram precision.
         assert(float(modified_precision(references, hyp1, n=2)) == 1.0)
-        
+
 
         # Example 3: Proper MT outputs.
         hyp1 = str('It is a guide to action which ensures that the military '
                    'always obeys the commands of the party').split()
         hyp2 = str('It is to insure the troops forever hearing the activity '
                    'guidebook that party direct').split()
-        
+
         references = [ref1, ref2, ref3]
-        
+
         # Unigram precision.
         hyp1_unigram_precision = float(modified_precision(references, hyp1, n=1))
         hyp2_unigram_precision = float(modified_precision(references, hyp2, n=1))
@@ -69,7 +72,7 @@ class TestBLEU(unittest.TestCase):
         # Test unigram precision with rounding.
         assert (round(hyp1_unigram_precision, 4) == 0.9444)
         assert (round(hyp2_unigram_precision, 4) == 0.5714)
-        
+
         # Bigram precision
         hyp1_bigram_precision = float(modified_precision(references, hyp1, n=2))
         hyp2_bigram_precision = float(modified_precision(references, hyp2, n=2))
@@ -79,32 +82,47 @@ class TestBLEU(unittest.TestCase):
         # Test bigram precision with rounding.
         assert (round(hyp1_bigram_precision, 4) == 0.5882)
         assert (round(hyp2_bigram_precision, 4) == 0.0769)
-        
+
+    def test_brevity_penalty(self):
+        # Test case from brevity_penalty_closest function in mteval-v13a.pl.
+        # Same test cases as in the doctest in nltk.translate.bleu_score.py
+        references = [['a'] * 11, ['a'] * 8]
+        hypothesis = ['a'] * 7
+        hyp_len = len(hypothesis)
+        closest_ref_len =  closest_ref_length(references, hyp_len)
+        self.assertAlmostEqual(brevity_penalty(closest_ref_len, hyp_len), 0.8669, places=4)
+
+        references = [['a'] * 11, ['a'] * 8, ['a'] * 6, ['a'] * 7]
+        hypothesis = ['a'] * 7
+        hyp_len = len(hypothesis)
+        closest_ref_len =  closest_ref_length(references, hyp_len)
+        assert brevity_penalty(closest_ref_len, hyp_len) == 1.0
+
     def test_zero_matches(self):
         # Test case where there's 0 matches
         references = ['The candidate has no alignment to any of the references'.split()]
         hypothesis = 'John loves Mary'.split()
-        
-        # Test BLEU to nth order of n-grams, where n is len(hypothesis). 
+
+        # Test BLEU to nth order of n-grams, where n is len(hypothesis).
         for n in range(1,len(hypothesis)):
             weights = [1.0/n] * n # Uniform weights.
             assert(sentence_bleu(references, hypothesis, weights) == 0)
-    
-    def test_full_matches(self):    
+
+    def test_full_matches(self):
         # Test case where there's 100% matches
         references = ['John loves Mary'.split()]
         hypothesis = 'John loves Mary'.split()
-    
-        # Test BLEU to nth order of n-grams, where n is len(hypothesis). 
+
+        # Test BLEU to nth order of n-grams, where n is len(hypothesis).
         for n in range(1,len(hypothesis)):
             weights = [1.0/n] * n # Uniform weights.
             assert(sentence_bleu(references, hypothesis, weights) == 1.0)
-    
+
     def test_partial_matches_hypothesis_longer_than_reference(self):
         references = ['John loves Mary'.split()]
         hypothesis = 'John loves Mary who loves Mike'.split()
         self.assertAlmostEqual(sentence_bleu(references, hypothesis), 0.4729, places=4)
-            
+
 
 #@unittest.skip("Skipping fringe cases for BLEU.")
 class TestBLEUFringeCases(unittest.TestCase):
@@ -113,33 +131,81 @@ class TestBLEUFringeCases(unittest.TestCase):
         # Test BLEU to nth order of n-grams, where n > len(hypothesis).
         references = ['John loves Mary ?'.split()]
         hypothesis = 'John loves Mary'.split()
-        n = len(hypothesis) + 1 # 
+        n = len(hypothesis) + 1 #
         weights = [1.0/n] * n # Uniform weights.
         self.assertAlmostEqual(sentence_bleu(references, hypothesis, weights), 0.7165, places=4)
-        
+
         # Test case where n > len(hypothesis) but so is n > len(reference), and
         # it's a special case where reference == hypothesis.
         references = ['John loves Mary'.split()]
         hypothesis = 'John loves Mary'.split()
         assert(sentence_bleu(references, hypothesis, weights) == 1.0)
-    
+
     def test_empty_hypothesis(self):
         # Test case where there's hypothesis is empty.
         references = ['The candidate has no alignment to any of the references'.split()]
         hypothesis = []
         assert(sentence_bleu(references, hypothesis) == 0)
-        
+
     def test_empty_references(self):
         # Test case where there's reference is empty.
         references = [[]]
         hypothesis = 'John loves Mary'.split()
         assert(sentence_bleu(references, hypothesis) == 0)
-        
+
     def test_empty_references_and_hypothesis(self):
         # Test case where both references and hypothesis is empty.
         references = [[]]
         hypothesis = []
         assert(sentence_bleu(references, hypothesis) == 0)
-        
-    def test_brevity_penalty(self):
-        pass
+
+
+class TestBLEUvsMteval13a(unittest.TestCase):
+
+    def test_corpus_bleu(self):
+        ref_file = find('models/wmt15_eval/ref.ru')
+        hyp_file = find('models/wmt15_eval/google.ru')
+        mteval_output_file = find('models/wmt15_eval/mteval-13a.output')
+
+        # Reads the BLEU scores from the `mteval-13a.output` file.
+        # The order of the list corresponds to the order of the ngrams.
+        with open(mteval_output_file, 'r') as mteval_fin:
+            # The numbers are located in the last 2nd line of the file.
+            # The first and 2nd item in the list are the score and system names.
+            mteval_bleu_scores = map(float, mteval_fin.readlines()[-2].split()[1:-1])
+
+        with io.open(ref_file, 'r', encoding='utf8') as ref_fin:
+            with io.open(hyp_file, 'r', encoding='utf8') as hyp_fin:
+                # Whitespace tokenize the file.
+                # Note: split() automatically strip().
+                hypothesis = map(lambda x: x.split(), hyp_fin)
+                # Note that the corpus_bleu input is list of list of references.
+                references = map(lambda x: [x.split()],ref_fin)
+                for i, mteval_bleu in zip(range(1,10), mteval_bleu_scores):
+                    nltk_bleu = corpus_bleu(references, hypothesis, weights=(1.0/i,)*i)
+                    # Check that the BLEU scores difference is less than 0.5 .
+                    # Note: This is an approximate comparison; as much as
+                    #       +/- 1.0 BLEU might be "statistically significant",
+                    #       the actual translation quality might not be.
+                    assert abs(mteval_bleu - nltk_bleu) < 0.5
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+            #

--- a/nltk/test/unit/translate/test_bleu.py
+++ b/nltk/test/unit/translate/test_bleu.py
@@ -187,7 +187,7 @@ class TestBLEUvsMteval13a(unittest.TestCase):
                     nltk_bleu = corpus_bleu(references, hypothesis, weights=(1.0/i,)*i)
                     # Check that the BLEU scores difference is less than 0.005 .
                     # Note: This is an approximate comparison; as much as
-                    #       +/- 1.0 BLEU might be "statistically significant",
+                    #       +/- 0.01 BLEU might be "statistically significant",
                     #       the actual translation quality might not be.
                     assert abs(mteval_bleu - nltk_bleu) < 0.005
 

--- a/nltk/test/unit/translate/test_bleu.py
+++ b/nltk/test/unit/translate/test_bleu.py
@@ -7,7 +7,7 @@ import functools
 import io
 import unittest
 
-from nltk.data import find, load
+from nltk.data import find
 from nltk.translate.bleu_score import modified_precision, brevity_penalty, closest_ref_length
 from nltk.translate.bleu_score import sentence_bleu, corpus_bleu, SmoothingFunction
 

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -166,17 +166,16 @@ def corpus_bleu(list_of_references, hypotheses, weights=(0.25, 0.25, 0.25, 0.25)
     if p_numerators[1] == 0:
         return 0
 
-    # Smoothen the modified precision.
-    # Note: smooth_precision() converts values into float.
-    if not smoothing_function:
-        smoothing_function = SmoothingFunction().method0
-    p_n = smoothing_function(p_n, references=references,
-                             hypothesis=hypothesis, hyp_len=hyp_len)
-
-    # Calculates the overall modified precision for all ngrams.
-    # By sum of the product of the weights and the respective *p_n*
-    s = (w * math.log(p_i) for w, p_i in zip(weights, p_n)
-         if p_i.numerator != 0)
+    if not smoothing_function: # No smoothing, values remain as Fractions.
+        s = (w * math.log(p_i) for i, (w, p_i) in enumerate(zip(weights, p_n))
+             if p_i.numerator != 0)
+    else: # Smoothen the modified precision.
+        # Note: smoothing_function() may convert values into floats;
+        #       it tries to retain the Fraction object as much as the
+        #       smoothing method allows.
+        p_n = smoothing_function(p_n, references=references,
+                                 hypothesis=hypothesis, hyp_len=hyp_len)
+        s = (w * math.log(p_i) for i, (w, p_i) in enumerate(zip(weights, p_n)))
 
     return bp * math.exp(math.fsum(s))
 


### PR DESCRIPTION
**Wrote tests to validate NLTK BLEU with mteval-13a.pl**:

Currently, it's checking that NLTK implementations don't stray too far away from mteval's by 0.05 BLEU, when it ranges between [0.0, 1.0]; i.e. 0.5 BLEU if score range between [0.0, 100.0]. Details on #1330 

**Tweak in BLEU sum(log(p_i)**:

One thing that cannot be controlled is the data structures that the different smoothing methods can return. As much as possible, the code will try to keep the `Fraction` object, but when it's float, then checking the `p_i.numerator` wouldn't be possible. Since smoothen values are always floatable and non-zero and unsmoothen values are always `Fractions`, we can tease apart the sum log calculations and that would look a little ugly but that'll avoid creation of a new polymorphic float-fraction object that allow floats to hallucinate a numerator/denominator.
