### PR TITLE
Fixes StopIteration warnings when casting empty list to Counter object

### DIFF
--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -273,7 +273,7 @@ def modified_precision(references, hypothesis, n):
     ## max_counts = reduce(or_, [Counter(ngrams(ref, n)) for ref in references])
     max_counts = {}
     for reference in references:
-        reference_counts = Counter(ngrams(reference, n))
+        reference_counts = Counter(ngrams(reference, n)) if reference else Counter()
         for ngram in counts:
             max_counts[ngram] = max(max_counts.get(ngram, 0),
                                     reference_counts[ngram])

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -265,8 +265,9 @@ def modified_precision(references, hypothesis, n):
     :return: BLEU's modified precision for the nth order ngram.
     :rtype: Fraction
     """
-    # Extracts all ngrams in hypothesis.
-    counts = Counter(ngrams(hypothesis, n))
+    # Extracts all ngrams in hypothesis
+    # Set an empty Counter if hypothesis is empty.
+    counts = Counter(ngrams(hypothesis, n)) if hypothesis else Counter()
 
     # Extract a union of references' counts.
     ## max_counts = reduce(or_, [Counter(ngrams(ref, n)) for ref in references])


### PR DESCRIPTION
Fixes #1504 for

- test_empty_hypothesis (nltk.test.unit.translate.test_bleu.TestBLEUFringeCases) ... ok
- test_empty_references (nltk.test.unit.translate.test_bleu.TestBLEUFringeCases) ... ok
- test_empty_references_and_hypothesis (nltk.test.unit.translate.test_bleu.TestBLEUFringeCases) ... ok

But still couldn't figure out why the warning is still raised for 

 - test_corpus_bleu (nltk.test.unit.translate.test_bleu.TestBLEUvsMteval13a)