### PR TITLE
Fix random seeding in LanguageModel.generate

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -246,6 +246,7 @@
 - Uday Krishna <https://github.com/udaykrishna>
 - Osman Zubair <https://github.com/okz12>
 - Viresh Gupta <https://github.com/virresh>
+- Ondřej Cífka <https://github.com/cifkao>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 ### Contributors to the Porter Stemmer

--- a/nltk/lm/__init__.py
+++ b/nltk/lm/__init__.py
@@ -202,7 +202,7 @@ One cool feature of ngram models is that they can be used to generate text.
     >>> lm.generate(1, random_seed=3)
     '<s>'
     >>> lm.generate(5, random_seed=3)
-    ['<s>', 'a', 'b', 'c', '</s>']
+    ['<s>', 'a', 'b', 'c', 'd']
 
 Provide `random_seed` if you want to consistently reproduce the same text all
 other things being equal. Here we are using it to test the examples.
@@ -211,7 +211,7 @@ You can also condition your generation on some preceding text with the `context`
 argument.
 
     >>> lm.generate(5, text_seed=['c'], random_seed=3)
-    ['</s>', '<s>', 'a', 'b', 'c']
+    ['</s>', 'c', 'd', 'c', 'd']
 
 Note that an ngram model is restricted in how much preceding context it can
 take into account. For example, a trigram model can only condition its output

--- a/nltk/test/unit/lm/test_models.py
+++ b/nltk/test/unit/lm/test_models.py
@@ -412,10 +412,14 @@ class NgramModelTextGenerationTests(unittest.TestCase):
             self.model.generate(text_seed=("a", "<s>"), random_seed=2), "a"
         )
 
-    def test_generate_no_seed_unigrams(self):
+    def test_generate_cycle(self):
+        # Add a cycle to the model: bd -> b, db -> d
+        more_training_text = [list(padded_everygrams(self.model.order, list("bdbdbd")))]
+        self.model.fit(more_training_text)
+        # Test that we can escape the cycle
         self.assertEqual(
-            self.model.generate(5, random_seed=3),
-            ["<UNK>", "</s>", "</s>", "</s>", "</s>"],
+            self.model.generate(7, text_seed=("b", "d"), random_seed=5),
+            ["b", "d", "b", "d", "b", "d", "</s>"],
         )
 
     def test_generate_with_text_seed(self):


### PR DESCRIPTION
In the current implementation of `LanguageModel.generate`, the random number generator is re-seeded (in fact re-instantiated) before every word:
https://github.com/nltk/nltk/blob/66f56ead003e64c5bd215427c8d09b4a5fd7fd78/nltk/lm/api.py#L89-L92
This is especially unfortunate when `random_seed` is not `None`, because it makes the model always predict the same token for a given context.

This PR fixes this issue by seeding the generator only once.