### PR TITLE
Add Jenkins CI tests badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Natural Language Toolkit (NLTK)
-[![PyPI](https://img.shields.io/pypi/v/nltk.svg)](https://pypi.python.org/pypi/nltk)
+[![PyPI](https://img.shields.io/pypi/v/nltk.svg)](https://pypi.python.org/pypi/nltk) [![Jenkins](https://img.shields.io/jenkins/s/https/nltk.ci.cloudbees.com/job/nltk.svg)](https://nltk.ci.cloudbees.com/job/nltk/lastCompletedBuild/testReport/)
 
 NLTK -- the Natural Language Toolkit -- is a suite of open source Python
 modules, data sets and tutorials supporting research and development in Natural


### PR DESCRIPTION
This PR aims to add a Jenkins CI status badge to the README file. Having this badge would be useful to inform users about the current status of the `develop` branch.

Preview:

![image](https://cloud.githubusercontent.com/assets/2814672/22756568/d815934c-ee47-11e6-9c59-a9ef3d9eecec.png)
