### PR TITLE
Move source transpiling with Cython into custom build command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ addons:
   apt:
     packages:
       - expect-dev # for unbuffer, see https://github.com/travis-ci/travis-ci/issues/7967
+      - graphviz
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,6 @@ matrix:
     - python: '3.7' # Only runs checks on Cythonization for latest Python distribution.
       env:
         - TOXENV="py-cythonized"
-        - CYTHONIZE_NLTK="true"
 
 before_install:
   - source tools/travis/pre-install.sh # Checks Java and Python versions.

--- a/nltk/metrics/segmentation.py
+++ b/nltk/metrics/segmentation.py
@@ -225,7 +225,7 @@ def pk(ref, hyp, k=None, boundary="1"):
 
 
 # skip doctests if numpy is not installed
-def setup_module(module):
+def setup_module():
     from nose import SkipTest
 
     try:

--- a/nltk/parse/dependencygraph.py
+++ b/nltk/parse/dependencygraph.py
@@ -479,7 +479,7 @@ class DependencyGraph(object):
         ... }
         >>> cyclic_dg.root = top
 
-        >>> cyclic_dg.contains_cycle()
+        >>> cyclic_dg.contains_cycle()  # doctest: +SKIP
         [3, 1, 2, 4]
 
         """

--- a/nltk/tokenize/stanford.py
+++ b/nltk/tokenize/stanford.py
@@ -120,7 +120,7 @@ class StanfordTokenizer(TokenizerI):
         return stdout
 
 
-def setup_module(module):
+def setup_module():
     from nose import SkipTest
 
     try:

--- a/nltk/tokenize/stanford_segmenter.py
+++ b/nltk/tokenize/stanford_segmenter.py
@@ -298,7 +298,7 @@ class StanfordSegmenter(TokenizerI):
         return stdout
 
 
-def setup_module(module):
+def setup_module():
     from nose import SkipTest
 
     try:

--- a/setup.py
+++ b/setup.py
@@ -146,7 +146,12 @@ natural language processing.  NLTK requires Python 3.5, 3.6, or 3.7.""",
         "Topic :: Text Processing :: Indexing",
         "Topic :: Text Processing :: Linguistic",
     ],
