### PR TITLE
Addresses #1667; add gleu_score.corpus_gleu()

### DIFF
--- a/nltk/translate/gleu_score.py
+++ b/nltk/translate/gleu_score.py
@@ -3,7 +3,7 @@
 #
 # Copyright (C) 2001-2017 NLTK Project
 # Authors:
-# Contributors:
+# Contributors: Mike Schuster, Michael Wayne Goodman, Liling Tan
 # URL: <http://nltk.org/>
 # For license information, see LICENSE.TXT
 

--- a/nltk/translate/gleu_score.py
+++ b/nltk/translate/gleu_score.py
@@ -46,9 +46,9 @@ def sentence_gleu(references, hypothesis, min_len=1, max_len=4):
          metric on a corpus level but does not have its drawbacks for our per
          sentence reward objective."
 
-    Note: The previous implementation only allowed a single reference; in order
-          to maintain backward compatibility, the first argument may be given
-          as a single reference or a list of references.
+    Note: The initial implementation only allowed a single reference, but now
+          a list of references is required (which is consistent with
+          bleu_score.sentence_bleu()).
 
     The infamous "the the the ... " example
 
@@ -81,11 +81,6 @@ def sentence_gleu(references, hypothesis, min_len=1, max_len=4):
     :return: the sentence level GLEU score.
     :rtype: float
     """
-
-    # compatibility with previous single-reference API:
-    if not references or isinstance(references[0], string_types):
-        references = [references]
-
     return corpus_gleu(
         [references],
         [hypothesis],

--- a/nltk/translate/gleu_score.py
+++ b/nltk/translate/gleu_score.py
@@ -12,7 +12,7 @@ from __future__ import division
 from collections import Counter
 
 from nltk.util import ngrams, everygrams
-from nltk.compat import string_types
+
 
 def sentence_gleu(references, hypothesis, min_len=1, max_len=4):
     """
@@ -158,7 +158,7 @@ def corpus_gleu(list_of_references, hypotheses, min_len=1, max_len=4):
         hyp_ngrams = Counter(everygrams(hypothesis, min_len, max_len))
         tpfp = sum(hyp_ngrams.values())  # True positives + False positives.
         
-        scores_by_ref = []
+        hyp_counts = []
         for reference in references:
             ref_ngrams = Counter(everygrams(reference, min_len, max_len))
             tpfn = sum(ref_ngrams.values())  # True positives + False negatives.
@@ -176,11 +176,11 @@ def corpus_gleu(list_of_references, hypotheses, min_len=1, max_len=4):
             n_all = max(tpfp, tpfn)
 
             if n_all > 0:
-                scores_by_ref.append((tp/n_all, tp, n_all))
+                hyp_counts.append((tp, n_all))
 
         # use the reference yielding the highest score
-        if scores_by_ref:
-            _, n_match, n_all = max(scores_by_ref)
+        if hyp_counts:
+            n_match, n_all = max(hyp_counts, key=lambda hc: hc[0]/hc[1])
             corpus_n_match += n_match
             corpus_n_all += n_all
 

--- a/nltk/translate/gleu_score.py
+++ b/nltk/translate/gleu_score.py
@@ -45,9 +45,8 @@ def sentence_gleu(reference, hypothesis, min_len=1, max_len=4):
          metric on a corpus level but does not have its drawbacks for our per
          sentence reward objective."
 
-    Note: The GLEU score is designed for sentence based evaluation thus there is
-          no corpus based scores implemented in NLTK. Also, unlike
-          multi-reference BLEU, GLEU only supports a single reference.
+    Note: Unlike multi-reference BLEU, this implementation of GLEU only
+          supports a single reference.
 
     The infamous "the the the ... " example
 
@@ -87,9 +86,92 @@ def sentence_gleu(reference, hypothesis, min_len=1, max_len=4):
     overlap_ngrams = ref_ngrams & hyp_ngrams
     tp = sum(overlap_ngrams.values()) # True positives.
     tpfp = sum(hyp_ngrams.values()) # True positives + False positives.
-    tffn = sum(ref_ngrams.values()) # True posities + False negatives.
+    tpfn = sum(ref_ngrams.values()) # True positives + False negatives.
 
-    precision = tp / tpfp
-    recall = tp / tffn
+    # While defined as the minimum of precision and recall, we can
+    # reduce the number of division operations by one by instead finding
+    # the maximum of the denominators for the precision and recall
+    # formulae, since the numerators are the same:
+    #     precision = tp / tpfp
+    #     recall = tp / tpfn
+    #     min(precision, recall) == tp / max(tpfp, tpfn)
 
