### PR TITLE
Fix failing doctest on chrf_score 

### DIFF
--- a/nltk/translate/chrf_score.py
+++ b/nltk/translate/chrf_score.py
@@ -55,8 +55,8 @@ def sentence_chrf(reference, hypothesis, min_len=1, max_len=6, beta=3.0):
         ...            'always obeys the commands of the party')
         >>> sentence_chrf(ref1, hyp1) # doctest: +ELLIPSIS
         0.6768...
-        >>> type(ref1), type(hyp1)
-        (<type 'str'>, <type 'str'>)
+        >>> type(ref1) == type(hyp1) == str
+        True
         >>> sentence_chrf(ref1.split(), hyp1.split()) # doctest: +ELLIPSIS
         0.6768...
 


### PR DESCRIPTION
Fix #1515. The failing doctest on `chrf_score` is caused by the changed in how Python3 treat `type`.  (Spillover from #1540, cleaned up dirty git tree and hence a new PR)