### PR TITLE
Added minimum edit/Levenshtein distance based alignment function with doctest

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -244,6 +244,7 @@
 - Nat Quayle Nelson <https://github.com/nqnstudios>
 - Matan Rak <https://github.com/matanrak>
 - Uday Krishna <https://github.com/udaykrishna>
+- Osman Zubair <https://github.com/okz12>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 ### Contributors to the Porter Stemmer

--- a/nltk/metrics/__init__.py
+++ b/nltk/metrics/__init__.py
@@ -24,6 +24,7 @@ from nltk.metrics.scores import (
 from nltk.metrics.confusionmatrix import ConfusionMatrix
 from nltk.metrics.distance import (
     edit_distance,
+    edit_distance_align,
     binary_distance,
     jaccard_distance,
     masi_distance,

--- a/nltk/metrics/distance.py
+++ b/nltk/metrics/distance.py
@@ -103,6 +103,76 @@ def edit_distance(s1, s2, substitution_cost=1, transpositions=False):
     return lev[len1][len2]
 
 
+def _edit_dist_backtrace(lev_map):
+    i, j = len(lev_map) - 1, len(lev_map[1]) - 1
+    alignment = [(i, j)]
+
+    while (i, j) != (0, 0):
+        # find direction of minimum cost
+        s1_skip_cost = s2_skip_cost = sub_cost = float('inf')
+        if i - 1 >= 0:
+            s1_skip_cost = lev_map[i - 1][j]
+        if j - 1 >= 0:
+            s2_skip_cost = lev_map[i][j - 1]
+        if i - 1 >= 0 and j - 1 >= 0:
+            sub_cost = lev_map[i - 1][j - 1]
+
+        # move in direction of minimum cost
+        if sub_cost <= s1_skip_cost and sub_cost <= s2_skip_cost:
+            i, j = i - 1, j - 1
+        elif s2_skip_cost <= s1_skip_cost:
+            i, j = i, j - 1
+        else:
+            i, j = i - 1, j
+
+        alignment.append((i, j))
+    alignment.reverse()
+    return alignment
+
+
+def edit_distance_align(s1, s2, substitution_cost=1):
+    """
+    Calculate the minimum Levenshtein edit-distance based alignment
+    mapping between two strings. The alignment finds the mapping
+    from string s1 to s2 that minimizes the edit distance cost.
+    For example, mapping "rain" to "shine" would involve 2
+    substitutions, 2 matches and an insertion resulting in
+    the following mapping:
+    [(0, 0), (1, 1), (2, 2), (3, 3), (4, 4), (4, 5)]
+    NB: (0, 0) is the start state without any letters associated
+    See more: https://web.stanford.edu/class/cs124/lec/med.pdf
+
+    This function does not support transposition.
+
+    :param s1, s2: The strings to be aligned
+    :type s1: str
+    :type s2: str
+    :type substitution_cost: int
+    :rtype List[Tuple(int, int)]
+    """
+    # set up a 2-D array
+    len1 = len(s1)
+    len2 = len(s2)
+    lev = _edit_dist_init(len1 + 1, len2 + 1)
+
+    # iterate over the array
+    for i in range(len1):
+        for j in range(len2):
+            _edit_dist_step(
+                lev,
+                i + 1,
+                j + 1,
+                s1,
+                s2,
+                substitution_cost=substitution_cost,
+                transpositions=False,
+            )
+
+    # backtrace to find alignment
+    alignment = _edit_dist_backtrace(lev)
+    return alignment
+
+
 def binary_distance(label1, label2):
     """Simple equality test.
 

--- a/nltk/metrics/distance.py
+++ b/nltk/metrics/distance.py
@@ -24,7 +24,7 @@ from __future__ import print_function
 from __future__ import division
 
 import warnings
-
+import operator
 
 def _edit_dist_init(len1, len2):
     lev = []
@@ -134,6 +134,13 @@ def edit_distance_align(s1, s2, substitution_cost=1):
     [(0, 0), (1, 1), (2, 2), (3, 3), (4, 4), (4, 5)]
     NB: (0, 0) is the start state without any letters associated
     See more: https://web.stanford.edu/class/cs124/lec/med.pdf
+
+    In case of multiple valid minimum-distance alignments, the
+    backtrace has the following operation precedence:
+    1. Skip s1 character
+    2. Skip s2 character
+    3. Substitute s1 and s2 characters
+    The backtrace is carried out in reverse string order.
 
     This function does not support transposition.
 

--- a/nltk/metrics/distance.py
+++ b/nltk/metrics/distance.py
@@ -103,31 +103,24 @@ def edit_distance(s1, s2, substitution_cost=1, transpositions=False):
     return lev[len1][len2]
 
 
-def _edit_dist_backtrace(lev_map):
-    i, j = len(lev_map) - 1, len(lev_map[1]) - 1
+def _edit_dist_backtrace(lev):
+    i, j = len(lev) - 1, len(lev[0]) - 1
     alignment = [(i, j)]
 
     while (i, j) != (0, 0):
-        # find direction of minimum cost
-        s1_skip_cost = s2_skip_cost = sub_cost = float('inf')
-        if i - 1 >= 0:
-            s1_skip_cost = lev_map[i - 1][j]
-        if j - 1 >= 0:
-            s2_skip_cost = lev_map[i][j - 1]
-        if i - 1 >= 0 and j - 1 >= 0:
-            sub_cost = lev_map[i - 1][j - 1]
+        directions = [
+            (i - 1, j),  # skip s1
+            (i, j - 1),  # skip s2
+            (i - 1, j - 1),  # substitution
+        ]
 
-        # move in direction of minimum cost
-        if sub_cost <= s1_skip_cost and sub_cost <= s2_skip_cost:
-            i, j = i - 1, j - 1
-        elif s2_skip_cost <= s1_skip_cost:
-            i, j = i, j - 1
-        else:
-            i, j = i - 1, j
+        direction_costs = (
+            (lev[i][j] if (i >= 0 and j >= 0) else float('inf'), (i, j)) for i, j in directions
+        )
+        _, (i, j) = min(direction_costs, key=operator.itemgetter(0))
 
         alignment.append((i, j))
-    alignment.reverse()
-    return alignment
+    return list(reversed(alignment))
 
 
 def edit_distance_align(s1, s2, substitution_cost=1):

--- a/nltk/test/metrics.doctest
+++ b/nltk/test/metrics.doctest
@@ -52,6 +52,8 @@ String edit distance (Levenshtein):
 
     >>> edit_distance("rain", "shine")
     3
+    >>> edit_distance_align("rain", "brainy")
+    [(0, 0), (0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (4, 6)]
 
 Other distance measures:
 

--- a/nltk/test/metrics.doctest
+++ b/nltk/test/metrics.doctest
@@ -55,7 +55,7 @@ String edit distance (Levenshtein):
     >>> edit_distance_align("shine", "shine")
     [(0, 0), (1, 1), (2, 2), (3, 3), (4, 4), (5, 5)]
     >>> edit_distance_align("rain", "brainy")
-    [(0, 0), (0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (4, 6)]
+    [(0, 0), (1, 1), (1, 2), (2, 3), (3, 4), (4, 5), (4, 6)]
     >>> edit_distance_align("", "brainy")
     [(0, 0), (0, 1), (0, 2), (0, 3), (0, 4), (0, 5), (0, 6)]
     >>> edit_distance_align("", "")

--- a/nltk/test/metrics.doctest
+++ b/nltk/test/metrics.doctest
@@ -52,8 +52,14 @@ String edit distance (Levenshtein):
 
     >>> edit_distance("rain", "shine")
     3
+    >>> edit_distance_align("shine", "shine")
+    [(0, 0), (1, 1), (2, 2), (3, 3), (4, 4), (5, 5)]
     >>> edit_distance_align("rain", "brainy")
     [(0, 0), (0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (4, 6)]
+    >>> edit_distance_align("", "brainy")
+    [(0, 0), (0, 1), (0, 2), (0, 3), (0, 4), (0, 5), (0, 6)]
+    >>> edit_distance_align("", "")
+    [(0, 0)]
 
 Other distance measures:
 


### PR DESCRIPTION
Created this for feature/issue #2221, a minimum edit-distance based alignment of two strings. The implementation reuses edit_distance functions in nltk.metrics but adds backtrace to be able to recover the original strings with minimum distance mappings.

E.g., 'f', 'bar' will align in 'fubar' and 'foobar'. 

`print(edit_distance_align('fubar', 'foobar'))`
> [(0, 0), (1, 1), (1, 2), (2, 3), (3, 4), (4, 5), (5, 6)]
NB: 0 is a null/stop index

The mapping from first string to second printed out:
```
s1 = '_fubar'
s2 = '_foobar'
print([(s1[x[0]], s2[x[1]]) for x in edit_distance_align('fubar','foobar')])
```
> [('_', '_'), ('f', 'f'), ('f', 'o'), ('u', 'o'), ('b', 'b'), ('a', 'a'), ('r', 'r')]