### PR TITLE
Split CoNLL lines at single tabs

### DIFF
--- a/nltk/corpus/reader/conll.py
+++ b/nltk/corpus/reader/conll.py
@@ -70,7 +70,7 @@ class ConllCorpusReader(CorpusReader):
     def __init__(self, root, fileids, columntypes,
                  chunk_types=None, root_label='S', pos_in_tree=False,
                  srl_includes_roleset=True, encoding='utf8',
-                 tree_class=Tree, tagset=None):
+                 tree_class=Tree, tagset=None, separator=' '):
         for columntype in columntypes:
             if columntype not in self.COLUMN_TYPES:
                 raise ValueError('Bad column type %r' % columntype)
@@ -84,6 +84,7 @@ class ConllCorpusReader(CorpusReader):
         self._tree_class = tree_class
         CorpusReader.__init__(self, root, fileids, encoding)
         self._tagset = tagset
+        self.sep = separator
 
     #/////////////////////////////////////////////////////////////////
     # Data Access Methods
@@ -194,7 +195,7 @@ class ConllCorpusReader(CorpusReader):
             block = block.strip()
             if not block: continue
 
-            grid = [line.split('\t') for line in block.split('\n')]
+            grid = [line.split(self.sep) for line in block.split('\n')]
 
             # If there's a docstart row, then discard. ([xx] eventually it
             # would be good to actually use it)

--- a/nltk/corpus/reader/conll.py
+++ b/nltk/corpus/reader/conll.py
@@ -194,7 +194,7 @@ class ConllCorpusReader(CorpusReader):
             block = block.strip()
             if not block: continue
 
-            grid = [line.split() for line in block.split('\n')]
+            grid = [line.split('\t') for line in block.split('\n')]
 
             # If there's a docstart row, then discard. ([xx] eventually it
             # would be good to actually use it)

--- a/nltk/corpus/reader/conll.py
+++ b/nltk/corpus/reader/conll.py
@@ -517,8 +517,8 @@ class ConllChunkCorpusReader(ConllCorpusReader):
     pos, and chunk.
     """
     def __init__(self, root, fileids, chunk_types, encoding='utf8',
-                 tagset=None):
+                 tagset=None, separator=None):
         ConllCorpusReader.__init__(
             self, root, fileids, ('words', 'pos', 'chunk'),
             chunk_types=chunk_types, encoding=encoding,
-            tagset=tagset)
+            tagset=tagset, separator=separator)

--- a/nltk/corpus/reader/conll.py
+++ b/nltk/corpus/reader/conll.py
@@ -35,7 +35,11 @@ class ConllCorpusReader(CorpusReader):
     annotation type.  The set of columns used by CoNLL-style files can
     vary from corpus to corpus; the ``ConllCorpusReader`` constructor
     therefore takes an argument, ``columntypes``, which is used to
-    specify the columns that are used by a given corpus.
+    specify the columns that are used by a given corpus. By default
+    columns are split by consecutive whitespaces, with the
+    ``separator`` argument you can set a string to split by (e.g.
+    ``\'\t\'``).
+
 
     @todo: Add support for reading from corpora where different
         parallel files contain different columns.

--- a/nltk/corpus/reader/conll.py
+++ b/nltk/corpus/reader/conll.py
@@ -70,7 +70,7 @@ class ConllCorpusReader(CorpusReader):
     def __init__(self, root, fileids, columntypes,
                  chunk_types=None, root_label='S', pos_in_tree=False,
                  srl_includes_roleset=True, encoding='utf8',
-                 tree_class=Tree, tagset=None, separator=''):
+                 tree_class=Tree, tagset=None, separator=None):
         for columntype in columntypes:
             if columntype not in self.COLUMN_TYPES:
                 raise ValueError('Bad column type %r' % columntype)

--- a/nltk/corpus/reader/conll.py
+++ b/nltk/corpus/reader/conll.py
@@ -70,7 +70,7 @@ class ConllCorpusReader(CorpusReader):
     def __init__(self, root, fileids, columntypes,
                  chunk_types=None, root_label='S', pos_in_tree=False,
                  srl_includes_roleset=True, encoding='utf8',
-                 tree_class=Tree, tagset=None, separator=' '):
+                 tree_class=Tree, tagset=None, separator=''):
         for columntype in columntypes:
             if columntype not in self.COLUMN_TYPES:
                 raise ValueError('Bad column type %r' % columntype)

--- a/nltk/test/corpus.doctest
+++ b/nltk/test/corpus.doctest
@@ -1472,12 +1472,12 @@ constructor will first call its base class's constructor, and then
 store the customizable parameters.  For example, the
 `ConllChunkCorpusReader`\ 's constructor is defined as follows:
 
-    >>> def __init__(self, root, fileids, chunk_types, encoding='utf8',
-    ...          tagset=None, separator=None):
-    ... ConllCorpusReader.__init__(
-    ...     self, root, fileids, ('words', 'pos', 'chunk'),
-    ...     chunk_types=chunk_types, encoding=encoding,
-    ...     tagset=tagset, separator=separator)
+    def __init__(self, root, fileids, chunk_types, encoding='utf8',
+                 tagset=None, separator=None):
+        ConllCorpusReader.__init__(
+                self, root, fileids, ('words', 'pos', 'chunk'),
+                chunk_types=chunk_types, encoding=encoding,
+                tagset=tagset, separator=separator)
 
 If your corpus reader does not implement any customization parameters,
 then you can often just inherit the base class's constructor.

--- a/nltk/test/corpus.doctest
+++ b/nltk/test/corpus.doctest
@@ -1472,9 +1472,12 @@ constructor will first call its base class's constructor, and then
 store the customizable parameters.  For example, the
 `ConllChunkCorpusReader`\ 's constructor is defined as follows:
 
-    >>> def __init__(self, root, files, chunk_types):
-    ...     CorpusReader.__init__(self, root, files)
-    ...     self.chunk_types = tuple(chunk_types)
+    >>> def __init__(self, root, fileids, chunk_types, encoding='utf8',
+    ...          tagset=None, separator=None):
+    ... ConllCorpusReader.__init__(
+    ...     self, root, fileids, ('words', 'pos', 'chunk'),
+    ...     chunk_types=chunk_types, encoding=encoding,
+    ...     tagset=tagset, separator=separator)
 
 If your corpus reader does not implement any customization parameters,
 then you can often just inherit the base class's constructor.


### PR DESCRIPTION
CoNLL should be separated by a single tab.
Some CoNLL files (like the Hamburg Dependency Treebank) are treating words like "New York" as a single form with a space!
The CoNLLReader couldn't read those files.

CoNLL-X Specification defines TAB as the separator:
http://anthology.aclweb.org/W/W06/W06-2920.pdf
References:
HDT: https://corpora.uni-hamburg.de/hzsk/de/islandora/object/treebank:hdt