### PR TITLE
Add self for constants to avoid NameError

### DIFF
--- a/nltk/tokenize/moses.py
+++ b/nltk/tokenize/moses.py
@@ -248,10 +248,10 @@ class MosesTokenizer(TokenizerI):
         return re.sub(r'DOTMULTI', r'.', text)
 
     def islower(self, text):
-        return not set(text).difference(set(IsLower))
+        return not set(text).difference(set(self.IsLower))
 
     def isalpha(self, text):
-        return not set(text).difference(set(IsAlpha))
+        return not set(text).difference(set(self.IsAlpha))
 
     def has_numeric_only(self, text):
         return bool(re.search(r'(.*)[\s]+(\#NUMERIC_ONLY\#)', text))


### PR DESCRIPTION
Two constants `IsLower` and `IsAlpha` were not correctly referenced in the later corresponding methods. This causes NameError (for example when you call `tokenize_sents`) as follows:

```python
In [5]: from nltk.tokenize.moses import MosesTokenizer

In [6]: tok = MosesTokenizer()

In [7]: tok.isalpha("abc")

NameError                                 Traceback (most recent call last)
<ipython-input-7-0a65ead90c72> in <module>()
> 1 tok.isalpha("abc")

/path/to/packages/site-packages/nltk/tokenize/moses.py in isalpha(self, text)
    252
    253     def isalpha(self, text):
 >  254         return not set(text).difference(set(IsAlpha))
    255
    256     def has_numeric_only(self, text):

NameError: name 'IsAlpha' is not defined
```
Avoiding this by referring to them with `self.` prefix.