### PR TITLE
fix LazyCorpusLoader for python 3.7+ 

### DIFF
--- a/nltk/corpus/util.py
+++ b/nltk/corpus/util.py
@@ -66,7 +66,7 @@ class LazyCorpusLoader(object):
 
     def __load(self):
         # Find the corpus root directory.
-        zip_name = re.sub(r'(([^/]*)(/.*)?)', r'\2.zip/\1/', self.__name)
+        zip_name = re.sub(r'(([^/]+)(/.*)?)', r'\2.zip/\1/', self.__name)
         if TRY_ZIPFILE_FIRST:
             try:
                 root = nltk.data.find('{}/{}'.format(self.subdir, zip_name))

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{27,35,36}
+    py{27,35,36,37}
     pypy
     py{27,35,36}-nodeps
     py{27,35,36}-jenkins


### PR DESCRIPTION
This pull request addresses Python 3.7 compatibility issue outlined in: https://github.com/nltk/nltk/issues/2145