### PR TITLE
Patch for span_tokenize in TreebankWordTokenizer

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -214,6 +214,7 @@
 - Jaehoon Hwang <https://github.com/jaehoonhwang>
 - sbagan
 - Zicheng Xu
+- Albert Au Yeung <https://github.com/albertauyeung>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 ### Contributors to the Porter Stemmer

--- a/nltk/test/tokenize.doctest
+++ b/nltk/test/tokenize.doctest
@@ -193,7 +193,7 @@ The sentence splitter should remove whitespace following the sentence boundary.
     ['See Section 3.', ')  Or Section 2.', ')']
 
 
-Regression Tests: aling_tokens
+Regression Tests: align_tokens
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Post-hoc alignment of tokens with a source string
 

--- a/nltk/test/unit/test_tokenize.py
+++ b/nltk/test/unit/test_tokenize.py
@@ -5,7 +5,7 @@ See also nltk/test/tokenize.doctest
 """
 
 from __future__ import unicode_literals
-from nltk.tokenize import TweetTokenizer, StanfordSegmenter
+from nltk.tokenize import TweetTokenizer, StanfordSegmenter, TreebankWordTokenizer
 from nose import SkipTest
 import unittest
 import os
@@ -106,4 +106,44 @@ class TestTokenize(unittest.TestCase):
         test7 = "@abcdefghijklmnopqrstu@abcde @abcdefghijklmnopqrst@abcde @abcdefghijklmnopqrst_@abcde @abcdefghijklmnopqrst5@abcde"
         expected = ['u', '@abcde', '@abcdefghijklmnopqrst', '@abcde', '_', '@abcde', '5', '@abcde']
         result = tokenizer.tokenize(test7)
+        self.assertEqual(result, expected)
+
+    def test_treebank_span_tokenizer(self):
+        """
+        Test TreebankWordTokenizer.span_tokenize function
+        """
+
+        tokenizer = TreebankWordTokenizer()
+
+        # Test case in the docstring
+        test1 = "Good muffins cost $3.88\nin New (York).  Please (buy) me\ntwo of them.\n(Thanks)."
+        expected = [
+            (0, 4), (5, 12), (13, 17), (18, 19), (19, 23),
+            (24, 26), (27, 30), (31, 32), (32, 36), (36, 37), (37, 38),
+            (40, 46), (47, 48), (48, 51), (51, 52), (53, 55), (56, 59),
+            (60, 62), (63, 68), (69, 70), (70, 76), (76, 77), (77, 78)
+        ]
+        result = tokenizer.span_tokenize(test1)
+        self.assertEqual(result, expected)
+
+        # Test case with double quotation
+        test2 = "The DUP is similar to the \"religious right\" in the United States and takes a hardline stance on social issues"
+        expected = [
+            (0, 3), (4, 7), (8, 10), (11, 18), (19, 21), (22, 25), (26, 27),
+            (27, 36), (37, 42), (42, 43), (44, 46), (47, 50), (51, 57), (58, 64),
+            (65, 68), (69, 74), (75, 76), (77, 85), (86, 92), (93, 95), (96, 102),
+            (103, 109)
+        ]
+        result = tokenizer.span_tokenize(test2)
+        self.assertEqual(result, expected)
+
+        # Test case with double qoutation as well as converted quotations
+        test3 = "The DUP is similar to the \"religious right\" in the United States and takes a ``hardline'' stance on social issues"
+        expected = [
+            (0, 3), (4, 7), (8, 10), (11, 18), (19, 21), (22, 25), (26, 27),
+            (27, 36), (37, 42), (42, 43), (44, 46), (47, 50), (51, 57), (58, 64),
+            (65, 68), (69, 74), (75, 76), (77, 79), (79, 87), (87, 89), (90, 96),
+            (97, 99), (100, 106), (107, 113)
+        ]
+        result = tokenizer.span_tokenize(test3)
         self.assertEqual(result, expected)

--- a/nltk/tokenize/treebank.py
+++ b/nltk/tokenize/treebank.py
@@ -163,7 +163,22 @@ class TreebankWordTokenizer(TokenizerI):
             True
 
         """
-        tokens = self.tokenize(text)
+        raw_tokens = self.tokenize(text)
+
+        # Find double quotes and converted quotes
+        matched = [m.group() for m in re.finditer(r'[(``)('')(")]+', text)]
+
+        # Convert converted quotes back to original double quotes
+        index = 0
+        tokens = []
+        for tok in raw_tokens:
+            if tok in ["\"", "``", "''"]:
+                if matched[index] == "\"":
+                    tokens.append("\"")
+                    index += 1
+                    continue
+            tokens.append(tok)
+
         return align_tokens(tokens, text)
 
 

--- a/nltk/tokenize/treebank.py
+++ b/nltk/tokenize/treebank.py
@@ -165,19 +165,23 @@ class TreebankWordTokenizer(TokenizerI):
         """
         raw_tokens = self.tokenize(text)
 
-        # Find double quotes and converted quotes
-        matched = [m.group() for m in re.finditer(r'[(``)('')(")]+', text)]
-
         # Convert converted quotes back to original double quotes
-        index = 0
-        tokens = []
-        for tok in raw_tokens:
-            if tok in ["\"", "``", "''"]:
-                if matched[index] == "\"":
-                    tokens.append("\"")
+        # Do this only if original text contains double quote(s)
+        if '"' in text:
+            # Find double quotes and converted quotes
+            matched = [m.group() for m in re.finditer(r'[(``)(\'\')(")]+', text)]
+            
+            # Replace converted quotes back to double quotes
+            index = 0
+            tokens = []
+            for tok in raw_tokens:
+                if tok in ['"', "``", "''"]:
+                    tokens.append(matched[index])
                     index += 1
-                    continue
-            tokens.append(tok)
+                else:
+                    tokens.append(tok)
+        else:
+            tokens = raw_tokens
 
         return align_tokens(tokens, text)
 

--- a/nltk/tokenize/treebank.py
+++ b/nltk/tokenize/treebank.py
@@ -172,14 +172,7 @@ class TreebankWordTokenizer(TokenizerI):
             matched = [m.group() for m in re.finditer(r'[(``)(\'\')(")]+', text)]
             
             # Replace converted quotes back to double quotes
-            index = 0
-            tokens = []
-            for tok in raw_tokens:
-                if tok in ['"', "``", "''"]:
-                    tokens.append(matched[index])
-                    index += 1
-                else:
-                    tokens.append(tok)
+            tokens = [matched.pop(0) if tok in ['"', "``", "''"] else tok for tok in raw_tokens]
         else:
             tokens = raw_tokens
 


### PR DESCRIPTION
Ref: #1750 The original code in `span_tokenize `will fail when the input sentence contains double quotation marks. This patch adds additional logic to convert "converted quotes (e.g. `` and '') back to double quotation before calling `align_tokens`.