### PR TITLE
specify tagset for russian tagger in tag init documentation

### DIFF
--- a/nltk/tag/__init__.py
+++ b/nltk/tag/__init__.py
@@ -19,12 +19,16 @@ the word ``'fly'`` with a noun part of speech tag (``'NN'``):
 
     >>> tagged_tok = ('fly', 'NN')
 
-An off-the-shelf tagger is available.  It uses the Penn Treebank tagset:
+An off-the-shelf tagger is available.  It uses the Penn Treebank tagset for English and 
+Russian National Corpus tagset for Russian:
 
     >>> from nltk import pos_tag, word_tokenize
     >>> pos_tag(word_tokenize("John's big idea isn't all that bad."))
     [('John', 'NNP'), ("'s", 'POS'), ('big', 'JJ'), ('idea', 'NN'), ('is', 'VBZ'),
     ("n't", 'RB'), ('all', 'PDT'), ('that', 'DT'), ('bad', 'JJ'), ('.', '.')]
+    >>> pos_tag(word_tokenize("Илья оторопел и дважды перечитал бумажку."), lang='rus')
+    [('Илья', 'S'), ('оторопел', 'V'), ('и', 'CONJ'), ('дважды', 'ADV'), ('перечитал', 'V'),
+	('бумажку', 'S'), ('.', 'NONLEX')]
 
 This package defines several taggers, which take a list of tokens,
 assign a tag to each one, and return the resulting list of tagged tokens.

--- a/nltk/tag/__init__.py
+++ b/nltk/tag/__init__.py
@@ -28,7 +28,7 @@ the Russian National Corpus tagset for Russian:
     ("n't", 'RB'), ('all', 'PDT'), ('that', 'DT'), ('bad', 'JJ'), ('.', '.')]
     >>> pos_tag(word_tokenize("Илья оторопел и дважды перечитал бумажку."), lang='rus')
     [('Илья', 'S'), ('оторопел', 'V'), ('и', 'CONJ'), ('дважды', 'ADV'), ('перечитал', 'V'),
-	('бумажку', 'S'), ('.', 'NONLEX')]
+    ('бумажку', 'S'), ('.', 'NONLEX')]
 
 This package defines several taggers, which take a list of tokens,
 assign a tag to each one, and return the resulting list of tagged tokens.

--- a/nltk/tag/__init__.py
+++ b/nltk/tag/__init__.py
@@ -19,13 +19,19 @@ the word ``'fly'`` with a noun part of speech tag (``'NN'``):
 
     >>> tagged_tok = ('fly', 'NN')
 
-An off-the-shelf tagger is available.  It uses the Penn Treebank tagset for English and 
-the Russian National Corpus tagset for Russian:
+An off-the-shelf tagger is available for English. It uses the Penn Treebank tagset:
 
     >>> from nltk import pos_tag, word_tokenize
     >>> pos_tag(word_tokenize("John's big idea isn't all that bad."))
     [('John', 'NNP'), ("'s", 'POS'), ('big', 'JJ'), ('idea', 'NN'), ('is', 'VBZ'),
     ("n't", 'RB'), ('all', 'PDT'), ('that', 'DT'), ('bad', 'JJ'), ('.', '.')]
+
+A Russian tagger is also available if you specify lang="rus". It uses 
+the Russian National Corpus tagset:
+
+    >>> pos_tag(word_tokenize("Илья оторопел и дважды перечитал бумажку."), lang='rus')    # doctest: +SKIP
+    [('Илья', 'S'), ('оторопел', 'V'), ('и', 'CONJ'), ('дважды', 'ADV'), ('перечитал', 'V'),
+    ('бумажку', 'S'), ('.', 'NONLEX')]
 
 This package defines several taggers, which take a list of tokens,
 assign a tag to each one, and return the resulting list of tagged tokens.

--- a/nltk/tag/__init__.py
+++ b/nltk/tag/__init__.py
@@ -20,7 +20,7 @@ the word ``'fly'`` with a noun part of speech tag (``'NN'``):
     >>> tagged_tok = ('fly', 'NN')
 
 An off-the-shelf tagger is available.  It uses the Penn Treebank tagset for English and 
-Russian National Corpus tagset for Russian:
+the Russian National Corpus tagset for Russian:
 
     >>> from nltk import pos_tag, word_tokenize
     >>> pos_tag(word_tokenize("John's big idea isn't all that bad."))

--- a/nltk/tag/__init__.py
+++ b/nltk/tag/__init__.py
@@ -26,9 +26,6 @@ the Russian National Corpus tagset for Russian:
     >>> pos_tag(word_tokenize("John's big idea isn't all that bad."))
     [('John', 'NNP'), ("'s", 'POS'), ('big', 'JJ'), ('idea', 'NN'), ('is', 'VBZ'),
     ("n't", 'RB'), ('all', 'PDT'), ('that', 'DT'), ('bad', 'JJ'), ('.', '.')]
-    >>> pos_tag(word_tokenize("Илья оторопел и дважды перечитал бумажку."), lang='rus')
-    [('Илья', 'S'), ('оторопел', 'V'), ('и', 'CONJ'), ('дважды', 'ADV'), ('перечитал', 'V'),
-    ('бумажку', 'S'), ('.', 'NONLEX')]
 
 This package defines several taggers, which take a list of tokens,
 assign a tag to each one, and return the resulting list of tagged tokens.


### PR DESCRIPTION
Specifies the tagset for the russian tagger and adds an example in tag/init's documentation.