### PR TITLE
Better treebank detokenizer for punctuations

### DIFF
--- a/nltk/tokenize/treebank.py
+++ b/nltk/tokenize/treebank.py
@@ -235,7 +235,7 @@ class TreebankWordDetokenizer(TokenizerI):
     #punctuation
     PUNCTUATION = [
         (re.compile(r"([^'])\s'\s"), r"\1' "),
-        (re.compile(r'\s([?!])\s'), r'\g<1>'),
+        (re.compile(r'\s([?!])\s'), r'\g<1> '), # Strip left pad but keep right pad after [?!]
         (re.compile(r'([^\.])\s(\.)([\]\)}>"\']*)\s*$'), r'\1\2\3'),
         # When tokenizing, [;@#$%&] are padded with whitespace regardless of
         # whether there are spaces before or after them.
@@ -246,7 +246,7 @@ class TreebankWordDetokenizer(TokenizerI):
         (re.compile(r'\s([&])\s'), r' \g<1> '), # Unknown pad.
         (re.compile(r'\s\.\.\.\s'), r'...'),
         (re.compile(r'\s([:,])\s$'), r'\1'),
-        (re.compile(r'\s([:,])\s([^\d])'), r'\1 \2')
+        (re.compile(r'\s([:,])\s([^\d])'), r'\1 \2') # Keep right pad after comma/colon before non-digits.
         ]
 
     #starting quotes

--- a/nltk/tokenize/treebank.py
+++ b/nltk/tokenize/treebank.py
@@ -204,13 +204,13 @@ class TreebankWordDetokenizer(TokenizerI):
     True
 
     During tokenization it's safe to add more spaces but during detokenization,
-    simply undoing the padding doesn't really help. We have to
+    simply undoing the padding doesn't really help. 
 
-    - during tokenization, left and right pad is added to [!?], when
+    - During tokenization, left and right pad is added to [!?], when
       detokenizing, only left shift the [!?] is needed.
       Thus (re.compile(r'\s([?!])'), r'\g<1>')
 
-    - during tokenization [:,] are left and right padded but when detokenizing,
+    - During tokenization [:,] are left and right padded but when detokenizing,
       only left shift is necessary and we keep right pad after comma/colon
       if the string after is a non-digit.
       Thus (re.compile(r'\s([:,])\s([^\d])'), r'\1 \2')

--- a/nltk/tokenize/treebank.py
+++ b/nltk/tokenize/treebank.py
@@ -235,7 +235,7 @@ class TreebankWordDetokenizer(TokenizerI):
     #punctuation
     PUNCTUATION = [
         (re.compile(r"([^'])\s'\s"), r"\1' "),
-        (re.compile(r'\s([?!])\s'), r'\g<1> '), # Strip left pad but keep right pad after [?!]
+        (re.compile(r'\s([?!])'), r'\g<1>'), # Strip left pad for [?!]
         (re.compile(r'([^\.])\s(\.)([\]\)}>"\']*)\s*$'), r'\1\2\3'),
         # When tokenizing, [;@#$%&] are padded with whitespace regardless of
         # whether there are spaces before or after them.

--- a/nltk/tokenize/treebank.py
+++ b/nltk/tokenize/treebank.py
@@ -246,7 +246,7 @@ class TreebankWordDetokenizer(TokenizerI):
         (re.compile(r'\s([&])\s'), r' \g<1> '), # Unknown pad.
         (re.compile(r'\s\.\.\.\s'), r'...'),
         (re.compile(r'\s([:,])\s$'), r'\1'),
-        (re.compile(r'\s([:,])\s([^\d])'), r'\1\2')
+        (re.compile(r'\s([:,])\s([^\d])'), r'\1 \2')
         ]
 
     #starting quotes


### PR DESCRIPTION
Originally, before this PR, the punctuations simply did the reverse of the tokenization regexes and that's results in erroneous left/right shifts. 

It's because during tokenization it's safe to add more spaces but during detokenization, simply undoing the padding doesn't really help.

Before this PR:

```python
>>> from nltk.tokenize.treebank import TreebankWordDetokenizer
>>> twd = TreebankWordDetokenizer()
>>> toks = ['hello', ',', 'i', 'ca', "n't", 'feel', 'my', 'feet', '!', 'Help', '!', '!']
>>> twd.detokenize(toks)
"hello,i can't feel my feet!Help!!"
```

After:

```python
>>> from nltk.tokenize.treebank import TreebankWordDetokenizer
>>> toks = ['hello', ',', 'i', 'can't", 'feel', 'my', 'feet', '!', 'Help', '!', '!']
>>> twd = TreebankWordDetokenizer()
>>> twd.detokenize(toks)
"hello, i can't feel my feet! Help!!"

>>> toks = ['hello', ',', 'i', 'ca', "n't", 'feel', ';', 'my', 'feet', '!', 'Help', '!', '!', 'He', 'said', ':', 'Help', ',', 'help', '?', '!']
>>> twd.detokenize(toks)
"hello, i can't feel; my feet! Help!! He said: Help, help?!"
```