### PR TITLE
Use time.perf_counter instead of time.clock for python 3.8 compatibility

### DIFF
--- a/nltk/compat.py
+++ b/nltk/compat.py
@@ -28,6 +28,7 @@ if PY3:
     StringIO = io.StringIO
     BytesIO = io.BytesIO
 
+    from time import perf_counter as time_clock
     from datetime import timezone
 
     UTC = timezone.utc
@@ -45,6 +46,7 @@ else:
         from StringIO import StringIO
     BytesIO = StringIO
 
+    from time import clock as time_clock
     from datetime import tzinfo, timedelta
 
     ZERO = timedelta(0)

--- a/nltk/parse/earleychart.py
+++ b/nltk/parse/earleychart.py
@@ -29,6 +29,7 @@ from __future__ import print_function, division
 
 from six.moves import range
 
+from nltk.compat import time_clock
 from nltk.parse.chart import (
     Chart,
     ChartParser,
@@ -535,10 +536,10 @@ def demo(
 
     # Do the parsing.
     earley = EarleyChartParser(grammar, trace=trace)
-    t = time.clock()
+    t = time_clock()
     chart = earley.chart_parse(tokens)
     parses = list(chart.parses(grammar.start()))
-    t = time.clock() - t
+    t = time_clock() - t
 
     # Print results.
     if numparses:

--- a/nltk/parse/featurechart.py
+++ b/nltk/parse/featurechart.py
@@ -14,6 +14,7 @@ feature structures as nodes.
 
 from six.moves import range
 
+from nltk.compat import time_clock
 from nltk.featstruct import FeatStruct, unify, TYPE, find_variables
 from nltk.sem import logic
 from nltk.tree import Tree
@@ -640,12 +641,12 @@ def demo(
     if print_sentence:
         print("Sentence:", sent)
     tokens = sent.split()
-    t = time.clock()
+    t = time_clock()
     cp = parser(grammar, trace=trace)
     chart = cp.chart_parse(tokens)
     trees = list(chart.parses(grammar.start()))
     if print_times:
-        print("Time: %s" % (time.clock() - t))
+        print("Time: %s" % (time_clock() - t))
     if print_trees:
         for tree in trees:
             print(tree)


### PR DESCRIPTION
`time.clock` was deprecated in Python 3.4 and removed in Python 3.8 . Use `time.perf_counter` on Python 3 and use `time.clock` under Python 2 for compatibility.

Fixes #2484 