### PR TITLE
Hotfix/texttiling unbound local variable

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -233,6 +233,7 @@
 - Somnath Rakshit <https://github.com/somnathrakshit>
 - Anlan Du
 - Pulkit Maloo <https://github.com/pulkitmaloo>
+- Brandon M. Burroughs <https://github.com/brandonmburroughs>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 ### Contributors to the Porter Stemmer

--- a/nltk/test/tokenize.doctest
+++ b/nltk/test/tokenize.doctest
@@ -248,3 +248,26 @@ Pickle an MWETokenizer
     >>> unpickeled.tokenize("An hors d'oeuvre tonight, sir?".split())
     ['An', "hors+d'oeuvre", 'tonight,', 'sir?']
 
+
+Regression Tests: TextTilingTokenizer
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+TextTilingTokneizer tokenizes text into coherent subtopic chunks based upon Hearst's TextTiling algorithm.
+
+    >>> from nltk.tokenize import TextTilingTokenizer
+    >>> from nltk.corpus import brown
+    >>> tt = TextTilingTokenizer()
+    >>> tt.tokenize(brown.raw()[0:1000])
+    ["\n\n\tThe/at Fulton/np-tl County/nn-tl Grand/jj-tl Jury/nn-tl said/vbd Friday/nr an/at investigation/nn of/in Atlanta's/np$ recent/jj primary/nn election/nn produced/vbd ``/`` no/at evidence/nn ''/'' that/cs any/dti irregularities/nns took/vbd place/nn ./.\n\n\n\tThe/at jury/nn further/rbr said/vbd in/in term-end/nn presentments/nns that/cs the/at City/nn-tl Executive/jj-tl Committee/nn-tl ,/, which/wdt had/hvd over-all/jj charge/nn of/in the/at election/nn ,/, ``/`` deserves/vbz the/at praise/nn and/cc thanks/nns of/in the/at City/nn-tl of/in-tl Atlanta/np-tl ''/'' for/in the/at manner/nn in/in which/wdt the/at election/nn was/bedz conducted/vbn ./.\n\n\n\tThe/at September-October/np term/nn jury/nn had/hvd been/ben charged/vbn by/in Fulton/np-tl Superior/jj-tl Court/nn-tl Judge/nn-tl Durwood/np Pye/np to/to investigate/vb reports/nns of/in possible/jj ``/`` irregularities/nns ''/'' in/in the/at hard-fought/jj primary/nn which/wdt was/bedz won/vbn by/in Mayor-nominate/nn-tl Ivan/np Allen/np Jr./"]
+
+Test that `ValueError` exceptions are raised when illegal arguments are used.
+
+    >>> TextTilingTokenizer(similarity_method='foo').tokenize(brown.raw()[0:1000])
+    Traceback (most recent call last):
+      ...
+    ValueError: Similarity method foo not recognized
+    >>> TextTilingTokenizer(smoothing_method='bar').tokenize(brown.raw()[0:1000])
+    Traceback (most recent call last):
+      ...
+    ValueError: Smoothing method bar not recognized
+

--- a/nltk/tokenize/texttiling.py
+++ b/nltk/tokenize/texttiling.py
@@ -72,7 +72,6 @@ class TextTilingTokenizer(TokenizerI):
                  cutoff_policy=HC,
                  demo_mode=False):
 
-
         if stopwords is None:
             from nltk.corpus import stopwords
             stopwords = stopwords.words('english')
@@ -101,7 +100,7 @@ class TextTilingTokenizer(TokenizerI):
         # implementation states that it offers no benefit to the
         # process. It might be interesting to test the existing
         # stemmers though.
-        #words = _stem_words(words)
+        # words = _stem_words(words)
 
         # Filter stopwords
         for ts in tokseqs:
@@ -142,7 +141,7 @@ class TextTilingTokenizer(TokenizerI):
             segmented_text.append(text[prevb:b])
             prevb = b
 
-        if prevb < text_length: # append any text that may be remaining
+        if prevb < text_length:  # append any text that may be remaining
             segmented_text.append(text[prevb:])
 
         if not segmented_text:
@@ -153,7 +152,7 @@ class TextTilingTokenizer(TokenizerI):
         return segmented_text
 
     def _block_comparison(self, tokseqs, token_table):
