### PR TITLE
Make tox aware of environment variables

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,9 @@ setenv =
     LAPACK=
     ATLAS=None
 
+; Copy all environment variables to the tox test environment
+passenv = *
+
 deps =
     numpy
     nose >= 1.2.1


### PR DESCRIPTION
This PR makes `tox` aware of system environment variables (see [tox configuration specification][1]).

This is needed, for example, to run tests in a system where custom environment variables (e.g. `NLTK_DATA` or `SENNA`) have been set. See [Installing NLTK data](http://www.nltk.org/data.html) and [Installing Third Party Software](https://github.com/nltk/nltk/wiki/Installing-Third-Party-Software) for more info.

Related issues: #1466 

[1]:http://tox.readthedocs.io/en/latest/config.html#confval-passenv=SPACE-SEPARATED-GLOBNAMES