### PR TITLE
Clean tox output hiding warnings

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist = py27,py34,py35,pypy,py27-nodeps,py34-nodeps,py35-nodeps,py27-jenkins,p
 setenv =
     LAPACK=
     ATLAS=None
+    PYTHONWARNINGS=ignore
 
 deps =
     numpy


### PR DESCRIPTION
When using `tox`, all warnings set within NLTK are currently displayed. This makes `tox` output less readable. For example:
```
py34 runtests: commands[1] | python runtests.py ../app/__init__.py
nltk/nltk/app/__init__.py:29: UserWarning: nltk.app package not loaded (please install Tkinter library).
  warnings.warn("nltk.app package not loaded "
```

This PR aims to hide all warnings by setting a specific environment variable during `tox` tests:
```
PYTHONWARNINGS=ignore
``` 

I would like to have your opinion about it. I personally prefer having a clean `tox` output, especially since these warnings do not currently affect tests.

In any case, I think it would be a good idea to also write specific tests for warnings. For example, since `tox` tests will not install many optional dependencies, we could check that a warning is actually displayed when some module tries to use them (see for example [`twitter/__init__.py`][1]). If you think this could be a good idea, please let me know so that I can start working on it.

[1]: https://github.com/nltk/nltk/blob/develop/nltk/twitter/__init__.py#L16