### PR TITLE
Experimental wrapper over SpaCy

### DIFF
--- a/nltk/astronaut.py
+++ b/nltk/astronaut.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# Natural Language Toolkit: Spacy wrapper
+#
+# Copyright (C) 2001-2019 NLTK Project
+# Authors:
+# Contributors:
+# URL: <http://nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""
+This is SpaCy wrapper that overrides the existing NLTK functions:
+    - word_tokenize
+    - pos_tag
+It'll emulate the NLTK API to the NLP functions,
+but uses the `en_core_web_sm` models from SpaCy (https://spacy.io/models)
+"""
+
+import sys
+
+try: # Try importing SpaCy if it's installed.
+    import spacy
+    import en_core_web_sm
+    nlp = en_core_web_sm.load()
+
+    module = sys.modules['nltk']
+
+    def spacy_pos_tag(input):
+        if all(isinstance(item, str) for item in input):
+            input = " ".join(input)
+        return [(token.text, token.tag_) for token in nlp(input)]
+
+    module.word_tokenize = lambda input: [token.text for token in nlp(input)]
+    module.pos_tag = lambda input: spacy_pos_tag(input)
+except ImportError:
+    pass

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ extras_require = {
     "tgrep": ["pyparsing"],
     "twitter": ["twython"],
     "corenlp": ["requests"],
+    "spacy": ["spacy", "en_core_web_sm"],
 }
 
 # Add a group made up of all optional dependencies

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     py{35,36,37}-nodeps
     py{35,36,37}-jenkins
     py-travis
+    py-spacy
 
 [testenv]
 ; simplify numpy installation
@@ -89,6 +90,12 @@ setenv =
 
 [testenv:py-travis]
 extras = all
+setenv =
+    NLTK_DATA = {homedir}/nltk_data/
+commands = {toxinidir}/tools/travis/coverage-pylint.sh
+
+[testenv:py-spacy]
+extras = spacy
 setenv =
     NLTK_DATA = {homedir}/nltk_data/
 commands = {toxinidir}/tools/travis/coverage-pylint.sh


### PR DESCRIPTION
This should automate installation of spacy.

```
pip install -U nltk[spacy] 
```

(Note: The usual `pip install -U nltk[all]` would also install SpaCy.)

And to use, the `from nltk import astronaut` line must come first:

```python
>>> from nltk import astronaut 
>>> from nltk import word_tokenize, pos_tag

>>> word_tokenize("how are you? I'm fine. Thank you")
['how', 'are', 'you', '?', 'I', "'m", 'fine', '.', 'Thank', 'you']

>>> pos_tag(word_tokenize("how are you? I'm fine. Thank you"))
[('how', 'WRB'), ('are', 'VBP'), ('you', 'PRP'), ('?', '.'), ('I', 'PRP'), ("'", "''"), ('m', 'VBZ'), ('fine', 'JJ'), ('.', '.'), ('Thank', 'VBP'), ('you', 'PRP')]

>>> word_tokenize
<function nltk.astronaut.<lambda>(input)>

>>> pos_tag
<function nltk.astronaut.<lambda>(input)>
```