-    return min(precision, recall)
+    return tp / max(tpfp, tpfn)
+
+
+def corpus_gleu(references, hypotheses, min_len=1, max_len=4):
+    """
+    Calculate a single corpus-level GLEU score (aka. system-level GLEU) for all
+    the hypotheses and their respective references.
+
+    Instead of averaging the sentence level GLEU scores (i.e. macro-average
+    precision), Wu et al. (2016) sum up the matching tokens and the max of
+    hypothesis and reference tokens for each sentence, then compute using the
+    aggregate values.
+
+    From Mike Schuster (via email):
+        "For the corpus, we just add up the two statistics n_match and
+         n_all = max(n_all_output, n_all_target) for all sentences, then
+         calculate gleu_score = n_match / n_all, so it is not just a mean of
+         the sentence gleu scores (in our case, longer sentences count more,
+         which I think makes sense as they are more difficult to translate)."
+
+    >>> hyp1 = ['It', 'is', 'a', 'guide', 'to', 'action', 'which',
+    ...         'ensures', 'that', 'the', 'military', 'always',
+    ...         'obeys', 'the', 'commands', 'of', 'the', 'party']
+    >>> ref1 = ['It', 'is', 'a', 'guide', 'to', 'action', 'that',
+    ...          'ensures', 'that', 'the', 'military', 'will', 'forever',
+    ...          'heed', 'Party', 'commands']
+
+    >>> hyp2 = ['he', 'read', 'the', 'book', 'because', 'he', 'was',
+    ...         'interested', 'in', 'world', 'history']
+    >>> ref2 = ['he', 'was', 'interested', 'in', 'world', 'history',
+    ...          'because', 'he', 'read', 'the', 'book']
+
+    >>> references = [ref1, ref2]
+    >>> hypotheses = [hyp1, hyp2]
+    >>> corpus_gleu(references, hypotheses) # doctest: +ELLIPSIS
+    0.5673...
+
+    The example below show that corpus_gleu() is different from averaging
+    sentence_gleu() for hypotheses
+
+    >>> score1 = sentence_gleu(ref1, hyp1)
+    >>> score2 = sentence_gleu(ref2, hyp2)
+    >>> (score1 + score2) / 2 # doctest: +ELLIPSIS
+    0.6144...
+
+    :param references: a list of reference sentences, w.r.t. hypotheses
+    :type references: list(list(str))
+    :param hypotheses: a list of hypothesis sentences
+    :type hypotheses: list(list(str))
+    :param min_len: The minimum order of n-gram this function should extract.
+    :type min_len: int
+    :param max_len: The maximum order of n-gram this function should extract.
+    :type max_len: int
+    :return: The corpus-level GLEU score.
+    :rtype: float
+    """
+    # sanity checks
+    assert len(references) == len(hypotheses), "The number of hypotheses and references should be the same"
+    assert len(references) > 0, "Cannot compute GLEU score for an empty corpus."
+    # should the following use all()?
+    assert any(len(ref) for ref in references), "At least one reference must be non-empty."
+
+    # sum matches and max-token-lengths over all sentences
+    n_match = 0
+    n_all = 0
+
+    for reference, hypothesis in zip(references, hypotheses):    
+        ref_ngrams = Counter(everygrams(reference, min_len, max_len))
+        hyp_ngrams = Counter(everygrams(hypothesis, min_len, max_len))
+        overlap_ngrams = ref_ngrams & hyp_ngrams
+
+        tp = sum(overlap_ngrams.values()) # True positives.
+        tpfp = sum(hyp_ngrams.values()) # True positives + False positives.
+        tpfn = sum(ref_ngrams.values()) # True positives + False negatives.
+
+        n_match += tp
+        n_all += max(tpfp, tpfn)
+
+    return n_match / n_all


### PR DESCRIPTION
From an email thread on nltk-dev, we got some more information about
the corpus-level GLEU calculation. I used that to create a
corpus_gleu() function in nltk.translate.gleu_score. I did not change
the functions to accept multiple references per hypothesis because
that would change the API, and it doesn't appear that the authors of
GLEU implemented it (though they suggested it could just be the max
score among the references). If we want to allow it, we could do
something like:

 1. Inspect if the reference argument is `list(str)` or
    `list(list(str))` automatically, and silently adapt to the input.
 2. Allow an optional `multiple_reference` parameter which, when True,
    expects the reference argument to be multiple references.
 3. Wait for the next major version of NLTK and change the API.