### PR TITLE
fix "list index out of range" in handles_nonbreaking_prefixes

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -215,6 +215,7 @@
 - sbagan
 - Zicheng Xu
 - Albert Au Yeung <https://github.com/albertauyeung>
+- Shenjian Zhao
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 ### Contributors to the Porter Stemmer

--- a/nltk/tokenize/moses.py
+++ b/nltk/tokenize/moses.py
@@ -285,8 +285,8 @@ class MosesTokenizer(TokenizerI):
                     pass # No change to the token.
                 # Checks if the prefix is in NUMERIC_ONLY_PREFIXES
                 # and ensures that the next word is a digit.
-                elif (prefix in self.NUMERIC_ONLY_PREFIXES and
-                      re.search(r'^[0-9]+', tokens[i+1])):
+                elif (prefix in self.NUMERIC_ONLY_PREFIXES and i != num_tokens-1
+                      and re.search(r'^[0-9]+', tokens[i+1])):
                     pass # No change to the token.
                 else: # Otherwise, adds a space after the tokens before a dot.
                     tokens[i] = prefix + ' .'


### PR DESCRIPTION
The following code would raise an Error ("IndexError: list index out of range"), because the index has not been checked.
```
from nltk.tokenize.moses import MosesTokenizer
a = 'No doubt the given aid will be popular with those who aim to unearth the mysteries of the world of Art.'
tokenizer = MosesTokenizer()
e = tokenizer.tokenize(a)
```