### PR TITLE
Typo in tokenizer docstring

### DIFF
--- a/nltk/tokenize/__init__.py
+++ b/nltk/tokenize/__init__.py
@@ -119,7 +119,7 @@ def word_tokenize(text, language='english', preserve_line=False):
     for the specified language).
 
     :param text: text to split into words
-    :param text: str
+    :type text: str
     :param language: the model name in the Punkt corpus
     :type language: str
     :param preserve_line: An option to keep the preserve the sentence and not sentence tokenize it.


### PR DESCRIPTION
I think this is suppose to be the type of the `text` param instead of the param itself right?