### PR TITLE
Fix some lgtm alerts

### DIFF
--- a/nltk/classify/rte_classify.py
+++ b/nltk/classify/rte_classify.py
@@ -32,7 +32,7 @@ def ne(token):
         return True
     return False
 
-def lemmatize(word):
+def _lemmatize(word):
     """
     Use morphy from WordNet to find the base form of verbs.
     """
@@ -70,8 +70,8 @@ class RTEFeatureExtractor(object):
         self.hyp_words = set(self.hyp_tokens)
 
         if lemmatize:
-            self.text_words = set(lemmatize(token) for token in self.text_tokens)
-            self.hyp_words = set(lemmatize(token) for token in self.hyp_tokens)
+            self.text_words = set(_lemmatize(token) for token in self.text_tokens)
+            self.hyp_words = set(_lemmatize(token) for token in self.hyp_tokens)
 
         if self.stop:
             self.text_words = self.text_words - self.stopwords

--- a/nltk/collections.py
+++ b/nltk/collections.py
@@ -228,8 +228,7 @@ class AbstractLazySequence(object):
             length += len(pieces[-1]) + 2
             if length > self._MAX_REPR_SIZE and len(pieces) > 2:
                 return '[%s, ...]' % text_type(', ').join(pieces[:-1])
-        else:
-            return '[%s]' % text_type(', ').join(pieces)
+        return '[%s]' % text_type(', ').join(pieces)
 
     def __eq__(self, other):
         return (type(self) == type(other) and list(self) == list(other))

--- a/nltk/corpus/reader/framenet.py
+++ b/nltk/corpus/reader/framenet.py
@@ -877,8 +877,7 @@ class PrettyLazyMap(LazyMap):
             length += len(pieces[-1]) + 2
             if length > self._MAX_REPR_SIZE and len(pieces) > 2:
                 return "[%s, ...]" % text_type(', ').join(pieces[:-1])
-        else:
-            return "[%s]" % text_type(', ').join(pieces)
+        return "[%s]" % text_type(', ').join(pieces)
 
 @python_2_unicode_compatible
 class PrettyLazyIteratorList(LazyIteratorList):
@@ -900,8 +899,7 @@ class PrettyLazyIteratorList(LazyIteratorList):
             length += len(pieces[-1]) + 2
             if length > self._MAX_REPR_SIZE and len(pieces) > 2:
                 return "[%s, ...]" % text_type(', ').join(pieces[:-1])
-        else:
-            return "[%s]" % text_type(', ').join(pieces)
+        return "[%s]" % text_type(', ').join(pieces)
 
 @python_2_unicode_compatible
 class PrettyLazyConcatenation(LazyConcatenation):
@@ -923,8 +921,7 @@ class PrettyLazyConcatenation(LazyConcatenation):
             length += len(pieces[-1]) + 2
             if length > self._MAX_REPR_SIZE and len(pieces) > 2:
                 return "[%s, ...]" % text_type(', ').join(pieces[:-1])
-        else:
-            return "[%s]" % text_type(', ').join(pieces)
+        return "[%s]" % text_type(', ').join(pieces)
 
     def __add__(self, other):
         """Return a list concatenating self with other."""

--- a/nltk/corpus/reader/nombank.py
+++ b/nltk/corpus/reader/nombank.py
@@ -111,9 +111,7 @@ class NombankCorpusReader(CorpusReader):
         for roleset in etree.findall('predicate/roleset'):
             if roleset.attrib['id'] == roleset_id:
                 return roleset
-        else:
-            raise ValueError('Roleset %s not found in %s' %
-                             (roleset_id, framefile))
+        raise ValueError('Roleset %s not found in %s' % (roleset_id, framefile))
 
     def rolesets(self, baseform=None):
         """

--- a/nltk/corpus/reader/propbank.py
+++ b/nltk/corpus/reader/propbank.py
@@ -108,9 +108,7 @@ class PropbankCorpusReader(CorpusReader):
         for roleset in etree.findall('predicate/roleset'):
             if roleset.attrib['id'] == roleset_id:
                 return roleset
-        else:
-            raise ValueError('Roleset %s not found in %s' %
-                             (roleset_id, framefile))
+        raise ValueError('Roleset %s not found in %s' % (roleset_id, framefile))
 
     def rolesets(self, baseform=None):
         """

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -132,13 +132,13 @@ class _WordNetObject(object):
         return self._related('@')
 
     def _hypernyms(self):
-        return self._related('@', sort=False)
+        return self._related('@')
 
     def instance_hypernyms(self):
         return self._related('@i')
 
     def _instance_hypernyms(self):
-        return self._related('@i', sort=False)
+        return self._related('@i')
 
     def hyponyms(self):
         return self._related('~')

