### PR TITLE
Isolate imports for parallelization inside function.

### DIFF
--- a/nltk/util.py
+++ b/nltk/util.py
@@ -30,8 +30,6 @@ from six.moves.urllib.request import (
     ProxyDigestAuthHandler,
     HTTPPasswordMgrWithDefaultRealm,
 )
-from tqdm import tqdm
-from joblib import Parallel, delayed
 
 from nltk.internals import slice_bounds, raise_unorderable_types
 from nltk.collections import *
@@ -833,6 +831,9 @@ def choose(n, k):
 
 
 def parallelize_preprocess(func, iterator, processes, progress_bar=False):
+    from tqdm import tqdm
+    from joblib import Parallel, delayed
+
     iterator = tqdm(iterator) if progress_bar else iterator
     if processes <= 1:
         return map(func, iterator)


### PR DESCRIPTION
This should fix the CI issues. 

The global imports from #2337 caused the CI to break at and `nltk_data` wasn't downloaded in the CI, https://api.travis-ci.org/v3/job/573307302/log.txt

```
+++python -c 'import nltk; nltk.download('\''all'\'')'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/travis/build/nltk/nltk/nltk/__init__.py", line 128, in <module>
    from nltk.collocations import *
  File "/home/travis/build/nltk/nltk/nltk/collocations.py", line 37, in <module>
    from nltk.util import ngrams
  File "/home/travis/build/nltk/nltk/nltk/util.py", line 33, in <module>
    from tqdm import tqdm
ImportError: No module named 'tqdm'
+++echo 'NLTK data download failed: 1'
NLTK data download failed: 1
``