### PR TITLE
Hotfix/bug on bleu score

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -205,6 +205,7 @@
 - J Richard Snape
 - Tsolak Ghukasyan
 - Prasasto Adi
+- Qi Liu
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 ### Contributors to the Porter Stemmer

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -166,19 +166,18 @@ def corpus_bleu(list_of_references, hypotheses, weights=(0.25, 0.25, 0.25, 0.25)
     if p_numerators[1] == 0:
         return 0
 
-    if not smoothing_function: # No smoothing, values remain as Fractions.
-        s = (w * math.log(p_i) for i, (w, p_i) in enumerate(zip(weights, p_n))
-             if p_i.numerator != 0)
-    else: # Smoothen the modified precision.
-        # Note: smoothing_function() may convert values into floats;
-        #       it tries to retain the Fraction object as much as the
-        #       smoothing method allows.
+    if smoothing_function:
+        # Smoothen the modified precision
         p_n = smoothing_function(p_n, references=references,
                                  hypothesis=hypothesis, hyp_len=hyp_len)
-        s = (w * math.log(p_i) for i, (w, p_i) in enumerate(zip(weights, p_n)))
 
-    return bp * math.exp(math.fsum(s))
+    s = (w * math.log(p_i) for i, (w, p_i) in enumerate(zip(weights, p_n)))
 
+    try:
+        return bp * math.exp(math.fsum(s))
+    except ValueError, e:
+        # ValueError means log(0.0). Return 0
+        return 0.0
 
 def modified_precision(references, hypothesis, n):
     """


### PR DESCRIPTION
The total bleu score is the geometric mean of n-gram count. If one n-gram count equals zero, the bleu score should be zero.
The original code will ignore the zero value to avoid log(0.0), but it will return a non-zero value, I think it is wrong.

The uni-gram check is also wrong. Even with no unigrams, the fraction can be non-zero due to the smoothing function.

Sorry for my poor English