### PR TITLE
fix ResourceWarning: unclosed file

### DIFF
--- a/nltk/data.py
+++ b/nltk/data.py
@@ -1270,6 +1270,11 @@ class SeekableUnicodeStreamReader(object):
         """Return self"""
         return self
 
+    def __del__(self):
+        # let garbage collector deal with still opened streams
+        if not self.closed:
+            self.close()
+
     def xreadlines(self):
         """Return self"""
         return self

--- a/nltk/test/unit/test_seekable_unicode_stream_reader.py
+++ b/nltk/test/unit/test_seekable_unicode_stream_reader.py
@@ -127,6 +127,13 @@ def test_reader_on_large_string():
             pass
 
 
+def test_reader_stream_is_closed():
+    reader = SeekableUnicodeStreamReader(BytesIO(b''), 'ascii')
+    assert reader.stream.closed is False
+    reader.__del__()
+    assert reader.stream.closed is True
+
+
 def teardown_module(module=None):
     import gc
 


### PR DESCRIPTION
Fix for issue https://github.com/nltk/nltk/issues/1928

This approach closes opened resources during garbage collection.

How to reproduce:

```bash
python -Wd -c "import nltk; print(nltk.corpus.stopwords.words('english'))"
```