### PR TITLE
Ignore pyenv python version files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ web/api/*.rst
 # iPython notebooks
 
 .ipynb_checkpoints
+
+# pyenv files
+.python-version


### PR DESCRIPTION
The python version management [`pyenv`][1] uses a file called `.python-version` to determine which Python version to use in the application folder. This PR ignores `.python-version` files.

[1]: https://github.com/pyenv/pyenv