### PR TITLE
Remove special handling of slices in getitem methods

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -229,6 +229,7 @@
 - Oleg Chislov
 - Pavan Gururaj Joshi <https://github.com/PavanGJ>
 - Ethan Hill <https://github.com/hill1303>
+- Vivek Lakshmanan
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 ### Contributors to the Porter Stemmer

--- a/nltk/text.py
+++ b/nltk/text.py
@@ -332,10 +332,7 @@ class Text(object):
     #////////////////////////////////////////////////////////////
 
     def __getitem__(self, i):
-        if isinstance(i, slice):
-            return self.tokens[i.start:i.stop]
-        else:
-            return self.tokens[i]
+        return self.tokens[i]
 
     def __len__(self):
         return len(self.tokens)


### PR DESCRIPTION
Fixes #1854 
Hi! I'd like to work on this issue as my first contribution to this project! However, there are some doubts that I would like to clarify as explained in my comment in #1854. Here is the updated list of occurrences of the `if isinstance(i, slice):`.

```
[vivek@ThinkPad nltk]$ grep -n "isinstance" nltk/** | grep "slice"

nltk/collections.py:165:        if isinstance(i, slice):
nltk/collections.py:438:        if isinstance(index, slice):

nltk/featstruct.py:955:        if isinstance(name_or_path, (integer_types, slice)):
nltk/featstruct.py:973:        if isinstance(name_or_path, (integer_types, slice)):

grep: nltk/tokenizenltk/text.py:335:        if isinstance(i, slice):

nltk/tree.py:154:        if isinstance(index, (int, slice)):
nltk/tree.py:168:        if isinstance(index, (int, slice)):
nltk/tree.py:183:        if isinstance(index, (int, slice)):
nltk/tree.py:972:        if isinstance(index, slice):
nltk/tree.py:1008:        if isinstance(index, slice):

```
Please do correct me if i'm wrong, but for a particular slice usage to be related to PEP-357, it's usage is such that the check `if isinstance(i, slice):` is redundant since `arbitrary objects can be used whenever integers are explicitly needed in Python, such as in slice syntax` as stated in PEP-357. For instance, in [line 335 of text.py](https://github.com/nltk/nltk/blob/develop/nltk/text.py#L335): 
```
def __getitem__(self, i):
        if isinstance(i, slice):
            return self.tokens[i.start:i.stop]
        else:
            return self.tokens[i]
```
As stated in #1845, the `if isinstance(i, slice):` can be removed to make it simpler. If that's the case, after grepping and looking through each line, every line except [line 335 of text.py](https://github.com/nltk/nltk/blob/develop/nltk/text.py#L335) are not related to PEP-357. For example, [line 165 of collections.py](https://github.com/nltk/nltk/blob/develop/nltk/collections.py#L165),
```
def __getitem__(self, i):
        """
        Return the *i* th token in the corpus file underlying this
        corpus view.  Negative indices and spans are both supported.
        """
        if isinstance(i, slice):
            start, stop = slice_bounds(self, i)
            return LazySubsequence(self, start, stop)
        else:
            # Handle negative indices
            if i < 0: i += len(self)
            if i < 0: raise IndexError('index out of range')
            # Use iterate_from to extract it.
            try:
                return next(self.iterate_from(i))
            except StopIteration:
                raise IndexError('index out of range')
```
is not related to PEP-357 right?