### PR TITLE
LazyIteratorList bugfix/simplification

### DIFF
--- a/nltk/collections.py
+++ b/nltk/collections.py
@@ -552,35 +552,33 @@ class LazyIteratorList(AbstractLazySequence):
     and making them subscriptable.
     __repr__ displays only the first few elements.
     """
-    def __init__(self, it, cache_limit=None, known_len=None):
+    def __init__(self, it, known_len=None):
         self._it = it
         self._len = known_len
         self._cache = []
-        self._cache_limit = cache_limit
-        self._i = 0 # Number of items consumed so far
 
     def __len__(self):
         if self._len:
             return self._len
         for x in self.iterate_from(len(self._cache)):
             pass
-        return len(self._cache)
+        self._len = len(self._cache)
+        return self._len
 
     def iterate_from(self, start):
-        while self._i<start:
+        """Create a new iterator over this list starting at the given offset."""
+        while len(self._cache)<start:
             v = next(self._it)
-            if self._cache_limit is None or len(self._cache)+1<self._cache_limit:
-                self._cache.append(v)
-            self._i += 1
+            self._cache.append(v)
         i = start
         while i<len(self._cache):
             yield self._cache[i]
             i += 1
         while True:
             v = next(self._it)
-            if self._cache_limit is None or len(self._cache)+1<self._cache_limit:
-                self._cache.append(v)
+            self._cache.append(v)
             yield v
+            i += 1
 
     def __add__(self, other):
         """Return a list concatenating self with other."""


### PR DESCRIPTION
Bugs in the `iterate_from()` method meant it was possible to get spurious `IndexError`s when accessing list elements. Removed the `cache_limit` option, which greatly simplifies the implementation.