### PR TITLE
Add a corpus reader to the MWA subset of PPDB 

### DIFF
--- a/nltk/corpus/__init__.py
+++ b/nltk/corpus/__init__.py
@@ -285,6 +285,9 @@ nonbreaking_prefixes = LazyCorpusLoader(
 perluniprops = LazyCorpusLoader(
     'perluniprops', UnicharsCorpusReader, r'(?!README|\.).*', nltk_data_subdir='misc', encoding='utf8')
 
+mwa_ppdb = LazyCorpusLoader(
+    'mwa_ppdb', MWAPPDBCorpusReader, r'(?!README|\.).*', nltk_data_subdir='misc', encoding='utf8')
+
 
 def demo():
     # This is out-of-date:

--- a/nltk/corpus/reader/__init__.py
+++ b/nltk/corpus/reader/__init__.py
@@ -142,5 +142,6 @@ __all__ = [
     'MTECorpusReader', 'ReviewsCorpusReader', 'OpinionLexiconCorpusReader',
     'ProsConsCorpusReader', 'CategorizedSentencesCorpusReader',
     'ComparativeSentencesCorpusReader', 'PanLexLiteCorpusReader',
-    'NonbreakingPrefixesCorpusReader', 'UnicharsCorpusReader'
+    'NonbreakingPrefixesCorpusReader', 'UnicharsCorpusReader',
+    'MWAPPDBCorpusReader',
 ]

--- a/nltk/corpus/reader/wordlist.py
+++ b/nltk/corpus/reader/wordlist.py
@@ -7,7 +7,9 @@
 # URL: <http://nltk.org/>
 # For license information, see LICENSE.TXT
 
-from nltk import compat
+from __future__ import unicode_literals
+
+from nltk.compat import string_types
 from nltk.tokenize import line_tokenize
 
 from nltk.corpus.reader.util import *
@@ -23,7 +25,7 @@ class WordListCorpusReader(CorpusReader):
 
     def raw(self, fileids=None):
         if fileids is None: fileids = self._fileids
-        elif isinstance(fileids, compat.string_types): fileids = [fileids]
+        elif isinstance(fileids, string_types): fileids = [fileids]
         return concat([self.open(f).read() for f in fileids])
 
 
@@ -61,9 +63,9 @@ class NonbreakingPrefixesCorpusReader(WordListCorpusReader):
         language(s).
 
         >>> from nltk.corpus import nonbreaking_prefixes as nbp
-        >>> nbp.words('en')[:10] == [u'A', u'B', u'C', u'D', u'E', u'F', u'G', u'H', u'I', u'J']
+        >>> nbp.words('en')[:10] == ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J']
         True
-        >>> nbp.words('ta')[:5] == [u'\u0b85', u'\u0b86', u'\u0b87', u'\u0b88', u'\u0b89']
+        >>> nbp.words('ta')[:5] == ['\u0b85', '\u0b86', '\u0b87', '\u0b88', '\u0b89']
         True
 
         :return: a list words for the specified language(s).
@@ -76,6 +78,7 @@ class NonbreakingPrefixesCorpusReader(WordListCorpusReader):
             fileids = ['nonbreaking_prefix.'+lang]
         return [line for line in line_tokenize(self.raw(fileids))
                 if not line.startswith(ignore_lines_startswith)]
+
 
 class UnicharsCorpusReader(WordListCorpusReader):
     """
@@ -95,9 +98,9 @@ class UnicharsCorpusReader(WordListCorpusReader):
         They are very useful when porting Perl tokenizers to Python.
 
         >>> from nltk.corpus import perluniprops as pup
-        >>> pup.chars('Open_Punctuation')[:5] == [u'(', u'[', u'{', u'\u0f3a', u'\u0f3c']
+        >>> pup.chars('Open_Punctuation')[:5] == ['(', '[', '{', '\u0f3a', '\u0f3c']
         True
-        >>> pup.chars('Currency_Symbol')[:5] == [u'$', u'\xa2', u'\xa3', u'\xa4', u'\xa5']
+        >>> pup.chars('Currency_Symbol')[:5] == ['$', '\xa2', '\xa3', '\xa4', '\xa5']
         True
         >>> pup.available_categories
         ['Close_Punctuation', 'Currency_Symbol', 'IsAlnum', 'IsAlpha', 'IsLower', 'IsN', 'IsSc', 'IsSo', 'Open_Punctuation']

--- a/nltk/corpus/reader/wordlist.py
+++ b/nltk/corpus/reader/wordlist.py
@@ -42,8 +42,8 @@ class SwadeshCorpusReader(WordListCorpusReader):
 class NonbreakingPrefixesCorpusReader(WordListCorpusReader):
     """
     This is a class to read the nonbreaking prefixes textfiles from the
-    Moses Machine Translation toolkit. These lists are used in the Python port 
-    of the Moses' word tokenizer.  
+    Moses Machine Translation toolkit. These lists are used in the Python port
+    of the Moses' word tokenizer.
     """
     available_langs = {'catalan': 'ca', 'czech': 'cs', 'german': 'de',
                         'greek': 'el', 'english': 'en', 'spanish': 'es',
@@ -54,22 +54,22 @@ class NonbreakingPrefixesCorpusReader(WordListCorpusReader):
                         'slovenian': 'sl', 'swedish': 'sv',  'tamil': 'ta'}
     # Also, add the lang IDs as the keys.
     available_langs.update({v:v for v in available_langs.values()})
-    
+
     def words(self, lang=None, fileids=None, ignore_lines_startswith='#'):
         """
         This module returns a list of nonbreaking prefixes for the specified
         language(s).
-        
+
         >>> from nltk.corpus import nonbreaking_prefixes as nbp
         >>> nbp.words('en')[:10] == [u'A', u'B', u'C', u'D', u'E', u'F', u'G', u'H', u'I', u'J']
         True
         >>> nbp.words('ta')[:5] == [u'\u0b85', u'\u0b86', u'\u0b87', u'\u0b88', u'\u0b89']
         True
-        
+
         :return: a list words for the specified language(s).
         """
         # If *lang* in list of languages available, allocate apt fileid.
-        # Otherwise, the function returns non-breaking prefixes for 
+        # Otherwise, the function returns non-breaking prefixes for
         # all languages when fileids==None.
         if lang in self.available_langs:
             lang = self.available_langs[lang]
@@ -79,21 +79,21 @@ class NonbreakingPrefixesCorpusReader(WordListCorpusReader):
 
 class UnicharsCorpusReader(WordListCorpusReader):
     """
-    This class is used to read lists of characters from the Perl Unicode 
+    This class is used to read lists of characters from the Perl Unicode
     Properties (see http://perldoc.perl.org/perluniprops.html).
-    The files in the perluniprop.zip are extracted using the Unicode::Tussle 
+    The files in the perluniprop.zip are extracted using the Unicode::Tussle
     module from http://search.cpan.org/~bdfoy/Unicode-Tussle-1.11/lib/Unicode/Tussle.pm
     """
     # These are categories similar to the Perl Unicode Properties
-    available_categories = ['Close_Punctuation', 'Currency_Symbol', 
-                            'IsAlnum', 'IsAlpha', 'IsLower', 'IsN', 'IsSc', 
+    available_categories = ['Close_Punctuation', 'Currency_Symbol',
+                            'IsAlnum', 'IsAlpha', 'IsLower', 'IsN', 'IsSc',
                             'IsSo', 'Open_Punctuation']
-    
+
     def chars(self, category=None, fileids=None):
         """
         This module returns a list of characters from  the Perl Unicode Properties.
         They are very useful when porting Perl tokenizers to Python.
-        
+
         >>> from nltk.corpus import perluniprops as pup
         >>> pup.chars('Open_Punctuation')[:5] == [u'(', u'[', u'{', u'\u0f3a', u'\u0f3c']
         True
@@ -101,9 +101,31 @@ class UnicharsCorpusReader(WordListCorpusReader):
         True
         >>> pup.available_categories
         ['Close_Punctuation', 'Currency_Symbol', 'IsAlnum', 'IsAlpha', 'IsLower', 'IsN', 'IsSc', 'IsSo', 'Open_Punctuation']
-        
-        :return: a list of characters given the specific unicode character category 
+
+        :return: a list of characters given the specific unicode character category
         """
         if category in self.available_categories:
             fileids = [category+'.txt']
         return list(self.raw(fileids).strip())
+
+
+class MWAPPDBCorpusReader(WordListCorpusReader):
+    """
+    This class is used to read lists of word pairs from the subset of lexical
+    pairs of The Paraphrase Database (PPDB) XXXL used in the Monolingual Word
+    Alignment (MWA) algorithm described in Sultan et al. (2014a, 2014b, 2015):
+     - http://acl2014.org/acl2014/Q14/pdf/Q14-1017
+     - http://www.aclweb.org/anthology/S14-2039
+     - http://www.aclweb.org/anthology/S15-2027
+
+    The original source of the PPDB corpus can be found on
+    http://www.cis.upenn.edu/~ccb/ppdb/
+
+    :return: a list of tuples of similar lexical terms.
+    """
+    mwa_ppdb_xxxl_file = 'ppdb-1.0-xxxl-lexical.extended.synonyms.uniquepairs'
+    def entries(self, fileids=mwa_ppdb_xxxl_file):
+        """
+        :return: a tuple of synonym word pairs.
+        """
+        return [tuple(line.split('\t')) for line in line_tokenize(self.raw(fileids))]

--- a/nltk/corpus/reader/wordlist.py
+++ b/nltk/corpus/reader/wordlist.py
@@ -7,7 +7,7 @@
 # URL: <http://nltk.org/>
 # For license information, see LICENSE.TXT
 
-from nltk.compat import string_types
+from nltk.compat import string_types, python_2_unicode_compatible
 from nltk.tokenize import line_tokenize
 
 from nltk.corpus.reader.util import *

--- a/nltk/corpus/reader/wordlist.py
+++ b/nltk/corpus/reader/wordlist.py
@@ -111,14 +111,14 @@ class UnicharsCorpusReader(WordListCorpusReader):
 
 class MWAPPDBCorpusReader(WordListCorpusReader):
     """
-    This class is used to read lists of word pairs from the subset of lexical
+    This class is used to read the list of word pairs from the subset of lexical
     pairs of The Paraphrase Database (PPDB) XXXL used in the Monolingual Word
     Alignment (MWA) algorithm described in Sultan et al. (2014a, 2014b, 2015):
      - http://acl2014.org/acl2014/Q14/pdf/Q14-1017
      - http://www.aclweb.org/anthology/S14-2039
      - http://www.aclweb.org/anthology/S15-2027
 
-    The original source of the PPDB corpus can be found on
+    The original source of the full PPDB corpus can be found on
     http://www.cis.upenn.edu/~ccb/ppdb/
 
     :return: a list of tuples of similar lexical terms.

--- a/nltk/corpus/reader/wordlist.py
+++ b/nltk/corpus/reader/wordlist.py
@@ -7,8 +7,6 @@
 # URL: <http://nltk.org/>
 # For license information, see LICENSE.TXT
 
-from __future__ import unicode_literals
-
 from nltk.compat import string_types
 from nltk.tokenize import line_tokenize
 
@@ -41,6 +39,7 @@ class SwadeshCorpusReader(WordListCorpusReader):
         return list(zip(*wordlists))
 
 
+@python_2_unicode_compatible
 class NonbreakingPrefixesCorpusReader(WordListCorpusReader):
     """
     This is a class to read the nonbreaking prefixes textfiles from the
@@ -80,6 +79,7 @@ class NonbreakingPrefixesCorpusReader(WordListCorpusReader):
                 if not line.startswith(ignore_lines_startswith)]
 
 
+@python_2_unicode_compatible
 class UnicharsCorpusReader(WordListCorpusReader):
     """
     This class is used to read lists of characters from the Perl Unicode
@@ -112,6 +112,7 @@ class UnicharsCorpusReader(WordListCorpusReader):
         return list(self.raw(fileids).strip())
 
 
+@python_2_unicode_compatible
 class MWAPPDBCorpusReader(WordListCorpusReader):
     """
     This class is used to read the list of word pairs from the subset of lexical

--- a/nltk/test/unit/test_corpora.py
+++ b/nltk/test/unit/test_corpora.py
@@ -2,7 +2,8 @@
 from __future__ import absolute_import, unicode_literals
 import unittest
 from nltk.corpus import (sinica_treebank, conll2007, indian, cess_cat, cess_esp,
-                         floresta, ptb, udhr)
+                         floresta, ptb, udhr, mwa_ppdb)
+
 from nltk.tree import Tree
 from nltk.test.unit.utils import skipIf
 
@@ -178,6 +179,20 @@ class TestPTB(unittest.TestCase):
             ptb.words(categories=['humor','fiction'])[:6],
             ['Thirty-three', 'Scotty', 'did', 'not', 'go', 'back']
         )
+
+
+class TestMWAPPDB(unittest.TestCase):
+    def test_fileids(self):
+        self.assertEqual(mwa_ppdb.fileids(),
+            [u'ppdb-1.0-xxxl-lexical.extended.synonyms.uniquepairs'])
+
+    def test_entries(self):
+        self.assertEqual(mwa_ppdb.entries()[:10],
+            [(u'10/17/01', u'17/10/2001'), (u'102,70', u'102.70'),
+            (u'13,53', u'13.53'), (u'3.2.5.3.2.1', u'3.2.5.3.2.1.'),
+            (u'53,76', u'53.76'), (u'6.9.5', u'6.9.5.'),
+            (u'7.7.6.3', u'7.7.6.3.'), (u'76,20', u'76.20'),
+            (u'79,85', u'79.85'), (u'93,65', u'93.65')] )
 
 # unload corpora
 from nltk.corpus import teardown_module

--- a/nltk/test/unit/test_corpora.py
+++ b/nltk/test/unit/test_corpora.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import
 import unittest
 
 from nltk.corpus import (sinica_treebank, conll2007, indian, cess_cat, cess_esp,
                          floresta, ptb, udhr, mwa_ppdb)
 
+from nltk.compat import python_2_unicode_compatible
 from nltk.tree import Tree
 from nltk.test.unit.utils import skipIf
 
@@ -26,6 +27,7 @@ class TestUdhr(unittest.TestCase):
             assert not isinstance(txt, bytes), name
 
 
+@python_2_unicode_compatible
 class TestIndian(unittest.TestCase):
 
     def test_words(self):
@@ -37,6 +39,7 @@ class TestIndian(unittest.TestCase):
         self.assertEqual(tagged_words, [('মহিষের', 'NN'), ('সন্তান', 'NN'), (':', 'SYM')])
 
 
+@python_2_unicode_compatible
 class TestCess(unittest.TestCase):
     def test_catalan(self):
         words = cess_cat.words()[:15]
@@ -51,12 +54,15 @@ class TestCess(unittest.TestCase):
         self.assertEqual(cess_esp.words()[115], "años")
 
 
+@python_2_unicode_compatible
 class TestFloresta(unittest.TestCase):
     def test_words(self):
         words = floresta.words()[:10]
         txt = "Um revivalismo refrescante O 7_e_Meio é um ex-libris de a"
         self.assertEqual(words, txt.split())
 
+
+@python_2_unicode_compatible
 class TestSinicaTreebank(unittest.TestCase):
 
     def test_sents(self):
@@ -81,6 +87,7 @@ class TestSinicaTreebank(unittest.TestCase):
             ]))
 
 
+@python_2_unicode_compatible
 class TestCoNLL2007(unittest.TestCase):
     # Reading the CoNLL 2007 Dependency Treebanks
 
@@ -144,6 +151,7 @@ class TestCoNLL2007(unittest.TestCase):
 
 
 @skipIf(not ptb.fileids(), "A full installation of the Penn Treebank is not available")
+@python_2_unicode_compatible
 class TestPTB(unittest.TestCase):
     def test_fileids(self):
         self.assertEqual(
@@ -182,6 +190,7 @@ class TestPTB(unittest.TestCase):
         )
 
 
+@python_2_unicode_compatible
 class TestMWAPPDB(unittest.TestCase):
     def test_fileids(self):
         self.assertEqual(mwa_ppdb.fileids(),

--- a/nltk/test/unit/test_corpora.py
+++ b/nltk/test/unit/test_corpora.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 import unittest
+
 from nltk.corpus import (sinica_treebank, conll2007, indian, cess_cat, cess_esp,
                          floresta, ptb, udhr, mwa_ppdb)
 
@@ -188,11 +189,11 @@ class TestMWAPPDB(unittest.TestCase):
 
     def test_entries(self):
         self.assertEqual(mwa_ppdb.entries()[:10],
-            [(u'10/17/01', u'17/10/2001'), (u'102,70', u'102.70'),
-            (u'13,53', u'13.53'), (u'3.2.5.3.2.1', u'3.2.5.3.2.1.'),
-            (u'53,76', u'53.76'), (u'6.9.5', u'6.9.5.'),
-            (u'7.7.6.3', u'7.7.6.3.'), (u'76,20', u'76.20'),
-            (u'79,85', u'79.85'), (u'93,65', u'93.65')] )
+            [('10/17/01', '17/10/2001'), ('102,70', '102.70'),
+            ('13,53', '13.53'), ('3.2.5.3.2.1', '3.2.5.3.2.1.'),
+            ('53,76', '53.76'), ('6.9.5', '6.9.5.'),
+            ('7.7.6.3', '7.7.6.3.'), ('76,20', '76.20'),
+            ('79,85', '79.85'), ('93,65', '93.65')] )
 
 # unload corpora
 from nltk.corpus import teardown_module


### PR DESCRIPTION
Moving on with #1489 , the corpus reader from the Sultan et al. (2014) subset of the PPDB is ready.

The original data source is on https://raw.githubusercontent.com/ma-sultan/monolingual-word-aligner/master/Resources/ppdb-1.0-xxxl-lexical.extended.synonyms.uniquepairs and it's a post-processed dataset from the full [PPDB](http://www.cis.upenn.edu/~ccb/ppdb/)

@stevenbird can you help to upload [this zipball](https://drive.google.com/file/d/0Bzz3wLacJ7WoN2pIOFBHanVCbk0/view?usp=sharing), so that it's accessible on `nltk_data`. I'm not sure where it should go to so now the code is putting it at `nltk_data/misc/mwa_ppdb`. 

I'll move on the other steps in the mini-roadmap while reviewing is done on this PR. 