### PR TITLE
Force travis to always redownload and reinstall, hopefully also re-unzipping

### DIFF
--- a/tools/travis/install.sh
+++ b/tools/travis/install.sh
@@ -7,4 +7,4 @@ pip install --upgrade -r pip-req.txt
 pip install --upgrade https://github.com/PyCQA/pylint/archive/master.zip
 
 #download nltk data packages
-python -c "import nltk; nltk.download('all')" || echo "NLTK data download failed: $?"
+python -c "import nltk; nltk.download('all', force=True)" || echo "NLTK data download failed: $?"


### PR DESCRIPTION
@stevenbird The CI passes =)

Re-forcing the update on the CI cache, during the travis installs step, seems to resolve the problem. The travis cache should cleverly minimize the no. of times the "force" download is actually used.

LTGM, but I think this is still a temporary fix. 

We really need to:

 - Update/upgrade to a better alternative in handling `nltk_data`
 - Handling ZipFile pointers reading
 

C.f. #2461 and lots of other `nltk_data` related issues https://github.com/nltk/nltk/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+nltk_data =(