### PR TITLE
Fixed #1920: checking whether a string is ascii in py35

### DIFF
--- a/nltk/parse/bllip.py
+++ b/nltk/parse/bllip.py
@@ -98,7 +98,7 @@ except ImportError as ie:
 def _ensure_ascii(words):
     try:
         for i, word in enumerate(words):
-            word.decode('ascii')
+            word.encode('ascii')
     except UnicodeDecodeError:
         raise ValueError("Token %d (%r) is non-ASCII. BLLIP Parser "
                          "currently doesn't support non-ASCII inputs." %


### PR DESCRIPTION
To solve #1920, firstly I was thinking to use the same approach as in solution for #507, i.e. differentiate code for python2 and python3. Then figured out, that to check whether a string is ascii, we might as well use `.encode('ascii')` instead of `.decode('ascii')`, because `encode` can be applied to strings both in Py2 and Py3, unlike `decode`, but serves the same purpose.

Would that be a correct solution?