### PR TITLE
Better Treebank tokenizer

### DIFF
--- a/nltk/test/tokenize.doctest
+++ b/nltk/test/tokenize.doctest
@@ -191,3 +191,40 @@ The sentence splitter should remove whitespace following the sentence boundary.
     ['See Section 3.)', 'Or Section 2.)']
     >>> pst.tokenize('See Section 3.)  Or Section 2.)  ', realign_boundaries=False)
     ['See Section 3.', ')  Or Section 2.', ')']
+
+
+Regression Tests: aling_tokens
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Post-hoc alignment of tokens with a source string
+
+    >>> from nltk.tokenize.util import align_tokens
+    >>> list(align_tokens(word_tokenize(s1), s1))
+    [(0, 2), (3, 4), (5, 6), (6, 12), (13, 21), (22, 24), (25, 27), (28, 33), (34, 36), (37, 38), (39, 46), (46, 47), (48, 51), (52, 59), (60, 67), (68, 73), (74, 76), (77, 78), (78, 84), (84, 85)]
+    >>> list(align_tokens([''], ""))
+    [(0, 0)]
+    >>> list(align_tokens([''], " "))
+    [(0, 0)]
+    >>> list(align_tokens([], ""))
+    []
+    >>> list(align_tokens([], " "))
+    []
+    >>> list(align_tokens(['a'], "a"))
+    [(0, 1)]
+    >>> list(align_tokens(['abc', 'def'], "abcdef"))
+    [(0, 3), (3, 6)]
+    >>> list(align_tokens(['abc', 'def'], "abc def"))
+    [(0, 3), (4, 7)]
+    >>> list(align_tokens(['ab', 'cd'], "ab cd ef"))
+    [(0, 2), (3, 5)]
+    >>> list(align_tokens(['ab', 'cd', 'ef'], "ab cd ef"))
+    [(0, 2), (3, 5), (6, 8)]
+    >>> list(align_tokens(['ab', 'cd', 'efg'], "ab cd ef"))
+    Traceback (most recent call last):
+    ....
+    ValueError: substring "efg" not found in "ab cd ef"
+    >>> list(align_tokens(['ab', 'cd', 'ef', 'gh'], "ab cd ef"))
+    Traceback (most recent call last):
+    ....
+    ValueError: substring "gh" not found in "ab cd ef"
+    >>> list(align_tokens(['The', 'plane', ',', 'bound', 'for', 'St', 'Petersburg', ',', 'crashed', 'in', 'Egypt', "'s", 'Sinai', 'desert', 'just', '23', 'minutes', 'after', 'take-off', 'from', 'Sharm', 'el-Sheikh', 'on', 'Saturday', '.'], "The plane, bound for St Petersburg, crashed in Egypt's Sinai desert just 23 minutes after take-off from Sharm el-Sheikh on Saturday."))
+    [(0, 3), (4, 9), (9, 10), (11, 16), (17, 20), (21, 23), (24, 34), (34, 35), (36, 43), (44, 46), (47, 52), (52, 54), (55, 60), (61, 67), (68, 72), (73, 75), (76, 83), (84, 89), (90, 98), (99, 103), (104, 109), (110, 119), (120, 122), (123, 131), (131, 132)]

--- a/nltk/test/tokenize.doctest
+++ b/nltk/test/tokenize.doctest
@@ -198,8 +198,6 @@ Regression Tests: aling_tokens
 Post-hoc alignment of tokens with a source string
 
     >>> from nltk.tokenize.util import align_tokens
-    >>> list(align_tokens(word_tokenize(s1), s1))
-    [(0, 2), (3, 4), (5, 6), (6, 12), (13, 21), (22, 24), (25, 27), (28, 33), (34, 36), (37, 38), (39, 46), (46, 47), (48, 51), (52, 59), (60, 67), (68, 73), (74, 76), (77, 78), (78, 84), (84, 85)]
     >>> list(align_tokens([''], ""))
     [(0, 0)]
     >>> list(align_tokens([''], " "))

