### PR TITLE
Hotfix/bug in bleu score

### DIFF
--- a/AUTHORS.markdown
+++ b/AUTHORS.markdown
@@ -1,1 +1,0 @@
-Björn Mattsson

--- a/AUTHORS.markdown
+++ b/AUTHORS.markdown
@@ -1,0 +1,1 @@
+Björn Mattsson

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -222,6 +222,7 @@
 - Ali Abdullah
 - Stoytcho Stoytchev
 - Lakhdar Benzahia
+- Björn Mattsson
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 ### Contributors to the Porter Stemmer

--- a/nltk/test/unit/translate/test_bleu.py
+++ b/nltk/test/unit/translate/test_bleu.py
@@ -122,8 +122,10 @@ class TestBLEU(unittest.TestCase):
     def test_partial_matches_hypothesis_longer_than_reference(self):
         references = ['John loves Mary'.split()]
         hypothesis = 'John loves Mary who loves Mike'.split()
-        self.assertAlmostEqual(sentence_bleu(references, hypothesis), 0.4729, places=4)
-        # Checks that the warning has been raised because len(reference) < 4.
+        # Since no 4-grams matches were found the result should be zero
+        # exp(w_1 * 1 * w_2 * 1 * w_3 * 1 * w_4 * -inf) = 0
+        self.assertAlmostEqual(sentence_bleu(references, hypothesis), 0.0, places=4)
+        # Checks that the warning has been raised.
         try:
             self.assertWarns(UserWarning, sentence_bleu, references, hypothesis)
         except AttributeError:
@@ -138,8 +140,10 @@ class TestBLEUFringeCases(unittest.TestCase):
         hypothesis = 'John loves Mary'.split()
         n = len(hypothesis) + 1 #
         weights = [1.0/n] * n # Uniform weights.
-        self.assertAlmostEqual(sentence_bleu(references, hypothesis, weights), 0.7165, places=4)
-        # Checks that the warning has been raised because len(hypothesis) < 4.
+        # Since no n-grams matches were found the result should be zero
+        # exp(w_1 * 1 * w_2 * 1 * w_3 * 1 * w_4 * -inf) = 0
+        self.assertAlmostEqual(sentence_bleu(references, hypothesis, weights), 0.0, places=4)
+        # Checks that the warning has been raised.
         try:
             self.assertWarns(UserWarning, sentence_bleu, references, hypothesis)
         except AttributeError:
@@ -149,7 +153,9 @@ class TestBLEUFringeCases(unittest.TestCase):
         # it's a special case where reference == hypothesis.
         references = ['John loves Mary'.split()]
         hypothesis = 'John loves Mary'.split()
-        assert(sentence_bleu(references, hypothesis, weights) == 1.0)
+        # Since no 4-grams matches were found the result should be zero
+        # exp(w_1 * 1 * w_2 * 1 * w_3 * 1 * w_4 * -inf) = 0
+        self.assertAlmostEqual(sentence_bleu(references, hypothesis, weights), 0.0, places=4)
 
     def test_empty_hypothesis(self):
         # Test case where there's hypothesis is empty.
@@ -174,8 +180,9 @@ class TestBLEUFringeCases(unittest.TestCase):
         # is shorter than 4.
         references = ['let it go'.split()]
         hypothesis = 'let go it'.split()
-        # Checks that the value the hypothesis and reference returns is 1.0
-        assert(sentence_bleu(references, hypothesis) == 1.0)
+        # Checks that the value the hypothesis and reference returns is 0.0
+        # exp(w_1 * 1 * w_2 * 1 * w_3 * 1 * w_4 * -inf) = 0
+        self.assertAlmostEqual(sentence_bleu(references, hypothesis), 0.0, places=4)
         # Checks that the warning has been raised.
         try:
             self.assertWarns(UserWarning, sentence_bleu, references, hypothesis)

--- a/nltk/test/unit/translate/test_bleu.py
+++ b/nltk/test/unit/translate/test_bleu.py
@@ -125,12 +125,13 @@ class TestBLEU(unittest.TestCase):
         self.assertAlmostEqual(sentence_bleu(references, hypothesis, backoff=True), 0.4729, places=4)
         # Since no 4-grams matches were found the result should be zero
         # exp(w_1 * 1 * w_2 * 1 * w_3 * 1 * w_4 * -inf) = 0
-        self.assertAlmostEqual(sentence_bleu(references, hypothesis, enable_multibleu=True), 0.0, places=4)
+        self.assertAlmostEqual(sentence_bleu(references, hypothesis, emulate_multibleu=True), 0.0, places=4)
         # Checks that the warning has been raised because len(reference) < 4.
         try:
             self.assertWarns(UserWarning, sentence_bleu, references, hypothesis)
         except AttributeError:
             pass # unittest.TestCase.assertWarns is only supported in Python >= 3.2.
+
 
 #@unittest.skip("Skipping fringe cases for BLEU.")
 class TestBLEUFringeCases(unittest.TestCase):
