### PR TITLE
Fix nonescaped openning bracket in  stating quote

### DIFF
--- a/nltk/tokenize/treebank.py
+++ b/nltk/tokenize/treebank.py
@@ -67,7 +67,7 @@ class TreebankWordTokenizer(TokenizerI):
     STARTING_QUOTES = [
         (re.compile(r'^\"'), r'``'),
         (re.compile(r'(``)'), r' \1 '),
-        (re.compile(r"([ (\[{<])(\"|\'{2})"), r'\1 `` '),
+        (re.compile(r"([ \(\[{<])(\"|\'{2})"), r'\1 `` '),
     ]
 
     # punctuation


### PR DESCRIPTION
The regex had an unbalanced opening quote,
because (I believe) it meant the literal openning quote.

I am surprised `re.compile` don't error at that.
Maybe I am missing something, though.

This has been in the code in one form or another since
https://github.com/nltk/nltk/commit/e660a6827d44e242b4114abba7fc30fef6b0125c