--- a/nltk/tokenize/__init__.py
+++ b/nltk/tokenize/__init__.py
@@ -106,13 +106,13 @@ _treebank_word_tokenizer = TreebankWordTokenizer()
 
 improved_open_quote_regex = re.compile(u'([«“‘])', re.U)
 improved_close_quote_regex = re.compile(u'([»”’])', re.U)
-improved_punct_regex = re.compile(r'([^\.])(\.)([\]\)}>"\'' u'»”’' r']*)\s*$', re.U)
+improved_punct_regex = re.compile(r'([^\.])(\.)([\]\)}>"\'' u'»”’ ' r']*)\s*$', re.U)
 _treebank_word_tokenizer.STARTING_QUOTES.insert(0, (improved_open_quote_regex, r' \1 '))
 _treebank_word_tokenizer.ENDING_QUOTES.insert(0, (improved_close_quote_regex, r' \1 '))
 _treebank_word_tokenizer.PUNCTUATION.insert(0, (improved_punct_regex, r'\1 \2 \3 '))
 
 
-def word_tokenize(text, language='english'):
+def word_tokenize(text, language='english', preserve_line=False):
     """
     Return a tokenized copy of *text*,
     using NLTK's recommended word tokenizer
@@ -121,7 +121,12 @@ def word_tokenize(text, language='english'):
     for the specified language).
 
     :param text: text to split into words
+    :param text: str
     :param language: the model name in the Punkt corpus
+    :type language: str
+    :param preserve_line: An option to keep the preserve the sentence and not sentence tokenize it.
+    :type preserver_line: bool
     """
-    return [token for sent in sent_tokenize(text, language)
+    sentences = [text] if preserve_line else sent_tokenize(text, language)
+    return [token for sent in sentences
             for token in _treebank_word_tokenizer.tokenize(sent)]

--- a/nltk/tokenize/treebank.py
+++ b/nltk/tokenize/treebank.py
@@ -151,12 +151,16 @@ class TreebankWordTokenizer(TokenizerI):
             >>> from nltk.tokenize import TreebankWordTokenizer
             >>> s = '''Good muffins cost $3.88\\nin New (York).  Please (buy) me\\ntwo of them.\\n(Thanks).'''
             >>> expected = [(0, 4), (5, 12), (13, 17), (18, 19), (19, 23),
-            ... (24, 26), (27, 30), (31, 36), (38, 44), (45, 48), (49, 51),
-            ... (52, 55), (56, 58), (59, 64), (65, 71), (71, 72)]
-            >>> TreebankWordTokenizer().span_tokenize(s)
-            []
-            >>> [s[start:end] for start, end in TreebankWordTokenizer().span_tokenize(s)]
-            []
+            ... (24, 26), (27, 30), (31, 32), (32, 36), (36, 37), (37, 38),
+            ... (40, 46), (47, 48), (48, 51), (51, 52), (53, 55), (56, 59),
+            ... (60, 62), (63, 68), (69, 70), (70, 76), (76, 77), (77, 78)]
+            >>> TreebankWordTokenizer().span_tokenize(s) == expected
+            True
+            >>> expected = ['Good', 'muffins', 'cost', '$', '3.88', 'in',
+            ... 'New', '(', 'York', ')', '.', 'Please', '(', 'buy', ')',
+            ... 'me', 'two', 'of', 'them.', '(', 'Thanks', ')', '.']
+            >>> [s[start:end] for start, end in TreebankWordTokenizer().span_tokenize(s)] == expected
+            True
 
         """
         tokens = self.tokenize(text)

--- a/nltk/tokenize/treebank.py
+++ b/nltk/tokenize/treebank.py
@@ -154,7 +154,10 @@ class TreebankWordTokenizer(TokenizerI):
             ... (24, 26), (27, 30), (31, 36), (38, 44), (45, 48), (49, 51),
             ... (52, 55), (56, 58), (59, 64), (65, 71), (71, 72)]
             >>> TreebankWordTokenizer().span_tokenize(s)
-            
+            []
+            >>> [s[start:end] for start, end in TreebankWordTokenizer().span_tokenize(s)]
+            []
+
         """
         tokens = self.tokenize(text)
         return align_tokens(tokens, text)

