### PR TITLE
Fix Aline tests

### DIFF
--- a/nltk/metrics/aline.py
+++ b/nltk/metrics/aline.py
@@ -516,7 +516,10 @@ def demo():
     """
     data = [pair.split(',') for pair in cognate_data.split('\n')]
     for pair in data:
-        print(pair[0], "~", pair[1], ":", align(pair[0], pair[1])[0])
+        alignment = align(pair[0], pair[1])[0]
+        alignment = ['({}, {})'.format(a[0], a[1]) for a in alignment]
+        alignment = ' '.join(alignment)
+        print('{} ~ {} : {}'.format(pair[0], pair[1], alignment))
 
 cognate_data = """jo,ʒə
 tu,ty

--- a/nltk/metrics/aline.py
+++ b/nltk/metrics/aline.py
@@ -40,7 +40,10 @@ University of Toronto.
 
 from __future__ import unicode_literals
 
-import numpy as np
+try:
+    import numpy as np
+except ImportError:
+    np = None
 
 # === Constants ===
 
@@ -380,6 +383,9 @@ def align(str1, str2, epsilon=0):
 
     (Kondrak 2002: 51)
     """
+    if np == None:
+      raise ImportError('You need numpy in order to use the align function')
+
     assert 0.0 <= epsilon <= 1.0, "Epsilon must be between 0.0 and 1.0."
     m = len(str1)
     n = len(str2)

--- a/nltk/metrics/aline.py
+++ b/nltk/metrics/aline.py
@@ -13,17 +13,17 @@ http://webdocs.cs.ualberta.ca/~kondrak/
 Copyright 2002 by Grzegorz Kondrak.
 
 ALINE is an algorithm for aligning phonetic sequences, described in [1].
-This module is a port of Kondrak's (2002) ALINE. It provides functions for 
-phonetic sequence alignment and similarity analysis. These are useful in 
+This module is a port of Kondrak's (2002) ALINE. It provides functions for
+phonetic sequence alignment and similarity analysis. These are useful in
 historical linguistics, sociolinguistics and synchronic phonology.
 
 ALINE has parameters that can be tuned for desired output. These parameters are:
 - C_skip, C_sub, C_exp, C_vwl
 - Salience weights
-- Segmental features 
+- Segmental features
 
-In this implementation, some parameters have been changed from their default 
-values as described in [1], in order to replicate published results. All changes 
+In this implementation, some parameters have been changed from their default
+values as described in [1], in order to replicate published results. All changes
 are noted in comments.
 
 Example usage
@@ -34,24 +34,24 @@ Example usage
 >>> align('θin', 'tenwis')
 [[('θ', 't'), ('i', 'e'), ('n', 'n'), ('-', 'w'), ('-', 'i'), ('-', 's')]]
 
-[1] G. Kondrak. Algorithms for Language Reconstruction. PhD dissertation, 
+[1] G. Kondrak. Algorithms for Language Reconstruction. PhD dissertation,
 University of Toronto.
 """
 import numpy as np
 
 # === Constants ===
- 
-inf = float('inf')
-    
-# Default values for maximum similarity scores (Kondrak 2002: 54) 
-C_skip = 10 # Indels
-C_sub = 35  # Substitutions
-C_exp = 45  # Expansions/compressions
-C_vwl = 5  # Vowel/consonant relative weight (decreased from 10) 
 
