### PR TITLE
Added Two functions to that are missing in the _WordNetObject class.

### DIFF
--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -167,8 +167,14 @@ class _WordNetObject(object):
     def topic_domains(self):
         return self._related(';c')
 
+    def in_topic_domains(self):
+        return self._related('-c')
+    
     def region_domains(self):
         return self._related(';r')
+    
+    def in_region_domains(self):
+        return self._related('-r')
 
     def usage_domains(self):
         return self._related(';u')


### PR DESCRIPTION
Added Two functions to that was missing in the _WordNetObject class.
They read in_topic_domains and in_region_domains relations from WordNet dataset.  
These relations are already in WordNet. 
Cheers,
Afshin Sadeghi (University of Bonn)