--- a/nltk/tokenize/treebank.py
+++ b/nltk/tokenize/treebank.py
@@ -175,8 +175,10 @@ class TreebankWordDetokenizer(TokenizerI):
     ... 'New', '-LRB-', 'York', '-RRB-', '.', 'Please', '-LRB-', 'buy',
     ... '-RRB-', 'me', 'two', 'of', 'them.', '-LRB-', 'Thanks', '-RRB-', '.']
     >>> expected == t.tokenize(s, convert_parentheses=True)
+    True
     >>> expected_detoken = 'Good muffins cost $3.88 in New (York). Please (buy) me two of them. (Thanks).'
     >>> expected_detoken == d.detokenize(t.tokenize(s, convert_parentheses=True), convert_parentheses=True)
+    True
     """
     _contractions = MacIntyreContractions()
     CONTRACTIONS2 = [re.compile(pattern.replace('(?#X)', '\s'))

--- a/nltk/tokenize/treebank.py
+++ b/nltk/tokenize/treebank.py
@@ -31,7 +31,7 @@ class MacIntyreContractions:
                      r"(?i)\b(got)(?#X)(ta)\b",
                      r"(?i)\b(lem)(?#X)(me)\b",
                      r"(?i)\b(mor)(?#X)('n)\b",
-                     r"(?i)\b(wan)(?#X)(na)\b"]
+                     r"(?i)\b(wan)(?#X)(na)\s"]
     CONTRACTIONS3 = [r"(?i) ('t)(?#X)(is)\b", r"(?i) ('t)(?#X)(was)\b"]
     CONTRACTIONS4 = [r"(?i)\b(whad)(dd)(ya)\b",
                      r"(?i)\b(wha)(t)(cha)\b"]

--- a/nltk/tokenize/treebank.py
+++ b/nltk/tokenize/treebank.py
@@ -153,8 +153,8 @@ class TreebankWordTokenizer(TokenizerI):
             >>> expected = [(0, 4), (5, 12), (13, 17), (18, 19), (19, 23),
             ... (24, 26), (27, 30), (31, 36), (38, 44), (45, 48), (49, 51),
             ... (52, 55), (56, 58), (59, 64), (65, 71), (71, 72)]
-            >>> TreebankWordTokenizer().span_tokenize(s) == expected
-            True
+            >>> TreebankWordTokenizer().span_tokenize(s)
+            
         """
         tokens = self.tokenize(text)
         return align_tokens(tokens, text)

--- a/nltk/tokenize/treebank.py
+++ b/nltk/tokenize/treebank.py
@@ -134,8 +134,12 @@ class TreebankWordDetokenizer(TokenizerI):
     The Treebank detokenizer uses the reverse regex operations corresponding to
     the Treebank tokenizer's regexes.
 
