### PR TITLE
Fix Stanford interfaces

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -54,14 +54,22 @@ if [[ ! -d $senna_folder_name ]]; then
 fi
 
 # Setup the Enviroment variable
+export CLASSPATH=$(pwd)"/${stanford_corenlp_package_name}"
+export CLASSPATH=${CLASSPATH}:$(pwd)"/${stanford_parser_package_name}"
+export CLASSPATH=${CLASSPATH}:$(pwd)"/${stanford_tagger_package_name}"
 export STANFORD_CORENLP=$(pwd)'/stanford-corenlp'
 export STANFORD_PARSER=$(pwd)'/stanford-parser'
-export STANFORD_MODELS=$(pwd)'/stanford-parser'
+export STANFORD_MODELS=$(pwd)'/stanford-postagger/models'
 export STANFORD_POSTAGGER=$(pwd)'/stanford-postagger'
 export SENNA=$(pwd)'/senna'
 
 popd
 popd
+
+echo "---- CLASSPATH: ----"
+echo $CLASSPATH
+echo "---- MODELS: ----"
+echo $STANFORD_MODELS
 
 #coverage
 coverage erase

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -35,7 +35,7 @@ from nltk import compat
 _java_bin = None
 _java_options = []
 # [xx] add classpath option to config_java?
-def config_java(bin=None, options=None, verbose=True):
+def config_java(bin=None, options=None, verbose=False):
     """
     Configure nltk's java interface, by letting nltk know where it can
     find the Java binary, and what extra options (if any) should be
@@ -173,21 +173,21 @@ def read_str(s, start_position):
     containing the value of the string literal and the position where
     it ends.  Otherwise, raise a ``ReadError``.
 
-    :param s: A string that will be checked to see if within which a 
+    :param s: A string that will be checked to see if within which a
         Python string literal exists.
     :type s: str
-    
+
     :param start_position: The specified beginning position of the string ``s``
         to begin regex matching.
     :type start_position: int
-    
-    :return: A tuple containing the matched string literal evaluated as a 
+
+    :return: A tuple containing the matched string literal evaluated as a
         string and the end position of the string literal.
     :rtype: tuple(str, int)
 
     :raise ReadError: If the ``_STRING_START_RE`` regex doesn't return a
-        match in ``s`` at ``start_position``, i.e., open quote. If the 
-        ``_STRING_END_RE`` regex doesn't return a match in ``s`` at the 
+        match in ``s`` at ``start_position``, i.e., open quote. If the
+        ``_STRING_END_RE`` regex doesn't return a match in ``s`` at the
         end of the first match, i.e., close quote.
     :raise ValueError: If an invalid string (i.e., contains an invalid
         escape sequence) is passed into the ``eval``.
@@ -227,14 +227,14 @@ def read_int(s, start_position):
     value of the integer and the position where it ends.  Otherwise,
     raise a ``ReadError``.
 
-    :param s: A string that will be checked to see if within which a 
+    :param s: A string that will be checked to see if within which a
         Python integer exists.
     :type s: str
-    
+
     :param start_position: The specified beginning position of the string ``s``
         to begin regex matching.
     :type start_position: int
-    
+
     :return: A tuple containing the matched integer casted to an int,
         and the end position of the int in ``s``.
     :rtype: tuple(int, int)
@@ -246,7 +246,7 @@ def read_int(s, start_position):
     >>> from nltk.internals import read_int
     >>> read_int('42 is the answer', 0)
     (42, 2)
-    
+
     """
     m = _READ_INT_RE.match(s, start_position)
     if not m: raise ReadError('integer', start_position)
@@ -260,14 +260,14 @@ def read_number(s, start_position):
     containing the value of the number and the position where it ends.
     Otherwise, raise a ``ReadError``.
 
-    :param s: A string that will be checked to see if within which a 
+    :param s: A string that will be checked to see if within which a
         Python number exists.
     :type s: str
-    
+
     :param start_position: The specified beginning position of the string ``s``
         to begin regex matching.
     :type start_position: int
-    
+
     :return: A tuple containing the matched number casted to a ``float``,
         and the end position of the number in ``s``.
     :rtype: tuple(float, int)
