### PR TITLE
Fix tox dependencies

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps =
     coverage
     text-unidecode
     twython
+    pyparsing
 
 changedir = nltk/test
 commands =
@@ -40,6 +41,7 @@ deps =
     coverage
     text-unidecode
     twython
+    pyparsing
 
 commands =
     ; scipy and scikit-learn requires numpy even to run setup.py so
@@ -56,6 +58,7 @@ deps =
     coverage
     text-unidecode
     twython
+    pyparsing
 
 commands =
     ; scipy and scikit-learn requires numpy even to run setup.py so

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ deps =
     text-unidecode
     twython
     pyparsing
+    python-crfsuite
 
 changedir = nltk/test
 commands =
@@ -42,6 +43,7 @@ deps =
     text-unidecode
     twython
     pyparsing
+    python-crfsuite
 
 commands =
     ; scipy and scikit-learn requires numpy even to run setup.py so
@@ -59,6 +61,7 @@ deps =
     text-unidecode
     twython
     pyparsing
+    python-crfsuite
 
 commands =
     ; scipy and scikit-learn requires numpy even to run setup.py so


### PR DESCRIPTION
This PR adds `pyparsing` and `python-crfsuite` packages to `tox` dependencies.

This fixes the following test failures: 
  
```
NameError: name 'pyparsing' is not defined
NameError: name 'pycrfsuite' is not defined
```

Related issue: #1466