### PR TITLE
Fix JSON serialization of some PoS taggers

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -257,7 +257,7 @@
 - Gerhard Kremer <https://github.com/GerhardKa>
 - Nicolas Darr <https://github.com/ndarr>
 - Hervé Nicol <https://github.com/hervenicol>
-
+- Alexandre H. T. Dias <https://github.com/alexandredias3d>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 ### Contributors to the Porter Stemmer

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,8 +118,6 @@ Summary of our git branching model:
   [GitHub issue system](https://github.com/nltk/nltk/issues));
 - Run all tests before pushing (just execute `tox`) so you will know if your
   changes broke something;
-- Try to write both Python 2 and Python3-friendly code so won't be a pain for
-  us to support both versions.
 
 See also our [developer's
 guide](https://github.com/nltk/nltk/wiki/Developers-Guide).

--- a/nltk/tag/brill_trainer.py
+++ b/nltk/tag/brill_trainer.py
@@ -280,7 +280,7 @@ class BrillTaggerTrainer(object):
             print("Finding initial useful rules...")
         self._init_mappings(test_sents, train_sents)
         if self._trace:
-            print(("    Found %d useful rules." % len(self._rule_scores)))
+            print(("    Found {} useful rules.".format(len(self._rule_scores))))
 
         # Let the user know what we're up to.
         if self._trace > 2:
@@ -318,7 +318,7 @@ class BrillTaggerTrainer(object):
 
         # The user can cancel training manually:
         except KeyboardInterrupt:
-            print("Training stopped manually -- %d rules found" % len(rules))
+            print("Training stopped manually -- {} rules found".format(len(rules)))
 
         # Discard our tag position mapping & rule mappings.
         self._clean()
@@ -600,7 +600,7 @@ class BrillTaggerTrainer(object):
         rulestr = rule.format(self._ruleformat)
         if self._trace > 2:
             print(
-                "%4d%4d%4d%4d  |" % (score, num_fixed, num_broken, num_other), end=" "
+                "{:4d}{:4d}{:4d}{:4d}  |".format(score, num_fixed, num_broken, num_other), end=" "
             )
             print(
                 textwrap.fill(
@@ -616,14 +616,14 @@ class BrillTaggerTrainer(object):
     def _trace_apply(self, num_updates):
         prefix = " " * 18 + "|"
         print(prefix)
-        print(prefix, "Applying rule to %d positions." % num_updates)
+        print(prefix, "Applying rule to {} positions.".format(num_updates))
 
     def _trace_update_rules(self, num_obsolete, num_new, num_unseen):
         prefix = " " * 18 + "|"
         print(prefix, "Updated rule tables:")
-        print(prefix, ("  - %d rule applications removed" % num_obsolete))
+        print(prefix, ("  - {} rule applications removed".format(num_obsolete)))
         print(
             prefix,
-            ("  - %d rule applications added (%d novel)" % (num_new, num_unseen)),
+            ("  - {} rule applications added ({} novel)".format(num_new, num_unseen)),
         )
         print(prefix)

--- a/nltk/tag/perceptron.py
+++ b/nltk/tag/perceptron.py
@@ -27,7 +27,7 @@ except ImportError:
 PICKLE = "averaged_perceptron_tagger.pickle"
 
 @jsontags.register_tag
-class AveragedPerceptron(object):
+class AveragedPerceptron:
 
     """An averaged perceptron, as implemented by Matthew Honnibal.
 

--- a/nltk/tag/sequential.py
+++ b/nltk/tag/sequential.py
@@ -125,7 +125,7 @@ class ContextTagger(SequentialBackoffTagger):
         :param context_to_tag: A dictionary mapping contexts to tags.
         :param backoff: The backoff tagger that should be used for this tagger.
         """
-        SequentialBackoffTagger.__init__(self, backoff)
+        super().__init__(backoff)
         self._context_to_tag = context_to_tag if context_to_tag else {}
 
     @abstractmethod
@@ -149,7 +149,7 @@ class ContextTagger(SequentialBackoffTagger):
         return len(self._context_to_tag)
 
     def __repr__(self):
-        return "<%s: size=%d>" % (self.__class__.__name__, self.size())
+        return "<{}: size={}>".format(self.__class__.__name__, self.size())
 
     def _train(self, tagged_corpus, cutoff=0, verbose=False):
         """
@@ -208,7 +208,7 @@ class ContextTagger(SequentialBackoffTagger):
             backoff = 100 - (hit_count * 100.0) / token_count
             pruning = 100 - (size * 100.0) / len(fd.conditions())
             print("[Trained Unigram tagger:", end=" ")
-            print("size=%d, backoff=%.2f%%, pruning=%.2f%%]" % (size, backoff, pruning))
+            print("size={}, backoff={:.2f}%, pruning={:.2f}%]".format(size, backoff, pruning))
 
 
 ######################################################################
@@ -238,7 +238,7 @@ class DefaultTagger(SequentialBackoffTagger):
 
     def __init__(self, tag):
         self._tag = tag
-        SequentialBackoffTagger.__init__(self, None)
+        super().__init__(None)
 
     def encode_json_obj(self):
         return self._tag
@@ -252,7 +252,7 @@ class DefaultTagger(SequentialBackoffTagger):
         return self._tag  # ignore token and history
 
     def __repr__(self):
-        return "<DefaultTagger: tag=%s>" % self._tag
+        return "<DefaultTagger: tag={}>".format(self._tag)
 
 
 @jsontags.register_tag
@@ -288,7 +288,7 @@ class NgramTagger(ContextTagger):
         self._n = n
         self._check_params(train, model)
 
-        ContextTagger.__init__(self, model, backoff)
+        super().__init__(model, backoff)
 
         if train:
             self._train(train, cutoff, verbose)
@@ -335,7 +335,7 @@ class UnigramTagger(NgramTagger):
         >>> test_sent = brown.sents(categories='news')[0]
         >>> unigram_tagger = UnigramTagger(brown.tagged_sents(categories='news')[:500])
         >>> for tok, tag in unigram_tagger.tag(test_sent):
-        ...     print("(%s, %s), " % (tok, tag))
+        ...     print("({}, {}), ".format(tok, tag))
         (The, AT), (Fulton, NP-TL), (County, NN-TL), (Grand, JJ-TL),
         (Jury, NN-TL), (said, VBD), (Friday, NR), (an, AT),
         (investigation, NN), (of, IN), (Atlanta's, NP$), (recent, JJ),
@@ -358,7 +358,7 @@ class UnigramTagger(NgramTagger):
     json_tag = "nltk.tag.sequential.UnigramTagger"
 
     def __init__(self, train=None, model=None, backoff=None, cutoff=0, verbose=False):
-        NgramTagger.__init__(self, 1, train, model, backoff, cutoff, verbose)
+        super().__init__(1, train, model, backoff, cutoff, verbose)
 
     def context(self, tokens, index, history):
         return tokens[index]
@@ -387,7 +387,7 @@ class BigramTagger(NgramTagger):
     json_tag = "nltk.tag.sequential.BigramTagger"
 
     def __init__(self, train=None, model=None, backoff=None, cutoff=0, verbose=False):
-        NgramTagger.__init__(self, 2, train, model, backoff, cutoff, verbose)
+        super().__init__(2, train, model, backoff, cutoff, verbose)
 
 
 @jsontags.register_tag
@@ -413,7 +413,7 @@ class TrigramTagger(NgramTagger):
     json_tag = "nltk.tag.sequential.TrigramTagger"
 
     def __init__(self, train=None, model=None, backoff=None, cutoff=0, verbose=False):
-        NgramTagger.__init__(self, 3, train, model, backoff, cutoff, verbose)
+        super().__init__(3, train, model, backoff, cutoff, verbose)
 
 
 @jsontags.register_tag
@@ -451,7 +451,7 @@ class AffixTagger(ContextTagger):
 
         self._check_params(train, model)
 
-        ContextTagger.__init__(self, model, backoff)
+        super().__init__(model, backoff)
 
         self._affix_length = affix_length
         self._min_word_length = min_stem_length + abs(affix_length)
@@ -535,7 +535,7 @@ class RegexpTagger(SequentialBackoffTagger):
     def __init__(self, regexps, backoff=None):
         """
         """
-        SequentialBackoffTagger.__init__(self, backoff)
+        super().__init__(backoff)
         try:
             self._regexps = [(re.compile(regexp), tag,) for regexp, tag in regexps]
         except Exception as e:
@@ -557,7 +557,7 @@ class RegexpTagger(SequentialBackoffTagger):
         return None
 
     def __repr__(self):
-        return "<Regexp Tagger: size=%d>" % len(self._regexps)
+        return "<Regexp Tagger: size={}>".format(len(self._regexps))
 
 
 class ClassifierBasedTagger(SequentialBackoffTagger, FeaturesetTaggerI):
@@ -615,7 +615,7 @@ class ClassifierBasedTagger(SequentialBackoffTagger, FeaturesetTaggerI):
     ):
         self._check_params(train, classifier)
 
-        SequentialBackoffTagger.__init__(self, backoff)
+        super().__init__(backoff)
 
         if (train and classifier) or (not train and not classifier):
             raise ValueError(
@@ -670,11 +670,11 @@ class ClassifierBasedTagger(SequentialBackoffTagger, FeaturesetTaggerI):
                 history.append(tags[index])
 
         if verbose:
-            print("Training classifier (%d instances)" % len(classifier_corpus))
+            print("Training classifier ({} instances)".format(len(classifier_corpus)))
         self._classifier = classifier_builder(classifier_corpus)
 
     def __repr__(self):
-        return "<ClassifierBasedTagger: %r>" % self._classifier
+        return "<ClassifierBasedTagger: {}>".format(self._classifier)
 
     def feature_detector(self, tokens, index, history):
         """
@@ -742,9 +742,9 @@ class ClassifierBasedPOSTagger(ClassifierBasedTagger):
             "suffix1": word.lower()[-1:],
             "prevprevword": prevprevword,
             "prevword": prevword,
-            "prevtag+word": "%s+%s" % (prevtag, word.lower()),
-            "prevprevtag+word": "%s+%s" % (prevprevtag, word.lower()),
-            "prevword+word": "%s+%s" % (prevword, word.lower()),
+            "prevtag+word": "{}+{}".format(prevtag, word.lower()),
+            "prevprevtag+word": "{}+{}".format(prevprevtag, word.lower()),
+            "prevword+word": "{}+{}".format(prevword, word.lower()),
             "shape": shape,
         }
         return features

--- a/nltk/tag/sequential.py
+++ b/nltk/tag/sequential.py
@@ -551,7 +551,7 @@ class RegexpTagger(SequentialBackoffTagger):
                 'Invalid RegexpTagger regexp:', str(e), 'regexp:', regexp, 'tag:', tag)
 
     def encode_json_obj(self):
-        return [(regexp.patten, tag) for regexp, tag in self._regexs], self.backoff
+        return [(regexp.pattern, tag) for regexp, tag in self._regexs], self.backoff
 
     @classmethod
     def decode_json_obj(cls, obj):

--- a/nltk/tag/sequential.py
+++ b/nltk/tag/sequential.py
@@ -537,13 +537,13 @@ class RegexpTagger(SequentialBackoffTagger):
         """
         SequentialBackoffTagger.__init__(self, backoff)
         try:
-            self._regexs = [(re.compile(regexp), tag,) for regexp, tag in regexps]
+            self._regexps = [(re.compile(regexp), tag,) for regexp, tag in regexps]
         except Exception as e:
             raise Exception(
                 'Invalid RegexpTagger regexp:', str(e), 'regexp:', regexp, 'tag:', tag)
 
     def encode_json_obj(self):
-        return [(regexp.pattern, tag) for regexp, tag in self._regexs], self.backoff
+        return [(regexp.pattern, tag) for regexp, tag in self._regexps], self.backoff
 
     @classmethod
     def decode_json_obj(cls, obj):
@@ -551,13 +551,13 @@ class RegexpTagger(SequentialBackoffTagger):
         return cls(regexps, backoff)
 
     def choose_tag(self, tokens, index, history):
-        for regexp, tag in self._regexs:
+        for regexp, tag in self._regexps:
             if re.match(regexp, tokens[index]):
                 return tag
         return None
 
     def __repr__(self):
-        return "<Regexp Tagger: size=%d>" % len(self._regexs)
+        return "<Regexp Tagger: size=%d>" % len(self._regexps)
 
 
 class ClassifierBasedTagger(SequentialBackoffTagger, FeaturesetTaggerI):

--- a/nltk/tbl/feature.py
+++ b/nltk/tbl/feature.py
@@ -13,7 +13,7 @@ from six import add_metaclass
 
 
 @add_metaclass(ABCMeta)
-class Feature(object):
+class Feature:
     """
     An abstract base class for Features. A Feature is a combination of
     a specific property-computing method and a list of relative positions

--- a/nltk/tbl/rule.py
+++ b/nltk/tbl/rule.py
@@ -19,7 +19,7 @@ from nltk import jsontags
 # Tag Rules
 ######################################################################
 @add_metaclass(ABCMeta)
-class TagRule(object):
+class TagRule:
     """
     An interface for tag transformations on a tagged corpus, as
     performed by tbl taggers.  Each transformation finds all tokens

--- a/nltk/tbl/rule.py
+++ b/nltk/tbl/rule.py
@@ -149,7 +149,10 @@ class Rule(TagRule):
     @classmethod
     def decode_json_obj(cls, obj):
         return cls(
-            obj["templateid"], obj["original"], obj["replacement"], obj["conditions"]
+            obj["templateid"],
+            obj["original"],
+            obj["replacement"],
+            tuple(tuple(feat) for feat in obj["conditions"])
         )
 
     def applies(self, tokens, index):

--- a/nltk/tbl/template.py
+++ b/nltk/tbl/template.py
@@ -16,7 +16,7 @@ from nltk.tbl.rule import Rule
 
 
 @add_metaclass(ABCMeta)
-class BrillTemplateI(object):
+class BrillTemplateI:
     """
     An interface for generating lists of transformational rules that
     apply at given sentence positions.  ``BrillTemplateI`` is used by

--- a/nltk/test/unit/test_json_serialization.py
+++ b/nltk/test/unit/test_json_serialization.py
@@ -1,0 +1,87 @@
+import unittest
+
+from nltk.corpus import brown
+from nltk.jsontags import JSONTaggedDecoder, JSONTaggedEncoder
+from nltk.tag import DefaultTagger, RegexpTagger, AffixTagger
+from nltk.tag import UnigramTagger, BigramTagger, TrigramTagger, NgramTagger
+from nltk.tag import PerceptronTagger
+from nltk.tag import BrillTaggerTrainer, BrillTagger
+from nltk.tag.brill import nltkdemo18
+
+    
+class TestJSONSerialization(unittest.TestCase):
+    def setUp(self):
+        self.corpus = brown.tagged_sents()[:35]
+        self.decoder = JSONTaggedDecoder()
+        self.encoder = JSONTaggedEncoder()
+        self.default_tagger = DefaultTagger("NN")
+
+    def test_default_tagger(self):
+        encoded = self.encoder.encode(self.default_tagger)
+        decoded = self.decoder.decode(encoded)
+
+        self.assertEqual(repr(self.default_tagger), repr(decoded))
+        self.assertEqual(self.default_tagger._tag, decoded._tag)
+
+    def test_regexp_tagger(self):
+        tagger = RegexpTagger([(r".*", "NN")], backoff=self.default_tagger)
+
+        encoded = self.encoder.encode(tagger)
+        decoded = self.decoder.decode(encoded)
+
+        self.assertEqual(repr(tagger), repr(decoded))
+        self.assertEqual(repr(tagger.backoff), repr(decoded.backoff))
+        self.assertEqual(tagger._regexps, decoded._regexps)
+
+    def test_affix_tagger(self):
+        tagger = AffixTagger(self.corpus, backoff=self.default_tagger)
+
+        encoded = self.encoder.encode(tagger)
+        decoded = self.decoder.decode(encoded)
+
+        self.assertEqual(repr(tagger), repr(decoded))
+        self.assertEqual(repr(tagger.backoff), repr(decoded.backoff))
+        self.assertEqual(tagger._affix_length, decoded._affix_length)
+        self.assertEqual(tagger._min_word_length, decoded._min_word_length)
+        self.assertEqual(tagger._context_to_tag, decoded._context_to_tag)
+
+    def test_ngram_taggers(self):
+        unitagger = UnigramTagger(self.corpus, backoff=self.default_tagger)
+        bitagger = BigramTagger(self.corpus, backoff=unitagger)
+        tritagger = TrigramTagger(self.corpus, backoff=bitagger)
+        ntagger = NgramTagger(4, self.corpus, backoff=tritagger)
+
+        encoded = self.encoder.encode(ntagger)
+        decoded = self.decoder.decode(encoded)
+
+        self.assertEqual(repr(ntagger), repr(decoded))
+        self.assertEqual(repr(tritagger), repr(decoded.backoff))
+        self.assertEqual(repr(bitagger), repr(decoded.backoff.backoff))
+        self.assertEqual(repr(unitagger), repr(decoded.backoff.backoff.backoff))
+        self.assertEqual(repr(self.default_tagger), 
+                         repr(decoded.backoff.backoff.backoff.backoff))
+
+    def test_perceptron_tagger(self):
+        tagger = PerceptronTagger(load=False)
+        tagger.train(self.corpus)
+
+        encoded = self.encoder.encode(tagger)
+        decoded = self.decoder.decode(encoded)
+
+        self.assertEqual(tagger.model.weights, decoded.model.weights)
+        self.assertEqual(tagger.tagdict, decoded.tagdict)
+        self.assertEqual(tagger.classes, decoded.classes)
+
+    def test_brill_tagger(self):
+        trainer = BrillTaggerTrainer(self.default_tagger, nltkdemo18(),
+                                     deterministic=True)
+        tagger = trainer.train(self.corpus, max_rules=30)
+
+        encoded = self.encoder.encode(tagger)
+        decoded = self.decoder.decode(encoded)
+
+        self.assertEqual(repr(tagger._initial_tagger),
+                         repr(decoded._initial_tagger))
+        self.assertEqual(tagger._rules, decoded._rules)
+        self.assertEqual(tagger._training_stats, decoded._training_stats)
+


### PR DESCRIPTION
I tried to find an alternative for serializing taggers other than using Pickle. I believe this is important to provide trained models in a safe fashion using the library.

This pull request fixes the error when using ```JSONTaggedEncoder``` on a ```NgramTagger``` with ```n``` greater than 1. Without the fix, it tries to serialize tuples and raises ```TypeError```. The workaround uses ```ast.literal_eval``` to read tuples in `repr` format. Also, this pull request can encode and decode PerceptronTagger and BrillTagger correctly.