### PR TITLE
Fix error in grammar.CFG.eliminate_start

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -258,6 +258,7 @@
 - Nicolas Darr <https://github.com/ndarr>
 - Hervé Nicol <https://github.com/hervenicol>
 - Alexandre H. T. Dias <https://github.com/alexandredias3d>
+- Jacob Weightman <https://github.com/jacobdweightman>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 ### Contributors to the Porter Stemmer

--- a/nltk/grammar.py
+++ b/nltk/grammar.py
@@ -851,7 +851,7 @@ class CFG(object):
             result.append(rule)
         if need_to_add:
             start = Nonterminal("S0_SIGMA")
-            result.append(Production(start, grammar.start()))
+            result.append(Production(start, [grammar.start()]))
             n_grammar = CFG(start, result)
             return n_grammar
         return grammar


### PR DESCRIPTION
Previously, CFG.eliminate_start raised a TypeError whenever a new start symbol was actually required by the grammar. This change fixes that error.