### PR TITLE
fixes 'requres str not bytes' error when writing ps file

### DIFF
--- a/nltk/draw/util.py
+++ b/nltk/draw/util.py
@@ -1719,7 +1719,7 @@ class CanvasFrame(object):
                                 pagex=0, pagey=0)
         # workaround for bug in Tk font handling
         postscript = postscript.replace(' 0 scalefont ', ' 9 scalefont ')
-        with open(filename, 'w') as f:
+        with open(filename, 'wb') as f:
             f.write(postscript.encode('utf8'))
 
     def scrollregion(self):


### PR DESCRIPTION
With python 3.5.2 using a jupyter notebook I got a 'write requires str not bytes' error. Writing to the file as binary fixes this and the png shows up properly in the notebook.