### PR TITLE
Add PyPI version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Natural Language Toolkit (NLTK)
+[![PyPI](https://img.shields.io/pypi/v/nltk.svg)](https://pypi.python.org/pypi/nltk)
 
 NLTK -- the Natural Language Toolkit -- is a suite of open source Python
 modules, data sets and tutorials supporting research and development in Natural


### PR DESCRIPTION
This PR aims to add a PyPI version badge to the NLTK readme file. 
> Version Badge provides a consistent way for the community to learn about the package associated with a particular Github repository and other documentation pages. Once the package owner adds this badge to their README file, it will inform and link all visitors to the latest version of that package.
*([source][1])*

It is a common practice for open source projects and I think it would be good for NLTK.
Preview:
![image](https://cloud.githubusercontent.com/assets/2814672/21280338/b42f385c-c3e5-11e6-8b20-1921ec4201fa.png)

It would also be possible to add a badge for supported python versions, like the following:
![image](https://cloud.githubusercontent.com/assets/2814672/21280484/82aaa3b0-c3e6-11e6-91d9-dc4ca5e45bf3.png)

This would refer to the versions listed on PyPI (taken from `setup.py`), and not to the ones related to the latest NLTK build on the `develop` branch. Please let me know if I should add this badge too.

[1]: https://badge.fury.io/