### PR TITLE
Feature/corenlp server options

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -241,6 +241,7 @@
 - Andrew Owen Martin
 - Adrian Ellis <https://github.com/adrianjellis>
 - Nat Quayle Nelson <https://github.com/nqnstudios>
+- Matan Rak <https://github.com/matanrak>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 ### Contributors to the Porter Stemmer

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -113,7 +113,7 @@ def java(cmd, classpath=None, stdin=None, stdout=None, stderr=None, blocking=Tru
 
     stdin = subprocess_output_dict.get(stdin, stdin)
     stdout = subprocess_output_dict.get(stdout, stdout)
-    stderr = subprocess_output_dict.get(stderr, stdout)
+    stderr = subprocess_output_dict.get(stderr, stderr)
 
     if isinstance(cmd, string_types):
         raise TypeError('cmd should be a list of strings')

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -88,7 +88,7 @@ def java(cmd, classpath=None, stdin=None, stdout=None, stderr=None, blocking=Tru
         standard input, standard output and standard error file
         handles, respectively.  Valid values are ``subprocess.PIPE``,
         an existing file descriptor (a positive integer), an existing
-        file object, and None.  ``subprocess.PIPE`` indicates that a
+        file object, 'pipe', 'stdout', 'devnull' and None.  ``subprocess.PIPE`` indicates that a
         new pipe to the child should be created.  With None, no
         redirection will occur; the child's file handles will be
         inherited from the parent.  Additionally, stderr can be

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -108,12 +108,13 @@ def java(cmd, classpath=None, stdin=None, stdout=None, stderr=None, blocking=Tru
 
     :raise OSError: If the java command returns a nonzero return code.
     """
-    if stdin == 'pipe':
-        stdin = subprocess.PIPE
-    if stdout == 'pipe':
-        stdout = subprocess.PIPE
-    if stderr == 'pipe':
-        stderr = subprocess.PIPE
+
+    subprocess_output_dict = {'pipe': subprocess.PIPE, 'stdout': subprocess.STDOUT, 'devnull': subprocess.DEVNULL}
+
+    stdin = subprocess_output_dict.get(stdin)
+    stdout = subprocess_output_dict.get(stdout)
+    stderr = subprocess_output_dict.get(stderr)
+
     if isinstance(cmd, string_types):
         raise TypeError('cmd should be a list of strings')
 

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -111,9 +111,9 @@ def java(cmd, classpath=None, stdin=None, stdout=None, stderr=None, blocking=Tru
 
     subprocess_output_dict = {'pipe': subprocess.PIPE, 'stdout': subprocess.STDOUT, 'devnull': subprocess.DEVNULL}
 
-    stdin = subprocess_output_dict.get(stdin)
-    stdout = subprocess_output_dict.get(stdout)
-    stderr = subprocess_output_dict.get(stderr)
+    stdin = subprocess_output_dict.get(stdin, stdin)
+    stdout = subprocess_output_dict.get(stdout, stdout)
+    stderr = subprocess_output_dict.get(stderr, stdout)
 
     if isinstance(cmd, string_types):
         raise TypeError('cmd should be a list of strings')

--- a/nltk/parse/corenlp.py
+++ b/nltk/parse/corenlp.py
@@ -105,7 +105,12 @@ class CoreNLPServer(object):
         self.corenlp_options = corenlp_options
         self.java_options = java_options or ['-mx2g']
 
-    def start(self):
+    def start(self, stdout='devnull', stderr='devnull'):
+        """ Starts the CoreNLP server
+
+        :param stdout: Specifies the subprocess's loc Either 'devnull', 'stdout' or 'pipe'
+        :param stderr: Specifies the subprocess's stdout loc Either 'devnull', 'stdout' or 'pipe'
+        """
         import requests
 
         cmd = ['edu.stanford.nlp.pipeline.StanfordCoreNLPServer']
@@ -118,14 +123,12 @@ class CoreNLPServer(object):
         config_java(options=self.java_options, verbose=self.verbose)
 
         try:
-            # TODO: it's probably a bad idea to pipe stdout, as it will
-            #       accumulate when lots of text is being parsed.
             self.popen = java(
                 cmd,
                 classpath=self._classpath,
                 blocking=False,
-                stdout='pipe',
-                stderr='pipe',
+                stdout=stdout,
+                stderr=stderr,
             )
         finally:
             # Return java configurations to their default values.

--- a/nltk/parse/corenlp.py
+++ b/nltk/parse/corenlp.py
@@ -230,7 +230,7 @@ class GenericCoreNLPParser(ParserI, TokenizerI, TaggerI):
             )
         )
 
-    def api_call(self, data, properties=None):
+    def api_call(self, data, properties=None, timeout=60):
         default_properties = {
             'outputFormat': 'json',
             'annotators': 'tokenize,pos,lemma,ssplit,{parser_annotator}'.format(
@@ -244,7 +244,7 @@ class GenericCoreNLPParser(ParserI, TokenizerI, TaggerI):
             self.url,
             params={'properties': json.dumps(default_properties)},
             data=data.encode(self.encoding),
-            timeout=60,
+            timeout=timeout,
         )
 
         response.raise_for_status()

--- a/nltk/parse/corenlp.py
+++ b/nltk/parse/corenlp.py
@@ -108,8 +108,7 @@ class CoreNLPServer(object):
     def start(self, stdout='devnull', stderr='devnull'):
         """ Starts the CoreNLP server
 
-        :param stdout: Specifies the subprocess's loc Either 'devnull', 'stdout' or 'pipe'
-        :param stderr: Specifies the subprocess's stdout loc Either 'devnull', 'stdout' or 'pipe'
+        :param stdout, stderr: Specifies where CoreNLP output is redirected. Valid values are 'devnull', 'stdout', 'pipe'
         """
         import requests
 


### PR DESCRIPTION
Due to the stdout and stderr params being 'pipe' when creating a CoreNLP server, the server would become unresponsive and each request to it will timeout once the pipe has been filled (As was stated in a #TODO by @dimazest 2 years ago).

So I have added made those params configureable :D