### PR TITLE
Patching wordnet issues

### DIFF
--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -1648,7 +1648,7 @@ class WordNetCorpusReader(CorpusReader):
                     continue
                 lemma.extend(self._lang_data[lang][0][i])
 
-            lemma = list(set(lemma))
+            lemma = iter(set(lemma))
             return lemma
 
     def all_synsets(self, pos=None):

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -1999,17 +1999,16 @@ class WordNetCorpusReader(CorpusReader):
         if len(lang) != 3:
             raise ValueError('lang should be a (3 character) ISO 639-3 code')
         self._lang_data[lang] = [defaultdict(list), defaultdict(list)]
-        for l in tab_file.readlines():
-            if isinstance(l, bytes):
+        for line in tab_file.readlines():
+            if isinstance(line, bytes):
                 # Support byte-stream files (e.g. as returned by Python 2's
                 # open() function) as well as text-stream ones
-                l = l.decode('utf-8')
-            l = l.replace('\n', '')
-            l = l.replace(' ', '_')
-            if l[0] != '#':
-                word = l.split('\t')
-                self._lang_data[lang][0][word[0]].append(word[2])
-                self._lang_data[lang][1][word[2].lower()].append(word[0])
+                line = line.decode('utf-8')
+            if not line.startswith('#'):
+                offset_pos, lemma_type, lemma  = line.strip().split('\t')
+                lemma = lemma.strip().replace(' ', '_')
+                self._lang_data[lang][0][offset_pos].append(lemma)
+                self._lang_data[lang][1][lemma.lower()].append(offset_pos)
         # Make sure no more entries are accidentally added subsequently
         self._lang_data[lang][0].default_factory = None
         self._lang_data[lang][1].default_factory = None

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -1407,7 +1407,7 @@ class WordNetCorpusReader(CorpusReader):
             for example in examples:
                 synset._examples.append(example)
 
-            synset._definition = definition
+            synset._definition = definition.strip('; ')
 
             # split the other info into fields
             _iter = iter(columns_str.split())

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -1401,16 +1401,13 @@ class WordNetCorpusReader(CorpusReader):
         try:
 
             # parse out the definitions and examples from the gloss
-            columns_str, gloss = data_file_line.split('|')
-            gloss = gloss.strip()
-            definitions = []
-            for gloss_part in gloss.split(';'):
-                gloss_part = gloss_part.strip()
-                if gloss_part.startswith('"'):
-                    synset._examples.append(gloss_part.strip('"'))
-                else:
-                    definitions.append(gloss_part)
-            synset._definition = '; '.join(definitions)
+            columns_str, gloss = data_file_line.strip().split('|')
+            definition = re.sub(r"[\"].*?[\"]", "", gloss).strip()
+            examples = re.findall(r'"([^"]*)"', gloss)
+            for example in examples:
+                synset._examples.append(example)
+
+            synset._definition = definition
 
             # split the other info into fields
             _iter = iter(columns_str.split())

--- a/nltk/test/unit/test_wordnet.py
+++ b/nltk/test/unit/test_wordnet.py
@@ -29,7 +29,7 @@ class WordnNetDemo(unittest.TestCase):
         self.assertEqual(move_synset.name(), "move.v.15")
         self.assertEqual(move_synset.lemma_names(), ['move', 'go'])
         self.assertEqual(
-            move_synset.definition(), "have a turn; make one's move in a game"
+            move_synset.definition(), "have a turn; make one's move in a game;"
         )
         self.assertEqual(move_synset.examples(), ['Can I go now?'])
 

--- a/nltk/test/unit/test_wordnet.py
+++ b/nltk/test/unit/test_wordnet.py
@@ -195,3 +195,12 @@ class WordnNetDemo(unittest.TestCase):
         self.assertAlmostEqual(
             S('dog.n.01').lin_similarity(S('cat.n.01'), semcor_ic), 0.8863, places=3
         )
+
+    def test_omw_lemma_no_trailing_underscore(self):
+        expected = [
+            u'popolna_sprememba_v_mišljenju',
+            u'popoln_obrat',
+            u'preobrat',
+            u'preobrat_v_mišljenju'
+            ]
+        self.assertEqual(S('about-face.n.02').lemma_names(lang='slv'), expected)

--- a/nltk/test/unit/test_wordnet.py
+++ b/nltk/test/unit/test_wordnet.py
@@ -6,6 +6,7 @@ See also nltk/test/wordnet.doctest
 
 from __future__ import unicode_literals
 
+import collections
 import os
 import unittest
 
@@ -204,3 +205,17 @@ class WordnNetDemo(unittest.TestCase):
             u'preobrat_v_mišljenju'
             ]
         self.assertEqual(S('about-face.n.02').lemma_names(lang='slv'), expected)
+
+    def test_iterable_type_for_all_lemma_names(self):
+        # Duck-test for iterables.
+        # See https://stackoverflow.com/a/36230057/610569
+        cat_lemmas = wn.all_lemma_names(lang='cat')
+        eng_lemmas = wn.all_lemma_names(lang='eng')
+
+        self.assertTrue(hasattr(eng_lemmas, '__iter__'))
+        self.assertTrue(hasattr(eng_lemmas, '__next__'))
+        self.assertTrue(eng_lemmas.__iter__() is eng_lemmas)
+
+        self.assertTrue(hasattr(cat_lemmas, '__iter__'))
+        self.assertTrue(hasattr(cat_lemmas, '__next__'))
+        self.assertTrue(cat_lemmas.__iter__() is cat_lemmas)

