### PR TITLE
rtype of span_tokenize Standardized

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -232,6 +232,7 @@
 - Vivek Lakshmanan
 - Somnath Rakshit <https://github.com/somnathrakshit>
 - Anlan Du
+- Pulkit Maloo <https://github.com/pulkitmaloo>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 ### Contributors to the Porter Stemmer

--- a/nltk/test/unit/test_tokenize.py
+++ b/nltk/test/unit/test_tokenize.py
@@ -142,7 +142,7 @@ class TestTokenize(unittest.TestCase):
             (40, 46), (47, 48), (48, 51), (51, 52), (53, 55), (56, 59),
             (60, 62), (63, 68), (69, 70), (70, 76), (76, 77), (77, 78)
         ]
-        result = tokenizer.span_tokenize(test1)
+        result = list(tokenizer.span_tokenize(test1))
         self.assertEqual(result, expected)
 
         # Test case with double quotation
@@ -153,7 +153,7 @@ class TestTokenize(unittest.TestCase):
             (65, 68), (69, 74), (75, 76), (77, 85), (86, 92), (93, 95), (96, 102),
             (103, 109)
         ]
-        result = tokenizer.span_tokenize(test2)
+        result = list(tokenizer.span_tokenize(test2))
         self.assertEqual(result, expected)
 
         # Test case with double qoutation as well as converted quotations
@@ -164,5 +164,5 @@ class TestTokenize(unittest.TestCase):
             (65, 68), (69, 74), (75, 76), (77, 79), (79, 87), (87, 89), (90, 96),
             (97, 99), (100, 106), (107, 113)
         ]
-        result = tokenizer.span_tokenize(test3)
+        result = list(tokenizer.span_tokenize(test3))
         self.assertEqual(result, expected)

--- a/nltk/tokenize/__init__.py
+++ b/nltk/tokenize/__init__.py
@@ -102,7 +102,7 @@ _treebank_word_tokenizer = TreebankWordTokenizer()
 # - chervon quotes u'\xab' and u'\xbb' .
 # - unicode quotes u'\u2018', u'\u2019', u'\u201c' and u'\u201d'
 
-improved_open_quote_regex = re.compile(u'([«“‘„])', re.U)
+improved_open_quote_regex = re.compile(u'([«“‘„]|[`]+)', re.U)
 improved_close_quote_regex = re.compile(u'([»”’])', re.U)
 improved_punct_regex = re.compile(r'([^\.])(\.)([\]\)}>"\'' u'»”’ ' r']*)\s*$', re.U)
 _treebank_word_tokenizer.STARTING_QUOTES.insert(0, (improved_open_quote_regex, r' \1 '))

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -1272,13 +1272,14 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
 
     def span_tokenize(self, text, realign_boundaries=True):
         """
-        Given a text, returns a list of the (start, end) spans of sentences
+        Given a text, generates (start, end) spans of sentences
         in the text.
         """
         slices = self._slices_from_text(text)
         if realign_boundaries:
             slices = self._realign_boundaries(text, slices)
-        return [(sl.start, sl.stop) for sl in slices]
+        for sl in slices:
+            yield (sl.start, sl.stop)
 
     def sentences_from_text(self, text, realign_boundaries=True):
         """

--- a/nltk/tokenize/treebank.py
+++ b/nltk/tokenize/treebank.py
@@ -154,7 +154,7 @@ class TreebankWordTokenizer(TokenizerI):
             ... (24, 26), (27, 30), (31, 32), (32, 36), (36, 37), (37, 38),
             ... (40, 46), (47, 48), (48, 51), (51, 52), (53, 55), (56, 59),
             ... (60, 62), (63, 68), (69, 70), (70, 76), (76, 77), (77, 78)]
-            >>> TreebankWordTokenizer().span_tokenize(s) == expected
+            >>> list(TreebankWordTokenizer().span_tokenize(s)) == expected
             True
             >>> expected = ['Good', 'muffins', 'cost', '$', '3.88', 'in',
             ... 'New', '(', 'York', ')', '.', 'Please', '(', 'buy', ')',
@@ -170,7 +170,7 @@ class TreebankWordTokenizer(TokenizerI):
             ... (37, 44), (44, 45), (46, 51), (52, 56), (57, 58), (58, 62),
             ... (64, 68), (69, 71), (72, 75), (76, 77), (77, 81), (81, 82),
             ... (82, 83), (83, 84)]
-            >>> TreebankWordTokenizer().span_tokenize(s) == expected
+            >>> list(TreebankWordTokenizer().span_tokenize(s)) == expected
             True
             >>> expected = ['I', 'said', ',', '"', 'I', "'d", 'like', 'to',
             ... 'buy', 'some', "''", "good", 'muffins', '"', 'which', 'cost',
@@ -194,7 +194,8 @@ class TreebankWordTokenizer(TokenizerI):
         else:
             tokens = raw_tokens
 
-        return align_tokens(tokens, text)
+        for tok in align_tokens(tokens, text):
+            yield tok
 
 
 class TreebankWordDetokenizer(TokenizerI):
@@ -234,7 +235,7 @@ class TreebankWordDetokenizer(TokenizerI):
     True
 
     During tokenization it's safe to add more spaces but during detokenization,
-    simply undoing the padding doesn't really help. 
+    simply undoing the padding doesn't really help.
 
     - During tokenization, left and right pad is added to [!?], when
       detokenizing, only left shift the [!?] is needed.

--- a/nltk/tokenize/treebank.py
+++ b/nltk/tokenize/treebank.py
@@ -190,7 +190,8 @@ class TreebankWordTokenizer(TokenizerI):
             matched = [m.group() for m in re.finditer(r"``|'{2}|\"", text)]
 
             # Replace converted quotes back to double quotes
-            tokens = [matched.pop(0) if tok in ['"', "``", "''"] else tok for tok in raw_tokens]
+            tokens = [matched.pop(0) if tok in ['"', "``", "''"] else tok
+                      for tok in raw_tokens]
         else:
             tokens = raw_tokens
 


### PR DESCRIPTION
* Issue #1980 
* Updated all span_tokenize function to rtype `generator `
* Updated unit test cases for TreebankWordTokenizer
* Updated AUTHORS.md