### PR TITLE
fix bug about utf-8 space

### DIFF
--- a/nltk/parse/stanford.py
+++ b/nltk/parse/stanford.py
@@ -216,7 +216,7 @@ class GenericStanfordParser(ParserI):
                                       stdout=PIPE, stderr=PIPE)
                 
             stdout = stdout.replace(b'\xc2\xa0',b' ')
-            stdout = stdout.replace(b'\xa0',b' ')
+            stdout = stdout.replace(b'\x00\xa0',b' ')
             stdout = stdout.decode(encoding)
 
         os.unlink(input_file.name)


### PR DESCRIPTION
replace b'\xa0' with b'\x00\xa0'.
'\x00\xa0' is a white space in utf-8 but not 'x\a0'.
The old version may trigger a 'utf-8 decode error' in python when the string contains a utf-8 character which has a byte a0, such as '传' in chinese.

eg:
parser=StanfordParser(model_path='PATH_TO_chineseFactored.ser.gz')
parser.parse('射雕英雄传 是 谁 的 作品')