### PR TITLE
Patch Tree classes to work with native Python copy library

### DIFF
--- a/nltk/tree.py
+++ b/nltk/tree.py
@@ -556,11 +556,18 @@ class Tree(list):
         else:
             return tree
 
+    def __copy__(self):
+        return self.copy()
+
+    def __deepcopy__(self, memo):
+        return self.copy(deep=True)
+
     def copy(self, deep=False):
         if not deep:
             return type(self)(self._label, self)
         else:
             return type(self).convert(self)
+
 
     def _frozen_class(self):
         return ImmutableTree


### PR DESCRIPTION
This refers to issue #1324.

Link \_\_copy\_\_ and \_\_deepcopy\_\_ to copy function defined in Tree
classes. This allows the native Python copy library to work with
Tree, ImmutableTree, and ParentedTree.