### PR TITLE
Framenet: Casting list and dict into sorted for doctests

### DIFF
--- a/nltk/corpus/reader/framenet.py
+++ b/nltk/corpus/reader/framenet.py
@@ -22,6 +22,7 @@ from six import string_types, text_type
 from six.moves import zip_longest
 
 from collections import defaultdict, OrderedDict
+from operator import itemgetter
 from pprint import pprint, pformat
 from nltk.internals import ElementWrapper
 from nltk.corpus.reader import XMLCorpusReader, XMLCorpusView
@@ -685,10 +686,6 @@ class AttrDict(dict):
         if isinstance(v,Future):
             return v._data()
         return v
-
-    def __lt__(self, other):
-        """ Comparison operator used mainly to sort a list of AttrDict by ID. """
-        return self['ID'] < other['ID']
 
     def _short_repr(self):
         if '_type' in self:
@@ -1426,7 +1423,7 @@ warnings(True) to display corpus consistency warnings when loading data
 
         >>> from nltk.corpus import framenet as fn
         >>> from nltk.corpus.reader.framenet import PrettyList
-        >>> PrettyList(sorted(fn.frames_by_lemma(r'(?i)a little'))) # doctest: +ELLIPSIS
+        >>> PrettyList(sorted(fn.frames_by_lemma(r'(?i)a little'), key=itemgetter('ID'))) # doctest: +ELLIPSIS
         [<frame ID=189 name=Quanti...>, <frame ID=2001 name=Degree>]
 
         :return: A list of frame objects.
@@ -1787,7 +1784,7 @@ warnings(True) to display corpus consistency warnings when loading data
         >>> len(fn.frames()) in (1019, 1221)    # FN 1.5 and 1.7, resp.
         True
         >>> x = PrettyList(fn.frames(r'(?i)crim'), maxReprSize=0, breakLines=True)
