### PR TITLE
Reverting to unicode_literal usage for test_corpora unittest and removing decorator from wordlist.py

### DIFF
--- a/nltk/corpus/reader/wordlist.py
+++ b/nltk/corpus/reader/wordlist.py
@@ -7,11 +7,12 @@
 # URL: <http://nltk.org/>
 # For license information, see LICENSE.TXT
 
-from nltk.compat import string_types, python_2_unicode_compatible
+from nltk.compat import string_types
 from nltk.tokenize import line_tokenize
 
 from nltk.corpus.reader.util import *
 from nltk.corpus.reader.api import *
+
 
 class WordListCorpusReader(CorpusReader):
     """
@@ -39,7 +40,6 @@ class SwadeshCorpusReader(WordListCorpusReader):
         return list(zip(*wordlists))
 
 
-@python_2_unicode_compatible
 class NonbreakingPrefixesCorpusReader(WordListCorpusReader):
     """
     This is a class to read the nonbreaking prefixes textfiles from the
@@ -62,9 +62,9 @@ class NonbreakingPrefixesCorpusReader(WordListCorpusReader):
         language(s).
 
         >>> from nltk.corpus import nonbreaking_prefixes as nbp
-        >>> nbp.words('en')[:10] == ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J']
+        >>> nbp.words('en')[:10] == [u'A', u'B', u'C', u'D', u'E', u'F', u'G', u'H', u'I', u'J']
         True
-        >>> nbp.words('ta')[:5] == ['\u0b85', '\u0b86', '\u0b87', '\u0b88', '\u0b89']
+        >>> nbp.words('ta')[:5] == [u'\u0b85', u'\u0b86', u'\u0b87', u'\u0b88', u'\u0b89']
         True
 
         :return: a list words for the specified language(s).
@@ -78,8 +78,6 @@ class NonbreakingPrefixesCorpusReader(WordListCorpusReader):
         return [line for line in line_tokenize(self.raw(fileids))
                 if not line.startswith(ignore_lines_startswith)]
 
-
-@python_2_unicode_compatible
 class UnicharsCorpusReader(WordListCorpusReader):
     """
     This class is used to read lists of characters from the Perl Unicode
@@ -98,9 +96,9 @@ class UnicharsCorpusReader(WordListCorpusReader):
         They are very useful when porting Perl tokenizers to Python.
 
         >>> from nltk.corpus import perluniprops as pup
-        >>> pup.chars('Open_Punctuation')[:5] == ['(', '[', '{', '\u0f3a', '\u0f3c']
+        >>> pup.chars('Open_Punctuation')[:5] == [u'(', u'[', u'{', u'\u0f3a', u'\u0f3c']
         True
-        >>> pup.chars('Currency_Symbol')[:5] == ['$', '\xa2', '\xa3', '\xa4', '\xa5']
+        >>> pup.chars('Currency_Symbol')[:5] == [u'$', u'\xa2', u'\xa3', u'\xa4', u'\xa5']
         True
         >>> pup.available_categories
         ['Close_Punctuation', 'Currency_Symbol', 'IsAlnum', 'IsAlpha', 'IsLower', 'IsN', 'IsSc', 'IsSo', 'Open_Punctuation']
@@ -112,7 +110,6 @@ class UnicharsCorpusReader(WordListCorpusReader):
         return list(self.raw(fileids).strip())
 
 
-@python_2_unicode_compatible
 class MWAPPDBCorpusReader(WordListCorpusReader):
     """
     This class is used to read the list of word pairs from the subset of lexical

--- a/nltk/test/unit/test_corpora.py
+++ b/nltk/test/unit/test_corpora.py
@@ -10,7 +10,6 @@ from nltk.tree import Tree
 from nltk.test.unit.utils import skipIf
 
 
-
 class TestUdhr(unittest.TestCase):
 
     def test_words(self):

--- a/nltk/test/unit/test_corpora.py
+++ b/nltk/test/unit/test_corpora.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 import unittest
 
 from nltk.corpus import (sinica_treebank, conll2007, indian, cess_cat, cess_esp,
@@ -8,6 +8,7 @@ from nltk.corpus import (sinica_treebank, conll2007, indian, cess_cat, cess_esp,
 from nltk.compat import python_2_unicode_compatible
 from nltk.tree import Tree
 from nltk.test.unit.utils import skipIf
+
 
 
 class TestUdhr(unittest.TestCase):
@@ -27,7 +28,6 @@ class TestUdhr(unittest.TestCase):
             assert not isinstance(txt, bytes), name
 
 
-@python_2_unicode_compatible
 class TestIndian(unittest.TestCase):
 
     def test_words(self):
@@ -39,7 +39,6 @@ class TestIndian(unittest.TestCase):
         self.assertEqual(tagged_words, [('মহিষের', 'NN'), ('সন্তান', 'NN'), (':', 'SYM')])
 
 
-@python_2_unicode_compatible
 class TestCess(unittest.TestCase):
     def test_catalan(self):
         words = cess_cat.words()[:15]
@@ -54,15 +53,12 @@ class TestCess(unittest.TestCase):
         self.assertEqual(cess_esp.words()[115], "años")
 
 
-@python_2_unicode_compatible
 class TestFloresta(unittest.TestCase):
     def test_words(self):
         words = floresta.words()[:10]
         txt = "Um revivalismo refrescante O 7_e_Meio é um ex-libris de a"
         self.assertEqual(words, txt.split())
 
-
-@python_2_unicode_compatible
 class TestSinicaTreebank(unittest.TestCase):
 
     def test_sents(self):
@@ -87,7 +83,6 @@ class TestSinicaTreebank(unittest.TestCase):
             ]))
 
 
-@python_2_unicode_compatible
 class TestCoNLL2007(unittest.TestCase):
     # Reading the CoNLL 2007 Dependency Treebanks
 
@@ -151,7 +146,6 @@ class TestCoNLL2007(unittest.TestCase):
 
 
 @skipIf(not ptb.fileids(), "A full installation of the Penn Treebank is not available")
-@python_2_unicode_compatible
 class TestPTB(unittest.TestCase):
     def test_fileids(self):
         self.assertEqual(
@@ -190,11 +184,10 @@ class TestPTB(unittest.TestCase):
         )
 
 
-@python_2_unicode_compatible
 class TestMWAPPDB(unittest.TestCase):
     def test_fileids(self):
         self.assertEqual(mwa_ppdb.fileids(),
-            [u'ppdb-1.0-xxxl-lexical.extended.synonyms.uniquepairs'])
+            ['ppdb-1.0-xxxl-lexical.extended.synonyms.uniquepairs'])
 
     def test_entries(self):
         self.assertEqual(mwa_ppdb.entries()[:10],


### PR DESCRIPTION
This is to fix the issue that is causing the CI tests failures. https://nltk.ci.cloudbees.com/job/nltk/TOXENV=py27-jenkins,jdk=jdk8latestOnlineInstall/lastCompletedBuild/testReport/

I've reverted the old code to before #1593
 - unittest code to 18be71298c1b829bb764aeea5428745f5e4a9517
 - wordlist.py code to 2c1966bb469d8a279d82e257a10d6c9da7ebc8e0

And fix the `nltk_data` issue with the new addition of `mwa_ppdb` from #1593 