### PR TITLE
Fix Porter stemmer failing on 'oed'

### DIFF
--- a/nltk/stem/porter.py
+++ b/nltk/stem/porter.py
@@ -211,6 +211,7 @@ class PorterStemmer(StemmerI):
         Returns True if word ends with a double consonant
         """
         return (
+            len(word) >= 2 and
             word[-1] == word[-2] and
             self._is_consonant(word, len(word)-1)
         )

--- a/nltk/test/unit/test_stem.py
+++ b/nltk/test/unit/test_stem.py
@@ -98,3 +98,10 @@ class PorterTest(unittest.TestCase):
                 .read()
                 .splitlines()
         )
+
+    def test_oed_bug(self):
+        """Test for bug https://github.com/nltk/nltk/issues/1581
+
+        Ensures that 'oed' can be stemmed without throwing an error.
+        """
+        assert PorterStemmer().stem('oed') == 'o'


### PR DESCRIPTION
Fixes https://github.com/nltk/nltk/issues/1581, which was a regression caused by https://github.com/nltk/nltk/pull/1261

[fievelk's analysis](https://github.com/nltk/nltk/issues/1581#issuecomment-271104670) there is entirely correct; I missed an important length check from my function to see if a stem ends with a double consonant, and remarkably this didn't blow up on any of the tens of thousands of cases in the testing vocabulary. :(

All Porter tests now pass (including the new one, of course).