### PR TITLE
Patching #1932

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -13,7 +13,7 @@ pushd ${HOME}
 [[ ! -d 'third' ]] && mkdir 'third'
 pushd 'third'
 
-#download nltk stanford dependencies
+# Download nltk stanford dependencies
 stanford_corenlp_package_zip_name=$(curl -s 'http://stanfordnlp.github.io/CoreNLP/' | grep -o 'stanford-corenlp-full-.*\.zip' | head -n1)
 [[ ${stanford_corenlp_package_zip_name} =~ (.+)\.zip ]]
 stanford_corenlp_package_name=${BASH_REMATCH[1]}
@@ -22,16 +22,10 @@ if [[ ! -d ${stanford_corenlp_package_name} ]]; then
 	unzip ${stanford_corenlp_package_zip_name}
 	rm ${stanford_corenlp_package_zip_name}
 	ln -s ${stanford_corenlp_package_name} 'stanford-corenlp'
-	# Kill all Java instances.
-	#pkill -f '*edu.stanford.nlp.pipeline.StanfordCoreNLPServer*'
-	#cd stanford-corenlp
-	##nohup java -mx4g -cp "*" edu.stanford.nlp.pipeline.StanfordCoreNLPServer -port 9000 -timeout 15000 &
-	# Log the job ID and kill it before the end.
-	#CORENLP_PID=$!
-	#cd ..
 fi
 
-stanford_parser_package_zip_name=$(curl -s 'https://nlp.stanford.edu/software/lex-parser.shtml' | grep -o 'stanford-parser-full-.*\.zip' | head -n1)
+#stanford_parser_package_zip_name=$(curl -s 'https://nlp.stanford.edu/software/lex-parser.shtml' | grep -o 'stanford-parser-full-.*\.zip' | head -n1)
+stanford_parser_package_zip_name="https://nlp.stanford.edu/software/stanford-parser-full-2017-06-09.zip"
 [[ ${stanford_parser_package_zip_name} =~ (.+)\.zip ]]
 stanford_parser_package_name=${BASH_REMATCH[1]}
 if [[ ! -d ${stanford_parser_package_name} ]]; then
@@ -41,7 +35,8 @@ if [[ ! -d ${stanford_parser_package_name} ]]; then
 	ln -s ${stanford_parser_package_name} 'stanford-parser'
 fi
 
-stanford_tagger_package_zip_name=$(curl -s 'https://nlp.stanford.edu/software/tagger.shtml' | grep -o 'stanford-postagger-full-.*\.zip' | head -n1)
+#stanford_tagger_package_zip_name=$(curl -s 'https://nlp.stanford.edu/software/tagger.shtml' | grep -o 'stanford-postagger-full-.*\.zip' | head -n1)
+stanford_tagger_package_zip_name="https://nlp.stanford.edu/software/stanford-postagger-full-2017-06-09.zip"
 [[ ${stanford_tagger_package_zip_name} =~ (.+)\.zip ]]
 stanford_tagger_package_name=${BASH_REMATCH[1]}
 if [[ ! -d ${stanford_tagger_package_name} ]]; then
@@ -52,10 +47,10 @@ if [[ ! -d ${stanford_tagger_package_name} ]]; then
 fi
 
 # Download SENNA
-senna_file_name=$(curl -s 'http://ml.nec-labs.com/senna/download.html' | grep -o 'senna-v.*.tgz' | head -n1)
+senna_file_name=$(curl -s 'https://ronan.collobert.com/senna/download.html' | grep -o 'senna-v.*.tgz' | head -n1)
 senna_folder_name='senna'
 if [[ ! -d $senna_folder_name ]]; then
-        wget -nv "http://ml.nec-labs.com/senna/$senna_file_name"
+        wget -nv "https://ronan.collobert.com/senna/$senna_file_name"
         tar -xvzf ${senna_file_name}
         rm ${senna_file_name}
 fi
@@ -85,8 +80,6 @@ coverage xml --omit=nltk/test/*
 iconv -c -f utf-8 -t utf-8 nosetests.xml > nosetests_scrubbed.xml
 pylint -f parseable nltk > pylintoutput
 
-# Kill the core NLP server.
-#kill -9 $CORENLP_PID
 
 #script always succeeds
 true

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -25,7 +25,7 @@ if [[ ! -d ${stanford_corenlp_package_name} ]]; then
 fi
 
 #stanford_parser_package_zip_name=$(curl -s 'https://nlp.stanford.edu/software/lex-parser.shtml' | grep -o 'stanford-parser-full-.*\.zip' | head -n1)
-stanford_parser_package_zip_name="https://nlp.stanford.edu/software/stanford-parser-full-2017-06-09.zip"
+stanford_parser_package_zip_name="stanford-parser-full-2017-06-09.zip"
 [[ ${stanford_parser_package_zip_name} =~ (.+)\.zip ]]
 stanford_parser_package_name=${BASH_REMATCH[1]}
 if [[ ! -d ${stanford_parser_package_name} ]]; then
@@ -36,7 +36,7 @@ if [[ ! -d ${stanford_parser_package_name} ]]; then
 fi
 
 #stanford_tagger_package_zip_name=$(curl -s 'https://nlp.stanford.edu/software/tagger.shtml' | grep -o 'stanford-postagger-full-.*\.zip' | head -n1)
-stanford_tagger_package_zip_name="https://nlp.stanford.edu/software/stanford-postagger-full-2017-06-09.zip"
+stanford_tagger_package_zip_name="stanford-postagger-full-2017-06-09.zip"
 [[ ${stanford_tagger_package_zip_name} =~ (.+)\.zip ]]
 stanford_tagger_package_name=${BASH_REMATCH[1]}
 if [[ ! -d ${stanford_tagger_package_name} ]]; then


### PR DESCRIPTION
- Removed unused code to launch and disable corenlp
- Temporarily hardcore the Stanford parser and postagger version until their site is back up
- Use Collobert's personal site for SENNA instead of NEC Labs'