### PR TITLE
Fix Moses Tokenizer and Detokenizer

### DIFF
--- a/nltk/tokenize/moses.py
+++ b/nltk/tokenize/moses.py
@@ -389,6 +389,18 @@ class MosesDetokenizer(TokenizerI):
     >>> detokenized_text = detokenizer.detokenize(tokenized_text.split(), return_str=True)
     >>> detokenized_text == expected_detokenized
     True
+
+    >>> from nltk.tokenize.moses import MosesTokenizer, MosesDetokenizer
+    >>> t, d = MosesTokenizer(), MosesDetokenizer()
+    >>> sent = "This ain't funny. It's actually hillarious, yet double Ls. | [] < > [ ] & You're gonna shake it off? Don't?"
+    >>> expected_tokens = [u'This', u'ain', u'&apos;t', u'funny.', u'It', u'&apos;s', u'actually', u'hillarious', u',', u'yet', u'double', u'Ls.', u'&#124;', u'&#91;', u'&#93;', u'&lt;', u'&gt;', u'&#91;', u'&#93;', u'&amp;', u'You', u'&apos;re', u'gonna', u'shake', u'it', u'off', u'?', u'Don', u'&apos;t', u'?']
+    >>> expected_detokens = "This ain't funny. It's actually hillarious, yet double Ls. | [] < > [] & You're gonna shake it off? Don't?"
+    >>> tokens = t.tokenize(sent)
+    >>> tokens == expected_tokens
+    True
+    >>> detokens = d.detokenize(tokens)
+    >>> " ".join(detokens) == expected_detokens
+    True
     """
     # Currency Symbols.
     IsAlnum = text_type(''.join(perluniprops.chars('IsAlnum')))

--- a/nltk/tokenize/moses.py
+++ b/nltk/tokenize/moses.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Natural Language Toolkit: 
+# Natural Language Toolkit:
 #
 # Copyright (C) 2001-2015 NLTK Project
 # Author: Pidong Wang, Josh Schroeder, Ondrej Bojar, based on code by Philipp Koehn
@@ -19,9 +19,9 @@ from nltk.corpus import perluniprops, nonbreaking_prefixes
 
 class MosesTokenizer(TokenizerI):
     """
-    This is a Python port of the Moses Tokenizer from 
+    This is a Python port of the Moses Tokenizer from
     https://github.com/moses-smt/mosesdecoder/blob/master/scripts/tokenizer/tokenizer.perl
-    
+
     >>> tokenizer = MosesTokenizer()
     >>> text = u'This, is a sentence with weird\xbb symbols\u2026 appearing everywhere\xbf'
     >>> expected_tokenized = u'This , is a sentence with weird \xbb symbols \u2026 appearing everywhere \xbf'
@@ -31,7 +31,7 @@ class MosesTokenizer(TokenizerI):
     >>> tokenizer.tokenize(text) == [u'This', u',', u'is', u'a', u'sentence', u'with', u'weird', u'\xbb', u'symbols', u'\u2026', u'appearing', u'everywhere', u'\xbf']
     True
     """
-    
+
     # Perl Unicode Properties character sets.
     IsN = text_type(''.join(perluniprops.chars('IsN')))
     IsAlnum = text_type(''.join(perluniprops.chars('IsAlnum')))
@@ -39,29 +39,29 @@ class MosesTokenizer(TokenizerI):
     IsSo = text_type(''.join(perluniprops.chars('IsSo')))
     IsAlpha = text_type(''.join(perluniprops.chars('IsAlpha')))
     IsLower = text_type(''.join(perluniprops.chars('IsLower')))
-    
+
     # Remove ASCII junk.
     DEDUPLICATE_SPACE = r'\s+', r' '
     ASCII_JUNK = r'[\000-\037]', r''
-    
+
     # Neurotic Perl heading space, multi-space and trailing space chomp.
     # These regexes are kept for reference purposes and shouldn't be used!!
     MID_STRIP = r" +", r" "     # Use DEDUPLICATE_SPACE instead.
     LEFT_STRIP = r"^ ", r""     # Uses text.lstrip() instead.
     RIGHT_STRIP = r" $", r""    # Uses text.rstrip() instead.
-    
+
     # Pad all "other" special characters not in IsAlnum.
     PAD_NOT_ISALNUM = u'([^{}\s\.\'\`\,\-])'.format(IsAlnum), r' \1 '
-    
+
     # Splits all hypens (regardless of circumstances), e.g.
     # 'foo -- bar' -> 'foo @-@ @-@ bar' , 'foo-bar' -> 'foo @-@ bar'
     AGGRESSIVE_HYPHEN_SPLIT = u'([{alphanum}])\-(?=[{alphanum}])'.format(alphanum=IsAlnum), r'\1 \@-\@ '
-    
+
     # Make multi-dots stay together.
     REPLACE_DOT_WITH_LITERALSTRING_1 = r'\.([\.]+)', ' DOTMULTI\1'
     REPLACE_DOT_WITH_LITERALSTRING_2 = r'DOTMULTI\.([^\.])', 'DOTDOTMULTI \1'
     REPLACE_DOT_WITH_LITERALSTRING_3 = r'DOTMULTI\.', 'DOTDOTMULTI'
-  
+
     # Separate out "," except if within numbers (5,300)
     # e.g.  A,B,C,D,E > A , B,C , D,E
     # First application uses up B so rule can't see B,C
@@ -69,7 +69,7 @@ class MosesTokenizer(TokenizerI):
     # will also space digit,letter or letter,digit forms (redundant with next section)
     COMMA_SEPARATE_1 = u'([^{}])[,]'.format(IsN), r'\1 , '
     COMMA_SEPARATE_2 = u'[,]([^{}])'.format(IsN), r' , \1'
-    
+
     # Attempt to get correct directional quotes.
     DIRECTIONAL_QUOTE_1 = r'^``',               r'`` '
     DIRECTIONAL_QUOTE_2 = r'^"',                r'`` '
@@ -79,31 +79,31 @@ class MosesTokenizer(TokenizerI):
     DIRECTIONAL_QUOTE_6 = r'([ ([{<])``',       r'\1 `` '
     DIRECTIONAL_QUOTE_7 = r'([ ([{<])`([^`])',  r'\1 ` \2'
     DIRECTIONAL_QUOTE_8 = r"([ ([{<])'",        r'\1 ` '
-    
+
     # Replace ... with _ELLIPSIS_
     REPLACE_ELLIPSIS = r'\.\.\.',       r' _ELLIPSIS_ '
     # Restore _ELLIPSIS_ with ...
     RESTORE_ELLIPSIS = r'_ELLIPSIS_',   r'\.\.\.'
-    
+
     # Pad , with tailing space except if within numbers, e.g. 5,300
     # These are used in nltk.tokenize.moses.penn_tokenize()
-    COMMA_1 = u'([^{numbers})[,]([^{numbers}])'.format(numbers=IsN), r'\1 , \2'
+    COMMA_1 = u'([^{numbers}])[,]([^{numbers}])'.format(numbers=IsN), r'\1 , \2'
     COMMA_2 = u'([{numbers}])[,]([^{numbers}])'.format(numbers=IsN), r'\1 , \2'
     COMMA_3 = u'([^{numbers}])[,]([{numbers}])'.format(numbers=IsN), r'\1 , \2'
-    
+
     # Pad unicode symbols with spaces.
     SYMBOLS = u'([;:@#\$%&{}{}])'.format(IsSc, IsSo), r' \1 '
-    
+
     # Separate out intra-token slashes.  PTB tokenization doesn't do this, so
     # the tokens should be merged prior to parsing with a PTB-trained parser.
     # e.g. "and/or" -> "and @/@ or"
     INTRATOKEN_SLASHES = u'([{alphanum}])\/([{alphanum}])'.format(alphanum=IsAlnum), r'$1 \@\/\@ $2'
-    
+
     # Splits final period at end of string.
     FINAL_PERIOD = r"""([^.])([.])([\]\)}>"']*) ?$""", r'\1 \2\3'
     # Pad all question marks and exclamation marks with spaces.
     PAD_QUESTION_EXCLAMATION_MARK = r'([?!])', r' \1 '
