### PR TITLE
Fix Issue #1946 by correcting typo from presnet to present

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -230,6 +230,7 @@
 - Pavan Gururaj Joshi <https://github.com/PavanGJ>
 - Ethan Hill <https://github.com/hill1303>
 - Vivek Lakshmanan
+- Somnath Rakshit <https://github.com/somnathrakshit>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 ### Contributors to the Porter Stemmer

--- a/nltk/stem/snowball.py
+++ b/nltk/stem/snowball.py
@@ -403,7 +403,7 @@ class ArabicStemmer(_LanguageSpecificStemmer):
 
     __conjugation_suffix_verb_past = ('\u0646\u0627', '\u062a\u0627', '\u062a\u0646') # نا، تا، تن
 
-    __conjugation_suffix_verb_presnet = ('\u0627\u0646', '\u0648\u0646', '\u064a\u0646') # ان، ون، ين
+    __conjugation_suffix_verb_present = ('\u0627\u0646', '\u0648\u0646', '\u064a\u0646') # ان، ون، ين
 
     # Suffixes added due to derivation Names
     __conjugation_suffix_noun_1 = ('\u064a', '\u0643', '\u0647') # ي، ك، ه


### PR DESCRIPTION
Changed `__conjugation_suffix_verb_presnet` to `__conjugation_suffix_verb_present`  in nltk/stem/snowball.py