### PR TITLE
don't require lists as arguments to PositiveNaiveBayesClassifier.train

### DIFF
--- a/nltk/classify/positivenaivebayes.py
+++ b/nltk/classify/positivenaivebayes.py
@@ -59,8 +59,8 @@ The features of a sentence are simply the words it contains:
 
 We use the sports sentences as positive examples, the mixed ones ad unlabeled examples:
 
-    >>> positive_featuresets = list(map(features, sports_sentences))
-    >>> unlabeled_featuresets = list(map(features, various_sentences))
+    >>> positive_featuresets = map(features, sports_sentences)
+    >>> unlabeled_featuresets = map(features, various_sentences)
     >>> classifier = PositiveNaiveBayesClassifier.train(positive_featuresets,
     ...                                                 unlabeled_featuresets)
 
@@ -95,10 +95,10 @@ class PositiveNaiveBayesClassifier(NaiveBayesClassifier):
         estimator=ELEProbDist,
     ):
         """
-        :param positive_featuresets: A list of featuresets that are known as positive
+        :param positive_featuresets: An iterable of featuresets that are known as positive
             examples (i.e., their label is ``True``).
 
-        :param unlabeled_featuresets: A list of featuresets whose label is unknown.
+        :param unlabeled_featuresets: An iterable of featuresets whose label is unknown.
 
         :param positive_prob_prior: A prior estimate of the probability of the label
             ``True`` (default 0.5).
@@ -109,28 +109,30 @@ class PositiveNaiveBayesClassifier(NaiveBayesClassifier):
         fnames = set()
 
         # Count up how many times each feature value occurred in positive examples.
+        num_positive_examples = 0
         for featureset in positive_featuresets:
             for fname, fval in featureset.items():
                 positive_feature_freqdist[fname][fval] += 1
                 feature_values[fname].add(fval)
                 fnames.add(fname)
+            num_positive_examples += 1
 
         # Count up how many times each feature value occurred in unlabeled examples.
+        num_unlabeled_examples = 0
         for featureset in unlabeled_featuresets:
             for fname, fval in featureset.items():
                 unlabeled_feature_freqdist[fname][fval] += 1
                 feature_values[fname].add(fval)
                 fnames.add(fname)
+            num_unlabeled_examples += 1
 
         # If a feature didn't have a value given for an instance, then we assume that
         # it gets the implicit value 'None'.
-        num_positive_examples = len(positive_featuresets)
         for fname in fnames:
             count = positive_feature_freqdist[fname].N()
             positive_feature_freqdist[fname][None] += num_positive_examples - count
             feature_values[fname].add(None)
 
-        num_unlabeled_examples = len(unlabeled_featuresets)
         for fname in fnames:
             count = unlabeled_feature_freqdist[fname].N()
             unlabeled_feature_freqdist[fname][None] += num_unlabeled_examples - count


### PR DESCRIPTION
Requiring a list as an input may produce significant memory overhead. The only obvious list function used is the call to len() but since we've just iterated over the iterable, counting up the values ahead of time is trivial.