### PR TITLE
Allow [CI: retest] for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,11 @@ cache:
 
 dist: xenial
 
+addons:
+  apt:
+    packages:
+      - expect-dev # for unbuffer, see https://github.com/travis-ci/travis-ci/issues/7967
+
 matrix:
   include:
 #    - python: '2.7'
@@ -41,7 +46,7 @@ install:
   - pip install tox
 
 script:
-  - tox -e $TOXENV tox.ini -vv
+  - unbuffer tox --color=auto -e $TOXENV tox.ini -vv
 
 after_success:
   - tools/travis/travis-ci-commenter.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ install:
   - pip install tox
 
 script:
-  - unbuffer tox --color=auto -e $TOXENV tox.ini -vv
+  - unbuffer tox -e $TOXENV tox.ini -vv
 
 after_success:
   - tools/travis/travis-ci-commenter.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,3 +42,6 @@ install:
 
 script:
   - tox -e $TOXENV tox.ini -vv
+
+after_success:
+  - tools/travis/travis-ci-commenter.sh

--- a/tools/travis/travis-ci-commenter.sh
+++ b/tools/travis/travis-ci-commenter.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [ "$TRAVIS_PULL_REQUEST" != "false" ] ; then
+    curl -H "Authorization: token ${GITHUB_TOKEN}" -X POST \
+    -d "{\"body\": \"[CI: retest]\"}" \
+    "https://api.github.com/repos/${TRAVIS_REPO_SLUG}/issues/${TRAVIS_PULL_REQUEST}/comments"


### PR DESCRIPTION
This PR would allow admins to use the `[CI: retest]` function as we have with Jenkins for the Travis CI. 

But please do not merge this as yet, there're some unresolved issues on Travis where the colors of the passed/failed tests is gone after adding the `travis-ci-commenter.sh` in the `after_success` step. See https://github.com/travis-ci/travis-ci/issues/7967#issuecomment-422259013 for details.