### PR TITLE
Close #2196 by refactoring Text.collocations()

### DIFF
--- a/nltk/collocations.py
+++ b/nltk/collocations.py
@@ -30,6 +30,7 @@ from __future__ import print_function
 #   approximation is good enough for fragmented data, and mention it
 # - add a n-gram collocation finder with measures which only utilise n-gram
 #   and unigram counts (raw_freq, pmi, student_t)
+# - allow case-insensitive ngram searching through AbstractCollocationFinder
 
 import itertools as _itertools
 from six import iteritems

--- a/nltk/text.py
+++ b/nltk/text.py
@@ -432,7 +432,7 @@ class Text(object):
             finder = BigramCollocationFinder.from_words(self.tokens, window_size)
             finder.apply_freq_filter(2)
             finder.apply_word_filter(lambda w: len(w) < 3 or w.lower() in ignored_words)
-            finder.apply_ngram_filter(lambda bg: bg in ignored_bigrams)
+            finder.apply_ngram_filter(lambda w1, w2: (w1, w2) in ignored_bigrams)
 
             bigram_measures = BigramAssocMeasures()
             self._collocations = finder.nbest(bigram_measures.likelihood_ratio, num)


### PR DESCRIPTION
I refactored Text.collocations() to call a Text.collocation_list() function, so now you can retrieve the list of bigram tuples instead of printing them directly to console.

I may have gone overboard in also adding the ability to specify extra ignore words, and a list of bigrams to ignore. These are useful in my particular use-case, but I still need to test them. If these functionalities aren't desired in core nltk, I can remove them.