### PR TITLE
Fix SENNA tests

### DIFF
--- a/nltk/classify/senna.py
+++ b/nltk/classify/senna.py
@@ -22,17 +22,19 @@ system specific binary should be rebuilt. Otherwise this could introduce
 misalignment errors.
 
 The input is:
-- path to the directory that contains SENNA executables. If the path is incorrect, 
+- path to the directory that contains SENNA executables. If the path is incorrect,
    Senna will automatically search for executable file specified in SENNA environment variable
 - List of the operations needed to be performed.
 - (optionally) the encoding of the input data (default:utf-8)
+
+Note: Unit tests for this module can be found in test/unit/test_senna.py
 
     >>> from __future__ import unicode_literals
     >>> from nltk.classify import Senna
     >>> pipeline = Senna('/usr/share/senna-v3.0', ['pos', 'chk', 'ner'])
     >>> sent = 'Dusseldorf is an international business center'.split()
-    >>> [(token['word'], token['chk'], token['ner'], token['pos']) for token in pipeline.tag(sent)]
-    [('Dusseldorf', 'B-NP', 'B-LOC', 'NNP'), ('is', 'B-VP', 'O', 'VBZ'), ('an', 'B-NP', 'O', 'DT'), 
+    >>> [(token['word'], token['chk'], token['ner'], token['pos']) for token in pipeline.tag(sent)] # doctest: +SKIP
+    [('Dusseldorf', 'B-NP', 'B-LOC', 'NNP'), ('is', 'B-VP', 'O', 'VBZ'), ('an', 'B-NP', 'O', 'DT'),
     ('international', 'I-NP', 'O', 'JJ'), ('business', 'I-NP', 'O', 'NN'), ('center', 'I-NP', 'O', 'NN')]
 """
 
@@ -55,29 +57,29 @@ class Senna(TaggerI):
 
     def __init__(self, senna_path, operations, encoding='utf-8'):
         self._encoding = encoding
-        self._path = path.normpath(senna_path) + sep 
-        
-        # Verifies the existence of the executable on the self._path first    
+        self._path = path.normpath(senna_path) + sep
+
+        # Verifies the existence of the executable on the self._path first
         #senna_binary_file_1 = self.executable(self._path)
         exe_file_1 = self.executable(self._path)
         if not path.isfile(exe_file_1):
-            # Check for the system environment 
+            # Check for the system environment
             if 'SENNA' in environ:
-                #self._path = path.join(environ['SENNA'],'')  
-                self._path = path.normpath(environ['SENNA']) + sep 
+                #self._path = path.join(environ['SENNA'],'')
+                self._path = path.normpath(environ['SENNA']) + sep
                 exe_file_2 = self.executable(self._path)
                 if not path.isfile(exe_file_2):
                     raise OSError("Senna executable expected at %s or %s but not found" % (exe_file_1,exe_file_2))
-        
+
         self.operations = operations
 
-    
+
     def executable(self, base_path):
         """
         The function that determines the system specific binary that should be
         used in the pipeline. In case, the system is not known the default senna binary will
         be used.
-        """ 
+        """
         os_name = system()
         if os_name == 'Linux':
             bits = architecture()[0]
@@ -89,7 +91,7 @@ class Senna(TaggerI):
         if os_name == 'Darwin':
             return path.join(base_path, 'senna-osx')
         return path.join(base_path, 'senna')
-        
+
     def _map(self):
         """
         A method that calculates the order of the columns that SENNA pipeline
@@ -116,11 +118,11 @@ class Senna(TaggerI):
         calculated annotations/tags.
         """
         encoding = self._encoding
-        
+
         if not path.isfile(self.executable(self._path)):
             raise OSError("Senna executable expected at %s but not found" % self.executable(self._path))
-        
-         
+
+
         # Build the senna command to run the tagger
         _senna_cmd = [self.executable(self._path), '-path', self._path, '-usrtokens', '-iobtags']
         _senna_cmd.extend(['-'+op for op in self.operations])

--- a/nltk/tag/senna.py
+++ b/nltk/tag/senna.py
@@ -10,29 +10,31 @@
 Senna POS tagger, NER Tagger, Chunk Tagger
 
 The input is:
-- path to the directory that contains SENNA executables. If the path is incorrect, 
-   SennaTagger will automatically search for executable file specified in SENNA environment variable 
+- path to the directory that contains SENNA executables. If the path is incorrect,
+   SennaTagger will automatically search for executable file specified in SENNA environment variable
 - (optionally) the encoding of the input data (default:utf-8)
+
+Note: Unit tests for this module can be found in test/unit/test_senna.py
 
     >>> from nltk.tag import SennaTagger
     >>> tagger = SennaTagger('/usr/share/senna-v3.0')
-    >>> tagger.tag('What is the airspeed of an unladen swallow ?'.split())
+    >>> tagger.tag('What is the airspeed of an unladen swallow ?'.split()) # doctest: +SKIP
     [('What', 'WP'), ('is', 'VBZ'), ('the', 'DT'), ('airspeed', 'NN'),
     ('of', 'IN'), ('an', 'DT'), ('unladen', 'NN'), ('swallow', 'NN'), ('?', '.')]
 
     >>> from nltk.tag import SennaChunkTagger
     >>> chktagger = SennaChunkTagger('/usr/share/senna-v3.0')
-    >>> chktagger.tag('What is the airspeed of an unladen swallow ?'.split())
+    >>> chktagger.tag('What is the airspeed of an unladen swallow ?'.split()) # doctest: +SKIP
     [('What', 'B-NP'), ('is', 'B-VP'), ('the', 'B-NP'), ('airspeed', 'I-NP'),
     ('of', 'B-PP'), ('an', 'B-NP'), ('unladen', 'I-NP'), ('swallow', 'I-NP'),
     ('?', 'O')]
 
     >>> from nltk.tag import SennaNERTagger
     >>> nertagger = SennaNERTagger('/usr/share/senna-v3.0')
-    >>> nertagger.tag('Shakespeare theatre was in London .'.split())
+    >>> nertagger.tag('Shakespeare theatre was in London .'.split()) # doctest: +SKIP
     [('Shakespeare', 'B-PER'), ('theatre', 'O'), ('was', 'O'), ('in', 'O'),
     ('London', 'B-LOC'), ('.', 'O')]
-    >>> nertagger.tag('UN headquarters are in NY , USA .'.split())
+    >>> nertagger.tag('UN headquarters are in NY , USA .'.split()) # doctest: +SKIP
     [('UN', 'B-ORG'), ('headquarters', 'O'), ('are', 'O'), ('in', 'O'),
     ('NY', 'B-LOC'), (',', 'O'), ('USA', 'B-LOC'), ('.', 'O')]
 """
@@ -73,29 +75,29 @@ class SennaChunkTagger(Senna):
                 annotations = tagged_sents[i][j]
                 tagged_sents[i][j] = (annotations['word'], annotations['chk'])
         return tagged_sents
-        
+
     def bio_to_chunks(self, tagged_sent, chunk_type):
         """
         Extracts the chunks in a BIO chunk-tagged sentence.
-        
+
         >>> from nltk.tag import SennaChunkTagger
         >>> chktagger = SennaChunkTagger('/usr/share/senna-v3.0')
         >>> sent = 'What is the airspeed of an unladen swallow ?'.split()
-        >>> tagged_sent = chktagger.tag(sent)
-        >>> tagged_sent
+        >>> tagged_sent = chktagger.tag(sent) # doctest: +SKIP
+        >>> tagged_sent # doctest: +SKIP
         [('What', 'B-NP'), ('is', 'B-VP'), ('the', 'B-NP'), ('airspeed', 'I-NP'),
         ('of', 'B-PP'), ('an', 'B-NP'), ('unladen', 'I-NP'), ('swallow', 'I-NP'),
         ('?', 'O')]
-        >>> list(chktagger.bio_to_chunks(tagged_sent, chunk_type='NP'))
+        >>> list(chktagger.bio_to_chunks(tagged_sent, chunk_type='NP')) # doctest: +SKIP
         [('What', '0'), ('the airspeed', '2-3'), ('an unladen swallow', '5-6-7')]
-        
+
         :param tagged_sent: A list of tuples of word and BIO chunk tag.
         :type tagged_sent: list(tuple)
         :param tagged_sent: The chunk tag that users want to extract, e.g. 'NP' or 'VP'
         :type tagged_sent: str
-        
+
         :return: An iterable of tuples of chunks that users want to extract
-          and their corresponding indices. 
+          and their corresponding indices.
         :rtype: iter(tuple(str))
         """
         current_chunk = []
@@ -107,14 +109,14 @@ class SennaChunkTagger(Senna):
                 current_chunk_position.append((idx))
             else:
                 if current_chunk: # Flush the full chunk when out of an NP.
-                    _chunk_str = ' '.join(current_chunk) 
+                    _chunk_str = ' '.join(current_chunk)
                     _chunk_pos_str = '-'.join(map(str, current_chunk_position))
-                    yield _chunk_str, _chunk_pos_str 
+                    yield _chunk_str, _chunk_pos_str
                     current_chunk = []
                     current_chunk_position = []
         if current_chunk: # Flush the last chunk.
             yield ' '.join(current_chunk), '-'.join(map(str, current_chunk_position))
-    
+
 
 @python_2_unicode_compatible
 class SennaNERTagger(Senna):

--- a/nltk/test/unit/test_senna.py
+++ b/nltk/test/unit/test_senna.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests for Senna
+"""
+
+from __future__ import unicode_literals
+from os import environ, path, sep
+
+import logging
+import unittest
+
+from nltk.classify import Senna
+from nltk.tag import SennaTagger, SennaChunkTagger, SennaNERTagger
+
+# Set Senna executable path for tests if it is not specified as an environment variable
+if 'SENNA' in environ:
+    SENNA_EXECUTABLE_PATH = path.normpath(environ['SENNA']) + sep
+else:
+    SENNA_EXECUTABLE_PATH = '/usr/share/senna-v3.0'
+
+class TestSennaPipeline(unittest.TestCase):
+    """Unittest for nltk.classify.senna"""
+
+    def test_senna_pipeline(self):
+        """Senna pipeline interface"""
+
+        pipeline = Senna(SENNA_EXECUTABLE_PATH, ['pos', 'chk', 'ner'])
+        sent = 'Dusseldorf is an international business center'.split()
+
+        if path.exists(SENNA_EXECUTABLE_PATH):
+            result = [(token['word'], token['chk'], token['ner'], token['pos']) for token in pipeline.tag(sent)]
+            expected = [('Dusseldorf', 'B-NP', 'B-LOC', 'NNP'), ('is', 'B-VP',
+                'O', 'VBZ'), ('an', 'B-NP', 'O', 'DT'), ('international', 'I-NP',
+                'O', 'JJ'), ('business', 'I-NP', 'O', 'NN'), ('center', 'I-NP',
+                'O', 'NN')]
+            self.assertEqual(result, expected)
+        else:
+            # Check that an OSError exception is raised if Senna executable is missing
+            with self.assertRaises(OSError):
+                [(token['word'], token['chk'], token['ner'], token['pos']) for token in pipeline.tag(sent)]
+
+class TestSennaTagger(unittest.TestCase):
+    """Unittest for nltk.tag.senna"""
+
+    def test_senna_tagger(self):
+        tagger = SennaTagger(SENNA_EXECUTABLE_PATH)
+        if path.exists(SENNA_EXECUTABLE_PATH):
+            result = tagger.tag('What is the airspeed of an unladen swallow ?'.split())
+            expected = [('What', 'WP'), ('is', 'VBZ'), ('the', 'DT'), ('airspeed',
+                'NN'),('of', 'IN'), ('an', 'DT'), ('unladen', 'NN'), ('swallow',
+                'NN'), ('?', '.')]
+            self.assertEqual(result, expected)
+        else:
+            # Check that an OSError exception is raised if Senna executable is missing
+            with self.assertRaises(OSError):
+                tagger.tag('What is the airspeed of an unladen swallow ?'.split())
+
+    def test_senna_chunk_tagger(self):
+        chktagger = SennaChunkTagger(SENNA_EXECUTABLE_PATH)
+        if path.exists(SENNA_EXECUTABLE_PATH):
+            result_1 = chktagger.tag('What is the airspeed of an unladen swallow ?'.split())
+            expected_1 = [('What', 'B-NP'), ('is', 'B-VP'), ('the', 'B-NP'), ('airspeed',
+                'I-NP'), ('of', 'B-PP'), ('an', 'B-NP'), ('unladen', 'I-NP'), ('swallow',
+                'I-NP'), ('?', 'O')]
+
+            result_2 = list(chktagger.bio_to_chunks(result_1, chunk_type='NP'))
+            expected_2 = [('What', '0'), ('the airspeed', '2-3'), ('an unladen swallow',
+                '5-6-7')]
+            self.assertEqual(result_1, expected_1)
+            self.assertEqual(result_2, expected_2)
+        else:
+            with self.assertRaises(OSError):
+                chktagger.tag('What is the airspeed of an unladen swallow ?'.split())
+
+    def test_senna_ner_tagger(self):
+        nertagger = SennaNERTagger(SENNA_EXECUTABLE_PATH)
+        if path.exists(SENNA_EXECUTABLE_PATH):
+            result_1 = nertagger.tag('Shakespeare theatre was in London .'.split())
+            expected_1 = [('Shakespeare', 'B-PER'), ('theatre', 'O'), ('was', 'O'),
+                    ('in', 'O'), ('London', 'B-LOC'), ('.', 'O')]
+
+            result_2 = nertagger.tag('UN headquarters are in NY , USA .'.split())
+            expected_2 = [('UN', 'B-ORG'), ('headquarters', 'O'), ('are', 'O'),
+            ('in', 'O'), ('NY', 'B-LOC'), (',', 'O'), ('USA', 'B-LOC'), ('.', 'O')]
+            self.assertEqual(result_1, expected_1)
+            self.assertEqual(result_2, expected_2)
+        else:
+            print("OKKK")
+            print("OKKK")
+            print("OKKK")
+            print("OKKK")
+            with self.assertRaises(OSError):
+                nertagger.tag('Shakespeare theatre was in London .'.split())
+                nertagger.tag('UN headquarters are in NY , USA .'.split())

--- a/nltk/test/unit/test_senna.py
+++ b/nltk/test/unit/test_senna.py
@@ -18,6 +18,9 @@ if 'SENNA' in environ:
 else:
     SENNA_EXECUTABLE_PATH = '/usr/share/senna-v3.0'
 
+senna_is_installed = path.exists(SENNA_EXECUTABLE_PATH)
+
+@unittest.skipUnless(senna_is_installed, "Requires Senna executable")
 class TestSennaPipeline(unittest.TestCase):
     """Unittest for nltk.classify.senna"""
 
@@ -26,69 +29,46 @@ class TestSennaPipeline(unittest.TestCase):
 
         pipeline = Senna(SENNA_EXECUTABLE_PATH, ['pos', 'chk', 'ner'])
         sent = 'Dusseldorf is an international business center'.split()
+        result = [(token['word'], token['chk'], token['ner'], token['pos']) for token in pipeline.tag(sent)]
+        expected = [('Dusseldorf', 'B-NP', 'B-LOC', 'NNP'), ('is', 'B-VP',
+            'O', 'VBZ'), ('an', 'B-NP', 'O', 'DT'), ('international', 'I-NP',
+            'O', 'JJ'), ('business', 'I-NP', 'O', 'NN'), ('center', 'I-NP',
+            'O', 'NN')]
+        self.assertEqual(result, expected)
 
-        if path.exists(SENNA_EXECUTABLE_PATH):
-            result = [(token['word'], token['chk'], token['ner'], token['pos']) for token in pipeline.tag(sent)]
-            expected = [('Dusseldorf', 'B-NP', 'B-LOC', 'NNP'), ('is', 'B-VP',
-                'O', 'VBZ'), ('an', 'B-NP', 'O', 'DT'), ('international', 'I-NP',
-                'O', 'JJ'), ('business', 'I-NP', 'O', 'NN'), ('center', 'I-NP',
-                'O', 'NN')]
-            self.assertEqual(result, expected)
-        else:
-            # Check that an OSError exception is raised if Senna executable is missing
-            with self.assertRaises(OSError):
-                [(token['word'], token['chk'], token['ner'], token['pos']) for token in pipeline.tag(sent)]
-
+@unittest.skipUnless(senna_is_installed, "Requires Senna executable")
 class TestSennaTagger(unittest.TestCase):
     """Unittest for nltk.tag.senna"""
 
     def test_senna_tagger(self):
         tagger = SennaTagger(SENNA_EXECUTABLE_PATH)
-        if path.exists(SENNA_EXECUTABLE_PATH):
-            result = tagger.tag('What is the airspeed of an unladen swallow ?'.split())
-            expected = [('What', 'WP'), ('is', 'VBZ'), ('the', 'DT'), ('airspeed',
-                'NN'),('of', 'IN'), ('an', 'DT'), ('unladen', 'NN'), ('swallow',
-                'NN'), ('?', '.')]
-            self.assertEqual(result, expected)
-        else:
-            # Check that an OSError exception is raised if Senna executable is missing
-            with self.assertRaises(OSError):
-                tagger.tag('What is the airspeed of an unladen swallow ?'.split())
+        result = tagger.tag('What is the airspeed of an unladen swallow ?'.split())
+        expected = [('What', 'WP'), ('is', 'VBZ'), ('the', 'DT'), ('airspeed',
+            'NN'),('of', 'IN'), ('an', 'DT'), ('unladen', 'NN'), ('swallow',
+            'NN'), ('?', '.')]
+        self.assertEqual(result, expected)
 
     def test_senna_chunk_tagger(self):
         chktagger = SennaChunkTagger(SENNA_EXECUTABLE_PATH)
-        if path.exists(SENNA_EXECUTABLE_PATH):
-            result_1 = chktagger.tag('What is the airspeed of an unladen swallow ?'.split())
-            expected_1 = [('What', 'B-NP'), ('is', 'B-VP'), ('the', 'B-NP'), ('airspeed',
-                'I-NP'), ('of', 'B-PP'), ('an', 'B-NP'), ('unladen', 'I-NP'), ('swallow',
-                'I-NP'), ('?', 'O')]
+        result_1 = chktagger.tag('What is the airspeed of an unladen swallow ?'.split())
+        expected_1 = [('What', 'B-NP'), ('is', 'B-VP'), ('the', 'B-NP'), ('airspeed',
+            'I-NP'), ('of', 'B-PP'), ('an', 'B-NP'), ('unladen', 'I-NP'), ('swallow',
+            'I-NP'), ('?', 'O')]
 
-            result_2 = list(chktagger.bio_to_chunks(result_1, chunk_type='NP'))
-            expected_2 = [('What', '0'), ('the airspeed', '2-3'), ('an unladen swallow',
-                '5-6-7')]
-            self.assertEqual(result_1, expected_1)
-            self.assertEqual(result_2, expected_2)
-        else:
-            with self.assertRaises(OSError):
-                chktagger.tag('What is the airspeed of an unladen swallow ?'.split())
+        result_2 = list(chktagger.bio_to_chunks(result_1, chunk_type='NP'))
+        expected_2 = [('What', '0'), ('the airspeed', '2-3'), ('an unladen swallow',
+            '5-6-7')]
+        self.assertEqual(result_1, expected_1)
+        self.assertEqual(result_2, expected_2)
 
     def test_senna_ner_tagger(self):
         nertagger = SennaNERTagger(SENNA_EXECUTABLE_PATH)
-        if path.exists(SENNA_EXECUTABLE_PATH):
-            result_1 = nertagger.tag('Shakespeare theatre was in London .'.split())
-            expected_1 = [('Shakespeare', 'B-PER'), ('theatre', 'O'), ('was', 'O'),
-                    ('in', 'O'), ('London', 'B-LOC'), ('.', 'O')]
+        result_1 = nertagger.tag('Shakespeare theatre was in London .'.split())
+        expected_1 = [('Shakespeare', 'B-PER'), ('theatre', 'O'), ('was', 'O'),
+                ('in', 'O'), ('London', 'B-LOC'), ('.', 'O')]
 
-            result_2 = nertagger.tag('UN headquarters are in NY , USA .'.split())
-            expected_2 = [('UN', 'B-ORG'), ('headquarters', 'O'), ('are', 'O'),
-            ('in', 'O'), ('NY', 'B-LOC'), (',', 'O'), ('USA', 'B-LOC'), ('.', 'O')]
-            self.assertEqual(result_1, expected_1)
-            self.assertEqual(result_2, expected_2)
-        else:
-            print("OKKK")
-            print("OKKK")
-            print("OKKK")
-            print("OKKK")
-            with self.assertRaises(OSError):
-                nertagger.tag('Shakespeare theatre was in London .'.split())
-                nertagger.tag('UN headquarters are in NY , USA .'.split())
+        result_2 = nertagger.tag('UN headquarters are in NY , USA .'.split())
+        expected_2 = [('UN', 'B-ORG'), ('headquarters', 'O'), ('are', 'O'),
+        ('in', 'O'), ('NY', 'B-LOC'), (',', 'O'), ('USA', 'B-LOC'), ('.', 'O')]
+        self.assertEqual(result_1, expected_1)
+        self.assertEqual(result_2, expected_2)


### PR DESCRIPTION
This PR replaces Senna doctests with unit tests.

Doctests were failing on systems that did not have a `Senna` executable in `/usr/share/senna-v3.0`. Since SENNA is optional, this behaviour is not optimal. New tests check if Senna is present on the system and, if the executable is not found, tests are skipped.

Note: this PR is related to #1500 (`SENNA` environment variable would not work otherwise).

Related issue: #1466