### PR TITLE
fix infinite-loop of extract when fe not in f_aligned or fe is over t…

### DIFF
--- a/nltk/translate/phrase_based.py
+++ b/nltk/translate/phrase_based.py
@@ -78,7 +78,7 @@ def extract(
                 ((e_start, e_end + 1), (f_start, f_end + 1), src_phrase, trg_phrase)
             )
             fe += 1
-            if fe in f_aligned or fe == trglen:
+            if fe in f_aligned or fe >= trglen:
                 break
         fs -= 1
         if fs in f_aligned or fs < 0:


### PR DESCRIPTION
I found the infinite-loop when I extract phrase using alignments.
Main reason is caused by `fe`. 
when fe is equal `trglen`,  fe(`fe +=1`) is not in f_aligned and fe is over trglen. then the loop goes into infite-loop.


 