@@ -144,7 +145,7 @@ class TestBLEUFringeCases(unittest.TestCase):
         self.assertAlmostEqual(sentence_bleu(references, hypothesis, weights, backoff=True), 0.7165, places=4)
         # Since no n-grams matches were found the result should be zero
         # exp(w_1 * 1 * w_2 * 1 * w_3 * 1 * w_4 * -inf) = 0
-        self.assertAlmostEqual(sentence_bleu(references, hypothesis, weights, enable_multibleu=True), 0.0, places=4)
+        self.assertAlmostEqual(sentence_bleu(references, hypothesis, weights, emulate_multibleu=True), 0.0, places=4)
         # Checks that the warning has been raised because len(hypothesis) < 4.
         try:
             self.assertWarns(UserWarning, sentence_bleu, references, hypothesis)
@@ -158,7 +159,7 @@ class TestBLEUFringeCases(unittest.TestCase):
         assert(sentence_bleu(references, hypothesis, weights, backoff=True) == 1.0)
         # Since no 4-grams matches were found the result should be zero
         # exp(w_1 * 1 * w_2 * 1 * w_3 * 1 * w_4 * -inf) = 0
-        self.assertAlmostEqual(sentence_bleu(references, hypothesis, weights, enable_multibleu=True), 0.0, places=4)
+        self.assertAlmostEqual(sentence_bleu(references, hypothesis, weights, emulate_multibleu=True), 0.0, places=4)
 
     def test_empty_hypothesis(self):
         # Test case where there's hypothesis is empty.
@@ -187,7 +188,7 @@ class TestBLEUFringeCases(unittest.TestCase):
         assert(sentence_bleu(references, hypothesis, backoff=True) == 1.0)
         # Checks that the value the hypothesis and reference returns is 0.0
         # exp(w_1 * 1 * w_2 * 1 * w_3 * 1 * w_4 * -inf) = 0
-        self.assertAlmostEqual(sentence_bleu(references, hypothesis, enable_multibleu=True), 0.0, places=4)
+        self.assertAlmostEqual(sentence_bleu(references, hypothesis, emulate_multibleu=True), 0.0, places=4)
         # Checks that the warning has been raised.
         try:
             self.assertWarns(UserWarning, sentence_bleu, references, hypothesis)

--- a/nltk/test/unit/translate/test_bleu.py
+++ b/nltk/test/unit/translate/test_bleu.py
@@ -228,20 +228,17 @@ class TestBLEUvsMteval13a(unittest.TestCase):
                                             smoothing_function=chencherry.method3)
                     assert abs(mteval_bleu - nltk_bleu) < 0.005
 
-class TestEmulateMultiBLEU(unittest.TestCase):
+class TestBLEUWithBadSentence(unittest.TestCase):
     def test_corpus_bleu_with_bad_sentence(self):
         hyp = "Teo S yb , oe uNb , R , T t , , t Tue Ar saln S , , 5istsi l , 5oe R ulO sae oR R"
         ref = str("Their tasks include changing a pump on the faulty stokehold ."
                   "Likewise , two species that are very similar in morphology "
                   "were distinguished using genetics .")
         references = [[ref.split()]]
-        hypothese = [hyp.split()]
+        hypotheses = [hyp.split()]
         try: # Check that the warning is raised since no. of 2-grams < 0.
             with self.assertWarns(UserWarning):
                 # Verify that the BLEU output is undesired since no. of 2-grams < 0.
-                self.assertAlmostEqual(corpus_bleu(references, hypothese), 0.4309, places=4)
-        except AttributeError:
-            pass # unittest.TestCase.assertWarns is only supported in Python >= 3.2.
-        desired_output = corpus_bleu(references, hypothese)
-        #assert
-        assert desired_output == 0.0
+                self.assertAlmostEqual(corpus_bleu(references, hypotheses), 0.0, places=4)
+        except AttributeError: # unittest.TestCase.assertWarns is only supported in Python >= 3.2.
+            self.assertAlmostEqual(corpus_bleu(references, hypotheses), 0.0, places=4)

--- a/nltk/test/unit/translate/test_bleu.py
+++ b/nltk/test/unit/translate/test_bleu.py
@@ -122,6 +122,9 @@ class TestBLEU(unittest.TestCase):
     def test_partial_matches_hypothesis_longer_than_reference(self):
         references = ['John loves Mary'.split()]
         hypothesis = 'John loves Mary who loves Mike'.split()
+        # Test with 3-gram BLEU scores
+        weights = [1.0/3] * 3  # Uniform weights
+        self.assertAlmostEqual(sentence_bleu(references, hypothesis, weights), 0.36840, places=4)
         # Since no 4-grams matches were found the result should be zero
         # exp(w_1 * 1 * w_2 * 1 * w_3 * 1 * w_4 * -inf) = 0
         self.assertAlmostEqual(sentence_bleu(references, hypothesis), 0.0, places=4)
@@ -156,6 +159,11 @@ class TestBLEUFringeCases(unittest.TestCase):
         # Since no 4-grams matches were found the result should be zero
         # exp(w_1 * 1 * w_2 * 1 * w_3 * 1 * w_4 * -inf) = 0
         self.assertAlmostEqual(sentence_bleu(references, hypothesis, weights), 0.0, places=4)
