### PR TITLE
Skip Stanford tagger tests when jar is not found

### DIFF
--- a/nltk/tag/stanford.py
+++ b/nltk/tag/stanford.py
@@ -188,3 +188,12 @@ class StanfordNERTagger(StanfordTagger):
             return result
 
         raise NotImplementedError
+
+def setup_module(module):
+    from nose import SkipTest
+
+    try:
+        StanfordPOSTagger('english-bidirectional-distsim.tagger')
+    except LookupError:
+        raise SkipTest('Doctests from nltk.tag.stanford are skipped because one \
+                       of the stanford jars cannot be found.')


### PR DESCRIPTION
[Third-party libraries][1] are not supposed to be required in order to run the test suite locally. This PR follows the strategy already applied to `nltk.parse.stanford` and `nltk.tokenize.stanford` and applies it to `nltk.tag.stanford`.

[1]: https://github.com/nltk/nltk/wiki/Installing-Third-Party-Software