### PR TITLE
expand error message to include full resource name

### DIFF
--- a/nltk/data.py
+++ b/nltk/data.py
@@ -689,6 +689,10 @@ def find(resource_name, paths=None):
     ).format(resource=resource_zipname)
     msg = textwrap_indent(msg)
 
+    msg += '\n  Attempted to load \33[93m{resource_name}\033[0m\n'.format(
+        resource_name=resource_name
+    )
+
     msg += '\n  Searched in:' + ''.join('\n    - %r' % d for d in paths)
     sep = '*' * 70
     resource_not_found = '\n%s\n%s\n%s\n' % (sep, msg, sep)

--- a/nltk/test/unit/test_data.py
+++ b/nltk/test/unit/test_data.py
@@ -1,0 +1,22 @@
+import unittest
+import nltk.data
+from nose.tools import assert_raises
+
+
+class TestData(unittest.TestCase):
+    def test_find_raises_exception(self):
+
+        with assert_raises(LookupError) as context:
+            nltk.data.find('no_such_resource/foo')
+
+        assert type(context.exception) == LookupError, 'Unexpected exception raised'
+
+    def test_find_raises_exception_with_full_resource_name(self):
+        no_such_thing = 'no_such_thing/bar'
+
+        with assert_raises(LookupError) as context:
+            nltk.data.find(no_such_thing)
+
+        assert no_such_thing in str(
+            context.exception
+        ), 'Exception message does not include full resource name'

--- a/nltk/tokenize/__init__.py
+++ b/nltk/tokenize/__init__.py
@@ -89,6 +89,7 @@ from nltk.tokenize.treebank import TreebankWordTokenizer
 from nltk.tokenize.util import string_span_tokenize, regexp_span_tokenize
 from nltk.tokenize.stanford_segmenter import StanfordSegmenter
 
+
 # Standard sentence tokenizer.
 def sent_tokenize(text, language='english'):
     """
@@ -137,7 +138,7 @@ def word_tokenize(text, language='english', preserve_line=False):
     :param language: the model name in the Punkt corpus
     :type language: str
     :param preserve_line: An option to keep the preserve the sentence and not sentence tokenize it.
-    :type preserver_line: bool
+    :type preserve_line: bool
     """
     sentences = [text] if preserve_line else sent_tokenize(text, language)
     return [


### PR DESCRIPTION
This PR addresses https://github.com/nltk/nltk/issues/2132 by expanding the error message to include the full resource name of the model that failed to load, for example:
```
>>> import nltk
>>> nltk.tokenize.word_tokenize('Abc cde def, abc?', language='esperanto')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/foo/projects/nltk/nltk/tokenize/__init__.py", line 143, in word_tokenize
    sentences = [text] if preserve_line else sent_tokenize(text, language)
  File "/home/foo/projects/nltk/nltk/tokenize/__init__.py", line 104, in sent_tokenize
    tokenizer = load('tokenizers/punkt/{0}.pickle'.format(language))
  File "/home/foo/projects/nltk/nltk/data.py", line 868, in load
    opened_resource = _open(resource_url)
  File "/home/foo/projects/nltk/nltk/data.py", line 993, in _open
    return find(path_, path + ['']).open()
  File "/home/foo/projects/nltk/nltk/data.py", line 699, in find
    raise LookupError(resource_not_found)
LookupError: 
**********************************************************************
  Resource punkt not found.
  Please use the NLTK Downloader to obtain the resource:

  >>> import nltk
  >>> nltk.download('punkt')
  
  Attempted to load tokenizers/punkt/PY3/esperanto.pickle

  Searched in:
    - '/home/foo/nltk_data'
    - '/home/foo/.pyenv/versions/nltk37/nltk_data'
    - '/home/foo/.pyenv/versions/nltk37/share/nltk_data'
    - '/home/foo/.pyenv/versions/nltk37/lib/nltk_data'
    - '/usr/share/nltk_data'
    - '/usr/local/share/nltk_data'
    - '/usr/lib/nltk_data'
    - '/usr/local/lib/nltk_data'
    - ''
**********************************************************************
```

The line ```Attempted to load tokenizers/punkt/PY3/esperanto.pickle``` is the new addition.