-    Note: There're additional assumption mades when undoing the padding of
-    [;@#$%&] punctuation symbols that isn't presupposed in the TreebankTokenizer.
+    Note:
+    - There're additional assumption mades when undoing the padding of [;@#$%&]
+      punctuation symbols that isn't presupposed in the TreebankTokenizer.
+    - It's not possible to return the original whitespaces as they were because
+      there wasn't explicit records of where '\n', '\t' or '\s' were removed at
+      the text.split() operation.
 
         >>> from nltk.tokenize.treebank import TreebankWordTokenizer, TreebankWordDetokenizer
         >>> s = '''Good muffins cost $3.88\\nin New York.  Please buy me\\ntwo of them.\\nThanks.'''
@@ -143,7 +147,7 @@ class TreebankWordDetokenizer(TokenizerI):
         >>> t = TreebankWordTokenizer()
         >>> toks = t.tokenize(s)
         >>> d.detokenize(toks)
-        'Good muffins cost $3.88\\nin New York. Please buy me\\ntwo of them.\\nThanks.'
+        'Good muffins cost $3.88 in New York. Please buy me two of them. Thanks.'
     """
     _contractions = MacIntyreContractions()
     CONTRACTIONS2 = [re.compile(pattern.replace('(?#X)', '\s'))

--- a/nltk/tokenize/treebank.py
+++ b/nltk/tokenize/treebank.py
@@ -51,7 +51,7 @@ class TreebankWordTokenizer(TokenizerI):
     - separate periods that appear at the end of line
 
         >>> from nltk.tokenize import TreebankWordTokenizer
-        >>> s = 'Good muffins cost $3.88\nin New York.  Please buy me\ntwo of them.\nThanks.'
+        >>> s = '''Good muffins cost $3.88\\nin New York.  Please buy me\\ntwo of them.\\nThanks.'''
         >>> TreebankWordTokenizer().tokenize(s)
         ['Good', 'muffins', 'cost', '$', '3.88', 'in', 'New', 'York.', 'Please', 'buy', 'me', 'two', 'of', 'them.', 'Thanks', '.']
         >>> s = "They'll save and invest more."
@@ -170,7 +170,7 @@ class TreebankWordDetokenizer(TokenizerI):
     The MXPOST parentheses substitution can be undone using the `convert_parentheses`
     parameter:
 
-    >>> s = 'Good muffins cost $3.88\nin New (York).  Please (buy) me\ntwo of them.\n(Thanks).'
+    >>> s = '''Good muffins cost $3.88\\nin New (York).  Please (buy) me\\ntwo of them.\\n(Thanks).'''
     >>> expected_tokens = ['Good', 'muffins', 'cost', '$', '3.88', 'in',
     ... 'New', '-LRB-', 'York', '-RRB-', '.', 'Please', '-LRB-', 'buy',
     ... '-RRB-', 'me', 'two', 'of', 'them.', '-LRB-', 'Thanks', '-RRB-', '.']

--- a/nltk/tokenize/treebank.py
+++ b/nltk/tokenize/treebank.py
@@ -162,7 +162,7 @@ class TreebankWordDetokenizer(TokenizerI):
     #parens, brackets, etc.
     PARENS_BRACKETS = [
         (re.compile(r' -- '), r'--'),
-        (re.compile(r'[\]\[\(\)\{\}\<\>]'), r'\g<1>')
+        (re.compile(r'\s([\]\[\(\)\{\}\<\>])\s'), r'\g<1>')
         ]
 
     #punctuation

--- a/nltk/tokenize/treebank.py
+++ b/nltk/tokenize/treebank.py
@@ -18,6 +18,7 @@ and available at http://www.cis.upenn.edu/~treebank/tokenizer.sed.
 
 import re
 from nltk.tokenize.api import TokenizerI
+from nltk.tokenize.util import align_tokens
 
 
 class MacIntyreContractions:
@@ -142,6 +143,22 @@ class TreebankWordTokenizer(TokenizerI):
         #     text = regexp.sub(r' \1 \2 \3 ', text)
 
         return text if return_str else text.split()
+
+    def span_tokenize(self, text):
+        """
+        Uses the post-hoc nltk.tokens.align_tokens to return the offset spans.
+
+            >>> from nltk.tokenize import TreebankWordTokenizer
+            >>> s = '''Good muffins cost $3.88\\nin New (York).  Please (buy) me\\ntwo of them.\\n(Thanks).'''
+            >>> expected = [(0, 4), (5, 12), (13, 17), (18, 19), (19, 27),
+            ... (28, 31), (32, 33), (33, 37), (37, 38), (38, 39), (41, 47),
+            ... (48, 49), (49, 52), (52, 53), (54, 61), (62, 64), (65, 72),
+            ... (72, 73), (73, 79), (79, 80), (80, 81)]
+            >>> TreebankWordTokenizer().span_tokenize(s) == expected
+            True
+        """
+        tokens = self.tokenize(text)
+        return align_tokens(tokens, text)
 
 
 class TreebankWordDetokenizer(TokenizerI):

--- a/nltk/tokenize/treebank.py
+++ b/nltk/tokenize/treebank.py
@@ -174,7 +174,7 @@ class TreebankWordDetokenizer(TokenizerI):
     >>> expected_tokens = ['Good', 'muffins', 'cost', '$', '3.88', 'in',
     ... 'New', '-LRB-', 'York', '-RRB-', '.', 'Please', '-LRB-', 'buy',
     ... '-RRB-', 'me', 'two', 'of', 'them.', '-LRB-', 'Thanks', '-RRB-', '.']
-    >>> expected == t.tokenize(s, convert_parentheses=True)
+    >>> expected_tokens == t.tokenize(s, convert_parentheses=True)
     True
     >>> expected_detoken = 'Good muffins cost $3.88 in New (York). Please (buy) me two of them. (Thanks).'
     >>> expected_detoken == d.detokenize(t.tokenize(s, convert_parentheses=True), convert_parentheses=True)

--- a/nltk/tokenize/treebank.py
+++ b/nltk/tokenize/treebank.py
@@ -150,10 +150,9 @@ class TreebankWordTokenizer(TokenizerI):
 
             >>> from nltk.tokenize import TreebankWordTokenizer
             >>> s = '''Good muffins cost $3.88\\nin New (York).  Please (buy) me\\ntwo of them.\\n(Thanks).'''
-            >>> expected = [(0, 4), (5, 12), (13, 17), (18, 19), (19, 27),
-            ... (28, 31), (32, 33), (33, 37), (37, 38), (38, 39), (41, 47),
-            ... (48, 49), (49, 52), (52, 53), (54, 61), (62, 64), (65, 72),
-            ... (72, 73), (73, 79), (79, 80), (80, 81)]
+            >>> expected = [(0, 4), (5, 12), (13, 17), (18, 19), (19, 23),
+            ... (24, 26), (27, 30), (31, 36), (38, 44), (45, 48), (49, 51),
+            ... (52, 55), (56, 58), (59, 64), (65, 71), (71, 72)]
             >>> TreebankWordTokenizer().span_tokenize(s) == expected
             True
         """

--- a/nltk/tokenize/util.py
+++ b/nltk/tokenize/util.py
@@ -200,16 +200,24 @@ def align_tokens(tokens, sentence):
 
         >>> from nltk.tokenize import TreebankWordTokenizer
         >>> from nltk.tokenize.util import align_tokens
-        >>> s = '''The plane, bound for St Petersburg, crashed in Egypt's
-        ... Sinai desert just 23 minutes after take-off from Sharm el-Sheikh
-        ... on Saturday.'''
+        >>> s = str("The plane, bound for St Petersburg, crashed in Egypt's "
+        ... "Sinai desert just 23 minutes after take-off from Sharm el-Sheikh "
+        ... "on Saturday.")
+        >>> tokens = TreebankWordTokenizer().tokenize(s)
         >>> expected = [(0, 3), (4, 9), (9, 10), (11, 16), (17, 20), (21, 23),
         ... (24, 34), (34, 35), (36, 43), (44, 46), (47, 52), (52, 54),
         ... (55, 60), (61, 67), (68, 72), (73, 75), (76, 83), (84, 89),
         ... (90, 98), (99, 103), (104, 109), (110, 119), (120, 122),
         ... (123, 131), (131, 132)]
-        >>> expected == list(align_tokens(TreebankWordTokenizer().tokenize(s), s))
+        >>> output = list(align_tokens(tokens, s))
+        # Check that length of tokens and tuples are the same.
+        >>> len(tokens) == len(expected) == len(output)
         True
+        # Check that the output is as expected.
+        >>> expected == list(align_tokens(, s))
+        True
+        # Check that the slices of the string corresponds to the tokens.
+        >>> tokens == [s[start:end] for start, end in output]
 
     :param tokens: The list of strings that are the result of tokenization
     :type tokens: list(str)

--- a/nltk/tokenize/util.py
+++ b/nltk/tokenize/util.py
@@ -194,7 +194,7 @@ def xml_escape(text):
 
 
 def align_tokens(tokens, sentence):
-    r"""
+    """
     This module attempt to find the offsets of the tokens in *s*, as a sequence
     of ``(start, end)`` tuples, given the tokens and also the source string.
 
@@ -208,6 +208,7 @@ def align_tokens(tokens, sentence):
         (34, 35), (36, 43), (44, 46), (47, 52), (52, 54), (55, 60), (61, 67),
         (68, 72), (73, 75), (76, 83), (84, 89), (90, 98), (99, 103), (104, 109),
         (110, 119), (120, 122), (123, 131), (131, 132)]
