### PR TITLE
improved tag formatting to spanish POS

### DIFF
--- a/nltk/tag/stanford.py
+++ b/nltk/tag/stanford.py
@@ -132,7 +132,7 @@ class StanfordTagger(TaggerI):
             sentence = []
             for tagged_word in tagged_sentence.strip().split():
                 word_tags = tagged_word.strip().split(self._SEPARATOR)
-                sentence.append(("".join(word_tags[:-1]), word_tags[-1]))
+                sentence.append(("".join(word_tags[:-1]), word_tags[-1].replace('0', '').upper()))
             tagged_sentences.append(sentence)
         return tagged_sentences
 


### PR DESCRIPTION
The table presented in the message below has been generated from the information presented in https://nlp.stanford.edu/software/spanish-faq.shtml#tagset, but with the formatting as the one presented in: https://www.ling.upenn.edu/courses/Fall_2003/ling001/penn_treebank_pos.html.

So on, the presented table is a modification with the formatting implemented in this PR so that users can get the P.O.S. Tag with a clearer format. Some checks have been made so to check that the formatting does not affect any of the indexed languages since none of them uses zero's or mandatory lower case.