### PR TITLE
Add environment variable option for DL_URL

### DIFF
--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -2258,7 +2258,8 @@ if __name__ == '__main__':
     parser.add_option("-e", "--exit-on-error", dest="halt_on_error", action="store_true",
         default=False, help="exit if an error occurs")
     parser.add_option("-u", "--url", dest="server_index_url",
-        default=None, help="download server index url")
+        default=os.environ.get('NLTK_DOWNLOAD_URL'),
+        help="download server index url")
 
     (options, args) = parser.parse_args()
 


### PR DESCRIPTION
With GH-1787 we have come to realize that we need a method to locally
cache NLTK data so that we are not affected by outages caused by
upstream infrastructure. The proposal here is to allow an environment
variable NLTK_DOWNLOAD_URL to be set which will allow us to configure an
override on CI systems to force all of our projects that call
ntlk.downloader to download from a local copy of nltk data instead of
from upstream default URL.

Issue: GH-1787
Signed-off-by: Thanh Ha <thanh.ha@linuxfoundation.org>