### PR TITLE
Fixed invalid target position when extracting phrases.

### DIFF
--- a/nltk/translate/phrase_based.py
+++ b/nltk/translate/phrase_based.py
@@ -41,11 +41,11 @@ def extract(
     :type f_start: int
     :param f_start: Starting index of the possible foreign language phrases
     :type f_end: int
-    :param f_end: Starting index of the possible foreign language phrases
+    :param f_end: End index of the possible foreign language phrases
     :type e_start: int
     :param e_start: Starting index of the possible source language phrases
     :type e_end: int
-    :param e_end: Starting index of the possible source language phrases
+    :param e_end: End index of the possible source language phrases
     :type srctext: list
     :param srctext: The source language tokens, a list of string.
     :type trgtext: list
@@ -75,7 +75,7 @@ def extract(
             trg_phrase = " ".join(trgtext[fs : fe + 1])
             # Include more data for later ordering.
             phrases.add(
-                ((e_start, e_end + 1), (f_start, f_end + 1), src_phrase, trg_phrase)
+                ((e_start, e_end + 1), (fs, fe + 1), src_phrase, trg_phrase)
             )
             fe += 1
             if fe in f_aligned or fe >= trglen:
@@ -111,20 +111,20 @@ def phrase_extraction(srctext, trgtext, alignment, max_phrase_length=0):
     ...
     ((0, 1), (0, 1), 'michael', 'michael')
     ((0, 2), (0, 4), 'michael assumes', 'michael geht davon aus')
-    ((0, 2), (0, 4), 'michael assumes', 'michael geht davon aus ,')
+    ((0, 2), (0, 5), 'michael assumes', 'michael geht davon aus ,')
     ((0, 3), (0, 6), 'michael assumes that', 'michael geht davon aus , dass')
     ((0, 4), (0, 7), 'michael assumes that he', 'michael geht davon aus , dass er')
     ((0, 9), (0, 10), 'michael assumes that he will stay in the house', 'michael geht davon aus , dass er im haus bleibt')
     ((1, 2), (1, 4), 'assumes', 'geht davon aus')
-    ((1, 2), (1, 4), 'assumes', 'geht davon aus ,')
+    ((1, 2), (1, 5), 'assumes', 'geht davon aus ,')
     ((1, 3), (1, 6), 'assumes that', 'geht davon aus , dass')
     ((1, 4), (1, 7), 'assumes that he', 'geht davon aus , dass er')
     ((1, 9), (1, 10), 'assumes that he will stay in the house', 'geht davon aus , dass er im haus bleibt')
-    ((2, 3), (5, 6), 'that', ', dass')
+    ((2, 3), (4, 6), 'that', ', dass')
     ((2, 3), (5, 6), 'that', 'dass')
-    ((2, 4), (5, 7), 'that he', ', dass er')
+    ((2, 4), (4, 7), 'that he', ', dass er')
     ((2, 4), (5, 7), 'that he', 'dass er')
-    ((2, 9), (5, 10), 'that he will stay in the house', ', dass er im haus bleibt')
+    ((2, 9), (4, 10), 'that he will stay in the house', ', dass er im haus bleibt')
     ((2, 9), (5, 10), 'that he will stay in the house', 'dass er im haus bleibt')
     ((3, 4), (6, 7), 'he', 'er')
     ((3, 9), (6, 10), 'he will stay in the house', 'er im haus bleibt')


### PR DESCRIPTION
Using `nltk.translate.phrase_based.phrase_extraction()` I've noticed a bug.  The target indices are not correctly computed for certain target phrases.  That problem is even shown in the current example.
```
...
((2, 3), (5, 6), 'that', ', dass')
((2, 3), (5, 6), 'that', 'dass')
...
```
These two phrase pairs are valid but not their target indices.  Clearly, we cannot get phrase pairs for ((2,3), (5,6)) twice and more specifically, `((2, 3), (5, 6), 'that', ', dass')` has its target indices suggest a target phrase length of 1 token where as the target phrase itself is a 2 token phrase aka `, dass`.  The correct answer should be:
```
((2, 3), (4, 6), 'that', ', dass')
((2, 3), (5, 6), 'that', 'dass')
```