+        # Checks that the warning has been raised because len(hypothesis)
+        try:
+            self.assertWarns(UserWarning, sentence_bleu, references, hypothesis)
+        except AttributeError:
+            pass # unittest.TestCase.assertWarns is only supported in Python >= 3.2.
 
     def test_empty_hypothesis(self):
         # Test case where there's hypothesis is empty.

--- a/nltk/test/unit/translate/test_bleu.py
+++ b/nltk/test/unit/translate/test_bleu.py
@@ -125,7 +125,7 @@ class TestBLEU(unittest.TestCase):
         # Since no 4-grams matches were found the result should be zero
         # exp(w_1 * 1 * w_2 * 1 * w_3 * 1 * w_4 * -inf) = 0
         self.assertAlmostEqual(sentence_bleu(references, hypothesis), 0.0, places=4)
-        # Checks that the warning has been raised.
+        # Checks that the warning has been raised because len(reference) < 4.
         try:
             self.assertWarns(UserWarning, sentence_bleu, references, hypothesis)
         except AttributeError:
@@ -143,7 +143,7 @@ class TestBLEUFringeCases(unittest.TestCase):
         # Since no n-grams matches were found the result should be zero
         # exp(w_1 * 1 * w_2 * 1 * w_3 * 1 * w_4 * -inf) = 0
         self.assertAlmostEqual(sentence_bleu(references, hypothesis, weights), 0.0, places=4)
-        # Checks that the warning has been raised.
+        # Checks that the warning has been raised because len(hypothesis) < 4.
         try:
             self.assertWarns(UserWarning, sentence_bleu, references, hypothesis)
         except AttributeError:

--- a/nltk/test/unit/translate/test_bleu.py
+++ b/nltk/test/unit/translate/test_bleu.py
@@ -122,12 +122,10 @@ class TestBLEU(unittest.TestCase):
     def test_partial_matches_hypothesis_longer_than_reference(self):
         references = ['John loves Mary'.split()]
         hypothesis = 'John loves Mary who loves Mike'.split()
-        # Test with 3-gram BLEU scores
-        weights = [1.0/3] * 3  # Uniform weights
-        self.assertAlmostEqual(sentence_bleu(references, hypothesis, weights), 0.36840, places=4)
+        self.assertAlmostEqual(sentence_bleu(references, hypothesis, backoff=True), 0.4729, places=4)
         # Since no 4-grams matches were found the result should be zero
         # exp(w_1 * 1 * w_2 * 1 * w_3 * 1 * w_4 * -inf) = 0
-        self.assertAlmostEqual(sentence_bleu(references, hypothesis), 0.0, places=4)
+        self.assertAlmostEqual(sentence_bleu(references, hypothesis, enable_multibleu=True), 0.0, places=4)
         # Checks that the warning has been raised because len(reference) < 4.
         try:
             self.assertWarns(UserWarning, sentence_bleu, references, hypothesis)
@@ -143,9 +141,10 @@ class TestBLEUFringeCases(unittest.TestCase):
         hypothesis = 'John loves Mary'.split()
         n = len(hypothesis) + 1 #
         weights = [1.0/n] * n # Uniform weights.
+        self.assertAlmostEqual(sentence_bleu(references, hypothesis, weights, backoff=True), 0.7165, places=4)
         # Since no n-grams matches were found the result should be zero
         # exp(w_1 * 1 * w_2 * 1 * w_3 * 1 * w_4 * -inf) = 0
-        self.assertAlmostEqual(sentence_bleu(references, hypothesis, weights), 0.0, places=4)
+        self.assertAlmostEqual(sentence_bleu(references, hypothesis, weights, enable_multibleu=True), 0.0, places=4)
         # Checks that the warning has been raised because len(hypothesis) < 4.
         try:
             self.assertWarns(UserWarning, sentence_bleu, references, hypothesis)
@@ -156,14 +155,10 @@ class TestBLEUFringeCases(unittest.TestCase):
         # it's a special case where reference == hypothesis.
         references = ['John loves Mary'.split()]
         hypothesis = 'John loves Mary'.split()
+        assert(sentence_bleu(references, hypothesis, weights, backoff=True) == 1.0)
         # Since no 4-grams matches were found the result should be zero
         # exp(w_1 * 1 * w_2 * 1 * w_3 * 1 * w_4 * -inf) = 0
-        self.assertAlmostEqual(sentence_bleu(references, hypothesis, weights), 0.0, places=4)
-        # Checks that the warning has been raised because len(hypothesis)
-        try:
-            self.assertWarns(UserWarning, sentence_bleu, references, hypothesis)
-        except AttributeError:
-            pass # unittest.TestCase.assertWarns is only supported in Python >= 3.2.
+        self.assertAlmostEqual(sentence_bleu(references, hypothesis, weights, enable_multibleu=True), 0.0, places=4)
 
     def test_empty_hypothesis(self):
         # Test case where there's hypothesis is empty.
@@ -188,9 +183,11 @@ class TestBLEUFringeCases(unittest.TestCase):
         # is shorter than 4.
         references = ['let it go'.split()]
         hypothesis = 'let go it'.split()
