### PR TITLE
PunktBaseClass uses new PunktParameters per instantiation

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -218,6 +218,7 @@
 - Shenjian Zhao 
 - Deng Wang <https://github.com/lmatt-bit>
 - Ali Abdullah
+- Stoytcho Stoytchev
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 ### Contributors to the Porter Stemmer

--- a/nltk/test/tokenize.doctest
+++ b/nltk/test/tokenize.doctest
@@ -193,6 +193,13 @@ The sentence splitter should remove whitespace following the sentence boundary.
     ['See Section 3.', ')  Or Section 2.', ')']
 
 
+Two instances of PunktSentenceTokenizer should not share PunktParameters.
+
+    >>> pst = PunktSentenceTokenizer()
+    >>> pst2 = PunktSentenceTokenizer()
+    >>> pst._params is pst2._params
+    False
+
 Regression Tests: align_tokens
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Post-hoc alignment of tokens with a source string

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -521,7 +521,9 @@ class PunktBaseClass(object):
     """
 
     def __init__(self, lang_vars=PunktLanguageVars(), token_cls=PunktToken,
-            params=PunktParameters()):
+            params=None):
+        if params is None:
+            params = PunktParameters() 
         self._params = params
         self._lang_vars = lang_vars
         self._Token = token_cls


### PR DESCRIPTION
Instantiating child classes of PunktBaseClass without providing a new PunktParameters leads to all children sharing the same instance of PunktParameters. The behavior is confusing if you assume default arguments are safe and have several instances of PunktSentenceTokenizer and PunktTrainer running around. Additionally, this params link causes nltk.sent_tokenize to pick up new training without notice if PunktTrainer is instantiated by default. 
It looks like [this change ](https://github.com/nltk/nltk/commit/5357521020280da88b2b0ba29668b25fa39555e6) introduced the switch from creating a new parameters instance in __init__ to using a default arg, which is where the single-instance PunktParameters comes from. 

This patch reverts that change, making default instantiations have their own PunktParamters object. I've added a test to check this, using two instances of PunktSentenceTokenizer. 