### PR TITLE
Fix logger name

### DIFF
--- a/nltk/metrics/agreement.py
+++ b/nltk/metrics/agreement.py
@@ -82,7 +82,7 @@ from nltk.compat import python_2_unicode_compatible
 
 from nltk.metrics.distance import binary_distance
 
-log = logging.getLogger(__file__)
+log = logging.getLogger(__name__)
 
 @python_2_unicode_compatible
 class AnnotationTask(object):


### PR DESCRIPTION
Stop creating strange loggers 
`
"/Users/user/PycharmProjects/code/.env/lib/python3.6/site-packages/nltk/metrics/agreement.py"
`
