### PR TITLE
Evaluate type before comparing equality of WordNet and other objects

### DIFF
--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -195,13 +195,20 @@ class _WordNetObject(object):
         return hash(self._name)
 
     def __eq__(self, other):
-        return self._name == other._name
+        try:
+            return self.name() == other.name()
+        except (AttributeError, TypeError):
+            return False
+
 
     def __ne__(self, other):
-        return self._name != other._name
+        return not self.__eq__(other)
 
     def __lt__(self, other):
-        return self._name < other._name
+        try:
+            return self.name() < other.name()
+        except (AttributeError, TypeError):
+            return False
 
 
 @python_2_unicode_compatible

--- a/nltk/test/unit/test_wordnet.py
+++ b/nltk/test/unit/test_wordnet.py
@@ -132,3 +132,8 @@ class WordnNetDemo(unittest.TestCase):
         self.assertAlmostEqual(S('dog.n.01').jcn_similarity(S('cat.n.01'), brown_ic), 0.4497, places=3)
         semcor_ic = wnic.ic('ic-semcor.dat')
         self.assertAlmostEqual(S('dog.n.01').lin_similarity(S('cat.n.01'), semcor_ic), 0.8863, places=3)
+
+    def test_wordnet_compare(self):
+        self.assertEqual(True, S('dog.n.01') == (S('dog.n.01')))
+        self.assertEqual(True, S('dog.n.01') != S('cat.n.01'))
+        self.assertEqual(False, S('dog.n.01') == 'dog')


### PR DESCRIPTION
Fixes #1944 

As explained in the commit message,

When comparing the equality of WordNet objects with other objects, it is assumed that the other object is a WordNet object and hence the name attribute of the other object is compared with the name attribute of the WordNet object even though the other object might not be a WordNet object.

This will result in an AttributeError exception to be thrown in the case where the other object is not a WordNet object. For instance, when comparing a WordNet object with a string, since the string does not contain a name attribute, an exception is thrown.

To prevent this from happening, the type of the objects should be evaluated before checking for equality like so:
```python
def __eq__(self, other):
        return type(self) == type(other) and self._name == other._name

    def __ne__(self, other):
        return not self.__eq__(other)

    def __lt__(self, other):
        return type(self) == type(other) and self._name < other._name
```