### PR TITLE
Text's collocation_list should return a list of tuples

### DIFF
--- a/nltk/text.py
+++ b/nltk/text.py
@@ -403,6 +403,10 @@ class Text(object):
     def collocation_list(self, num=20, window_size=2):
         """
         Return collocations derived from the text, ignoring stopwords.
+        
+            >>> from nltk.book import text4
+            >>> text4.collocation_list()[:2]
+            [('United', 'States'), ('fellow', 'citizens')]
 
         :param num: The maximum number of collocations to return.
         :type num: int

--- a/nltk/text.py
+++ b/nltk/text.py
@@ -436,6 +436,10 @@ class Text(object):
     def collocations(self, num=20, window_size=2):
         """
         Print collocations derived from the text, ignoring stopwords.
+        
+            >>> from nltk.book import text4
+            >>> text4.collocations()[:2]
+            ['United States', 'fellow citizens']
 
         :param num: The maximum number of collocations to print.
         :type num: int

--- a/nltk/text.py
+++ b/nltk/text.py
@@ -438,8 +438,8 @@ class Text(object):
         Print collocations derived from the text, ignoring stopwords.
         
             >>> from nltk.book import text4
-            >>> text4.collocations()[:2]
-            ['United States', 'fellow citizens']
+            >>> text4.collocations() # doctest: +ELLIPSIS
+            ['United States', 'fellow citizens', ...]
 
         :param num: The maximum number of collocations to print.
         :type num: int

--- a/nltk/text.py
+++ b/nltk/text.py
@@ -439,7 +439,7 @@ class Text(object):
         
             >>> from nltk.book import text4
             >>> text4.collocations() # doctest: +ELLIPSIS
-            ['United States', 'fellow citizens', ...]
+            United States; fellow citizens; four years; ...
 
         :param num: The maximum number of collocations to print.
         :type num: int

--- a/nltk/text.py
+++ b/nltk/text.py
@@ -408,6 +408,7 @@ class Text(object):
         :type num: int
         :param window_size: The number of tokens spanned by a collocation (default=2)
         :type window_size: int
+        :rtype: list(tuple(str, str))
         """
         if not (
             "_collocations" in self.__dict__
@@ -425,8 +426,8 @@ class Text(object):
             finder.apply_freq_filter(2)
             finder.apply_word_filter(lambda w: len(w) < 3 or w.lower() in ignored_words)
             bigram_measures = BigramAssocMeasures()
-            self._collocations = finder.nbest(bigram_measures.likelihood_ratio, num)
-        return [w1 + " " + w2 for w1, w2 in self._collocations]
+            self._collocations = list(finder.nbest(bigram_measures.likelihood_ratio, num))
+        return self._collocations
 
     def collocations(self, num=20, window_size=2):
         """


### PR DESCRIPTION
From #2227 , fixes the bug where:

```python
>>> from nltk.book import *
*** Introductory Examples for the NLTK Book ***
Loading text1, ..., text9 and sent1, ..., sent9
Type the name of the text or sentence to view it.
Type: 'texts()' or 'sents()' to list the materials.
text1: Moby Dick by Herman Melville 1851
text2: Sense and Sensibility by Jane Austen 1811
text3: The Book of Genesis
text4: Inaugural Address Corpus
text5: Chat Corpus
text6: Monty Python and the Holy Grail
text7: Wall Street Journal
text8: Personals Corpus
text9: The Man Who Was Thursday by G . K . Chesterton 1908
>>> text4.collocations()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/liling.tan/git-stuff/nltk/nltk/text.py", line 442, in collocations
    w1 + " " + w2 for w1, w2 in self.collocation_list(num, window_size)
  File "/Users/liling.tan/git-stuff/nltk/nltk/text.py", line 442, in <listcomp>
    w1 + " " + w2 for w1, w2 in self.collocation_list(num, window_size)
ValueError: too many values to unpack (expected 2)
```

The `Text.collocations()` should print the list and the `Text.collocation_list()` should return the collocations as a list of tuples of 2 strings. Since that's the expected collocations from the bigrams count.


This patch should work and the expected behavior:

```python
>>> from nltk.book import text4

>>> text4.collocation_list() # Returns a list of tuples of two strings.
[('United', 'States'), ('fellow', 'citizens'), ('four', 'years'), ('years', 'ago'), ('Federal', 'Government'), ('General', 'Government'), ('American', 'people'), ('Vice', 'President'), ('Old', 'World'), ('Almighty', 'God'), ('Fellow', 'citizens'), ('Chief', 'Magistrate'), ('Chief', 'Justice'), ('God', 'bless'), ('every', 'citizen'), ('Indian', 'tribes'), ('public', 'debt'), ('one', 'another'), ('foreign', 'nations'), ('political', 'parties')]

>>> text4.collocations() # Prints collocations.
United States; fellow citizens; four years; ...
```