### PR TITLE
Update decisiontree.py allowing for feature values None/False/True in pretty_print() and pseudocode()

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -247,6 +247,7 @@
 - Osman Zubair <https://github.com/okz12>
 - Viresh Gupta <https://github.com/virresh>
 - Ondřej Cífka <https://github.com/cifkao>
+- Gerhard Kremer <https://github.com/GerhardKa>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 ### Contributors to the Porter Stemmer

--- a/nltk/classify/decisiontree.py
+++ b/nltk/classify/decisiontree.py
@@ -85,7 +85,10 @@ class DecisionTreeClassifier(ClassifierI):
             return '{0}{1} {2}\n'.format(prefix, '.' * n, self._label)
         s = ''
         for i, (fval, result) in enumerate(sorted(self._decisions.items(), 
-                                                  key=lambda item: (item in [None, False, True], str(item).lower()))):
+                                                  key=lambda item: 
+                                                  (item[0] in [None, False, True], str(item[0]).lower())
+                                                 )
+                                          ):
             hdr = '{0}{1}={2}? '.format(prefix, self._fname, fval)
             n = width - 15 - len(hdr)
             s += '{0}{1} {2}\n'.format(hdr, '.' * (n), result._label)
@@ -108,7 +111,9 @@ class DecisionTreeClassifier(ClassifierI):
             return "{0}return {1!r}\n".format(prefix, self._label)
         s = ''
         for (fval, result) in sorted(self._decisions.items(),
-                                    key=lambda it: (it in [None, False, True], str(it).lower())):
+                                    key=lambda item: 
+                                     (item in [None, False, True], str(item[0]).lower())
+                                    ):
             s += '{0}if {1} == {2!r}: '.format(prefix, self._fname, fval)
             if result._fname is not None and depth > 1:
                 s += '\n' + result.pseudocode(prefix + '  ', depth - 1)

--- a/nltk/classify/decisiontree.py
+++ b/nltk/classify/decisiontree.py
@@ -84,7 +84,8 @@ class DecisionTreeClassifier(ClassifierI):
             n = width - len(prefix) - 15
             return '{0}{1} {2}\n'.format(prefix, '.' * n, self._label)
         s = ''
-        for i, (fval, result) in enumerate(sorted(self._decisions.items())):
+        for i, (fval, result) in enumerate(sorted(self._decisions.items(), 
+                                                  key=lambda item: (item in [None, False, True], str(item).lower()))):
             hdr = '{0}{1}={2}? '.format(prefix, self._fname, fval)
             n = width - 15 - len(hdr)
             s += '{0}{1} {2}\n'.format(hdr, '.' * (n), result._label)
@@ -106,7 +107,8 @@ class DecisionTreeClassifier(ClassifierI):
         if self._fname is None:
             return "{0}return {1!r}\n".format(prefix, self._label)
         s = ''
-        for (fval, result) in sorted(self._decisions.items()):
+        for (fval, result) in sorted(self._decisions.items(),
+                                    key=lambda it: (it in [None, False, True], str(it).lower())):
             s += '{0}if {1} == {2!r}: '.format(prefix, self._fname, fval)
             if result._fname is not None and depth > 1:
                 s += '\n' + result.pseudocode(prefix + '  ', depth - 1)


### PR DESCRIPTION
See issue #1524.

For classifier features having a boolean value or being of NoneType 
and being mixed with features of type String, 
sorted() does not work in Python3 (but it did in Python2).

This resulted in an error message and no output
when trying to pretty_print() the decision tree or printing it in pseudocode().

I added a sort key function, which creates a tuple for each decisions-item (feature value and result) to be sorted:

First element in the sort tuple is a truth value 
(True if feature value is None/True/False, otherwise False), 
second element ot the sort tuple is the item's feature value cast to a lowercase string.

This results in a sorting order where ...
- all items w/ feature value of non-None/True/False-type 
  come first (first element of sort tuple is True and True < False)
  and will be sorted by their lowercase string version
- items w/ feature value of type None/True/False will follow 
  (in the order of their lowercase string version, so: False, None, True)

This change will allow users working with feature values None/True/False in Python3, 
being able to use pretty_print() and pseudocode().

Output feature values will still be sorted, 
feature values None/True/False will be added at the end.