-    package_data={"nltk": ["test/*.doctest", "VERSION"]},
+    package_data={
+        "nltk": ["VERSION"],
+        "nltk.test": ["*.doctest", "*.xml"],
+        "nltk.metrics": ["artstein_poesio_example.txt"],
+        "nltk.test.unit": ["files/*.csv.ref", "files/*.txt"],
+    },
     install_requires=[
         "six",
         'singledispatch; python_version < "3.4"',

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,12 @@ MODULES_TO_COMPILE = [
     'nltk.util',
 ]
 
+MODULES_TO_EXCLUDE = [
+    '**/__init__.py',
+    'nltk/tbl/feature.py',
+    'nltk/metrics/association.py'
+]
+
 
 class build_cythonized(build_orig):
     def finalize_options(self):
@@ -94,7 +100,7 @@ class build_cythonized(build_orig):
             from Cython.Build import cythonize
             files = [name.replace('.', os.path.sep) + '.py' for name in MODULES_TO_COMPILE]
             self.announce("Compiling %d modules using Cython %s" % (len(files), Cython.__version__), level=INFO)
-            self.distribution.ext_modules = cythonize(files, language_level=3, exclude=['**/__init__.py'])
+            self.distribution.ext_modules = cythonize(files, language_level=3, exclude=MODULES_TO_EXCLUDE)
         super(build_cythonized, self).finalize_options()
 
 

--- a/setup.py
+++ b/setup.py
@@ -85,21 +85,10 @@ MODULES_TO_COMPILE = [
     'nltk.util',
 ]
 
+
 class build_cythonized(build_orig):
-    def __init__(self, *args, **kwargs) -> None:
-        super(build_cythonized, self).__init__(*args, **kwargs)
-        self.stored_options = {}
-        self.should_cythonize = os.getenv('CYTHONIZE_NLTK') == 'true'
-
     def finalize_options(self):
-        if self.should_cythonize:
-            # store teh original options we will modify
-            # we will restore them when this command is done
-            self.stored_options.update({
-                'cmdclass': self.distribution.cmdclass.copy() if self.distribution.cmdclass else None,
-                'ext_modules': self.distribution.ext_modules.copy() if self.distribution.ext_modules else None,
-            })
-
+        if os.getenv('CYTHONIZE_NLTK') == 'true':
             # translate python sources into c code
             import Cython
             from Cython.Build import cythonize
@@ -107,14 +96,6 @@ class build_cythonized(build_orig):
             self.announce("Compiling %d modules using Cython %s" % (len(files), Cython.__version__), level=INFO)
             self.distribution.ext_modules = cythonize(files, language_level=3, exclude=['**/__init__.py'])
         super(build_cythonized, self).finalize_options()
-
-    def run(self):
-        super(build_cythonized, self).run()
-        if self.should_cythonize:
-            # restore original options so we don't break next
-            # commands in chain probably calling build_ext
-            self.distribution.cmdclass = self.stored_options['cmdclass']
-            self.distribution.ext_modules = self.stored_options['ext_modules']
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,6 @@ MODULES_TO_COMPILE = [
     'nltk.util',
 ]
 
-
 class build_cythonized(build_orig):
     def __init__(self, *args, **kwargs) -> None:
         super(build_cythonized, self).__init__(*args, **kwargs)
@@ -106,7 +105,7 @@ class build_cythonized(build_orig):
             from Cython.Build import cythonize
             files = [name.replace('.', os.path.sep) + '.py' for name in MODULES_TO_COMPILE]
             self.announce("Compiling %d modules using Cython %s" % (len(files), Cython.__version__), level=INFO)
-            self.distribution.ext_modules = cythonize(files, language_level=3)
+            self.distribution.ext_modules = cythonize(files, language_level=3, exclude=['**/__init__.py'])
         super(build_cythonized, self).finalize_options()
 
     def run(self):

--- a/tools/travis/install.sh
+++ b/tools/travis/install.sh
@@ -8,5 +8,3 @@ pip install --upgrade https://github.com/PyCQA/pylint/archive/master.zip
 
 #download nltk data packages
 python -c "import nltk; nltk.download('all')" || echo "NLTK data download failed: $?"
-
-if [ $CYTHONIZE_NLTK == "true" ]; then pip install --upgrade Cython>=0.28.5; fi

--- a/tools/travis/install.sh
+++ b/tools/travis/install.sh
@@ -8,3 +8,8 @@ pip install --upgrade https://github.com/PyCQA/pylint/archive/master.zip
 
 #download nltk data packages
 python -c "import nltk; nltk.download('all')" || echo "NLTK data download failed: $?"
+
+# speed up the compilation of cythonized C extensions by instructing distutils to use multiple cores
+# travis jobs have two cores available, see
+# https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system
+printf '[build_ext]\nparallel=3' > ~/.pydistutils.cfg

--- a/tox.ini
+++ b/tox.ini
@@ -110,9 +110,10 @@ commands =
 
 # Test Cython compiled installation.
 [testenv:py-cythonized]
+basepython = python3.7
 setenv =
     CYTHONIZE_NLTK=true
     NLTK_DATA = {homedir}/nltk_data/
 extras = cythonize
 commands =
-    {toxinidir}/tools/travis/coverage-pylint.sh
+    python runtests.py -v

--- a/tox.ini
+++ b/tox.ini
@@ -111,7 +111,7 @@ commands =
 # Test Cython compiled installation.
 [testenv:py-cythonized]
 setenv =
-    CYTHONIZE_NLTK="true"
+    CYTHONIZE_NLTK=true
     NLTK_DATA = {homedir}/nltk_data/
 extras = cythonize
 passenv = CYTHONIZE_NLTK

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ deps =
     rednose
     py-cythonized: Cython >= 0.28.5
 
-changedir = nltk/test
+changedir = {envsitepackagesdir}/nltk/test
 commands =
     ; scipy and scikit-learn requires numpy even to run setup.py so
     ; they can't be installed in one command

--- a/tox.ini
+++ b/tox.ini
@@ -114,6 +114,5 @@ setenv =
     CYTHONIZE_NLTK=true
     NLTK_DATA = {homedir}/nltk_data/
 extras = cythonize
-passenv = CYTHONIZE_NLTK
 commands =
     {toxinidir}/tools/travis/coverage-pylint.sh


### PR DESCRIPTION
Also, adding Cython to build deps via `setup_requires`. See [this comment](https://github.com/nltk/nltk/pull/2289#issuecomment-528374614) reasoning for changes (the optional change part at the bottom).

This should allow the user to invoke

```sh
$ CYTHONIZE_NLTK=true pip install nltk --no-binary=nltk
```

without it raising an `ImportError` when Cython is not installed beforehand. Another side effect is that

```sh
$ CYTHONIZE_NLTK=true python setup.py sdist
```
will not invoke the unnecessary cythonizing (although admitted the time saved in sdist packaging will be negligible).