### PR TITLE
fix RuntimeError in unit test as per PEP 479

### DIFF
--- a/nltk/util.py
+++ b/nltk/util.py
@@ -464,7 +464,13 @@ def ngrams(sequence, n, pad_left=False, pad_right=False,
 
     history = []
     while n > 1:
-        history.append(next(sequence))
+        # PEP 479, prevent RuntimeError from being raised when StopIteration bubbles out of generator
+        try:
+            next_item = next(sequence)
+        except StopIteration:
+            # no more data, terminate the generator
+            return
+        history.append(next_item)
         n -= 1
     for item in sequence:
         history.append(item)


### PR DESCRIPTION
Fixes `test_sentence_nist` unit test when executed with python 3.7 as per https://github.com/nltk/nltk/issues/2148

Example stack trace:
```
1) ERROR: test_sentence_nist (nltk.test.unit.translate.test_nist.TestNIST)
----------------------------------------------------------------------
   Traceback (most recent call last):
    unit/translate/test_nist.py line 35 in test_sentence_nist
      nltk_nist = corpus_nist(references, hypotheses, i)
    /home/foo/projects/nltk/nltk/translate/nist_score.py line 97 in corpus_nist
      ngram_freq.update(ngrams(reference, i))
    /home/foo/projects/nltk/.tox/py37/lib/python3.7/collections/__init__.py line 653 in update
      _count_elements(self, iterable)
   RuntimeError: generator raised StopIteration
```

Can also be reproduced with:
```
>>> from nltk.util import ngrams
>>> list(ngrams([], 3))
Traceback (most recent call last):
  File "/home/foo/projects/nltk/nltk/util.py", line 467, in ngrams
    history.append(next(sequence))
StopIteration

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
RuntimeError: generator raised StopIteration
```