### PR TITLE
make FreqDist iterable

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -260,6 +260,7 @@
 - Hervé Nicol <https://github.com/hervenicol>
 - Alexandre H. T. Dias <https://github.com/alexandredias3d>
 - Jacob Weightman <https://github.com/jacobdweightman>
+- Bonifacio de Oliveira <https://github.com/Bonifacio2>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 ### Contributors to the Porter Stemmer

--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -439,6 +439,15 @@ class FreqDist(Counter):
         """
         return "<FreqDist with %d samples and %d outcomes>" % (len(self), self.N())
 
+    def __iter__(self):
+        """
+        Return an iterator which yields tokens ordered by frequency.
+
+        :rtype: iterator
+        """
+        for token, _ in self.most_common(self.B()):
+            yield token
+
 
 ##//////////////////////////////////////////////////////
 ##  Probability Distributions

--- a/nltk/test/unit/test_freqdist.py
+++ b/nltk/test/unit/test_freqdist.py
@@ -1,0 +1,16 @@
+import unittest
+import nltk
+
+
+class TestFreqDist(unittest.TestCase):
+
+    def test_iterating_returns_an_iterator_ordered_by_frequency(self):
+
+        samples = ['one', 'two', 'two']
+
+        distribution = nltk.FreqDist(samples)
+
+        most_frequent, less_frequent = [entry for entry in distribution]
+
+        self.assertEqual(most_frequent, 'two')
+        self.assertEqual(less_frequent, 'one')


### PR DESCRIPTION
I was kinda surprised when I tried to iterate over a `FreqDist` and what it returned wasn't ordered. So I thought this change would be useful.

Thoughts?