### PR TITLE
add no_escaping option

### DIFF
--- a/nltk/tokenize/moses.py
+++ b/nltk/tokenize/moses.py
@@ -43,6 +43,12 @@ class MosesTokenizer(TokenizerI):
     >>> m = MosesTokenizer()
     >>> m.tokenize('2016, pp.')
     [u'2016', u',', u'pp', u'.']
+    
+    >>> sent = "This ain't funny. It's actually hillarious, yet double Ls. | [] < > [ ] & You're gonna shake it off? Don't?"
+    >>> m.tokenize(sent, escape=True)
+    ['This', 'ain', '&apos;t', 'funny', '.', 'It', '&apos;s', 'actually', 'hillarious', ',', 'yet', 'double', 'Ls', '.', '&#124;', '&#91;', '&#93;', '&lt;', '&gt;', '&#91;', '&#93;', '&amp;', 'You', '&apos;re', 'gonna', 'shake', 'it', 'off', '?', 'Don', '&apos;t', '?']
+    >>> m.tokenize(sent, escape=False)
+    ['This', 'ain', "'t", 'funny', '.', 'It', "'s", 'actually', 'hillarious', ',', 'yet', 'double', 'Ls', '.', '|', '[', ']', '<', '>', '[', ']', '&', 'You', "'re", 'gonna', 'shake', 'it', 'off', '?', 'Don', "'t", '?']
     """
 
     # Perl Unicode Properties character sets.
@@ -417,6 +423,11 @@ class MosesDetokenizer(TokenizerI):
     >>> detokens = d.detokenize(tokens)
     >>> " ".join(detokens) == expected_detokens
     True
+    
+    >>> d.detokenize(expected_tokens, unescape=True)
+    ['This', "ain't", 'funny.', "It's", 'actually', 'hillarious,', 'yet', 'double', 'Ls.', '|', '[]', '<', '>', '[]', '&', "You're", 'gonna', 'shake', 'it', 'off?', "Don't?"]
+    >>> d.detokenize(expected_tokens, unescape=False)
+    ['This', 'ain', '&apos;t', 'funny.', 'It', '&apos;s', 'actually', 'hillarious,', 'yet', 'double', 'Ls.', '&#124;', '&#91;', '&#93;', '&lt;', '&gt;', '&#91;', '&#93;', '&amp;', 'You', '&apos;re', 'gonna', 'shake', 'it', 'off?', 'Don', '&apos;t?']
     """
     # Currency Symbols.
     IsAlnum = text_type(''.join(perluniprops.chars('IsAlnum')))
@@ -618,6 +629,6 @@ class MosesDetokenizer(TokenizerI):
 
         return detokenized_text if return_str else detokenized_text.split()
 
-    def detokenize(self, tokens, return_str=False):
+    def detokenize(self, tokens, return_str=False, unescape=True):
         """ Duck-typing the abstract *tokenize()*."""
-        return self.tokenize(tokens, return_str)
+        return self.tokenize(tokens, return_str, unescape)

--- a/nltk/tokenize/moses.py
+++ b/nltk/tokenize/moses.py
@@ -236,7 +236,7 @@ class MosesTokenizer(TokenizerI):
                                 ESCAPE_LEFT_SQUARE_BRACKET,
                                 ESCAPE_RIGHT_SQUARE_BRACKET]
 
-    def __init__(self, lang='en', no_escaping=False):
+    def __init__(self, lang='en'):
         # Initialize the object.
         super(MosesTokenizer, self).__init__()
         self.lang = lang
@@ -245,7 +245,6 @@ class MosesTokenizer(TokenizerI):
         self.NUMERIC_ONLY_PREFIXES = [w.rpartition(' ')[0] for w in
                                       self.NONBREAKING_PREFIXES if
                                       self.has_numeric_only(w)]
-        self.no_escaping = no_escaping
 
 
 
@@ -324,7 +323,7 @@ class MosesTokenizer(TokenizerI):
             text = re.sub(regexp, substitution, text)
         return text if return_str else text.split()
 
-    def tokenize(self, text, agressive_dash_splits=False, return_str=False):
+    def tokenize(self, text, agressive_dash_splits=False, return_str=False, escape=True):
         """
         Python port of the Moses tokenizer.
 
@@ -383,7 +382,7 @@ class MosesTokenizer(TokenizerI):
         text = re.sub(regexp,substitution, text).strip()
         # Restore multidots.
         text = self.restore_multidots(text)
-        if not self.no_escaping:
+        if escape:
             # Escape XML symbols.
             text = self.escape_xml(text)
 
@@ -484,7 +483,7 @@ class MosesDetokenizer(TokenizerI):
         return text
 
 
-    def tokenize(self, tokens, return_str=False):
+    def tokenize(self, tokens, return_str=False, unescape=True):
         """
         Python port of the Moses detokenizer.
 
@@ -499,8 +498,9 @@ class MosesDetokenizer(TokenizerI):
         # Detokenize the agressive hyphen split.
         regexp, substitution = self.AGGRESSIVE_HYPHEN_SPLIT
         text = re.sub(regexp, substitution, text)
-        # Unescape the XML symbols.
-        text = self.unescape_xml(text)
+        if unescape:
+            # Unescape the XML symbols.
+            text = self.unescape_xml(text)
         # Keep track of no. of quotation marks.
         quote_counts = {u"'":0 , u'"':0, u"``":0, u"`":0, u"''":0}
 

--- a/nltk/tokenize/moses.py
+++ b/nltk/tokenize/moses.py
@@ -236,7 +236,7 @@ class MosesTokenizer(TokenizerI):
                                 ESCAPE_LEFT_SQUARE_BRACKET,
                                 ESCAPE_RIGHT_SQUARE_BRACKET]
 
-    def __init__(self, lang='en'):
+    def __init__(self, lang='en', no_escaping=False):
         # Initialize the object.
         super(MosesTokenizer, self).__init__()
         self.lang = lang
@@ -245,6 +245,7 @@ class MosesTokenizer(TokenizerI):
         self.NUMERIC_ONLY_PREFIXES = [w.rpartition(' ')[0] for w in
                                       self.NONBREAKING_PREFIXES if
                                       self.has_numeric_only(w)]
+        self.no_escaping = no_escaping
 
 
 
@@ -382,8 +383,9 @@ class MosesTokenizer(TokenizerI):
         text = re.sub(regexp,substitution, text).strip()
         # Restore multidots.
         text = self.restore_multidots(text)
-        # Escape XML symbols.
-        text = self.escape_xml(text)
+        if not self.no_escaping:
+            # Escape XML symbols.
+            text = self.escape_xml(text)
 
         return text if return_str else text.split()
 


### PR DESCRIPTION
Adding option from the perl version of moses tokenizer to not perform html escaping https://github.com/moses-smt/mosesdecoder/blob/master/scripts/tokenizer/tokenizer.perl#L83