### PR TITLE
Ensure self is its own lowest subsumer when needed

### DIFF
--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -905,7 +905,7 @@ class Synset(_WordNetObject):
         if len(subsumers) == 0:
             return None
 
-        subsumer = subsumers[0]
+        subsumer = self if self in subsumers else subsumers[0]
 
         # Get the longest path from the LCS to the root,
         # including a correction:


### PR DESCRIPTION
Patching #1030 

Related to #1724 

Before the patch:

```python
>>> from nltk.corpus import wordnet as wn
>>> orange = wn.synsets('orange')[0]
>>> orange.lowest_common_hypernyms(orange, simulate_root=(False and orange._needs_root()), use_min_depth=True)
[Synset('fruit.n.01'), Synset('orange.n.01')]
>>> orange.wup_similarity(orange)
0.75
```

After the patch:

```python
>>> from nltk.corpus import wordnet as wn
>>> orange = wn.synsets('orange')[0]
>>> orange.lowest_common_hypernyms(orange, simulate_root=(False and orange._needs_root()), use_min_depth=True)
[Synset('fruit.n.01'), Synset('orange.n.01')]
>>> orange.wup_similarity(orange)
1.0
```