### PR TITLE
Git ignores common virtualenvs set up locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,12 @@ web/api/*.rst
 
 # pyenv files
 .python-version
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/


### PR DESCRIPTION
When working on stuff locally I find it more convenient to create a virtualenv in the nltk folder and would like to prevent git from tracking this env folder.

To make this a bit more general I copied the relevant section from [here](http://gitignore.io/api/python)