### PR TITLE
decouple sentiment and twitter packages

### DIFF
--- a/nltk/sentiment/util.py
+++ b/nltk/sentiment/util.py
@@ -27,7 +27,6 @@ import nltk
 from nltk.corpus import CategorizedPlaintextCorpusReader
 from nltk.data import load
 from nltk.tokenize.casual import EMOTICON_RE
-from nltk.twitter.common import outf_writer_compat, extract_fields
 
 # ////////////////////////////////////////////////////////////
 # { Regular expressions
@@ -924,6 +923,7 @@ if __name__ == '__main__':
     from nltk.classify import NaiveBayesClassifier, MaxentClassifier
     from nltk.classify.scikitlearn import SklearnClassifier
     from sklearn.svm import LinearSVC
+    from nltk.twitter.common import outf_writer_compat, extract_fields
 
     naive_bayes = NaiveBayesClassifier.train
     svm = SklearnClassifier(LinearSVC()).train


### PR DESCRIPTION
This PR addresses https://github.com/nltk/nltk/issues/2053

### How to reproduce:
```
>>> import twython
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'twython'
>>> import nltk
>>> from nltk.sentiment import SentimentIntensityAnalyzer
/home/foo/projects/nltk/nltk/twitter/__init__.py:22: UserWarning: The twython library has not been installed. Some functionality from the twitter package will not be available.
  "The twython library has not been installed. "
```

1 Ensure that `twython` is not installed.
2 Attempt to import a class from `sentiment` module.
3 See warning from `twitter` module.

### Current situation
`sentiment` package includes demo code that that makes use of utility functions from `twitter` package. This demo code is currently exposed through a user facing public api in `sentiment\util.py` module. Because of this, any `sentiment` package class that attempts to make use of functions in `util.py` will also cause the interpreter to load `twitter` package at runtime, which causes `twitter` specific code to run and generates the warning.

### Proposed change
`sentiment\util.py` is refactored to only depend on `twitter` when executing demo code.
Utility functions from `util.py` are still accessible to `sentiment` package without importing `twitter` at runtime while still preserving the existing public api for demo code.