@@ -279,7 +279,7 @@ def read_number(s, start_position):
     >>> from nltk.internals import read_number
     >>> read_number('Pi is 3.14159', 6)
     (3.14159, 13)
-    
+
     """
     m = _READ_NUMBER_VALUE.match(s, start_position)
     if not m or not (m.group(1) or m.group(2)):
@@ -451,7 +451,7 @@ class Counter:
 ##########################################################################
 
 def find_file_iter(filename, env_vars=(), searchpath=(),
-    file_names=None, url=None, verbose=True, finding_dir=False):
+    file_names=None, url=None, verbose=False, finding_dir=False):
     """
     Search for a file to be used by nltk.
 
@@ -498,7 +498,7 @@ def find_file_iter(filename, env_vars=(), searchpath=(),
             if finding_dir: # This is to file a directory instead of file
                 yielded = True
                 yield os.environ[env_var]
-        		
+
             for env_dir in os.environ[env_var].split(os.pathsep):
                 # Check if the environment variable contains a direct path to the bin
                 if os.path.isfile(env_dir):
@@ -568,19 +568,19 @@ def find_file_iter(filename, env_vars=(), searchpath=(),
 
 
 def find_file(filename, env_vars=(), searchpath=(),
-        file_names=None, url=None, verbose=True):
+        file_names=None, url=None, verbose=False):
     return next(find_file_iter(filename, env_vars, searchpath,
                                file_names, url, verbose))
 
 
 def find_dir(filename, env_vars=(), searchpath=(),
-        file_names=None, url=None, verbose=True):
+        file_names=None, url=None, verbose=False):
     return next(find_file_iter(filename, env_vars, searchpath,
                                file_names, url, verbose, finding_dir=True))
 
 
 def find_binary_iter(name, path_to_bin=None, env_vars=(), searchpath=(),
-                binary_names=None, url=None, verbose=True):
+                binary_names=None, url=None, verbose=False):
     """
     Search for a file to be used by nltk.
 
@@ -597,12 +597,12 @@ def find_binary_iter(name, path_to_bin=None, env_vars=(), searchpath=(),
         yield file
 
 def find_binary(name, path_to_bin=None, env_vars=(), searchpath=(),
-                binary_names=None, url=None, verbose=True):
+                binary_names=None, url=None, verbose=False):
     return next(find_binary_iter(name, path_to_bin, env_vars, searchpath,
                                  binary_names, url, verbose))
 
 def find_jar_iter(name_pattern, path_to_jar=None, env_vars=(),
-        searchpath=(), url=None, verbose=True, is_regex=False):
+        searchpath=(), url=None, verbose=False, is_regex=False):
     """
     Search for a jar that is used by nltk.
 
