### PR TITLE
Remove redundant specifications for py34 and py35 within tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -40,44 +40,6 @@ deps =
 commands =
     python runtests.py []
 
-[testenv:py34]
-deps =
-    numpy
-    nose >= 1.2.1
-    coverage
-    text-unidecode
-    twython
-    pyparsing
-    python-crfsuite
-    rednose
-
-commands =
-    ; scipy and scikit-learn requires numpy even to run setup.py so
-    ; they can't be installed in one command
-    pip install scipy scikit-learn
-
-    ; python runtests.py --with-coverage --cover-inclusive --cover-package=nltk --cover-html --cover-html-dir={envdir}/docs []
-    python runtests.py []
-
-[testenv:py35]
-deps =
-    numpy
-    nose >= 1.2.1
-    coverage
-    text-unidecode
-    twython
-    pyparsing
-    python-crfsuite
-    rednose
-
-commands =
-    ; scipy and scikit-learn requires numpy even to run setup.py so
-    ; they can't be installed in one command
-    pip install scipy scikit-learn
-
-    ; python runtests.py --with-coverage --cover-inclusive --cover-package=nltk --cover-html --cover-html-dir={envdir}/docs []
-    python runtests.py []
-
 [testenv:py27-nodeps]
 basepython = python2.7
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,9 @@
 [tox]
-envlist = py27,py34,py35,pypy,py27-nodeps,py34-nodeps,py35-nodeps,py27-jenkins,py34-jenkins,py35-jenkins
+envlist =
+    py{27,34,35}
+    pypy
+    py{27,34,35}-nodeps
+    py{27,34,35}-jenkins
 
 [testenv]
 ; simplify numpy installation


### PR DESCRIPTION
The `tox.ini` configuration file is currently specifying settings for python3.4 and python3.5. 
However, these specifications are automatically inherited from the base `testenv` and do not therefore need to be repeated (see [Tox docs - Virtualenv test environment settings][1]).

This PR also refactors the list of environments using [Tox generative envlist][2] syntax.

[1]: http://tox.readthedocs.io/en/latest/config.html#virtualenv-test-environment-settings
[2]: http://tox.readthedocs.io/en/latest/config.html#generative-envlist