### PR TITLE
Fix documentation errors in translate module

### DIFF
--- a/nltk/translate/api.py
+++ b/nltk/translate/api.py
@@ -39,9 +39,9 @@ class AlignedSent(object):
         >>> print(comtrans.aligned_sents()[54].alignment)
         0-0 0-1 1-0 2-2 3-4 3-5 4-7 5-8 6-3 7-9 8-9 9-10 9-11 10-12 11-6 12-6 13-13
 
-    :param words: Words in the first sentence
+    :param words: Words in the target language sentence
     :type words: list(str)
-    :param mots: Words in the second sentence
+    :param mots: Words in the source language sentence
     :type mots: list(str)
     :param alignment: Word-level alignments between ``words`` and ``mots``.
         Each alignment is represented as a 2-tuple (words_index, mots_index).

--- a/nltk/translate/api.py
+++ b/nltk/translate/api.py
@@ -21,27 +21,30 @@ class AlignedSent(object):
     Return an aligned sentence object, which encapsulates two sentences
     along with an ``Alignment`` between them.
 
+    Typically used in machine translation to represent a sentence and
+    its translation.
+
         >>> from nltk.translate import AlignedSent, Alignment
         >>> algnsent = AlignedSent(['klein', 'ist', 'das', 'Haus'],
-        ...     ['the', 'house', 'is', 'small'], Alignment.fromstring('0-2 1-3 2-1 3-0'))
+        ...     ['the', 'house', 'is', 'small'], Alignment.fromstring('0-3 1-2 2-0 3-1'))
         >>> algnsent.words
         ['klein', 'ist', 'das', 'Haus']
         >>> algnsent.mots
         ['the', 'house', 'is', 'small']
         >>> algnsent.alignment
-        Alignment([(0, 2), (1, 3), (2, 1), (3, 0)])
+        Alignment([(0, 3), (1, 2), (2, 0), (3, 1)])
         >>> from nltk.corpus import comtrans
         >>> print(comtrans.aligned_sents()[54])
         <AlignedSent: 'Weshalb also sollten...' -> 'So why should EU arm...'>
         >>> print(comtrans.aligned_sents()[54].alignment)
         0-0 0-1 1-0 2-2 3-4 3-5 4-7 5-8 6-3 7-9 8-9 9-10 9-11 10-12 11-6 12-6 13-13
 
-    :param words: source language words
+    :param words: Words in the first sentence
     :type words: list(str)
-    :param mots: target language words
+    :param mots: Words in the second sentence
     :type mots: list(str)
-    :param alignment: the word-level alignments between the source
-        and target language
+    :param alignment: Word-level alignments between ``words`` and ``mots``.
+        Each alignment is represented as a 2-tuple (words_index, mots_index).
     :type alignment: Alignment
     """
 

--- a/nltk/translate/ibm1.py
+++ b/nltk/translate/ibm1.py
@@ -15,22 +15,25 @@
 """
 Lexical translation model that ignores word order.
 
-In IBM Model 1, word order is ignored for simplicity. Thus, the
-following three alignments are equally likely. As long as the word
-alignments are equivalent, it doesn't matter where the word
-occurs in the source or target sentence.
+In IBM Model 1, word order is ignored for simplicity. As long as the
+word alignments are equivalent, it doesn't matter where the word occurs
+in the source or target sentence. Thus, the following three alignments
+are equally likely.
 
 Source: je mange du jambon
 Target: i eat some ham
-Alignment: (1,1) (2,2) (3,3) (4,4)
+Alignment: (0,0) (1,1) (2,2) (3,3)
 
 Source: je mange du jambon
 Target: some ham eat i
-Alignment: (1,4) (2,3) (3,1) (4,2)
+Alignment: (0,2) (1,3) (2,1) (3,1)
 
 Source: du jambon je mange
 Target: eat i some ham
-Alignment: (1,3) (2,4) (3,2) (4,1)
+Alignment: (0,3) (1,2) (2,0) (3,1)
+
+Note that an alignment is represented here as
+(word_index_in_target, word_index_in_source).
 
 The EM algorithm used in Model 1 is:
 E step - In the training data, count how many times a source language


### PR DESCRIPTION
* Avoid mention of source and target language in AlignedSent
* Fix wrong alignment example in AlignedSent.__init__
* In the explanatory notes of IBMModel1, change the alignment format to be consistent with that used in the IBM models.

Related issue: #1888