### PR TITLE
Fix ignoring non-Cyrillic in RussianStemmer

### DIFF
--- a/nltk/stem/snowball.py
+++ b/nltk/stem/snowball.py
@@ -4898,8 +4898,10 @@ class RussianStemmer(_LanguageSpecificStemmer):
                 chr_exceeded = True
                 break
 
-        if chr_exceeded:
-            word = self.__cyrillic_to_roman(word)
+        if not chr_exceeded:
+            return word
+
+        word = self.__cyrillic_to_roman(word)
 
         step1_success = False
         adjectival_removed = False
@@ -5162,8 +5164,7 @@ class RussianStemmer(_LanguageSpecificStemmer):
             if word.endswith("'"):
                 word = word[:-1]
 
-        if chr_exceeded:
-            word = self.__roman_to_cyrillic(word)
+        word = self.__roman_to_cyrillic(word)
 
         return word
 

--- a/nltk/test/unit/test_stem.py
+++ b/nltk/test/unit/test_stem.py
@@ -41,11 +41,8 @@ class SnowballTest(unittest.TestCase):
         assert ar_stemmer.stem("الكلمات") == "كلم"
 
     def test_russian(self):
-        # Russian words both consisting of Cyrillic
-        # and Roman letters can be stemmed.
         stemmer_russian = SnowballStemmer("russian")
         assert stemmer_russian.stem("авантненькая") == "авантненьк"
-        assert stemmer_russian.stem("avenantnen'kai^a") == "avenantnen'k"
 
     def test_german(self):
         stemmer_german = SnowballStemmer("german")


### PR DESCRIPTION
This fixes bug with processing English words in Russian (Cyrillic) text.

For example, if we use word "life" in text, the result now will be "lif" (wrong).

So the best is just to ignore all non-Cyrillic word (i.e. it can be brand names).