### PR TITLE
add step support to Text splicing

### DIFF
--- a/nltk/text.py
+++ b/nltk/text.py
@@ -311,7 +311,7 @@ class Text(object):
 
     def __getitem__(self, i):
         if isinstance(i, slice):
-            return self.tokens[i.start:i.stop]
+            return self.tokens[i.start:i.stop:i.step]
         else:
             return self.tokens[i]
 


### PR DESCRIPTION
The current behaviour of splicing a Text instance is unexpected:

```python
>>> import nltk
>>> text = nltk.Text(nltk.word_tokenize("okay when lisa and raymond got home from school"))
>>> text
<Text: okay when lisa and raymond got home from...>
>>> text[:2]
['okay', 'when']
>>> text[:2:2]
['okay', 'when']
```

This change simply takes into consideration the `step` attribute of a `slice` when one is provided.