### PR TITLE
Make vader negation case insensitive

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -212,6 +212,7 @@
 - Arthur Tilley
 - Vilhjalmur Thorsteinsson
 - Jaehoon Hwang <https://github.com/jaehoonhwang>
+- sbagan
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 ### Contributors to the Porter Stemmer

--- a/nltk/sentiment/util.py
+++ b/nltk/sentiment/util.py
@@ -12,7 +12,6 @@ Utility methods for Sentiment Analysis.
 """
 from __future__ import division
 
-from copy import deepcopy
 import codecs
 import csv
 import json
@@ -21,6 +20,8 @@ import random
 import re
 import sys
 import time
+from copy import deepcopy
+from itertools import tee
 
 import nltk
 from nltk.corpus import CategorizedPlaintextCorpusReader
@@ -64,6 +65,7 @@ SAD = set([
     ':c', ':{', '>:\\', ';('
     ])
 
+
 def timer(method):
     """
     A timer decorator to measure execution performance of methods.
@@ -83,6 +85,13 @@ def timer(method):
             print('[TIMER] {0}(): {1}h {2}m {3}s'.format(method.__name__, hours, mins, secs))
         return result
     return timed
+
+
+def pairwise(iterable):
+    """s -> (s0,s1), (s1,s2), (s2, s3), ..."""
+    a, b = tee(iterable)
+    next(b, None)
+    return zip(a, b)
 
 #////////////////////////////////////////////////////////////
 #{ Feature extractor functions
@@ -409,7 +418,7 @@ def demo_tweets(trainer, n_instances=None, output=None):
     """
     from nltk.tokenize import TweetTokenizer
     from nltk.sentiment import SentimentAnalyzer
-    from nltk.corpus import twitter_samples, stopwords
+    from nltk.corpus import twitter_samples
 
     # Different customizations for the TweetTokenizer
     tokenizer = TweetTokenizer(preserve_case=False)

--- a/nltk/sentiment/util.py
+++ b/nltk/sentiment/util.py
@@ -418,7 +418,7 @@ def demo_tweets(trainer, n_instances=None, output=None):
     """
     from nltk.tokenize import TweetTokenizer
     from nltk.sentiment import SentimentAnalyzer
-    from nltk.corpus import twitter_samples
+    from nltk.corpus import twitter_samples, stopwords
 
     # Different customizations for the TweetTokenizer
     tokenizer = TweetTokenizer(preserve_case=False)

--- a/nltk/sentiment/vader.py
+++ b/nltk/sentiment/vader.py
@@ -27,6 +27,7 @@ import re
 import string
 from itertools import product
 import nltk.data
+from .util import pairwise
 
 ##Constants##
 
@@ -88,15 +89,13 @@ def negated(input_words, include_nt=True):
     Determine if input contains negation words
     """
     neg_words = NEGATE
-    for word in input_words:
-        if word.lower() in neg_words:
-            return True
+    if any(word.lower() in neg_words for word in input_words):
+        return True
     if include_nt:
-        for word in input_words:
-            if "n't" in word.lower():
-                return True
-    for i, word in enumerate(input_words):
-        if i > 0 and word.lower() == "least" and input_words[i-1].lower() != 'at':
+        if any("n't" in word.lower() for word in input_words):
+            return True
+    for first, second in pairwise(input_words):
+        if second.lower() == "least" and first.lower() != 'at':
             return True
     return False
 

--- a/nltk/sentiment/vader.py
+++ b/nltk/sentiment/vader.py
@@ -45,15 +45,14 @@ REGEX_REMOVE_PUNCTUATION = re.compile('[{0}]'.format(re.escape(string.punctuatio
 
 PUNC_LIST = [".", "!", "?", ",", ";", ":", "-", "'", "\"",
              "!!", "!!!", "??", "???", "?!?", "!?!", "?!?!", "!?!?"]
-NEGATE = \
-["aint", "arent", "cannot", "cant", "couldnt", "darent", "didnt", "doesnt",
+NEGATE = {"aint", "arent", "cannot", "cant", "couldnt", "darent", "didnt", "doesnt",
  "ain't", "aren't", "can't", "couldn't", "daren't", "didn't", "doesn't",
  "dont", "hadnt", "hasnt", "havent", "isnt", "mightnt", "mustnt", "neither",
  "don't", "hadn't", "hasn't", "haven't", "isn't", "mightn't", "mustn't",
  "neednt", "needn't", "never", "none", "nope", "nor", "not", "nothing", "nowhere",
  "oughtnt", "shant", "shouldnt", "uhuh", "wasnt", "werent",
  "oughtn't", "shan't", "shouldn't", "uh-uh", "wasn't", "weren't",
- "without", "wont", "wouldnt", "won't", "wouldn't", "rarely", "seldom", "despite"]
+ "without", "wont", "wouldnt", "won't", "wouldn't", "rarely", "seldom", "despite"}
 
 # booster/dampener 'intensifiers' or 'degree adverbs'
 # http://en.wiktionary.org/wiki/Category:English_degree_adverbs
@@ -88,18 +87,16 @@ def negated(input_words, include_nt=True):
     """
     Determine if input contains negation words
     """
-    neg_words = []
-    neg_words.extend(NEGATE)
-    for word in neg_words:
-        if word in input_words:
+    neg_words = NEGATE
+    for word in input_words:
+        if word.lower() in neg_words:
             return True
     if include_nt:
         for word in input_words:
-            if "n't" in word:
+            if "n't" in word.lower():
                 return True
-    if "least" in input_words:
-        i = input_words.index("least")
-        if i > 0 and input_words[i-1] != "at":
+    for i, word in enumerate(input_words):
+        if i > 0 and word.lower() == "least" and input_words[i-1].lower() != 'at':
             return True
     return False
 


### PR DESCRIPTION
From my point of view negated function of vader sentiment intensity analyzer is not working correctly now, as it looks for NEGATE parts in case-sensitive words, while NEGATE contains case-insensitive ones. This can be ilustrated by a simle example:

`
In [1]: from nltk.sentiment.vader import SentimentIntensityAnalyzer
`
`
In [2]: sid = SentimentIntensityAnalyzer()
`
`
In [3]: print(sid.polarity_scores('Not as good as previous'))
`
`
{'neu': 0.58, 'pos': 0.42, 'compound': 0.4404, 'neg': 0.0}
`
`
In [4]: print(sid.polarity_scores('not as good as previous'))
`
`
{'neu': 0.624, 'pos': 0.0, 'compound': -0.3412, 'neg': 0.376}
`

I suppose check in negated function should be case-insensitive. I tried to find similar issues or pull-requests, but haven't found any, which is surprising, as from my point of view this thing is quite huge. So please correct me if I'm wrong.