-        "Implements the block comparison method"
+        """Implements the block comparison method"""
         def blk_frq(tok, block):
             ts_occs = filter(lambda o: o[0] in block,
                              token_table[tok].ts_occurences)
@@ -166,7 +165,7 @@ class TextTilingTokenizer(TokenizerI):
         for curr_gap in range(numgaps):
             score_dividend, score_divisor_b1, score_divisor_b2 = 0.0, 0.0, 0.0
             score = 0.0
-            #adjust window size for boundary conditions
+            # adjust window size for boundary conditions
             if curr_gap < self.k-1:
                 window_size = curr_gap + 1
             elif curr_gap > numgaps-self.k:
@@ -175,19 +174,19 @@ class TextTilingTokenizer(TokenizerI):
                 window_size = self.k
 
             b1 = [ts.index
-                  for ts in tokseqs[curr_gap-window_size+1 : curr_gap+1]]
+                  for ts in tokseqs[curr_gap-window_size+1:curr_gap+1]]
             b2 = [ts.index
-                  for ts in tokseqs[curr_gap+1 : curr_gap+window_size+1]]
+                  for ts in tokseqs[curr_gap+1:curr_gap+window_size+1]]
 
             for t in token_table:
                 score_dividend += blk_frq(t, b1)*blk_frq(t, b2)
                 score_divisor_b1 += blk_frq(t, b1)**2
                 score_divisor_b2 += blk_frq(t, b2)**2
             try:
-                score = score_dividend/math.sqrt(score_divisor_b1*
-                                                 score_divisor_b2)
+                score = score_dividend / math.sqrt(score_divisor_b1 *
+                                                   score_divisor_b2)
             except ZeroDivisionError:
-                pass # score += 0.0
+                pass  # score += 0.0
 
             gap_scores.append(score)
 
@@ -196,7 +195,7 @@ class TextTilingTokenizer(TokenizerI):
     def _smooth_scores(self, gap_scores):
         "Wraps the smooth function from the SciPy Cookbook"
         return list(smooth(numpy.array(gap_scores[:]),
-                           window_len = self.smoothing_width+1))
+                           window_len=self.smoothing_width+1))
 
     def _mark_paragraph_breaks(self, text):
         """Identifies indented text or line breaks as the beginning of
@@ -235,7 +234,7 @@ class TextTilingTokenizer(TokenizerI):
         current_par_break = next(pb_iter)
         if current_par_break == 0:
             try:
-                current_par_break = next(pb_iter) #skip break at 0
+                current_par_break = next(pb_iter)  # skip break at 0
             except StopIteration:
                 raise ValueError(
                     "No paragraph breaks were found(text too short perhaps?)"
@@ -247,7 +246,7 @@ class TextTilingTokenizer(TokenizerI):
                         current_par_break = next(pb_iter)
                         current_par += 1
                 except StopIteration:
-                    #hit bottom
+                    # hit bottom
                     pass
 
                 if word in token_table:
@@ -260,18 +259,16 @@ class TextTilingTokenizer(TokenizerI):
                     if token_table[word].last_tok_seq != current_tok_seq:
                         token_table[word].last_tok_seq = current_tok_seq
                         token_table[word]\
-                                .ts_occurences.append([current_tok_seq,1])
+                            .ts_occurences.append([current_tok_seq, 1])
                     else:
                         token_table[word].ts_occurences[-1][1] += 1
-                else: #new word
+                else:  # new word
                     token_table[word] = TokenTableField(first_pos=index,
-                                                        ts_occurences= \
-                                                          [[current_tok_seq,1]],
+                                                        ts_occurences=[[current_tok_seq, 1]],
                                                         total_count=1,
                                                         par_count=1,
                                                         last_par=current_par,
-                                                        last_tok_seq= \
-                                                          current_tok_seq)
+                                                        last_tok_seq=current_tok_seq)
 
             current_tok_seq += 1
 
@@ -286,7 +283,7 @@ class TextTilingTokenizer(TokenizerI):
         avg = sum(depth_scores)/len(depth_scores)
         stdev = numpy.std(depth_scores)
 
-        #SB: what is the purpose of this conditional?
+        # SB: what is the purpose of this conditional?
         if self.cutoff_policy == LC:
             cutoff = avg-stdev/2.0
         else:
@@ -294,11 +291,11 @@ class TextTilingTokenizer(TokenizerI):
 
         depth_tuples = sorted(zip(depth_scores, range(len(depth_scores))))
         depth_tuples.reverse()
-        hp = list(filter(lambda x:x[0]>cutoff, depth_tuples))
+        hp = list(filter(lambda x: x[0] > cutoff, depth_tuples))
 
         for dt in hp:
             boundaries[dt[1]] = 1
-            for dt2 in hp: #undo if there is a boundary close already
+            for dt2 in hp:  # undo if there is a boundary close already
                 if dt[1] != dt2[1] and abs(dt2[1]-dt[1]) < 4 \
                        and boundaries[dt2[1]] == 1:
                     boundaries[dt[1]] = 0
@@ -309,9 +306,9 @@ class TextTilingTokenizer(TokenizerI):
         between the left and right peaks and the gap's score"""
 
         depth_scores = [0 for x in scores]
