### PR TITLE
Fix to MosesTokenizer, related to unexpected tokens for 'No. #NUMERIC#'

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -217,6 +217,7 @@
 - Albert Au Yeung <https://github.com/albertauyeung>
 - Shenjian Zhao 
 - Deng Wang <https://github.com/lmatt-bit>
+- Ali Abdullah
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 ### Contributors to the Porter Stemmer

--- a/nltk/tokenize/moses.py
+++ b/nltk/tokenize/moses.py
@@ -241,7 +241,7 @@ class MosesTokenizer(TokenizerI):
         super(MosesTokenizer, self).__init__()
         self.lang = lang
         # Initialize the language specific nonbreaking prefixes.
-        self.NONBREAKING_PREFIXES = nonbreaking_prefixes.words(lang)
+        self.NONBREAKING_PREFIXES = [_nbp.strip() for _nbp in nonbreaking_prefixes.words(lang)]
         self.NUMERIC_ONLY_PREFIXES = [w.rpartition(' ')[0] for w in
                                       self.NONBREAKING_PREFIXES if
                                       self.has_numeric_only(w)]


### PR DESCRIPTION
This is related to issue #1796 

Previously tokenising with MosesTokenizer for the test string : 
`1 Official Records of the General Assembly, Fifty-sixth Session, Supplement No. 21 . ` 
would result in "No" and "." being split. 

````
>>> tokenizer = MosesTokenizer()
>>> tokenized_test = tokenizer.tokenize(test)
>>> tokenized_test
[u'1', u'Official', u'Records', u'of', u'the', u'General', u'Assembly', u',', u'Fifty-sixth', u'Session', u',', u'Supplement', u'No', u'.', u'21', u'.']
````

After applying the changes @alvations suggested, they remain together as they are suppose to

```
>>> tokenized_test = tokenizer.tokenize(test)
>>> tokenized_test
[u'1', u'Official', u'Records', u'of', u'the', u'General', u'Assembly', u',', u'Fifty-sixth', u'Session', u',', u'Supplement', u'No.', u'21', u'.']
```