+
     :param tokens: the list of strings that are the result of tokenization
     :type s: list(str)
     :param sentence: the original string

--- a/nltk/tokenize/util.py
+++ b/nltk/tokenize/util.py
@@ -203,16 +203,19 @@ def align_tokens(tokens, sentence):
         >>> s = '''The plane, bound for St Petersburg, crashed in Egypt's
         ... Sinai desert just 23 minutes after take-off from Sharm el-Sheikh
         ... on Saturday.'''
-        >>> list(align_tokens(TreebankWordTokenizer().tokenize(s), s))
-        [(0, 3), (4, 9), (9, 10), (11, 16), (17, 20), (21, 23), (24, 34),
-        (34, 35), (36, 43), (44, 46), (47, 52), (52, 54), (55, 60), (61, 67),
-        (68, 72), (73, 75), (76, 83), (84, 89), (90, 98), (99, 103), (104, 109),
-        (110, 119), (120, 122), (123, 131), (131, 132)]
+        >>> expected = [(0, 3), (4, 9), (9, 10), (11, 16), (17, 20), (21, 23),
+        ... (24, 34), (34, 35), (36, 43), (44, 46), (47, 52), (52, 54),
+        ... (55, 60), (61, 67), (68, 72), (73, 75), (76, 83), (84, 89),
+        ... (90, 98), (99, 103), (104, 109), (110, 119), (120, 122),
+        ... (123, 131), (131, 132)]
+        >>> expected == list(align_tokens(TreebankWordTokenizer().tokenize(s), s))
+        True
 
