### PR TITLE
Added NIST MT evaluation metric and added NIST international_tokenize() 

### DIFF
--- a/nltk/corpus/reader/wordlist.py
+++ b/nltk/corpus/reader/wordlist.py
@@ -88,7 +88,9 @@ class UnicharsCorpusReader(WordListCorpusReader):
     # These are categories similar to the Perl Unicode Properties
     available_categories = ['Close_Punctuation', 'Currency_Symbol',
                             'IsAlnum', 'IsAlpha', 'IsLower', 'IsN', 'IsSc',
-                            'IsSo', 'Open_Punctuation']
+                            'IsSo', 'IsUpper', 'Line_Separator', 'Number',
+                            'Open_Punctuation', 'Punctuation', 'Separator',
+                            'Symbol']
 
     def chars(self, category=None, fileids=None):
         """
@@ -101,7 +103,7 @@ class UnicharsCorpusReader(WordListCorpusReader):
         >>> pup.chars('Currency_Symbol')[:5] == [u'$', u'\xa2', u'\xa3', u'\xa4', u'\xa5']
         True
         >>> pup.available_categories
-        ['Close_Punctuation', 'Currency_Symbol', 'IsAlnum', 'IsAlpha', 'IsLower', 'IsN', 'IsSc', 'IsSo', 'Open_Punctuation']
+        ['Close_Punctuation', 'Currency_Symbol', 'IsAlnum', 'IsAlpha', 'IsLower', 'IsN', 'IsSc', 'IsSo', 'IsUpper', 'Line_Separator', 'Number', 'Open_Punctuation', 'Punctuation', 'Separator', 'Symbol']
 
         :return: a list of characters given the specific unicode character category
         """

--- a/nltk/tokenize/nist.py
+++ b/nltk/tokenize/nist.py
@@ -49,7 +49,7 @@ class NISTTokenizer(TokenizerI):
     >>> from nltk.tokenize.nist import NISTTokenizer
     >>> nist = NISTTokenizer()
 
-    # Intput strings.
+    # Input strings.
     >>> albb = u'Alibaba Group Holding Limited (Chinese: 阿里巴巴集团控股 有限公司) us a Chinese e-commerce company...'
     >>> amz = u'Amazon.com, Inc. (/ˈæməzɒn/) is an American electronic commerce...'
     >>> rkt = u'Rakuten, Inc. (楽天株式会社 Rakuten Kabushiki-gaisha) is a Japanese electronic commerce and Internet company based in Tokyo.'

--- a/nltk/tokenize/nist.py
+++ b/nltk/tokenize/nist.py
@@ -3,7 +3,7 @@
 #
 # Copyright (C) 2001-2015 NLTK Project
 # Author:
-# Contributors: Ozan Caglayan
+# Contributors: Ozan Caglayan, Wiktor Stribizew
 #
 # URL: <http://nltk.sourceforge.net>
 # For license information, see LICENSE.TXT
@@ -15,12 +15,16 @@ which was also ported into Python in
 https://github.com/lium-lst/nmtpy/blob/master/nmtpy/metrics/mtevalbleu.py#L162
 """
 
+from __future__ import unicode_literals
+
 import io
 import re
 from six import text_type
 
+from nltk.corpus import perluniprops
 from nltk.tokenize.api import TokenizerI
 from nltk.tokenize.util import xml_unescape
+
 
 class NISTTokenizer(TokenizerI):
     """
@@ -34,9 +38,32 @@ class NISTTokenizer(TokenizerI):
     >>> s = "Good muffins cost $3.88 in New York."
     >>> expected_lower = [u'good', u'muffins', u'cost', u'$', u'3.88', u'in', u'new', u'york', u'.']
     >>> expected_cased = [u'Good', u'muffins', u'cost', u'$', u'3.88', u'in', u'New', u'York', u'.']
-    >>> nist.tokenize(s, preserve_case=True) == expected_cased
+    >>> nist.tokenize(s, lowercase=False) == expected_cased
     True
