### PR TITLE
Adds 'lang' being passed to _pos_tag in pos_tag_sents. Closes 2184.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -238,6 +238,7 @@
 - Iaroslav Tymchenko <https://github.com/myproblemchild>
 - Aleš Tamchyna
 - Tim Gianitsos <https://github.com/timgianitsos>
+- Andrew Owen Martin
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 ### Contributors to the Porter Stemmer

--- a/nltk/tag/__init__.py
+++ b/nltk/tag/__init__.py
@@ -177,4 +177,4 @@ def pos_tag_sents(sentences, tagset=None, lang='eng'):
     :rtype: list(list(tuple(str, str)))
     """
     tagger = _get_tagger(lang)
-    return [_pos_tag(sent, tagset, tagger) for sent in sentences]
+    return [_pos_tag(sent, tagset, tagger, lang) for sent in sentences]


### PR DESCRIPTION
nltk.tag.pos_tag_sents was failing because it didn't pass the lang parameter into _pos_tag.