### PR TITLE
Testing jenkins.sh with senna files

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -59,6 +59,8 @@ if [[ ! -d $senna_folder_name ]]; then
         rm ${senna_file_name}
 fi
 
+ls /home/jenkins/third/senna/data/
+
 # Setup the Enviroment variable
 export CLASSPATH=$(pwd)"/${stanford_corenlp_package_name}"
 export CLASSPATH=${CLASSPATH}:$(pwd)"/${stanford_parser_package_name}"


### PR DESCRIPTION
CI is showing some irregularities in Python2.7 vs Python3.x 

It can't seem to read the `/home/jenkins/third/senna/data/ner.loc.dat` file in https://nltk.ci.cloudbees.com/job/pull_request_tests/PYV=3.5.4,jdk=jdk8latestOnlineInstall/lastCompletedBuild/console for Python3.x but it works fine in Python2.7

Adding the `ls` in `jenkin.sh` to see what's happening.