### PR TITLE
Float checking in doctest should use round/ellipsis

### DIFF
--- a/nltk/tag/__init__.py
+++ b/nltk/tag/__init__.py
@@ -51,8 +51,8 @@ of ``None``.
 
 We evaluate a tagger on data that was not seen during training:
 
-    >>> tagger.evaluate(brown.tagged_sents(categories='news')[500:600]) # doctest: +ELLIPSIS
-    0.73...
+    >>> round(tagger.evaluate(brown.tagged_sents(categories='news')[500:600]), 2)
+    0.74
 
 For more information, please consult chapter 5 of the NLTK Book.
 """

--- a/nltk/tag/__init__.py
+++ b/nltk/tag/__init__.py
@@ -51,7 +51,7 @@ of ``None``.
 
 We evaluate a tagger on data that was not seen during training:
 
-    >>> tagger.evaluate(brown.tagged_sents(categories='news')[500:600])
+    >>> tagger.evaluate(brown.tagged_sents(categories='news')[500:600]) # doctest: +ELLIPSIS
     0.73...
 
 For more information, please consult chapter 5 of the NLTK Book.


### PR DESCRIPTION
c.f. #1333 , non-ellipsis doctest and floating point is causing uncertain checks. Preferred float checking methods should be explicitly using  (i) `# doctest: +ELLIPSIS` or (ii) `round(float)`.