### PR TITLE
[FIX] Protection against invalid data collections added to nltk

### DIFF
--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -859,8 +859,10 @@ class Downloader(object):
             for child in queue:
                 if isinstance(child, Collection):
                     queue.extend(child.children)
-                else:
+                elif isinstance(child, Package):
                     packages[child.id] = child
+                else:
+                    print('Invalid package provided - {}'.format(child))
             collection.packages = packages.values()
 
         # Flush the status cache


### PR DESCRIPTION
https://github.com/nltk/nltk/issues/1338
https://github.com/nltk/nltk_data/issues/35
https://github.com/nltk/nltk/issues/882

These are all cases of (what I understand) bad packages added to the nltk index.

This causes pain :), the idea here is simply to protect the code from such cases.

