### PR TITLE
Speed up TnT tagger; improve FreqDist and ConditionalFreqDist

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -209,6 +209,7 @@
 - Prasasto Adi
 - Safwan Kamarrudin
 - Arthur Tilley
+- Vilhjalmur Thorsteinsson
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 ### Contributors to the Porter Stemmer

--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -116,6 +116,17 @@ class FreqDist(Counter):
         """
         return sum(self.values())
 
+    def freeze_N(self):
+        """
+        Set N permanently to its current value, making subsequent
+        calls to ``FreqDist.N()`` much faster. Use this for instance
+        after training a tagger, but before running it. After calling
+        ``FreqDist.freeze_N()``, no more samples should be added to the
+        FreqDist object.
+        """
+        n = self.N()
+        self.N = lambda: n
+
     def B(self):
         """
         Return the total number of sample values (or "bins") that
@@ -192,9 +203,10 @@ class FreqDist(Counter):
         :type sample: any
         :rtype: float
         """
-        if self.N() == 0:
+        n = self.N()
+        if n == 0:
             return 0
-        return self[sample] / self.N()
+        return self[sample] / n
 
     def max(self):
         """
@@ -1777,6 +1789,19 @@ class ConditionalFreqDist(defaultdict):
         :rtype: int
         """
         return sum(fdist.N() for fdist in compat.itervalues(self))
+
+    def freeze_N(self):
+        """
+        Set N permanently to its current value, making subsequent
+        calls to ``ConditionalFreqDist.N()`` much faster. Use this for
+        instance after training a tagger, but before running it. After
+        calling ``ConditionalFreqDist.freeze_N()``, no more samples
+        should be added to the ConditionalFreqDist object.
+        """
+        for fdist in compat.itervalues(self):
+            fdist.freeze_N()
+        n = self.N()
+        self.N = lambda: n
 
     def plot(self, *args, **kwargs):
         """

--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -105,6 +105,9 @@ class FreqDist(Counter):
         """
         Counter.__init__(self, samples)
 
+        # Cached number of samples in this FreqDist
+        self._N = None
+
     def N(self):
         """
         Return the total number of sample outcomes that have been
@@ -114,18 +117,38 @@ class FreqDist(Counter):
 
         :rtype: int
         """
-        return sum(self.values())
+        if self._N is None:
+            # Not already cached, or cache has been invalidated
+            self._N = sum(self.values())
+        return self._N
 
-    def freeze_N(self):
+    def __setitem__(self, key, val):
         """
-        Set N permanently to its current value, making subsequent
-        calls to ``FreqDist.N()`` much faster. Use this for instance
-        after training a tagger, but before running it. After calling
-        ``FreqDist.freeze_N()``, no more samples should be added to the
-        FreqDist object.
+        Override ``Counter.__setitem__()`` to invalidate the cached N
         """
-        n = self.N()
-        self.N = lambda: n
+        self._N = None
+        super(FreqDist, self).__setitem__(key, val)
+
+    def __delitem__(self, key):
+        """
+        Override ``Counter.__delitem__()`` to invalidate the cached N
+        """
+        self._N = None
+        super(FreqDist, self).__delitem__(key)
+
+    def update(self, *args, **kwargs):
+        """
+        Override ``Counter.update()`` to invalidate the cached N
+        """
+        self._N = None
+        super(FreqDist, self).update(*args, **kwargs)
+
+    def setdefault(self, key, val):
+        """
+        Override ``Counter.setdefault()`` to invalidate the cached N
+        """
+        self._N = None
+        super(FreqDist, self).setdefault(key, val)
 
     def B(self):
         """
@@ -1761,6 +1784,7 @@ class ConditionalFreqDist(defaultdict):
         :type cond_samples: Sequence of (condition, sample) tuples
         """
         defaultdict.__init__(self, FreqDist)
+
         if cond_samples:
             for (cond, sample) in cond_samples:
                 self[cond][sample] += 1
@@ -1789,19 +1813,6 @@ class ConditionalFreqDist(defaultdict):
         :rtype: int
         """
         return sum(fdist.N() for fdist in compat.itervalues(self))
