### PR TITLE
Fix #1387: clean up Tk's postscript output

### DIFF
--- a/nltk/draw/util.py
+++ b/nltk/draw/util.py
@@ -1712,11 +1712,15 @@ class CanvasFrame(object):
                                          defaultextension='.ps')
             if not filename: return
         (x0, y0, w, h) = self.scrollregion()
-        self._canvas.postscript(file=filename, x=x0, y=y0,
+        postscript = self._canvas.postscript(x=x0, y=y0,
                                 width=w+2, height=h+2,
                                 pagewidth=w+2, # points = 1/72 inch
                                 pageheight=h+2, # points = 1/72 inch
                                 pagex=0, pagey=0)
+        # workaround for bug in Tk font handling
+        postscript = postscript.replace(' 0 scalefont ', ' 9 scalefont ')
+        with open(filename, 'w') as f:
+            f.write(postscript.encode('utf8'))
 
     def scrollregion(self):
         """


### PR DESCRIPTION
There is a bug in Tk on Linux which causes font sizes to be reported as 0 occasionally. That doesn't seem to impact display, but when saving to postscript, the output contains `0 scalefont` for each text item. When nltk calls Ghostscript to convert the postscript file to an image in `Tree._repr_png_`, it rightfully complains about divide-by-zero errors caused by this.

A workaround is to replace each instance of `0 scalefont` by `9 scalefont`, using the default size Tk would generate if it weren't for the bug. (I don't think nltk sets the font size anywhere?)