### PR TITLE
Fix BLEU Smoothing Method 2 Citation

### DIFF
--- a/converter.py
+++ b/converter.py
@@ -1,0 +1,14 @@
+import sys
+import re
+
+lines = []
+
+with open(sys.argv[1]) as log:
+    for line in log.readlines():
+        path = re.search(r"^.*:\d", line)
+        if path:
+            lines.append([path.group(0)])
+        else:
+            lines[-1].append(line[:-1])
+
+print(lines)

--- a/nltk/app/chunkparser_app.py
+++ b/nltk/app/chunkparser_app.py
@@ -203,7 +203,7 @@ class RegexpChunkApp(object):
             "\t<regexp><RB>?<VBD></regexp>\n"
             '\t\tMatches <match>"ran/VBD"</match>\n'
             '\t\tMatches <match>"slowly/RB ate/VBD"</match>\n'
-            "\t<regexp><\#><CD> # This is a comment...</regexp>\n"
+            r"\t<regexp><\#><CD> # This is a comment...</regexp>\n"
             '\t\tMatches <match>"#/# 100/CD"</match>\n'
             "</hangindent>",
         ),
@@ -312,7 +312,7 @@ class RegexpChunkApp(object):
         grammar = re.sub(r"((\\.|[^#])*)(#.*)?", r"\1", grammar)
         # Normalize whitespace
         grammar = re.sub(" +", " ", grammar)
-        grammar = re.sub("\n\s+", "\n", grammar)
+        grammar = re.sub(r"\n\s+", "\n", grammar)
         grammar = grammar.strip()
         # [xx] Hack: automatically backslash $!
         grammar = re.sub(r"([^\\])\$", r"\1\\$", grammar)
@@ -1058,7 +1058,7 @@ class RegexpChunkApp(object):
                             "\t%s\t%s" % item
                             for item in sorted(
                                 list(self.tagset.items()),
-                                key=lambda t_w: re.match("\w+", t_w[0])
+                                key=lambda t_w: re.match(r"\w+", t_w[0])
                                 and (0, t_w[0])
                                 or (1, t_w[0]),
                             )
@@ -1419,7 +1419,7 @@ class RegexpChunkApp(object):
         with open(filename, "r") as infile:
             grammar = infile.read()
         grammar = re.sub(
-            "^\# Regexp Chunk Parsing Grammar[\s\S]*" "F-score:.*\n", "", grammar
+            r"^\# Regexp Chunk Parsing Grammar[\s\S]*" "F-score:.*\n", "", grammar
         ).lstrip()
         self.grammarbox.insert("1.0", grammar)
         self.update()

--- a/nltk/ccg/combinator.py
+++ b/nltk/ccg/combinator.py
@@ -217,7 +217,7 @@ BackwardBx = BackwardCombinator(
 
 
 class UndirectedSubstitution(UndirectedBinaryCombinator):
-    """
+    r"""
     Substitution (permutation) combinator.
     Implements rules of the form
     Y/Z (X\Y)/Z -> X/Z (<Sx)

--- a/nltk/chat/iesha.py
+++ b/nltk/chat/iesha.py
@@ -49,7 +49,7 @@ pairs = (
     (
         r"(.*) don\'t you (.*)",
         (
-            "u think I can%2??! really?? kekeke \<_\<",
+            r"u think I can%2??! really?? kekeke \<_\<",
             "what do u mean%2??!",
             "i could if i wanted, don't you think!! kekeke",
         ),

--- a/nltk/chunk/named_entity.py
+++ b/nltk/chunk/named_entity.py
@@ -171,11 +171,11 @@ class NEChunkParser(ChunkParserI):
 
 
 def shape(word):
-    if re.match("[0-9]+(\.[0-9]*)?|[0-9]*\.[0-9]+$", word, re.UNICODE):
+    if re.match(r"[0-9]+(\.[0-9]*)?|[0-9]*\.[0-9]+$", word, re.UNICODE):
         return "number"
-    elif re.match("\W+$", word, re.UNICODE):
+    elif re.match(r"\W+$", word, re.UNICODE):
         return "punct"
-    elif re.match("\w+$", word, re.UNICODE):
+    elif re.match(r"\w+$", word, re.UNICODE):
         if word.istitle():
             return "upcase"
         elif word.islower():
@@ -247,8 +247,8 @@ def load_ace_file(textfile, fmt):
     def subfunc(m):
         return " " * (m.end() - m.start() - 6)
 
-    text = re.sub("[\s\S]*<TEXT>", subfunc, text)
-    text = re.sub("</TEXT>[\s\S]*", "", text)
+    text = re.sub(r"[\s\S]*<TEXT>", subfunc, text)
+    text = re.sub(r"</TEXT>[\s\S]*", "", text)
 
     # Simplify quotes
     text = re.sub("``", ' "', text)

--- a/nltk/chunk/regexp.py
+++ b/nltk/chunk/regexp.py
@@ -67,7 +67,7 @@ class ChunkString(object):
     _CHUNK = r"(\{%s+?\})+?" % CHUNK_TAG
     _CHINK = r"(%s+?)+?" % CHUNK_TAG
     _VALID = re.compile(r"^(\{?%s\}?)*?$" % CHUNK_TAG)
-    _BRACKETS = re.compile("[^\{\}]+")
+    _BRACKETS = re.compile(r"[^\{\}]+")
     _BALANCED_BRACKETS = re.compile(r"(\{\})*$")
 
     def __init__(self, chunk_struct, debug_level=1):
@@ -212,7 +212,7 @@ class ChunkString(object):
         # The substitution might have generated "empty chunks"
         # (substrings of the form "{}").  Remove them, so they don't
         # interfere with other transformations.
-        s = re.sub("\{\}", "", s)
+        s = re.sub(r"\{\}", "", s)
 
         # Make sure that the transformation was legal.
         if self._debug > 1:
@@ -423,7 +423,7 @@ class ChunkRule(RegexpChunkRule):
             "(?P<chunk>%s)%s"
             % (tag_pattern2re_pattern(tag_pattern), ChunkString.IN_CHINK_PATTERN)
         )
-        RegexpChunkRule.__init__(self, regexp, "{\g<chunk>}", descr)
+        RegexpChunkRule.__init__(self, regexp, r"{\g<chunk>}", descr)
 
     def __repr__(self):
         """
@@ -468,7 +468,7 @@ class ChinkRule(RegexpChunkRule):
             "(?P<chink>%s)%s"
             % (tag_pattern2re_pattern(tag_pattern), ChunkString.IN_CHUNK_PATTERN)
         )
-        RegexpChunkRule.__init__(self, regexp, "}\g<chink>{", descr)
+        RegexpChunkRule.__init__(self, regexp, r"}\g<chink>{", descr)
 
     def __repr__(self):
         """
@@ -507,8 +507,8 @@ class UnChunkRule(RegexpChunkRule):
             of this rule.
         """
         self._pattern = tag_pattern
-        regexp = re.compile("\{(?P<chunk>%s)\}" % tag_pattern2re_pattern(tag_pattern))
-        RegexpChunkRule.__init__(self, regexp, "\g<chunk>", descr)
+        regexp = re.compile(r"\{(?P<chunk>%s)\}" % tag_pattern2re_pattern(tag_pattern))
+        RegexpChunkRule.__init__(self, regexp, r"\g<chunk>", descr)
 
     def __repr__(self):
         """
@@ -572,7 +572,7 @@ class MergeRule(RegexpChunkRule):
                 tag_pattern2re_pattern(right_tag_pattern),
             )
         )
