### PR TITLE
Issue #1859: TypeError in HiddenMarkovModelTrainer train_unsupervised

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,4 +1,4 @@
-﻿# Natural Language Toolkit (NLTK) Authors
+# Natural Language Toolkit (NLTK) Authors
 
 ## Original Authors
 
@@ -223,6 +223,7 @@
 - Stoytcho Stoytchev
 - Lakhdar Benzahia
 - Oleg Chislov
+- Pavan Gururaj Joshi <https://github.com/PavanGJ>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 ### Contributors to the Porter Stemmer

--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -603,6 +603,11 @@ class RandomProbDist(ProbDistI):
 
         return dict((s, randrow[i]) for i, s in enumerate(samples))
 
+    def max(self):
+        if not hasattr(self, '_max'):
+            self._max = max((p,v) for (v,p) in self._probs.items())[1]
+        return self._max
+
     def prob(self, sample):
         return self._probs.get(sample, 0)
 
@@ -1521,6 +1526,10 @@ class MutableProbDist(ProbDistI):
             else:
                 self._data[i] = prob_dist.prob(samples[i])
         self._logs = store_logs
+
+    def max(self):
+        # inherit documentation
+        return max((p,v) for (v,p) in self._sample_dict.items())[1]
 
     def samples(self):
         # inherit documentation


### PR DESCRIPTION
Added a method definition for abstract method max in RandomProbDist and MutableProbDist classes.