### PR TITLE
Improve error message when data/model not found

### DIFF
--- a/nltk/data.py
+++ b/nltk/data.py
@@ -35,15 +35,23 @@ from __future__ import division
 from abc import ABCMeta, abstractmethod
 from six import add_metaclass
 
-import sys
+import functools
+import textwrap
 import io
 import os
-import textwrap
 import re
+import sys
 import zipfile
 import codecs
 
 from gzip import GzipFile, READ as GZ_READ, WRITE as GZ_WRITE
+
+try: # Python 3.
+    textwrap_indent = functools.partial(textwrap.indent, prefix='  ')
+except AttributeError: # Python 2; indent() not available for Python2.
+    textwrap_indent = functools.partial(textwrap.fill,
+                                        initial_indent='  ',
+                                        subsequent_indent='  ')
 
 try:
     from zlib import Z_SYNC_FLUSH as FLUSH
@@ -652,7 +660,7 @@ def find(resource_name, paths=None):
               ">>> import nltk\n"
               ">>> nltk.download(\'{resource}\')\n"
               "\033[0m").format(resource=resource_zipname)
-    msg = textwrap.indent(msg, '  ')
+    msg = textwrap_indent(msg)
 
     msg += '\n  Searched in:' + ''.join('\n    - %r' % d for d in paths)
     sep = '*' * 70

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -641,15 +641,21 @@ def find(resource_name, paths=None):
             except LookupError:
                 pass
 
+    # Identify the package (i.e. the .zip file) to download.
+    resource_zipname = resource_name.split('/')[1]
     # Display a friendly error message if the resource wasn't found:
-    msg = textwrap.fill(
-        'Resource %r not found.  Please use the NLTK Downloader to '
-        'obtain the resource:  >>> nltk.download()' %
-        (resource_name,), initial_indent='  ', subsequent_indent='  ',
-        width=66)
+
+    msg = str("Resource \33[93m{resource}\033[0m not found.\n"
+              "Please use the NLTK Downloader to obtain the resource:\n\n"
+              "\33[31m" # To display red text in terminal.
+              ">>> import nltk\n"
+              ">>> nltk.download(\'{resource}\')\n"
+              "\033[0m").format(resource=resource_zipname)
+    msg = textwrap.indent(msg, '  ')
+
     msg += '\n  Searched in:' + ''.join('\n    - %r' % d for d in paths)
     sep = '*' * 70
-    resource_not_found = '\n%s\n%s\n%s' % (sep, msg, sep)
+    resource_not_found = '\n%s\n%s\n%s\n' % (sep, msg, sep)
     raise LookupError(resource_not_found)
 
 

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -49,9 +49,12 @@ from gzip import GzipFile, READ as GZ_READ, WRITE as GZ_WRITE
 try: # Python 3.
     textwrap_indent = functools.partial(textwrap.indent, prefix='  ')
 except AttributeError: # Python 2; indent() not available for Python2.
-    textwrap_indent = functools.partial(textwrap.fill,
+    textwrap_fill = functools.partial(textwrap.fill,
                                         initial_indent='  ',
-                                        subsequent_indent='  ')
+                                        subsequent_indent='  ',
+                                        replace_whitespace=False)
+    def textwrap_indent(text):
+        return '\n'.join(textwrap_fill(line) for line in text.splitlines())
 
 try:
     from zlib import Z_SYNC_FLUSH as FLUSH

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -643,8 +643,9 @@ def find(resource_name, paths=None):
 
     # Identify the package (i.e. the .zip file) to download.
     resource_zipname = resource_name.split('/')[1]
+    if resource_zipname.endswith('.zip'):
+        resource_zipname = resource_zipname.rpartition('.')[0]
     # Display a friendly error message if the resource wasn't found:
-
     msg = str("Resource \33[93m{resource}\033[0m not found.\n"
               "Please use the NLTK Downloader to obtain the resource:\n\n"
               "\33[31m" # To display red text in terminal.


### PR DESCRIPTION
To discourage users from `nltk.download('all')`, @alexisdimi suggested for more informative error messages when a resource/model is not found. 

This PR attends to #1793 and #1794.

Previously, the error messages were:

```
>>> from nltk.corpus import wordnet as wn
>>> wn.all_synsets()
Traceback (most recent call last):
  File "/Users/liling.tan/anaconda3/lib/python3.6/site-packages/nltk/corpus/util.py", line 80, in __load
    try: root = nltk.data.find('{}/{}'.format(self.subdir, zip_name))
  File "/Users/liling.tan/anaconda3/lib/python3.6/site-packages/nltk/data.py", line 653, in find
    raise LookupError(resource_not_found)
LookupError: 
**********************************************************************
  Resource 'corpora/wordnet.zip/wordnet/' not found.  Please use
  the NLTK Downloader to obtain the resource:  >>> nltk.download()
  Searched in:
    - '/Users/liling.tan/nltk_data'
    - '/usr/share/nltk_data'
    - '/usr/local/share/nltk_data'
    - '/usr/lib/nltk_data'
    - '/usr/local/lib/nltk_data'
**********************************************************************
```

This new error message will look as such:

```
>>> from nltk import word_tokenize
>>> word_tokenize('x')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/liling.tan/git-stuff/nltk-alvas/nltk/tokenize/__init__.py", line 128, in word_tokenize
    sentences = [text] if preserve_line else sent_tokenize(text, language)
  File "/Users/liling.tan/git-stuff/nltk-alvas/nltk/tokenize/__init__.py", line 94, in sent_tokenize
    tokenizer = load('tokenizers/punkt/{0}.pickle'.format(language))
  File "/Users/liling.tan/git-stuff/nltk-alvas/nltk/data.py", line 820, in load
    opened_resource = _open(resource_url)
  File "/Users/liling.tan/git-stuff/nltk-alvas/nltk/data.py", line 938, in _open
    return find(path_, path + ['']).open()
  File "/Users/liling.tan/git-stuff/nltk-alvas/nltk/data.py", line 659, in find
    raise LookupError(resource_not_found)
LookupError: 
**********************************************************************
  Resource punkt not found.
  Please use the NLTK Downloader to obtain the resource:

  >>> import nltk
  >>> nltk.download('punkt')
  
  Searched in:
    - '/Users/liling.tan/nltk_data'
    - '/usr/share/nltk_data'
    - '/usr/local/share/nltk_data'
    - '/usr/lib/nltk_data'
    - '/usr/local/lib/nltk_data'
    - ''
**********************************************************************
```

Another e.g.

```
>>> from nltk.corpus import wordnet as wn
>>> wn.all_synsets()
Traceback (most recent call last):
  File "/Users/liling.tan/git-stuff/nltk-alvas/nltk/corpus/util.py", line 80, in __load
    try: root = nltk.data.find('{}/{}'.format(self.subdir, zip_name))
  File "/Users/liling.tan/git-stuff/nltk-alvas/nltk/data.py", line 659, in find
    raise LookupError(resource_not_found)
LookupError: 
**********************************************************************
  Resource wordnet.zip not found.
  Please use the NLTK Downloader to obtain the resource:

  >>> import nltk
  >>> nltk.download('wordnet')
  
  Searched in:
    - '/Users/liling.tan/nltk_data'
    - '/usr/share/nltk_data'
    - '/usr/local/share/nltk_data'
    - '/usr/lib/nltk_data'
    - '/usr/local/lib/nltk_data'
**********************************************************************
```