+        # Checks that the value the hypothesis and reference returns is 1.0
+        assert(sentence_bleu(references, hypothesis, backoff=True) == 1.0)
         # Checks that the value the hypothesis and reference returns is 0.0
         # exp(w_1 * 1 * w_2 * 1 * w_3 * 1 * w_4 * -inf) = 0
-        self.assertAlmostEqual(sentence_bleu(references, hypothesis), 0.0, places=4)
+        self.assertAlmostEqual(sentence_bleu(references, hypothesis, enable_multibleu=True), 0.0, places=4)
         # Checks that the warning has been raised.
         try:
             self.assertWarns(UserWarning, sentence_bleu, references, hypothesis)

--- a/nltk/test/unit/translate/test_bleu.py
+++ b/nltk/test/unit/translate/test_bleu.py
@@ -122,10 +122,9 @@ class TestBLEU(unittest.TestCase):
     def test_partial_matches_hypothesis_longer_than_reference(self):
         references = ['John loves Mary'.split()]
         hypothesis = 'John loves Mary who loves Mike'.split()
-        self.assertAlmostEqual(sentence_bleu(references, hypothesis, backoff=True), 0.4729, places=4)
         # Since no 4-grams matches were found the result should be zero
         # exp(w_1 * 1 * w_2 * 1 * w_3 * 1 * w_4 * -inf) = 0
-        self.assertAlmostEqual(sentence_bleu(references, hypothesis, emulate_multibleu=True), 0.0, places=4)
+        self.assertAlmostEqual(sentence_bleu(references, hypothesis), 0.0, places=4)
         # Checks that the warning has been raised because len(reference) < 4.
         try:
             self.assertWarns(UserWarning, sentence_bleu, references, hypothesis)
@@ -142,10 +141,9 @@ class TestBLEUFringeCases(unittest.TestCase):
         hypothesis = 'John loves Mary'.split()
         n = len(hypothesis) + 1 #
         weights = [1.0/n] * n # Uniform weights.
-        self.assertAlmostEqual(sentence_bleu(references, hypothesis, weights, backoff=True), 0.7165, places=4)
         # Since no n-grams matches were found the result should be zero
         # exp(w_1 * 1 * w_2 * 1 * w_3 * 1 * w_4 * -inf) = 0
-        self.assertAlmostEqual(sentence_bleu(references, hypothesis, weights, emulate_multibleu=True), 0.0, places=4)
+        self.assertAlmostEqual(sentence_bleu(references, hypothesis, weights), 0.0, places=4)
         # Checks that the warning has been raised because len(hypothesis) < 4.
         try:
             self.assertWarns(UserWarning, sentence_bleu, references, hypothesis)
@@ -156,10 +154,9 @@ class TestBLEUFringeCases(unittest.TestCase):
         # it's a special case where reference == hypothesis.
         references = ['John loves Mary'.split()]
         hypothesis = 'John loves Mary'.split()
-        assert(sentence_bleu(references, hypothesis, weights, backoff=True) == 1.0)
         # Since no 4-grams matches were found the result should be zero
         # exp(w_1 * 1 * w_2 * 1 * w_3 * 1 * w_4 * -inf) = 0
-        self.assertAlmostEqual(sentence_bleu(references, hypothesis, weights, emulate_multibleu=True), 0.0, places=4)
+        self.assertAlmostEqual(sentence_bleu(references, hypothesis, weights), 0.0, places=4)
 
     def test_empty_hypothesis(self):
         # Test case where there's hypothesis is empty.
@@ -184,11 +181,9 @@ class TestBLEUFringeCases(unittest.TestCase):
         # is shorter than 4.
         references = ['let it go'.split()]
         hypothesis = 'let go it'.split()
-        # Checks that the value the hypothesis and reference returns is 1.0
-        assert(sentence_bleu(references, hypothesis, backoff=True) == 1.0)
         # Checks that the value the hypothesis and reference returns is 0.0
         # exp(w_1 * 1 * w_2 * 1 * w_3 * 1 * w_4 * -inf) = 0
-        self.assertAlmostEqual(sentence_bleu(references, hypothesis, emulate_multibleu=True), 0.0, places=4)
+        self.assertAlmostEqual(sentence_bleu(references, hypothesis), 0.0, places=4)
         # Checks that the warning has been raised.
         try:
             self.assertWarns(UserWarning, sentence_bleu, references, hypothesis)
@@ -234,7 +229,7 @@ class TestBLEUvsMteval13a(unittest.TestCase):
                     assert abs(mteval_bleu - nltk_bleu) < 0.005
 
 class TestEmulateMultiBLEU(unittest.TestCase):
