### PR TITLE
Corrected the syntax of the shell for [CI: retest]

### DIFF
--- a/tools/travis/travis-ci-commenter.sh
+++ b/tools/travis/travis-ci-commenter.sh
@@ -4,3 +4,4 @@ if [ "$TRAVIS_PULL_REQUEST" != "false" ] ; then
     curl -H "Authorization: token ${GITHUB_TOKEN}" -X POST \
     -d "{\"body\": \"[CI: retest]\"}" \
     "https://api.github.com/repos/${TRAVIS_REPO_SLUG}/issues/${TRAVIS_PULL_REQUEST}/comments"
+fi


### PR DESCRIPTION
Merging and finger crossing on the Travis. I'm not sure how else to test an `after_success` script other than merging and waiting for it to kick in on Travis. 

Sorry for the multiple merges. 