### PR TITLE
remove unused side effect

### DIFF
--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -27,7 +27,6 @@ except ImportError:
 
 from six import string_types
 
-from nltk import __file__
 from nltk import compat
 
 ##########################################################################


### PR DESCRIPTION
As a followup from https://github.com/nltk/nltk/issues/2168

The removed line changed `__file__` from pointing to `nltk/internals.py` to pointing to `nltk/__init__.py`. This side effect may have previously been used [here](https://github.com/nltk/nltk/commit/701468b184400511bbefc8053629e975f9d89bc1#diff-6d3d9c7d1794a239ab676fc6fce3131fL168) but the code has since been deleted. `__file__` is not referenced anywhere else in `internals.py` and all other references to `__file__` in the code base do not rely on this side effect.