-consonants = ['B', 'N', 'R', 'b', 'c', 'd', 'f', 'g', 'h', 'j', 'k', 'l', 'm', 
-              'n', 'p', 'q', 'r', 's', 't', 'v', 'x', 'z', 'ç', 'ð', 'ħ', 
-              'ŋ', 'ɖ', 'ɟ', 'ɢ', 'ɣ', 'ɦ', 'ɬ', 'ɮ', 'ɰ', 'ɱ', 'ɲ', 'ɳ', 'ɴ', 
+inf = float('inf')
+
+# Default values for maximum similarity scores (Kondrak 2002: 54)
+C_skip = 10 # Indels
+C_sub  = 35  # Substitutions
+C_exp  = 45  # Expansions/compressions
+C_vwl  = 5  # Vowel/consonant relative weight (decreased from 10)
+
+consonants = ['B', 'N', 'R', 'b', 'c', 'd', 'f', 'g', 'h', 'j', 'k', 'l', 'm',
+              'n', 'p', 'q', 'r', 's', 't', 'v', 'x', 'z', 'ç', 'ð', 'ħ',
+              'ŋ', 'ɖ', 'ɟ', 'ɢ', 'ɣ', 'ɦ', 'ɬ', 'ɮ', 'ɰ', 'ɱ', 'ɲ', 'ɳ', 'ɴ',
               'ɸ', 'ɹ', 'ɻ', 'ɽ', 'ɾ', 'ʀ', 'ʁ', 'ʂ', 'ʃ', 'ʈ', 'ʋ', 'ʐ ', 'ʒ',
               'ʔ', 'ʕ', 'ʙ', 'ʝ', 'β', 'θ', 'χ', 'ʐ', 'w']
 
@@ -60,48 +60,49 @@ R_c = ['aspirated', 'lateral', 'manner', 'nasal', 'place', 'retroflex',
        'syllabic', 'voice']
 # 'high' taken out of R_v because same as manner
 R_v = ['back', 'lateral', 'long', 'manner', 'nasal', 'place',
-       'retroflex', 'round', 'syllabic', 'voice'] 
+       'retroflex', 'round', 'syllabic', 'voice']
 
 # Flattened feature matrix (Kondrak 2002: 56)
 similarity_matrix = {
-                     #place
-                     'bilabial': 1.0, 'labiodental': 0.95, 'dental': 0.9, 
-                     'alveolar': 0.85, 'retroflex': 0.8, 'palato-alveolar': 0.75,
-                     'palatal': 0.7, 'velar': 0.6, 'uvular': 0.5, 'pharyngeal': 0.3,
-                     'glottal': 0.1, 'labiovelar': 1.0, 'vowel': -1.0, # added 'vowel'
-                     #manner
-                     'stop': 1.0, 'affricate': 0.9, 'fricative': 0.85, # increased fricative from 0.8
-                     'trill': 0.7, 'tap': 0.65, 'approximant': 0.6, 'high vowel': 0.4,
-                     'mid vowel': 0.2, 'low vowel': 0.0, 'vowel2': 0.5, # added vowel
-                     #high
-                     'high': 1.0, 'mid': 0.5, 'low': 0.0,
-                     #back
-                     'front': 1.0, 'central': 0.5, 'back': 0.0,
-                     #binary features
-                     'plus': 1.0, 'minus': 0.0}
+   #place
+   'bilabial': 1.0, 'labiodental': 0.95, 'dental': 0.9,
+   'alveolar': 0.85, 'retroflex': 0.8, 'palato-alveolar': 0.75,
+   'palatal': 0.7, 'velar': 0.6, 'uvular': 0.5, 'pharyngeal': 0.3,
+   'glottal': 0.1, 'labiovelar': 1.0, 'vowel': -1.0, # added 'vowel'
+   #manner
+   'stop': 1.0, 'affricate': 0.9, 'fricative': 0.85, # increased fricative from 0.8
+   'trill': 0.7, 'tap': 0.65, 'approximant': 0.6, 'high vowel': 0.4,
+   'mid vowel': 0.2, 'low vowel': 0.0, 'vowel2': 0.5, # added vowel
+   #high
+   'high': 1.0, 'mid': 0.5, 'low': 0.0,
+   #back
+   'front': 1.0, 'central': 0.5, 'back': 0.0,
+   #binary features
+   'plus': 1.0, 'minus': 0.0
+}
 