@@ -648,7 +648,7 @@ def find_jar_iter(name_pattern, path_to_jar=None, env_vars=(),
                                 print('[Found %s: %s]' % (name_pattern, cp))
                             yielded = True
                             yield cp
-                    # The case where user put directory containing the jar file in the classpath 
+                    # The case where user put directory containing the jar file in the classpath
                     if os.path.isdir(cp):
                         if not is_regex:
                             if os.path.isfile(os.path.join(cp,name_pattern)):
@@ -657,14 +657,14 @@ def find_jar_iter(name_pattern, path_to_jar=None, env_vars=(),
                                 yielded = True
                                 yield os.path.join(cp,name_pattern)
                         else:
-                            # Look for file using regular expression 
+                            # Look for file using regular expression
                             for file_name in os.listdir(cp):
                                 if re.match(name_pattern,file_name):
                                     if verbose:
                                         print('[Found %s: %s]' % (name_pattern, os.path.join(cp,file_name)))
                                     yielded = True
                                     yield os.path.join(cp,file_name)
-                                
+
             else:
                 jar_env = os.environ[env_var]
                 jar_iter = ((os.path.join(jar_env, path_to_jar) for path_to_jar in os.listdir(jar_env))
@@ -714,21 +714,21 @@ def find_jar_iter(name_pattern, path_to_jar=None, env_vars=(),
         raise LookupError('\n\n%s\n%s\n%s' % (div, msg, div))
 
 def find_jar(name_pattern, path_to_jar=None, env_vars=(),
-        searchpath=(), url=None, verbose=True, is_regex=False):
+        searchpath=(), url=None, verbose=False, is_regex=False):
     return next(find_jar_iter(name_pattern, path_to_jar, env_vars,
                          searchpath, url, verbose, is_regex))
 
-                
+
 def find_jars_within_path(path_to_jars):
-	return [os.path.join(root, filename) 
-			for root, dirnames, filenames in os.walk(path_to_jars) 
+	return [os.path.join(root, filename)
+			for root, dirnames, filenames in os.walk(path_to_jars)
 			for filename in fnmatch.filter(filenames, '*.jar')]
 
 def _decode_stdoutdata(stdoutdata):
     """ Convert data read from stdout/stderr to unicode """
     if not isinstance(stdoutdata, bytes):
         return stdoutdata
-    
+
     encoding = getattr(sys.__stdout__, "encoding", locale.getpreferredencoding())
     if encoding is None:
         return stdoutdata.decode()
@@ -978,5 +978,3 @@ def is_writable(path):
 
 def raise_unorderable_types(ordering, a, b):
     raise TypeError("unorderable types: %s() %s %s()" % (type(a).__name__, ordering, type(b).__name__))
-
-

--- a/nltk/tag/stanford.py
+++ b/nltk/tag/stanford.py
@@ -54,11 +54,11 @@ class StanfordTagger(TaggerI):
 
         self._stanford_model = find_file(model_filename,
                 env_vars=('STANFORD_MODELS',), verbose=verbose)
-        
-        # Adding logging jar files to classpath 
+
+        # Adding logging jar files to classpath
         stanford_dir = os.path.split(self._stanford_jar)[0]
         self._stanford_jar = tuple(find_jars_within_path(stanford_dir))
-        
+
         self._encoding = encoding
         self.java_options = java_options
 
@@ -67,8 +67,8 @@ class StanfordTagger(TaggerI):
       raise NotImplementedError
 
     def tag(self, tokens):
-        # This function should return list of tuple rather than list of list 
-        return sum(self.tag_sents([tokens]), []) 
+        # This function should return list of tuple rather than list of list
+        return sum(self.tag_sents([tokens]), [])
 
     def tag_sents(self, sentences):
         encoding = self._encoding
@@ -80,7 +80,7 @@ class StanfordTagger(TaggerI):
 
         cmd = list(self._cmd)
         cmd.extend(['-encoding', encoding])
-        
+
         # Write the actual sentences to the temporary input file
         _input_fh = os.fdopen(_input_fh, 'wb')
         _input = '\n'.join((' '.join(x) for x in sentences))
@@ -88,18 +88,18 @@ class StanfordTagger(TaggerI):
             _input = _input.encode(encoding)
         _input_fh.write(_input)
         _input_fh.close()
-        
+
         # Run the tagger and get the output
         stanpos_output, _stderr = java(cmd, classpath=self._stanford_jar,
                                                        stdout=PIPE, stderr=PIPE)
         stanpos_output = stanpos_output.decode(encoding)
-        
+
         # Delete the temporary file
-        os.unlink(self._input_file_path) 
+        os.unlink(self._input_file_path)
 
         # Return java configurations to their default values
         config_java(options=default_options, verbose=False)
-                
+
         return self.parse_output(stanpos_output, sentences)
 
     def parse_output(self, text, sentences = None):
@@ -169,28 +169,26 @@ class StanfordNERTagger(StanfordTagger):
 
     @property
     def _cmd(self):
-        # Adding -tokenizerFactory edu.stanford.nlp.process.WhitespaceTokenizer -tokenizerOptions tokenizeNLs=false for not using stanford Tokenizer  
+        # Adding -tokenizerFactory edu.stanford.nlp.process.WhitespaceTokenizer -tokenizerOptions tokenizeNLs=false for not using stanford Tokenizer
         return ['edu.stanford.nlp.ie.crf.CRFClassifier',
                 '-loadClassifier', self._stanford_model, '-textFile',
                 self._input_file_path, '-outputFormat', self._FORMAT, '-tokenizerFactory', 'edu.stanford.nlp.process.WhitespaceTokenizer', '-tokenizerOptions','\"tokenizeNLs=false\"']
 
     def parse_output(self, text, sentences):
         if self._FORMAT == 'slashTags':
-            # Joint together to a big list    
+            # Joint together to a big list
             tagged_sentences = []
             for tagged_sentence in text.strip().split("\n"):
                 for tagged_word in tagged_sentence.strip().split():
                     word_tags = tagged_word.strip().split(self._SEPARATOR)
                     tagged_sentences.append((''.join(word_tags[:-1]), word_tags[-1]))
-                
+
             # Separate it according to the input
             result = []
-            start = 0 
+            start = 0
             for sent in sentences:
                 result.append(tagged_sentences[start:start + len(sent)])
                 start += len(sent);
-            return result 
+            return result
 
         raise NotImplementedError
-
-

--- a/nltk/tag/stanford.py
+++ b/nltk/tag/stanford.py
@@ -22,7 +22,7 @@ import tempfile
 from subprocess import PIPE
 import warnings
 
-from nltk.internals import find_file, find_jar, config_java, java, _java_options, find_jars_within_path
+from nltk.internals import find_file, find_jar, config_java, java, _java_options
 from nltk.tag.api import TaggerI
 from nltk import compat
 
@@ -54,10 +54,6 @@ class StanfordTagger(TaggerI):
 
         self._stanford_model = find_file(model_filename,
                 env_vars=('STANFORD_MODELS',), verbose=verbose)
-
-        # Adding logging jar files to classpath
-        stanford_dir = os.path.split(self._stanford_jar)[0]
-        self._stanford_jar = tuple(find_jars_within_path(stanford_dir))
 
         self._encoding = encoding
         self.java_options = java_options
@@ -124,8 +120,8 @@ class StanfordPOSTagger(StanfordTagger):
     Example:
 
         >>> from nltk.tag import StanfordPOSTagger
-        >>> st = StanfordPOSTagger('english-bidirectional-distsim.tagger') # doctest: +SKIP
-        >>> st.tag('What is the airspeed of an unladen swallow ?'.split()) # doctest: +SKIP
+        >>> st = StanfordPOSTagger('english-bidirectional-distsim.tagger')
+        >>> st.tag('What is the airspeed of an unladen swallow ?'.split())
         [('What', 'WP'), ('is', 'VBZ'), ('the', 'DT'), ('airspeed', 'NN'), ('of', 'IN'), ('an', 'DT'), ('unladen', 'JJ'), ('swallow', 'VB'), ('?', '.')]
     """
 

--- a/nltk/tokenize/stanford.py
+++ b/nltk/tokenize/stanford.py
@@ -15,7 +15,7 @@ import json
 from subprocess import PIPE
 
 from nltk import compat
-from nltk.internals import find_jar, config_java, java, _java_options, find_jars_within_path
+from nltk.internals import find_jar, config_java, java, _java_options
 
 from nltk.tokenize.api import TokenizerI
 
@@ -43,11 +43,7 @@ class StanfordTokenizer(TokenizerI):
             searchpath=(), url=_stanford_url,
             verbose=verbose
         )
-        
-        # Adding logging jar files to classpath 
-        stanford_dir = os.path.split(self._stanford_jar)[0]
-        self._stanford_jar = tuple(find_jars_within_path(stanford_dir))
-        
+
         self._encoding = encoding
         self.java_options = java_options
 
@@ -109,5 +105,3 @@ def setup_module(module):
         StanfordTokenizer()
     except LookupError:
         raise SkipTest('doctests from nltk.tokenize.stanford are skipped because the stanford postagger jar doesn\'t exist')
-
-


### PR DESCRIPTION
Related issue: #1584

---

This PR aims to solve the problems we currently experience with Stanford tokenizers and taggers.
We use too many arguments in our classpath, and some of them (i.e. the `slf4j.jar` paths) are breaking current functionalities. This new problem is also related to some changes recently made to the Stanford CoreNLP codebase.

Note: I also took the chance to change some verbosity levels to `False`, as requested in #1509.