### PR TITLE
Add optional dependencies for NLTK installation

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,4 @@
+tox
+nose
+coverage
+pylint

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ natural language processing.  NLTK requires Python 2.7, or 3.4+.""",
     'Topic :: Text Processing :: Linguistic',
     ],
     package_data = {'nltk': ['test/*.doctest', 'VERSION']},
-    install_requires = ['six>=1.10.0'],
+    install_requires = ['six'],
     extras_require = extras_require,
     packages = find_packages(),
     zip_safe=False, # since normal files will be present too?

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,22 @@ natural language processing.  NLTK requires Python 2.7, or 3.4+.""",
     ],
     package_data = {'nltk': ['test/*.doctest', 'VERSION']},
     install_requires = ['six>=1.10.0'],
+    extras_require = {
+        'all': [
+            'nose>=1.3.0',
+            'tox>=1.6.1',
+            'coverage>=3.7.1',
+            'pylint>=1.1.0',
+            'numpy>=1.8.0',
+            'scipy>=0.13.2',
+            'matplotlib>=1.3.1',
+            'scikit-learn>=0.14.1',
+            'python-crfsuite>=0.8.2',
+            'gensim>=0.11.1',
+            'pyparsing>=2.0.3',
+            'twython>=3.2.0'
+        ]
+    },
     packages = find_packages(),
     zip_safe=False, # since normal files will be present too?
     )

--- a/setup.py
+++ b/setup.py
@@ -41,12 +41,6 @@ extras_require = {
     'plot': [
         'matplotlib',
     ],
-    'tests': [
-        'coverage',
-        'nose',
-        'pylint',
-        'tox'
-    ],
     'tgrep': [
         'pyparsing',
     ],

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ extras_require = {
     'machine_learning': [
         'gensim',
         'numpy',
-        'pyparsing',
         'python-crfsuite',
         'scikit-learn',
         'scipy'
@@ -47,6 +46,9 @@ extras_require = {
         'nose',
         'pylint',
         'tox'
+    ],
+    'tgrep': [
+        'pyparsing',
     ],
     'twitter': [
         'twython'

--- a/setup.py
+++ b/setup.py
@@ -71,38 +71,38 @@ natural language processing.  NLTK requires Python 2.7, or 3.4+.""",
     install_requires = ['six>=1.10.0'],
     extras_require = {
         'all': [
-            'nose>=1.3.0',
-            'tox>=1.6.1',
-            'coverage>=3.7.1',
-            'pylint>=1.1.0',
-            'numpy>=1.8.0',
-            'scipy>=0.13.2',
-            'matplotlib>=1.3.1',
-            'scikit-learn>=0.14.1',
-            'python-crfsuite>=0.8.2',
-            'gensim>=0.11.1',
-            'pyparsing>=2.0.3',
-            'twython>=3.2.0'
+            'nose',
+            'tox',
+            'coverage',
+            'pylint',
+            'numpy',
+            'scipy',
+            'matplotlib',
+            'scikit-learn',
+            'python-crfsuite',
+            'gensim',
+            'pyparsing',
+            'twython'
         ],
         'machine_learning': [
-            'gensim>=0.11.1',
-            'numpy>=1.8.0',
-            'pyparsing>=2.0.3',
-            'python-crfsuite>=0.8.2',
-            'scikit-learn>=0.14.1',
-            'scipy>=0.13.2'
+            'gensim',
+            'numpy',
+            'pyparsing',
+            'python-crfsuite',
+            'scikit-learn',
+            'scipy'
         ],
         'plot': [
-            'matplotlib>=1.3.1',
+            'matplotlib',
         ],
         'tests': [
-            'coverage>=3.7.1',
-            'nose>=1.3.0',
-            'pylint>=1.1.0',
-            'tox>=1.6.1'
+            'coverage',
+            'nose',
+            'pylint',
+            'tox'
         ],
         'twitter': [
-            'twython>=3.2.0'
+            'twython'
         ]
     },
     packages = find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,26 @@ natural language processing.  NLTK requires Python 2.7, or 3.4+.""",
             'gensim>=0.11.1',
             'pyparsing>=2.0.3',
             'twython>=3.2.0'
+        ],
+        'machine_learning': [
+            'gensim>=0.11.1',
+            'numpy>=1.8.0',
+            'pyparsing>=2.0.3',
+            'python-crfsuite>=0.8.2',
+            'scikit-learn>=0.14.1',
+            'scipy>=0.13.2'
+        ],
+        'plot': [
+            'matplotlib>=1.3.1',
+        ],
+        'tests': [
+            'coverage>=3.7.1',
+            'nose>=1.3.0',
+            'pylint>=1.1.0',
+            'tox>=1.6.1'
+        ],
+        'twitter': [
+            'twython>=3.2.0'
         ]
     },
     packages = find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,33 @@ with open(version_file) as fh:
 # setuptools
 from setuptools import setup, find_packages
 
+# Specify groups of optional dependencies
+extras_require = {
+    'machine_learning': [
+        'gensim',
+        'numpy',
+        'pyparsing',
+        'python-crfsuite',
+        'scikit-learn',
+        'scipy'
+    ],
+    'plot': [
+        'matplotlib',
+    ],
+    'tests': [
+        'coverage',
+        'nose',
+        'pylint',
+        'tox'
+    ],
+    'twitter': [
+        'twython'
+    ]
+}
+
+# Add a group made up of all optional dependencies
+extras_require['all'] = set(package for group in extras_require.values() for package in group)
+
 setup(
     name = "nltk",
     description = "Natural Language Toolkit",
@@ -69,42 +96,7 @@ natural language processing.  NLTK requires Python 2.7, or 3.4+.""",
     ],
     package_data = {'nltk': ['test/*.doctest', 'VERSION']},
     install_requires = ['six>=1.10.0'],
-    extras_require = {
-        'all': [
-            'nose',
-            'tox',
-            'coverage',
-            'pylint',
-            'numpy',
-            'scipy',
-            'matplotlib',
-            'scikit-learn',
-            'python-crfsuite',
-            'gensim',
-            'pyparsing',
-            'twython'
-        ],
-        'machine_learning': [
-            'gensim',
-            'numpy',
-            'pyparsing',
-            'python-crfsuite',
-            'scikit-learn',
-            'scipy'
-        ],
-        'plot': [
-            'matplotlib',
-        ],
-        'tests': [
-            'coverage',
-            'nose',
-            'pylint',
-            'tox'
-        ],
-        'twitter': [
-            'twython'
-        ]
-    },
+    extras_require = extras_require,
     packages = find_packages(),
     zip_safe=False, # since normal files will be present too?
     )


### PR DESCRIPTION
Reference: #1531 

---

This PR aims to include all optional dependencies to `setup.py` using [`extras_require`][1].

This will allow users to install NLTK with specific sets of additional (non-required) dependencies using commands like to the following:
```bash
pip install nltk[all]    # Install all optional Python dependencies
pip install nltk[plot]   # Install optional dependencies for plots
# etc.
```

For the moment, the `'all'` requirements list contains all the dependencies that were already written in `pip-req.txt`.

I would like to have your opinion about the best strategy to create a list of these requirements for other subsets (e.g. `'plot'` or `'machine-learning'`, as suggested by @alvations). 

1. Do you think we should do it in `setup.py`, or should we use a different module instead? I am thinking about something like a module called `optional_dependencies.py` that could define several arrays of dependencies (one for each `extras_require` key).

2. As for the content, what do you think would be the best way to group these packages? Could you please provide some kind of classification to create the groups?

[1]: http://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies