### PR TITLE
Fixed pickle bug for MWETokenizer #1761

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -226,6 +226,7 @@
 - Björn Mattsson
 - Oleg Chislov
 - Pavan Gururaj Joshi <https://github.com/PavanGJ>
+- Ethan Hill <https://github.com/hill1303>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 ### Contributors to the Porter Stemmer

--- a/nltk/collections.py
+++ b/nltk/collections.py
@@ -591,7 +591,7 @@ class LazyIteratorList(AbstractLazySequence):
 ######################################################################
 # Trie Implementation
 ######################################################################
-class Trie(defaultdict):
+class Trie(dict):
     """A Trie implementation for strings"""
     LEAF = True
 
@@ -607,7 +607,7 @@ class Trie(defaultdict):
         :type strings: list(str)
 
         """
-        defaultdict.__init__(self, Trie)
+        super(Trie, self).__init__()
         if strings:
             for string in strings:
                 self.insert(string)
@@ -621,9 +621,11 @@ class Trie(defaultdict):
         :Example:
 
         >>> from nltk.collections import Trie
-        >>> trie = Trie(["ab"])
-        >>> trie
-        defaultdict(<class 'nltk.collections.Trie'>, {'a': defaultdict(<class 'nltk.collections.Trie'>, {'b': defaultdict(<class 'nltk.collections.Trie'>, {True: None})})})
+        >>> trie = Trie(["abc", "def"])
+        >>> expected = {'a': {'b': {'c': {True: None}}}, \
+                        'd': {'e': {'f': {True: None}}}}
+        >>> trie == expected
+        True
 
         """
         if len(string):
@@ -632,56 +634,7 @@ class Trie(defaultdict):
             # mark the string is complete
             self[Trie.LEAF] = None
 
-    def __str__(self):
-        return str(self.as_dict())
+    def __missing__(self, key):
+        self[key] = Trie()
+        return self[key]
 
-    def as_dict(self, d=None):
-        """Convert ``defaultdict`` to common ``dict`` representation.
-
-        :param: A defaultdict containing strings mapped to nested defaultdicts.
-            This is the structure of the trie. (Default is None)
-        :type: defaultdict(str -> defaultdict)
-        :return: Even though ``defaultdict`` is a subclass of ``dict`` and thus
-            can be converted to a simple ``dict`` using ``dict()``, in our case
-            it's a nested ``defaultdict``, so here's a quick trick to provide to
-            us the ``dict`` representation of the ``Trie`` without
-            ``defaultdict(<class 'nltk.collections.Trie'>, ...``
-        :rtype: dict(str -> dict(bool -> None))
-            Note: there can be an arbitrarily deeply nested
-            ``dict(str -> dict(str -> dict(..))``, but the last
-            level will have ``dict(str -> dict(bool -> None))``
-
-        :Example:
-
-        >>> from nltk.collections import Trie
-        >>> trie = Trie(["abc", "def"])
-        >>> expected = {'a': {'b': {'c': {True: None}}}, 'd': {'e': {'f': {True: None}}}}
-        >>> trie.as_dict() == expected
-        True
-
-        """
-        def _default_to_regular(d):
-            """
-            Source: http://stackoverflow.com/a/26496899/4760801
-
-            :param d: Nested ``defaultdict`` to convert to regular ``dict``
-            :type d: defaultdict(str -> defaultdict(...))
-            :return: A dict representation of the defaultdict
-            :rtype: dict(str -> dict(str -> ...))
-
-            :Example:
-
-            >>> from collections import defaultdict
-            >>> d = defaultdict(defaultdict)
-            >>> d["one"]["two"] = "three"
-            >>> d
-            defaultdict(<type 'collections.defaultdict'>, {'one': defaultdict(None, {'two': 'three'})})
-            >>> _default_to_regular(d)
-            {'one': {'two': 'three'}}
-
-            """
-            if isinstance(d, defaultdict):
-                d = {k: _default_to_regular(v) for k, v in d.items()}
-            return d
-
-        return _default_to_regular(self)

--- a/nltk/collections.py
+++ b/nltk/collections.py
@@ -15,7 +15,7 @@ import bisect
 import os
 from itertools import islice, chain, combinations
 from functools import total_ordering
-from collections import defaultdict, deque, Counter
+from collections import deque, Counter
 
 from six import text_type
 
@@ -596,7 +596,7 @@ class Trie(dict):
     LEAF = True
 
     def __init__(self, strings=None):
-        """Builds a Trie object, which is built around a ``defaultdict``
+        """Builds a Trie object, which is built around a ``dict``
 
         If ``strings`` is provided, it will add the ``strings``, which
         consist of a ``list`` of ``strings``, to the Trie.

--- a/nltk/collections.py
+++ b/nltk/collections.py
@@ -15,7 +15,7 @@ import bisect
 import os
 from itertools import islice, chain, combinations
 from functools import total_ordering
-from collections import deque, Counter
+from collections import defaultdict, deque, Counter
 
 from six import text_type
 

--- a/nltk/test/collections.doctest
+++ b/nltk/test/collections.doctest
@@ -1,0 +1,20 @@
+.. Copyright (C) 2001-2017 NLTK Project
+.. For license information, see LICENSE.TXT
+
+===========
+Collections
+===========
+
+    >>> import nltk
+    >>> from nltk.collections import *
+
+Trie
+----
+
+Trie can be pickled:
+
+    >>> import pickle
+    >>> trie = nltk.collections.Trie(['a'])
+    >>> s = pickle.dumps(trie)
+    >>> pickle.loads(s)
+    {'a': {True: None}}

--- a/nltk/test/tokenize.doctest
+++ b/nltk/test/tokenize.doctest
@@ -233,3 +233,18 @@ Post-hoc alignment of tokens with a source string
     ValueError: substring "gh" not found in "ab cd ef"
     >>> list(align_tokens(['The', 'plane', ',', 'bound', 'for', 'St', 'Petersburg', ',', 'crashed', 'in', 'Egypt', "'s", 'Sinai', 'desert', 'just', '23', 'minutes', 'after', 'take-off', 'from', 'Sharm', 'el-Sheikh', 'on', 'Saturday', '.'], "The plane, bound for St Petersburg, crashed in Egypt's Sinai desert just 23 minutes after take-off from Sharm el-Sheikh on Saturday."))
     [(0, 3), (4, 9), (9, 10), (11, 16), (17, 20), (21, 23), (24, 34), (34, 35), (36, 43), (44, 46), (47, 52), (52, 54), (55, 60), (61, 67), (68, 72), (73, 75), (76, 83), (84, 89), (90, 98), (99, 103), (104, 109), (110, 119), (120, 122), (123, 131), (131, 132)]
+
+
+Regression Tests: MWETokenizer
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Pickle an MWETokenizer
+
+    >>> from nltk.tokenize import MWETokenizer
+    >>> import pickle
+
+    >>> tokenizer = MWETokenizer([('hors', "d'oeuvre")], separator='+')
+    >>> p = pickle.dumps(tokenizer)
+    >>> unpickeled = pickle.loads(p)
+    >>> unpickeled.tokenize("An hors d'oeuvre tonight, sir?".split())
+    ['An', "hors+d'oeuvre", 'tonight,', 'sir?']
+

--- a/nltk/tokenize/mwe.py
+++ b/nltk/tokenize/mwe.py
@@ -71,7 +71,7 @@ class MWETokenizer(TokenizerI):
         >>> tokenizer.add_mwe(('a', 'b', 'c'))
         >>> tokenizer.add_mwe(('a', 'x'))
         >>> expected = {'a': {'x': {True: None}, 'b': {True: None, 'c': {True: None}}}}
-        >>> tokenizer._mwes.as_dict() == expected
+        >>> tokenizer._mwes == expected
         True
 
         """


### PR DESCRIPTION
To support pickling for MWETokenizer and fix #1761, I used a similar approach to the solution for #393.
The issue, as a commenter (Dobatymo) already pointed out, was that `MWETokenizer` makes use of `Trie` in collections. Since `Trie` is a `defaultdict`, pickling is difficult without heavy modification. The path of least resistance seemed to be to make `Trie` inherit from a plain dictionary instead and simply override `__missing__`. This allowed me to remove the `as_dict()` from `Trie`, which converted the underlying `defaultdict` to `dict`
I'll leave it up to the reviewers to decide whether `as_dict` should be put back in order to avoid breaking code that might make use of it, since it was a part of the public contract of `Trie`

Thanks for taking the time to review my PR, hope this helps!