### PR TITLE
.gitignore some non-ignored stuff that running `tox` creates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,14 +10,16 @@ dist/
 nltk.egg-info/
 web/_build
 
-# Unit test / coverage reports
+# Test artifacts and coverage reports
 *.tox
 *.errs
 .noseids
 .coverage
 nltk/test/*.html
 nltk/test/tweets*
-nltk/test/model.crf.tagger
+model.crf.tagger
+brown.embedding
+pylintoutput
 nosetests.xml
 nosetests_scrubbed.xml
 coverage.xml


### PR DESCRIPTION
Just now after I ran `tox` from the root of the repo I saw all this untracked stuff:

```
mark@lunchbox:~/nltk$ git status
On branch develop
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	brown.embedding
	model.crf.tagger
	pylintoutput
```

I'm guessing it should all be ignored.