-        >>> x.sort(key=lambda f: f.ID)
+        >>> x.sort(key=itemgetter('ID'))
         >>> x
         [<frame ID=200 name=Criminal_process>,
          <frame ID=500 name=Criminal_investigation>,
@@ -1916,11 +1913,11 @@ warnings(True) to display corpus consistency warnings when loading data
         >>> from nltk.corpus import framenet as fn
         >>> len(fn.lus()) in (11829, 13572) # FN 1.5 and 1.7, resp.
         True
-        >>> PrettyList(sorted(fn.lus(r'(?i)a little')), maxReprSize=0, breakLines=True)
+        >>> PrettyList(sorted(fn.lus(r'(?i)a little'), key=itemgetter('ID')), maxReprSize=0, breakLines=True)
         [<lu ID=14733 name=a little.n>,
          <lu ID=14743 name=a little.adv>,
          <lu ID=14744 name=a little bit.adv>]
-        >>> PrettyList(sorted(fn.lus(r'interest', r'(?i)stimulus')))
+        >>> PrettyList(sorted(fn.lus(r'interest', r'(?i)stimulus'), key=itemgetter('ID')))
         [<lu ID=14894 name=interested.a>, <lu ID=14920 name=interesting.a>]
 
         A brief intro to Lexical Units (excerpted from "FrameNet II:
@@ -2247,7 +2244,7 @@ warnings(True) to display corpus consistency warnings when loading data
         Obtain a list of frame relation types.
 
         >>> from nltk.corpus import framenet as fn
-        >>> frts = sorted(fn.frame_relation_types())
+        >>> frts = sorted(fn.frame_relation_types(), key=itemgetter('ID'))
         >>> isinstance(frts, list)
         True
         >>> len(frts) in (9, 10)    # FN 1.5 and 1.7, resp.

--- a/nltk/corpus/reader/framenet.py
+++ b/nltk/corpus/reader/framenet.py
@@ -2247,7 +2247,7 @@ warnings(True) to display corpus consistency warnings when loading data
         Obtain a list of frame relation types.
 
         >>> from nltk.corpus import framenet as fn
-        >>> frts = sorted(list(fn.frame_relation_types()))
+        >>> frts = sorted(fn.frame_relation_types())
         >>> isinstance(frts, list)
         True
         >>> len(frts) in (9, 10)    # FN 1.5 and 1.7, resp.

--- a/nltk/corpus/reader/framenet.py
+++ b/nltk/corpus/reader/framenet.py
@@ -686,6 +686,10 @@ class AttrDict(dict):
             return v._data()
         return v
 
+    def __lt__(self, other):
+        """ Comparison operator used mainly to sort a list of AttrDict by ID. """
+        return self['ID'] < other['ID']
+
     def _short_repr(self):
         if '_type' in self:
             if self['_type'].endswith('relation'):

--- a/nltk/corpus/reader/framenet.py
+++ b/nltk/corpus/reader/framenet.py
@@ -1425,7 +1425,8 @@ warnings(True) to display corpus consistency warnings when loading data
         search through ALL of the frame XML files in the db.
 
         >>> from nltk.corpus import framenet as fn
-        >>> fn.frames_by_lemma(r'(?i)a little') # doctest: +ELLIPSIS
+        >>> from nltk.corpus.reader.framenet import PrettyList
+        >>> PrettyList(sorted(fn.frames_by_lemma(r'(?i)a little'))) # doctest: +ELLIPSIS
         [<frame ID=189 name=Quanti...>, <frame ID=2001 name=Degree>]
 
         :return: A list of frame objects.

--- a/nltk/corpus/reader/framenet.py
+++ b/nltk/corpus/reader/framenet.py
@@ -352,10 +352,10 @@ def _pretty_annotation(sent, aset_level=False):
     Gov (governor), X. Gov and X always cooccur.
 
     >>> from nltk.corpus import framenet as fn
->>> def f(luRE, lyr, ignore=set()):
-...   for i,ex in enumerate(fn.exemplars(luRE)):
-...     if lyr in ex and ex[lyr] and set(zip(*ex[lyr])[2]) - ignore:
-...       print(i,ex[lyr])
+    >>> def f(luRE, lyr, ignore=set()):
+    ...   for i,ex in enumerate(fn.exemplars(luRE)):
+    ...     if lyr in ex and ex[lyr] and set(zip(*ex[lyr])[2]) - ignore:
+    ...       print(i,ex[lyr])
 
     - Verb: Asp, Non-Asp
     - Noun: Cop, Supp, Ctrlr, Gov, X
@@ -1000,8 +1000,8 @@ class FramenetCorpusReader(XMLCorpusReader):
 
 
         msg = """
-Citation: Nathan Schneider and Chuck Wooters (2017), 
-"The NLTK FrameNet API: Designing for Discoverability with a Rich Linguistic Resource". 
+Citation: Nathan Schneider and Chuck Wooters (2017),
+"The NLTK FrameNet API: Designing for Discoverability with a Rich Linguistic Resource".
 Proceedings of EMNLP: System Demonstrations. https://arxiv.org/abs/1703.07438
 
 Use the following methods to access data in FrameNet.
@@ -1911,12 +1911,12 @@ warnings(True) to display corpus consistency warnings when loading data
         >>> from nltk.corpus import framenet as fn
         >>> len(fn.lus()) in (11829, 13572) # FN 1.5 and 1.7, resp.
         True
-        >>> PrettyList(fn.lus(r'(?i)a little'), maxReprSize=0, breakLines=True)
-        [<lu ID=14744 name=a little bit.adv>,
-         <lu ID=14733 name=a little.n>,
-         <lu ID=14743 name=a little.adv>]
-        >>> fn.lus(r'interest', r'(?i)stimulus')
-        [<lu ID=14920 name=interesting.a>, <lu ID=14894 name=interested.a>]
+        >>> PrettyList(sorted(fn.lus(r'(?i)a little')), maxReprSize=0, breakLines=True)
+        [<lu ID=14733 name=a little.n>,
+         <lu ID=14743 name=a little.adv>,
+         <lu ID=14744 name=a little bit.adv>]
+        >>> PrettyList(sorted(fn.lus(r'interest', r'(?i)stimulus')))
+        [<lu ID=14894 name=interested.a>, <lu ID=14920 name=interesting.a>]
 
         A brief intro to Lexical Units (excerpted from "FrameNet II:
         Extended Theory and Practice" by Ruppenhofer et. al., 2010):
@@ -2242,7 +2242,7 @@ warnings(True) to display corpus consistency warnings when loading data
         Obtain a list of frame relation types.
 
         >>> from nltk.corpus import framenet as fn
-        >>> frts = list(fn.frame_relation_types())
+        >>> frts = sorted(list(fn.frame_relation_types()))
         >>> isinstance(frts, list)
         True
         >>> len(frts) in (9, 10)    # FN 1.5 and 1.7, resp.

--- a/nltk/test/framenet.doctest
+++ b/nltk/test/framenet.doctest
@@ -69,13 +69,14 @@ To get a list of all of the Frames in FrameNet, you can use the
 that pattern:
 
     >>> from pprint import pprint
+    >>> from operator import itemgetter
     >>> from nltk.corpus import framenet as fn
     >>> from nltk.corpus.reader.framenet import PrettyList
     >>> x = fn.frames(r'(?i)crim')
-    >>> x.sort(key=lambda f: f.ID)
+    >>> x.sort(key=itemgetter('ID'))
     >>> x
     [<frame ID=200 name=Criminal_process>, <frame ID=500 name=Criminal_investigation>, ...]
-    >>> PrettyList(sorted(x))
+    >>> PrettyList(sorted(x, key=itemgetter('ID')))
     [<frame ID=200 name=Criminal_process>, <frame ID=500 name=Criminal_investigation>, ...]
 
 To get the details of a particular Frame, you can use the `frame()`
@@ -119,7 +120,7 @@ expression. Note that LU names are composed of "lemma.POS", where the
 "lemma" part can be made up of either a single lexeme (e.g. 'run') or
 multiple lexemes (e.g. 'a little') (see below).
 
-    >>> PrettyList(sorted(fn.frames_by_lemma(r'(?i)a little'))) # doctest: +ELLIPSIS
+    >>> PrettyList(sorted(fn.frames_by_lemma(r'(?i)a little'), key=itemgetter('ID'))) # doctest: +ELLIPSIS
     [<frame ID=189 name=Quanti...>, <frame ID=2001 name=Degree>]
 
 -------------
@@ -188,7 +189,7 @@ Details for a specific lexical unit can be obtained using this class's
 pattern that will be matched against the name of the lexical unit:
 
     >>> from pprint import pprint
-    >>> PrettyList(sorted(fn.lus(r'(?i)a little')))
+    >>> PrettyList(sorted(fn.lus(r'(?i)a little'), key=itemgetter('ID')))
     [<lu ID=14733 name=a little.n>, <lu ID=14743 name=a little.adv>, ...]
 
 You can obtain detailed information on a particular LU by calling the

--- a/nltk/test/framenet.doctest
+++ b/nltk/test/framenet.doctest
@@ -117,8 +117,9 @@ expression. Note that LU names are composed of "lemma.POS", where the
 multiple lexemes (e.g. 'a little') (see below).
 
     >>> from nltk.corpus import framenet as fn
-    >>> fn.frames_by_lemma(r'(?i)a little') # doctest: +ELLIPSIS
-    [<frame ID=189 name=Quanti...>, <frame ID=2001 name=Degree>]
+    >>> from nltk.corpus.reader.framenet import PrettyList
+    >>> PrettyList(sorted(fn.frames_by_lemma(r'(?i)a little'))) # doctest: +ELLIPSIS
+    [<frame ID=2001 name=Degree>, <frame ID=189 name=Quanti...>]
 
 -------------
 Lexical Units

--- a/nltk/test/framenet.doctest
+++ b/nltk/test/framenet.doctest
@@ -70,9 +70,12 @@ that pattern:
 
     >>> from pprint import pprint
     >>> from nltk.corpus import framenet as fn
+    >>> from nltk.corpus.reader.framenet import PrettyList
     >>> x = fn.frames(r'(?i)crim')
     >>> x.sort(key=lambda f: f.ID)
     >>> x
+    [<frame ID=200 name=Criminal_process>, <frame ID=500 name=Criminal_investigation>, ...]
+    >>> PrettyList(sorted(x))
     [<frame ID=200 name=Criminal_process>, <frame ID=500 name=Criminal_investigation>, ...]
 
 To get the details of a particular Frame, you can use the `frame()`
@@ -116,10 +119,8 @@ expression. Note that LU names are composed of "lemma.POS", where the
 "lemma" part can be made up of either a single lexeme (e.g. 'run') or
 multiple lexemes (e.g. 'a little') (see below).
 
-    >>> from nltk.corpus import framenet as fn
-    >>> from nltk.corpus.reader.framenet import PrettyList
     >>> PrettyList(sorted(fn.frames_by_lemma(r'(?i)a little'))) # doctest: +ELLIPSIS
-    [<frame ID=2001 name=Degree>, <frame ID=189 name=Quanti...>]
+    [<frame ID=189 name=Quanti...>, <frame ID=2001 name=Degree>]
 
 -------------
 Lexical Units
@@ -187,9 +188,8 @@ Details for a specific lexical unit can be obtained using this class's
 pattern that will be matched against the name of the lexical unit:
 
     >>> from pprint import pprint
-    >>> from nltk.corpus import framenet as fn
-    >>> pprint(fn.lus(r'(?i)a little'))
-    [<lu ID=14744 name=a little bit.adv>, <lu ID=14733 name=a little.n>, ...]
+    >>> PrettyList(sorted(fn.lus(r'(?i)a little')))
+    [<lu ID=14733 name=a little.n>, <lu ID=14743 name=a little.adv>, ...]
 
 You can obtain detailed information on a particular LU by calling the
 `lu()` function and passing in an LU's 'ID' number:


### PR DESCRIPTION
Added a `__lt__` function so that frames (i.e. `AttrDict`) can be sorted by their IDs. 

Making sure that doctests for Framenet are consistent across Python versions. #1901 

Preparing for Py3.6 support #1659 