### PR TITLE
Allow iterator in perceptron tagger training

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -98,6 +98,7 @@
 - Pierre-François Laquerre
 - Stefano Lattarini
 - Haejoong Lee
+- Jackson Lee
 - Max Leonov
 - Chris Liechti
 - Tom Lippincott

--- a/nltk/tag/perceptron.py
+++ b/nltk/tag/perceptron.py
@@ -183,9 +183,8 @@ class PerceptronTagger(TaggerI):
         for iter_ in range(nr_iter):
             c = 0
             n = 0
-            for sentence  in self._sentences:
-                words = [word for word,tag in sentence]
-                tags  = [tag for word,tag in sentence]
+            for sentence in self._sentences:
+                words, tags = zip(*sentence)
                 
                 prev, prev2 = self.START
                 context = self.START + [self.normalize(w) for w in words] \

--- a/nltk/tag/perceptron.py
+++ b/nltk/tag/perceptron.py
@@ -201,6 +201,11 @@ class PerceptronTagger(TaggerI):
                     n += 1
             random.shuffle(self._sentences)
             logging.info("Iter {0}: {1}/{2}={3}".format(iter_, c, n, _pc(c, n)))
+
+        # We don't need the training sentences anymore, and we don't want to
+        # waste space on them when we pickle the trained tagger.
+        self._sentences = None
+
         self.model.average_weights()
         # Pickle as a binary file
         if save_loc is not None:


### PR DESCRIPTION
This pull request resolves issue #1486.

Goal: To allow the training ``sentences`` for the `PerceptronTagger` class to be a *generator/iterator* of sentences as well (in addition to a list).

Because ``self._make_tagdict(sentences)`` runs at the beginning of the `train` method and iterates through the sentences, we first initialize an empty list of `self._sentences`  and make `self._make_tagdict` populate ``self._sentences`` with all the sentences. This saves the overheard of just iterating through ``sentences`` to get the list by ``sentences = list(sentences)``. Now `random.shuffle` can happily take `self._sentences`. 

With this update/fix, the following doesn't throw an error anymore:

```python
>>> from nltk.tag import PerceptronTagger
>>> from nltk.corpus import alpino as alp
>>> training_corpus = alp.tagged_sents()
>>> tagger = PerceptronTagger(load=False)
>>> tagger.train(training_corpus)
```