### PR TITLE
Added deprecation warning to the old Stanford API

### DIFF
--- a/nltk/parse/corenlp.py
+++ b/nltk/parse/corenlp.py
@@ -201,7 +201,7 @@ class GenericCoreNLPParser(ParserI, TokenizerI):
         :type sentences: list(list(str))
         :rtype: iter(iter(Tree))
         """
-
+        # Converting list(list(str)) -> list(str)
         sentences = (' '.join(words) for words in sentences)
         return self.raw_parse_sents(sentences, *args, **kwargs)
 
@@ -271,11 +271,13 @@ class GenericCoreNLPParser(ParserI, TokenizerI):
 
         """
         default_properties = {
-            'ssplit.isOneSentence': 'true',
+            # Only splits on '\n', never inside the sentence.
+            'ssplit.ssplit.eolonly': 'true',
         }
 
         default_properties.update(properties or {})
 
+        """
         for sentence in sentences:
             parsed_data = self.api_call(sentence, properties=default_properties)
 
@@ -284,6 +286,12 @@ class GenericCoreNLPParser(ParserI, TokenizerI):
             for parse in parsed_data['sentences']:
                 tree = self.make_tree(parse)
                 yield iter([tree])
+        """
+        parsed_data = self.api_call('\n'.join(sentences), properties=default_properties)
+        for parsed_sent in parsed_data['sentences']:
+            tree = self.make_tree(parsed_sent)
+            yield iter([tree])
+
 
     def parse_text(self, text, *args, **kwargs):
         """Parse a piece of text.
@@ -320,6 +328,7 @@ class GenericCoreNLPParser(ParserI, TokenizerI):
         """
         default_properties = {
             'annotators': 'tokenize,ssplit',
+
         }
 
         default_properties.update(properties or {})

--- a/nltk/tag/stanford.py
+++ b/nltk/tag/stanford.py
@@ -221,7 +221,8 @@ class CoreNLPTagger(CoreNLPParser, TaggerI):
         super(CoreNLPTagger, self).__init__(url, encoding)
 
     def tag_sents(self, sentences):
-        sentences = ('\n'.join(sent) for sent in sentences)
+        # Converting list(list(str)) -> list(str)
+        sentences = (' '.join(words) for words in sentences)
         return list(self.raw_tag_sents(sentences))
 
 

--- a/nltk/tag/stanford.py
+++ b/nltk/tag/stanford.py
@@ -52,7 +52,8 @@ class StanfordTagger(TaggerI):
         warnings.simplefilter('always', DeprecationWarning)
         warnings.warn(str("\nThe StanfordTokenizer will "
                           "be deprecated in version 3.2.5.\n"
-                          "Please use \033[91mnltk.parse.corenlp.CoreNLPTokenizer\033[0m instead.'"),
+                          "Please use \033[91mnltk.tag.corenlp.CoreNLPPOSTagger\033[0m "
+                          "or \033[91mnltk.tag.corenlp.CoreNLPNERTagger\033[0m instead."),
                       DeprecationWarning, stacklevel=2)
         warnings.simplefilter('ignore', DeprecationWarning)
         if not self._JAR:

--- a/nltk/tag/stanford.py
+++ b/nltk/tag/stanford.py
@@ -48,7 +48,13 @@ class StanfordTagger(TaggerI):
 
     def __init__(self, model_filename, path_to_jar=None, encoding='utf8',
                  verbose=False, java_options='-mx1000m'):
-
+        # Raise deprecation warning.
+        warnings.simplefilter('always', DeprecationWarning)
+        warnings.warn(str("\nThe StanfordTokenizer will "
+                          "be deprecated in version 3.2.5.\n"
+                          "Please use \033[91mnltk.parse.corenlp.CoreNLPTokenizer\033[0m instead.'"),
+                      DeprecationWarning, stacklevel=2)
+        warnings.simplefilter('ignore', DeprecationWarning)
         if not self._JAR:
             warnings.warn('The StanfordTagger class is not meant to be '
                           'instantiated directly. Did you mean '
@@ -215,7 +221,7 @@ class CoreNLPTagger(CoreNLPParser, TaggerI):
         super(CoreNLPTagger, self).__init__(url, encoding)
 
     def tag_sents(self, sentences):
-        sentences = (' '.join(words) for words in sentences)
+        sentences = ('\n'.join(sent) for sent in sentences)
         return list(self.raw_tag_sents(sentences))
 
 

--- a/nltk/tokenize/stanford.py
+++ b/nltk/tokenize/stanford.py
@@ -13,6 +13,7 @@ import tempfile
 import os
 import json
 from subprocess import PIPE
+import warnings
 
 from six import text_type
 
@@ -38,6 +39,13 @@ class StanfordTokenizer(TokenizerI):
     _JAR = 'stanford-postagger.jar'
 
     def __init__(self, path_to_jar=None, encoding='utf8', options=None, verbose=False, java_options='-mx1000m'):
+        # Raise deprecation warning.
+        warnings.simplefilter('always', DeprecationWarning)
+        warnings.warn(str("\nThe StanfordTokenizer will "
+                          "be deprecated in version 3.2.5.\n"
+                          "Please use \033[91mnltk.parse.corenlp.CoreNLPTokenizer\033[0m instead.'"),
+                      DeprecationWarning, stacklevel=2)
+        warnings.simplefilter('ignore', DeprecationWarning)
         self._stanford_jar = find_jar(
             self._JAR, path_to_jar,
             env_vars=('STANFORD_POSTAGGER',),

--- a/nltk/tokenize/stanford_segmenter.py
+++ b/nltk/tokenize/stanford_segmenter.py
@@ -17,6 +17,7 @@ import tempfile
 import os
 import json
 from subprocess import PIPE
+import warnings
 
 from nltk import compat
 from nltk.internals import find_jar, find_file, find_dir, \
@@ -30,7 +31,7 @@ _stanford_url = 'https://nlp.stanford.edu/software'
 
 class StanfordSegmenter(TokenizerI):
     """Interface to the Stanford Segmenter
-    
+
     If stanford-segmenter version is older than 2016-10-31, then path_to_slf4j
     should be provieded, for example::
 
@@ -63,6 +64,13 @@ class StanfordSegmenter(TokenizerI):
                  keep_whitespaces='false',
                  encoding='UTF-8', options=None,
                  verbose=False, java_options='-mx2g'):
+        # Raise deprecation warning.
+        warnings.simplefilter('always', DeprecationWarning)
+        warnings.warn(str("\nThe StanfordTokenizer will "
+                          "be deprecated in version 3.2.5.\n"
+                          "Please use \033[91mnltk.parse.corenlp.CoreNLPTokenizer\033[0m instead.'"),
+                      DeprecationWarning, stacklevel=2)
+        warnings.simplefilter('ignore', DeprecationWarning)
 
         stanford_segmenter = find_jar(
                 self._JAR, path_to_jar,


### PR DESCRIPTION
Attending to #1753

Additionally, to ensure that the `raw_parse_sents()` in `GenericCoreNLPParser` is efficient, using the `ssplit.ssplit.eolonly` to indicate end of sentences is much faster than having multiple POST-GET requests for individual sentences. This should resolve #1755.

----

And hopefully, these issues will be fixed by suggesting users to use the new wrappers around the corenlp servers:
 
 - #929
 - #1311
 - #1375 
 - #1390 
 - #1396 
 - #1424
 - #1426
 - #1443
 - #1476
 - #1518
 - #1523 
 - #1603
 - #1625
 - #1632
 - #1652
 - #1733
 - #1746