-# Relative weights of phonetic features (Kondrak 2002: 55)          
+# Relative weights of phonetic features (Kondrak 2002: 55)
 salience = {
-            'syllabic': 5, 
-			'place': 40, 
-			'manner': 50, 
-			'voice': 5, # decreased from 10
-			'nasal': 20, # increased from 10
-			'retroflex': 10, 
-			'lateral': 10, 
-			'aspirated': 5,
-			'long': 0, # decreased from 1 
-			'high': 3, # decreased from 5
-			'back': 2, # decreased from 5
-			'round': 2 # decreased from 5
-			}
-            
-# (Kondrak 2002: 59-60)        
+   'syllabic': 5,
+   'place': 40,
+   'manner': 50,
+   'voice': 5, # decreased from 10
+   'nasal': 20, # increased from 10
+   'retroflex': 10,
+   'lateral': 10,
+   'aspirated': 5,
+   'long': 0, # decreased from 1
+   'high': 3, # decreased from 5
+   'back': 2, # decreased from 5
+   'round': 2 # decreased from 5
+}
+
+# (Kondrak 2002: 59-60)
 feature_matrix = {
 # Consonants
 'p': {'place': 'bilabial', 'manner': 'stop', 'syllabic': 'minus', 'voice': 'minus',
 'nasal': 'minus', 'retroflex': 'minus', 'lateral': 'minus', 'aspirated': 'minus'},
-                  
+
 'b': {'place': 'bilabial', 'manner': 'stop', 'syllabic': 'minus', 'voice': 'plus',
 'nasal': 'minus', 'retroflex': 'minus', 'lateral': 'minus', 'aspirated': 'minus'},
 
@@ -361,30 +362,30 @@ feature_matrix = {
 }
 
 # === Algorithm ===
- 
+
 def align(str1, str2, epsilon=0):
     """
     Compute the alignment of two phonetic strings.
-    
+
     :type str1, str2: str
     :param str1, str2: Two strings to be aligned
     :type epsilon: float (0.0 to 1.0)
     :param epsilon: Adjusts threshold similarity score for near-optimal alignments
-    
+
     :rtpye: list(list(tuple(str, str)))
-    :return: Alignment(s) of str1 and str2 
-     
+    :return: Alignment(s) of str1 and str2
+
     (Kondrak 2002: 51)
     """
     assert 0.0 <= epsilon <= 1.0, "Epsilon must be between 0.0 and 1.0."
     m = len(str1)
     n = len(str2)
     # This includes Kondrak's initialization of row 0 and column 0 to all 0s.
-    S = np.zeros((m+1, n+1), dtype=float) 
+    S = np.zeros((m+1, n+1), dtype=float)
 
     # If i <= 1 or j <= 1, don't allow expansions as it doesn't make sense,
     # and breaks array and string indices. Make sure they never get chosen
-    # by setting them to -inf. 
+    # by setting them to -inf.
     for i in range(1, m+1):
         for j in range(1, n+1):
             edit1 = S[i-1, j] + sigma_skip(str1[i-1])
@@ -397,22 +398,22 @@ def align(str1, str2, epsilon=0):
             if j > 1:
                 edit5 = S[i-1, j-2] + sigma_exp(str1[i-1], str2[j-2:j])
             else:
-                edit5 = -inf   
+                edit5 = -inf
             S[i, j] = max(edit1, edit2, edit3, edit4, edit5, 0)
 
     T = (1-epsilon)*np.amax(S) # Threshold score for near-optimal alignments
-    
+
     alignments = []
     for i in range(1, m+1):
         for j in range(1, n+1):
             if S[i,j] >= T:
                 alignments.append(_retrieve(i, j, 0, S, T, str1, str2, []))
     return alignments
-                                   
+
 def _retrieve(i, j, s, S, T, str1, str2, out):
     """
     Retrieve the path through the similarity matrix S starting at (i, j).
-    
+
     :rtype: list(tuple(str, str))
     :return: Alignment of str1 and str2
     """
@@ -421,7 +422,7 @@ def _retrieve(i, j, s, S, T, str1, str2, out):
     else:
         if j > 1 and S[i-1, j-2] + sigma_exp(str1[i-1], str2[j-2:j]) + s >= T:
             out.insert(0, (str1[i-1], str2[j-2:j]))
-            _retrieve(i-1, j-2, s+sigma_exp(str1[i-1], str2[j-2:j]), S, T, str1, str2, out) 
+            _retrieve(i-1, j-2, s+sigma_exp(str1[i-1], str2[j-2:j]), S, T, str1, str2, out)
         elif i > 1 and S[i-2, j-1] + sigma_exp(str2[j-1], str1[i-2:i]) + s >= T:
             out.insert(0, (str1[i-2:i], str2[j-1]))
             _retrieve(i-2, j-1, s+sigma_exp(str2[j-1], str1[i-2:i]), S, T, str1, str2, out)
@@ -435,37 +436,37 @@ def _retrieve(i, j, s, S, T, str1, str2, out):
             out.insert(0, (str1[i-1], str2[j-1]))
             _retrieve(i-1, j-1, s+sigma_sub(str1[i-1], str2[j-1]), S, T, str1, str2, out)
     return out
-       
+
 def sigma_skip(p):
     """
-    Returns score of an indel of P. 
-    
+    Returns score of an indel of P.
+
     (Kondrak 2002: 54)
     """
     return C_skip
 
 def sigma_sub(p, q):
     """
-    Returns score of a substitution of P with Q. 
-    
+    Returns score of a substitution of P with Q.
+
     (Kondrak 2002: 54)
     """
     return C_sub - delta(p, q) - V(p) - V(q)
-    
+
 def sigma_exp(p, q):
     """
-    Returns score of an expansion/compression. 
-    
+    Returns score of an expansion/compression.
+
     (Kondrak 2002: 54)
     """
     q1 = q[0]
     q2 = q[1]
     return C_exp - delta(p, q1) - delta(p, q2) - V(p) - max(V(q1), V(q2))
-    
+
 def delta(p, q):
     """
     Return weighted sum of difference between P and Q.
-    
+
     (Kondrak 2002: 54)
     """
     features = R(p, q)
@@ -473,20 +474,20 @@ def delta(p, q):
     for f in features:
         total += diff(p, q, f) * salience[f]
     return total
-    
+
 def diff(p, q, f):
     """
     Returns difference between phonetic segments P and Q for feature F.
-    
+
     (Kondrak 2002: 52, 54)
     """
     p_features, q_features = feature_matrix[p], feature_matrix[q]
     return abs(similarity_matrix[p_features[f]] - similarity_matrix[q_features[f]])
-        
+
 def R(p, q):
     """
     Return relevant features for segment comparsion.
-    
+
     (Kondrak 2002: 54)
     """
     if p in consonants or q in consonants:
@@ -496,13 +497,13 @@ def R(p, q):
 def V(p):
     """
     Return vowel weight if P is vowel.
-    
+
     (Kondrak 2002: 54)
     """
     if p in consonants:
         return 0
     return C_vwl
-    
+
 # === Test ===
 
 def demo():

--- a/nltk/metrics/aline.py
+++ b/nltk/metrics/aline.py
@@ -31,12 +31,15 @@ Example usage
 
 # Get optimal alignment of two phonetic sequences
 
->>> align('θin', 'tenwis')
+>>> align('θin', 'tenwis') # doctest: +SKIP
 [[('θ', 't'), ('i', 'e'), ('n', 'n'), ('-', 'w'), ('-', 'i'), ('-', 's')]]
 
 [1] G. Kondrak. Algorithms for Language Reconstruction. PhD dissertation,
 University of Toronto.
 """
+
+from __future__ import unicode_literals
+
 import numpy as np
 
 # === Constants ===

--- a/nltk/test/unit/test_aline.py
+++ b/nltk/test/unit/test_aline.py
@@ -22,39 +22,32 @@ class TestAline(unittest.TestCase):
         
         result = aline.align('jo', 'ʒə')
         expected = [[('j', 'ʒ'), ('o', 'ə')]]
+        
         self.assertEqual(result, expected)
         
         result = aline.align('pematesiweni', 'pematesewen')
         expected = [[('p', 'p'), ('e', 'e'), ('m', 'm'), ('a', 'a'), ('t', 't'), ('e', 'e'), 
                      ('s', 's'), ('i', 'e'), ('w', 'w'), ('e', 'e'), ('n', 'n'), ('i', '-')]]
+        
         self.assertEqual(result, expected)
         
         result = aline.align('tuwθ', 'dentis')
         expected = [[('t', 'd'), ('u', 'e'), ('w', '-'), ('-', 'n'), ('-', 't'), ('-', 'i'), ('θ', 's')]]
+        
+        self.assertEqual(result, expected)
+    
+    def test_aline_delta(self):
+        """
+        Test aline for computing the difference between two segments
+        """
+        result = aline.delta('p', 'q')
+        expected = 20.0
+        
         self.assertEqual(result, expected)
         
-        result = aline.align('wən', 'unus')
-        expected = [[('ə', 'u'), ('n', 'n'), ('-', 'u'), ('-', 's')]]
-        self.assertEqual(result, expected)
+        result = aline.delta('a', 'A')
+        expected = 0.0
         
-        result = aline.align('flow', 'fluere')
-        expected = [[('f', 'f'), ('l', 'l'), ('o', 'u'), ('w', '-'), ('-', 'e'), ('-', 'r'), ('-', 'e')]]
-        self.assertEqual(result, expected)
-        
-        result = aline.align('wat', 'vas')
-        expected = [[('w', 'v'), ('a', 'a'), ('t', 's')]]
-        self.assertEqual(result, expected)
-        
-        result = aline.align('boka', 'buʃ')
-        expected = [[('b', 'b'), ('o', 'u'), ('k', 'ʃ'), ('a', '-')]]
-        self.assertEqual(result, expected)
-        
-        result = aline.align('ombre', 'om')
-        expected = [[('o', 'o'), ('m', 'm'), ('b', '-'), ('r', '-'), ('e', '-')]]
-        self.assertEqual(result, expected)
-        
-        result = aline.align('feðər', 'fEdər')
-        expected = [[('f', 'f'), ('e', 'E'), ('ð', 'd'), ('ə', 'ə'), ('r', 'r')]]
         self.assertEqual(result, expected)
         
         

--- a/nltk/test/unit/test_aline.py
+++ b/nltk/test/unit/test_aline.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests for nltk.metrics.aline
+"""
+
+from __future__ import unicode_literals
+
+import unittest
+
+from nltk.metrics import aline
+
+class TestAline(unittest.TestCase):
+    """
+    Test Aline algorithm for aligning phonetic sequences
+    """
+
+    def test_aline(self):
+        result = aline.align('θin', 'tenwis')
+        expected = [[('θ', 't'), ('i', 'e'), ('n', 'n'), ('-', 'w'), ('-', 'i'), ('-', 's')]]
+
+        self.assertEqual(result, expected)

--- a/nltk/test/unit/test_aline.py
+++ b/nltk/test/unit/test_aline.py
@@ -19,3 +19,44 @@ class TestAline(unittest.TestCase):
         expected = [[('θ', 't'), ('i', 'e'), ('n', 'n'), ('-', 'w'), ('-', 'i'), ('-', 's')]]
 
         self.assertEqual(result, expected)
+        
+        result = aline.align('jo', 'ʒə')
+        expected = [[('j', 'ʒ'), ('o', 'ə')]]
+        self.assertEqual(result, expected)
+        
+        result = aline.align('pematesiweni', 'pematesewen')
+        expected = [[('p', 'p'), ('e', 'e'), ('m', 'm'), ('a', 'a'), ('t', 't'), ('e', 'e'), 
+                     ('s', 's'), ('i', 'e'), ('w', 'w'), ('e', 'e'), ('n', 'n'), ('i', '-')]]
+        self.assertEqual(result, expected)
+        
+        result = aline.align('tuwθ', 'dentis')
+        expected = [[('t', 'd'), ('u', 'e'), ('w', '-'), ('-', 'n'), ('-', 't'), ('-', 'i'), ('θ', 's')]]
+        self.assertEqual(result, expected)
+        
+        result = aline.align('wən', 'unus')
+        expected = [[('ə', 'u'), ('n', 'n'), ('-', 'u'), ('-', 's')]]
+        self.assertEqual(result, expected)
+        
+        result = aline.align('flow', 'fluere')
+        expected = [[('f', 'f'), ('l', 'l'), ('o', 'u'), ('w', '-'), ('-', 'e'), ('-', 'r'), ('-', 'e')]]
+        self.assertEqual(result, expected)
+        
+        result = aline.align('wat', 'vas')
+        expected = [[('w', 'v'), ('a', 'a'), ('t', 's')]]
+        self.assertEqual(result, expected)
+        
+        result = aline.align('boka', 'buʃ')
+        expected = [[('b', 'b'), ('o', 'u'), ('k', 'ʃ'), ('a', '-')]]
+        self.assertEqual(result, expected)
+        
+        result = aline.align('ombre', 'om')
+        expected = [[('o', 'o'), ('m', 'm'), ('b', '-'), ('r', '-'), ('e', '-')]]
+        self.assertEqual(result, expected)
+        
+        result = aline.align('feðər', 'fEdər')
+        expected = [[('f', 'f'), ('e', 'E'), ('ð', 'd'), ('ə', 'ə'), ('r', 'r')]]
+        self.assertEqual(result, expected)
+        
+        
+        
+        

--- a/nltk/test/unit/test_aline.py
+++ b/nltk/test/unit/test_aline.py
@@ -50,6 +50,3 @@ class TestAline(unittest.TestCase):
         
         self.assertEqual(result, expected)
         
-        
-        
-        


### PR DESCRIPTION
This PR fixes `aline.py` tests (see #1418) and adds more test cases.

Doctests were failing with `python2.7` because of encoding problems. We now use unittest and add `from __future__ import unicode_literals` in the module. 

The `numpy` import strategy as also been fixed: this import used to break NLTK since `numpy` is considered to be optional.

Thanks @geoffbacon for your help.