### PR TITLE
Rte minor bug fix

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -208,6 +208,7 @@
 - Tsolak Ghukasyan
 - Prasasto Adi
 - Safwan Kamarrudin
+- Arthur Tilley
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 ### Contributors to the Porter Stemmer

--- a/nltk/classify/rte_classify.py
+++ b/nltk/classify/rte_classify.py
@@ -61,7 +61,7 @@ class RTEFeatureExtractor(object):
         # Try to tokenize so that abbreviations, monetary amounts, email
         # addresses, URLs are single tokens.
         from nltk.tokenize import RegexpTokenizer
-        tokenizer = RegexpTokenizer('([\w.@:/])+|\w+|\$[\d.]+')
+        tokenizer = RegexpTokenizer('[\w.@:/]+|\w+|\$[\d.]+')
 
         #Get the set of word types for text and hypothesis
         self.text_tokens = tokenizer.tokenize(rtepair.text)


### PR DESCRIPTION
@ClaudeCoulombe, @stevenbird

Have you found that the change made in 96f3e8f accomplishes what you want? For me it still gives incorrect tokens (this time just the last letter of each word).

I believe the cause of the empty tokens before the change, and the cause of the new incorrect tokens after the change is in the first internal set of parentheses in either

`tokenizer = RegexpTokenizer('([A-Z]\.)+|\w+|\$[\d\.]+')`

or in

`tokenizer = RegexpTokenizer('([\w.@:/])+|\w+|\$[\d.]+')`

The RegexpTokenizer documentation says:

:param pattern: The pattern used to build this tokenizer.
(This pattern must not contain capturing parentheses;
Use non-capturing parentheses, e.g. (?:...), instead)

I have been able to fix this problem by either changing

`tokenizer = RegexpTokenizer('([\w.@:/])+|\w+|\$[\d.]+')`

to

`tokenizer = RegexpTokenizer('(?:[\w.@:/])+|\w+|\$[\d.]+')`

or by simply getting rid of the first set of parentheses entirely, since they are redundant in the new regex:

`tokenizer = RegexpTokenizer('[\w.@:/]+|\w+|\$[\d.]+')`

This last change is what is new in this pull request.
