### PR TITLE
Consistent pos argument between wn.synsets() and WordNetLemmatizer.lemmatize()   Issue #1978

### DIFF
--- a/nltk/stem/wordnet.py
+++ b/nltk/stem/wordnet.py
@@ -36,7 +36,8 @@ class WordNetLemmatizer(object):
     def __init__(self):
         pass
 
-    def lemmatize(self, word, pos=NOUN):
+    def lemmatize(self, word, pos=None):
+        pos=NOUN if pos == None else pos=pos
         lemmas = wordnet._morphy(word, pos)
         return min(lemmas, key=len) if lemmas else word
 


### PR DESCRIPTION
The **pos** argument accepts **None** type value for **wn.synsets()** and defaults that to **Noun**. However **WordNetLemmatizer().lemmatize()** doesn't do the same and it raises a **KeyError** when **pos=None** is entered. 

The changes made to original code involves sorting out this problem such that **pos argument defaults the None type value to Noun.**

This issue was raised by @alvations . 

