### PR TITLE
Added Command Line Interface (CLI) for word_tokenize

### DIFF
--- a/nltk/cli.py
+++ b/nltk/cli.py
@@ -17,14 +17,19 @@ from nltk.util import parallelize_preprocess
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
+
 @click.group(context_settings=CONTEXT_SETTINGS)
 @click.version_option()
 def cli():
     pass
 
+
 @cli.command("tokenize")
 @click.option(
-    "--language", "-l", default="en", help="The language for the Punkt sentence tokenization."
+    "--language",
+    "-l",
+    default="en",
+    help="The language for the Punkt sentence tokenization.",
 )
 @click.option(
     "--preserve-line",
@@ -35,14 +40,10 @@ def cli():
 )
 @click.option("--processes", "-j", default=1, help="No. of processes.")
 @click.option("--encoding", "-e", default="utf8", help="Specify encoding of file.")
-@click.option("--delimiter", "-d", default=" ", help="Specify delimiter to join the tokens.")
-def tokenize_file(
-    language,
-    preserve_line,
-    processes,
-    encoding,
-    delimiter
-):
+@click.option(
+    "--delimiter", "-d", default=" ", help="Specify delimiter to join the tokens."
+)
+def tokenize_file(language, preserve_line, processes, encoding, delimiter):
     """ This command tokenizes text stream using nltk.word_tokenize """
     with click.get_text_stream("stdin", encoding=encoding) as fin:
         with click.get_text_stream("stdout", encoding=encoding) as fout:

--- a/nltk/cli.py
+++ b/nltk/cli.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# Natural Language Toolkit: BLEU Score
+#
+# Copyright (C) 2001-2019 NLTK Project
+# URL: <http://nltk.org/>
+# For license information, see LICENSE.TXT
+
+
+from functools import partial
+from itertools import chain
+from tqdm import tqdm
+
+import click
+
+from nltk import word_tokenize
+from nltk.util import parallelize_preprocess
+
+CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
+
+@click.group(context_settings=CONTEXT_SETTINGS)
+@click.version_option()
+def cli():
+    pass
+
+@cli.command("tokenize")
+@click.option(
+    "--language", "-l", default="en", help="The language for the Punkt sentence tokenization."
+)
+@click.option(
+    "--preserve-line",
+    "-l",
+    default=True,
+    is_flag=True,
+    help="An option to keep the preserve the sentence and not sentence tokenize it.",
+)
+@click.option("--processes", "-j", default=1, help="No. of processes.")
+@click.option("--encoding", "-e", default="utf8", help="Specify encoding of file.")
+@click.option("--delimiter", "-d", default=" ", help="Specify encoding of file.")
+def tokenize_file(
+    language,
+    preserve_line,
+    processes,
+    encoding,
+    delimiter
+):
+    with click.get_text_stream("stdin", encoding=encoding) as fin:
+        with click.get_text_stream("stdout", encoding=encoding) as fout:
+            # If it's single process, joblib parallization is slower,
+            # so just process line by line normally.
+            if processes == 1:
+                for line in tqdm(fin.readlines()):
+                    print(delimiter.join(word_tokenize(line)), end="\n", file=fout)
+            else:
+                for outline in parallelize_preprocess(
+                    word_tokenize, fin.readlines(), processes, progress_bar=True
+                ):
+                    print(delimiter.join(outline), end="\n", file=fout)

--- a/nltk/cli.py
+++ b/nltk/cli.py
@@ -35,7 +35,7 @@ def cli():
 )
 @click.option("--processes", "-j", default=1, help="No. of processes.")
 @click.option("--encoding", "-e", default="utf8", help="Specify encoding of file.")
