### PR TITLE
Download correct version of Stanford CoreNLP in Jenkins CI

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -14,7 +14,7 @@ pushd ${HOME}
 pushd 'third'
 
 #download nltk stanford dependencies
-stanford_corenlp_package_zip_name=$(curl -s 'http://nlp.stanford.edu/software/corenlp.shtml' | grep -o 'stanford-corenlp-full-.*\.zip' | head -n1)
+stanford_corenlp_package_zip_name=$(curl -s 'http://stanfordnlp.github.io/CoreNLP/' | grep -o 'stanford-corenlp-full-.*\.zip' | head -n1)
 [[ ${stanford_corenlp_package_zip_name} =~ (.+)\.zip ]]
 stanford_corenlp_package_name=${BASH_REMATCH[1]}
 if [[ ! -d ${stanford_corenlp_package_name} ]]; then


### PR DESCRIPTION
Jenkins CI tests are currently passing. However, I found out that the CI is downloading the wrong Stanford CoreNLP version.

The problem is caused by this line in [`jenkins.sh`][1]:
```shell
stanford_corenlp_package_zip_name=$(curl -s 'http://nlp.stanford.edu/software/corenlp.shtml' | grep -o 'stanford-corenlp-full-.*\.zip' | head -n1)
```

The page we are referring to is not used anymore. In fact, the source code is redirecting users to another URL:
```html
<script language="javascript">
    window.location.href = "http://stanfordnlp.github.io/CoreNLP/"
</script>
```
With this PR, Jenkins CI will get the latest CoreNLP reference from this new URL instead.

**Note:** This will probably break existing tests, due to the fact that the new output from Stanford CoreNLP might be changed with the new version.

[1]: https://github.com/nltk/nltk/blob/develop/jenkins.sh#L17