### PR TITLE
Fix typo in `tokenize.word_tokenize()` docstring

### DIFF
--- a/nltk/tokenize/__init__.py
+++ b/nltk/tokenize/__init__.py
@@ -103,7 +103,7 @@ def word_tokenize(text, language='english'):
     along with :class:`.PunktSentenceTokenizer`
     for the specified language).
 
-    :param text: text to split into sentences
+    :param text: text to split into words
     :param language: the model name in the Punkt corpus
     """
     return [token for sent in sent_tokenize(text, language)


### PR DESCRIPTION
Unless I'm misunderstanding something, `nltk.tokenize.word_tokenize()` splits text into words, not into sentences (which `nltk.tokenize.sent_tokenize()` does).