### PR TITLE
Fix failing doctests in Python 2.7

### DIFF
--- a/nltk/corpus/reader/xmldocs.py
+++ b/nltk/corpus/reader/xmldocs.py
@@ -156,8 +156,11 @@ class XMLCorpusView(StreamBackedCorpusView):
 
     def _detect_encoding(self, fileid):
         if isinstance(fileid, PathPointer):
-            with fileid.open() as infile:
+            try:
+                infile = fileid.open()
                 s = infile.readline()
+            finally:
+                infile.close()
         else:
             with open(fileid, 'rb') as infile:
                 s = infile.readline()


### PR DESCRIPTION
I've modified the code to use `try-finally` instead. 

What I don't fully understand is why other calls to `with` aren't failing. Care to explain?