### PR TITLE
FrameNet corpus reader overhaul

### DIFF
--- a/nltk/corpus/reader/framenet.py
+++ b/nltk/corpus/reader/framenet.py
@@ -1886,7 +1886,7 @@ class FramenetCorpusReader(XMLCorpusReader):
         """Load a subcorpus of a lexical unit from the given xml."""
         sc = AttrDict()
         try:
-            sc['name'] = str(elt.get('name'))
+            sc['name'] = elt.get('name')    # was wrapped in str(), but some subcorpus names have Unicode chars
         except AttributeError:
             return None
         sc['_type'] = "lusubcorpus"

--- a/nltk/corpus/reader/framenet.py
+++ b/nltk/corpus/reader/framenet.py
@@ -332,8 +332,8 @@ def _pretty_annotation(sent, aset_level=False):
     """
 
     sentkeys = sent.keys()
-    outstr = ""
-    outstr += "exemplar sentence ({0.ID}):\n\n".format(sent)
+    outstr = "annotation set" if aset_level else "exemplar sentence"
+    outstr += " ({0.ID}):\n\n".format(sent)
     for k in ('corpID', 'docID', 'paragNo', 'sentNo', 'aPos'):
         if k in sentkeys:
             outstr += "[{0}] {1}\n".format(k, sent[k])
@@ -1865,7 +1865,7 @@ class FramenetCorpusReader(XMLCorpusReader):
         """
         Full-text annotation sentences, optionally filtered by document name.
         """
-        return PrettyLazyIteratorList(sent for d in self.docs(docNamePattern) for sent in self.docs().sentence)
+        return PrettyLazyIteratorList(sent for d in self.docs(docNamePattern) for sent in d.sentence)
 
 
     def frame_relation_types(self):

--- a/nltk/corpus/reader/framenet.py
+++ b/nltk/corpus/reader/framenet.py
@@ -1824,11 +1824,11 @@ class FramenetCorpusReader(XMLCorpusReader):
         """
         if exemplars:
             if full_text:
-                return self.exemplars() + self.ft_sentences()
+                return self.exemplars() + self.ft_sents()
             else:
                 return self.exemplars()
         elif full_text:
-            return self.ft_sentences()
+            return self.ft_sents()
     
     def annotations(self, luNamePattern=None, exemplars=True, full_text=True):
         """
@@ -1843,7 +1843,7 @@ class FramenetCorpusReader(XMLCorpusReader):
         if full_text:
             if luNamePattern is not None:
                 matchedLUIDs = set(self.lu_ids_and_names(luNamePattern).keys())
-            ftpart = PrettyLazyIteratorList(aset for sent in self.ft_sentences() for aset in sent.annotationSet[1:] if luNamePattern is None or aset.luID in matchedLUIDs)
+            ftpart = PrettyLazyIteratorList(aset for sent in self.ft_sents() for aset in sent.annotationSet[1:] if luNamePattern is None or aset.luID in matchedLUIDs)
         else:
             ftpart = []
         
@@ -1861,7 +1861,7 @@ class FramenetCorpusReader(XMLCorpusReader):
         """
         return PrettyLazyConcatenation(lu.exemplars for lu in self.lus(luNamePattern))
         
-    def ft_sentences(self, docNamePattern=None):
+    def ft_sents(self, docNamePattern=None):
         """
         Full-text annotation sentences, optionally filtered by document name.
         """

--- a/nltk/corpus/reader/framenet.py
+++ b/nltk/corpus/reader/framenet.py
@@ -1776,7 +1776,7 @@ class FramenetCorpusReader(XMLCorpusReader):
         >>> from nltk.corpus import framenet as fn
         >>> len(fn.docs())
         78
-        >>> set([x.corpname for x in fn.docs()])==set(['ANC', 'C-4', 'KBEval', \
+        >>> set([x.corpname for x in fn.docs_metadata()])==set(['ANC', 'C-4', 'KBEval', \
                     'LUCorpus-v0.3', 'Miscellaneous', 'NTI', 'PropBank', 'QA', 'SemAnno'])
         True
 


### PR DESCRIPTION
This adds support for accessing annotated corpus examples in the FrameNet database (lexicographic exemplar sentences + full-text documents). The sentences are loaded on demand, and are linked to the lexicon as appropriate. API methods `.sents()`, `.annotations()`, `.exemplars()`, `.ft_sents()`, and `.docs()` provide direct access. Pretty-print displays facilitate browsing the annotated sentences in the terminal. Tested on the recent 1.7 data release.

Fixes #1369, #1370, #1132, #1191, #1378