-    
+
     # Handles parentheses, brackets and converts them to PTB symbols.
     PAD_PARENTHESIS = r'([\]\[\(\){}<>])', r' \1 '
     CONVERT_PARENTHESIS_1 = r'\(', '-LRB-'
@@ -112,22 +112,22 @@ class MosesTokenizer(TokenizerI):
     CONVERT_PARENTHESIS_4 = r'\]', '-RSB-'
     CONVERT_PARENTHESIS_5 = r'\{', '-LCB-'
     CONVERT_PARENTHESIS_6 = r'\}', '-RCB-'
-    
+
     # Pads double dashes with spaces.
     PAD_DOUBLE_DASHES = r'--', ' -- '
-    
+
     # Adds spaces to start and end of string to simplify further regexps.
     PAD_START_OF_STR = r'^', ' '
-    PAD_END_OF_STR = r'$', ' ' 
-    
+    PAD_END_OF_STR = r'$', ' '
+
     # Converts double quotes to two single quotes and pad with spaces.
     CONVERT_DOUBLE_TO_SINGLE_QUOTES = r'"', " '' "
     # Handles single quote in possessives or close-single-quote.
     HANDLES_SINGLE_QUOTES = r"([^'])' ", r"\1 ' "
-    
+
     # Pad apostrophe in possessive or close-single-quote.
     APOSTROPHE = r"([^'])'", r"\1 ' "
-    
+
     # Prepend space on contraction apostrophe.
     CONTRACTION_1 = r"'([sSmMdD]) ", r" '\1 "
     CONTRACTION_2 = r"'ll ", r" 'll "
@@ -138,9 +138,9 @@ class MosesTokenizer(TokenizerI):
     CONTRACTION_7 = r"'RE ", r" 'RE "
     CONTRACTION_8 = r"'VE ", r" 'VE "
     CONTRACTION_9 = r"N'T ", r" N'T "
-    
+
     # Informal Contractions.
-    CONTRACTION_10 = r" ([Cc])annot ",  r" \1an not " 
+    CONTRACTION_10 = r" ([Cc])annot ",  r" \1an not "
     CONTRACTION_11 = r" ([Dd])'ye ",    r" \1' ye "
     CONTRACTION_12 = r" ([Gg])imme ",   r" \1im me "
     CONTRACTION_13 = r" ([Gg])onna ",   r" \1on na "
@@ -150,12 +150,12 @@ class MosesTokenizer(TokenizerI):
     CONTRACTION_17 = r" '([Tt])is ",    r" '\1 is "
     CONTRACTION_18 = r" '([Tt])was ",   r" '\1 was "
     CONTRACTION_19 = r" ([Ww])anna ",   r" \1an na "
-    
+
     # Clean out extra spaces
     CLEAN_EXTRA_SPACE_1 = r'  *', r' '
     CLEAN_EXTRA_SPACE_2 = r'^ *', r''
     CLEAN_EXTRA_SPACE_3 = r' *$', r''
-    
+
     # Escape special characters.
     ESCAPE_AMPERSAND = r'\&', r'\&amp;'
     ESCAPE_PIPE = r'\|', r'\&#124;'
@@ -165,72 +165,72 @@ class MosesTokenizer(TokenizerI):
     ESCAPE_DOUBLE_QUOTE = r'\"', r'\&quot;'
     ESCAPE_LEFT_SQUARE_BRACKET = r"\[", r"\&#91;"
     ESCAPE_RIGHT_SQUARE_BRACKET = r"\]", r"\&#93;"
-    
+
     EN_SPECIFIC_1 = u"([^{alpha}])[']([^{alpha}])".format(alpha=IsAlpha), r"\1 ' \2"
