### PR TITLE
Install matplotlib explicitly after pip install -r

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -3,7 +3,8 @@
 cd `dirname $0`
 
 #download nltk python dependencies
-pip install --upgrade -r pip-req.txt --allow-external matplotlib --allow-unverified matplotlib
+pip install --upgrade -r pip-req.txt --allow-unverified matplotlib --allow-external matplotlib
+pip install --upgrade scikit-learn
 pip install --upgrade https://github.com/PyCQA/pylint/archive/master.zip 
 
 #download nltk data packages

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -3,8 +3,8 @@
 cd `dirname $0`
 
 #download nltk python dependencies
-pip install --upgrade -r pip-req.txt --allow-unverified matplotlib --allow-external matplotlib
-pip install --upgrade scikit-learn
+pip install --upgrade -r pip-req.txt
+pip install --upgrade matplotlib
 pip install --upgrade https://github.com/PyCQA/pylint/archive/master.zip 
 
 #download nltk data packages


### PR DESCRIPTION
Removed the usage of `--allow-external`, instead just install in a separate line in the shell script.

```
pip install -U -r pip-req.txt
pip install -U matplotlib
```

I think putting it in a separate line is clearer than the alternative to repeat the dependency of the library as itself, something like:

```
pip install -U -r pip-req.txt —allow-external matplotlib matplotlib
```

That should clear up the problem on CI https://nltk.ci.cloudbees.com/job/pull_request_tests/PYV=2.7.14,jdk=jdk8latestOnlineInstall/669/console 