### PR TITLE
Make `CFG.fromstring` easy to inherit

### DIFF
--- a/nltk/grammar.py
+++ b/nltk/grammar.py
@@ -540,13 +540,13 @@ class CFG(object):
     @classmethod
     def fromstring(cls, input, encoding=None):
         """
-        Return the ``CFG`` corresponding to the input string(s).
+        Return the grammar instance corresponding to the input string(s).
 
         :param input: a grammar, either in the form of a string or as a list of strings.
         """
         start, productions = read_grammar(input, standard_nonterm_parser,
                                           encoding=encoding)
-        return CFG(start, productions)
+        return cls(start, productions)
 
     def start(self):
         """
@@ -802,7 +802,7 @@ class FeatureGrammar(CFG):
     def fromstring(cls, input, features=None, logic_parser=None, fstruct_reader=None,
                    encoding=None):
         """
-        Return a feature structure based ``FeatureGrammar``.
+        Return a feature structure based grammar.
 
         :param input: a grammar, either in the form of a string or else
         as a list of strings.
@@ -824,7 +824,7 @@ class FeatureGrammar(CFG):
 
         start, productions = read_grammar(input, fstruct_reader.read_partial,
                                           encoding=encoding)
-        return FeatureGrammar(start, productions)
+        return cls(start, productions)
 
     def productions(self, lhs=None, rhs=None, empty=False):
         """
@@ -949,7 +949,7 @@ class DependencyGrammar(object):
                 raise ValueError('Unable to parse line %s: %s' % (linenum, line))
         if len(productions) == 0:
             raise ValueError('No productions found!')
-        return DependencyGrammar(productions)
+        return cls(productions)
 
     def contains(self, head, mod):
         """
@@ -1118,7 +1118,7 @@ class PCFG(CFG):
     @classmethod
     def fromstring(cls, input, encoding=None):
         """
-        Return a probabilistic ``PCFG`` corresponding to the
+        Return a probabilistic context-free grammar corresponding to the
         input string(s).
 
         :param input: a grammar, either in the form of a string or else
@@ -1126,7 +1126,7 @@ class PCFG(CFG):
         """
         start, productions = read_grammar(input, standard_nonterm_parser,
                                           probabilistic=True, encoding=encoding)
-        return PCFG(start, productions)
+        return cls(start, productions)
 
 
 #################################################################


### PR DESCRIPTION
A while back I wanted to subclass `nltk.grammar.CFG` and found out that I had to copy/paste the `fromstring` method in order to instantiate my custom subclass from a string even though my initialization arguments didn't differ from `CFG` at all.

This was annoying, so I've added a little tweak to all the grammars that allows one to inherit `fromstring` more easily.