### PR TITLE
Clarify comment

### DIFF
--- a/nltk/tokenize/treebank.py
+++ b/nltk/tokenize/treebank.py
@@ -23,7 +23,7 @@ from nltk.tokenize.util import align_tokens
 
 class MacIntyreContractions:
     """
-    List of contractions adapted from Robert MacIntyre's tokenizer.
+    List of contractions from Robert MacIntyre's tokenizer.
     """
     CONTRACTIONS2 = [r"(?i)\b(can)(?#X)(not)\b",
                      r"(?i)\b(d)(?#X)('ye)\b",


### PR DESCRIPTION
List of tokens is not adapted from Robert MacIntyre's tokenizer. It *is* from then tokeniser -- it is identical AFAICT.
Compare to https://web.archive.org/web/20130804202913/http://www.cis.upenn.edu/%7Etreebank/tokenizer.sed