### PR TITLE
look for data in sys.prefix/share/nltk_data too

### DIFF
--- a/nltk/data.py
+++ b/nltk/data.py
@@ -95,6 +95,7 @@ if sys.platform.startswith('win'):
     path += [
         str(r'C:\nltk_data'), str(r'D:\nltk_data'), str(r'E:\nltk_data'),
         os.path.join(sys.prefix, str('nltk_data')),
+        os.path.join(sys.prefix, str('share'), str('nltk_data')),
         os.path.join(sys.prefix, str('lib'), str('nltk_data')),
         os.path.join(
             os.environ.get(str('APPDATA'), str('C:\\')), str('nltk_data'))
@@ -107,6 +108,7 @@ else:
         str('/usr/lib/nltk_data'),
         str('/usr/local/lib/nltk_data'),
         os.path.join(sys.prefix, str('nltk_data')),
+        os.path.join(sys.prefix, str('share'), str('nltk_data')),
         os.path.join(sys.prefix, str('lib'), str('nltk_data'))
     ]
 


### PR DESCRIPTION
It seems silly to look for `nltk_data` in `/usr/local/share/nltk_data` and in `os.path.join(sys.prefix, 'lib/nltk_data')` but not in `os.path.join(sys.prefix, 'share/nltk_data')`; imo `share` is the right place to put it. This change would look for data there too.