### PR TITLE
Use collections.abc when needed for Python 3.8 compatibility.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -256,6 +256,7 @@
 - Devashish Lal <https://github.com/BLaZeKiLL>
 - Gerhard Kremer <https://github.com/GerhardKa>
 - Nicolas Darr <https://github.com/ndarr>
+- Hervé Nicol <https://github.com/hervenicol>
 
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:

--- a/nltk/lm/counter.py
+++ b/nltk/lm/counter.py
@@ -10,7 +10,14 @@ Language Model Counter
 ----------------------
 """
 
-from collections import Sequence, defaultdict
+from collections import defaultdict
+
+try:
+    # Python >= 3.3
+    from collections.abc import Sequence
+except ImportError:
+    # Python < 3.3
+    from collections import Sequence
 
 from six import string_types
 from nltk.probability import ConditionalFreqDist, FreqDist

--- a/nltk/lm/vocabulary.py
+++ b/nltk/lm/vocabulary.py
@@ -8,7 +8,15 @@
 """Language Model Vocabulary"""
 
 import sys
-from collections import Counter, Iterable
+from collections import Counter
+
+try:
+    # Python >= 3.3
+    from collections.abc import Iterable
+except ImportError:
+    # Python < 3.3
+    from collections import Iterable
+
 from itertools import chain
 
 try:


### PR DESCRIPTION
Since Python version 3.3, Collections Abstract Base Classes have been moved to the collections.abc module. For backwards compatibility, they continue to be visible in this module through Python 3.7. Subsequently, they will be removed entirely.

(source: https://docs.python.org/3/library/collections.html)

Also, fixes part of #2338.
