### PR TITLE
Added ChrF and GLEU MT evaluation metrics

### DIFF
--- a/nltk/translate/chrf_score.py
+++ b/nltk/translate/chrf_score.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+# Natural Language Toolkit: ChrF score
+#
+# Copyright (C) 2001-2016 NLTK Project
+# Authors: Maja Popovic
+# Contributors: Liling Tan
+# URL: <http://nltk.org/>
+# For license information, see LICENSE.TXT
+
+""" ChrF score implementation """
+from __future__ import division
+from collections import Counter
+
+from nltk.util import ngrams, everygrams
+
+def sentence_chrf(reference, hypothesis, min_len=1, max_len=6, beta=3.0):
+    """
+    Calculates the sentence level CHRF (Character n-gram F-score) described in
+     - Maja Popovic. 2015. CHRF: Character n-gram F-score for Automatic MT Evaluation.
+       In Proceedings of the 10th Workshop on Machine Translation.
+       http://www.statmt.org/wmt15/pdf/WMT49.pdf
+     - Maja Popovic. 2016. CHRF Deconstructed: β Parameters and n-gram Weights.
+       In Proceedings of the 1st Conference on Machine Translation.
+       http://www.statmt.org/wmt16/pdf/W16-2341.pdf
+
+    Unlike multi-reference BLEU, CHRF only supports a single reference.
+
+    An example from the original BLEU paper
+    http://www.aclweb.org/anthology/P02-1040.pdf
+
+        >>> ref1 = str('It is a guide to action that ensures that the military '
+        ...            'will forever heed Party commands').split()
+        >>> hyp1 = str('It is a guide to action which ensures that the military '
+        ...            'always obeys the commands of the party').split()
+        >>> hyp2 = str('It is to insure the troops forever hearing the activity '
+        ...            'guidebook that party direct').split()
+        >>> sentence_chrf(ref1, hyp1) # doctest: +ELLIPSIS
+        0.6768...
+        >>> sentence_chrf(ref1, hyp2) # doctest: +ELLIPSIS
+        0.4201...
+
+    The infamous "the the the ... " example
+
+        >>> ref = 'the cat is on the mat'.split()
+        >>> hyp = 'the the the the the the the'.split()
+        >>> sentence_chrf(ref, hyp)  # doctest: +ELLIPSIS
+        0.2530...
+
+    An example to show that this function allows users to use strings instead of
+    tokens, i.e. list(str) as inputs.
+
+        >>> ref1 = str('It is a guide to action that ensures that the military '
+        ...            'will forever heed Party commands')
+        >>> hyp1 = str('It is a guide to action which ensures that the military '
+        ...            'always obeys the commands of the party')
+        >>> sentence_chrf(ref1, hyp1) # doctest: +ELLIPSIS
+        0.6768...
+        >>> type(ref1), type(hyp1)
+        (<type 'str'>, <type 'str'>)
+        >>> sentence_chrf(ref1.split(), hyp1.split()) # doctest: +ELLIPSIS
+        0.6768...
+
+    To skip the unigrams and only use 2- to 3-grams:
+
+        >>> sentence_chrf(ref1, hyp1, min_len=2, max_len=3) # doctest: +ELLIPSIS
+        0.7018...
+
+    :param references: reference sentence
+    :type references: list(str) / str
+    :param hypothesis: a hypothesis sentence
+    :type hypothesis: list(str) / str
+    :param min_len: The minimum order of n-gram this function should extract.
+    :type min_len: int
+    :param max_len: The maximum order of n-gram this function should extract.
+    :type max_len: int
+    :param beta: the parameter to assign more importance to recall over precision
+    :type beta: float
+    :return: the sentence level CHRF score.
+    :rtype: float
+    """
+    return corpus_chrf([reference], [hypothesis], min_len, max_len, beta=beta)
+
+
+def corpus_chrf(list_of_references, hypotheses, min_len=1, max_len=6, beta=3.0):
+    """
+    Calculates the corpus level CHRF (Character n-gram F-score), it is the
+    micro-averaged value of the sentence/segment level CHRF score.
+
+    CHRF only supports a single reference.
+
+        >>> ref1 = str('It is a guide to action that ensures that the military '
+        ...            'will forever heed Party commands').split()
+        >>> ref2 = str('It is the guiding principle which guarantees the military '
+        ...            'forces always being under the command of the Party').split()
+        >>>
+        >>> hyp1 = str('It is a guide to action which ensures that the military '
+        ...            'always obeys the commands of the party').split()
+        >>> hyp2 = str('It is to insure the troops forever hearing the activity '
+        ...            'guidebook that party direct')
+        >>> corpus_chrf([ref1, ref2, ref1, ref2], [hyp1, hyp2, hyp2, hyp1]) # doctest: +ELLIPSIS
+        0.4915...
+
+    :param references: a corpus of list of reference sentences, w.r.t. hypotheses
+    :type references: list(list(str)) / list(str)
+    :param hypotheses: a list of hypothesis sentences
+    :type hypotheses: list(list(str)) / list(str)
+    :param min_len: The minimum order of n-gram this function should extract.
+    :type min_len: int
+    :param max_len: The maximum order of n-gram this function should extract.
+    :type max_len: int
+    :param beta: the parameter to assign more importance to recall over precision
+    :type beta: float
+    :return: the sentence level CHRF score.
+    :rtype: float
+    """
+
+    assert len(list_of_references) == len(hypotheses), "The number of hypotheses and their references should be the same"
+
+    # Iterate through each hypothesis and their corresponding references.
+    for reference, hypothesis in zip(list_of_references, hypotheses):
+        # Cheating condition to allow users to input strings instead of tokens.
+        if type(reference) and type(hypothesis) != str:
+            reference, hypothesis = ' '.join(reference), ' '.join(hypothesis)
+        # For each order of ngram, calculate the no. of ngram matches and
+        # keep track of no. of ngram in references.
+        ref_ngrams = Counter(everygrams(reference, min_len, max_len))
+        hyp_ngrams = Counter(everygrams(hypothesis, min_len, max_len))
+        overlap_ngrams = ref_ngrams & hyp_ngrams
+        tp = sum(overlap_ngrams.values()) # True positives.
+        tpfp = sum(hyp_ngrams.values()) # True positives + False positives.
+        tffn = sum(ref_ngrams.values()) # True posities + False negatives.
+
+    precision = tp / tpfp
+    recall = tp / tffn
+    factor = beta**2
+    score = (1+ factor ) * (precision * recall) / ( factor * precision + recall)
+    return score