-    def test_corpus_bleu_with_emulate_multibleu(self):
+    def test_corpus_bleu_with_bad_sentence(self):
         hyp = "Teo S yb , oe uNb , R , T t , , t Tue Ar saln S , , 5istsi l , 5oe R ulO sae oR R"
         ref = str("Their tasks include changing a pump on the faulty stokehold ."
                   "Likewise , two species that are very similar in morphology "
@@ -247,7 +242,6 @@ class TestEmulateMultiBLEU(unittest.TestCase):
                 self.assertAlmostEqual(corpus_bleu(references, hypothese), 0.4309, places=4)
         except AttributeError:
             pass # unittest.TestCase.assertWarns is only supported in Python >= 3.2.
-        desired_output = corpus_bleu(references, hypothese,
-                                     emulate_multibleu=True)
+        desired_output = corpus_bleu(references, hypothese)
         #assert
         assert desired_output == 0.0

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -525,7 +525,6 @@ class SmoothingFunction:
         if _emulate_multibleu:
             _backoff = False
 
-        if _emulate_multibleu:
         for i, p_i in enumerate(p_n):
             if p_i.numerator != 0:
                 p_n_new.append(p_i)
@@ -534,7 +533,7 @@ class SmoothingFunction:
                     _msg = str("\nThe hypothesis contains 0 counts of {}-gram overlaps.\n"
                                "Therefore the BLEU score evaluates to 0, independently of\n"
                                "how many N-gram overlaps of lower order it contains.\n"
-                               "Consider using the SmoothingFunction().").format(i+1)
+                               "Consider using lower n-gram order or use SmoothingFunction()").format(i+1)
                     warnings.warn(_msg)
                     # When numerator==0 where denonminator==0 or !=0, the result
                     # for the precision score should be equal to 0 or undefined.

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -26,8 +26,7 @@ except TypeError:
 
 
 def sentence_bleu(references, hypothesis, weights=(0.25, 0.25, 0.25, 0.25),
-                  smoothing_function=None, auto_reweigh=False,
-                  emulate_multibleu=False, backoff=True):
+                  smoothing_function=None, auto_reweigh=False):
     """
     Calculate BLEU score (Bilingual Evaluation Understudy) from
     Papineni, Kishore, Salim Roukos, Todd Ward, and Wei-Jing Zhu. 2002.
@@ -60,7 +59,8 @@ def sentence_bleu(references, hypothesis, weights=(0.25, 0.25, 0.25, 0.25),
 
     If no ngram overlap exists for any of the orders that are used to evaluate BLEU
     it will return the value zero. This since BLEU is a geometric mean of the precisions
-    for the different ngram orders (no overlap means a precision of 0).
+    for the different ngram orders (no overlap means a precision of 0). The following example
+    has zero 3gram overlaps:
 
     >>> round(sentence_bleu([reference1, reference2, reference3], hypothesis2),4) # doctest: +ELLIPSIS
     0.0

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -142,7 +142,7 @@ def corpus_bleu(list_of_references, hypotheses, weights=(0.25, 0.25, 0.25, 0.25)
     :type smoothing_function: SmoothingFunction
     :param auto_reweigh: Option to re-normalize the weights uniformly.
     :type auto_reweigh: bool
-    :param emulate_multibleu: Option to emulate multi-bleu.pl behavior
+    :param emulate_multibleu: Option to return 0 BLEU score if there's less than one 4-gram overlap.
     :type emulate_multibleu: bool
     :param backoff: Option to backoff to the largest n-gram overlap if there's less than one 4-gram overlap.
     :type backoff: bool

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -200,7 +200,8 @@ def corpus_bleu(list_of_references, hypotheses, weights=(0.25, 0.25, 0.25, 0.25)
     #       it tries to retain the Fraction object as much as the
     #       smoothing method allows.
     p_n = smoothing_function(p_n, references=references, hypothesis=hypothesis,
-                             hyp_len=hyp_len, emulate_multibleu=emulate_multibleu)
+                             hyp_len=hyp_len, emulate_multibleu=emulate_multibleu,
+                             backoff=backoff)
     s = (w * math.log(p_i) for i, (w, p_i) in enumerate(zip(weights, p_n)))
     s =  bp * math.exp(math.fsum(s))
     return round(s, 4) if emulate_multibleu else s

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -197,7 +197,7 @@ def corpus_bleu(list_of_references, hypotheses, weights=(0.25, 0.25, 0.25, 0.25)
     #       smoothing method allows.
     p_n = smoothing_function(p_n, references=references, hypothesis=hypothesis,
                              hyp_len=hyp_len, emulate_multibleu=emulate_multibleu)
-    s = (w * math.log(p_i) for i, (w, p_i) in enumerate(zip(weights, p_n)))
+    s = (w_i * math.log(p_i) for w_i, p_i in zip(weights, p_n))
     s =  bp * math.exp(math.fsum(s))
     return round(s, 4) if emulate_multibleu else s
 
@@ -482,13 +482,13 @@ class SmoothingFunction:
             if p_i.numerator != 0:
                 p_n_new.append(p_i)
             else:
+                # To avoid math error when math.log(0) we replace 0 with
+                # sys.float_info.min
                 _msg = str("\nCorpus/Sentence contains 0 counts of {}-gram overlaps.\n"
                            "BLEU score will be zero; consider "
                            "using SmoothingFunction().").format(i+1)
                 warnings.warn(_msg)
-                return [sys.float_info.min]
-                # If this order of n-gram returns 0 counts, the higher order
-                # n-gram would also return 0, thus returning here.
+                p_n_new.append(sys.float_info.min)
         return p_n_new
 
     def method1(self, p_n, *args, **kwargs):

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -58,12 +58,23 @@ def sentence_bleu(references, hypothesis, weights=(0.25, 0.25, 0.25, 0.25),
     >>> sentence_bleu([reference1, reference2, reference3], hypothesis1) # doctest: +ELLIPSIS
     0.5045...
 
+    If no ngram overlap exists for any of the orders that are used to evaluate BLEU
+    it will return the value zero. This since BLEU is a geometric mean of the precisions
+    for the different ngram orders (no overlap means a precision of 0).
+
     >>> round(sentence_bleu([reference1, reference2, reference3], hypothesis2),4) # doctest: +ELLIPSIS
     0.0
 
+    To avoid this harsh behaviour when no ngram overlaps are found a smoothing function can be used.
+
+    >>> chencherry = SmoothingFunction()
+    >>> sentence_bleu([reference1, reference2, reference3], hypothesis2,
+    ...     smoothing_function=chencherry.method1) # doctest: +ELLIPSIS
+    0.0370...
+
     The default BLEU calculates a score for up to 4grams using uniform
     weights. To evaluate your translations with higher/lower order ngrams,
-    use customized weights. E.g. when accounting for up to 6grams with uniform
+    use customized weights. E.g. when accounting for up to 5grams with uniform
     weights:
 
     >>> weights = (0.1666, 0.1666, 0.1666, 0.1666, 0.1666)
@@ -78,7 +89,7 @@ def sentence_bleu(references, hypothesis, weights=(0.25, 0.25, 0.25, 0.25),
     :type weights: list(float)
     :param smoothing_function:
     :type smoothing_function: SmoothingFunction
-    :param auto_reweigh:
+    :param auto_reweigh: Option to re-normalize the weights uniformly.
     :type auto_reweigh: bool
     :return: The sentence-level BLEU score.
     :rtype: float
@@ -140,7 +151,6 @@ def corpus_bleu(list_of_references, hypotheses, weights=(0.25, 0.25, 0.25, 0.25)
     :param auto_reweigh: Option to re-normalize the weights uniformly.
     :type auto_reweigh: bool
     :return: The corpus-level BLEU score.
-    :
     :rtype: float
     """
     # Before proceeding to compute BLEU, perform sanity checks.
