### PR TITLE
Reverting some changes from #2130

### DIFF
--- a/nltk/lm/api.py
+++ b/nltk/lm/api.py
@@ -45,11 +45,15 @@ class Smoothing(object):
     Implements Chen & Goodman 1995's idea that all smoothing algorithms have
     certain features in common. This should ideally allow smoothing algoritms to
     work both with Backoff and Interpolation.
-
-    counter represents the number of counts for ngrams
     """
 
     def __init__(self, vocabulary, counter):
+        """
+        :param vocabulary: The Ngram vocabulary object.
+        :type vocabulary: nltk.lm.vocab.Vocabulary
+        :param counter: The counts of the vocabulary items.
+        :type counter: nltk.lm.counter.NgramCounter
+        """
         self.vocab = vocabulary
         self.counts = counter
 

--- a/nltk/lm/smoothing.py
+++ b/nltk/lm/smoothing.py
@@ -23,7 +23,6 @@ class WittenBell(Smoothing):
 
     def __init__(self, vocabulary, counter, discount=0.1, **kwargs):
         super(WittenBell, self).__init__(vocabulary, counter, *kwargs)
-        self.counts = counter
 
     def alpha_gamma(self, word, context):
         gamma = self.gamma(context)

--- a/nltk/lm/smoothing.py
+++ b/nltk/lm/smoothing.py
@@ -46,10 +46,9 @@ class KneserNey(Smoothing):
     def __init__(self, vocabulary, counter, discount=0.1, **kwargs):
         super(KneserNey, self).__init__(vocabulary, counter, *kwargs)
         self.discount = discount
-        self.vocabulary = vocabulary
 
     def unigram_score(self, word):
-        return 1.0 / len(self.vocabulary)
+        return 1.0 / len(self.vocab)
 
     def alpha_gamma(self, word, context):
         prefix_counts = self.counts[context]


### PR DESCRIPTION
There are some changes that are superfluous. Which makes the updates for `self.vocab` vs `self.vocabulary` and 'self.counts` vs `self.counter` confusing. c.f. #2130 

It's best to stick with the current default in `nltk.lm.api` for now and then re-open a PR for refactoring. 

Regarding `GoodTuring` addition in #2130 by @sahitpj , there might be implementation missing as reported  @Copper-Head 

We should either:

 1. Correct the implementation and add more tests 
 2. Remove the incomplete implementation
 3. Write more tests to check that the expected output from GoodTuring is correct

@Copper-Head @sahitpj , please advise. 