-        #clip boundaries: this holds on the rule of thumb(my thumb)
-        #that a section shouldn't be smaller than at least 2
-        #pseudosentences for small texts and around 5 for larger ones.
+        # clip boundaries: this holds on the rule of thumb(my thumb)
+        # that a section shouldn't be smaller than at least 2
+        # pseudosentences for small texts and around 5 for larger ones.
 
         clip = min(max(len(scores) // 10, 2), 5)
         index = clip
@@ -348,11 +345,11 @@ class TextTilingTokenizer(TokenizerI):
                 seen_word = False
                 word_count += 1
             if char not in " \t\n" and not seen_word:
-                seen_word=True
+                seen_word = True
             if gaps_seen < len(boundaries) and word_count > \
-                                               (max(gaps_seen*self.w, self.w)):
+               (max(gaps_seen*self.w, self.w)):
                 if boundaries[gaps_seen] == 1:
-                    #find closest paragraph break
+                    # find closest paragraph break
                     best_fit = len(text)
                     for br in paragraph_breaks:
                         if best_fit > abs(br-char_count):
@@ -360,7 +357,7 @@ class TextTilingTokenizer(TokenizerI):
                             bestbr = br
                         else:
                             break
-                    if bestbr not in norm_boundaries: #avoid duplicates
+                    if bestbr not in norm_boundaries:  # avoid duplicates
                         norm_boundaries.append(bestbr)
                 gaps_seen += 1
 
@@ -380,19 +377,20 @@ class TokenTableField(object):
         self.__dict__.update(locals())
         del self.__dict__['self']
 
+
 class TokenSequence(object):
     "A token list with its original length and its index"
     def __init__(self,
                  index,
                  wrdindex_list,
                  original_length=None):
-        original_length=original_length or len(wrdindex_list)
+        original_length = original_length or len(wrdindex_list)
         self.__dict__.update(locals())
         del self.__dict__['self']
 
 
-#Pasted from the SciPy cookbook: http://www.scipy.org/Cookbook/SignalSmooth
-def smooth(x,window_len=11,window='flat'):
+# Pasted from the SciPy cookbook: http://www.scipy.org/Cookbook/SignalSmooth
+def smooth(x, window_len=11, window='flat'):
     """smooth the data using a window with requested size.
 
     This method is based on the convolution of a scaled window with the signal.
@@ -428,14 +426,14 @@ def smooth(x,window_len=11,window='flat'):
     if window_len < 3:
         return x
 
-    if not window in ['flat', 'hanning', 'hamming', 'bartlett', 'blackman']:
+    if window not in ['flat', 'hanning', 'hamming', 'bartlett', 'blackman']:
         raise ValueError("Window is on of 'flat', 'hanning', 'hamming', 'bartlett', 'blackman'")
 
-    s=numpy.r_[2*x[0]-x[window_len:1:-1],x,2*x[-1]-x[-1:-window_len:-1]]
+    s = numpy.r_[2*x[0]-x[window_len:1:-1], x, 2*x[-1]-x[-1:-window_len:-1]]
 
-    #print(len(s))
-    if window == 'flat': #moving average
-        w = numpy.ones(window_len,'d')
+    # print(len(s))
+    if window == 'flat':  # moving average
+        w = numpy.ones(window_len, 'd')
     else:
         w = eval('numpy.' + window + '(window_len)')
 
@@ -448,7 +446,8 @@ def demo(text=None):
     from nltk.corpus import brown
     from matplotlib import pylab
     tt = TextTilingTokenizer(demo_mode=True)
-    if text is None: text = brown.raw()[:10000]
+    if text is None:
+        text = brown.raw()[:10000]
     s, ss, d, b = tt.tokenize(text)
     pylab.xlabel("Sentence Gap index")
     pylab.ylabel("Gap Scores")
@@ -458,5 +457,3 @@ def demo(text=None):
     pylab.stem(range(len(b)), b)
     pylab.legend()
     pylab.show()
-
-

--- a/nltk/tokenize/texttiling.py
+++ b/nltk/tokenize/texttiling.py
@@ -116,9 +116,13 @@ class TextTilingTokenizer(TokenizerI):
             gap_scores = self._block_comparison(tokseqs, token_table)
         elif self.similarity_method == VOCABULARY_INTRODUCTION:
             raise NotImplementedError("Vocabulary introduction not implemented")
+        else:
+            raise ValueError("Similarity method {} not recognized".format(self.similarity_method))
 
         if self.smoothing_method == DEFAULT_SMOOTHING:
             smooth_scores = self._smooth_scores(gap_scores)
+        else:
+            raise ValueError("Smoothing method {} not recognized".format(self.smoothing_method))
         # End of Lexical score Determination
 
         # Boundary identification

--- a/nltk/tokenize/texttiling.py
+++ b/nltk/tokenize/texttiling.py
@@ -100,7 +100,7 @@ class TextTilingTokenizer(TokenizerI):
         # implementation states that it offers no benefit to the
         # process. It might be interesting to test the existing
         # stemmers though.
-        # words = _stem_words(words)
+        #words = _stem_words(words)
 
         # Filter stopwords
         for ts in tokseqs:
@@ -174,9 +174,9 @@ class TextTilingTokenizer(TokenizerI):
                 window_size = self.k
 
             b1 = [ts.index
-                  for ts in tokseqs[curr_gap-window_size+1:curr_gap+1]]
+                  for ts in tokseqs[curr_gap-window_size+1 : curr_gap+1]]
             b2 = [ts.index
-                  for ts in tokseqs[curr_gap+1:curr_gap+window_size+1]]
+                  for ts in tokseqs[curr_gap+1 : curr_gap+window_size+1]]
 
             for t in token_table:
                 score_dividend += blk_frq(t, b1)*blk_frq(t, b2)
@@ -258,8 +258,7 @@ class TextTilingTokenizer(TokenizerI):
 
                     if token_table[word].last_tok_seq != current_tok_seq:
                         token_table[word].last_tok_seq = current_tok_seq
-                        token_table[word]\
-                            .ts_occurences.append([current_tok_seq, 1])
+                        token_table[word].ts_occurences.append([current_tok_seq, 1])
                     else:
                         token_table[word].ts_occurences[-1][1] += 1
                 else:  # new word


### PR DESCRIPTION
This PR addresses a few things:

* Whenever an illegal argument for `similarity_method` or `smoothing_method ` is passed into `TextTilingTokenizer`, an `UnboundLocalError` is thrown.  This is caused by local variables being set in an `if` statement with no `else` branch.  This fix adds an `else` branch that raises an exception if an illegal argument is used.  Here is the code to produce the original error.
```python
>>> from nltk.tokenize import TextTilingTokenizer
>>> from nltk.corpus import brown
>>> 
>>> 
>>> tt = TextTilingTokenizer(similarity_method='foo')  # Illegal argument
>>> tt.tokenize(brown.raw()[0:1000])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".../python3.6/site-packages/nltk/tokenize/texttiling.py", line 123, in tokenize
    smooth_scores = self._smooth_scores(gap_scores)
UnboundLocalError: local variable 'gap_scores' referenced before assignment
```
* I added some doc tests for `TextTilingTokenizer`.
* I linted `nltk/tokenize/texttiling.py` and fixed the PEP8 violations.  The only thing I didn't fix was line length violations since none seemed glaringly bad and `nltk` doesn't have a defined line lenght.

Let me know if there is anything else I need to add or that I should change.  Thanks!