### PR TITLE
Strip trailing whitespace in sentence splitting with Punkt.

### DIFF
--- a/nltk/test/tokenize.doctest
+++ b/nltk/test/tokenize.doctest
@@ -164,3 +164,17 @@ It should not hang on long sequences of the same punctuation character.
     >>> s10 = "Photo: Aujourd'hui sur http://t.co/0gebOFDUzn Projet... http://t.co/bKfIUbydz2.............................. http://fb.me/3b6uXpz0L"
     >>> tknzr.tokenize(s10)
     [u'Photo', u':', u"Aujourd'hui", u'sur', u'http://t.co/0gebOFDUzn', u'Projet', u'...', u'http://t.co/bKfIUbydz2', u'...', u'http://fb.me/3b6uXpz0L']
+
+
+Regression Tests: PunktSentenceTokenizer
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The sentence splitter should remove whitespace following the sentence boundary.
+
+    >>> pst = PunktSentenceTokenizer()
+    >>> pst.tokenize('See Section 3).  Or Section 2).  ')
+    ['See Section 3).', 'Or Section 2).']
+    >>> pst.tokenize('See Section 3.)  Or Section 2.)  ')
+    ['See Section 3.)', 'Or Section 2.)']
+    >>> pst.tokenize('See Section 3.)  Or Section 2.)  ', realign_boundaries=False)
+    ['See Section 3.', ')  Or Section 2.', ')']

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -1296,7 +1296,8 @@ class PunktSentenceTokenizer(PunktBaseClass,TokenizerI):
                 else:
                     # next sentence starts at following punctuation
                     last_break = match.end()
-        yield slice(last_break, len(text))
+        # The last sentence should not contain trailing whitespace.
+        yield slice(last_break, len(text.rstrip()))
 
     def _realign_boundaries(self, text, slices):
         """


### PR DESCRIPTION
This addresses [issue 1433](https://github.com/nltk/nltk/issues/1433).

Currently, sentence splitting with the PunktSentenceTokenizer behaves as follows:
- Whitespace between sentences is removed.
- Whitespace following the last sentence is kept.
- As an exception to the previous statement, whitespace following the last sentence is removed if realign_boundaries is True and the last sentence ends in a closing parenthesis.

Examples:
```
>>> from nltk.tokenize import PunktSentenceTokenizer
>>> pst = PunktSentenceTokenizer()
>>> pst.tokenize('See Section 3).  Or Section 2).  ')
['See Section 3).', 'Or Section 2).  ']        # ws kept
>>> pst.tokenize('See Section 3.)  Or Section 2.)  ')
['See Section 3.)', 'Or Section 2.)']          # ws removed
>>> pst.tokenize('See Section 3.)  Or Section 2.)  ', realign_boundaries=False)
['See Section 3.', ')  Or Section 2.', ')  ']  # ws kept
```

There are two inconsistencies with respect to trailing whitespace:
- The last sentence is treated differently from all other sentences.
- Across multiple inputs, the respective last sentence is not always treated the same (in some corner cases it is treated like a non-last sentence).

The proposed changes fix this inconsistency by simply never returning trailing whitespace.
The change affects the span_tokenize() method and all methods calling it, such as tokenize() and [the badly named] tokenize_sents().

This change will break existing code that relies on trailing whitespace in the last sentence.
However, such code is already broken, as trailing whitespace is not returned reliably now.
