### PR TITLE
Fix Python 3.x incompatibity bug with pl196x corpus reader

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -57,6 +57,7 @@
 - Campion Fellin
 - Michelle Fullwood
 - Dan Garrette
+- Maciej Gawinecki
 - Jean Mark Gawron
 - Sumukh Ghodke
 - Yoav Goldberg

--- a/nltk/corpus/reader/pl196x.py
+++ b/nltk/corpus/reader/pl196x.py
@@ -130,11 +130,11 @@ class Pl196xCorpusReader(CategorizedCorpusReader, XMLCorpusReader):
     def _resolve(self, fileids, categories, textids=None):
         tmp = None
         if (
-            len(
+            len(list(
                 filter(
                     lambda accessor: accessor is None, (fileids, categories, textids)
                 )
-            )
+            ))
             != 1
         ):
 

--- a/nltk/test/unit/test_pl196x.py
+++ b/nltk/test/unit/test_pl196x.py
@@ -1,0 +1,14 @@
+import unittest
+
+import nltk
+from nltk.corpus.reader import pl196x
+
+
+class TestCorpusViews(unittest.TestCase):
+
+    def test_corpus_reader(self):
+        pl196x_dir = nltk.data.find('corpora/pl196x')
+        pl = pl196x.Pl196xCorpusReader(pl196x_dir, r'.*\.xml',
+                                       textids='textids.txt',
+                                       cat_file='cats.txt')
+        pl.tagged_words(fileids=pl.fileids(), categories='cats.txt')


### PR DESCRIPTION
Using pl196x corpus reader:
```
pl196x_dir = nltk.data.find('corpora/pl196x')
        pl = pl196x.Pl196xCorpusReader(pl196x_dir, r'.*\.xml',
                                       textids='textids.txt',
                                       cat_file='cats.txt')
        pl.tagged_words(fileids=pl.fileids(), categories='cats.txt')
```
returns the following error in Python 3
```
TypeError: object of type 'filter' has no len()
```
because in Python 2 `filter` is returning a list, but in Python 3 it is giving you an iterator.

I'm proposing a simple fix.