### PR TITLE
Added "percents" argument to plot() functions

### DIFF
--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -273,9 +273,13 @@ class FreqDist(Counter):
         samples = [item for item, _ in self.most_common(*args)]
 
         cumulative = _get_kwarg(kwargs, 'cumulative', False)
+        percents = _get_kwarg(kwargs, 'percents', False)
         if cumulative:
             freqs = list(self._cumulative_frequencies(samples))
             ylabel = "Cumulative Counts"
+            if percents:
+                freqs = [f/freqs[len(freqs) - 1]*100 for f in freqs]
+                ylabel = "Cumulative Percents"
         else:
             freqs = [self[sample] for sample in samples]
             ylabel = "Counts"
@@ -1848,6 +1852,7 @@ class ConditionalFreqDist(defaultdict):
                          'See http://matplotlib.org/')
 
         cumulative = _get_kwarg(kwargs, 'cumulative', False)
+        percents = _get_kwarg(kwargs, 'percents', False)
         conditions = _get_kwarg(kwargs, 'conditions', sorted(self.conditions()))
         title = _get_kwarg(kwargs, 'title', '')
         samples = _get_kwarg(kwargs, 'samples',
@@ -1860,6 +1865,9 @@ class ConditionalFreqDist(defaultdict):
                 freqs = list(self[condition]._cumulative_frequencies(samples))
                 ylabel = "Cumulative Counts"
                 legend_loc = 'lower right'
+                if percents:
+                    freqs = [f/freqs[len(freqs) - 1]*100 for f in freqs]
+                    ylabel = "Cumulative Percents"
             else:
                 freqs = [self[condition][sample] for sample in samples]
                 ylabel = "Counts"


### PR DESCRIPTION
Look, i don't mean to waste anyone's time and pollute in here, and i know it's not an important issue, this is why i decided not to create an _issue_ for such a small "problem". Since i've changed source for myself anyway and i find that little change useful, i was wondering if that'll be an appropriate suggestion.

There is at least two reasons for that change:
1. It matches with the nltk book. [Here (ch2 1.7)](http://www.nltk.org/book/ch02.html#corpora-in-other-languages) it demonstrates how `plot(cumulative=True)` function of the `ConditionalFreqDist` works. And in that example it uses _cumulative percents_, not _counts_ as it is today. As i understand it, code was changed since then, but then, that means book is also have to be changed.
2. In my view, with _cumulative percents_ it is much easier to illustrate distribution and so it's easier to comprehend the information. Of course, that is just my opinion, but why not have _cumulative percents_ as an option?