### PR TITLE
Fix a bug on Python 3.3 and earlier versions

### DIFF
--- a/nltk/compat.py
+++ b/nltk/compat.py
@@ -16,6 +16,7 @@ import fractions
 # Python 2/3 compatibility layer. Based on six.
 
 PY3 = sys.version_info[0] == 3
+PY3_IMP = sys.version_info[1] <= 3
 
 if PY3:
     def b(s):
@@ -36,7 +37,12 @@ if PY3:
     _iterkeys = "keys"
     _itervalues = "values"
     _iteritems = "items"
-    from importlib import reload
+
+    if PY3_IMP:
+        from imp import reload
+    else:
+        from importlib import reload
+
     raw_input = input
 
     imap = map


### PR DESCRIPTION
The `reload` function in python version 3.0 to 3.3 is located in the `imp` module and after 3.4 the `imp` module gets depracated and the `reload` function moved to `importlib` module

You can see:

https://docs.python.org/3/whatsnew/3.0.html?highlight=reload#builtins

https://docs.python.org/3/whatsnew/3.4.html?highlight=reload#importlib