### PR TITLE
Run tests for Python 3.7 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,14 @@ matrix:
     - python: '3.6' # Only runs checks on 3rd party for latest Python distribution
       env: TOXENV="py-travis-third-party"
 
+    - python: 3.7
+      env: TOXENV="py-travis"
+      sudo: required
+
+    - python: 3.7
+      env: TOXENV="py-travis-third-party"
+      sudo: required
+
 before_install:
   - source tools/travis/pre-install.sh # Checks Java and Python versions.
   - chmod +x tools/travis/coverage-pylint.sh

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{27,35,36}
+    py{27,35,36,37}
     pypy
-    py{27,35,36}-nodeps
+    py{27,35,36,37}-nodeps
     py{27,35,36}-jenkins
     py-travis
 


### PR DESCRIPTION
Python 3.7 was released on 2018-06-27. Running automated tests for this version of Python will help future proof existing and new contributions.