### PR TITLE
data.py: Add sys.prefix in the paths for unix

### DIFF
--- a/nltk/data.py
+++ b/nltk/data.py
@@ -105,7 +105,9 @@ else:
         str('/usr/share/nltk_data'),
         str('/usr/local/share/nltk_data'),
         str('/usr/lib/nltk_data'),
-        str('/usr/local/lib/nltk_data')
+        str('/usr/local/lib/nltk_data'),
+        os.path.join(sys.prefix, str('nltk_data')),
+        os.path.join(sys.prefix, str('lib'), str('nltk_data'))
     ]
 
 


### PR DESCRIPTION
This is already present in Windows but not for Unix. Hence
Anaconda in Unix doesn't work easily.