### PR TITLE
Corenlp typeerror

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -215,6 +215,7 @@
 - sbagan
 - Zicheng Xu
 - Albert Au Yeung <https://github.com/albertauyeung>
+- Alex Diep
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 ### Contributors to the Porter Stemmer

--- a/nltk/parse/corenlp.py
+++ b/nltk/parse/corenlp.py
@@ -66,7 +66,7 @@ class CoreNLPServer(object):
         # find the most recent code and model jar
         stanford_jar = max(
             jars,
-            key=lambda model_name: re.match(self._JAR, model_name)
+            key=lambda model_name: re.search(self._JAR, model_name).group()
         )
 
         if port is None:


### PR DESCRIPTION
If I change the doctest from 9 to 10, the test goes through just fine. I don't know if this is just my setup or not, so I am avoiding changing the doctest.
```
Failed example:
    next(
        parser.raw_parse(
            "The broader Standard & Poor's 500 Index <.SPX> was 0.46 points lower, or "
            '0.05 percent, at 997.02.'
        )
    ).height()
Expected:
    9
Got:
    10
```

Anyway, originally I got TypeErrors when I run CoreNLPServer and I fixed it.