@@ -194,7 +204,7 @@ def corpus_bleu(list_of_references, hypotheses, weights=(0.25, 0.25, 0.25, 0.25)
     #       smoothing method allows.
     p_n = smoothing_function(p_n, references=references, hypothesis=hypothesis,
                              hyp_len=hyp_len)
-    s = (w * math.log(p_i) for i, (w, p_i) in enumerate(zip(weights, p_n)))
+    s = (w_i * math.log(p_i) for w_i, p_i in zip(weights, p_n))
     s =  bp * math.exp(math.fsum(s))
     return s
 

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -145,8 +145,8 @@ def corpus_bleu(list_of_references, hypotheses, weights=(0.25, 0.25, 0.25, 0.25)
     :param emulate_multibleu: Option to emulate multi-bleu.pl behavior
     :type emulate_multibleu: bool
     :param backoff: Option to backoff to the largest n-gram overlap if there's less than one 4-gram overlap.
+    :type backoff: bool
     :return: The corpus-level BLEU score.
-    :param backoff: bool
     :
     :rtype: float
     """

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -3,7 +3,7 @@
 #
 # Copyright (C) 2001-2017 NLTK Project
 # Authors: Chin Yee Lee, Hengfeng Li, Ruxin Hou, Calvin Tanujaya Lim
-# Contributors: Dmitrijs Milajevs, Liling Tan
+# Contributors: Björn Mattsson, Dmitrijs Milajevs, Liling Tan
 # URL: <http://nltk.org/>
 # For license information, see LICENSE.TXT
 

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -481,16 +481,14 @@ class SmoothingFunction:
         for i, p_i in enumerate(p_n):
             if p_i.numerator != 0:
                 p_n_new.append(p_i)
-            elif _emulate_multibleu and i < 5:
-                return [sys.float_info.min]
             else:
                 _msg = str("\nCorpus/Sentence contains 0 counts of {}-gram overlaps.\n"
-                           "BLEU scores might be undesirable; "
-                           "use SmoothingFunction().").format(i+1)
+                           "BLEU score will be zero; consider "
+                           "using SmoothingFunction().").format(i+1)
                 warnings.warn(_msg)
+                return [sys.float_info.min]
                 # If this order of n-gram returns 0 counts, the higher order
-                # n-gram would also return 0, thus breaking the loop here.
-                break
+                # n-gram would also return 0, thus returning here.
         return p_n_new
 
     def method1(self, p_n, *args, **kwargs):

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -80,7 +80,6 @@ def sentence_bleu(references, hypothesis, weights=(0.25, 0.25, 0.25, 0.25),
     :type smoothing_function: SmoothingFunction
     :param auto_reweigh:
     :type auto_reweigh: bool
-    :param emulate_multibleu: bool
     :return: The sentence-level BLEU score.
     :rtype: float
     """
@@ -90,8 +89,7 @@ def sentence_bleu(references, hypothesis, weights=(0.25, 0.25, 0.25, 0.25),
 
 
 def corpus_bleu(list_of_references, hypotheses, weights=(0.25, 0.25, 0.25, 0.25),
-                smoothing_function=None, auto_reweigh=False,
-                emulate_multibleu=False, backoff=True):
+                smoothing_function=None, auto_reweigh=False):
     """
     Calculate a single corpus-level BLEU score (aka. system-level BLEU) for all
     the hypotheses and their respective references.
@@ -142,10 +140,6 @@ def corpus_bleu(list_of_references, hypotheses, weights=(0.25, 0.25, 0.25, 0.25)
     :type smoothing_function: SmoothingFunction
     :param auto_reweigh: Option to re-normalize the weights uniformly.
     :type auto_reweigh: bool
-    :param emulate_multibleu: Option to return 0 BLEU score if there's less than one 4-gram overlap.
-    :type emulate_multibleu: bool
-    :param backoff: Option to backoff to the largest n-gram overlap if there's less than one 4-gram overlap.
-    :type backoff: bool
     :return: The corpus-level BLEU score.
     :
     :rtype: float
@@ -200,11 +194,10 @@ def corpus_bleu(list_of_references, hypotheses, weights=(0.25, 0.25, 0.25, 0.25)
     #       it tries to retain the Fraction object as much as the
     #       smoothing method allows.
     p_n = smoothing_function(p_n, references=references, hypothesis=hypothesis,
-                             hyp_len=hyp_len, emulate_multibleu=emulate_multibleu,
-                             backoff=backoff)
+                             hyp_len=hyp_len)
     s = (w * math.log(p_i) for i, (w, p_i) in enumerate(zip(weights, p_n)))
     s =  bp * math.exp(math.fsum(s))
-    return round(s, 4) if emulate_multibleu else s
+    return s
 
 
 def modified_precision(references, hypothesis, n):
@@ -482,74 +475,23 @@ class SmoothingFunction:
     def method0(self, p_n, *args, **kwargs):
         """
         No smoothing.
-
-        The original BLEU score (Papineni et al. 1992) is focused on corpus
-        level BLEU where the assumption is that there is at least 1 n-gram overlap
-        between the hypothesis and the reference for the largest n-th order of ngrams.
-
-        There is no explicit strategy to handle fringe cases otherwise, e.g.
-        where there are < 1 4-grams overlap.
-
-        There are two options to handle:
-
-         1. Traditionally, the multi-bleu.pl and mteval-v13a.pl scripts returns 0
-            BLEU score for these fringe cases even when its a perfect sentence:
-
-                $ cat ref.txt
-                1 2 3
-                $ cat hyp.txt
-                1 2 3
-                $ perl multi-bleu.perl ref.txt < hyp.txt
-                BLEU = 0.00, 100.0/100.0/100.0/0.0 (BP=1.000, ratio=1.000, hyp_len=3, ref_len=3)
-
-         2. Alternatively, we can backoff the to the previous n-grams precision
-            and skip the values of the higher order n-grams that returns 0 overlaps
-
-        To toggle between strategy (1) and (2), we have the `emulate_multibleu`
-        and `backoff` option where users can choose between either strategies
-        to handle, where (1) is seeing the glass should-be-empty by being
-        overly conservative setting BLEU score to 0 and (2) is seeing th glass
-        should-have-something by being overly confident and backing off precision
-        to the previous n-gram overlap value that gives a non-zero BLEU score.
-
-        The default is to use the backoff strategy (perhaps unique to NLTK)
-        because we had more user issues/complaints when we followed the (1)
-        paradigm, see the wack-a-mole issues linked to https://github.com/nltk/nltk/issues/1330
-
-        Note that the `emulate_multibleu` option always overrides `backoff` but
-        the `backoff` option is set as the default.
         """
         p_n_new = []
-        _emulate_multibleu = kwargs['emulate_multibleu']
-        _backoff = kwargs['backoff']
-
-        if _emulate_multibleu:
-            _backoff = False
-
         for i, p_i in enumerate(p_n):
             if p_i.numerator != 0:
                 p_n_new.append(p_i)
             else:
-                if _emulate_multibleu:
-                    _msg = str("\nThe hypothesis contains 0 counts of {}-gram overlaps.\n"
-                               "Therefore the BLEU score evaluates to 0, independently of\n"
-                               "how many N-gram overlaps of lower order it contains.\n"
-                               "Consider using lower n-gram order or use SmoothingFunction()").format(i+1)
-                    warnings.warn(_msg)
-                    # When numerator==0 where denonminator==0 or !=0, the result
-                    # for the precision score should be equal to 0 or undefined.
-                    # Due to BLEU geometric mean computation in logarithm space,
-                    # we we need to take the return sys.float_info.min such that
-                    # math.log(sys.float_info.min) returns a 0 precision score.
-                    p_n_new.append(sys.float_info.min)
-                elif _backoff:
-                    _msg = str("\nCorpus/Sentence contains 0 counts of {}-gram overlaps.\n"
-                               "BLEU scores might be undesirable; "
-                               "use SmoothingFunction()").format(i+1)
-                    warnings.warn(_msg)
-                    # If this order of n-gram returns 0 counts, the higher order
-                    # n-gram would also return 0, thus breaking the loop here.
-                    break
+                _msg = str("\nThe hypothesis contains 0 counts of {}-gram overlaps.\n"
+                           "Therefore the BLEU score evaluates to 0, independently of\n"
+                           "how many N-gram overlaps of lower order it contains.\n"
+                           "Consider using lower n-gram order or use SmoothingFunction()").format(i+1)
+                warnings.warn(_msg)
+                # When numerator==0 where denonminator==0 or !=0, the result
+                # for the precision score should be equal to 0 or undefined.
+                # Due to BLEU geometric mean computation in logarithm space,
+                # we we need to take the return sys.float_info.min such that
+                # math.log(sys.float_info.min) returns a 0 precision score.
+                p_n_new.append(sys.float_info.min)
         return p_n_new
 
     def method1(self, p_n, *args, **kwargs):

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -57,29 +57,32 @@ def sentence_bleu(references, hypothesis, weights=(0.25, 0.25, 0.25, 0.25),
     >>> sentence_bleu([reference1, reference2, reference3], hypothesis1) # doctest: +ELLIPSIS
     0.5045...
 
-    If no ngram overlap exists for any of the orders that are used to evaluate BLEU
-    it will return the value zero. This since BLEU is a geometric mean of the precisions
-    for the different ngram orders (no overlap means a precision of 0). The following example
-    has zero 3gram overlaps:
+    If there is no ngrams overlap for any order of n-grams, BLEU returns the
+    value 0. This is because the precision for the order of n-grams without
+    overlap is 0, and the geometric mean in the final BLEU score computation
+    multiplies the 0 with the precision of other n-grams. This results in 0
+    (independently of the precision of the othe n-gram orders). The following
+    example has zero 3-gram and 4-gram overlaps:
 
     >>> round(sentence_bleu([reference1, reference2, reference3], hypothesis2),4) # doctest: +ELLIPSIS
     0.0
 
-    To avoid this harsh behaviour when no ngram overlaps are found a smoothing function can be used.
+    To avoid this harsh behaviour when no ngram overlaps are found a smoothing
+    function can be used.
 
     >>> chencherry = SmoothingFunction()
     >>> sentence_bleu([reference1, reference2, reference3], hypothesis2,
     ...     smoothing_function=chencherry.method1) # doctest: +ELLIPSIS
     0.0370...
 
-    The default BLEU calculates a score for up to 4grams using uniform
-    weights. To evaluate your translations with higher/lower order ngrams,
-    use customized weights. E.g. when accounting for up to 5grams with uniform
-    weights:
+    The default BLEU calculates a score for up to 4-grams using uniform
+    weights (this is called BLEU-4). To evaluate your translations with
+    higher/lower order ngrams, use customized weights. E.g. when accounting
+    for up to 5-grams with uniform weights (this is called BLEU-5) use:
 
-    >>> weights = (0.1666, 0.1666, 0.1666, 0.1666, 0.1666)
+    >>> weights = (1./5., 1./5., 1./5., 1./5., 1./5.)
     >>> sentence_bleu([reference1, reference2, reference3], hypothesis1, weights) # doctest: +ELLIPSIS
-    0.4583...
+    0.3920...
 
     :param references: reference sentences
     :type references: list(list(str))

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -58,8 +58,8 @@ def sentence_bleu(references, hypothesis, weights=(0.25, 0.25, 0.25, 0.25),
     >>> sentence_bleu([reference1, reference2, reference3], hypothesis1) # doctest: +ELLIPSIS
     0.5045...
 
-    >>> sentence_bleu([reference1, reference2, reference3], hypothesis2) # doctest: +ELLIPSIS
-    0.3969...
+    >>> round(sentence_bleu([reference1, reference2, reference3], hypothesis2),4) # doctest: +ELLIPSIS
+    0.0
 
     The default BLEU calculates a score for up to 4grams using uniform
     weights. To evaluate your translations with higher/lower order ngrams,
@@ -84,8 +84,7 @@ def sentence_bleu(references, hypothesis, weights=(0.25, 0.25, 0.25, 0.25),
     :rtype: float
     """
     return corpus_bleu([references], [hypothesis],
-                        weights, smoothing_function, auto_reweigh,
-                        emulate_multibleu, backoff)
+                        weights, smoothing_function, auto_reweigh)
 
 
 def corpus_bleu(list_of_references, hypotheses, weights=(0.25, 0.25, 0.25, 0.25),


### PR DESCRIPTION
Fixing the bug discussed in #1838

I opted for using `p_n_new.append(sys.float_info.min)` instead of `return [sys.float_info.min]` which also would have worked. I made this decision since it makes the code cleaner and more easy to understand. The computational bottle-neck will never be in this part of the code anyway so optimising it to avoid one or two extra passes through this loop is irrelevant. Especially since it made the code a bit cryptic.