### PR TITLE
Add max on CrossValidationProbDist

### DIFF
--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -1165,6 +1165,9 @@ class CrossValidationProbDist(ProbDistI):
     def discount(self):
         raise NotImplementedError()
 
+    def max(self):
+        raise NotImplementedError()
+
     def __repr__(self):
         """
         Return a string representation of this ``ProbDist``.


### PR DESCRIPTION
Could not instantiate `CrossValidationProbDist` due to unimplemented abstract method `max`.