### PR TITLE
Reviving mwa_ppdb - WIP (Do not merge)

### DIFF
--- a/nltk/corpus/__init__.py
+++ b/nltk/corpus/__init__.py
@@ -286,8 +286,8 @@ nonbreaking_prefixes = LazyCorpusLoader(
 perluniprops = LazyCorpusLoader(
     'perluniprops', UnicharsCorpusReader, r'(?!README|\.).*', nltk_data_subdir='misc', encoding='utf8')
 
-# mwa_ppdb = LazyCorpusLoader(
-#     'mwa_ppdb', MWAPPDBCorpusReader, r'(?!README|\.).*', nltk_data_subdir='misc', encoding='utf8')
+mwa_ppdb = LazyCorpusLoader(
+    'mwa_ppdb', MWAPPDBCorpusReader, r'(?!README|\.).*', nltk_data_subdir='misc', encoding='utf8')
 
 
 def demo():

--- a/nltk/corpus/util.py
+++ b/nltk/corpus/util.py
@@ -22,7 +22,7 @@ class LazyCorpusLoader(object):
     """
     To see the API documentation for this lazily loaded corpus, first
     run corpus.ensure_loaded(), and then run help(this_corpus).
-    
+
     LazyCorpusLoader is a proxy object which is used to stand in for a
     corpus object before the corpus is loaded.  This allows NLTK to
     create an object for each corpus, but defer the costs associated
@@ -38,7 +38,7 @@ class LazyCorpusLoader(object):
     NLTK data package.  Once they've properly installed the data
     package (or modified ``nltk.data.path`` to point to its location),
     they can then use the corpus object without restarting python.
-    
+
     :param name: The name of the corpus
     :type name: str
     :param reader_cls: The specific CorpusReader class, e.g. PlaintextCorpusReader, WordListCorpusReader
@@ -53,7 +53,7 @@ class LazyCorpusLoader(object):
         assert issubclass(reader_cls, CorpusReader)
         self.__name = self.__name__ = name
         self.__reader_cls = reader_cls
-        # If nltk_data_subdir is set explicitly 
+        # If nltk_data_subdir is set explicitly
         if 'nltk_data_subdir' in kwargs:
             # Use the specified subdirectory path
             self.subdir = kwargs['nltk_data_subdir']
@@ -120,7 +120,8 @@ class LazyCorpusLoader(object):
 
     def __repr__(self):
         return '<%s in %r (not loaded yet)>' % (
-            self.__reader_cls.__name__, '.../corpora/'+self.__name)
+            self.__reader_cls.__name__,
+            '.../{}/{}'.format(self.subdir, self.__name))
 
     def _unload(self):
         # If an exception occures during corpus loading then

--- a/nltk/corpus/util.py
+++ b/nltk/corpus/util.py
@@ -65,6 +65,7 @@ class LazyCorpusLoader(object):
         self.__kwargs = kwargs
 
     def __load(self):
+        print(self.__name, self.subdir, self.__kwargs)
         # Find the corpus root directory.
         zip_name = re.sub(r'(([^/]*)(/.*)?)', r'\2.zip/\1/', self.__name)
         if TRY_ZIPFILE_FIRST:

--- a/nltk/test/unit/test_corpora.py
+++ b/nltk/test/unit/test_corpora.py
@@ -182,7 +182,7 @@ class TestPTB(unittest.TestCase):
             ['Thirty-three', 'Scotty', 'did', 'not', 'go', 'back']
         )
 
-@unittest.skip("Skipping test for mwa_ppdb.")
+#@unittest.skip("Skipping test for mwa_ppdb.")
 class TestMWAPPDB(unittest.TestCase):
     def test_fileids(self):
         self.assertEqual(mwa_ppdb.fileids(),

--- a/nltk/test/unit/test_corpora.py
+++ b/nltk/test/unit/test_corpora.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 import unittest
 
 from nltk.corpus import (sinica_treebank, conll2007, indian, cess_cat, cess_esp,
-                         floresta, ptb, udhr) # mwa_ppdb
+                         floresta, ptb, udhr, mwa_ppdb)
 
 from nltk.compat import python_2_unicode_compatible
 from nltk.tree import Tree
@@ -187,7 +187,6 @@ class TestMWAPPDB(unittest.TestCase):
     def test_fileids(self):
         self.assertEqual(mwa_ppdb.fileids(),
             ['ppdb-1.0-xxxl-lexical.extended.synonyms.uniquepairs'])
-
     def test_entries(self):
         self.assertEqual(mwa_ppdb.entries()[:10],
             [('10/17/01', '17/10/2001'), ('102,70', '102.70'),


### PR DESCRIPTION
From #1606,  #1608 and #1627, something is wrong when corpus is loading from other subdirectory in `nltk_data` other than `nltk_data/corpora`. 