### PR TITLE
Further improve tests output

### DIFF
--- a/nltk/test/runtests.py
+++ b/nltk/test/runtests.py
@@ -16,17 +16,26 @@ NLTK_TEST_DIR = os.path.join(NLTK_ROOT, 'nltk')
 if __name__ == '__main__':
     # there shouldn't be import from NLTK for coverage to work properly
     from doctest_nose_plugin import DoctestFix
+    try:
+        # Import RedNose plugin for colored test output
+        from rednose import RedNose
+        rednose_available = True
+    except ImportError:
+        rednose_available = False
 
     class NltkPluginManager(PluginManager):
         """
         Nose plugin manager that replaces standard doctest plugin
-        with a patched version.
+        with a patched version and adds RedNose plugin for colored test output.
         """
         def loadPlugins(self):
             for plug in builtin.plugins:
                 if plug != Doctest:
                     self.addPlugin(plug())
             self.addPlugin(DoctestFix())
+            if rednose_available:
+                self.addPlugin(RedNose())
+
             super(NltkPluginManager, self).loadPlugins()
 
     manager = NltkPluginManager()
@@ -46,6 +55,13 @@ if __name__ == '__main__':
     if all(arg.startswith('-') for arg in args):
         # only extra options were passed
         args += [NLTK_TEST_DIR]
+
+    # Activate RedNose and hide skipped test messages from output
+    if rednose_available:
+        args += [
+            '--rednose',
+            '--hide-skips'
+        ]
 
     arguments = [
         '--exclude=', # why is this needed?

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ deps =
     twython
     pyparsing
     python-crfsuite
+    rednose
 
 changedir = nltk/test
 commands =
@@ -48,6 +49,7 @@ deps =
     twython
     pyparsing
     python-crfsuite
+    rednose
 
 commands =
     ; scipy and scikit-learn requires numpy even to run setup.py so
@@ -66,6 +68,7 @@ deps =
     twython
     pyparsing
     python-crfsuite
+    rednose
 
 commands =
     ; scipy and scikit-learn requires numpy even to run setup.py so
@@ -79,18 +82,21 @@ commands =
 basepython = python2.7
 deps =
     nose >= 1.2.1
+    rednose
 commands = python runtests.py []
 
 [testenv:py34-nodeps]
 basepython = python3.4
 deps =
     nose >= 1.2.1
+    rednose
 commands = python runtests.py []
 
 [testenv:py35-nodeps]
 basepython = python3.5
 deps =
     nose >= 1.2.1
+    rednose
 commands = python runtests.py []
 
 [testenv:py27-jenkins]


### PR DESCRIPTION
This PR aims to further improve test output readability using [`rednose`][1] plugin for `nose`.

Here is a comparison between test outputs before and after:
- Before
![tox_before_rednose1](https://cloud.githubusercontent.com/assets/2814672/20867857/ea0f12ae-ba4d-11e6-8b7c-3b7ec52aab68.png)

- After
![tox_after_rednose1](https://cloud.githubusercontent.com/assets/2814672/20867860/f36d7a34-ba4d-11e6-971a-ce6135fd870b.png)

(Note: `gluesemantics` tests are still broken, so the output is slightly different. However the difference is still very clear).

I do not think that `rednose` should be added to `setup.py` as a required NLTK dependency. Therefore, I modified `runtests.py` so that it can be run (without `tox`) using `rednose` just as an optional package.

[1]:https://github.com/JBKahn/rednose