### PR TITLE
Make word_tokenize treat two single quotes ('') consistently.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -40,6 +40,7 @@
 - Claude Coulombe
 - Lucas Cooper
 - Robin Cooper
+- Piero Cornice
 - Chris Crowner
 - James Curran
 - Arthur Darcet

--- a/nltk/test/unit/test_tokenize.py
+++ b/nltk/test/unit/test_tokenize.py
@@ -320,7 +320,7 @@ class TestTokenize(unittest.TestCase):
         result = list(tokenizer.span_tokenize(test2))
         self.assertEqual(result, expected)
 
-        # Test case with double qoutation as well as converted quotations
+        # Test case with double quotation as well as converted quotations
         test3 = "The DUP is similar to the \"religious right\" in the United States and takes a ``hardline'' stance on social issues"
         expected = [
             (0, 3),
@@ -363,6 +363,10 @@ class TestTokenize(unittest.TestCase):
         
         sentence = "'v' 're'"
         expected = ["'", 'v', "'", "'re", "'"]
+        self.assertEqual(word_tokenize(sentence), expected)
+
+        sentence = "Here is a ''double quoted'' text"
+        expected = ['Here', 'is', 'a', '``', 'double', 'quoted', '``', 'text']
         self.assertEqual(word_tokenize(sentence), expected)
 
     def test_punkt_pair_iter(self):

--- a/nltk/tokenize/__init__.py
+++ b/nltk/tokenize/__init__.py
@@ -110,12 +110,12 @@ _treebank_word_tokenizer = TreebankWordTokenizer()
 
 # See discussion on https://github.com/nltk/nltk/pull/1437
 # Adding to TreebankWordTokenizer, nltk.word_tokenize now splits on
-# - chervon quotes u'\xab' and u'\xbb' .
+# - chevron quotes u'\xab' and u'\xbb' .
 # - unicode quotes u'\u2018', u'\u2019', u'\u201c' and u'\u201d'
 # See https://github.com/nltk/nltk/issues/1995#issuecomment-376741608
 # Also, behavior of splitting on clitics now follows Stanford CoreNLP
 # - clitics covered (?!re|ve|ll|m|t|s|d)(\w)\b
-improved_open_quote_regex = re.compile(u'([«“‘„]|[`]+)', re.U)
+improved_open_quote_regex = re.compile(u'([«“‘„]|[\']{2}|[`]+)', re.U)
 improved_open_single_quote_regex = re.compile(r"(?i)(\')(?!re|ve|ll|m|t|s|d)(\w)\b", re.U)
 improved_close_quote_regex = re.compile(u'([»”’])', re.U)
 improved_punct_regex = re.compile(r'([^\.])(\.)([\]\)}>"\'' u'»”’ ' r']*)\s*$', re.U)


### PR DESCRIPTION
Example:

    "Here is a ''double quoted'' text"

Tokenization before this commit:

    ['Here', 'is', 'a', '``', 'double', 'quoted', "''", 'text']

Tokenization after this commit:

    ['Here', 'is', 'a', '``', 'double', 'quoted', '``', 'text']