-        RegexpChunkRule.__init__(self, regexp, "\g<left>", descr)
+        RegexpChunkRule.__init__(self, regexp, r"\g<left>", descr)
 
     def __repr__(self):
         """
@@ -705,13 +705,13 @@ class ExpandLeftRule(RegexpChunkRule):
         self._left_tag_pattern = left_tag_pattern
         self._right_tag_pattern = right_tag_pattern
         regexp = re.compile(
-            "(?P<left>%s)\{(?P<right>%s)"
+            r"(?P<left>%s)\{(?P<right>%s)"
             % (
                 tag_pattern2re_pattern(left_tag_pattern),
                 tag_pattern2re_pattern(right_tag_pattern),
             )
         )
-        RegexpChunkRule.__init__(self, regexp, "{\g<left>\g<right>", descr)
+        RegexpChunkRule.__init__(self, regexp, r"{\g<left>\g<right>", descr)
 
     def __repr__(self):
         """
@@ -775,13 +775,13 @@ class ExpandRightRule(RegexpChunkRule):
         self._left_tag_pattern = left_tag_pattern
         self._right_tag_pattern = right_tag_pattern
         regexp = re.compile(
-            "(?P<left>%s)\}(?P<right>%s)"
+            r"(?P<left>%s)\}(?P<right>%s)"
             % (
                 tag_pattern2re_pattern(left_tag_pattern),
                 tag_pattern2re_pattern(right_tag_pattern),
             )
         )
