### PR TITLE
refactor none comparison

### DIFF
--- a/nltk/corpus/reader/panlex_lite.py
+++ b/nltk/corpus/reader/panlex_lite.py
@@ -64,7 +64,7 @@ class PanLexLiteCorpusReader(CorpusReader):
         :rtype: list(tuple)
         """
 
-        if lc == None:
+        if lc is None:
             return self._c.execute('SELECT uid, tt FROM lv ORDER BY uid').fetchall()
         else:
             return self._c.execute(

--- a/nltk/metrics/aline.py
+++ b/nltk/metrics/aline.py
@@ -1092,7 +1092,7 @@ def align(str1, str2, epsilon=0):
 
     (Kondrak 2002: 51)
     """
-    if np == None:
+    if np is None:
         raise ImportError('You need numpy in order to use the align function')
 
     assert 0.0 <= epsilon <= 1.0, "Epsilon must be between 0.0 and 1.0."

--- a/nltk/parse/malt.py
+++ b/nltk/parse/malt.py
@@ -89,7 +89,7 @@ def find_malt_model(model_filename):
     """
     A module to find pre-trained MaltParser model.
     """
-    if model_filename == None:
+    if model_filename is None:
         return 'malt_temp.mco'
     elif os.path.exists(model_filename):  # If a full path is given.
         return model_filename


### PR DESCRIPTION
As per [programming recommendations](https://www.python.org/dev/peps/pep-0008/#programming-recommendations) in PEP8: 

_Comparisons to singletons like None should always be done with is or is not, never the equality operators._

This PR is a straightforward refactoring of `== None` into `is None`.