### PR TITLE
Checks that order of ngram >= length of sentence to avoid Python3.5 warning

### DIFF
--- a/nltk/test/unit/translate/test_bleu.py
+++ b/nltk/test/unit/translate/test_bleu.py
@@ -181,7 +181,7 @@ class TestBLEUvsMteval13a(unittest.TestCase):
                 # Note: split() automatically strip().
                 hypothesis = list(map(lambda x: x.split(), hyp_fin))
                 # Note that the corpus_bleu input is list of list of references.
-                references = list(map(lambda x: [x.split()],ref_fin))
+                references = list(map(lambda x: [x.split()], ref_fin))
                 # Without smoothing.
                 for i, mteval_bleu in zip(range(1,10), mteval_bleu_scores):
                     nltk_bleu = corpus_bleu(references, hypothesis, weights=(1.0/i,)*i)

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -22,6 +22,7 @@ try:
 except TypeError:
     from nltk.compat import Fraction
 
+
 def sentence_bleu(references, hypothesis, weights=(0.25, 0.25, 0.25, 0.25),
                   smoothing_function=None):
     """

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -22,6 +22,18 @@ try:
 except TypeError:
     from nltk.compat import Fraction
 
+import traceback
+import warnings
+import sys
+
+def warn_with_traceback(message, category, filename, lineno, file=None, line=None):
+    traceback.print_stack()
+    log = file if hasattr(file,'write') else sys.stderr
+    log.write(warnings.formatwarning(message, category, filename, lineno, line))
+    exit()
+
+warnings.showwarning = warn_with_traceback
+
 
 def sentence_bleu(references, hypothesis, weights=(0.25, 0.25, 0.25, 0.25),
                   smoothing_function=None):
@@ -267,13 +279,12 @@ def modified_precision(references, hypothesis, n):
     """
     # Extracts all ngrams in hypothesis
     # Set an empty Counter if hypothesis is empty.
-    counts = Counter(ngrams(hypothesis, n)) if hypothesis else Counter()
-
+    counts = Counter(ngrams(hypothesis, n)) if len(hypothesis) >= n else Counter()
     # Extract a union of references' counts.
     ## max_counts = reduce(or_, [Counter(ngrams(ref, n)) for ref in references])
     max_counts = {}
     for reference in references:
-        reference_counts = Counter(ngrams(reference, n)) if reference else Counter()
+        reference_counts = Counter(ngrams(reference, n)) if len(reference) >= n else Counter()
         for ngram in counts:
             max_counts[ngram] = max(max_counts.get(ngram, 0),
                                     reference_counts[ngram])

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -21,7 +21,6 @@ try:
     from fractions import Fraction
 except TypeError:
     from nltk.compat import Fraction
-    
 
 def sentence_bleu(references, hypothesis, weights=(0.25, 0.25, 0.25, 0.25),
                   smoothing_function=None):

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -21,19 +21,7 @@ try:
     from fractions import Fraction
 except TypeError:
     from nltk.compat import Fraction
-
-import traceback
-import warnings
-import sys
-
-def warn_with_traceback(message, category, filename, lineno, file=None, line=None):
-    traceback.print_stack()
-    log = file if hasattr(file,'write') else sys.stderr
-    log.write(warnings.formatwarning(message, category, filename, lineno, line))
-    exit()
-
-warnings.showwarning = warn_with_traceback
-
+    
 
 def sentence_bleu(references, hypothesis, weights=(0.25, 0.25, 0.25, 0.25),
                   smoothing_function=None):


### PR DESCRIPTION
Fixes the last warning raised in #1529. Now the unittest for nltk.test.unit.translate.test_bleu` should be warning free:

```bash
~/git-stuff/nltk$ python3 -Wd -m unittest nltk.test.unit.translate.test_bleu -v
/Users/liling.tan/git-stuff/nltk/nltk/decorators.py:59: DeprecationWarning: inspect.getargspec() is deprecated, use inspect.signature() instead
  regargs, varargs, varkwargs, defaults = inspect.getargspec(func)
test_brevity_penalty (nltk.test.unit.translate.test_bleu.TestBLEU) ... ok
test_full_matches (nltk.test.unit.translate.test_bleu.TestBLEU) ... ok
test_modified_precision (nltk.test.unit.translate.test_bleu.TestBLEU) ... ok
test_partial_matches_hypothesis_longer_than_reference (nltk.test.unit.translate.test_bleu.TestBLEU) ... ok
test_zero_matches (nltk.test.unit.translate.test_bleu.TestBLEU) ... ok
test_case_where_n_is_bigger_than_hypothesis_length (nltk.test.unit.translate.test_bleu.TestBLEUFringeCases) ... ok
test_empty_hypothesis (nltk.test.unit.translate.test_bleu.TestBLEUFringeCases) ... ok
test_empty_references (nltk.test.unit.translate.test_bleu.TestBLEUFringeCases) ... ok
test_empty_references_and_hypothesis (nltk.test.unit.translate.test_bleu.TestBLEUFringeCases) ... ok
test_corpus_bleu (nltk.test.unit.translate.test_bleu.TestBLEUvsMteval13a) ... ok

----------------------------------------------------------------------
Ran 10 tests in 0.282s

OK
```

This check would avoid obscure bug coming from generator's `StopIteration` as suggested in [PEP 479](https://www.python.org/dev/peps/pep-0479/)

(Note that the deprecation warning that comes from #1530 hasn't been fixed)