### PR TITLE
Adds unicode support via __future__

### DIFF
--- a/nltk/chunk/named_entity.py
+++ b/nltk/chunk/named_entity.py
@@ -9,6 +9,7 @@
 Named entity chunker
 """
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import os, re, pickle
 from xml.etree import ElementTree as ET
@@ -328,4 +329,3 @@ if __name__ == '__main__':
 
     build_model('binary')
     build_model('multiclass')
-


### PR DESCRIPTION
Address the small issue in #1877 

Anything else I should do here? I may need some help with the unit testing framework going further.

I choose just to import __future__ as it seems the repo is moving towards support python 3. Of course, I can go through and change the `.format` calls to be `u'...'.format` if that's the preferred method. 