### PR TITLE
Include "Paice/Husk" in lancaster.py's docstring for Googleability

### DIFF
--- a/nltk/stem/lancaster.py
+++ b/nltk/stem/lancaster.py
@@ -6,7 +6,7 @@
 # For license information, see LICENSE.TXT
 
 """
-A word stemmer based on the Lancaster stemming algorithm.
+A word stemmer based on the Lancaster (Paice/Husk) stemming algorithm.
 Paice, Chris D. "Another Stemmer." ACM SIGIR Forum 24.3 (1990): 56-61.
 """
 from __future__ import unicode_literals


### PR DESCRIPTION
Should help users who are looking for an NLTK implementation of Paice/Husk but don't realise that Lancaster == Paice/Husk.

https://github.com/nltk/nltk/pull/1654 was the (somewhat comical) inspiration for this.