### PR TITLE
add bigrams function import to book.py

### DIFF
--- a/nltk/book.py
+++ b/nltk/book.py
@@ -11,6 +11,7 @@ from nltk.corpus import (gutenberg, genesis, inaugural,
                          nps_chat, webtext, treebank, wordnet)
 from nltk.text import Text
 from nltk.probability import FreqDist
+from nltk.util import bigrams
 
 print("*** Introductory Examples for the NLTK Book ***")
 print("Loading text1, ..., text9 and sent1, ..., sent9")


### PR DESCRIPTION
Add missing bigrams function import to book.py. Adding this import because the bigrams function is used in chapter 1 section 3.3 of the nltk book (http://www.nltk.org/book/ch01.html).