### PR TITLE
fix RuntimeError in doctest as per PEP 479

### DIFF
--- a/nltk/toolbox.py
+++ b/nltk/toolbox.py
@@ -69,7 +69,12 @@ class StandardFormat(object):
         # need to get first line outside the loop for correct handling
         # of the first marker if it spans multiple lines
         file_iter = iter(self._file)
-        line = next(file_iter)
+        # PEP 479, prevent RuntimeError when StopIteration is raised inside generator
+        try:
+            line = next(file_iter)
+        except StopIteration:
+            # no more data is available, terminate the generator
+            return
         mobj = re.match(first_line_pat, line)
         mkr, line_value = mobj.groups()
         value_lines = [line_value,]


### PR DESCRIPTION
Fix failing `toolbox.doctest` when executing with python 3.7 as per https://github.com/nltk/nltk/issues/2148

How to reproduce:
```
>>> from nltk import toolbox
>>> f = toolbox.StandardFormat()
>>> f.open_string('')
>>> list(f.raw_fields())
Traceback (most recent call last):
  File "/home/foo/projects/nltk/nltk/toolbox.py", line 72, in raw_fields
    line = next(file_iter)
StopIteration

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: generator raised StopIteration
```
