### PR TITLE
Fix nonetype return from grammar.CFG.chomsky_normal_form

### DIFF
--- a/nltk/grammar.py
+++ b/nltk/grammar.py
@@ -757,7 +757,7 @@ class CFG(object):
             Customise new rule formation during binarisation
         """
         if self.is_chomsky_normal_form():
-            return
+            return self
         if self.productions(empty=True):
             raise ValueError(
                 ("Grammar has Empty rules. " "Cannot deal with them at the moment")


### PR DESCRIPTION
Previously, CFG.chomsky_normal_form returned None if the grammar was already in chomsky normal form, while it would return a modified grammar if it was not.