### PR TITLE
Fix docstring for load() to match implementation

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -247,6 +247,7 @@
 - Osman Zubair <https://github.com/okz12>
 - Viresh Gupta <https://github.com/virresh>
 - Ondřej Cífka <https://github.com/cifkao>
+- Bharat Raghunathan <https://github.com/Bharat123rox>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 ### Contributors to the Porter Stemmer

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -818,9 +818,9 @@ def load(
     :type cache: bool
     :param cache: If true, add this resource to a cache.  If load()
         finds a resource in its cache, then it will return it from the
-        cache rather than loading it.  The cache uses weak references,
-        so a resource wil automatically be expunged from the cache
-        when no more objects are using it.
+        cache rather than loading it.  The cache uses a dictionary
+        instead of a weak dictionary since it reduces reloading in the
+        common case.
     :type verbose: bool
     :param verbose: If true, print a message when loading a resource.
         Messages are not displayed when a resource is retrieved from


### PR DESCRIPTION
Fix #2271 by updating the docstring to mention that it is a dictionary, not a weak dictionary