--- a/nltk/translate/gleu_score.py
+++ b/nltk/translate/gleu_score.py
@@ -15,7 +15,7 @@ from nltk.util import ngrams, everygrams
 
 def sentence_gleu(reference, hypothesis, min_len=1, max_len=4):
     """
-    Calculates the sentence level CHRF (Character n-gram F-score) described in
+    Calculates the sentence level GLEU (Google-BLEU) score described in
 
         Yonghui Wu, Mike Schuster, Zhifeng Chen, Quoc V. Le, Mohammad Norouzi,
         Wolfgang Macherey, Maxim Krikun, Yuan Cao, Qin Gao, Klaus Macherey,

--- a/nltk/translate/gleu_score.py
+++ b/nltk/translate/gleu_score.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+# Natural Language Toolkit: GLEU Score
+#
+# Copyright (C) 2001-2016 NLTK Project
+# Authors:
+# Contributors:
+# URL: <http://nltk.org/>
+# For license information, see LICENSE.TXT
+
+""" GLEU score implementation. """
+from __future__ import division
+from collections import Counter
+
+from nltk.util import ngrams, everygrams
+
+def sentence_gleu(reference, hypothesis, min_len=1, max_len=4):
+    """
+    Calculates the sentence level CHRF (Character n-gram F-score) described in
+
+        Yonghui Wu, Mike Schuster, Zhifeng Chen, Quoc V. Le, Mohammad Norouzi,
+        Wolfgang Macherey, Maxim Krikun, Yuan Cao, Qin Gao, Klaus Macherey,
+        Jeff Klingner, Apurva Shah, Melvin Johnson, Xiaobing Liu, Lukasz Kaiser,
+        Stephan Gouws, Yoshikiyo Kato, Taku Kudo, Hideto Kazawa, Keith Stevens,
+        George Kurian, Nishant Patil, Wei Wang, Cliff Young, Jason Smith,
+        Jason Riesa, Alex Rudnick, Oriol Vinyals, Greg Corrado, Macduff Hughes,
+        Jeffrey Dean. (2016) Google’s Neural Machine Translation System:
+        Bridging the Gap between Human and Machine Translation.
+        eprint arXiv:1609.08144. https://arxiv.org/pdf/1609.08144v2.pdf
+        Retrieved on 27 Oct 2016.
+
+    From Wu et al. (2016):
+        "The BLEU score has some undesirable properties when used for single
+         sentences, as it was designed to be a corpus measure. We therefore
+         use a slightly different score for our RL experiments which we call
+         the 'GLEU score'. For the GLEU score, we record all sub-sequences of
+         1, 2, 3 or 4 tokens in output and target sequence (n-grams). We then
+         compute a recall, which is the ratio of the number of matching n-grams
+         to the number of total n-grams in the target (ground truth) sequence,
+         and a precision, which is the ratio of the number of matching n-grams
+         to the number of total n-grams in the generated output sequence. Then
+         GLEU score is simply the minimum of recall and precision. This GLEU
+         score's range is always between 0 (no matches) and 1 (all match) and
+         it is symmetrical when switching output and target. According to
+         our experiments, GLEU score correlates quite well with the BLEU
+         metric on a corpus level but does not have its drawbacks for our per
+         sentence reward objective."
+
+    Note: The GLEU score is designed for sentence based evaluation thus there is
+          no corpus based scores implemented in NLTK.
+
+    The infamous "the the the ... " example
+
+        >>> ref = 'the cat is on the mat'.split()
+        >>> hyp = 'the the the the the the the'.split()
+        >>> sentence_gleu(ref, hyp)  # doctest: +ELLIPSIS
+        0.0909...
+
+    An example to evaluate normal machine translation outputs
+
+        >>> ref1 = str('It is a guide to action that ensures that the military '
+        ...            'will forever heed Party commands').split()
+        >>> hyp1 = str('It is a guide to action which ensures that the military '
+        ...            'always obeys the commands of the party').split()
+        >>> hyp2 = str('It is to insure the troops forever hearing the activity '
+        ...            'guidebook that party direct').split()
+        >>> sentence_gleu(ref1, hyp1) # doctest: +ELLIPSIS
+        0.4393...
+        >>> sentence_gleu(ref1, hyp2) # doctest: +ELLIPSIS
+        0.1206...
+
+    :param references: reference sentence
+    :type references: list(str)
+    :param hypothesis: a hypothesis sentence
+    :type hypothesis: list(str)
+    :param min_len: The minimum order of n-gram this function should extract.
+    :type min_len: int
+    :param max_len: The maximum order of n-gram this function should extract.
+    :type max_len: int
+    :return: the sentence level CHRF score.
+    :rtype: float
+    """
+    # For each order of ngram, calculate the no. of ngram matches and
+    # keep track of no. of ngram in references.
+    ref_ngrams = Counter(everygrams(reference, min_len, max_len))
+    hyp_ngrams = Counter(everygrams(hypothesis, min_len, max_len))
+    overlap_ngrams = ref_ngrams & hyp_ngrams
+    tp = sum(overlap_ngrams.values()) # True positives.
+    tpfp = sum(hyp_ngrams.values()) # True positives + False positives.
+    tffn = sum(ref_ngrams.values()) # True posities + False negatives.
+
+    precision = tp / tpfp
+    recall = tp / tffn
+
+    return min(precision, recall)


### PR DESCRIPTION
ChrF is basically a character level BLEU without brevity penalty but it that takes an interpolated score between ngram precision and recall. There's no sentence-level version of this. 

GLEU is the Google Neural Machine Translation version for sentence BLEU where it takes the `min(precision, recall)` as the score. There's no corpus-level version of this either. 

Do we raise an error if users try to do sentence-level chrf like `sentence_chrf` or corpus-level gleu like `corpus_gleu`? 