-    >>> nist.tokenize(s, preserve_case=False) == expected_lower  # Lowercased.
+    >>> nist.tokenize(s, lowercase=True) == expected_lower  # Lowercased.
+    True
+
+    The international_tokenize() is the preferred function when tokenizing
+    non-european text, e.g.
+
+    >>> from nltk.tokenize.nist import NISTTokenizer
+    >>> nist = NISTTokenizer()
+
+    # Intput strings.
+    >>> albb = u'Alibaba Group Holding Limited (Chinese: 阿里巴巴集团控股 有限公司) us a Chinese e-commerce company...'
+    >>> amz = u'Amazon.com, Inc. (/ˈæməzɒn/) is an American electronic commerce...'
+    >>> rkt = u'Rakuten, Inc. (楽天株式会社 Rakuten Kabushiki-gaisha) is a Japanese electronic commerce and Internet company based in Tokyo.'
+
+    # Expected tokens.
+    >>> expected_albb = [u'Alibaba', u'Group', u'Holding', u'Limited', u'(', u'Chinese', u':', u'\u963f\u91cc\u5df4\u5df4\u96c6\u56e2\u63a7\u80a1', u'\u6709\u9650\u516c\u53f8', u')']
+    >>> expected_amz = [u'Amazon', u'.', u'com', u',', u'Inc', u'.', u'(', u'/', u'\u02c8\xe6', u'm']
+    >>> expected_rkt = [u'Rakuten', u',', u'Inc', u'.', u'(', u'\u697d\u5929\u682a\u5f0f\u4f1a\u793e', u'Rakuten', u'Kabushiki', u'-', u'gaisha']
+
+    >>> nist.international_tokenize(albb)[:10] == expected_albb
+    True
+    >>> nist.international_tokenize(amz)[:10] == expected_amz
+    True
+    >>> nist.international_tokenize(rkt)[:10] == expected_rkt
     True
     """
     # Strip "skipped" tags
@@ -55,6 +82,35 @@ class NISTTokenizer(TokenizerI):
     LANG_DEPENDENT_REGEXES = [PUNCT, PERIOD_COMMA_PRECEED,
                               PERIOD_COMMA_FOLLOW, DASH_PRECEED_DIGIT]
 
+    # Perluniprops characters used in NIST tokenizer.
+    Number = text_type(''.join(set(perluniprops.chars('Number')))) # i.e. \p{N}
+    Punctuation = text_type(''.join(set(perluniprops.chars('Punctuation')))) # i.e. \p{P}
+    Symbol = text_type(''.join(set(perluniprops.chars('Symbol')))) # i.e. \p{S}
+
+    # Python regexes needs to escape some special symbols, see
+    # see https://stackoverflow.com/q/45670950/610569
+    Number = re.sub(r'[]^\\-]', r'\\\g<0>', Number)
+    Punctuation = re.sub(r'[]^\\-]', r'\\\g<0>', Punctuation)
+    Symbol = re.sub(r'[]^\\-]', r'\\\g<0>', Symbol)
+
+    # Note: In the original perl implementation, \p{Z} and \p{Zl} were used to
+    #       (i) strip trailing and heading spaces  and
+    #       (ii) de-deuplicate spaces.
+    #       In Python, this would do: ' '.join(str.strip().split())
+    # Thus, the next two lines were commented out.
+    #Line_Separator = text_type(''.join(perluniprops.chars('Line_Separator'))) # i.e. \p{Zl}
+    #Separator = text_type(''.join(perluniprops.chars('Separator'))) # i.e. \p{Z}
+
+    # Pads non-ascii strings with space.
+    NONASCII = re.compile('([\x00-\x7f]+)'), r' \1 '
+    #  Tokenize any punctuation unless followed AND preceded by a digit.
+    PUNCT_1 = re.compile(u"([{n}])([{p}])".format(n=Number, p=Punctuation)), '\\1 \\2 '
+    PUNCT_2 = re.compile(u"([{p}])([{n}])".format(n=Number, p=Punctuation)), ' \\1 \\2'
+    # Tokenize symbols
+    SYMBOLS = re.compile(u"({s})".format(s=Symbol)), ' \\1 '
+
+    INTERNATIONAL_REGEXES = [NONASCII, PUNCT_1, PUNCT_2, SYMBOLS]
+
     def lang_independent_sub(self, text):
         """Performs the language independent string substituitions. """
         # It's a strange order of regexes.
@@ -67,7 +123,7 @@ class NISTTokenizer(TokenizerI):
         text = regexp.sub(subsitution, text)
         return text
 
-    def tokenize(self, text, preserve_case=True,
+    def tokenize(self, text, lowercase=False,
                  western_lang=True, return_str=False):
         text = text_type(text)
         # Language independent regex.
@@ -76,7 +132,7 @@ class NISTTokenizer(TokenizerI):
         if western_lang:
             # Pad string with whitespace.
             text = ' ' + text + ' '
-            if not preserve_case:
+            if lowercase:
                 text = text.lower()
             for regexp, subsitution in self.LANG_DEPENDENT_REGEXES:
                 text = regexp.sub(subsitution, text)
@@ -87,8 +143,25 @@ class NISTTokenizer(TokenizerI):
         text = text_type(text.strip())
         return text if return_str else text.split()
 
-    def international_tokenize(self, text, preserve_case=True, return_str=False):
+    def international_tokenize(self, text, lowercase=False,
+                               split_non_ascii=True,
+                               return_str=False):
         text = text_type(text)
-        # Language independent regex.
-        text = self.lang_independent_sub(text)
-        #
+        # Different from the 'normal' tokenize(), STRIP_EOL_HYPHEN is applied
+        # first before unescaping.
+        regexp, subsitution = self.STRIP_SKIP
+        text = regexp.sub(subsitution, text)
+        regexp, subsitution = self.STRIP_EOL_HYPHEN
+        text = regexp.sub(subsitution, text)
+        text = xml_unescape(text)
+
+        if lowercase:
+            text = text.lower()
+
+        for regexp, subsitution in self.INTERNATIONAL_REGEXES:
+            text = regexp.sub(subsitution, text)
+
+        # Make sure that there's only one space only between words.
+        # Strip leading and trailing spaces.
+        text = ' '.join(text.strip().split())
+        return text if return_str else text.split()

--- a/nltk/translate/nist_score.py
+++ b/nltk/translate/nist_score.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+# Natural Language Toolkit: BLEU Score
+#
+# Copyright (C) 2001-2017 NLTK Project
+# Authors: Chin Yee Lee, Hengfeng Li, Ruxin Hou, Calvin Tanujaya Lim
+# Contributors: Dmitrijs Milajevs, Liling Tan
+# URL: <http://nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""NIST score implementation."""
+from __future__ import division
+
+import math
+import fractions
+from collections import Counter
+
+from nltk.util import ngrams
+from nltk.tokenize.nist import NISTTokenizer
+from nltk.translate.bleu_score import modified_precision, closest_ref_length
+
+try:
+    fractions.Fraction(0, 1000, _normalize=False)
+    from fractions import Fraction
+except TypeError:
+    from nltk.compat import Fraction
+
+
+def sentence_nist(references, hypothesis, n=4):
+    """
+    Calculate NIST score from
+    George Doddington. 2002. "Automatic evaluation of machine translation quality
+    using n-gram co-occurrence statistics." Proceedings of HLT.
+    Morgan Kaufmann Publishers Inc. http://dl.acm.org/citation.cfm?id=1289189.1289273
+
+    DARPA commissioned NIST to develop an MT evaluation facility based on the BLEU
+    score. The official script used by NIST to compute BLEU and NIST score is
+    mteval-14.pl. The main differences are:
+
+     - BLEU uses geometric mean of the ngram overlaps, NIST uses arithmetic mean.
+     - NIST has a different brevity penalty
+     - NIST score from mteval-14.pl has a self-contained tokenizer
+
+    Note: The mteval-14.pl includes a smoothing function for BLEU score that is NOT
+          used in the NIST score computation.
+
+    :param references: reference sentences
+    :type references: list(list(str))
+    :param hypothesis: a hypothesis sentence
+    :type hypothesis: list(str)
+    :param n: highest n-gram order
+    :type n: int
+    """
+    return corpus_bleu([references], [hypothesis], n)
+
+def corpus_nist(list_of_references, hypotheses, n=4):
+    """
+
+    :param references: a corpus of lists of reference sentences, w.r.t. hypotheses
+    :type references: list(list(list(str)))
+    :param hypotheses: a list of hypothesis sentences
+    :type hypotheses: list(list(str))
+    :param n: highest n-gram order
+    :type n: int
+    """
+    # Before proceeding to compute NIST, perform sanity checks.
+    assert len(list_of_references) == len(hypotheses), "The number of hypotheses and their reference(s) should be the same"
+
+    p_numerators = Counter() # Key = ngram order, and value = no. of ngram matches.
+    p_denominators = Counter() # Key = ngram order, and value = no. of ngram in ref.
+    hyp_lengths, ref_lengths = 0, 0
+    # Iterate through each hypothesis and their corresponding references.
+    for references, hypothesis in zip(list_of_references, hypotheses):
+        # For each order of ngram, calculate the numerator and
+        # denominator for the corpus-level modified precision.
+        for i, _ in enumerate(range(1,n+1)):
+            p_i = modified_precision(references, hypothesis, i)
+            p_numerators[i] += p_i.numerator
+            p_denominators[i] += p_i.denominator
+
+        # Calculate the hypothesis length and the closest reference length.
+        # Adds them to the corpus-level hypothesis and reference counts.
+        hyp_len =  len(hypothesis)
+        hyp_lengths += hyp_len
+        ref_lengths += closest_ref_length(references, hyp_len)
+
+    # Calculate corpus-level brevity penalty.
+    bp = nist_length_penalty(ref_lengths, hyp_lengths)
+
+    # Collects the various precision values for the different ngram orders.
+    p_n = [Fraction(p_numerators[i], p_denominators[i], _normalize=False)
+           for i, _ in enumerate(range(1,n+1))]
+
+    return bp * sum(p_n)
+
+
+def nist_length_penalty(closest_ref_len, hyp_len):
+    """
+    Calculates the NIST length penalty, from Eq. 3 in Doddington (2002)
+
+        penalty = exp( beta * log( min( len(hyp)/len(ref) , 1.0 )))
+
+    where,
+
+        `beta` is chosen to make the brevity penalty factor = 0.5 when the
+        no. of words in the system output (hyp) is 2/3 of the average
+        no. of words in the reference translation (ref)
+
+    The NIST penalty is different from BLEU's such that it minimize the impact
+    of the score of small variations in the length of a translation.
+    See Fig. 4 in  Doddington (2002)
+    """
+    ratio = closest_ref_len / hyp_len
+    if 0 < ratio < 1:
+        ratio_x, score_x = 1.5, 0.5
+        beta = math.log(score_x) / math.log(score_x)**2
+        return math.exp(beta * math.log(ratio)**2)
+    else: # ratio <= 0 or ratio >= 1
+        return max(min(x, 1.0), 0.0)


### PR DESCRIPTION
Added the NIST score, based on http://dl.acm.org/citation.cfm?id=1289273 and [mteval-14.pl](https://github.com/moses-smt/mosesdecoder/blob/master/scripts/generic/mteval-v14.pl#L889) implementation

I'm unsure of whether the final arithmetic mean computation is correct, i.e. https://github.com/alvations/nltk/blob/develop/nltk/translate/nist_score.py#L121 . 

~Should it be `return bp * sum(p_n)` or `return bp * sum(map(math.log, p_n))`? If anyone knows the right answer, please help to clarify. Thanks in advance!~
