### PR TITLE
Fixed parentheses in MASI distance

### DIFF
--- a/nltk/metrics/distance.py
+++ b/nltk/metrics/distance.py
@@ -121,7 +121,7 @@ def masi_distance(label1, label2):
 
     >>> from nltk.metrics import masi_distance
     >>> masi_distance(set([1, 2]), set([1, 2, 3, 4]))
-    0.335
+    0.665
 
     Passonneau 2006, Measuring Agreement on Set-Valued Items (MASI)
     for Semantic and Pragmatic Annotation.
@@ -140,7 +140,7 @@ def masi_distance(label1, label2):
     else:
         m = 0
 
-    return (1 - (len_intersection / float(len_union))) * m
+    return 1 - len_intersection / float(len_union) * m
 
 
 def interval_distance(label1,label2):

--- a/nltk/metrics/distance.py
+++ b/nltk/metrics/distance.py
@@ -140,7 +140,7 @@ def masi_distance(label1, label2):
     else:
         m = 0
 
-    return 1 - len_intersection / float(len_union) * m
+    return 1 - len_intersection / len_union * m
 
 
 def interval_distance(label1,label2):

--- a/nltk/test/metrics.doctest
+++ b/nltk/test/metrics.doctest
@@ -62,7 +62,7 @@ Other distance measures:
     >>> print(jaccard_distance(s1, s2))
     0.6
     >>> print(masi_distance(s1, s2))
-    0.198
+    0.868
 
 ----------------------
 Miscellaneous Measures


### PR DESCRIPTION
This fixes MASI distance so it is calculated without parentheses as in the original paper (see https://github.com/nltk/nltk/pull/295#commitcomment-25409252 and below).
A counterexample provided by @drevicko against the current implementation: if two sets are disjoint, the distance between them will be 0 instead of 1.

Doctest related to MASI is also modified accordingly.