-    :param tokens: the list of strings that are the result of tokenization
-    :type s: list(str)
-    :param sentence: the original string
-    :rtype: iter(tuple(int,int))
+    :param tokens: The list of strings that are the result of tokenization
+    :type tokens: list(str)
+    :param sentence: The original string
+    :type sentence: str
+    :rtype: list(tuple(int,int))
     """
     point = 0
     offsets = []

--- a/nltk/tokenize/util.py
+++ b/nltk/tokenize/util.py
@@ -191,3 +191,35 @@ def xml_escape(text):
     return escape(text, entities={ r"'": r"&apos;", r'"': r"&quot;",
                                    r"|": r"&#124;",
                                    r"[": r"&#91;",  r"]": r"&#93;", })
+
+
+def align_tokens(tokens, sentence):
+    r"""
+    This module attempt to find the offsets of the tokens in *s*, as a sequence
+    of ``(start, end)`` tuples, given the tokens and also the source string.
+
+        >>> from nltk.tokenize import TreebankWordTokenizer
+        >>> from nltk.tokenize.util import align_tokens
+        >>> s = '''The plane, bound for St Petersburg, crashed in Egypt's
+        ... Sinai desert just 23 minutes after take-off from Sharm el-Sheikh
+        ... on Saturday.'''
+        >>> list(align_tokens(TreebankWordTokenizer().tokenize(s), s))
+        [(0, 3), (4, 9), (9, 10), (11, 16), (17, 20), (21, 23), (24, 34),
+        (34, 35), (36, 43), (44, 46), (47, 52), (52, 54), (55, 60), (61, 67),
+        (68, 72), (73, 75), (76, 83), (84, 89), (90, 98), (99, 103), (104, 109),
+        (110, 119), (120, 122), (123, 131), (131, 132)]
+    :param tokens: the list of strings that are the result of tokenization
+    :type s: list(str)
+    :param sentence: the original string
+    :rtype: iter(tuple(int,int))
+    """
+    point = 0
+    offsets = []
+    for token in tokens:
+        try:
+            start = sentence.index(token, point)
+        except ValueError:
+            raise ValueError('substring "{}" not found in "{}"'.format(token, sentence))
+        point = start + len(token)
+        offsets.append((start, point))
+    return offsets

--- a/nltk/tokenize/util.py
+++ b/nltk/tokenize/util.py
@@ -214,7 +214,7 @@ def align_tokens(tokens, sentence):
         >>> len(tokens) == len(expected) == len(output)
         True
         # Check that the output is as expected.
-        >>> expected == list(align_tokens(, s))
+        >>> expected == list(align_tokens(tokens, s))
         True
         # Check that the slices of the string corresponds to the tokens.
         >>> tokens == [s[start:end] for start, end in output]

--- a/nltk/tokenize/util.py
+++ b/nltk/tokenize/util.py
@@ -209,15 +209,13 @@ def align_tokens(tokens, sentence):
         ... (55, 60), (61, 67), (68, 72), (73, 75), (76, 83), (84, 89),
         ... (90, 98), (99, 103), (104, 109), (110, 119), (120, 122),
         ... (123, 131), (131, 132)]
-        >>> output = list(align_tokens(tokens, s))
-        # Check that length of tokens and tuples are the same.
+        >>> output = list(align_tokens(tokens, s))  # Check that length of tokens and tuples are the same.
         >>> len(tokens) == len(expected) == len(output)
         True
-        # Check that the output is as expected.
-        >>> expected == list(align_tokens(tokens, s))
+        >>> expected == list(align_tokens(tokens, s))  # Check that the output is as expected.
         True
-        # Check that the slices of the string corresponds to the tokens.
-        >>> tokens == [s[start:end] for start, end in output]
+        >>> tokens == [s[start:end] for start, end in output]  # Check that the slices of the string corresponds to the tokens.
+        True
 
     :param tokens: The list of strings that are the result of tokenization
     :type tokens: list(str)

--- a/nltk/tokenize/util.py
+++ b/nltk/tokenize/util.py
@@ -209,8 +209,8 @@ def align_tokens(tokens, sentence):
         ... (55, 60), (61, 67), (68, 72), (73, 75), (76, 83), (84, 89),
         ... (90, 98), (99, 103), (104, 109), (110, 119), (120, 122),
         ... (123, 131), (131, 132)]
-        >>> output = list(align_tokens(tokens, s))  # Check that length of tokens and tuples are the same.
-        >>> len(tokens) == len(expected) == len(output)
+        >>> output = list(align_tokens(tokens, s))
+        >>> len(tokens) == len(expected) == len(output)  # Check that length of tokens and tuples are the same.
         True
         >>> expected == list(align_tokens(tokens, s))  # Check that the output is as expected.
         True


### PR DESCRIPTION
Adding on to #1214, this PR:

 - Added detokenization abilities by reversing the regexes operations 
 - Post-hoc tokens mapping to original sentence; might not be 100% correctly aligned but I can't think of any counter examples yet..., c.f. #1190
 - Allow MXPOST parentheses that PTB uses (also in the original sed treebank tokenizer)
 - Allow additional parameters for `word_tokenize` to preserve the sentence without calling the `sent_tokenize` step.
 - ~~(moonshot) keeping explicit offset during tokenization.~~

----

This PR should resolve:

#948 

```
>>> from nltk import word_tokenize
>>> word_tokenize("hi, my name can't hello,")
['hi', ',', 'my', 'name', 'ca', "n't", 'hello', ',']
```

#916

```
>>> word_tokenize(u'«Esto es un ejemplo de cómo se suele hacer una cita literal en español».')
[u'\xab', u'Esto', u'es', u'un', u'ejemplo', u'de', u'c\xf3mo', u'se', u'suele', u'hacer', u'una', u'cita', u'literal', u'en', u'espa\xf1ol', u'\xbb', u'.']
```

#1699 

```
>>> from nltk import word_tokenize
>>> s = 'A. Young c Moin Khan b Wasim 0'
>>> word_tokenize(s)
['A', '.', 'Young', 'c', 'Moin', 'Khan', 'b', 'Wasim', '0']
>>> word_tokenize(s, preserve_line=True)
['A.', 'Young', 'c', 'Moin', 'Khan', 'b', 'Wasim', '0']
```

Also, The detokenizer and `align_sent` also attends to #1217 and #1190 

And the `span_tokenize` duck function using `align_sent` should also attend to #1054, #131 and #78.


