### PR TITLE
fix unit test

### DIFF
--- a/nltk/test/unit/test_wordnet.py
+++ b/nltk/test/unit/test_wordnet.py
@@ -125,9 +125,9 @@ class WordnNetDemo(unittest.TestCase):
 
     def test_in_topic_domains(self):
         # Test in domains.
-        self.assertEqual(S('computer_science.n.01').in_topic_domains()[0], [S('access.n.05')])
-        self.assertEqual(S('germany.n.01').in_region_domains()[23], [S('trillion.n.02')])
-        self.assertEqual(S('slang.n.02').in_usage_domains()[1], [S('airhead.n.01')])
+        self.assertEqual(S('computer_science.n.01').in_topic_domains()[0], S('access.n.05'))
+        self.assertEqual(S('germany.n.01').in_region_domains()[23], S('trillion.n.02'))
+        self.assertEqual(S('slang.n.02').in_usage_domains()[1], S('airhead.n.01'))
 
     def test_wordnet_similarities(self):
         # Path based similarities.


### PR DESCRIPTION
Currently, latest build on develop fails as can be seen here https://travis-ci.org/nltk/nltk/builds/440880582 with the following message:

```
ERROR: test_in_topic_domains (nltk.test.unit.test_wordnet.WordnNetDemo)
----------------------------------------------------------------------
   Traceback (most recent call last):
    unit/test_wordnet.py line 128 in test_in_topic_domains
      self.assertEqual(S('computer_science.n.01').in_topic_domains()[0], [S('access.n.05')])
    /home/travis/build/nltk/nltk/nltk/corpus/reader/wordnet.py line 207 in __eq__
      return self._name == other._name
   AttributeError: 'list' object has no attribute '_name'

```

This is due to a unit test introduced in the following PR: https://github.com/nltk/nltk/pull/2078

This PR fixes the unit test by removing what looks like accidentally added square brackets which resulted in an object being compared to a list containing a similar object.