--- a/nltk/parse/recursivedescent.py
+++ b/nltk/parse/recursivedescent.py
@@ -351,8 +351,7 @@ class SteppingRecursiveDescentParser(RecursiveDescentParser):
     :see: ``nltk.grammar``
     """
     def __init__(self, grammar, trace=0):
-        self._grammar = grammar
-        self._trace = trace
+        super(SteppingRecursiveDescentParser, self).__init__(grammar, trace)
         self._rtext = None
         self._tree = None
         self._frontier = [()]

--- a/nltk/parse/shiftreduce.py
+++ b/nltk/parse/shiftreduce.py
@@ -290,8 +290,7 @@ class SteppingShiftReduceParser(ShiftReduceParser):
     :see: ``nltk.grammar``
     """
     def __init__(self, grammar, trace=0):
-        self._grammar = grammar
-        self._trace = trace
+        super(SteppingShiftReduceParser, self).__init__(grammar, trace)
         self._stack = None
         self._remaining_text = None
         self._history = []

--- a/nltk/sem/logic.py
+++ b/nltk/sem/logic.py
@@ -803,7 +803,7 @@ def read_type(type_string):
 
 class TypeException(Exception):
     def __init__(self, msg):
-        Exception.__init__(self, msg)
+        super(TypeException, self).__init__(msg)
 
 class InconsistentTypeHierarchyException(TypeException):
     def __init__(self, variable, expression=None):
@@ -813,21 +813,20 @@ class InconsistentTypeHierarchyException(TypeException):
         else:
             msg = "The variable '%s' was found in multiple places with different"\
                 " types." % (variable)
-        Exception.__init__(self, msg)
+        super(InconsistentTypeHierarchyException, self).__init__(msg)
 
 class TypeResolutionException(TypeException):
     def __init__(self, expression, other_type):
-        Exception.__init__(self, "The type of '%s', '%s', cannot be "
-                           "resolved with type '%s'" % \
-                           (expression, expression.type, other_type))
+        super(TypeResolutionException, self).__init__(
+            "The type of '%s', '%s', cannot be resolved with type '%s'" %
+            (expression, expression.type, other_type))
 
 class IllegalTypeException(TypeException):
     def __init__(self, expression, other_type, allowed_type):
-        Exception.__init__(self, "Cannot set type of %s '%s' to '%s'; "
-                           "must match type '%s'." %
-                           (expression.__class__.__name__, expression,
-                            other_type, allowed_type))
-
+        super(IllegalTypeException, self).__init__(
+            "Cannot set type of %s '%s' to '%s'; must match type '%s'." %
+            (expression.__class__.__name__, expression, other_type,
+            allowed_type))
 
 def typecheck(expressions, signature=None):
     """

--- a/nltk/tokenize/stanford.py
+++ b/nltk/tokenize/stanford.py
@@ -118,7 +118,7 @@ class CoreNLPTokenizer(CoreNLPParser):
             >>> CoreNLPTokenizer(url='http://localhost:9000').tokenize(s) == expected # doctest: +SKIP
             [u'Good', u'muffins', u'cost', u'$', u'3.88', u'in', u'New', u'York', u'.', u'Please', u'buy', u'me', u'two', u'of', u'them', u'.', u'Thanks', u'.']
         """
-        super(self.__class__, self).__init__(url, encoding)
+        super(CoreNLPTokenizer, self).__init__(url, encoding)
 
     def tokenize(self, text, properties=None):
         """

--- a/nltk/translate/ibm_model.py
+++ b/nltk/translate/ibm_model.py
@@ -496,6 +496,9 @@ class AlignmentInfo(object):
     def __eq__(self, other):
         return self.alignment == other.alignment
 
+    def __ne__(self, other):
+        return not self == other
+
     def __hash__(self):
         return hash(self.alignment)
 


### PR DESCRIPTION
This PR fixes some alerts flagged by lgtm.com code queries. Most are minor improvements suggestions but a few some should fix unintentional code behaviour (e.g. wrong signatures in calls). 

The standard lgtm engineering analytics highlights dependencies, vulnerabilities and tracks [introduced and fixed alerts as the code changes](https://lgtm.com/projects/g/nltk/nltk/). There are currently [188 alerts](https://lgtm.com/projects/g/nltk/nltk/alerts/) flagged, probably better investigated by someone more familiar with the code base than me, but you can also investigate further by writing [your own custom queries](https://lgtm.com/docs/ql/about-ql) to explore your code base.

I personally find lgtm alerts most useful when using [PR integration](https://lgtm.com/docs/lgtm/config/pr-integration) as it allows to check and deal with potential issues before they find their way into master. 

Full disclosure: I work on lgtm.com, hence my interest! I'm not very familiar with `nltk` but I hope you find this useful, any question please ask.