### PR TITLE
remove unused imports

### DIFF
--- a/nltk/ccg/lexicon.py
+++ b/nltk/ccg/lexicon.py
@@ -17,7 +17,7 @@ from nltk.ccg.api import PrimitiveCategory, Direction, CCGVar, FunctionalCategor
 from nltk.compat import python_2_unicode_compatible
 from nltk.internals import deprecated
 
-from nltk.sem.logic import *
+from nltk.sem.logic import Expression
 
 #------------
 # Regular expressions used for parsing components of the lexicon


### PR DESCRIPTION
As a followup to https://github.com/nltk/nltk/issues/2113, this change replaces wildcard import with importing a specific class. As a result the following `pylint` warnings are resolved:

```bash
nltk/ccg/lexicon.py:20:0: W0614: Unused import operator from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import APP from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import Tokens from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import boolean_ops from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import equality_preds from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import binding_ops from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import LogicParser from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import read_logic from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import Variable from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import unique_variable from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import skolem_function from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import Type from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import ComplexType from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import BasicType from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import EntityType from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import TruthValueType from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import EventType from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import AnyType from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import TRUTH_TYPE from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import ENTITY_TYPE from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import EVENT_TYPE from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import ANY_TYPE from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import read_type from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import TypeException from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import InconsistentTypeHierarchyException from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import TypeResolutionException from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import IllegalTypeException from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import typecheck from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import SubstituteBindingsI from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import ApplicationExpression from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import AbstractVariableExpression from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import IndividualVariableExpression from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import FunctionVariableExpression from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import EventVariableExpression from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import ConstantExpression from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import VariableExpression from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import VariableBinderExpression from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import LambdaExpression from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import QuantifiedExpression from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import ExistsExpression from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import AllExpression from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import NegatedExpression from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import BinaryExpression from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import BooleanExpression from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import AndExpression from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import OrExpression from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import ImpExpression from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import IffExpression from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import EqualityExpression from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import LogicalExpressionException from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import UnexpectedTokenException from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import ExpectedMoreTokensException from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import is_indvar from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import is_funcvar from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import is_eventvar from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import demo from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import demo_errors from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import demoException from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import printtype from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import reduce from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import total_ordering from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import string_types from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import Trie from wildcard import (unused-wildcard-import)
nltk/ccg/lexicon.py:20:0: W0614: Unused import Counter from wildcard import (unused-wildcard-import)
```