### PR TITLE
Fix #2444 by having a special case for py 2.7

### DIFF
--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -109,7 +109,11 @@ def java(cmd, classpath=None, stdin=None, stdout=None, stderr=None, blocking=Tru
     :raise OSError: If the java command returns a nonzero return code.
     """
 
-    subprocess_output_dict = {'pipe': subprocess.PIPE, 'stdout': subprocess.STDOUT, 'devnull': subprocess.DEVNULL}
+    try:
+        from subprocess import DEVNULL
+    except ImportError:
+        DEVNULL = open(os.devnull, 'wb')
+    subprocess_output_dict = {'pipe': subprocess.PIPE, 'stdout': subprocess.STDOUT, 'devnull': DEVNULL}
 
     stdin = subprocess_output_dict.get(stdin, stdin)
     stdout = subprocess_output_dict.get(stdout, stdout)


### PR DESCRIPTION
As Python 2.7 is still marked as supported by NLTK, version 3.4.5 shouldn't break compatibility.

This fixes #2444 which is one instance of regression that I was faced with. AFAIK, there are no other regressions.