### PR TITLE
Ensure file pointer is closed in xmldocs.py

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -206,6 +206,7 @@
 - J Richard Snape
 - Tsolak Ghukasyan
 - Prasasto Adi
+- Safwan Kamarrudin
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 ### Contributors to the Porter Stemmer

--- a/nltk/corpus/reader/xmldocs.py
+++ b/nltk/corpus/reader/xmldocs.py
@@ -156,7 +156,8 @@ class XMLCorpusView(StreamBackedCorpusView):
 
     def _detect_encoding(self, fileid):
         if isinstance(fileid, PathPointer):
-            s = fileid.open().readline()
+            with fileid.open() as infile:
+                s = infile.readline()
         else:
             with open(fileid, 'rb') as infile:
                 s = infile.readline()


### PR DESCRIPTION
When running a cross-validation test that uses the `nps_chat` corpus, I keep getting the following `ResourceWarning`

```
/home/ubuntu/virtualenvs/venv-3.6.0/lib/python3.6/site-packages/nltk/corpus/reader/xmldocs.py:159: ResourceWarning: unclosed file <_io.BufferedReader name='/home/ubuntu/nltk_data/corpora/nps_chat/10-19-20s_706posts.xml'>
  s = fileid.open().readline()
```

The fix ensures that the `PathPointer` used when detecting the file encoding is closed when it's done.