-    EN_SPECIFIC_2 = u"([^{alpha}{isn}])[']([{alpha}])".format(alpha=IsAlpha, isn=IsN), r"\1 ' \2" 
+    EN_SPECIFIC_2 = u"([^{alpha}{isn}])[']([{alpha}])".format(alpha=IsAlpha, isn=IsN), r"\1 ' \2"
     EN_SPECIFIC_3 = u"([{alpha}])[']([^{alpha}])".format(alpha=IsAlpha), r"\1 ' \2"
     EN_SPECIFIC_4 = u"([{alpha}])[']([{alpha}])".format(alpha=IsAlpha), r"\1 ' \2"
     EN_SPECIFIC_5 = u"([{isn}])[']([s])".format(isn=IsN), r"\1 '\2"
-    
-    ENGLISH_SPECIFIC_APOSTROPHE = [EN_SPECIFIC_1, EN_SPECIFIC_2, EN_SPECIFIC_3, 
+
+    ENGLISH_SPECIFIC_APOSTROPHE = [EN_SPECIFIC_1, EN_SPECIFIC_2, EN_SPECIFIC_3,
                                    EN_SPECIFIC_4, EN_SPECIFIC_5]
-    
+
     FR_IT_SPECIFIC_1 = u"([^{alpha}])[']([^{alpha}])".format(alpha=IsAlpha), r"\1 ' \2"
     FR_IT_SPECIFIC_2 = u"([^{alpha}])[']([{alpha}])".format(alpha=IsAlpha), r"\1 ' \2"
     FR_IT_SPECIFIC_3 = u"([{alpha}])[']([^{alpha}])".format(alpha=IsAlpha), r"\1 ' \2"
     FR_IT_SPECIFIC_4 = u"([{alpha}])[']([{alpha}])".format(alpha=IsAlpha), r"\1' \2"
-    
-    FR_IT_SPECIFIC_APOSTROPHE = [FR_IT_SPECIFIC_1, FR_IT_SPECIFIC_2, 
+
+    FR_IT_SPECIFIC_APOSTROPHE = [FR_IT_SPECIFIC_1, FR_IT_SPECIFIC_2,
                                  FR_IT_SPECIFIC_3, FR_IT_SPECIFIC_4]
-    
-    NON_SPECIFIC_APOSTROPHE = r"\'", r" \' " 
-    
+
+    NON_SPECIFIC_APOSTROPHE = r"\'", r" \' "
+
     MOSES_PENN_REGEXES_1 = [DEDUPLICATE_SPACE, ASCII_JUNK, DIRECTIONAL_QUOTE_1,
-                              DIRECTIONAL_QUOTE_2, DIRECTIONAL_QUOTE_3, 
+                              DIRECTIONAL_QUOTE_2, DIRECTIONAL_QUOTE_3,
                               DIRECTIONAL_QUOTE_4, DIRECTIONAL_QUOTE_5,
                               DIRECTIONAL_QUOTE_6, DIRECTIONAL_QUOTE_7,
-                              DIRECTIONAL_QUOTE_8, REPLACE_ELLIPSIS, COMMA_1, 
-                              COMMA_2, COMMA_3, SYMBOLS, INTRATOKEN_SLASHES, 
-                              FINAL_PERIOD, PAD_QUESTION_EXCLAMATION_MARK, 
-                              PAD_PARENTHESIS, CONVERT_PARENTHESIS_1, 
-                              CONVERT_PARENTHESIS_2, CONVERT_PARENTHESIS_3, 
-                              CONVERT_PARENTHESIS_4, CONVERT_PARENTHESIS_5, 
-                              CONVERT_PARENTHESIS_6, PAD_DOUBLE_DASHES, 
-                              PAD_START_OF_STR, PAD_END_OF_STR, 
-                              CONVERT_DOUBLE_TO_SINGLE_QUOTES, 
-                              HANDLES_SINGLE_QUOTES, APOSTROPHE, CONTRACTION_1, 
-                              CONTRACTION_2, CONTRACTION_3, CONTRACTION_4, 
-                              CONTRACTION_5, CONTRACTION_6, CONTRACTION_7, 
-                              CONTRACTION_8, CONTRACTION_9, CONTRACTION_10, 
-                              CONTRACTION_11, CONTRACTION_12, CONTRACTION_13, 
-                              CONTRACTION_14, CONTRACTION_15, CONTRACTION_16, 
+                              DIRECTIONAL_QUOTE_8, REPLACE_ELLIPSIS, COMMA_1,
+                              COMMA_2, COMMA_3, SYMBOLS, INTRATOKEN_SLASHES,
+                              FINAL_PERIOD, PAD_QUESTION_EXCLAMATION_MARK,
+                              PAD_PARENTHESIS, CONVERT_PARENTHESIS_1,
+                              CONVERT_PARENTHESIS_2, CONVERT_PARENTHESIS_3,
+                              CONVERT_PARENTHESIS_4, CONVERT_PARENTHESIS_5,
+                              CONVERT_PARENTHESIS_6, PAD_DOUBLE_DASHES,
+                              PAD_START_OF_STR, PAD_END_OF_STR,
+                              CONVERT_DOUBLE_TO_SINGLE_QUOTES,
+                              HANDLES_SINGLE_QUOTES, APOSTROPHE, CONTRACTION_1,
+                              CONTRACTION_2, CONTRACTION_3, CONTRACTION_4,
+                              CONTRACTION_5, CONTRACTION_6, CONTRACTION_7,
+                              CONTRACTION_8, CONTRACTION_9, CONTRACTION_10,
+                              CONTRACTION_11, CONTRACTION_12, CONTRACTION_13,
+                              CONTRACTION_14, CONTRACTION_15, CONTRACTION_16,
                               CONTRACTION_17, CONTRACTION_18, CONTRACTION_19]
-        
-    MOSES_PENN_REGEXES_2 = [RESTORE_ELLIPSIS, CLEAN_EXTRA_SPACE_1, 
-                        CLEAN_EXTRA_SPACE_2, CLEAN_EXTRA_SPACE_3, 
-                        ESCAPE_AMPERSAND, ESCAPE_PIPE, 
-                        ESCAPE_LEFT_ANGLE_BRACKET, ESCAPE_RIGHT_ANGLE_BRACKET, 
-                        ESCAPE_SINGLE_QUOTE, ESCAPE_DOUBLE_QUOTE]    
 
-    MOSES_ESCAPE_XML_REGEXES = [ESCAPE_AMPERSAND, ESCAPE_PIPE, 
-                                ESCAPE_LEFT_ANGLE_BRACKET, 
-                                ESCAPE_RIGHT_ANGLE_BRACKET, 
-                                ESCAPE_SINGLE_QUOTE, ESCAPE_DOUBLE_QUOTE, 
-                                ESCAPE_LEFT_SQUARE_BRACKET, 
+    MOSES_PENN_REGEXES_2 = [RESTORE_ELLIPSIS, CLEAN_EXTRA_SPACE_1,
+                        CLEAN_EXTRA_SPACE_2, CLEAN_EXTRA_SPACE_3,
+                        ESCAPE_AMPERSAND, ESCAPE_PIPE,
+                        ESCAPE_LEFT_ANGLE_BRACKET, ESCAPE_RIGHT_ANGLE_BRACKET,
+                        ESCAPE_SINGLE_QUOTE, ESCAPE_DOUBLE_QUOTE]
+
+    MOSES_ESCAPE_XML_REGEXES = [ESCAPE_AMPERSAND, ESCAPE_PIPE,
+                                ESCAPE_LEFT_ANGLE_BRACKET,
+                                ESCAPE_RIGHT_ANGLE_BRACKET,
+                                ESCAPE_SINGLE_QUOTE, ESCAPE_DOUBLE_QUOTE,
+                                ESCAPE_LEFT_SQUARE_BRACKET,
                                 ESCAPE_RIGHT_SQUARE_BRACKET]
-    
+
     def __init__(self, lang='en'):
         # Initialize the object.
         super(MosesTokenizer, self).__init__()
         self.lang = lang
         # Initialize the language specific nonbreaking prefixes.
         self.NONBREAKING_PREFIXES = nonbreaking_prefixes.words(lang)
-        self.NUMERIC_ONLY_PREFIXES = [w.rpartition(' ')[0] for w in 
-                                      self.NONBREAKING_PREFIXES if 
+        self.NUMERIC_ONLY_PREFIXES = [w.rpartition(' ')[0] for w in
+                                      self.NONBREAKING_PREFIXES if
                                       self.has_numeric_only(w)]
-        
-        
-    
+
+
+
     def replace_multidots(self, text):
         text = re.sub(r'\.([\.]+)', r' DOTMULTI\1', text)
         while re.search(r'DOTMULTI\.', text):
@@ -242,18 +242,18 @@ class MosesTokenizer(TokenizerI):
         while re.search(r'DOTDOTMULTI', text):
             text = re.sub(r'DOTDOTMULTI', r'DOTMULTI.', text)
         return re.sub(r'DOTMULTI', r'.', text)
-    
+
     def islower(self, text):
         return not set(text).difference(set(IsLower))
-    
+
     def isalpha(self, text):
         return not set(text).difference(set(IsAlpha))
-    
+
     def has_numeric_only(self, text):
         return bool(re.match(r'(.*)[\s]+(\#NUMERIC_ONLY\#)', text))
-    
+
     def handles_nonbreaking_prefixes(self, text):
-        # Splits the text into toknes to check for nonbreaking prefixes.
+        # Splits the text into tokens to check for nonbreaking prefixes.
         tokens = text.split()
         num_tokens = len(tokens)
         for i, token in enumerate(tokens):
@@ -265,10 +265,10 @@ class MosesTokenizer(TokenizerI):
                 # i.   the prefix is a token made up of chars within the IsAlpha
                 # ii.  the prefix is in the list of nonbreaking prefixes and
                 #      does not contain #NUMERIC_ONLY#
-                # iii. the token is not the last token and that the 
-                #      next token contains all lowercase. 
+                # iii. the token is not the last token and that the
+                #      next token contains all lowercase.
                 if ( (prefix and self.isalpha(prefix)) or
-                     (prefix in self.NONBREAKING_PREFIXES and 
+                     (prefix in self.NONBREAKING_PREFIXES and
                       prefix not in self.NUMERIC_ONLY_PREFIXES) or
                      (i != num_tokens-1 and self.islower(tokens[i+1])) ):
                     pass # No change to the token.
@@ -280,34 +280,34 @@ class MosesTokenizer(TokenizerI):
                 else: # Otherwise, adds a space after the tokens before a dot.
                     tokens[i] = prefix + ' .'
         return " ".join(tokens) # Stitch the tokens back.
-    
+
     def escape_xml(self, text):
-        for regexp, subsitution in self.MOSES_ESCAPE_XML_REGEXES:
-            text = re.sub(regexp, subsitution, text)
+        for regexp, substitution in self.MOSES_ESCAPE_XML_REGEXES:
+            text = re.sub(regexp, substitution, text)
         return text
-    
+
     def penn_tokenize(self, text, return_str=False):
         """
         This is a Python port of the Penn treebank tokenizer adapted by the Moses
-        machine translation community. It's a little different from the 
+        machine translation community. It's a little different from the
         version in nltk.tokenize.treebank.
         """
         # Converts input string into unicode.
-        text = text_type(text) 
+        text = text_type(text)
         # Perform a chain of regex substituitions using MOSES_PENN_REGEXES_1
-        for regexp, subsitution in self.MOSES_PENN_REGEXES_1:
-            text = re.sub(regexp, subsitution, text)
+        for regexp, substitution in self.MOSES_PENN_REGEXES_1:
+            text = re.sub(regexp, substitution, text)
         # Handles nonbreaking prefixes.
-        text = handles_nonbreaking_prefixes(text)
+        text = self.handles_nonbreaking_prefixes(text)
         # Restore ellipsis, clean extra spaces, escape XML symbols.
-        for regexp, subsitution in self.MOSES_PENN_REGEXES_2:
-            text = re.sub(regexp, subsitution, text)        
+        for regexp, substitution in self.MOSES_PENN_REGEXES_2:
+            text = re.sub(regexp, substitution, text)
         return text if return_str else text.split()
-    
+
     def tokenize(self, text, agressive_dash_splits=False, return_str=False):
         """
-        Python port of the Moses tokenizer. 
-        
+        Python port of the Moses tokenizer.
+
         >>> mtokenizer = MosesTokenizer()
         >>> text = u'Is 9.5 or 525,600 my favorite number?'
         >>> print (mtokenizer.tokenize(text, return_str=True))
@@ -318,62 +318,62 @@ class MosesTokenizer(TokenizerI):
         >>> text = u'This, is a sentence with weird\xbb symbols\u2026 appearing everywhere\xbf'
         >>> expected = u'This , is a sentence with weird \xbb symbols \u2026 appearing everywhere \xbf'
         >>> assert mtokenizer.tokenize(text, return_str=True) == expected
-        
+
         :param tokens: A single string, i.e. sentence text.
         :type tokens: str
         :param agressive_dash_splits: Option to trigger dash split rules .
         :type agressive_dash_splits: bool
         """
         # Converts input string into unicode.
-        text = text_type(text) 
-        
+        text = text_type(text)
+
         # De-duplicate spaces and clean ASCII junk
-        for regexp, subsitution in [self.DEDUPLICATE_SPACE, self.ASCII_JUNK]:
-            text = re.sub(regexp, subsitution, text)
+        for regexp, substitution in [self.DEDUPLICATE_SPACE, self.ASCII_JUNK]:
+            text = re.sub(regexp, substitution, text)
         # Strips heading and trailing spaces.
         text = text.strip()
         # Separate special characters outside of IsAlnum character set.
-        regexp, subsitution = self.PAD_NOT_ISALNUM
-        text = re.sub(regexp, subsitution, text)
+        regexp, substitution = self.PAD_NOT_ISALNUM
+        text = re.sub(regexp, substitution, text)
         # Aggressively splits dashes
         if agressive_dash_splits:
-            regexp, subsitution = self.AGGRESSIVE_HYPHEN_SPLIT
-            text = re.sub(regexp, subsitution, text)
+            regexp, substitution = self.AGGRESSIVE_HYPHEN_SPLIT
+            text = re.sub(regexp, substitution, text)
         # Replaces multidots with "DOTDOTMULTI" literal strings.
         text = self.replace_multidots(text)
         # Separate out "," except if within numbers e.g. 5,300
-        for regexp, subsitution in [self.COMMA_SEPARATE_1, self.COMMA_SEPARATE_2]:
-            text = re.sub(regexp, subsitution, text)
-        
+        for regexp, substitution in [self.COMMA_SEPARATE_1, self.COMMA_SEPARATE_2]:
+            text = re.sub(regexp, substitution, text)
+
         # (Language-specific) apostrophe tokenization.
         if self.lang == 'en':
-            for regexp, subsitution in self.ENGLISH_SPECIFIC_APOSTROPHE:
-                 text = re.sub(regexp, subsitution, text)
+            for regexp, substitution in self.ENGLISH_SPECIFIC_APOSTROPHE:
+                 text = re.sub(regexp, substitution, text)
         elif self.lang in ['fr', 'it']:
-            for regexp, subsitution in self.FR_IT_SPECIFIC_APOSTROPHE:
-                text = re.sub(regexp, subsitution, text)
+            for regexp, substitution in self.FR_IT_SPECIFIC_APOSTROPHE:
+                text = re.sub(regexp, substitution, text)
         else:
-            regexp, subsitution = self.NON_SPECIFIC_APOSTROPHE
-            text = re.sub(regexp, subsitution, text)
-        
+            regexp, substitution = self.NON_SPECIFIC_APOSTROPHE
+            text = re.sub(regexp, substitution, text)
+
         # Handles nonbreaking prefixes.
         text = self.handles_nonbreaking_prefixes(text)
         # Cleans up extraneous spaces.
-        regexp, subsitution = self.DEDUPLICATE_SPACE
-        text = re.sub(regexp,subsitution, text).strip()
+        regexp, substitution = self.DEDUPLICATE_SPACE
+        text = re.sub(regexp,substitution, text).strip()
         # Restore multidots.
         text = self.restore_multidots(text)
         # Escape XML symbols.
         text = self.escape_xml(text)
-        
+
         return text if return_str else text.split()
 
 
 class MosesDetokenizer(TokenizerI):
     """
-    This is a Python port of the Moses Detokenizer from 
+    This is a Python port of the Moses Detokenizer from
     https://github.com/moses-smt/mosesdecoder/blob/master/scripts/tokenizer/detokenizer.perl
-    
+
     >>> tokenizer = MosesTokenizer()
     >>> text = u'This, is a sentence with weird\xbb symbols\u2026 appearing everywhere\xbf'
     >>> expected_tokenized = u'This , is a sentence with weird \xbb symbols \u2026 appearing everywhere \xbf'
@@ -396,7 +396,7 @@ class MosesDetokenizer(TokenizerI):
     # Merge multiple spaces.
     ONE_SPACE = re.compile(r' {2,}'), ' '
 
-    # Unescape special characters. 
+    # Unescape special characters.
     UNESCAPE_FACTOR_SEPARATOR = r'\&#124;', r'\|'
     UNESCAPE_LEFT_ANGLE_BRACKET = r'\&lt;', r'\<'
     UNESCAPE_RIGHT_ANGLE_BRACKET = r'\&gt;', r'\>'
@@ -406,55 +406,55 @@ class MosesDetokenizer(TokenizerI):
     UNESCAPE_SYNTAX_NONTERMINAL_RIGHT = r'\&#93;', r'\]'
     UNESCAPE_AMPERSAND = r'\&amp;', r'\&'
     # The legacy regexes are used to support outputs from older Moses versions.
-    UNESCAPE_FACTOR_SEPARATOR_LEGACY = r'\&bar;', r'\|' 
+    UNESCAPE_FACTOR_SEPARATOR_LEGACY = r'\&bar;', r'\|'
     UNESCAPE_SYNTAX_NONTERMINAL_LEFT_LEGACY = r'\&bra;', r'\['
     UNESCAPE_SYNTAX_NONTERMINAL_RIGHT_LEGACY = r'\&ket;', r'\]'
-    
-    
-    MOSES_UNESCAPE_XML_REGEXES = [UNESCAPE_FACTOR_SEPARATOR_LEGACY, 
-                        UNESCAPE_FACTOR_SEPARATOR, UNESCAPE_LEFT_ANGLE_BRACKET, 
-                        UNESCAPE_RIGHT_ANGLE_BRACKET, 
-                        UNESCAPE_SYNTAX_NONTERMINAL_LEFT_LEGACY, 
-                        UNESCAPE_SYNTAX_NONTERMINAL_RIGHT_LEGACY, 
-                        UNESCAPE_DOUBLE_QUOTE, UNESCAPE_SINGLE_QUOTE, 
-                        UNESCAPE_SYNTAX_NONTERMINAL_LEFT, 
+
+
+    MOSES_UNESCAPE_XML_REGEXES = [UNESCAPE_FACTOR_SEPARATOR_LEGACY,
+                        UNESCAPE_FACTOR_SEPARATOR, UNESCAPE_LEFT_ANGLE_BRACKET,
+                        UNESCAPE_RIGHT_ANGLE_BRACKET,
+                        UNESCAPE_SYNTAX_NONTERMINAL_LEFT_LEGACY,
+                        UNESCAPE_SYNTAX_NONTERMINAL_RIGHT_LEGACY,
+                        UNESCAPE_DOUBLE_QUOTE, UNESCAPE_SINGLE_QUOTE,
+                        UNESCAPE_SYNTAX_NONTERMINAL_LEFT,
                         UNESCAPE_SYNTAX_NONTERMINAL_RIGHT, UNESCAPE_AMPERSAND]
 
-    FINNISH_MORPHSET_1 = [u'N', u'n', u'A', u'a', u'\xc4', u'\xe4', u'ssa', 
-                         u'Ssa', u'ss\xe4', u'Ss\xe4', u'sta', u'st\xe4', 
-                         u'Sta', u'St\xe4', u'hun', u'Hun', u'hyn', u'Hyn', 
-                         u'han', u'Han', u'h\xe4n', u'H\xe4n', u'h\xf6n', 
-                         u'H\xf6n', u'un', u'Un', u'yn', u'Yn', u'an', u'An', 
-                         u'\xe4n', u'\xc4n', u'\xf6n', u'\xd6n', u'seen', 
-                         u'Seen', u'lla', u'Lla', u'll\xe4', u'Ll\xe4', u'lta', 
-                         u'Lta', u'lt\xe4', u'Lt\xe4', u'lle', u'Lle', u'ksi', 
+    FINNISH_MORPHSET_1 = [u'N', u'n', u'A', u'a', u'\xc4', u'\xe4', u'ssa',
+                         u'Ssa', u'ss\xe4', u'Ss\xe4', u'sta', u'st\xe4',
+                         u'Sta', u'St\xe4', u'hun', u'Hun', u'hyn', u'Hyn',
+                         u'han', u'Han', u'h\xe4n', u'H\xe4n', u'h\xf6n',
+                         u'H\xf6n', u'un', u'Un', u'yn', u'Yn', u'an', u'An',
+                         u'\xe4n', u'\xc4n', u'\xf6n', u'\xd6n', u'seen',
+                         u'Seen', u'lla', u'Lla', u'll\xe4', u'Ll\xe4', u'lta',
+                         u'Lta', u'lt\xe4', u'Lt\xe4', u'lle', u'Lle', u'ksi',
                          u'Ksi', u'kse', u'Kse', u'tta', u'Tta', u'ine', u'Ine']
-    
+
     FINNISH_MORPHSET_2 = [u'ni', u'si', u'mme', u'nne', u'nsa']
-    
-    FINNISH_MORPHSET_3 = [u'ko', u'k\xf6', u'han', u'h\xe4n', u'pa', u'p\xe4', 
+
+    FINNISH_MORPHSET_3 = [u'ko', u'k\xf6', u'han', u'h\xe4n', u'pa', u'p\xe4',
                          u'kaan', u'k\xe4\xe4n', u'kin']
-    
-    FINNISH_REGEX = u'^({})({})?({})$'.format(text_type('|'.join(FINNISH_MORPHSET_1)), 
-                                               text_type('|'.join(FINNISH_MORPHSET_2)), 
+
+    FINNISH_REGEX = u'^({})({})?({})$'.format(text_type('|'.join(FINNISH_MORPHSET_1)),
+                                               text_type('|'.join(FINNISH_MORPHSET_2)),
                                                text_type('|'.join(FINNISH_MORPHSET_3)))
 
-    
+
     def __init__(self, lang='en'):
         super(MosesDetokenizer, self).__init__()
         self.lang = lang
 
 
     def unescape_xml(self, text):
-        for regexp, subsitution in self.MOSES_UNESCAPE_XML_REGEXES:
-            text = re.sub(regexp, subsitution, text)
+        for regexp, substitution in self.MOSES_UNESCAPE_XML_REGEXES:
+            text = re.sub(regexp, substitution, text)
         return text
-    
+
 
     def tokenize(self, tokens, return_str=False):
         """
         Python port of the Moses detokenizer.
-        
+
         :param tokens: A list of strings, i.e. tokenized text.
         :type tokens: list(str)
         :return: str
@@ -464,19 +464,19 @@ class MosesDetokenizer(TokenizerI):
         # Converts input string into unicode.
         text = text_type(text)
         # Detokenize the agressive hyphen split.
-        regexp, subsitution = self.AGGRESSIVE_HYPHEN_SPLIT
-        text = re.sub(regexp, subsitution, text)
+        regexp, substitution = self.AGGRESSIVE_HYPHEN_SPLIT
+        text = re.sub(regexp, substitution, text)
         # Unescape the XML symbols.
         text = self.unescape_xml(text)
         # Keep track of no. of quotation marks.
         quote_counts = {u"'":0 , u'"':0, u"``":0, u"`":0, u"''":0}
-        
-        # The *prepend_space* variable is used to control the "effects" of 
+
+        # The *prepend_space* variable is used to control the "effects" of
         # detokenization as the function loops through the list of tokens and
-        # changes the *prepend_space* accordingly as it sequentially checks 
-        # through the language specific and language independent conditions. 
-        prepend_space = " " 
-        detokenized_text = "" 
+        # changes the *prepend_space* accordingly as it sequentially checks
+        # through the language specific and language independent conditions.
+        prepend_space = " "
+        detokenized_text = ""
         tokens = text.split()
         # Iterate through every token and apply language specific detokenization rule(s).
         for i, token in enumerate(iter(tokens)):
@@ -488,8 +488,8 @@ class MosesDetokenizer(TokenizerI):
                 # But do nothing special if this is a CJK word that doesn't follow a CJK word
                 else:
                     detokenized_text += prepend_space + token
-                prepend_space = " " 
-                
+                prepend_space = " "
+
             # If it's a currency symbol.
             elif token in self.IsSc:
                 # Perform right shift on currency and other random punctuation items
@@ -502,15 +502,15 @@ class MosesDetokenizer(TokenizerI):
                     detokenized_text += " "
                 # Perform left shift on punctuation items.
                 detokenized_text += token
-                prepend_space = " " 
-               
-            elif (self.lang == 'en' and i > 0 
+                prepend_space = " "
+
+            elif (self.lang == 'en' and i > 0
                   and re.match(u'^[\'][{}]'.format(self.IsAlpha), token)
                   and re.match(u'[{}]'.format(self.IsAlnum), token)):
                 # For English, left-shift the contraction.
                 detokenized_text += token
                 prepend_space = " "
-                
+
             elif (self.lang == 'cs' and i > 1
                   and re.match(r'^[0-9]+$', tokens[-2]) # If the previous previous token is a number.
                   and re.match(r'^[.,]$', tokens[-1]) # If previous token is a dot.
@@ -518,14 +518,14 @@ class MosesDetokenizer(TokenizerI):
                 # In Czech, left-shift floats that are decimal numbers.
                 detokenized_text += token
                 prepend_space = " "
-            
+
             elif (self.lang in ['fr', 'it'] and i <= len(tokens)-2
                   and re.match(u'[{}][\']$'.format(self.IsAlpha), token)
                   and re.match(u'^[{}]$'.format(self.IsAlpha), tokens[i+1])): # If the next token is alpha.
                 # For French and Italian, right-shift the contraction.
                 detokenized_text += prepend_space + token
                 prepend_space = ""
-            
+
             elif (self.lang == 'cs' and i <= len(tokens)-3
                   and re.match(u'[{}][\']$'.format(self.IsAlpha), token)
                   and re.match(u'^[-–]$', tokens[i+1])
@@ -534,25 +534,25 @@ class MosesDetokenizer(TokenizerI):
                 detokenized_text += prepend_space + token + tokens[i+1]
                 next(tokens, None) # Advance over the dash
                 prepend_space = ""
-                
+
             # Combine punctuation smartly.
             elif re.match(r'''^[\'\"„“`]+$''', token):
                 normalized_quo = token
                 if re.match(r'^[„“”]+$', token):
                     normalized_quo = '"'
                 quote_counts.get(normalized_quo, 0)
-                
+
                 if self.lang == 'cs' and token == u"„":
                     quote_counts[normalized_quo] = 0
                 if self.lang == 'cs' and token == u"“":
                     quote_counts[normalized_quo] = 1
-            
-            
+
+
                 if quote_counts[normalized_quo] % 2 == 0:
-                    if (self.lang == 'en' and token == u"'" and i > 0 
+                    if (self.lang == 'en' and token == u"'" and i > 0
                         and re.match(r'[s]$', tokens[i-1]) ):
                         # Left shift on single quote for possessives ending
-                        # in "s", e.g. "The Jones' house" 
+                        # in "s", e.g. "The Jones' house"
                         detokenized_text += token
                         prepend_space = " "
                     else:
@@ -565,27 +565,26 @@ class MosesDetokenizer(TokenizerI):
                     text += token
                     prepend_space = " "
                     quote_counts[normalized_quo] += 1
-            
+
             elif (self.lang == 'fi' and re.match(r':$', tokens[i-1])
                   and re.match(self.FINNISH_REGEX, token)):
                 # Finnish : without intervening space if followed by case suffix
                 # EU:N EU:n EU:ssa EU:sta EU:hun EU:iin ...
                 detokenized_text += prepend_space + token
                 prepend_space = " "
-            
+
             else:
                 detokenized_text += prepend_space + token
                 prepend_space = " "
-                
+
         # Merge multiple spaces.
-        regexp, subsitution = self.ONE_SPACE
-        detokenized_text = re.sub(regexp, subsitution, detokenized_text)
+        regexp, substitution = self.ONE_SPACE
+        detokenized_text = re.sub(regexp, substitution, detokenized_text)
         # Removes heading and trailing spaces.
         detokenized_text = detokenized_text.strip()
-    
+
         return detokenized_text if return_str else detokenized_text.split()
-    
+
     def detokenize(self, tokens, return_str=False):
         """ Duck-typing the abstract *tokenize()*."""
         return self.tokenize(tokens, return_str)
-    

--- a/nltk/tokenize/util.py
+++ b/nltk/tokenize/util.py
@@ -7,6 +7,7 @@
 # For license information, see LICENSE.TXT
 
 from re import finditer
+from xml.sax.saxutils import escape
 
 def string_span_tokenize(s, sep):
     r"""
@@ -93,13 +94,13 @@ class CJKChars(object):
     """
     An object that enumerates the code points of the CJK characters as listed on
     http://en.wikipedia.org/wiki/Basic_Multilingual_Plane#Basic_Multilingual_Plane
-    
+
     This is a Python port of the CJK code point enumerations of Moses tokenizer:
     https://github.com/moses-smt/mosesdecoder/blob/master/scripts/tokenizer/detokenizer.perl#L309
     """
     # Hangul Jamo (1100–11FF)
     Hangul_Jamo = (4352, 4607) # (ord(u"\u1100"), ord(u"\u11ff"))
-    
+
     # CJK Radicals Supplement (2E80–2EFF)
     # Kangxi Radicals (2F00–2FDF)
     # Ideographic Description Characters (2FF0–2FFF)
@@ -120,16 +121,16 @@ class CJKChars(object):
     # Yi Syllables (A000–A48F)
     # Yi Radicals (A490–A4CF)
     CJK_Radicals = (11904, 42191) # (ord(u"\u2e80"), ord(u"\ua4cf"))
-    
+
     # Phags-pa (A840–A87F)
     Phags_Pa = (43072, 43135) # (ord(u"\ua840"), ord(u"\ua87f"))
 
     # Hangul Syllables (AC00–D7AF)
     Hangul_Syllables = (44032, 55215) # (ord(u"\uAC00"), ord(u"\uD7AF"))
-    
+
     # CJK Compatibility Ideographs (F900–FAFF)
     CJK_Compatibility_Ideographs = (63744, 64255) # (ord(u"\uF900"), ord(u"\uFAFF"))
-    
+
     # CJK Compatibility Forms (FE30–FE4F)
     CJK_Compatibility_Forms = (65072, 65103) # (ord(u"\uFE30"), ord(u"\uFE4F"))
 
@@ -138,9 +139,9 @@ class CJKChars(object):
 
     # Supplementary Ideographic Plane 20000–2FFFF
     Supplementary_Ideographic_Plane = (131072, 196607) # (ord(u"\U00020000"), ord(u"\U0002FFFF"))
-        
-    ranges = [Hangul_Jamo, CJK_Radicals, Phags_Pa, Hangul_Syllables, 
-              CJK_Compatibility_Ideographs, CJK_Compatibility_Forms, 
+
+    ranges = [Hangul_Jamo, CJK_Radicals, Phags_Pa, Hangul_Syllables,
+              CJK_Compatibility_Ideographs, CJK_Compatibility_Forms,
               Katakana_Hangul_Halfwidth, Supplementary_Ideographic_Plane]
 
 
@@ -148,20 +149,40 @@ class CJKChars(object):
 def is_cjk(character):
     """
     Python port of Moses' code to check for CJK character.
-    
+
     >>> CJKChars().ranges
     [(4352, 4607), (11904, 42191), (43072, 43135), (44032, 55215), (63744, 64255), (65072, 65103), (65381, 65500), (131072, 196607)]
     >>> is_cjk(u'\u33fe')
     True
     >>> is_cjk(u'\uFE5F')
     False
-    
+
     :param character: The character that needs to be checked.
     :type character: char
     :return: bool
     """
-    return any([start <= ord(character) <= end for start, end in 
-                [(4352, 4607), (11904, 42191), (43072, 43135), (44032, 55215), 
-                 (63744, 64255), (65072, 65103), (65381, 65500), 
+    return any([start <= ord(character) <= end for start, end in
+                [(4352, 4607), (11904, 42191), (43072, 43135), (44032, 55215),
+                 (63744, 64255), (65072, 65103), (65381, 65500),
                  (131072, 196607)]
                 ])
+
+
+def xml_escape(text):
+    """
+    This function transforms the input text into an "escaped" version suitable
+    for well-formed XML formatting.
+
+    Note that the default xml.sax.saxutils.escape() function don't escape
+    some characters that Moses does so we have to manually add them to the
+    entities dictionary.
+        >>> escape(''')| & < > ' " ] [''')
+        '| &amp; &lt; &gt; \' " ] ['
+
+    :param text: The text that needs to be escaped.
+    :type text: str
+    :rtype: str
+    """
+    return escape(text, entities={ r"'": "&apos;", r'"': r"&quot;",
+                                   r"|": "&amp;",  r"&": r"&#124;",
+                                   r"[": "&#91;",  r"]": r"&#93;", })


### PR DESCRIPTION
From #1551 , the initial implementation of the Python port of Moses' tokenizer and detokenizer went awry and thus the following fixes: 

 - Fixed by using the appropriate backslashes only at necessary places due to wrong use of escape for special regex characters cause by literal port of Perl's regexes
 - Corrected several instances of typo in regexes
 - Using `re.search` instead of `re.match`. The behavior in Perl for regex matching is for the whole string but the `re.match` is anchored to the start of the sting.

----

Moses expected outputs:

```
$ echo "This ain't funny. It's actually hillarious, yet double Ls. | [] < > [ ] & You're gonna shake it off? Don't?" | ~/mosesdecoder/scripts/tokenizer/tokenizer.perl 
Tokenizer Version 1.1
Language: en
Number of threads: 1
This ain &apos;t funny . It &apos;s actually hillarious , yet double Ls . &#124; &#91; &#93; &lt; &gt; &#91; &#93; &amp; You &apos;re gonna shake it off ? Don &apos;t ?

$ echo "This ain't funny. It's actually hillarious, yet double Ls. | [] < > [ ] & You're gonna shake it off? Don't?" | ~/mosesdecoder/scripts/tokenizer/tokenizer.perl | ~/mosesdecoder/scripts/tokenizer/detokenizer.perl 
Detokenizer Version $Revision: 4134 $
Language: en
Tokenizer Version 1.1
Language: en
Number of threads: 1
This ain't funny. It's actually hillarious, yet double Ls. | [] < > [] & You're gonna shake it off? Don't?
```

Outputs from this patch (both Py2.7 and Py3.5)

```python
>>> from nltk.tokenize.moses import MosesTokenizer, MosesDetokenizer
>>> t, d = MosesTokenizer(), MosesDetokenizer()
>>> sent = "This ain't funny. It's actually hillarious, yet double Ls. | [] < > [ ] & You're gonna shake it off? Don't?"
>>> expected_tokens = [u'This', u'ain', u'&apos;t', u'funny.', u'It', u'&apos;s', u'actually', u'hillarious', u',', u'yet', u'double', u'Ls.', u'&#124;', u'&#91;', u'&#93;', u'&lt;', u'&gt;', u'&#91;', u'&#93;', u'&amp;', u'You', u'&apos;re', u'gonna', u'shake', u'it', u'off', u'?', u'Don', u'&apos;t', u'?']
>>> expected_detokens = "This ain't funny. It's actually hillarious, yet double Ls. | [] < > [] & You're gonna shake it off? Don't?"
>>> tokens = t.tokenize(sent)
>>> tokens == expected_tokens
True
>>> detokens = d.detokenize(tokens)
>>> " ".join(detokens) == expected_detokens
True
```
