### PR TITLE
Fix StanfordNeuralDependencyParser tests

### DIFF
--- a/nltk/parse/stanford.py
+++ b/nltk/parse/stanford.py
@@ -62,8 +62,8 @@ class GenericStanfordParser(ParserI):
         )
 
         #self._classpath = (stanford_jar, model_jar)
-        
-        # Adding logging jar files to classpath 
+
+        # Adding logging jar files to classpath
         stanford_dir = os.path.split(stanford_jar)[0]
         self._classpath = tuple([model_jar] + find_jars_within_path(stanford_dir))
 
@@ -214,7 +214,7 @@ class GenericStanfordParser(ParserI):
                 cmd.append(input_file.name)
                 stdout, stderr = java(cmd, classpath=self._classpath,
                                       stdout=PIPE, stderr=PIPE)
-                
+
             stdout = stdout.replace(b'\xc2\xa0',b' ')
             stdout = stdout.replace(b'\x00\xa0',b' ')
             stdout = stdout.decode(encoding)
@@ -342,7 +342,7 @@ class StanfordDependencyParser(GenericStanfordParser):
 class StanfordNeuralDependencyParser(GenericStanfordParser):
     '''
     >>> from nltk.parse.stanford import StanfordNeuralDependencyParser
-    >>> dep_parser=StanfordNeuralDependencyParser()
+    >>> dep_parser=StanfordNeuralDependencyParser(java_options='-mx3g')
 
     >>> [parse.tree() for parse in dep_parser.raw_parse("The quick brown fox jumps over the lazy dog.")] # doctest: +NORMALIZE_WHITESPACE
     [Tree('jumps', [Tree('fox', ['The', 'quick', 'brown']), Tree('dog', ['over', 'the', 'lazy'])])]


### PR DESCRIPTION
# WIP

Reference: #1586 

---

This PR aims to solve `StanfordNeuralDependencyParser` test failures. It is supposed to be structured in two parts:

- [x] Fix java memory allocation issues in doctests

The `StanfordNeuralDependencyParser` needs a lot of memory in order to work. However, changing the default value of an argument in the constructor of a subclass is not very straightforward, especially when using `*args` and `*kwargs` (our case). I therefore decided to keep the current constructors and improve the documentation, fixing tests at the same time. This is done specifying the argument `java_options='-mx3g'` when instantiating the `StanfordNeuralDependencyParser`:
```python
dep_parser=StanfordNeuralDependencyParser(java_options='-mx3g')
```