### PR TITLE
Fix typo on naivebayes.py documentation

### DIFF
--- a/nltk/classify/naivebayes.py
+++ b/nltk/classify/naivebayes.py
@@ -21,7 +21,7 @@ independent, given the label:
 |  P(label|features) = --------------------------------------------
 |                                         P(features)
 
-Rather than computing P(featues) explicitly, the algorithm just
+Rather than computing P(features) explicitly, the algorithm just
 calculates the numerator for each label, and normalizes them so they
 sum to one:
 


### PR DESCRIPTION
- P(featues) -> P(features)