### PR TITLE
allow CorpusReader to load zip files without requiring a subfolder inside

### DIFF
--- a/nltk/data.py
+++ b/nltk/data.py
@@ -505,11 +505,12 @@ class ZipFilePathPointer(PathPointer):
         if isinstance(zipfile, string_types):
             zipfile = OpenOnDemandZipFile(os.path.abspath(zipfile))
 
-        # Normalize the entry string, it should be relative:
-        entry = normalize_resource_name(entry, True, '/').lstrip('/')
-
         # Check that the entry exists:
-        if entry != '.':
+        if entry:
+
+            # Normalize the entry string, it should be relative:
+            entry = normalize_resource_name(entry, True, '/').lstrip('/')
+
             try:
                 zipfile.getinfo(entry)
             except Exception:


### PR DESCRIPTION
This PR addresses https://github.com/nltk/nltk/issues/2090

While the fix for issue https://github.com/nltk/nltk/issues/1986 did suppress the exception, it did not go far enough in enabling corpus reader to work with zip files without a folder inside - https://github.com/nltk/nltk/pull/2013
