### PR TITLE
Fixes several errors in remove_handles

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -9,6 +9,7 @@
 
 ## Contributors
 
+- Hyuckin David Lim
 - Rami Al-Rfou'
 - Mark Amery
 - Greg Aumann

--- a/nltk/tokenize/casual.py
+++ b/nltk/tokenize/casual.py
@@ -324,7 +324,7 @@ def remove_handles(text):
     """
     Remove Twitter username handles from text.
     """
-    pattern = re.compile(r"(^|(?<=[^\w.-]))@[A-Za-z_]+\w+")
+    pattern = re.compile(r"(?<![A-Za-z0-9_!@#\$%&*])@(([A-Za-z0-9_]){20}(?!@))|(?<![A-Za-z0-9_!@#\$%&*])@(([A-Za-z0-9_]){1,19})(?![A-Za-z0-9_]*@)")
     return pattern.sub('', text)
 
 ######################################################################

--- a/nltk/tokenize/casual.py
+++ b/nltk/tokenize/casual.py
@@ -325,7 +325,8 @@ def remove_handles(text):
     Remove Twitter username handles from text.
     """
     pattern = re.compile(r"(?<![A-Za-z0-9_!@#\$%&*])@(([A-Za-z0-9_]){20}(?!@))|(?<![A-Za-z0-9_!@#\$%&*])@(([A-Za-z0-9_]){1,19})(?![A-Za-z0-9_]*@)")
-    return pattern.sub('', text)
+    # Substitute hadnles with ' ' to ensure that text on either side of removed handles are tokenized correctly
+    return pattern.sub(' ', text)
 
 ######################################################################
 # Tokenization Function


### PR DESCRIPTION
I updated the regular expression from remove_handles so that it now achieves the following:
 - Handles can begin with numbers
 - Handles are allowed to follow any of the following characters: `~()-=+\|[]{};:'\"/?.,<> \n
 - Handles are allowed to precede the following characters: !#$%&*
 - Handles have a max length of 20 (15 today, but it was 20 in the past so the max length handle you can tweet is 20)
 - Two @ in a string with only alphanumeric characters and _ between them are not handles
 - Unless the first handle is 20 characters long and there is at least one more character before the next @

The above changes may seem oddly specific, and that's because they are. These changes were not found through any Twitter documentation, but rather tweeting various test cases and observing which were tagged as handles by Twitter.

The following is a link to a gist that tests the previous regex against my suggested change:
(HINT: mine passes all the tests and the previous regex fails nearly all of them)
https://gist.github.com/hdlim15/2419dd8f6bb3987f4a3536a4008b0544