### PR TITLE
Fix deprecation message for Tagger classes

### DIFF
--- a/nltk/tag/stanford.py
+++ b/nltk/tag/stanford.py
@@ -52,8 +52,8 @@ class StanfordTagger(TaggerI):
         warnings.simplefilter('always', DeprecationWarning)
         warnings.warn(str("\nThe StanfordTokenizer will "
                           "be deprecated in version 3.2.5.\n"
-                          "Please use \033[91mnltk.tag.corenlp.CoreNLPPOSTagger\033[0m "
-                          "or \033[91mnltk.tag.corenlp.CoreNLPNERTagger\033[0m instead."),
+                          "Please use \033[91mnltk.tag.stanford.CoreNLPPOSTagger\033[0m "
+                          "or \033[91mnltk.tag.stanford.CoreNLPNERTagger\033[0m instead."),
                       DeprecationWarning, stacklevel=2)
         warnings.simplefilter('ignore', DeprecationWarning)
         if not self._JAR:


### PR DESCRIPTION
Small update to the deprecation message, which was wrongly pointing to `nltk.tag.corenlp.CoreNLP---Tagger` when it should have been `nltk.tag.stanford.CoreNLP---Tagger`.

I don't know if this is intentional to change the name of `stanford.py` to `corenlp.py` in the next release. But in my opinion the deprecation message should correctly point to the currently correct location (if I haven't missed anything here, this should be correct).