### PR TITLE
Change binary_search_file to avoid decoding part of a code point

### DIFF
--- a/nltk/data.py
+++ b/nltk/data.py
@@ -1139,6 +1139,13 @@ class SeekableUnicodeStreamReader(object):
 
         return chars
 
+    def discard_line(self):
+        if self.linebuffer and len(self.linebuffer) > 1:
+            line = self.linebuffer.pop(0)
+            self._rewind_numchars += len(line)
+        else:
+            self.stream.readline()
+
     def readline(self, size=None):
         """
         Read a line of text, decode it using this reader's encoding,

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -612,7 +612,7 @@ def binary_search_file(file, key, cache={}, cacheDepth=-1):
             while True:
                 file.seek(max(0, middle - 1))
                 if middle > 0:
-                    file.readline()
+                    file.discard_line()
                 offset = file.tell()
                 line = file.readline()
                 if line != "": break


### PR DESCRIPTION
This shows up when trying to: e.g. repurpose the Wordnet reading code to deal with reading other WordNets that contain characters outside the single byte UTF-8 character range. (I know about OMW -- but it doesn't suit my current use-case at the moment.) The problem is that when binary_search_file seeks to the middle of a line, it might seek to the middle of a code point, causing a UnicodeDecodingError. This patch makes to avoid decoding in this case.