### PR TITLE
Fix TransitionParser tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,6 @@ nltk/test/tweets*
 nosetests.xml
 nosetests_scrubbed.xml
 pylintoutput
-temp.acreager.model
-temp.arcstd.model
 model.crf.tagger
 coverage.xml
 brown.embedding

--- a/nltk/parse/transitionparser.py
+++ b/nltk/parse/transitionparser.py
@@ -328,8 +328,8 @@ class TransitionParser(ParserI):
     def _is_projective(self, depgraph):
         arc_list = []
         for key in depgraph.nodes:
-            node = depgraph.nodes[key]           
-            
+            node = depgraph.nodes[key]
+
             if 'head' in node:
                 childIdx = node['address']
                 parentIdx = node['head']
@@ -490,7 +490,7 @@ class TransitionParser(ParserI):
         print(" Number of valid (projective) examples : " + str(countProj))
         return training_seq
 
-    def train(self, depgraphs, modelfile):
+    def train(self, depgraphs, modelfile, verbose=True):
         """
         :param depgraphs : list of DependencyGraph as the training data
         :type depgraphs : DependencyGraph
@@ -522,7 +522,7 @@ class TransitionParser(ParserI):
                 coef0=0,
                 gamma=0.2,
                 C=0.5,
-                verbose=True,
+                verbose=verbose,
                 probability=True)
 
             model.fit(x_train, y_train)
@@ -730,10 +730,9 @@ def demo():
      Number of valid (projective) examples : 1
     SHIFT, LEFTARC:ATT, SHIFT, LEFTARC:SBJ, SHIFT, SHIFT, LEFTARC:ATT, SHIFT, SHIFT, SHIFT, LEFTARC:ATT, RIGHTARC:PC, RIGHTARC:ATT, RIGHTARC:OBJ, SHIFT, RIGHTARC:PU, RIGHTARC:ROOT, SHIFT
 
-    >>> parser_std.train([gold_sent],'temp.arcstd.model')
+    >>> parser_std.train([gold_sent],'temp.arcstd.model', verbose=False)
      Number of training examples : 1
      Number of valid (projective) examples : 1
-    ...
     >>> remove(input_file.name)
 
     B. Check the ARC-EAGER training
@@ -745,10 +744,9 @@ def demo():
      Number of valid (projective) examples : 1
     SHIFT, LEFTARC:ATT, SHIFT, LEFTARC:SBJ, RIGHTARC:ROOT, SHIFT, LEFTARC:ATT, RIGHTARC:OBJ, RIGHTARC:ATT, SHIFT, LEFTARC:ATT, RIGHTARC:PC, REDUCE, REDUCE, REDUCE, RIGHTARC:PU
 
-    >>> parser_eager.train([gold_sent],'temp.arceager.model')
+    >>> parser_eager.train([gold_sent],'temp.arceager.model', verbose=False)
      Number of training examples : 1
      Number of valid (projective) examples : 1
-    ...
 
     >>> remove(input_file.name)
 

--- a/nltk/parse/transitionparser.py
+++ b/nltk/parse/transitionparser.py
@@ -765,6 +765,10 @@ def demo():
     >>> de.eval() >= (0, 0)
     True
 
+    Remove test temporary files
+    >>> remove('temp.arceager.model')
+    >>> remove('temp.arcstd.model')
+
     Note that result is very poor because of only one training example.
     """
 


### PR DESCRIPTION
This PR fixes `TransitionParser` tests. 

These tests are currently producing an extremely verbose SVM output that messes up the normal `tox` output. Since we do not care about visualizing SVM output values during automated tests, I just added a `verbose` flag to the `train` method. Tests are now conducted using `verbose=False`.

`TransitionParser` tests were also generating temporary files that were not removed after testing:
```
temp.arceager.model
temp.arcstd.model
```
I removed the related entries from `.gitignore` (one of these entries was mistyped, so it was not working anyway) and made sure that these files are deleted after tests.