-
-    def freeze_N(self):
-        """
-        Set N permanently to its current value, making subsequent
-        calls to ``ConditionalFreqDist.N()`` much faster. Use this for
-        instance after training a tagger, but before running it. After
-        calling ``ConditionalFreqDist.freeze_N()``, no more samples
-        should be added to the ConditionalFreqDist object.
-        """
-        for fdist in compat.itervalues(self):
-            fdist.freeze_N()
-        n = self.N()
-        self.N = lambda: n
 
     def plot(self, *args, **kwargs):
         """

--- a/nltk/tag/tnt.py
+++ b/nltk/tag/tnt.py
@@ -176,13 +176,6 @@ class TnT(TaggerI):
         #print "lambdas"
         #print i, self._l1, i, self._l2, i, self._l3
 
-        # after training, freeze the frequency distributions
-        # to make subsequent frequency queries faster
-        self._uni.freeze_N()
-        self._bi.freeze_N()
-        self._tri.freeze_N()
-        self._wd.freeze_N()
-
 
     def _compute_lambda(self):
         '''

--- a/nltk/tag/tnt.py
+++ b/nltk/tag/tnt.py
@@ -176,6 +176,13 @@ class TnT(TaggerI):
         #print "lambdas"
         #print i, self._l1, i, self._l2, i, self._l3
 
+        # after training, freeze the frequency distributions
+        # to make subsequent frequency queries faster
+        self._uni.freeze_N()
+        self._bi.freeze_N()
+        self._tri.freeze_N()
+        self._wd.freeze_N()
+
 
     def _compute_lambda(self):
         '''
@@ -357,30 +364,24 @@ class TnT(TaggerI):
         # if word is known
         # compute the set of possible tags
         # and their associated log probabilities
-        if word in self._wd.conditions():
+        if word in self._wd:
             self.known += 1
 
             for (history, curr_sent_logprob) in current_states:
                 logprobs = []
 
                 for t in self._wd[word].keys():
-                    p_uni = self._uni.freq((t,C))
-                    p_bi = self._bi[history[-1]].freq((t,C))
-                    p_tri = self._tri[tuple(history[-2:])].freq((t,C))
-                    p_wd = self._wd[word][t] / self._uni[(t,C)]
+                    tC = (t,C)
+                    p_uni = self._uni.freq(tC)
+                    p_bi = self._bi[history[-1]].freq(tC)
+                    p_tri = self._tri[tuple(history[-2:])].freq(tC)
+                    p_wd = self._wd[word][t] / self._uni[tC]
                     p = self._l1 *p_uni + self._l2 *p_bi + self._l3 *p_tri
                     p2 = log(p, 2) + log(p_wd, 2)
 
-                    logprobs.append(((t,C), p2))
-
-
-                # compute the result of appending each tag to this history
-                for (tag, logprob) in logprobs:
-                    new_states.append((history + [tag],
-                                       curr_sent_logprob + logprob))
-
-
-
+                    # compute the result of appending each tag to this history
+                    new_states.append((history + [tC],
+                                       curr_sent_logprob + p2))
 
         # otherwise a new word, set of possible tags is unknown
         else:
@@ -398,7 +399,7 @@ class TnT(TaggerI):
                 tag = ('Unk',C)
 
             # otherwise apply the unknown word tagger
-            else :
+            else:
                 [(_w, t)] = list(self._unk.tag([word]))
                 tag = (t,C)
 
@@ -406,8 +407,6 @@ class TnT(TaggerI):
                 history.append(tag)
 
             new_states = current_states
-
-
 
         # now have computed a set of possible new_states
 
@@ -419,7 +418,6 @@ class TnT(TaggerI):
         # this is the beam search cut
         if len(new_states) > self._N:
             new_states = new_states[:self._N]
-
 
         # compute the tags for the rest of the sentence
         # return the best list of tags for the sentence


### PR DESCRIPTION
The current implementations of FreqDist and ConditionalFreqDist in probability.py have member functions called N() that return a count of the samples in the distribution. These functions are quite inefficient as they perform a sum each time over the contained sample buckets. In typical cases, for instance during POS tagging, these sums can loop over tens or hundreds of thousands of buckets for every call to N(). To add insult to injury, the FreqDist.freq() function unnecessarily calls N() twice.

This PR adds a function freeze_N() to FreqDist and ConditionalFreqDist. The function evaluates N() and then caches or memoizes it by replacing the self.N() function with a lambda that simply returns the memoized value, making subsequent calls to N() very fast. After freeze_N() has been called on a frequency distribution object, no further samples should be added to that object.

The PR modifies the nltk.tag.tnt.TnT class to call freeze_N() after training and before POS tagging commences, and serves as an example of how this functionality can be used.

With this PR applied, the **execution time of the nltk.tag.tnt.demo() function drops from 183 seconds to 107 seconds** on my Debian box, a speedup of ~70%. I have verified by profiling that the time saved was almost all previously spent in the N() function of FreqDist and ConditionalFreqDist. Test results are otherwise unaffected.

The PR also includes minor clean up of the main tagging loop of the TnT tagger.