-        RegexpChunkRule.__init__(self, regexp, "\g<left>\g<right>}", descr)
+        RegexpChunkRule.__init__(self, regexp, r"\g<left>\g<right>}", descr)
 
     def __repr__(self):
         """
@@ -893,7 +893,7 @@ class ChunkRuleWithContext(RegexpChunkRule):
 # this should probably be made more strict than it is -- e.g., it
 # currently accepts 'foo'.
 CHUNK_TAG_PATTERN = re.compile(
-    r"^((%s|<%s>)*)$" % ("([^\{\}<>]|\{\d+,?\}|\{\d*,\d+\})+", "[^\{\}<>]+")
+    r"^((%s|<%s>)*)$" % (r"([^\{\}<>]|\{\d+,?\}|\{\d*,\d+\})+", r"[^\{\}<>]+")
 )
 
 
@@ -1133,7 +1133,7 @@ class RegexpChunkParser(ChunkParserI):
 
 
 class RegexpParser(ChunkParserI):
-    """
+    r"""
     A grammar based chunk parser.  ``chunk.RegexpParser`` uses a set of
     regular expression patterns to specify the behavior of the parser.
     The chunking of the text is encoded using a ``ChunkString``, and

--- a/nltk/chunk/util.py
+++ b/nltk/chunk/util.py
@@ -368,7 +368,7 @@ def tagstr2tree(
 
 ### CONLL
 
-_LINE_RE = re.compile("(\S+)\s+(\S+)\s+([IOB])-?(\S+)?")
+_LINE_RE = re.compile(r"(\S+)\s+(\S+)\s+([IOB])-?(\S+)?")
 
 
 def conllstr2tree(s, chunk_types=("NP", "PP", "VP"), root_label="S"):
@@ -514,7 +514,7 @@ _IEER_DOC_RE = re.compile(
     re.DOTALL,
 )
 
-_IEER_TYPE_RE = re.compile('<b_\w+\s+[^>]*?type="(?P<type>\w+)"')
+_IEER_TYPE_RE = re.compile(r'<b_\w+\s+[^>]*?type="(?P<type>\w+)"')
 
 
 def _ieer_read_text(s, root_label):
@@ -523,7 +523,7 @@ def _ieer_read_text(s, root_label):
     # return the empty list in place of a Tree
     if s is None:
         return []
-    for piece_m in re.finditer("<[^>]+>|[^\s<]+", s):
+    for piece_m in re.finditer(r"<[^>]+>|[^\s<]+", s):
         piece = piece_m.group()
         try:
             if piece.startswith("<b_"):

--- a/nltk/classify/maxent.py
+++ b/nltk/classify/maxent.py
@@ -1289,7 +1289,7 @@ def calculate_deltas(
     nftranspose,
     encoding,
 ):
-    """
+    r"""
     Calculate the update values for the classifier weights for
     this iteration of IIS.  These update weights are the value of
     ``delta`` that solves the equation::

--- a/nltk/classify/rte_classify.py
+++ b/nltk/classify/rte_classify.py
@@ -58,7 +58,7 @@ class RTEFeatureExtractor(object):
         self.negwords = set(["no", "not", "never", "failed", "rejected", "denied"])
         # Try to tokenize so that abbreviations, monetary amounts, email
         # addresses, URLs are single tokens.
-        tokenizer = RegexpTokenizer("[\w.@:/]+|\w+|\$[\d.]+")
+        tokenizer = RegexpTokenizer(r"[\w.@:/]+|\w+|\$[\d.]+")
 
         # Get the set of word types for text and hypothesis
         self.text_tokens = tokenizer.tokenize(rtepair.text)

--- a/nltk/corpus/__init__.py
+++ b/nltk/corpus/__init__.py
@@ -113,19 +113,19 @@ conll2000 = LazyCorpusLoader(
 conll2002 = LazyCorpusLoader(
     "conll2002",
     ConllChunkCorpusReader,
-    ".*\.(test|train).*",
+    r".*\.(test|train).*",
     ("LOC", "PER", "ORG", "MISC"),
     encoding="utf-8",
 )
 conll2007 = LazyCorpusLoader(
     "conll2007",
     DependencyCorpusReader,
-    ".*\.(test|train).*",
+    r".*\.(test|train).*",
     encoding=[("eus", "ISO-8859-2"), ("esp", "utf8")],
 )
-crubadan = LazyCorpusLoader("crubadan", CrubadanCorpusReader, ".*\.txt")
+crubadan = LazyCorpusLoader("crubadan", CrubadanCorpusReader, r".*\.txt")
 dependency_treebank = LazyCorpusLoader(
-    "dependency_treebank", DependencyCorpusReader, ".*\.dp", encoding="ascii"
+    "dependency_treebank", DependencyCorpusReader, r".*\.dp", encoding="ascii"
 )
 floresta = LazyCorpusLoader(
     "floresta",
@@ -308,7 +308,7 @@ swadesh207 = LazyCorpusLoader(
 switchboard = LazyCorpusLoader("switchboard", SwitchboardCorpusReader, tagset="wsj")
 timit = LazyCorpusLoader("timit", TimitCorpusReader)
 timit_tagged = LazyCorpusLoader(
-    "timit", TimitTaggedCorpusReader, ".+\.tags", tagset="wsj", encoding="ascii"
+    "timit", TimitTaggedCorpusReader, r".+\.tags", tagset="wsj", encoding="ascii"
 )
 toolbox = LazyCorpusLoader(
     "toolbox", ToolboxCorpusReader, r"(?!.*(README|\.)).*\.(dic|txt)"
@@ -332,7 +332,7 @@ treebank_chunk = LazyCorpusLoader(
 treebank_raw = LazyCorpusLoader(
     "treebank/raw", PlaintextCorpusReader, r"wsj_.*", encoding="ISO-8859-2"
 )
-twitter_samples = LazyCorpusLoader("twitter_samples", TwitterCorpusReader, ".*\.json")
+twitter_samples = LazyCorpusLoader("twitter_samples", TwitterCorpusReader, r".*\.json")
 udhr = LazyCorpusLoader("udhr", UdhrCorpusReader)
 udhr2 = LazyCorpusLoader("udhr2", PlaintextCorpusReader, r".*\.txt", encoding="utf8")
 universal_treebanks = LazyCorpusLoader(
@@ -361,7 +361,7 @@ wordnet = LazyCorpusLoader(
     WordNetCorpusReader,
     LazyCorpusLoader("omw", CorpusReader, r".*/wn-data-.*\.tab", encoding="utf8"),
 )
-wordnet_ic = LazyCorpusLoader("wordnet_ic", WordNetICCorpusReader, ".*\.dat")
+wordnet_ic = LazyCorpusLoader("wordnet_ic", WordNetICCorpusReader, r".*\.dat")
 words = LazyCorpusLoader(
     "words", WordListCorpusReader, r"(?!README|\.).*", encoding="ascii"
 )
@@ -371,7 +371,7 @@ propbank = LazyCorpusLoader(
     "propbank",
     PropbankCorpusReader,
     "prop.txt",
-    "frames/.*\.xml",
+    r"frames/.*\.xml",
     "verbs.txt",
     lambda filename: re.sub(r"^wsj/\d\d/", "", filename),
     treebank,
@@ -380,7 +380,7 @@ nombank = LazyCorpusLoader(
     "nombank.1.0",
     NombankCorpusReader,
     "nombank.1.0",
-    "frames/.*\.xml",
+    r"frames/.*\.xml",
     "nombank.1.0.words",
     lambda filename: re.sub(r"^wsj/\d\d/", "", filename),
     treebank,
@@ -389,7 +389,7 @@ propbank_ptb = LazyCorpusLoader(
     "propbank",
     PropbankCorpusReader,
     "prop.txt",
-    "frames/.*\.xml",
+    r"frames/.*\.xml",
     "verbs.txt",
     lambda filename: filename.upper(),
     ptb,
@@ -398,7 +398,7 @@ nombank_ptb = LazyCorpusLoader(
     "nombank.1.0",
     NombankCorpusReader,
     "nombank.1.0",
-    "frames/.*\.xml",
+    r"frames/.*\.xml",
     "nombank.1.0.words",
     lambda filename: filename.upper(),
     ptb,

--- a/nltk/corpus/reader/api.py
+++ b/nltk/corpus/reader/api.py
@@ -74,7 +74,7 @@ class CorpusReader(object):
         """
         # Convert the root to a path pointer, if necessary.
         if isinstance(root, string_types) and not isinstance(root, PathPointer):
-            m = re.match("(.*\.zip)/?(.*)$|", root)
+            m = re.match(r"(.*\.zip)/?(.*)$|", root)
             zipfile, zipentry = m.groups()
             if zipfile:
                 root = ZipFilePathPointer(zipfile, zipentry)

--- a/nltk/corpus/reader/bnc.py
+++ b/nltk/corpus/reader/bnc.py
@@ -12,7 +12,7 @@ from nltk.corpus.reader.xmldocs import XMLCorpusReader, XMLCorpusView, ElementTr
 
 
 class BNCCorpusReader(XMLCorpusReader):
-    """Corpus reader for the XML version of the British National Corpus.
+    r"""Corpus reader for the XML version of the British National Corpus.
 
     For access to the complete XML data structure, use the ``xml()``
     method.  For access to simple word lists and tagged word lists, use

