### PR TITLE
Correctly handle Penn Treebank trees with a unlabeled branching top node

### DIFF
--- a/nltk/corpus/reader/bracket_parse.py
+++ b/nltk/corpus/reader/bracket_parse.py
@@ -80,10 +80,6 @@ class BracketParseCorpusReader(SyntaxCorpusReader):
             assert 0, "bad block type"
 
     def _normalize(self, t):
-        # If there's an empty set of brackets surrounding the actual
-        # parse, then strip them off.
-        if EMPTY_BRACKETS.match(t):
-            t = t.strip()[1:-1]
         # Replace leaves of the form (!), (,), with (! !), (, ,)
         t = re.sub(r"\((.)\)", r"(\1 \1)", t)
         # Replace leaves of the form (tag word root) with (tag word)
@@ -92,7 +88,12 @@ class BracketParseCorpusReader(SyntaxCorpusReader):
 
     def _parse(self, t):
         try:
-            return Tree.fromstring(self._normalize(t))
+            tree = Tree.fromstring(self._normalize(t))
+            # If there's an empty node at the top, strip it off
+            if tree.label() == '' and len(tree) == 1:
+                return tree[0]
+            else:
+                return tree
 
         except ValueError as e:
             sys.stderr.write("Bad tree detected; trying to recover...\n")


### PR DESCRIPTION
Currently, BracketParseCorpusReader removes the outermost set of unlabeled parens from a tree string before parsing.  This is to get rid of the unlabeled non-branching node at the top of most Penn Treebank trees.  But, it happens that the top node isn't always non-branching, and removing parens when it isn't creates an unparseable tree.  This PR changes it so that we parses the tree as is, and then remove the top node only if it turns out to be redundant.