### PR TITLE
fix set_proxy for https

### DIFF
--- a/nltk/util.py
+++ b/nltk/util.py
@@ -667,7 +667,7 @@ def set_proxy(proxy, user=None, password=''):
             raise ValueError('Could not detect default proxy settings')
 
     # Set up the proxy handler
-    proxy_handler = ProxyHandler({'http': proxy})
+    proxy_handler = ProxyHandler({'https': proxy, 'http': proxy})
     opener = build_opener(proxy_handler)
 
     if user is not None:


### PR DESCRIPTION
`set_proxy` not working due to current github is over https. 
Add support.

relate to https://github.com/nltk/nltk/issues/1623.