--- a/nltk/test/unit/test_wordnet.py
+++ b/nltk/test/unit/test_wordnet.py
@@ -29,7 +29,7 @@ class WordnNetDemo(unittest.TestCase):
         self.assertEqual(move_synset.name(), "move.v.15")
         self.assertEqual(move_synset.lemma_names(), ['move', 'go'])
         self.assertEqual(
-            move_synset.definition(), "have a turn; make one's move in a game;"
+            move_synset.definition(), "have a turn; make one's move in a game"
         )
         self.assertEqual(move_synset.examples(), ['Can I go now?'])
 
@@ -213,9 +213,9 @@ class WordnNetDemo(unittest.TestCase):
         eng_lemmas = wn.all_lemma_names(lang='eng')
 
         self.assertTrue(hasattr(eng_lemmas, '__iter__'))
-        self.assertTrue(hasattr(eng_lemmas, '__next__'))
+        self.assertTrue(hasattr(eng_lemmas, '__next__') or hasattr(eng_lemmas, 'next'))
         self.assertTrue(eng_lemmas.__iter__() is eng_lemmas)
 
         self.assertTrue(hasattr(cat_lemmas, '__iter__'))
-        self.assertTrue(hasattr(cat_lemmas, '__next__'))
+        self.assertTrue(hasattr(cat_lemmas, '__next__') or hasattr(eng_lemmas, 'next'))
         self.assertTrue(cat_lemmas.__iter__() is cat_lemmas)

--- a/nltk/test/wordnet.doctest
+++ b/nltk/test/wordnet.doctest
@@ -53,31 +53,31 @@ WordNet, using ISO-639 language codes.
     'nob', 'pol', 'por', 'qcn', 'slv', 'spa', 'swe', 'tha', 'zsm']
     >>> wn.synsets(b'\xe7\x8a\xac'.decode('utf-8'), lang='jpn')
     [Synset('dog.n.01'), Synset('spy.n.01')]
-    
+
     wn.synset('spy.n.01').lemma_names('jpn') # doctest: +NORMALIZE_WHITESPACE
     ['\u3044\u306c', '\u307e\u308f\u3057\u8005', '\u30b9\u30d1\u30a4', '\u56de\u3057\u8005',
     '\u56de\u8005', '\u5bc6\u5075', '\u5de5\u4f5c\u54e1', '\u5efb\u3057\u8005',
     '\u5efb\u8005', '\u63a2', '\u63a2\u308a', '\u72ac', '\u79d8\u5bc6\u635c\u67fb\u54e1',
     '\u8adc\u5831\u54e1', '\u8adc\u8005', '\u9593\u8005', '\u9593\u8adc', '\u96a0\u5bc6']
-    
+
     >>> wn.synset('dog.n.01').lemma_names('ita')
     ['cane', 'Canis_familiaris']
     >>> wn.lemmas('cane', lang='ita') # doctest: +NORMALIZE_WHITESPACE
-    [Lemma('dog.n.01.cane'), Lemma('cramp.n.02.cane'), Lemma('hammer.n.01.cane'), Lemma('bad_person.n.01.cane'), 
+    [Lemma('dog.n.01.cane'), Lemma('cramp.n.02.cane'), Lemma('hammer.n.01.cane'), Lemma('bad_person.n.01.cane'),
     Lemma('incompetent.n.01.cane')]
     >>> sorted(wn.synset('dog.n.01').lemmas('dan')) # doctest: +NORMALIZE_WHITESPACE
     [Lemma('dog.n.01.hund'), Lemma('dog.n.01.k\xf8ter'),
     Lemma('dog.n.01.vovhund'), Lemma('dog.n.01.vovse')]
-    
+
     sorted(wn.synset('dog.n.01').lemmas('por'))
 	[Lemma('dog.n.01.cachorra'), Lemma('dog.n.01.cachorro'), Lemma('dog.n.01.cadela'), Lemma('dog.n.01.c\xe3o')]
-    
+
     >>> dog_lemma = wn.lemma(b'dog.n.01.c\xc3\xa3o'.decode('utf-8'), lang='por')
     >>> dog_lemma
     Lemma('dog.n.01.c\xe3o')
     >>> dog_lemma.lang()
     'por'
-    >>> len(wordnet.all_lemma_names(pos='n', lang='jpn'))
+    >>> len(list(wordnet.all_lemma_names(pos='n', lang='jpn')))
     64797
 
 -------
@@ -431,7 +431,7 @@ Compute transitive closures of synsets
      Synset('leonberg.n.01'), Synset('mexican_hairless.n.01'),
      Synset('newfoundland.n.01'), Synset('pooch.n.01'), Synset('poodle.n.01'), ...]
     >>> list(dog.closure(hyper)) # doctest: +NORMALIZE_WHITESPACE
-    [Synset('canine.n.02'), Synset('domestic_animal.n.01'), Synset('carnivore.n.01'), Synset('animal.n.01'), 
+    [Synset('canine.n.02'), Synset('domestic_animal.n.01'), Synset('carnivore.n.01'), Synset('animal.n.01'),
     Synset('placental.n.01'), Synset('organism.n.01'), Synset('mammal.n.01'), Synset('living_thing.n.01'),
     Synset('vertebrate.n.01'), Synset('whole.n.02'), Synset('chordate.n.01'), Synset('object.n.01'),
     Synset('physical_entity.n.01'), Synset('entity.n.01')]


### PR DESCRIPTION
Fixing #2265 , #2274 and #2275 

 - #2275 OMW lemmas would not have trailing undersscores.
 - #2274 The return types for english and other OMW lemmas are both now of iterable types.
 - #2265 The definitions, examples will be extracted correctly now