--- a/nltk/corpus/reader/bracket_parse.py
+++ b/nltk/corpus/reader/bracket_parse.py
@@ -212,7 +212,7 @@ class AlpinoCorpusReader(BracketParseCorpusReader):
         BracketParseCorpusReader.__init__(
             self,
             root,
-            "alpino\.xml",
+            r"alpino\.xml",
             detect_blocks="blankline",
             encoding=encoding,
             tagset=tagset,

--- a/nltk/corpus/reader/childes.py
+++ b/nltk/corpus/reader/childes.py
@@ -278,7 +278,7 @@ class CHILDESCorpusReader(XMLCorpusReader):
 
     def convert_age(self, age_year):
         "Caclculate age in months from a string in CHILDES format"
-        m = re.match("P(\d+)Y(\d+)M?(\d?\d?)D?", age_year)
+        m = re.match(r"P(\d+)Y(\d+)M?(\d?\d?)D?", age_year)
         age_month = int(m.group(1)) * 12 + int(m.group(2))
         try:
             if int(m.group(3)) > 15:

--- a/nltk/corpus/reader/framenet.py
+++ b/nltk/corpus/reader/framenet.py
@@ -2745,7 +2745,7 @@ warnings(True) to display corpus consistency warnings when loading data
         """
 
         try:
-            """
+            r"""
             # Look for boundary issues in markup. (Sometimes FEs are pluralized in definitions.)
             m = re.search(r'\w[<][^/]|[<][/][^>]+[>](s\w|[a-rt-z0-9])', data)
             if m:

--- a/nltk/corpus/reader/plaintext.py
+++ b/nltk/corpus/reader/plaintext.py
@@ -44,7 +44,7 @@ class PlaintextCorpusReader(CorpusReader):
         para_block_reader=read_blankline_block,
         encoding="utf8",
     ):
-        """
+        r"""
         Construct a new plaintext corpus reader for a set of documents
         located at the given root directory.  Example usage:
 

--- a/nltk/corpus/reader/switchboard.py
+++ b/nltk/corpus/reader/switchboard.py
@@ -110,7 +110,7 @@ class SwitchboardCorpusReader(CorpusReader):
     def _tagged_words_block_reader(self, stream, tagset=None):
         return sum(self._tagged_discourses_block_reader(stream, tagset)[0], [])
 
-    _UTTERANCE_RE = re.compile("(\w+)\.(\d+)\:\s*(.*)")
+    _UTTERANCE_RE = re.compile(r"(\w+)\.(\d+)\:\s*(.*)")
     _SEP = "/"
 
     def _parse_utterance(self, utterance, include_tag, tagset=None):

--- a/nltk/corpus/reader/timit.py
+++ b/nltk/corpus/reader/timit.py
@@ -162,7 +162,7 @@ class TimitCorpusReader(CorpusReader):
         """
         # Ensure that wave files don't get treated as unicode data:
         if isinstance(encoding, string_types):
-            encoding = [(".*\.wav", None), (".*", encoding)]
+            encoding = [(r".*\.wav", None), (".*", encoding)]
 
         CorpusReader.__init__(
             self, root, find_corpus_fileids(root, self._FILE_RE), encoding=encoding

--- a/nltk/corpus/reader/twitter.py
+++ b/nltk/corpus/reader/twitter.py
@@ -22,7 +22,7 @@ from nltk.corpus.reader.api import CorpusReader
 
 
 class TwitterCorpusReader(CorpusReader):
-    """
+    r"""
     Reader for corpora that consist of Tweets represented as a list of line-delimited JSON.
 
     Individual Tweets can be tokenized using the default tokenizer, or by a

--- a/nltk/corpus/reader/udhr.py
+++ b/nltk/corpus/reader/udhr.py
@@ -27,7 +27,7 @@ class UdhrCorpusReader(PlaintextCorpusReader):
         ("Japanese_Nihongo-EUC", "EUC-JP"),
         ("Japanese_Nihongo-JIS", "iso2022_jp"),
         ("Chinese_Mandarin-HZ", "hz"),
-        ("Abkhaz\-Cyrillic\+Abkh", "cp1251"),
+        (r"Abkhaz\-Cyrillic\+Abkh", "cp1251"),
     ]
 
     SKIP = set(

--- a/nltk/corpus/reader/util.py
+++ b/nltk/corpus/reader/util.py
@@ -632,7 +632,7 @@ def read_alignedsent_block(stream):
         # Other line:
         else:
             s += line
-            if re.match("^\d+-\d+", line) is not None:
+            if re.match(r"^\d+-\d+", line) is not None:
                 return [s]
 
 
@@ -856,7 +856,7 @@ def tagged_treebank_para_block_reader(stream):
     while True:
         line = stream.readline()
         # End of paragraph:
-        if re.match("======+\s*$", line):
+        if re.match(r"======+\s*$", line):
             if para.strip():
                 return [para]
         # End of file:

--- a/nltk/corpus/reader/xmldocs.py
+++ b/nltk/corpus/reader/xmldocs.py
@@ -229,7 +229,7 @@ class XMLCorpusView(StreamBackedCorpusView):
 
     #: A regular expression used to extract the tag name from a start tag,
     #: end tag, or empty-elt tag string.
-    _XML_TAG_NAME = re.compile("<\s*/?\s*([^\s>]+)")
+    _XML_TAG_NAME = re.compile(r"<\s*/?\s*([^\s>]+)")
 
     #: A regular expression used to find all start-tags, end-tags, and
     #: emtpy-elt tags in an XML file.  This regexp is more lenient than

--- a/nltk/draw/cfg.py
+++ b/nltk/draw/cfg.py
@@ -163,12 +163,12 @@ class CFGEditor(object):
     # we can process the text faster.
     ARROW = SymbolWidget.SYMBOLS["rightarrow"]
     _LHS_RE = re.compile(r"(^\s*\w+\s*)(->|(" + ARROW + "))")
-    _ARROW_RE = re.compile("\s*(->|(" + ARROW + "))\s*")
+    _ARROW_RE = re.compile(r"\s*(->|(" + ARROW + r"))\s*")
     _PRODUCTION_RE = re.compile(
         r"(^\s*\w+\s*)"
         + "(->|("  # LHS
         + ARROW
-        + "))\s*"
+        + r"))\s*"
         + r"((\w+|'[\w ]*'|\"[\w ]*\"|\|)\s*)*$"  # arrow
     )  # RHS
     _TOKEN_RE = re.compile("\\w+|->|'[\\w ]+'|\"[\\w ]+\"|(" + ARROW + ")")

--- a/nltk/featstruct.py
+++ b/nltk/featstruct.py
@@ -1292,7 +1292,7 @@ def _rename_variables(fstruct, vars, used_vars, new_vars, fs_class, visited):
 
 
 def _rename_variable(var, used_vars):
-    name, n = re.sub("\d+$", "", var.name), 2
+    name, n = re.sub(r"\d+$", "", var.name), 2
     if not name:
         name = "?"
     while Variable("%s%s" % (name, n)) in used_vars:
@@ -2088,7 +2088,7 @@ class SlashFeature(Feature):
 
 
 class RangeFeature(Feature):
-    RANGE_RE = re.compile("(-?\d+):(-?\d+)")
+    RANGE_RE = re.compile(r"(-?\d+):(-?\d+)")
 
     def read_value(self, s, position, reentrances, parser):
         m = self.RANGE_RE.match(s, position)

--- a/nltk/grammar.py
+++ b/nltk/grammar.py
@@ -1275,7 +1275,7 @@ class PCFG(CFG):
 
 
 def induce_pcfg(start, productions):
-    """
+    r"""
     Induce a PCFG grammar from a list of productions.
 
     The probability of a production A -> B C in a PCFG is:
@@ -1460,7 +1460,7 @@ def read_grammar(input, nonterm_parser, probabilistic=False, encoding=None):
     return (start, productions)
 
 
-_STANDARD_NONTERM_RE = re.compile("( [\w/][\w/^<>-]* ) \s*", re.VERBOSE)
+_STANDARD_NONTERM_RE = re.compile(r"( [\w/][\w/^<>-]* ) \s*", re.VERBOSE)
 
 
 def standard_nonterm_parser(string, pos):

--- a/nltk/inference/discourse.py
+++ b/nltk/inference/discourse.py
@@ -6,7 +6,7 @@
 # URL: <http://nltk.org/>
 # For license information, see LICENSE.TXT
 
-"""
+r"""
 Module for incrementally developing simple discourses, and checking for semantic ambiguity,
 consistency and informativeness.
 

--- a/nltk/parse/chart.py
+++ b/nltk/parse/chart.py
@@ -1021,7 +1021,7 @@ class AbstractChartRule(ChartRuleI):
 
 
 class FundamentalRule(AbstractChartRule):
-    """
+    r"""
     A rule that joins two adjacent edges to form a single combined
     edge.  In particular, this rule specifies that any pair of edges
 
@@ -1054,7 +1054,7 @@ class FundamentalRule(AbstractChartRule):
 
 
 class SingleEdgeFundamentalRule(FundamentalRule):
-    """
+    r"""
     A rule that joins a given edge with adjacent edges in the chart,
     to form combined edges.  In particular, this rule specifies that
     either of the edges:
@@ -1120,7 +1120,7 @@ class LeafInitRule(AbstractChartRule):
 
 
 class TopDownInitRule(AbstractChartRule):
-    """
+    r"""
     A rule licensing edges corresponding to the grammar productions for
     the grammar's start symbol.  In particular, this rule specifies that
     ``[S -> \* alpha][0:i]`` is licensed for each grammar production
@@ -1137,7 +1137,7 @@ class TopDownInitRule(AbstractChartRule):
 
 
 class TopDownPredictRule(AbstractChartRule):
-    """
+    r"""
     A rule licensing edges corresponding to the grammar productions
     for the nonterminal following an incomplete edge's dot.  In
     particular, this rule specifies that
@@ -1210,7 +1210,7 @@ class CachedTopDownPredictRule(TopDownPredictRule):
 
 
 class BottomUpPredictRule(AbstractChartRule):
-    """
+    r"""
     A rule licensing any edge corresponding to a production whose
     right-hand side begins with a complete edge's left-hand side.  In
     particular, this rule specifies that ``[A -> alpha \*]`` licenses
@@ -1229,7 +1229,7 @@ class BottomUpPredictRule(AbstractChartRule):
 
 
 class BottomUpPredictCombineRule(BottomUpPredictRule):
-    """
+    r"""
     A rule licensing any edge corresponding to a production whose
     right-hand side begins with a complete edge's left-hand side.  In
     particular, this rule specifies that ``[A -> alpha \*]``

--- a/nltk/parse/featurechart.py
+++ b/nltk/parse/featurechart.py
@@ -248,7 +248,7 @@ class FeatureChart(Chart):
 
 
 class FeatureFundamentalRule(FundamentalRule):
-    """
+    r"""
     A specialized version of the fundamental rule that operates on
     nonterminals whose symbols are ``FeatStructNonterminal``s.  Rather
     tha simply comparing the nonterminals for equality, they are
@@ -350,7 +350,7 @@ class FeatureTopDownInitRule(TopDownInitRule):
 
 
 class FeatureTopDownPredictRule(CachedTopDownPredictRule):
-    """
+    r"""
     A specialized version of the (cached) top down predict rule that operates
     on nonterminals whose symbols are ``FeatStructNonterminal``s.  Rather
     than simply comparing the nonterminals for equality, they are

--- a/nltk/parse/malt.py
+++ b/nltk/parse/malt.py
@@ -201,7 +201,7 @@ class MaltParser(ParserI):
                 ret = self._execute(cmd, verbose)  # Run command.
                 os.chdir(_current_path)  # Change back to current path.
 
-                if ret is not 0:
+                if ret != 0:
                     raise Exception(
                         "MaltParser parsing (%s) failed with exit "
                         "code %d" % (" ".join(cmd), ret)

--- a/nltk/sem/boxer.py
+++ b/nltk/sem/boxer.py
@@ -773,7 +773,7 @@ class BoxerOutputDrsParser(DrtParser):
 
     def parse_variable(self):
         var = self.token()
-        assert re.match("^[exps]\d+$", var), var
+        assert re.match(r"^[exps]\d+$", var), var
         return var
 
     def parse_index(self):

--- a/nltk/sem/chat80.py
+++ b/nltk/sem/chat80.py
@@ -6,7 +6,7 @@
 # URL: <http://nltk.sourceforge.net>
 # For license information, see LICENSE.TXT
 
-"""
+r"""
 Overview
 ========
 
@@ -702,7 +702,7 @@ def make_lex(symbols):
 
 """
     lex.append(header)
-    template = "PropN[num=sg, sem=<\P.(P %s)>] -> '%s'\n"
+    template = r"PropN[num=sg, sem=<\P.(P %s)>] -> '%s'\n"
 
     for s in symbols:
         parts = s.split("_")

--- a/nltk/sem/cooper_storage.py
+++ b/nltk/sem/cooper_storage.py
@@ -45,7 +45,7 @@ class CooperStore(object):
             yield ()
 
     def s_retrieve(self, trace=False):
-        """
+        r"""
         Carry out S-Retrieval of binding operators in store. If hack=True,
         serialize the bindop and core as strings and reparse. Ugh.
 

--- a/nltk/sem/drt.py
+++ b/nltk/sem/drt.py
@@ -713,8 +713,8 @@ class DrtLambdaExpression(DrtExpression, LambdaExpression):
         blank = " " * len(var_string)
         return (
             ["    " + blank + line for line in term_lines[:1]]
-            + [" \  " + blank + line for line in term_lines[1:2]]
-            + [" /\ " + var_string + line for line in term_lines[2:3]]
+            + [r" \  " + blank + line for line in term_lines[1:2]]
+            + [r" /\ " + var_string + line for line in term_lines[2:3]]
             + ["    " + blank + line for line in term_lines[3:]]
         )
 

--- a/nltk/sem/evaluate.py
+++ b/nltk/sem/evaluate.py
@@ -254,7 +254,7 @@ def read_valuation(s, encoding=None):
 
 
 class Assignment(dict):
-    """
+    r"""
     A dictionary which represents an assignment of values to variables.
 
     An assigment can only assign values from its domain.

--- a/nltk/sem/relextract.py
+++ b/nltk/sem/relextract.py
@@ -125,7 +125,7 @@ def list2sym(lst):
     """
     sym = _join(lst, "_", untag=True)
     sym = sym.lower()
-    ENT = re.compile("&(\w+?);")
+    ENT = re.compile(r"&(\w+?);")
     sym = ENT.sub(descape_entity, sym)
     sym = sym.replace(".", "")
     return sym
@@ -379,7 +379,7 @@ def in_demo(trace=0, sql=True):
 def roles_demo(trace=0):
     from nltk.corpus import ieer
 
-    roles = """
+    roles = r"""
     (.*(                   # assorted roles
     analyst|
     chair(wo)?man|

--- a/nltk/stem/lancaster.py
+++ b/nltk/stem/lancaster.py
@@ -189,7 +189,7 @@ class LancasterStemmer(StemmerI):
         """
         # If there is no argument for the function, use class' own rule tuple.
         rule_tuple = rule_tuple if rule_tuple else self._rule_tuple
-        valid_rule = re.compile("^[a-z]+\*?\d[a-z]*[>\.]?$")
+        valid_rule = re.compile(r"^[a-z]+\*?\d[a-z]*[>\.]?$")
         # Empty any old rules from the rule set before adding new ones
         self.rule_dictionary = {}
 
@@ -222,7 +222,7 @@ class LancasterStemmer(StemmerI):
         """Perform the actual word stemming
         """
 
-        valid_rule = re.compile("^([a-z]+)(\*?)(\d)([a-z]*)([>\.]?)$")
+        valid_rule = re.compile(r"^([a-z]+)(\*?)(\d)([a-z]*)([>\.]?)$")
 
         proceed = True
 

--- a/nltk/stem/porter.py
+++ b/nltk/stem/porter.py
@@ -142,7 +142,7 @@ class PorterStemmer(StemmerI):
         return True
 
     def _measure(self, stem):
-        """Returns the 'measure' of stem, per definition in the paper
+        r"""Returns the 'measure' of stem, per definition in the paper
 
         From the paper:
 

--- a/nltk/tag/sequential.py
+++ b/nltk/tag/sequential.py
@@ -719,15 +719,15 @@ class ClassifierBasedPOSTagger(ClassifierBasedTagger):
             prevtag = history[index - 1]
             prevprevtag = history[index - 2]
 
-        if re.match("[0-9]+(\.[0-9]*)?|[0-9]*\.[0-9]+$", word):
+        if re.match(r"[0-9]+(\.[0-9]*)?|[0-9]*\.[0-9]+$", word):
             shape = "number"
-        elif re.match("\W+$", word):
+        elif re.match(r"\W+$", word):
             shape = "punct"
         elif re.match("[A-Z][a-z]+$", word):
             shape = "upcase"
         elif re.match("[a-z]+$", word):
             shape = "downcase"
-        elif re.match("\w+$", word):
+        elif re.match(r"\w+$", word):
             shape = "mixedcase"
         else:
             shape = "other"

--- a/nltk/text.py
+++ b/nltk/text.py
@@ -403,7 +403,7 @@ class Text(object):
     def collocation_list(self, num=20, window_size=2):
         """
         Return collocations derived from the text, ignoring stopwords.
-        
+
             >>> from nltk.book import text4
             >>> text4.collocation_list()[:2]
             [('United', 'States'), ('fellow', 'citizens')]
@@ -436,7 +436,7 @@ class Text(object):
     def collocations(self, num=20, window_size=2):
         """
         Print collocations derived from the text, ignoring stopwords.
-        
+
             >>> from nltk.book import text4
             >>> text4.collocations() # doctest: +ELLIPSIS
             United States; fellow citizens; four years; ...
@@ -647,7 +647,7 @@ class Text(object):
     # Helper Methods
     # ////////////////////////////////////////////////////////////
 
-    _CONTEXT_RE = re.compile("\w+|[\.\!\?]")
+    _CONTEXT_RE = re.compile(r"\w+|[\.\!\?]")
 
     def _context(self, tokens, i):
         """

--- a/nltk/tokenize/nist.py
+++ b/nltk/tokenize/nist.py
@@ -78,13 +78,13 @@ class NISTTokenizer(TokenizerI):
     #  Strip end-of-line hyphenation and join lines
     STRIP_EOL_HYPHEN = re.compile("\u2028"), " "
     # Tokenize punctuation.
-    PUNCT = re.compile("([\{-\~\[-\` -\&\(-\+\:-\@\/])"), " \\1 "
+    PUNCT = re.compile(r"([\{-\~\[-\` -\&\(-\+\:-\@\/])"), r" \1 "
     # Tokenize period and comma unless preceded by a digit.
-    PERIOD_COMMA_PRECEED = re.compile("([^0-9])([\.,])"), "\\1 \\2 "
+    PERIOD_COMMA_PRECEED = re.compile(r"([^0-9])([\.,])"), r"\1 \2 "
     # Tokenize period and comma unless followed by a digit.
-    PERIOD_COMMA_FOLLOW = re.compile("([\.,])([^0-9])"), " \\1 \\2"
+    PERIOD_COMMA_FOLLOW = re.compile(r"([\.,])([^0-9])"), r" \1 \2"
     # Tokenize dash when preceded by a digit
-    DASH_PRECEED_DIGIT = re.compile("([0-9])(-)"), "\\1 \\2 "
+    DASH_PRECEED_DIGIT = re.compile("([0-9])(-)"), r"\1 \2 "
 
     LANG_DEPENDENT_REGEXES = [
         PUNCT,

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -1459,7 +1459,7 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
             # token doesn't match, see if adding whitespace helps.
             # If so, then use the version with whitespace.
             if text[pos : pos + len(tok)] != tok:
-                pat = "\s*".join(re.escape(c) for c in tok)
+                pat = r"\s*".join(re.escape(c) for c in tok)
                 m = re.compile(pat).match(text, pos)
                 if m:
                     tok = m.group()

--- a/nltk/tokenize/regexp.py
+++ b/nltk/tokenize/regexp.py
@@ -73,7 +73,7 @@ from nltk.tokenize.util import regexp_span_tokenize
 
 
 class RegexpTokenizer(TokenizerI):
-    """
+    r"""
     A tokenizer that splits a string using a regular expression, which
     matches either the tokens or the separators between tokens.
 
@@ -181,12 +181,12 @@ class BlanklineTokenizer(RegexpTokenizer):
 
 
 class WordPunctTokenizer(RegexpTokenizer):
-    """
+    r"""
     Tokenize a text into a sequence of alphabetic and
     non-alphabetic characters, using the regexp ``\w+|[^\w\s]+``.
 
         >>> from nltk.tokenize import WordPunctTokenizer
-        >>> s = "Good muffins cost $3.88\\nin New York.  Please buy me\\ntwo of them.\\n\\nThanks."
+        >>> s = "Good muffins cost $3.88\nin New York.  Please buy me\ntwo of them.\n\nThanks."
         >>> WordPunctTokenizer().tokenize(s)
         ['Good', 'muffins', 'cost', '$', '3', '.', '88', 'in', 'New', 'York',
         '.', 'Please', 'buy', 'me', 'two', 'of', 'them', '.', 'Thanks', '.']

--- a/nltk/tokenize/repp.py
+++ b/nltk/tokenize/repp.py
@@ -130,7 +130,7 @@ class ReppTokenizer(TokenizerI):
         :return: an iterable of the tokenized sentences as tuples of strings
         :rtype: iter(tuple)
         """
-        line_regex = re.compile("^\((\d+), (\d+), (.+)\)$", re.MULTILINE)
+        line_regex = re.compile(r"^\((\d+), (\d+), (.+)\)$", re.MULTILINE)
         for section in repp_output.split("\n\n"):
             words_with_positions = [
                 (token, int(start), int(end))

--- a/nltk/tokenize/texttiling.py
+++ b/nltk/tokenize/texttiling.py
@@ -93,7 +93,7 @@ class TextTilingTokenizer(TokenizerI):
 
         # Remove punctuation
         nopunct_text = "".join(
-            c for c in lowercase_text if re.match("[a-z\-' \n\t]", c)
+            c for c in lowercase_text if re.match(r"[a-z\-' \n\t]", c)
         )
         nopunct_par_breaks = self._mark_paragraph_breaks(nopunct_text)
 
@@ -226,7 +226,7 @@ class TextTilingTokenizer(TokenizerI):
         "Divides the text into pseudosentences of fixed size"
         w = self.w
         wrdindex_list = []
-        matches = re.finditer("\w+", text)
+        matches = re.finditer(r"\w+", text)
         for match in matches:
             wrdindex_list.append((match.group(), match.start()))
         return [

--- a/nltk/tokenize/toktok.py
+++ b/nltk/tokenize/toktok.py
@@ -50,16 +50,16 @@ class ToktokTokenizer(TokenizerI):
     NON_BREAKING = re.compile(u"\u00A0"), " "
 
     # Pad some funky punctuation.
-    FUNKY_PUNCT_1 = re.compile(u'([،;؛¿!"\])}»›”؟¡%٪°±©®।॥…])'), r" \1 "
+    FUNKY_PUNCT_1 = re.compile(r'([،;؛¿!"\])}»›”؟¡%٪°±©®।॥…])'), r" \1 "
     # Pad more funky punctuation.
-    FUNKY_PUNCT_2 = re.compile(u"([({\[“‘„‚«‹「『])"), r" \1 "
+    FUNKY_PUNCT_2 = re.compile(r"([({\[“‘„‚«‹「『])"), r" \1 "
     # Pad En dash and em dash
     EN_EM_DASHES = re.compile(u"([–—])"), r" \1 "
 
     # Replace problematic character with numeric character reference.
     AMPERCENT = re.compile("& "), "&amp; "
     TAB = re.compile("\t"), " &#9; "
-    PIPE = re.compile("\|"), " &#124; "
+    PIPE = re.compile(r"\|"), " &#124; "
 
     # Pad numbers with commas to keep them from further tokenization.
     COMMA_IN_NUM = re.compile(r"(?<!,)([,،])(?![,\d])"), r" \1 "

--- a/nltk/tokenize/treebank.py
+++ b/nltk/tokenize/treebank.py
@@ -191,7 +191,7 @@ class TreebankWordTokenizer(TokenizerI):
 
 
 class TreebankWordDetokenizer(TokenizerI):
-    """
+    r"""
     The Treebank detokenizer uses the reverse regex operations corresponding to
     the Treebank tokenizer's regexes.
 
@@ -252,11 +252,11 @@ class TreebankWordDetokenizer(TokenizerI):
 
     _contractions = MacIntyreContractions()
     CONTRACTIONS2 = [
-        re.compile(pattern.replace("(?#X)", "\s"))
+        re.compile(pattern.replace("(?#X)", r"\s"))
         for pattern in _contractions.CONTRACTIONS2
     ]
     CONTRACTIONS3 = [
-        re.compile(pattern.replace("(?#X)", "\s"))
+        re.compile(pattern.replace("(?#X)", r"\s"))
         for pattern in _contractions.CONTRACTIONS3
     ]
 

--- a/nltk/toolbox.py
+++ b/nltk/toolbox.py
@@ -54,7 +54,7 @@ class StandardFormat(object):
         self._file = StringIO(s)
 
     def raw_fields(self):
-        """
+        u"""
         Return an iterator that returns the next field in a (marker, value)
         tuple. Linebreaks and trailing white space are preserved except
         for the final newline in each field.
@@ -62,7 +62,7 @@ class StandardFormat(object):
         :rtype: iter(tuple(str, str))
         """
         join_string = "\n"
-        line_regexp = r"^%s(?:\\(\S+)\s*)?(.*)$"
+        line_regexp = r"^%s(?:\(\S+)\s*)?(.*)$"
         # discard a BOM in the first line
         first_line_pat = re.compile(line_regexp % "(?:\xef\xbb\xbf)?")
         line_pat = re.compile(line_regexp % "")
@@ -156,7 +156,7 @@ class ToolboxData(StandardFormat):
             return self._record_parse(**kwargs)
 
     def _record_parse(self, key=None, **kwargs):
-        """
+        r"""
         Returns an element tree structure corresponding to a toolbox data file with
         all markers at the same level.
 

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -542,9 +542,9 @@ class SmoothingFunction:
     def method2(self, p_n, *args, **kwargs):
         """
         Smoothing method 2: Add 1 to both numerator and denominator from
-        Chin-Yew Lin and Franz Josef Och (2004) Automatic evaluation of
-        machine translation quality using longest common subsequence and
-        skip-bigram statistics. In ACL04.
+        Chin-Yew Lin and Franz Josef Och (2004) ORANGE: a Method for
+        Evaluating Automatic Evaluation Metrics for Machine Translation.
+        In COLING 2004.
         """
         return [
             Fraction(p_i.numerator + 1, p_i.denominator + 1, _normalize=False)

--- a/nltk/tree.py
+++ b/nltk/tree.py
@@ -35,7 +35,7 @@ from nltk.internals import raise_unorderable_types
 
 
 class Tree(list):
-    """
+    r"""
     A Tree represents a hierarchical grouping of leaves and subtrees.
     For example, each constituent in a syntax tree is represented by a single Tree.
 
@@ -649,17 +649,17 @@ class Tree(list):
         """
         if not isinstance(brackets, string_types) or len(brackets) != 2:
             raise TypeError("brackets must be a length-2 string")
-        if re.search("\s", brackets):
+        if re.search(r"\s", brackets):
             raise TypeError("whitespace brackets not allowed")
         # Construct a regexp that will tokenize the string.
         open_b, close_b = brackets
         open_pattern, close_pattern = (re.escape(open_b), re.escape(close_b))
         if node_pattern is None:
-            node_pattern = "[^\s%s%s]+" % (open_pattern, close_pattern)
+            node_pattern = r"[^\s%s%s]+" % (open_pattern, close_pattern)
         if leaf_pattern is None:
-            leaf_pattern = "[^\s%s%s]+" % (open_pattern, close_pattern)
+            leaf_pattern = r"[^\s%s%s]+" % (open_pattern, close_pattern)
         token_re = re.compile(
-            "%s\s*(%s)?|%s|(%s)"
+            r"%s\s*(%s)?|%s|(%s)"
             % (open_pattern, node_pattern, close_pattern, leaf_pattern)
         )
         # Walk through each token, updating a stack of trees.
@@ -897,7 +897,7 @@ class Tree(list):
         :return: A latex qtree representation of this tree.
         :rtype: str
         """
-        reserved_chars = re.compile("([#\$%&~_\{\}])")
+        reserved_chars = re.compile(r"([#\$%&~_\{\}])")
 
         pformat = self.pformat(indent=6, nodesep="", parens=("[.", " ]"))
         return r"\Tree " + re.sub(reserved_chars, r"\\\1", pformat)

--- a/nltk/treetransforms.py
+++ b/nltk/treetransforms.py
@@ -5,7 +5,7 @@
 # URL: <http://nltk.org/>
 # For license information, see LICENSE.TXT
 
-"""
+r"""
 A collection of methods for tree (grammar) transformations used
 in parsing natural language.
 

--- a/tools/find_deprecated.py
+++ b/tools/find_deprecated.py
@@ -40,11 +40,11 @@ from nltk import defaultdict
 #: A little over-simplified, but it'll do.
 STRING_PAT = (
     r'\s*[ur]{0,2}(?:'
-    '"""[\s\S]*?"""|'
-    '"[^"\n]+?"|'
-    "'''[\s\S]*?'''|"
-    "'[^'\n]+?'"
-    ")\s*"
+    r'"""[\s\S]*?"""|'
+    r'"[^"\n]+?"|'
+    r"'''[\s\S]*?'''|"
+    r"'[^'\n]+?'"
+    r")\s*"
 )
 STRING_RE = re.compile(STRING_PAT)
 
@@ -61,10 +61,10 @@ DEPRECATED_DEF_PAT = (
 DEPRECATED_DEF_RE = re.compile(DEPRECATED_DEF_PAT, re.MULTILINE)
 
 CORPUS_READ_METHOD_RE = re.compile(
-    '({})\.read\('.format('|'.join(re.escape(n) for n in dir(nltk.corpus)))
+    r'({})\.read\('.format('|'.join(re.escape(n) for n in dir(nltk.corpus)))
 )
 
-CLASS_DEF_RE = re.compile('^\s*class\s+(\w+)\s*[:\(]')
+CLASS_DEF_RE = re.compile(r'^\s*class\s+(\w+)\s*[:\(]')
 
 ######################################################################
 # Globals

--- a/tools/nltk_term_index.py
+++ b/tools/nltk_term_index.py
@@ -49,11 +49,11 @@ def find_all_names(stoplist):
     return names
 
 
-SCAN_RE1 = "<programlisting>[\s\S]*?</programlisting>"
-SCAN_RE2 = "<literal>[\s\S]*?</literal>"
+SCAN_RE1 = r"<programlisting>[\s\S]*?</programlisting>"
+SCAN_RE2 = r"<literal>[\s\S]*?</literal>"
 SCAN_RE = re.compile("({})|({})".format(SCAN_RE1, SCAN_RE2))
 
-TOKEN_RE = re.compile('[\w\.]+')
+TOKEN_RE = re.compile(r'[\w\.]+')
 
 LINE_RE = re.compile('.*')
 


### PR DESCRIPTION
As pointed out by @Prodigysov  BLEU Smoothing Method 2 cites the wrong paper in it's docstring.
The method was introduced by Lin and Och in _ORANGE: a Method for Evaluating Automatic Evaluation Metrics for Machine Translation_ and not _Automatic evaluation of machine translation quality using longest common subsequence and skip-bigram statistics_.

This PR fixes #2489 