### PR TITLE
pylint cleanup: remove unused imports

### DIFF
--- a/nltk/classify/maxent.py
+++ b/nltk/classify/maxent.py
@@ -60,7 +60,6 @@ except ImportError:
 
 import tempfile
 import os
-import re
 from collections import defaultdict
 
 from six import integer_types

--- a/nltk/collections.py
+++ b/nltk/collections.py
@@ -6,15 +6,10 @@
 # For license information, see LICENSE.TXT
 from __future__ import print_function, absolute_import
 
-import locale
-import re
-import types
-import textwrap
-import pydoc
 import bisect
-import os
-from itertools import islice, chain, combinations
+from itertools import islice, chain
 from functools import total_ordering
+# this unused import is for python 2.7
 from collections import defaultdict, deque, Counter
 
 from six import text_type

--- a/nltk/collocations.py
+++ b/nltk/collocations.py
@@ -36,6 +36,7 @@ from six import iteritems
 
 from nltk.probability import FreqDist
 from nltk.util import ngrams
+# these two unused imports are referenced in collocations.doctest
 from nltk.metrics import ContingencyMeasures, BigramAssocMeasures, TrigramAssocMeasures
 from nltk.metrics.spearman import ranks_from_scores, spearman_correlation
 

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -42,7 +42,7 @@ import zipfile
 import codecs
 
 from abc import ABCMeta, abstractmethod
-from gzip import GzipFile, READ as GZ_READ, WRITE as GZ_WRITE
+from gzip import GzipFile, WRITE as GZ_WRITE
 
 from six import add_metaclass
 from six import string_types, text_type

--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -43,7 +43,6 @@ import math
 import random
 import warnings
 import array
-from operator import itemgetter
 from collections import defaultdict, Counter
 from functools import reduce
 from abc import ABCMeta, abstractmethod

--- a/nltk/text.py
+++ b/nltk/text.py
@@ -18,12 +18,11 @@ from __future__ import print_function, division, unicode_literals, absolute_impo
 from math import log
 from collections import defaultdict, Counter, namedtuple
 from functools import reduce
-from itertools import islice
 import re
 
 from six import text_type
 
-from nltk.probability import FreqDist, LidstoneProbDist
+from nltk.probability import FreqDist
 from nltk.probability import ConditionalFreqDist as CFD
 from nltk.util import tokenwrap, LazyConcatenation
 from nltk.metrics import f_measure, BigramAssocMeasures

--- a/nltk/treeprettyprinter.py
+++ b/nltk/treeprettyprinter.py
@@ -21,16 +21,12 @@ http://jgaa.info/accepted/2006/EschbachGuentherBecker2006.10.2.pdf
 from __future__ import division, print_function, unicode_literals
 
 import re
-import sys
-import codecs
 from cgi import escape
 from collections import defaultdict
 from operator import itemgetter
-from itertools import chain, islice
 
-from nltk.util import slice_bounds, OrderedDict
-from nltk.compat import python_2_unicode_compatible, unicode_repr
-from nltk.internals import raise_unorderable_types
+from nltk.util import OrderedDict
+from nltk.compat import python_2_unicode_compatible
 from nltk.tree import Tree
 
 ANSICOLOR = {


### PR DESCRIPTION
As a followup to discussion in https://github.com/nltk/nltk/pull/2164, this cleans up more pylint warnings about unused imports in the code.

To reproduce: `pylint * | grep 'unused-import'`

```
nltk/classify/maxent.py:63:0: W0611: Unused import re (unused-import)
nltk/collections.py:10:0: W0611: Unused import re (unused-import)
nltk/collections.py:11:0: W0611: Unused import types (unused-import)
nltk/collections.py:12:0: W0611: Unused import textwrap (unused-import)
nltk/collections.py:13:0: W0611: Unused import pydoc (unused-import)
nltk/collections.py:15:0: W0611: Unused import os (unused-import)
nltk/collections.py:16:0: W0611: Unused combinations imported from itertools (unused-import)
nltk/collections.py:18:0: W0611: Unused Counter imported from collections (unused-import)
nltk/collections.py:18:0: W0611: Unused defaultdict imported from collections (unused-import)
nltk/collections.py:18:0: W0611: Unused deque imported from collections (unused-import)
nltk/collections.py:9:0: W0611: Unused import locale (unused-import)
nltk/collocations.py:39:0: W0611: Unused BigramAssocMeasures imported from nltk.metrics (unused-import)
nltk/collocations.py:39:0: W0611: Unused ContingencyMeasures imported from nltk.metrics (unused-import)
nltk/collocations.py:39:0: W0611: Unused TrigramAssocMeasures imported from nltk.metrics (unused-import)
nltk/collocations.py:40:0: W0611: Unused ranks_from_scores imported from nltk.metrics.spearman (unused-import)
nltk/collocations.py:40:0: W0611: Unused spearman_correlation imported from nltk.metrics.spearman (unused-import)
nltk/data.py:45:0: W0611: Unused READ imported from gzip as GZ_READ (unused-import)
nltk/probability.py:46:0: W0611: Unused itemgetter imported from operator (unused-import)
nltk/text.py:21:0: W0611: Unused islice imported from itertools (unused-import)
nltk/text.py:26:0: W0611: Unused LidstoneProbDist imported from nltk.probability (unused-import)
nltk/treeprettyprinter.py:24:0: W0611: Unused import sys (unused-import)
nltk/treeprettyprinter.py:25:0: W0611: Unused import codecs (unused-import)
nltk/treeprettyprinter.py:29:0: W0611: Unused chain imported from itertools (unused-import)
nltk/treeprettyprinter.py:29:0: W0611: Unused islice imported from itertools (unused-import)
nltk/treeprettyprinter.py:31:0: W0611: Unused slice_bounds imported from nltk.util (unused-import)
nltk/treeprettyprinter.py:32:0: W0611: Unused unicode_repr imported from nltk.compat (unused-import)
nltk/treeprettyprinter.py:33:0: W0611: Unused raise_unorderable_types imported from nltk.internals (unused-import)
```