-@click.option("--delimiter", "-d", default=" ", help="Specify encoding of file.")
+@click.option("--delimiter", "-d", default=" ", help="Specify delimiter to join the tokens.")
 def tokenize_file(
     language,
     preserve_line,
@@ -43,6 +43,7 @@ def tokenize_file(
     encoding,
     delimiter
 ):
+    """ This command tokenizes text stream using nltk.word_tokenize """
     with click.get_text_stream("stdin", encoding=encoding) as fin:
         with click.get_text_stream("stdout", encoding=encoding) as fout:
             # If it's single process, joblib parallization is slower,

--- a/nltk/cli.py
+++ b/nltk/cli.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Natural Language Toolkit: BLEU Score
+# Natural Language Toolkit: NLTK Command-Line Interface
 #
 # Copyright (C) 2001-2019 NLTK Project
 # URL: <http://nltk.org/>

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -30,6 +30,8 @@ from six.moves.urllib.request import (
     ProxyDigestAuthHandler,
     HTTPPasswordMgrWithDefaultRealm,
 )
+from tqdm import tqdm
+from joblib import Parallel, delayed
 
 from nltk.internals import slice_bounds, raise_unorderable_types
 from nltk.collections import *
@@ -823,3 +825,14 @@ def choose(n, k):
         return ntok // ktok
     else:
         return 0
+
+
+######################################################################
+# Parallization.
+######################################################################
+
+def parallelize_preprocess(func, iterator, processes, progress_bar=False):
+    iterator = tqdm(iterator) if progress_bar else iterator
+    if processes <= 1:
+        return map(func, iterator)
+    return Parallel(n_jobs=processes)(delayed(func)(line) for line in iterator)

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -831,6 +831,7 @@ def choose(n, k):
 # Parallization.
 ######################################################################
 
+
 def parallelize_preprocess(func, iterator, processes, progress_bar=False):
     iterator = tqdm(iterator) if progress_bar else iterator
     if processes <= 1:

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,12 @@ extras_require['all'] = set(
     package for group in extras_require.values() for package in group
 )
 
+# Adds CLI commands
+console_scripts = """
+[console_scripts]
+nltk=nltk.cli:cli
+"""
+
 setup(
     name="nltk",
     description="Natural Language Toolkit",
@@ -96,9 +102,12 @@ natural language processing.  NLTK requires Python 2.7, 3.5, 3.6, or 3.7.""",
     package_data={'nltk': ['test/*.doctest', 'VERSION']},
     install_requires=[
         'six',
-        'singledispatch; python_version < "3.4"'
+        'singledispatch; python_version < "3.4"',
+        'click',
+        'joblib'
     ],
     extras_require=extras_require,
     packages=find_packages(),
     zip_safe=False,  # since normal files will be present too?
+    entry_points=console_scripts,
 )

--- a/setup.py
+++ b/setup.py
@@ -14,16 +14,16 @@
 import codecs
 
 try:
-    codecs.lookup('mbcs')
+    codecs.lookup("mbcs")
 except LookupError:
-    ascii = codecs.lookup('ascii')
-    func = lambda name, enc=ascii: {True: enc}.get(name == 'mbcs')
+    ascii = codecs.lookup("ascii")
+    func = lambda name, enc=ascii: {True: enc}.get(name == "mbcs")
     codecs.register(func)
 
 import os
 
 # Use the VERSION file to get NLTK version
-version_file = os.path.join(os.path.dirname(__file__), 'nltk', 'VERSION')
+version_file = os.path.join(os.path.dirname(__file__), "nltk", "VERSION")
 with open(version_file) as fh:
     nltk_version = fh.read().strip()
 
@@ -32,15 +32,15 @@ from setuptools import setup, find_packages
 
 # Specify groups of optional dependencies
 extras_require = {
-    'machine_learning': ['gensim', 'numpy', 'python-crfsuite', 'scikit-learn', 'scipy'],
-    'plot': ['matplotlib'],
-    'tgrep': ['pyparsing'],
-    'twitter': ['twython'],
-    'corenlp': ['requests'],
+    "machine_learning": ["gensim", "numpy", "python-crfsuite", "scikit-learn", "scipy"],
+    "plot": ["matplotlib"],
+    "tgrep": ["pyparsing"],
+    "twitter": ["twython"],
+    "corenlp": ["requests"],
 }
 
 # Add a group made up of all optional dependencies
-extras_require['all'] = set(
+extras_require["all"] = set(
     package for group in extras_require.values() for package in group
 )
 
@@ -60,52 +60,52 @@ The Natural Language Toolkit (NLTK) is a Python package for
 natural language processing.  NLTK requires Python 2.7, 3.5, 3.6, or 3.7.""",
     license="Apache License, Version 2.0",
     keywords=[
-        'NLP',
-        'CL',
-        'natural language processing',
-        'computational linguistics',
-        'parsing',
-        'tagging',
-        'tokenizing',
-        'syntax',
-        'linguistics',
-        'language',
-        'natural language',
-        'text analytics',
+        "NLP",
+        "CL",
+        "natural language processing",
+        "computational linguistics",
+        "parsing",
+        "tagging",
+        "tokenizing",
+        "syntax",
+        "linguistics",
+        "language",
+        "natural language",
+        "text analytics",
     ],
     maintainer="Steven Bird",
     maintainer_email="stevenbird1@gmail.com",
     author="Steven Bird",
     author_email="stevenbird1@gmail.com",
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'Intended Audience :: Education',
-        'Intended Audience :: Information Technology',
-        'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: Apache Software License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Topic :: Scientific/Engineering',
-        'Topic :: Scientific/Engineering :: Artificial Intelligence',
-        'Topic :: Scientific/Engineering :: Human Machine Interfaces',
-        'Topic :: Scientific/Engineering :: Information Analysis',
-        'Topic :: Text Processing',
-        'Topic :: Text Processing :: Filters',
-        'Topic :: Text Processing :: General',
-        'Topic :: Text Processing :: Indexing',
-        'Topic :: Text Processing :: Linguistic',
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Education",
+        "Intended Audience :: Information Technology",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Topic :: Scientific/Engineering",
+        "Topic :: Scientific/Engineering :: Artificial Intelligence",
+        "Topic :: Scientific/Engineering :: Human Machine Interfaces",
+        "Topic :: Scientific/Engineering :: Information Analysis",
+        "Topic :: Text Processing",
+        "Topic :: Text Processing :: Filters",
+        "Topic :: Text Processing :: General",
+        "Topic :: Text Processing :: Indexing",
+        "Topic :: Text Processing :: Linguistic",
     ],
-    package_data={'nltk': ['test/*.doctest', 'VERSION']},
+    package_data={"nltk": ["test/*.doctest", "VERSION"]},
     install_requires=[
-        'six',
+        "six",
         'singledispatch; python_version < "3.4"',
-        'click',
-        'joblib',
-        'tqdm'
+        "click",
+        "joblib",
+        "tqdm",
     ],
     extras_require=extras_require,
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,8 @@ natural language processing.  NLTK requires Python 2.7, 3.5, 3.6, or 3.7.""",
         'six',
         'singledispatch; python_version < "3.4"',
         'click',
-        'joblib'
+        'joblib',
+        'tqdm'
     ],
     extras_require=extras_require,
     packages=find_packages(),


### PR DESCRIPTION
Having some CLI scripts had been quite nifty (for me personally), maybe more people would like similar functionalities. So the most basic one is the `nltk.word_tokenize`. 

Using Click, we can achieve something like:


```
$ nltk --help
Usage: nltk [OPTIONS] COMMAND [ARGS]...

Options:
  --version   Show the version and exit.
  -h, --help  Show this message and exit.

Commands:
  tokenize  This command tokenizes text stream using nltk.word_tokenize
```

To check version:

```
$ nltk --version
nltk, version 3.4.4
```

And the tokenization CLI:

```
$ nltk tokenize --help
Usage: nltk tokenize [OPTIONS]

  This command tokenizes text stream using nltk.word_tokenize

Options:
  -l, --language TEXT      The language for the Punkt sentence tokenization.
  -l, --preserve-line      An option to keep the preserve the sentence and not
                           sentence tokenize it.
  -j, --processes INTEGER  No. of processes.
  -e, --encoding TEXT      Specify encoding of file.
  -d, --delimiter TEXT     Specify the delimiter to join the tokens.
  -h, --help               Show this message and exit.

```

And example usage:

```
$ wget https://norvig.com/big.txt 
$ nltk tokenize < big.txt > big.txt.tok
100%|██████████████████| 128457/128457 [00:30<00:00, 4250.84it/s]

nltk tokenize -j 4 < big.txt > big.txt.tok
100%|██████████████████| 128457/128457 [00:37<00:00, 3399.43it/s
```

Note: The serialization/parallelization is quirky though, it's sometimes slower than single thread.