### PR TITLE
Remove Python 2 compatibility layer

### DIFF
--- a/nltk/__init__.py
+++ b/nltk/__init__.py
@@ -175,7 +175,7 @@ else:
 from nltk.downloader import download, download_shell
 
 try:
-    from six.moves import tkinter
+    import tkinter
 except ImportError:
     pass
 else:

--- a/nltk/app/__init__.py
+++ b/nltk/app/__init__.py
@@ -22,7 +22,7 @@ wordnet:      WordNet Browser
 
 # Import Tkinter-based modules if Tkinter is installed
 try:
-    from six.moves import tkinter
+    import tkinter
 except ImportError:
     import warnings
 

--- a/nltk/app/chartparser_app.py
+++ b/nltk/app/chartparser_app.py
@@ -40,7 +40,7 @@ edge you wish to apply a rule to.
 import pickle
 import os.path
 
-from six.moves.tkinter import (
+from tkinter import (
     Button,
     Canvas,
     Checkbutton,
@@ -52,9 +52,9 @@ from six.moves.tkinter import (
     Tk,
     Toplevel,
 )
-from six.moves.tkinter_font import Font
-from six.moves.tkinter_messagebox import showerror, showinfo
-from six.moves.tkinter_tkfiledialog import asksaveasfilename, askopenfilename
+from tkinter.font import Font
+from tkinter.messagebox import showerror, showinfo
+from tkinter.filedialog import asksaveasfilename, askopenfilename
 
 from nltk.parse.chart import (
     BottomUpPredictCombineRule,

--- a/nltk/app/chartparser_app.py
+++ b/nltk/app/chartparser_app.py
@@ -37,7 +37,6 @@ edge you wish to apply a rule to.
 # widget system.
 
 
-from __future__ import division
 import pickle
 import os.path
 

--- a/nltk/app/chunkparser_app.py
+++ b/nltk/app/chunkparser_app.py
@@ -20,7 +20,7 @@ import textwrap
 import re
 import random
 
-from six.moves.tkinter import (
+from tkinter import (
     Button,
     Canvas,
     Checkbutton,
@@ -32,8 +32,8 @@ from six.moves.tkinter import (
     Text,
     Tk,
 )
-from six.moves.tkinter_tkfiledialog import askopenfilename, asksaveasfilename
-from six.moves.tkinter_font import Font
+from tkinter.filedialog import askopenfilename, asksaveasfilename
+from tkinter.font import Font
 
 from nltk.tree import Tree
 from nltk.util import in_idle
@@ -1460,7 +1460,7 @@ class RegexpChunkApp(object):
         ABOUT = "NLTK RegExp Chunk Parser Application\n" + "Written by Edward Loper"
         TITLE = "About: Regular Expression Chunk Parser Application"
         try:
-            from six.moves.tkinter_messagebox import Message
+            from tkinter.messagebox import Message
 
             Message(message=ABOUT, title=TITLE).show()
         except:

--- a/nltk/app/chunkparser_app.py
+++ b/nltk/app/chunkparser_app.py
@@ -15,7 +15,6 @@ parser ``nltk.chunk.RegexpChunkParser``.
 # configuration parameters to select what's being chunked (eg VP vs NP)
 # and what part of the data is being used as the development set.
 
-from __future__ import division
 import time
 import textwrap
 import re

--- a/nltk/app/collocations_app.py
+++ b/nltk/app/collocations_app.py
@@ -7,8 +7,6 @@
 #
 
 
-from __future__ import division
-
 import threading
 
 from six.moves import queue as q

--- a/nltk/app/collocations_app.py
+++ b/nltk/app/collocations_app.py
@@ -9,9 +9,9 @@
 
 import threading
 
-from six.moves import queue as q
-from six.moves.tkinter_font import Font
-from six.moves.tkinter import (
+import queue as q
+from tkinter.font import Font
+from tkinter import (
     Button,
     END,
     Frame,

--- a/nltk/app/concordance_app.py
+++ b/nltk/app/concordance_app.py
@@ -8,9 +8,9 @@
 import re
 import threading
 
-from six.moves import queue as q
-from six.moves.tkinter_font import Font
-from six.moves.tkinter import (
+import queue as q
+from tkinter.font import Font
+from tkinter import (
     Tk,
     Button,
     END,
@@ -399,7 +399,7 @@ class ConcordanceSearchView(object):
         ABOUT = "NLTK Concordance Search Demo\n"
         TITLE = "About: NLTK Concordance Search Demo"
         try:
-            from six.moves.tkinter_messagebox import Message
+            from tkinter.messagebox import Message
 
             Message(message=ABOUT, title=TITLE, parent=self.main_frame).show()
         except:

--- a/nltk/app/nemo_app.py
+++ b/nltk/app/nemo_app.py
@@ -10,7 +10,7 @@ Created by Aristide Grange
 import re
 import itertools
 
-from six.moves.tkinter import (
+from tkinter import (
     Frame,
     Label,
     PhotoImage,

--- a/nltk/app/rdparser_app.py
+++ b/nltk/app/rdparser_app.py
@@ -64,8 +64,8 @@ Keyboard Shortcuts::
       [q]\t Quit
 """
 
-from six.moves.tkinter_font import Font
-from six.moves.tkinter import Listbox, IntVar, Button, Frame, Label, Menu, Scrollbar, Tk
+from tkinter.font import Font
+from tkinter import Listbox, IntVar, Button, Frame, Label, Menu, Scrollbar, Tk
 
 from nltk.tree import Tree
 from nltk.util import in_idle
@@ -705,7 +705,7 @@ class RecursiveDescentApp(object):
         )
         TITLE = "About: Recursive Descent Parser Application"
         try:
-            from six.moves.tkinter_messagebox import Message
+            from tkinter.messagebox import Message
 
             Message(message=ABOUT, title=TITLE).show()
         except:

--- a/nltk/app/rdparser_app.py
+++ b/nltk/app/rdparser_app.py
@@ -63,7 +63,6 @@ Keyboard Shortcuts::
       [Ctrl-p]\t Print
       [q]\t Quit
 """
-from __future__ import division
 
 from six.moves.tkinter_font import Font
 from six.moves.tkinter import Listbox, IntVar, Button, Frame, Label, Menu, Scrollbar, Tk

--- a/nltk/app/srparser_app.py
+++ b/nltk/app/srparser_app.py
@@ -62,8 +62,8 @@ Keyboard Shortcuts::
 
 """
 
-from six.moves.tkinter_font import Font
-from six.moves.tkinter import IntVar, Listbox, Button, Frame, Label, Menu, Scrollbar, Tk
+from tkinter.font import Font
+from tkinter import IntVar, Listbox, Button, Frame, Label, Menu, Scrollbar, Tk
 
 from nltk.tree import Tree
 from nltk.parse import SteppingShiftReduceParser
@@ -665,7 +665,7 @@ class ShiftReduceApp(object):
         ABOUT = "NLTK Shift-Reduce Parser Application\n" + "Written by Edward Loper"
         TITLE = "About: Shift-Reduce Parser Application"
         try:
-            from six.moves.tkinter_messagebox import Message
+            from tkinter.messagebox import Message
 
             Message(message=ABOUT, title=TITLE).show()
         except:

--- a/nltk/app/wordnet_app.py
+++ b/nltk/app/wordnet_app.py
@@ -44,7 +44,6 @@ Options::
 # modifying to be compliant with NLTK's coding standards.  Tests also
 # need to be develop to ensure this continues to work in the face of
 # changes to other NLTK packages.
-from __future__ import print_function
 
 # Allow this program to run inside the NLTK source tree.
 from sys import path

--- a/nltk/app/wordnet_app.py
+++ b/nltk/app/wordnet_app.py
@@ -62,7 +62,7 @@ import base64
 import pickle
 import copy
 
-from six.moves.urllib.parse import unquote_plus
+from urllib.parse import unquote_plus
 
 from nltk import compat
 from nltk.corpus import wordnet as wn

--- a/nltk/ccg/api.py
+++ b/nltk/ccg/api.py
@@ -8,15 +8,13 @@
 from functools import total_ordering
 
 from abc import ABCMeta, abstractmethod
-from six import add_metaclass
 
 from nltk.internals import raise_unorderable_types
 from nltk.compat import unicode_repr
 
 
-@add_metaclass(ABCMeta)
 @total_ordering
-class AbstractCCGCategory(object):
+class AbstractCCGCategory(metaclass=ABCMeta):
     """
     Interface for categories in combinatory grammars.
     """

--- a/nltk/ccg/chart.py
+++ b/nltk/ccg/chart.py
@@ -32,8 +32,6 @@ python chart.py
 
 import itertools
 
-from six import string_types
-
 from nltk.parse import ParserI
 from nltk.parse.chart import AbstractChartRule, EdgeI, Chart
 from nltk.tree import Tree

--- a/nltk/ccg/combinator.py
+++ b/nltk/ccg/combinator.py
@@ -9,13 +9,11 @@ CCG Combinators
 """
 
 from abc import ABCMeta, abstractmethod
-from six import add_metaclass
 
 from nltk.ccg.api import FunctionalCategory
 
 
-@add_metaclass(ABCMeta)
-class UndirectedBinaryCombinator(object):
+class UndirectedBinaryCombinator(metaclass=ABCMeta):
     """
     Abstract class for representing a binary combinator.
     Merely defines functions for checking if the function and argument
@@ -36,8 +34,7 @@ class UndirectedBinaryCombinator(object):
         pass
 
 
-@add_metaclass(ABCMeta)
-class DirectedBinaryCombinator(object):
+class DirectedBinaryCombinator(metaclass=ABCMeta):
     """
     Wrapper for the undirected binary combinator.
     It takes left and right categories, and decides which is to be

--- a/nltk/chat/util.py
+++ b/nltk/chat/util.py
@@ -11,8 +11,6 @@
 import re
 import random
 
-from six.moves import input
-
 
 reflections = {
     "i am": "you are",

--- a/nltk/chunk/regexp.py
+++ b/nltk/chunk/regexp.py
@@ -8,8 +8,6 @@
 
 import re
 
-from six import string_types
-
 from nltk.tree import Tree
 from nltk.chunk.api import ChunkParserI
 from nltk.compat import unicode_repr
@@ -298,7 +296,7 @@ class RegexpChunkRule(object):
         :param descr: A short description of the purpose and/or effect
             of this rule.
         """
-        if isinstance(regexp, string_types):
+        if isinstance(regexp, str):
             regexp = re.compile(regexp)
         self._repl = repl
         self._descr = descr
@@ -1196,7 +1194,7 @@ class RegexpParser(ChunkParserI):
         self._grammar = grammar
         self._loop = loop
 
-        if isinstance(grammar, string_types):
+        if isinstance(grammar, str):
             self._read_grammar(grammar, root_label, trace)
         else:
             # Make sur the grammar looks like it has the right type:

--- a/nltk/classify/maxent.py
+++ b/nltk/classify/maxent.py
@@ -60,8 +60,6 @@ import tempfile
 import os
 from collections import defaultdict
 
-from six import integer_types
-
 from nltk.data import gzip_open_unicode
 from nltk.util import OrderedDict
 from nltk.probability import DictionaryProbDist
@@ -597,7 +595,7 @@ class BinaryMaxentFeatureEncoding(MaxentFeatureEncodingI):
 
     def describe(self, f_id):
         # Inherit docs.
-        if not isinstance(f_id, integer_types):
+        if not isinstance(f_id, int):
             raise TypeError("describe() expected an int")
         try:
             self._inv_mapping
@@ -912,7 +910,7 @@ class TypedMaxentFeatureEncoding(MaxentFeatureEncodingI):
 
         # Convert input-features to joint-features:
         for fname, fval in featureset.items():
-            if isinstance(fval, (integer_types, float)):
+            if isinstance(fval, (int, float)):
                 # Known feature name & value:
                 if (fname, type(fval), label) in self._mapping:
                     encoding.append((self._mapping[fname, type(fval), label], fval))
@@ -940,7 +938,7 @@ class TypedMaxentFeatureEncoding(MaxentFeatureEncodingI):
 
     def describe(self, f_id):
         # Inherit docs.
-        if not isinstance(f_id, integer_types):
+        if not isinstance(f_id, int):
             raise TypeError("describe() expected an int")
         try:
             self._inv_mapping

--- a/nltk/classify/megam.py
+++ b/nltk/classify/megam.py
@@ -24,8 +24,6 @@ for details.
 """
 import subprocess
 
-from six import string_types
-
 from nltk.internals import find_binary
 
 try:
@@ -164,7 +162,7 @@ def call_megam(args):
     """
     Call the ``megam`` binary with the given arguments.
     """
-    if isinstance(args, string_types):
+    if isinstance(args, str):
         raise TypeError("args should be a list of strings")
     if _megam_bin is None:
         config_megam()
@@ -180,7 +178,7 @@ def call_megam(args):
         print(stderr)
         raise OSError("megam command failed!")
 
-    if isinstance(stdout, string_types):
+    if isinstance(stdout, str):
         return stdout
     else:
         return stdout.decode("utf-8")

--- a/nltk/classify/scikitlearn.py
+++ b/nltk/classify/scikitlearn.py
@@ -31,8 +31,6 @@ best 1000 features:
 >>> classif = SklearnClassifier(pipeline)
 """
 
-from six.moves import zip
-
 from nltk.classify.api import ClassifierI
 from nltk.probability import DictionaryProbDist
 

--- a/nltk/classify/senna.py
+++ b/nltk/classify/senna.py
@@ -29,7 +29,6 @@ The input is:
 
 Note: Unit tests for this module can be found in test/unit/test_senna.py
 
-    >>> from __future__ import unicode_literals
     >>> from nltk.classify import Senna
     >>> pipeline = Senna('/usr/share/senna-v3.0', ['pos', 'chk', 'ner'])
     >>> sent = 'Dusseldorf is an international business center'.split()

--- a/nltk/classify/senna.py
+++ b/nltk/classify/senna.py
@@ -41,8 +41,6 @@ from os import path, sep, environ
 from subprocess import Popen, PIPE
 from platform import architecture, system
 
-from six import text_type
-
 from nltk.tag.api import TaggerI
 
 _senna_url = "http://ml.nec-labs.com/senna/"
@@ -136,7 +134,7 @@ class Senna(TaggerI):
 
         # Serialize the actual sentences to a temporary string
         _input = "\n".join((" ".join(x) for x in sentences)) + "\n"
-        if isinstance(_input, text_type) and encoding:
+        if isinstance(_input, str) and encoding:
             _input = _input.encode(encoding)
 
         # Run the tagger and get the output

--- a/nltk/classify/tadm.py
+++ b/nltk/classify/tadm.py
@@ -8,8 +8,6 @@
 import sys
 import subprocess
 
-from six import string_types
-
 from nltk.internals import find_binary
 
 try:
@@ -77,7 +75,7 @@ def call_tadm(args):
     """
     Call the ``tadm`` binary with the given arguments.
     """
-    if isinstance(args, string_types):
+    if isinstance(args, str):
         raise TypeError("args should be a list of strings")
     if _tadm_bin is None:
         config_tadm()

--- a/nltk/classify/weka.py
+++ b/nltk/classify/weka.py
@@ -17,8 +17,6 @@ import re
 import zipfile
 from sys import stdin
 
-from six import integer_types
-
 from nltk.probability import DictionaryProbDist
 from nltk.internals import java, config_java
 
@@ -299,7 +297,7 @@ class ARFF_Formatter:
             for (fname, fval) in tok.items():
                 if issubclass(type(fval), bool):
                     ftype = "{True, False}"
-                elif issubclass(type(fval), (integer_types, float, bool)):
+                elif issubclass(type(fval), (int, float, bool)):
                     ftype = "NUMERIC"
                 elif issubclass(type(fval), str):
                     ftype = "STRING"
@@ -365,7 +363,7 @@ class ARFF_Formatter:
     def _fmt_arff_val(self, fval):
         if fval is None:
             return "?"
-        elif isinstance(fval, (bool, integer_types)):
+        elif isinstance(fval, (bool, int)):
             return "%s" % fval
         elif isinstance(fval, float):
             return "%r" % fval

--- a/nltk/classify/weka.py
+++ b/nltk/classify/weka.py
@@ -17,7 +17,7 @@ import re
 import zipfile
 from sys import stdin
 
-from six import integer_types, string_types
+from six import integer_types
 
 from nltk.probability import DictionaryProbDist
 from nltk.internals import java, config_java
@@ -301,7 +301,7 @@ class ARFF_Formatter:
                     ftype = "{True, False}"
                 elif issubclass(type(fval), (integer_types, float, bool)):
                     ftype = "NUMERIC"
-                elif issubclass(type(fval), string_types):
+                elif issubclass(type(fval), str):
                     ftype = "STRING"
                 elif fval is None:
                     continue  # can't tell the type.

--- a/nltk/cluster/api.py
+++ b/nltk/cluster/api.py
@@ -7,13 +7,11 @@
 # For license information, see LICENSE.TXT
 
 from abc import ABCMeta, abstractmethod
-from six import add_metaclass
 
 from nltk.probability import DictionaryProbDist
 
 
-@add_metaclass(ABCMeta)
-class ClusterI(object):
+class ClusterI(metaclass=ABCMeta):
     """
     Interface covering basic clustering functionality.
     """

--- a/nltk/collections.py
+++ b/nltk/collections.py
@@ -12,8 +12,6 @@ from functools import total_ordering
 # this unused import is for python 2.7
 from collections import defaultdict, deque, Counter
 
-from six import text_type
-
 from nltk.internals import slice_bounds, raise_unorderable_types
 
 
@@ -230,8 +228,8 @@ class AbstractLazySequence(object):
             pieces.append(repr(elt))
             length += len(pieces[-1]) + 2
             if length > self._MAX_REPR_SIZE and len(pieces) > 2:
-                return "[%s, ...]" % text_type(", ").join(pieces[:-1])
-        return "[%s]" % text_type(", ").join(pieces)
+                return "[%s, ...]" % ", ".join(pieces[:-1])
+        return "[%s]" % ", ".join(pieces)
 
     def __eq__(self, other):
         return type(self) == type(other) and list(self) == list(other)

--- a/nltk/collocations.py
+++ b/nltk/collocations.py
@@ -31,7 +31,6 @@ measures are provided in bigram_measures and trigram_measures.
 #   and unigram counts (raw_freq, pmi, student_t)
 
 import itertools as _itertools
-from six import iteritems
 
 from nltk.probability import FreqDist
 from nltk.util import ngrams
@@ -98,7 +97,7 @@ class AbstractCollocationFinder(object):
         if the function returns True when passed an ngram tuple.
         """
         tmp_ngram = FreqDist()
-        for ngram, freq in iteritems(self.ngram_fd):
+        for ngram, freq in self.ngram_fd.items():
             if not fn(ngram, freq):
                 tmp_ngram[ngram] = freq
         self.ngram_fd = tmp_ngram

--- a/nltk/compat.py
+++ b/nltk/compat.py
@@ -12,8 +12,6 @@ from functools import update_wrapper, wraps
 import fractions
 import unicodedata
 
-from six import string_types, text_type
-
 # Python 2/3 compatibility layer. Based on six.
 
 PY3 = sys.version_info[0] == 3
@@ -89,7 +87,7 @@ else:
             self.encoder = encoder_cls(errors=errors)
 
         def encode(self, data):
-            if isinstance(data, string_types):
+            if isinstance(data, str):
                 return data.encode("utf-8")
             else:
                 return data
@@ -298,21 +296,8 @@ def python_2_unicode_compatible(klass):
 
 def unicode_repr(obj):
     """
-    For classes that was fixed with @python_2_unicode_compatible
-    ``unicode_repr`` returns ``obj.unicode_repr()``; for unicode strings
-    the result is returned without "u" letter (to make output the
-    same under Python 2.x and Python 3.x); for other variables
-    it is the same as ``repr``.
+    Compatibility alias for ``repr``.
     """
-    if PY3:
-        return repr(obj)
-
-    # Python 2.x
-    if hasattr(obj, "unicode_repr"):
-        return obj.unicode_repr()
-
-    if isinstance(obj, text_type):
-        return repr(obj)[1:]  # strip "u" letter from output
 
     return repr(obj)
 

--- a/nltk/corpus/reader/aligned.py
+++ b/nltk/corpus/reader/aligned.py
@@ -5,8 +5,6 @@
 # Author: Steven Bird <stevenbird1@gmail.com>
 # For license information, see LICENSE.TXT
 
-from six import string_types
-
 from nltk.tokenize import WhitespaceTokenizer, RegexpTokenizer
 from nltk.translate import AlignedSent, Alignment
 
@@ -57,7 +55,7 @@ class AlignedCorpusReader(CorpusReader):
         """
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
         return concat([self.open(f).read() for f in fileids])
 

--- a/nltk/corpus/reader/api.py
+++ b/nltk/corpus/reader/api.py
@@ -15,8 +15,6 @@ import re
 from collections import defaultdict
 from itertools import chain
 
-from six import string_types
-
 from nltk.data import PathPointer, FileSystemPathPointer, ZipFilePathPointer
 
 from nltk.corpus.reader.util import *
@@ -73,7 +71,7 @@ class CorpusReader(object):
               tagged_...() methods.
         """
         # Convert the root to a path pointer, if necessary.
-        if isinstance(root, string_types) and not isinstance(root, PathPointer):
+        if isinstance(root, str) and not isinstance(root, PathPointer):
             m = re.match("(.*\.zip)/?(.*)$|", root)
             zipfile, zipentry = m.groups()
             if zipfile:
@@ -84,7 +82,7 @@ class CorpusReader(object):
             raise TypeError("CorpusReader: expected a string or a PathPointer")
 
         # If `fileids` is a regexp, then expand it.
-        if isinstance(fileids, string_types):
+        if isinstance(fileids, str):
             fileids = find_corpus_fileids(root, fileids)
 
         self._fileids = fileids
@@ -184,7 +182,7 @@ class CorpusReader(object):
         """
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
 
         paths = [self._root.join(f) for f in fileids]
@@ -346,7 +344,7 @@ class CategorizedCorpusReader(object):
             self._init()
         if fileids is None:
             return sorted(self._c2f)
-        if isinstance(fileids, string_types):
+        if isinstance(fileids, str):
             fileids = [fileids]
         return sorted(set.union(*[self._f2c[d] for d in fileids]))
 
@@ -357,7 +355,7 @@ class CategorizedCorpusReader(object):
         """
         if categories is None:
             return super(CategorizedCorpusReader, self).fileids()
-        elif isinstance(categories, string_types):
+        elif isinstance(categories, str):
             if self._f2c is None:
                 self._init()
             if categories in self._c2f:
@@ -405,7 +403,7 @@ class SyntaxCorpusReader(CorpusReader):
     def raw(self, fileids=None):
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
         return concat([self.open(f).read() for f in fileids])
 

--- a/nltk/corpus/reader/categorized_sents.py
+++ b/nltk/corpus/reader/categorized_sents.py
@@ -34,7 +34,6 @@ Related papers:
     sentiment categorization with respect to rating scales". Proceedings of the
     ACL, 2005.
 """
-from six import string_types
 
 from nltk.corpus.reader.api import *
 from nltk.tokenize import *
@@ -117,7 +116,7 @@ class CategorizedSentencesCorpusReader(CategorizedCorpusReader, CorpusReader):
         fileids = self._resolve(fileids, categories)
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
         return concat([self.open(f).read() for f in fileids])
 
@@ -142,7 +141,7 @@ class CategorizedSentencesCorpusReader(CategorizedCorpusReader, CorpusReader):
         fileids = self._resolve(fileids, categories)
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
         return concat(
             [
@@ -166,7 +165,7 @@ class CategorizedSentencesCorpusReader(CategorizedCorpusReader, CorpusReader):
         fileids = self._resolve(fileids, categories)
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
         return concat(
             [

--- a/nltk/corpus/reader/chasen.py
+++ b/nltk/corpus/reader/chasen.py
@@ -8,8 +8,6 @@
 
 import sys
 
-from six import string_types
-
 from nltk.corpus.reader import util
 
 from nltk.corpus.reader.util import *
@@ -24,7 +22,7 @@ class ChasenCorpusReader(CorpusReader):
     def raw(self, fileids=None):
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
         return concat([self.open(f).read() for f in fileids])
 
@@ -162,7 +160,7 @@ def test():
 
     jeita = LazyCorpusLoader("jeita", ChasenCorpusReader, r".*chasen", encoding="utf-8")
 
-    assert isinstance(jeita.tagged_words()[0][1], string_types)
+    assert isinstance(jeita.tagged_words()[0][1], str)
 
 
 if __name__ == "__main__":

--- a/nltk/corpus/reader/childes.py
+++ b/nltk/corpus/reader/childes.py
@@ -14,7 +14,6 @@ __docformat__ = "epytext en"
 
 import re
 from collections import defaultdict
-from six import string_types
 
 from nltk.util import flatten, LazyMap, LazyConcatenation
 
@@ -353,7 +352,7 @@ class CHILDESCorpusReader(XMLCorpusReader):
         self, fileid, speaker, sent, stem, relation, pos, strip_space, replace
     ):
         if (
-            isinstance(speaker, string_types) and speaker != "ALL"
+            isinstance(speaker, str) and speaker != "ALL"
         ):  # ensure we have a list of speakers
             speaker = [speaker]
         xmldoc = ElementTree.parse(fileid).getroot()

--- a/nltk/corpus/reader/chunked.py
+++ b/nltk/corpus/reader/chunked.py
@@ -13,8 +13,6 @@ documents.
 
 import os.path, codecs
 
-from six import string_types
-
 import nltk
 from nltk.corpus.reader.bracket_parse import BracketParseCorpusReader
 from nltk.tree import Tree
@@ -63,7 +61,7 @@ class ChunkedCorpusReader(CorpusReader):
         """
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
         return concat([self.open(f).read() for f in fileids])
 

--- a/nltk/corpus/reader/cmudict.py
+++ b/nltk/corpus/reader/cmudict.py
@@ -69,7 +69,7 @@ class CMUDictCorpusReader(CorpusReader):
         :return: the cmudict lexicon as a raw string.
         """
         fileids = self._fileids
-        if isinstance(fileids, string_types):
+        if isinstance(fileids, str):
             fileids = [fileids]
         return concat([self.open(f).read() for f in fileids])
 

--- a/nltk/corpus/reader/comparative_sents.py
+++ b/nltk/corpus/reader/comparative_sents.py
@@ -35,8 +35,6 @@ Related papers:
 """
 import re
 
-from six import string_types
-
 from nltk.corpus.reader.api import *
 from nltk.tokenize import *
 
@@ -147,7 +145,7 @@ class ComparativeSentencesCorpusReader(CorpusReader):
         """
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
         return concat(
             [
@@ -197,7 +195,7 @@ class ComparativeSentencesCorpusReader(CorpusReader):
         """
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
         return concat([self.open(f).read() for f in fileids])
 

--- a/nltk/corpus/reader/conll.py
+++ b/nltk/corpus/reader/conll.py
@@ -82,7 +82,7 @@ class ConllCorpusReader(CorpusReader):
         for columntype in columntypes:
             if columntype not in self.COLUMN_TYPES:
                 raise ValueError("Bad column type %r" % columntype)
-        if isinstance(chunk_types, string_types):
+        if isinstance(chunk_types, str):
             chunk_types = [chunk_types]
         self._chunk_types = chunk_types
         self._colmap = dict((c, i) for (i, c) in enumerate(columntypes))
@@ -101,7 +101,7 @@ class ConllCorpusReader(CorpusReader):
     def raw(self, fileids=None):
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
         return concat([self.open(f).read() for f in fileids])
 
@@ -332,7 +332,7 @@ class ConllCorpusReader(CorpusReader):
                     if (
                         isinstance(child, Tree)
                         and len(child) == 1
-                        and isinstance(child[0], string_types)
+                        and isinstance(child[0], str)
                     ):
                         subtree[i] = (child[0], child.label())
 
@@ -550,7 +550,7 @@ class ConllSRLInstanceList(list):
 
     def _tree2conll(self, tree, wordnum, words, pos, synt):
         assert isinstance(tree, Tree)
-        if len(tree) == 1 and isinstance(tree[0], string_types):
+        if len(tree) == 1 and isinstance(tree[0], str):
             pos[wordnum] = tree.label()
             assert words[wordnum] == tree[0]
             return wordnum + 1

--- a/nltk/corpus/reader/framenet.py
+++ b/nltk/corpus/reader/framenet.py
@@ -20,7 +20,6 @@ import types
 from collections import defaultdict, OrderedDict
 from operator import itemgetter
 
-from six import string_types, text_type
 from six.moves import zip_longest
 from pprint import pprint
 
@@ -84,7 +83,7 @@ def _pretty_any(obj):
 
     outstr = ""
     for k in obj:
-        if isinstance(obj[k], string_types) and len(obj[k]) > 65:
+        if isinstance(obj[k], str) and len(obj[k]) > 65:
             outstr += "[{0}]\n".format(k)
             outstr += "{0}".format(_pretty_longstring(obj[k], prefix="  "))
             outstr += "\n"
@@ -1001,10 +1000,10 @@ class PrettyList(list):
             )  # key difference from inherited version: call to _short_repr()
             length += len(pieces[-1]) + 2
             if self._MAX_REPR_SIZE and length > self._MAX_REPR_SIZE and len(pieces) > 2:
-                return "[%s, ...]" % text_type(
+                return "[%s, ...]" % str(
                     ",\n " if self._BREAK_LINES else ", "
                 ).join(pieces[:-1])
-        return "[%s]" % text_type(",\n " if self._BREAK_LINES else ", ").join(pieces)
+        return "[%s]" % str(",\n " if self._BREAK_LINES else ", ").join(pieces)
 
 
 class PrettyLazyMap(LazyMap):
@@ -1029,8 +1028,8 @@ class PrettyLazyMap(LazyMap):
             )  # key difference from inherited version: call to _short_repr()
             length += len(pieces[-1]) + 2
             if length > self._MAX_REPR_SIZE and len(pieces) > 2:
-                return "[%s, ...]" % text_type(", ").join(pieces[:-1])
-        return "[%s]" % text_type(", ").join(pieces)
+                return "[%s, ...]" % str(", ").join(pieces[:-1])
+        return "[%s]" % str(", ").join(pieces)
 
 
 class PrettyLazyIteratorList(LazyIteratorList):
@@ -1055,8 +1054,8 @@ class PrettyLazyIteratorList(LazyIteratorList):
             )  # key difference from inherited version: call to _short_repr()
             length += len(pieces[-1]) + 2
             if length > self._MAX_REPR_SIZE and len(pieces) > 2:
-                return "[%s, ...]" % text_type(", ").join(pieces[:-1])
-        return "[%s]" % text_type(", ").join(pieces)
+                return "[%s, ...]" % str(", ").join(pieces[:-1])
+        return "[%s]" % str(", ").join(pieces)
 
 
 class PrettyLazyConcatenation(LazyConcatenation):
@@ -1081,8 +1080,8 @@ class PrettyLazyConcatenation(LazyConcatenation):
             )  # key difference from inherited version: call to _short_repr()
             length += len(pieces[-1]) + 2
             if length > self._MAX_REPR_SIZE and len(pieces) > 2:
-                return "[%s, ...]" % text_type(", ").join(pieces[:-1])
-        return "[%s]" % text_type(", ").join(pieces)
+                return "[%s, ...]" % str(", ").join(pieces[:-1])
+        return "[%s]" % str(", ").join(pieces)
 
     def __add__(self, other):
         """Return a list concatenating self with other."""
@@ -1580,7 +1579,7 @@ warnings(True) to display corpus consistency warnings when loading data
         """
 
         # get the frame info by name or id number
-        if isinstance(fn_fid_or_fname, string_types):
+        if isinstance(fn_fid_or_fname, str):
             f = self.frame_by_name(fn_fid_or_fname, ignorekeys)
         else:
             f = self.frame_by_id(fn_fid_or_fname, ignorekeys)
@@ -2111,7 +2110,7 @@ warnings(True) to display corpus consistency warnings when loading data
         if frame is not None:
             if isinstance(frame, int):
                 frames = [self.frame(frame)]
-            elif isinstance(frame, string_types):
+            elif isinstance(frame, str):
                 frames = self.frames(frame)
             else:
                 frames = [frame]
@@ -2240,7 +2239,7 @@ warnings(True) to display corpus consistency warnings when loading data
             if frame is not None:
                 if isinstance(frame, int):
                     frameIDs = {frame}
-                elif isinstance(frame, string_types):
+                elif isinstance(frame, str):
                     frameIDs = {f.ID for f in self.frames(frame)}
                 else:
                     frameIDs = {frame.ID}
@@ -2248,7 +2247,7 @@ warnings(True) to display corpus consistency warnings when loading data
         elif frame is not None:  # all LUs in matching frames
             if isinstance(frame, int):
                 frames = [self.frame(frame)]
-            elif isinstance(frame, string_types):
+            elif isinstance(frame, str):
                 frames = self.frames(frame)
             else:
                 frames = [frame]
@@ -2386,15 +2385,15 @@ warnings(True) to display corpus consistency warnings when loading data
         if fe is None and fe2 is not None:
             raise FramenetError("exemplars(..., fe=None, fe2=<value>) is not allowed")
         elif fe is not None and fe2 is not None:
-            if not isinstance(fe2, string_types):
-                if isinstance(fe, string_types):
+            if not isinstance(fe2, str):
+                if isinstance(fe, str):
                     # fe2 is specific to a particular frame. swap fe and fe2 so fe is always used to determine the frame.
                     fe, fe2 = fe2, fe
                 elif fe.frame is not fe2.frame:  # ensure frames match
                     raise FramenetError(
                         "exemplars() call with inconsistent `fe` and `fe2` specification (frames must match)"
                     )
-        if frame is None and fe is not None and not isinstance(fe, string_types):
+        if frame is None and fe is not None and not isinstance(fe, str):
             frame = fe.frame
 
         # narrow down to frames matching criteria
@@ -2403,7 +2402,7 @@ warnings(True) to display corpus consistency warnings when loading data
             list
         )  # frame name -> matching LUs, if luNamePattern is specified
         if frame is not None or luNamePattern is not None:
-            if frame is None or isinstance(frame, string_types):
+            if frame is None or isinstance(frame, str):
                 if luNamePattern is not None:
                     frames = set()
                     for lu in self.lus(luNamePattern, frame=frame):
@@ -2422,7 +2421,7 @@ warnings(True) to display corpus consistency warnings when loading data
                     lusByFrame = {frame.name: self.lus(luNamePattern, frame=frame)}
 
             if fe is not None:  # narrow to frames that define this FE
-                if isinstance(fe, string_types):
+                if isinstance(fe, str):
                     frames = PrettyLazyIteratorList(
                         f
                         for f in frames
@@ -2437,7 +2436,7 @@ warnings(True) to display corpus consistency warnings when loading data
                     frames = [fe.frame]
 
                 if fe2 is not None:  # narrow to frames that ALSO define this FE
-                    if isinstance(fe2, string_types):
+                    if isinstance(fe2, str):
                         frames = PrettyLazyIteratorList(
                             f
                             for f in frames
@@ -2464,13 +2463,13 @@ warnings(True) to display corpus consistency warnings when loading data
                 if fe is not None:
                     fes = (
                         {ffe for ffe in f.FE.keys() if re.search(fe, ffe, re.I)}
-                        if isinstance(fe, string_types)
+                        if isinstance(fe, str)
                         else {fe.name}
                     )
                     if fe2 is not None:
                         fes2 = (
                             {ffe for ffe in f.FE.keys() if re.search(fe2, ffe, re.I)}
-                            if isinstance(fe2, string_types)
+                            if isinstance(fe2, str)
                             else {fe2.name}
                         )
 
@@ -3046,7 +3045,7 @@ warnings(True) to display corpus consistency warnings when loading data
                 luinfo["sentenceCount"] = self._load_xml_attributes(PrettyDict(), sub)
             elif sub.tag.endswith("lexeme"):
                 lexemeinfo = self._load_xml_attributes(PrettyDict(), sub)
-                if not isinstance(lexemeinfo.name, string_types):
+                if not isinstance(lexemeinfo.name, str):
                     # some lexeme names are ints by default: e.g.,
                     # thousand.num has lexeme with name="1000"
                     lexemeinfo.name = str(lexemeinfo.name)

--- a/nltk/corpus/reader/framenet.py
+++ b/nltk/corpus/reader/framenet.py
@@ -19,8 +19,8 @@ import sys
 import types
 from collections import defaultdict, OrderedDict
 from operator import itemgetter
+from itertools import zip_longest
 
-from six.moves import zip_longest
 from pprint import pprint
 
 from nltk.corpus.reader import XMLCorpusReader, XMLCorpusView

--- a/nltk/corpus/reader/ieer.py
+++ b/nltk/corpus/reader/ieer.py
@@ -21,8 +21,6 @@ The corpus contains the following files: APW_19980314, APW_19980424,
 APW_19980429, NYT_19980315, NYT_19980403, and NYT_19980407.
 """
 
-from six import string_types
-
 import nltk
 from nltk import compat
 from nltk.corpus.reader.api import *
@@ -71,7 +69,7 @@ class IEERCorpusReader(CorpusReader):
     def raw(self, fileids=None):
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
         return concat([self.open(f).read() for f in fileids])
 

--- a/nltk/corpus/reader/indian.py
+++ b/nltk/corpus/reader/indian.py
@@ -18,8 +18,6 @@ Contents:
   - Telugu: IIIT Hyderabad
 """
 
-from six import string_types
-
 from nltk.tag import str2tuple, map_tag
 
 from nltk.corpus.reader.util import *
@@ -74,7 +72,7 @@ class IndianCorpusReader(CorpusReader):
     def raw(self, fileids=None):
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
         return concat([self.open(f).read() for f in fileids])
 

--- a/nltk/corpus/reader/ipipan.py
+++ b/nltk/corpus/reader/ipipan.py
@@ -7,8 +7,6 @@
 
 import functools
 
-from six import string_types
-
 from nltk.corpus.reader.util import StreamBackedCorpusView, concat
 from nltk.corpus.reader.api import CorpusReader
 
@@ -98,11 +96,11 @@ class IPIPANCorpusReader(CorpusReader):
             )
         if channels is None and domains is None and categories is None:
             return CorpusReader.fileids(self)
-        if isinstance(channels, string_types):
+        if isinstance(channels, str):
             channels = [channels]
-        if isinstance(domains, string_types):
+        if isinstance(domains, str):
             domains = [domains]
-        if isinstance(categories, string_types):
+        if isinstance(categories, str):
             categories = [categories]
         if channels:
             return self._list_morph_files_by("channel", channels)

--- a/nltk/corpus/reader/knbc.py
+++ b/nltk/corpus/reader/knbc.py
@@ -8,7 +8,6 @@
 # For more information, see http://lilyx.net/pages/nltkjapanesecorpus.html
 
 import re
-from six import string_types
 
 from nltk.parse import DependencyGraph
 
@@ -183,8 +182,8 @@ def test():
     knbc = LazyCorpusLoader(
         "knbc/corpus1", KNBCorpusReader, r".*/KN.*", encoding="euc-jp"
     )
-    assert isinstance(knbc.words()[0], string_types)
-    assert isinstance(knbc.sents()[0][0], string_types)
+    assert isinstance(knbc.words()[0], str)
+    assert isinstance(knbc.sents()[0][0], str)
     assert isinstance(knbc.tagged_words()[0], tuple)
     assert isinstance(knbc.tagged_sents()[0][0], tuple)
 

--- a/nltk/corpus/reader/mte.py
+++ b/nltk/corpus/reader/mte.py
@@ -5,8 +5,6 @@ import os
 import re
 from functools import reduce
 
-from six import string_types
-
 from nltk.corpus.reader import concat, TaggedCorpusReader
 from nltk.corpus.reader.xmldocs import XMLCorpusView
 
@@ -232,7 +230,7 @@ class MTECorpusReader(TaggedCorpusReader):
     def __fileids(self, fileids):
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
         # filter wrong userinput
         fileids = filter(lambda x: x in self._fileids, fileids)

--- a/nltk/corpus/reader/nkjp.py
+++ b/nltk/corpus/reader/nkjp.py
@@ -10,8 +10,6 @@ import os
 import re
 import tempfile
 
-from six import string_types
-
 from nltk.corpus.reader.util import concat
 from nltk.corpus.reader.xmldocs import XMLCorpusReader, XMLCorpusView
 
@@ -55,7 +53,7 @@ class NKJPCorpusReader(XMLCorpusReader):
         x.header(fileids=['WilkDom', '/home/USER/nltk_data/corpora/nkjp/WilkWilczy'])
         x.tagged_words(fileids=['WilkDom', '/home/USER/nltk_data/corpora/nkjp/WilkWilczy'], tags=['subst', 'comp'])
         """
-        if isinstance(fileids, string_types):
+        if isinstance(fileids, str):
             XMLCorpusReader.__init__(self, root, fileids + ".*/header.xml")
         else:
             XMLCorpusReader.__init__(

--- a/nltk/corpus/reader/nombank.py
+++ b/nltk/corpus/reader/nombank.py
@@ -9,8 +9,6 @@
 from xml.etree import ElementTree
 from functools import total_ordering
 
-from six import string_types
-
 from nltk.tree import Tree
 from nltk.internals import raise_unorderable_types
 
@@ -58,7 +56,7 @@ class NombankCorpusReader(CorpusReader):
         """
 
         # If framefiles is specified as a regexp, expand it.
-        if isinstance(framefiles, string_types):
+        if isinstance(framefiles, str):
             self._fileids = find_corpus_fileids(root, framefiles)
         self._fileids = list(framefiles)
         # Initialze the corpus reader.
@@ -76,7 +74,7 @@ class NombankCorpusReader(CorpusReader):
         """
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
         return concat([self.open(f).read() for f in fileids])
 

--- a/nltk/corpus/reader/opinion_lexicon.py
+++ b/nltk/corpus/reader/opinion_lexicon.py
@@ -27,7 +27,6 @@ Related papers:
     Comparing Opinions on the Web". Proceedings of the 14th International World
     Wide Web conference (WWW-2005), May 10-14, 2005, Chiba, Japan.
 """
-from six import string_types
 
 from nltk.corpus.reader import WordListCorpusReader
 from nltk.corpus.reader.api import *
@@ -86,7 +85,7 @@ class OpinionLexiconCorpusReader(WordListCorpusReader):
         """
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
         return concat(
             [

--- a/nltk/corpus/reader/panlex_swadesh.py
+++ b/nltk/corpus/reader/panlex_swadesh.py
@@ -10,8 +10,6 @@
 
 from collections import namedtuple, defaultdict
 import re
-from six import string_types
-
 
 from nltk.tokenize import line_tokenize
 

--- a/nltk/corpus/reader/panlex_swadesh.py
+++ b/nltk/corpus/reader/panlex_swadesh.py
@@ -8,7 +8,6 @@
 # For license information, see LICENSE.TXT
 
 
-from __future__ import print_function
 from collections import namedtuple, defaultdict
 import re
 from six import string_types

--- a/nltk/corpus/reader/pl196x.py
+++ b/nltk/corpus/reader/pl196x.py
@@ -5,8 +5,6 @@
 # URL: <http://nltk.org/>
 # For license information, see LICENSE.TXT
 
-from six import string_types
-
 from nltk.corpus.reader.api import *
 from nltk.corpus.reader.xmldocs import XMLCorpusReader
 
@@ -149,7 +147,7 @@ class Pl196xCorpusReader(CategorizedCorpusReader, XMLCorpusReader):
             return self.fileids(categories), None
 
         if textids is not None:
-            if isinstance(textids, string_types):
+            if isinstance(textids, str):
                 textids = [textids]
             files = sum((self._t2f[t] for t in textids), [])
             tdict = dict()
@@ -173,7 +171,7 @@ class Pl196xCorpusReader(CategorizedCorpusReader, XMLCorpusReader):
         if fileids is None:
             return sorted(self._t2f)
 
-        if isinstance(fileids, string_types):
+        if isinstance(fileids, str):
             fileids = [fileids]
         return sorted(sum((self._f2t[d] for d in fileids), []))
 
@@ -181,7 +179,7 @@ class Pl196xCorpusReader(CategorizedCorpusReader, XMLCorpusReader):
         fileids, textids = self._resolve(fileids, categories, textids)
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
 
         if textids:
@@ -216,7 +214,7 @@ class Pl196xCorpusReader(CategorizedCorpusReader, XMLCorpusReader):
         fileids, textids = self._resolve(fileids, categories, textids)
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
 
         if textids:
@@ -247,7 +245,7 @@ class Pl196xCorpusReader(CategorizedCorpusReader, XMLCorpusReader):
         fileids, textids = self._resolve(fileids, categories, textids)
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
 
         if textids:
@@ -278,7 +276,7 @@ class Pl196xCorpusReader(CategorizedCorpusReader, XMLCorpusReader):
         fileids, textids = self._resolve(fileids, categories, textids)
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
 
         if textids:
@@ -309,7 +307,7 @@ class Pl196xCorpusReader(CategorizedCorpusReader, XMLCorpusReader):
         fileids, textids = self._resolve(fileids, categories, textids)
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
 
         if textids:
@@ -340,7 +338,7 @@ class Pl196xCorpusReader(CategorizedCorpusReader, XMLCorpusReader):
         fileids, textids = self._resolve(fileids, categories, textids)
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
 
         if textids:
@@ -378,6 +376,6 @@ class Pl196xCorpusReader(CategorizedCorpusReader, XMLCorpusReader):
         fileids, _ = self._resolve(fileids, categories)
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
         return concat([self.open(f).read() for f in fileids])

--- a/nltk/corpus/reader/plaintext.py
+++ b/nltk/corpus/reader/plaintext.py
@@ -72,7 +72,7 @@ class PlaintextCorpusReader(CorpusReader):
         """
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
         raw_texts = []
         for f in fileids:

--- a/nltk/corpus/reader/ppattach.py
+++ b/nltk/corpus/reader/ppattach.py
@@ -38,8 +38,6 @@ The PP Attachment Corpus is distributed with NLTK with the permission
 of the author.
 """
 
-from six import string_types
-
 from nltk.corpus.reader.util import *
 from nltk.corpus.reader.api import *
 
@@ -85,7 +83,7 @@ class PPAttachmentCorpusReader(CorpusReader):
     def raw(self, fileids=None):
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
         return concat([self.open(f).read() for f in fileids])
 

--- a/nltk/corpus/reader/propbank.py
+++ b/nltk/corpus/reader/propbank.py
@@ -9,8 +9,6 @@ import re
 from functools import total_ordering
 from xml.etree import ElementTree
 
-from six import string_types
-
 from nltk.tree import Tree
 from nltk.internals import raise_unorderable_types
 
@@ -57,7 +55,7 @@ class PropbankCorpusReader(CorpusReader):
             necessary to resolve the tree pointers used by propbank.
         """
         # If framefiles is specified as a regexp, expand it.
-        if isinstance(framefiles, string_types):
+        if isinstance(framefiles, str):
             framefiles = find_corpus_fileids(root, framefiles)
         framefiles = list(framefiles)
         # Initialze the corpus reader.
@@ -529,7 +527,7 @@ class PropbankInflection(object):
 
     @staticmethod
     def parse(s):
-        if not isinstance(s, string_types):
+        if not isinstance(s, str):
             raise TypeError("expected a string")
         if len(s) != 5 or not PropbankInflection._VALIDATE.match(s):
             raise ValueError("Bad propbank inflection string %r" % s)

--- a/nltk/corpus/reader/pros_cons.py
+++ b/nltk/corpus/reader/pros_cons.py
@@ -27,8 +27,6 @@ Related papers:
 """
 import re
 
-from six import string_types
-
 from nltk.corpus.reader.api import *
 from nltk.tokenize import *
 
@@ -84,7 +82,7 @@ class ProsConsCorpusReader(CategorizedCorpusReader, CorpusReader):
         fileids = self._resolve(fileids, categories)
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
         return concat(
             [
@@ -108,7 +106,7 @@ class ProsConsCorpusReader(CategorizedCorpusReader, CorpusReader):
         fileids = self._resolve(fileids, categories)
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
         return concat(
             [

--- a/nltk/corpus/reader/reviews.py
+++ b/nltk/corpus/reader/reviews.py
@@ -176,7 +176,6 @@ class ReviewsCorpusReader(CorpusReader):
 
     We can compute stats for specific product features:
 
-        >>> from __future__ import division
         >>> n_reviews = len([(feat,score) for (feat,score) in product_reviews_1.features('Canon_G3.txt') if feat=='picture'])
         >>> tot = sum([int(score) for (feat,score) in product_reviews_1.features('Canon_G3.txt') if feat=='picture'])
         >>> # We use float for backward compatibility with division in Python2.7

--- a/nltk/corpus/reader/reviews.py
+++ b/nltk/corpus/reader/reviews.py
@@ -61,8 +61,6 @@ Note: Some of the files (e.g. "ipod.txt", "Canon PowerShot SD500.txt") do not
 
 import re
 
-from six import string_types
-
 from nltk.corpus.reader.api import *
 from nltk.tokenize import *
 
@@ -212,7 +210,7 @@ class ReviewsCorpusReader(CorpusReader):
         """
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
         return concat(
             [
@@ -230,7 +228,7 @@ class ReviewsCorpusReader(CorpusReader):
         """
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
         return concat([self.open(f).read() for f in fileids])
 

--- a/nltk/corpus/reader/rte.py
+++ b/nltk/corpus/reader/rte.py
@@ -32,8 +32,6 @@ In order to provide globally unique IDs for each pair, a new attribute
 file, taking values 1, 2 or 3. The GID is formatted 'm-n', where 'm' is the
 challenge number and 'n' is the pair ID.
 """
-from six import string_types
-
 from nltk.corpus.reader.util import *
 from nltk.corpus.reader.api import *
 from nltk.corpus.reader.xmldocs import *
@@ -142,6 +140,6 @@ class RTECorpusReader(XMLCorpusReader):
         :type: list
         :rtype: list(RTEPair)
         """
-        if isinstance(fileids, string_types):
+        if isinstance(fileids, str):
             fileids = [fileids]
         return concat([self._read_etree(self.xml(fileid)) for fileid in fileids])

--- a/nltk/corpus/reader/senseval.py
+++ b/nltk/corpus/reader/senseval.py
@@ -25,8 +25,6 @@ is tagged with a sense identifier, and supplied with context.
 import re
 from xml.etree import ElementTree
 
-from six import string_types
-
 from nltk.tokenize import *
 
 from nltk.corpus.reader.util import *
@@ -64,7 +62,7 @@ class SensevalCorpusReader(CorpusReader):
         """
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
         return concat([self.open(f).read() for f in fileids])
 

--- a/nltk/corpus/reader/string_category.py
+++ b/nltk/corpus/reader/string_category.py
@@ -18,8 +18,6 @@ NUM:date When did Hawaii become a state ?
 """
 
 # based on PPAttachmentCorpusReader
-from six import string_types
-
 from nltk.corpus.reader.util import *
 from nltk.corpus.reader.api import *
 
@@ -39,7 +37,7 @@ class StringCategoryCorpusReader(CorpusReader):
     def tuples(self, fileids=None):
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
         return concat(
             [
@@ -54,7 +52,7 @@ class StringCategoryCorpusReader(CorpusReader):
         """
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
         return concat([self.open(f).read() for f in fileids])
 

--- a/nltk/corpus/reader/tagged.py
+++ b/nltk/corpus/reader/tagged.py
@@ -13,8 +13,6 @@ A reader for corpora whose documents contain part-of-speech-tagged words.
 
 import os
 
-from six import string_types
-
 from nltk.tag import str2tuple, map_tag
 from nltk.tokenize import *
 
@@ -74,7 +72,7 @@ class TaggedCorpusReader(CorpusReader):
         """
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
         return concat([self.open(f).read() for f in fileids])
 

--- a/nltk/corpus/reader/timit.py
+++ b/nltk/corpus/reader/timit.py
@@ -124,8 +124,6 @@ import re
 import tempfile
 import time
 
-from six import string_types
-
 from nltk.tree import Tree
 from nltk.internals import import_from_stdlib
 
@@ -161,7 +159,7 @@ class TimitCorpusReader(CorpusReader):
         :param root: The root directory for this corpus.
         """
         # Ensure that wave files don't get treated as unicode data:
-        if isinstance(encoding, string_types):
+        if isinstance(encoding, str):
             encoding = [(".*\.wav", None), (".*", encoding)]
 
         CorpusReader.__init__(
@@ -206,15 +204,15 @@ class TimitCorpusReader(CorpusReader):
         region, gender, sentence type, or sentence number, if
         specified.
         """
-        if isinstance(dialect, string_types):
+        if isinstance(dialect, str):
             dialect = [dialect]
-        if isinstance(sex, string_types):
+        if isinstance(sex, str):
             sex = [sex]
-        if isinstance(spkrid, string_types):
+        if isinstance(spkrid, str):
             spkrid = [spkrid]
-        if isinstance(sent_type, string_types):
+        if isinstance(sent_type, str):
             sent_type = [sent_type]
-        if isinstance(sentid, string_types):
+        if isinstance(sentid, str):
             sentid = [sentid]
 
         utterances = self._utterances[:]
@@ -339,7 +337,7 @@ class TimitCorpusReader(CorpusReader):
     def phone_trees(self, utterances=None):
         if utterances is None:
             utterances = self._utterances
-        if isinstance(utterances, string_types):
+        if isinstance(utterances, str):
             utterances = [utterances]
 
         trees = []
@@ -407,7 +405,7 @@ class TimitCorpusReader(CorpusReader):
     def _utterance_fileids(self, utterances, extension):
         if utterances is None:
             utterances = self._utterances
-        if isinstance(utterances, string_types):
+        if isinstance(utterances, str):
             utterances = [utterances]
         return ["%s%s" % (u, extension) for u in utterances]
 

--- a/nltk/corpus/reader/toolbox.py
+++ b/nltk/corpus/reader/toolbox.py
@@ -70,7 +70,7 @@ class ToolboxCorpusReader(CorpusReader):
     def raw(self, fileids):
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
         return concat([self.open(f).read() for f in fileids])
 

--- a/nltk/corpus/reader/twitter.py
+++ b/nltk/corpus/reader/twitter.py
@@ -13,8 +13,6 @@ have been serialised into line-delimited JSON.
 import json
 import os
 
-from six import string_types
-
 from nltk.tokenize import TweetTokenizer
 
 from nltk.corpus.reader.util import StreamBackedCorpusView, concat, ZipFilePathPointer
@@ -135,7 +133,7 @@ class TwitterCorpusReader(CorpusReader):
         """
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
         return concat([self.open(f).read() for f in fileids])
 

--- a/nltk/corpus/reader/util.py
+++ b/nltk/corpus/reader/util.py
@@ -22,8 +22,6 @@ try:  # Use the c version of ElementTree, which is faster, if possible.
 except ImportError:
     from xml.etree import ElementTree
 
-from six import string_types, text_type
-
 from nltk.tokenize import wordpunct_tokenize
 from nltk.internals import slice_bounds
 from nltk.data import PathPointer, FileSystemPathPointer, ZipFilePathPointer
@@ -445,7 +443,7 @@ def concat(docs):
     types = set(d.__class__ for d in docs)
 
     # If they're all strings, use string concatenation.
-    if all(isinstance(doc, string_types) for doc in docs):
+    if all(isinstance(doc, str) for doc in docs):
         return "".join(docs)
 
     # If they're all corpus views, then use ConcatenatedCorpusView.
@@ -544,7 +542,7 @@ class PickleCorpusView(StreamBackedCorpusView):
 
     @classmethod
     def write(cls, sequence, output_file):
-        if isinstance(output_file, string_types):
+        if isinstance(output_file, str):
             output_file = open(output_file, "wb")
         for item in sequence:
             pickle.dump(item, output_file, cls.PROTOCOL)
@@ -693,7 +691,7 @@ def read_sexpr_block(stream, block_size=16384, comment_char=None):
     start = stream.tell()
     block = stream.read(block_size)
     encoding = getattr(stream, "encoding", None)
-    assert encoding is not None or isinstance(block, text_type)
+    assert encoding is not None or isinstance(block, str)
     if encoding not in (None, "utf-8"):
         import warnings
 

--- a/nltk/corpus/reader/verbnet.py
+++ b/nltk/corpus/reader/verbnet.py
@@ -16,8 +16,6 @@ import re
 import textwrap
 from collections import defaultdict
 
-from six import string_types
-
 from nltk.corpus.reader.xmldocs import XMLCorpusReader
 
 
@@ -80,7 +78,7 @@ class VerbnetCorpusReader(XMLCorpusReader):
             return sorted(self._lemma_to_class.keys())
         else:
             # [xx] should this include subclass members?
-            if isinstance(vnclass, string_types):
+            if isinstance(vnclass, str):
                 vnclass = self.vnclass(vnclass)
             return [member.get("name") for member in vnclass.findall("MEMBERS/MEMBER")]
 
@@ -93,7 +91,7 @@ class VerbnetCorpusReader(XMLCorpusReader):
             return sorted(self._wordnet_to_class.keys())
         else:
             # [xx] should this include subclass members?
-            if isinstance(vnclass, string_types):
+            if isinstance(vnclass, str):
                 vnclass = self.vnclass(vnclass)
             return sum(
                 [
@@ -172,7 +170,7 @@ class VerbnetCorpusReader(XMLCorpusReader):
         """
         if vnclass_ids is None:
             return self._fileids
-        elif isinstance(vnclass_ids, string_types):
+        elif isinstance(vnclass_ids, str):
             return [self._class_to_fileid[self.longid(vnclass_ids)]]
         else:
             return [
@@ -193,7 +191,7 @@ class VerbnetCorpusReader(XMLCorpusReader):
             containing the xml contents of a VerbNet class.
         :return: frames - a list of frame dictionaries
         """
-        if isinstance(vnclass, string_types):
+        if isinstance(vnclass, str):
             vnclass = self.vnclass(vnclass)
         frames = []
         vnframes = vnclass.findall("FRAMES/FRAME")
@@ -218,7 +216,7 @@ class VerbnetCorpusReader(XMLCorpusReader):
             containing the xml contents of a VerbNet class.
         :return: list of subclasses
         """
-        if isinstance(vnclass, string_types):
+        if isinstance(vnclass, str):
             vnclass = self.vnclass(vnclass)
 
         subclasses = [
@@ -237,7 +235,7 @@ class VerbnetCorpusReader(XMLCorpusReader):
             containing the xml contents of a VerbNet class.
         :return: themroles: A list of thematic roles in the VerbNet class
         """
-        if isinstance(vnclass, string_types):
+        if isinstance(vnclass, str):
             vnclass = self.vnclass(vnclass)
 
         themroles = []
@@ -444,7 +442,7 @@ class VerbnetCorpusReader(XMLCorpusReader):
         :param vnclass: A VerbNet class identifier; or an ElementTree
         containing the xml contents of a VerbNet class.
         """
-        if isinstance(vnclass, string_types):
+        if isinstance(vnclass, str):
             vnclass = self.vnclass(vnclass)
 
         s = vnclass.get("ID") + "\n"
@@ -465,7 +463,7 @@ class VerbnetCorpusReader(XMLCorpusReader):
         :param vnclass: A VerbNet class identifier; or an ElementTree
             containing the xml contents of a VerbNet class.
         """
-        if isinstance(vnclass, string_types):
+        if isinstance(vnclass, str):
             vnclass = self.vnclass(vnclass)
 
         subclasses = self.subclasses(vnclass)
@@ -485,7 +483,7 @@ class VerbnetCorpusReader(XMLCorpusReader):
         :param vnclass: A VerbNet class identifier; or an ElementTree
             containing the xml contents of a VerbNet class.
         """
-        if isinstance(vnclass, string_types):
+        if isinstance(vnclass, str):
             vnclass = self.vnclass(vnclass)
 
         members = self.lemmas(vnclass)
@@ -505,7 +503,7 @@ class VerbnetCorpusReader(XMLCorpusReader):
         :param vnclass: A VerbNet class identifier; or an ElementTree
             containing the xml contents of a VerbNet class.
         """
-        if isinstance(vnclass, string_types):
+        if isinstance(vnclass, str):
             vnclass = self.vnclass(vnclass)
 
         pieces = []
@@ -529,7 +527,7 @@ class VerbnetCorpusReader(XMLCorpusReader):
         :param vnclass: A VerbNet class identifier; or an ElementTree
             containing the xml contents of a VerbNet class.
         """
-        if isinstance(vnclass, string_types):
+        if isinstance(vnclass, str):
             vnclass = self.vnclass(vnclass)
         pieces = []
         for vnframe in self.frames(vnclass):

--- a/nltk/corpus/reader/wordlist.py
+++ b/nltk/corpus/reader/wordlist.py
@@ -6,8 +6,6 @@
 #         Edward Loper <edloper@gmail.com>
 # URL: <http://nltk.org/>
 # For license information, see LICENSE.TXT
-from six import string_types
-
 from nltk.tokenize import line_tokenize
 
 from nltk.corpus.reader.util import *
@@ -29,7 +27,7 @@ class WordListCorpusReader(CorpusReader):
     def raw(self, fileids=None):
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
         return concat([self.open(f).read() for f in fileids])
 

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -36,7 +36,6 @@ from functools import total_ordering
 from operator import itemgetter
 from collections import defaultdict, deque
 
-from six import iteritems
 from six.moves import range
 
 from nltk.corpus.reader import CorpusReader
@@ -750,7 +749,7 @@ class Synset(_WordNetObject):
 
         inf = float("inf")
         path_distance = inf
-        for synset, d1 in iteritems(dist_dict1):
+        for synset, d1 in dist_dict1.items():
             d2 = dist_dict2.get(synset, inf)
             path_distance = min(path_distance, d1 + d2)
 

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -36,8 +36,6 @@ from functools import total_ordering
 from operator import itemgetter
 from collections import defaultdict, deque
 
-from six.moves import range
-
 from nltk.corpus.reader import CorpusReader
 from nltk.util import binary_search_file as _binary_search_file
 from nltk.probability import FreqDist

--- a/nltk/corpus/reader/xmldocs.py
+++ b/nltk/corpus/reader/xmldocs.py
@@ -19,8 +19,6 @@ try:
 except ImportError:
     from xml.etree import ElementTree
 
-from six import string_types
-
 from nltk.data import SeekableUnicodeStreamReader
 from nltk.tokenize import WordPunctTokenizer
 from nltk.internals import ElementWrapper
@@ -46,7 +44,7 @@ class XMLCorpusReader(CorpusReader):
         # Make sure we have exactly one file -- no concatenating XML.
         if fileid is None and len(self._fileids) == 1:
             fileid = self._fileids[0]
-        if not isinstance(fileid, string_types):
+        if not isinstance(fileid, str):
             raise TypeError("Expected a single file identifier string")
         # Read the XML in using ElementTree.
         elt = ElementTree.parse(self.abspath(fileid).open()).getroot()
@@ -84,7 +82,7 @@ class XMLCorpusReader(CorpusReader):
     def raw(self, fileids=None):
         if fileids is None:
             fileids = self._fileids
-        elif isinstance(fileids, string_types):
+        elif isinstance(fileids, str):
             fileids = [fileids]
         return concat([self.open(f).read() for f in fileids])
 

--- a/nltk/corpus/reader/ycoe.py
+++ b/nltk/corpus/reader/ycoe.py
@@ -22,8 +22,6 @@ to the YCOE standard: http://www-users.york.ac.uk/~lang22/YCOE/YcoeHome.htm
 import os
 import re
 
-from six import string_types
-
 from nltk.tokenize import RegexpTokenizer
 from nltk.corpus.reader.bracket_parse import BracketParseCorpusReader
 from nltk.corpus.reader.tagged import TaggedCorpusReader
@@ -67,7 +65,7 @@ class YCOECorpusReader(CorpusReader):
         """
         if fileids is None:
             return self._documents
-        if isinstance(fileids, string_types):
+        if isinstance(fileids, str):
             fileids = [fileids]
         for f in fileids:
             if f not in self._fileids:
@@ -82,7 +80,7 @@ class YCOECorpusReader(CorpusReader):
         """
         if documents is None:
             return self._fileids
-        elif isinstance(documents, string_types):
+        elif isinstance(documents, str):
             documents = [documents]
         return sorted(
             set(
@@ -99,7 +97,7 @@ class YCOECorpusReader(CorpusReader):
         if documents is None:
             documents = self._documents
         else:
-            if isinstance(documents, string_types):
+            if isinstance(documents, str):
                 documents = [documents]
             for document in documents:
                 if document not in self._documents:

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -44,7 +44,6 @@ from abc import ABCMeta, abstractmethod
 from gzip import GzipFile, WRITE as GZ_WRITE
 
 from six import add_metaclass
-from six import string_types, text_type
 from six.moves.urllib.request import urlopen, url2pathname
 
 try:
@@ -313,7 +312,7 @@ class PathPointer(object):
         """
 
 
-class FileSystemPathPointer(PathPointer, text_type):
+class FileSystemPathPointer(PathPointer, str):
     """
     A path pointer that identifies a file which can be accessed
     directly via a given absolute path.
@@ -501,7 +500,7 @@ class ZipFilePathPointer(PathPointer):
         :raise IOError: If the given zipfile does not exist, or if it
         does not contain the specified entry.
         """
-        if isinstance(zipfile, string_types):
+        if isinstance(zipfile, str):
             zipfile = OpenOnDemandZipFile(os.path.abspath(zipfile))
 
         # Check that the entry exists:
@@ -1049,7 +1048,7 @@ class OpenOnDemandZipFile(zipfile.ZipFile):
 
     @py3_data
     def __init__(self, filename):
-        if not isinstance(filename, string_types):
+        if not isinstance(filename, str):
             raise TypeError("ReopenableZipFile filename must be a string")
         zipfile.ZipFile.__init__(self, filename)
         assert self.filename == filename

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -43,7 +43,6 @@ import codecs
 from abc import ABCMeta, abstractmethod
 from gzip import GzipFile, WRITE as GZ_WRITE
 
-from six import add_metaclass
 from six.moves.urllib.request import urlopen, url2pathname
 
 try:
@@ -270,8 +269,7 @@ def normalize_resource_name(resource_name, allow_relative=True, relative_path=No
 ######################################################################
 
 
-@add_metaclass(ABCMeta)
-class PathPointer(object):
+class PathPointer(metaclass=ABCMeta):
     """
     An abstract base class for 'path pointers,' used by NLTK's data
     package to identify specific paths.  Two subclasses exist:

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -43,7 +43,7 @@ import codecs
 from abc import ABCMeta, abstractmethod
 from gzip import GzipFile, WRITE as GZ_WRITE
 
-from six.moves.urllib.request import urlopen, url2pathname
+from urllib.request import urlopen, url2pathname
 
 try:
     import cPickle as pickle

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -183,7 +183,6 @@ except ImportError:
     TKINTER = False
     TclError = ValueError
 
-from six import string_types, text_type
 from six.moves import input
 from six.moves.urllib.request import urlopen
 from six.moves.urllib.error import HTTPError, URLError
@@ -277,10 +276,10 @@ class Package(object):
 
     @staticmethod
     def fromxml(xml):
-        if isinstance(xml, string_types):
+        if isinstance(xml, str):
             xml = ElementTree.parse(xml)
         for key in xml.attrib:
-            xml.attrib[key] = text_type(xml.attrib[key])
+            xml.attrib[key] = str(xml.attrib[key])
         return Package(**xml.attrib)
 
     def __lt__(self, other):
@@ -317,10 +316,10 @@ class Collection(object):
 
     @staticmethod
     def fromxml(xml):
-        if isinstance(xml, string_types):
+        if isinstance(xml, str):
             xml = ElementTree.parse(xml)
         for key in xml.attrib:
-            xml.attrib[key] = text_type(xml.attrib[key])
+            xml.attrib[key] = str(xml.attrib[key])
         children = [child.get("ref") for child in xml.findall("item")]
         return Collection(children=children, **xml.attrib)
 
@@ -600,7 +599,7 @@ class Downloader(object):
     # /////////////////////////////////////////////////////////////////
 
     def _info_or_id(self, info_or_id):
-        if isinstance(info_or_id, string_types):
+        if isinstance(info_or_id, str):
             return self.info(info_or_id)
         else:
             return info_or_id
@@ -1649,7 +1648,7 @@ class DownloaderGUI(object):
 
     def _table_reprfunc(self, row, col, val):
         if self._table.column_names[col].endswith("Size"):
-            if isinstance(val, string_types):
+            if isinstance(val, str):
                 return "  %s" % val
             elif val < 1024 ** 2:
                 return "  %.1f KB" % (val / 1024.0 ** 1)
@@ -2208,7 +2207,7 @@ def md5_hexdigest(file):
     Calculate and return the MD5 checksum for a given file.
     ``file`` may either be a filename or an open stream.
     """
-    if isinstance(file, string_types):
+    if isinstance(file, str):
         with open(file, "rb") as infile:
             return _md5_hexdigest(infile)
     return _md5_hexdigest(file)

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -165,7 +165,7 @@ from xml.etree import ElementTree
 
 try:
     TKINTER = True
-    from six.moves.tkinter import (
+    from tkinter import (
         Tk,
         Frame,
         Label,
@@ -176,16 +176,15 @@ try:
         IntVar,
         TclError,
     )
-    from six.moves.tkinter_messagebox import showerror
+    from tkinter.messagebox import showerror
     from nltk.draw.table import Table
     from nltk.draw.util import ShowText
 except ImportError:
     TKINTER = False
     TclError = ValueError
 
-from six.moves import input
-from six.moves.urllib.request import urlopen
-from six.moves.urllib.error import HTTPError, URLError
+from urllib.request import urlopen
+from urllib.error import HTTPError, URLError
 
 import nltk
 
@@ -1984,7 +1983,7 @@ class DownloaderGUI(object):
         ABOUT = "NLTK Downloader\n" + "Written by Edward Loper"
         TITLE = "About: NLTK Downloader"
         try:
-            from six.moves.tkinter_messagebox import Message
+            from tkinter.messagebox import Message
 
             Message(message=ABOUT, title=TITLE).show()
         except ImportError:

--- a/nltk/draw/__init__.py
+++ b/nltk/draw/__init__.py
@@ -8,7 +8,7 @@
 
 # Import Tkinter-based modules if Tkinter is installed
 try:
-    from six.moves import tkinter
+    import tkinter
 except ImportError:
     import warnings
 

--- a/nltk/draw/cfg.py
+++ b/nltk/draw/cfg.py
@@ -48,7 +48,7 @@ Visualization tools for CFGs.
 
 import re
 
-from six.moves.tkinter import (
+from tkinter import (
     Button,
     Canvas,
     Entry,

--- a/nltk/draw/cfg.py
+++ b/nltk/draw/cfg.py
@@ -48,7 +48,6 @@ Visualization tools for CFGs.
 
 import re
 
-from six import string_types
 from six.moves.tkinter import (
     Button,
     Canvas,
@@ -676,7 +675,7 @@ class CFGDemo(object):
                 ):
                     pass  # matching nonterminal
                 elif (
-                    isinstance(node, string_types)
+                    isinstance(node, str)
                     and isinstance(widget, TextWidget)
                     and node == widget.text()
                 ):

--- a/nltk/draw/table.py
+++ b/nltk/draw/table.py
@@ -11,7 +11,7 @@ Tkinter widgets for displaying multi-column listboxes and tables.
 
 import operator
 
-from six.moves.tkinter import Frame, Label, Listbox, Scrollbar, Tk
+from tkinter import Frame, Label, Listbox, Scrollbar, Tk
 
 
 ######################################################################

--- a/nltk/draw/tree.py
+++ b/nltk/draw/tree.py
@@ -9,7 +9,7 @@
 Graphically display a Tree.
 """
 
-from six.moves.tkinter import IntVar, Menu, Tk
+from tkinter import IntVar, Menu, Tk
 
 from nltk.util import in_idle
 from nltk.tree import Tree

--- a/nltk/draw/util.py
+++ b/nltk/draw/util.py
@@ -34,7 +34,7 @@ homepage (http://www.ags.uni-sb.de/~konrad/clig.html).
 
 """
 from abc import ABCMeta, abstractmethod
-from six.moves.tkinter import (
+from tkinter import (
     Button,
     Canvas,
     Entry,
@@ -50,7 +50,7 @@ from six.moves.tkinter import (
     Widget,
     RAISED,
 )
-from six.moves.tkinter_tkfiledialog import asksaveasfilename
+from tkinter.filedialog import asksaveasfilename
 
 from nltk.util import in_idle
 

--- a/nltk/draw/util.py
+++ b/nltk/draw/util.py
@@ -34,7 +34,6 @@ homepage (http://www.ags.uni-sb.de/~konrad/clig.html).
 
 """
 from abc import ABCMeta, abstractmethod
-from six import add_metaclass
 from six.moves.tkinter import (
     Button,
     Canvas,
@@ -60,8 +59,7 @@ from nltk.util import in_idle
 ##//////////////////////////////////////////////////////
 
 
-@add_metaclass(ABCMeta)
-class CanvasWidget(object):
+class CanvasWidget(metaclass=ABCMeta):
     """
     A collection of graphical elements and bindings used to display a
     complex object on a Tkinter ``Canvas``.  A canvas widget is

--- a/nltk/featstruct.py
+++ b/nltk/featstruct.py
@@ -93,8 +93,6 @@ import re
 import copy
 from functools import total_ordering
 
-from six import integer_types
-
 from nltk.internals import read_str, raise_unorderable_types
 from nltk.sem.logic import (
     Variable,
@@ -962,7 +960,7 @@ class FeatList(FeatStruct, list):
     _INDEX_ERROR = "Expected int or feature path.  Got %r."
 
     def __getitem__(self, name_or_path):
-        if isinstance(name_or_path, integer_types):
+        if isinstance(name_or_path, int):
             return list.__getitem__(self, name_or_path)
         elif isinstance(name_or_path, tuple):
             try:
@@ -982,7 +980,7 @@ class FeatList(FeatStruct, list):
         its value; otherwise, raise ``KeyError``."""
         if self._frozen:
             raise ValueError(_FROZEN_ERROR)
-        if isinstance(name_or_path, (integer_types, slice)):
+        if isinstance(name_or_path, (int, slice)):
             return list.__delitem__(self, name_or_path)
         elif isinstance(name_or_path, tuple):
             if len(name_or_path) == 0:
@@ -1001,7 +999,7 @@ class FeatList(FeatStruct, list):
         ``KeyError``."""
         if self._frozen:
             raise ValueError(_FROZEN_ERROR)
-        if isinstance(name_or_path, (integer_types, slice)):
+        if isinstance(name_or_path, (int, slice)):
             return list.__setitem__(self, name_or_path, value)
         elif isinstance(name_or_path, tuple):
             if len(name_or_path) == 0:

--- a/nltk/featstruct.py
+++ b/nltk/featstruct.py
@@ -93,7 +93,7 @@ import re
 import copy
 from functools import total_ordering
 
-from six import integer_types, string_types
+from six import integer_types
 
 from nltk.internals import read_str, raise_unorderable_types
 from nltk.sem.logic import (
@@ -185,7 +185,7 @@ class FeatStruct(SubstituteBindingsI):
                     "Keyword arguments may only be specified "
                     "if features is None or is a mapping."
                 )
-            if isinstance(features, string_types):
+            if isinstance(features, str):
                 if FeatStructReader._START_FDICT_RE.match(features):
                     return FeatDict.__new__(FeatDict, features, **morefeatures)
                 else:
@@ -632,7 +632,7 @@ class FeatDict(FeatStruct, dict):
             ``morefeatures``, then the value from ``morefeatures`` will be
             used.
         """
-        if isinstance(features, string_types):
+        if isinstance(features, str):
             FeatStructReader().fromstring(features, self)
             self.update(**morefeatures)
         else:
@@ -647,7 +647,7 @@ class FeatDict(FeatStruct, dict):
     def __getitem__(self, name_or_path):
         """If the feature with the given name or path exists, return
         its value; otherwise, raise ``KeyError``."""
-        if isinstance(name_or_path, (string_types, Feature)):
+        if isinstance(name_or_path, (str, Feature)):
             return dict.__getitem__(self, name_or_path)
         elif isinstance(name_or_path, tuple):
             try:
@@ -687,7 +687,7 @@ class FeatDict(FeatStruct, dict):
         its value; otherwise, raise ``KeyError``."""
         if self._frozen:
             raise ValueError(_FROZEN_ERROR)
-        if isinstance(name_or_path, (string_types, Feature)):
+        if isinstance(name_or_path, (str, Feature)):
             return dict.__delitem__(self, name_or_path)
         elif isinstance(name_or_path, tuple):
             if len(name_or_path) == 0:
@@ -706,7 +706,7 @@ class FeatDict(FeatStruct, dict):
         ``KeyError``."""
         if self._frozen:
             raise ValueError(_FROZEN_ERROR)
-        if isinstance(name_or_path, (string_types, Feature)):
+        if isinstance(name_or_path, (str, Feature)):
             return dict.__setitem__(self, name_or_path, value)
         elif isinstance(name_or_path, tuple):
             if len(name_or_path) == 0:
@@ -737,11 +737,11 @@ class FeatDict(FeatStruct, dict):
             raise ValueError("Expected mapping or list of tuples")
 
         for key, val in items:
-            if not isinstance(key, (string_types, Feature)):
+            if not isinstance(key, (str, Feature)):
                 raise TypeError("Feature names must be strings")
             self[key] = val
         for key, val in morefeatures.items():
-            if not isinstance(key, (string_types, Feature)):
+            if not isinstance(key, (str, Feature)):
                 raise TypeError("Feature names must be strings")
             self[key] = val
 
@@ -799,7 +799,7 @@ class FeatDict(FeatStruct, dict):
             elif (
                 display == "prefix"
                 and not prefix
-                and isinstance(fval, (Variable, string_types))
+                and isinstance(fval, (Variable, str))
             ):
                 prefix = "%s" % fval
             elif display == "slash" and not suffix:
@@ -951,7 +951,7 @@ class FeatList(FeatStruct, list):
             ``FeatStructReader``.  Otherwise, it should be a sequence
             of basic values and nested feature structures.
         """
-        if isinstance(features, string_types):
+        if isinstance(features, str):
             FeatStructReader().fromstring(features, self)
         else:
             list.__init__(self, features)
@@ -1848,7 +1848,7 @@ def _is_sequence(v):
     return (
         hasattr(v, "__iter__")
         and hasattr(v, "__len__")
-        and not isinstance(v, string_types)
+        and not isinstance(v, str)
     )
 
 
@@ -2049,7 +2049,7 @@ class Feature(object):
         return "*%s*" % self.name
 
     def __lt__(self, other):
-        if isinstance(other, string_types):
+        if isinstance(other, str):
             return True
         if not isinstance(other, Feature):
             raise_unorderable_types("<", self, other)

--- a/nltk/grammar.py
+++ b/nltk/grammar.py
@@ -71,8 +71,6 @@ with the right hand side (*rhs*) in a tree (*tree*) is known as
 import re
 from functools import total_ordering
 
-from six import string_types
-
 from nltk.util import transitive_closure, invert_graph
 from nltk.compat import unicode_repr
 from nltk.internals import raise_unorderable_types
@@ -153,7 +151,7 @@ class Nonterminal(object):
 
         :rtype: str
         """
-        if isinstance(self._symbol, string_types):
+        if isinstance(self._symbol, str):
             return "%s" % self._symbol
         else:
             return "%s" % unicode_repr(self._symbol)
@@ -164,7 +162,7 @@ class Nonterminal(object):
 
         :rtype: str
         """
-        if isinstance(self._symbol, string_types):
+        if isinstance(self._symbol, str):
             return "%s" % self._symbol
         else:
             return "%s" % unicode_repr(self._symbol)
@@ -287,7 +285,7 @@ class Production(object):
         :param rhs: The right-hand side of the new ``Production``.
         :type rhs: sequence(Nonterminal and terminal)
         """
-        if isinstance(rhs, string_types):
+        if isinstance(rhs, str):
             raise TypeError(
                 "production right hand side should be a list, " "not a string"
             )
@@ -1422,7 +1420,7 @@ def read_grammar(input, nonterm_parser, probabilistic=False, encoding=None):
     """
     if encoding is not None:
         input = input.decode(encoding)
-    if isinstance(input, string_types):
+    if isinstance(input, str):
         lines = input.split("\n")
     else:
         lines = input

--- a/nltk/inference/api.py
+++ b/nltk/inference/api.py
@@ -22,11 +22,8 @@ from abc import ABCMeta, abstractmethod
 import threading
 import time
 
-from six import add_metaclass
 
-
-@add_metaclass(ABCMeta)
-class Prover(object):
+class Prover(metaclass=ABCMeta):
     """
     Interface for trying to prove a goal from assumptions.  Both the goal and
     the assumptions are constrained to be formulas of ``logic.Expression``.
@@ -47,8 +44,7 @@ class Prover(object):
         """
 
 
-@add_metaclass(ABCMeta)
-class ModelBuilder(object):
+class ModelBuilder(metaclass=ABCMeta):
     """
     Interface for trying to build a model of set of formulas.
     Open formulas are assumed to be universally quantified.
@@ -73,8 +69,7 @@ class ModelBuilder(object):
         """
 
 
-@add_metaclass(ABCMeta)
-class TheoremToolCommand(object):
+class TheoremToolCommand(metaclass=ABCMeta):
     """
     This class holds a goal and a list of assumptions to be used in proving
     or model building.

--- a/nltk/inference/discourse.py
+++ b/nltk/inference/discourse.py
@@ -48,7 +48,6 @@ from abc import ABCMeta, abstractmethod
 from operator import and_, add
 from functools import reduce
 
-from six import add_metaclass
 
 from nltk.data import show_cfg
 from nltk.tag import RegexpTagger
@@ -62,8 +61,7 @@ from nltk.inference.mace import MaceCommand
 from nltk.inference.prover9 import Prover9Command
 
 
-@add_metaclass(ABCMeta)
-class ReadingCommand(object):
+class ReadingCommand(metaclass=ABCMeta):
     @abstractmethod
     def parse_to_readings(self, sentence):
         """

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -24,8 +24,6 @@ try:
 except ImportError:
     from xml.etree import ElementTree
 
-from six import string_types
-
 from nltk import compat
 
 ##########################################################################
@@ -62,7 +60,7 @@ def config_java(bin=None, options=None, verbose=False):
     )
 
     if options is not None:
-        if isinstance(options, string_types):
+        if isinstance(options, str):
             options = options.split()
         _java_options = list(options)
 
@@ -118,7 +116,7 @@ def java(cmd, classpath=None, stdin=None, stdout=None, stderr=None, blocking=Tru
     stdout = subprocess_output_dict.get(stdout, stdout)
     stderr = subprocess_output_dict.get(stderr, stderr)
 
-    if isinstance(cmd, string_types):
+    if isinstance(cmd, str):
         raise TypeError("cmd should be a list of strings")
 
     # Make sure we know where a java binary is.
@@ -126,7 +124,7 @@ def java(cmd, classpath=None, stdin=None, stdout=None, stderr=None, blocking=Tru
         config_java()
 
     # Set up the classpath.
-    if isinstance(classpath, string_types):
+    if isinstance(classpath, str):
         classpaths = [classpath]
     else:
         classpaths = list(classpath)
@@ -531,10 +529,10 @@ def find_file_iter(
     :param verbose: Whether or not to print path when a file is found.
     """
     file_names = [filename] + (file_names or [])
-    assert isinstance(filename, string_types)
-    assert not isinstance(file_names, string_types)
-    assert not isinstance(searchpath, string_types)
-    if isinstance(env_vars, string_types):
+    assert isinstance(filename, str)
+    assert not isinstance(file_names, str)
+    assert not isinstance(searchpath, str)
+    if isinstance(env_vars, str):
         env_vars = env_vars.split()
     yielded = False
 
@@ -723,9 +721,9 @@ def find_jar_iter(
     :param is_regex: Whether name is a regular expression.
     """
 
-    assert isinstance(name_pattern, string_types)
-    assert not isinstance(searchpath, string_types)
-    if isinstance(env_vars, string_types):
+    assert isinstance(name_pattern, str)
+    assert not isinstance(searchpath, str)
+    if isinstance(env_vars, str):
         env_vars = env_vars.split()
     yielded = False
 
@@ -941,7 +939,7 @@ class ElementWrapper(object):
             <Element "<?xml version='1.0' encoding='utf8'?>\n<test />">
 
         """
-        if isinstance(etree, string_types):
+        if isinstance(etree, str):
             etree = ElementTree.fromstring(etree)
         self.__dict__["_etree"] = etree
 

--- a/nltk/lm/api.py
+++ b/nltk/lm/api.py
@@ -10,7 +10,6 @@ import random
 from abc import ABCMeta, abstractmethod
 from bisect import bisect
 
-from six import add_metaclass
 
 from nltk.lm.counter import NgramCounter
 from nltk.lm.util import log_base2
@@ -19,8 +18,7 @@ from nltk.lm.vocabulary import Vocabulary
 from itertools import accumulate
 
 
-@add_metaclass(ABCMeta)
-class Smoothing:
+class Smoothing(metaclass=ABCMeta):
     """Ngram Smoothing Interface
 
     Implements Chen & Goodman 1995's idea that all smoothing algorithms have
@@ -73,8 +71,7 @@ def _weighted_choice(population, weights, random_generator=None):
     return population[bisect(cum_weights, total * threshold)]
 
 
-@add_metaclass(ABCMeta)
-class LanguageModel:
+class LanguageModel(metaclass=ABCMeta):
     """ABC for Language Models.
 
     Cannot be directly instantiated itself.

--- a/nltk/lm/counter.py
+++ b/nltk/lm/counter.py
@@ -12,7 +12,6 @@ Language Model Counter
 from collections import defaultdict
 from collections.abc import Sequence
 
-from six import string_types
 from nltk.probability import ConditionalFreqDist, FreqDist
 
 
@@ -147,7 +146,7 @@ class NgramCounter:
         """User-friendly access to ngram counts."""
         if isinstance(item, int):
             return self._counts[item]
-        elif isinstance(item, string_types):
+        elif isinstance(item, str):
             return self._counts.__getitem__(1)[item]
         elif isinstance(item, Sequence):
             return self._counts.__getitem__(len(item) + 1)[tuple(item)]

--- a/nltk/metrics/agreement.py
+++ b/nltk/metrics/agreement.py
@@ -73,8 +73,6 @@ import logging
 from itertools import groupby
 from operator import itemgetter
 
-from six import iteritems
-
 from nltk.probability import FreqDist, ConditionalFreqDist
 from nltk.internals import deprecated
 
@@ -264,7 +262,7 @@ class AnnotationTask(object):
         """
         total = 0.0
         label_freqs = FreqDist(x["labels"] for x in self.data)
-        for k, f in iteritems(label_freqs):
+        for k, f in label_freqs.items():
             total += f ** 2
         Ae = total / ((len(self.I) * len(self.C)) ** 2)
         return (self.avg_Ao() - Ae) / (1 - Ae)
@@ -304,8 +302,8 @@ class AnnotationTask(object):
     def Disagreement(self, label_freqs):
         total_labels = sum(label_freqs.values())
         pairs = 0.0
-        for j, nj in iteritems(label_freqs):
-            for l, nl in iteritems(label_freqs):
+        for j, nj in label_freqs.items():
+            for l, nl in label_freqs.items():
                 pairs += float(nj * nl) * self.distance(l, j)
         return 1.0 * pairs / (total_labels * (total_labels - 1))
 

--- a/nltk/metrics/association.py
+++ b/nltk/metrics/association.py
@@ -15,7 +15,6 @@ import math as _math
 from abc import ABCMeta, abstractmethod
 from functools import reduce
 
-from six import add_metaclass
 
 _log2 = lambda x: _math.log(x, 2.0)
 _ln = _math.log
@@ -44,8 +43,7 @@ TOTAL = -1
 """Marginals index for the number of words in the data"""
 
 
-@add_metaclass(ABCMeta)
-class NgramAssocMeasures(object):
+class NgramAssocMeasures(metaclass=ABCMeta):
     """
     An abstract class defining a collection of generic association measures.
     Each public method returns a score, taking the following arguments::

--- a/nltk/metrics/scores.py
+++ b/nltk/metrics/scores.py
@@ -11,8 +11,6 @@ import operator
 from random import shuffle
 from functools import reduce
 
-from six.moves import range, zip
-
 try:
     from scipy.stats.stats import betai
 except ImportError:

--- a/nltk/metrics/segmentation.py
+++ b/nltk/metrics/segmentation.py
@@ -45,8 +45,6 @@ try:
 except ImportError:
     pass
 
-from six.moves import range
-
 
 def windowdiff(seg1, seg2, k, boundary="1", weighted=False):
     """

--- a/nltk/misc/chomsky.py
+++ b/nltk/misc/chomsky.py
@@ -118,8 +118,6 @@ scope of a complex symbol.
 import textwrap, random
 from itertools import chain, islice
 
-from six.moves import zip
-
 
 def generate_chomsky(times=5, line_length=72):
     parts = []

--- a/nltk/parse/chart.py
+++ b/nltk/parse/chart.py
@@ -41,8 +41,6 @@ import re
 import warnings
 from functools import total_ordering
 
-from six.moves import range
-
 from nltk.tree import Tree
 from nltk.grammar import PCFG, is_nonterminal, is_terminal
 from nltk.util import OrderedDict

--- a/nltk/parse/dependencygraph.py
+++ b/nltk/parse/dependencygraph.py
@@ -20,8 +20,6 @@ from pprint import pformat
 import subprocess
 import warnings
 
-from six import string_types
-
 from nltk.tree import Tree
 
 #################################################################
@@ -328,7 +326,7 @@ class DependencyGraph(object):
             10: extract_10_cells,
         }
 
-        if isinstance(input_, string_types):
+        if isinstance(input_, str):
             input_ = (line for line in input_.split("\n"))
 
         lines = (l.rstrip() for l in input_)

--- a/nltk/parse/earleychart.py
+++ b/nltk/parse/earleychart.py
@@ -26,8 +26,6 @@ The main parser class is ``EarleyChartParser``, which is a top-down
 algorithm, originally formulated by Jay Earley (1970).
 """
 
-from six.moves import range
-
 from nltk.compat import time_clock
 from nltk.parse.chart import (
     Chart,

--- a/nltk/parse/earleychart.py
+++ b/nltk/parse/earleychart.py
@@ -25,7 +25,6 @@ This is appealing for, say, speech recognizer hypothesis filtering.
 The main parser class is ``EarleyChartParser``, which is a top-down
 algorithm, originally formulated by Jay Earley (1970).
 """
-from __future__ import print_function, division
 
 from six.moves import range
 

--- a/nltk/parse/featurechart.py
+++ b/nltk/parse/featurechart.py
@@ -12,8 +12,6 @@ Extension of chart parsing implementation to handle grammars with
 feature structures as nodes.
 """
 
-from six.moves import range
-
 from nltk.compat import time_clock
 from nltk.featstruct import FeatStruct, unify, TYPE, find_variables
 from nltk.sem import logic

--- a/nltk/parse/malt.py
+++ b/nltk/parse/malt.py
@@ -14,8 +14,6 @@ import tempfile
 import subprocess
 import inspect
 
-from six import text_type
-
 from nltk.data import ZipFilePathPointer
 from nltk.internals import find_dir, find_file, find_jars_within_path
 
@@ -182,7 +180,7 @@ class MaltParser(ParserI):
             ) as output_file:
                 # Convert list of sentences to CONLL format.
                 for line in taggedsents_to_conll(sentences):
-                    input_file.write(text_type(line))
+                    input_file.write(str(line))
                 input_file.close()
 
                 # Generate command to run maltparser.
@@ -290,7 +288,7 @@ class MaltParser(ParserI):
             prefix="malt_train.conll.", dir=self.working_dir, mode="w", delete=False
         ) as input_file:
             input_str = "\n".join(dg.to_conll(10) for dg in depgraphs)
-            input_file.write(text_type(input_str))
+            input_file.write(str(input_str))
         # Trains the model with the malt_train.conll
         self.train_from_file(input_file.name, verbose=verbose)
         # Removes the malt_train.conll once training finishes.
@@ -311,7 +309,7 @@ class MaltParser(ParserI):
             ) as input_file:
                 with conll_file.open() as conll_input_file:
                     conll_str = conll_input_file.read()
-                    input_file.write(text_type(conll_str))
+                    input_file.write(str(conll_str))
                 return self.train_from_file(input_file.name, verbose=verbose)
 
         # Generate command to run maltparser.

--- a/nltk/parse/nonprojectivedependencyparser.py
+++ b/nltk/parse/nonprojectivedependencyparser.py
@@ -10,8 +10,6 @@
 import math
 import logging
 
-from six.moves import range
-
 from nltk.parse.dependencygraph import DependencyGraph
 
 logger = logging.getLogger(__name__)

--- a/nltk/parse/stanford.py
+++ b/nltk/parse/stanford.py
@@ -13,8 +13,6 @@ import warnings
 from unittest import skip
 from subprocess import PIPE
 
-from six import text_type
-
 from nltk.internals import (
     find_jar_iter,
     config_java,
@@ -243,7 +241,7 @@ class GenericStanfordParser(ParserI):
         # Windows is incompatible with NamedTemporaryFile() without passing in delete=False.
         with tempfile.NamedTemporaryFile(mode="wb", delete=False) as input_file:
             # Write the actual sentences to the temporary input file
-            if isinstance(input_, text_type) and encoding:
+            if isinstance(input_, str) and encoding:
                 input_ = input_.encode(encoding)
             input_file.write(input_)
             input_file.flush()

--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -46,7 +46,7 @@ from collections import defaultdict, Counter
 from functools import reduce
 from abc import ABCMeta, abstractmethod
 
-from six import itervalues, add_metaclass
+from six import itervalues
 
 from nltk.internals import raise_unorderable_types
 
@@ -454,8 +454,7 @@ class FreqDist(Counter):
 ##//////////////////////////////////////////////////////
 
 
-@add_metaclass(ABCMeta)
-class ProbDistI(object):
+class ProbDistI(metaclass=ABCMeta):
     """
     A probability distribution for the outcomes of an experiment.  A
     probability distribution specifies how likely it is that an
@@ -2106,8 +2105,7 @@ class ConditionalFreqDist(defaultdict):
 
 
 
-@add_metaclass(ABCMeta)
-class ConditionalProbDistI(dict):
+class ConditionalProbDistI(dict, metaclass=ABCMeta):
     """
     A collection of probability distributions for a single experiment
     run under different conditions.  Conditional probability

--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -46,7 +46,7 @@ from collections import defaultdict, Counter
 from functools import reduce
 from abc import ABCMeta, abstractmethod
 
-from six import itervalues, text_type, add_metaclass
+from six import itervalues, add_metaclass
 
 from nltk.internals import raise_unorderable_types
 
@@ -297,7 +297,7 @@ class FreqDist(Counter):
 
         ax.plot(freqs, **kwargs)
         ax.set_xticks(range(len(samples)))
-        ax.set_xticklabels([text_type(s) for s in samples], rotation=90)
+        ax.set_xticklabels([str(s) for s in samples], rotation=90)
         ax.set_xlabel("Samples")
         ax.set_ylabel(ylabel)
 
@@ -1955,7 +1955,7 @@ class ConditionalFreqDist(defaultdict):
             ax.legend(loc=legend_loc)
             ax.grid(True, color="silver")
             ax.set_xticks(range(len(samples)))
-            ax.set_xticklabels([text_type(s) for s in samples], rotation=90)
+            ax.set_xticklabels([str(s) for s in samples], rotation=90)
             if title:
                 ax.set_title(title)
             ax.set_xlabel("Samples")

--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -46,8 +46,6 @@ from collections import defaultdict, Counter
 from functools import reduce
 from abc import ABCMeta, abstractmethod
 
-from six import itervalues
-
 from nltk.internals import raise_unorderable_types
 
 _NINF = float("-1e300")
@@ -1894,7 +1892,7 @@ class ConditionalFreqDist(defaultdict):
 
         :rtype: int
         """
-        return sum(fdist.N() for fdist in itervalues(self))
+        return sum(fdist.N() for fdist in self.values())
 
     def plot(self, *args, **kwargs):
         """

--- a/nltk/sem/chat80.py
+++ b/nltk/sem/chat80.py
@@ -128,8 +128,6 @@ import shelve
 import os
 import sys
 
-from six import string_types
-
 import nltk.data
 
 ###########################################################################
@@ -727,7 +725,7 @@ def concepts(items=items):
     :return: the ``Concept`` objects which are extracted from the relations
     :rtype: list(Concept)
     """
-    if isinstance(items, string_types):
+    if isinstance(items, str):
         items = (items,)
 
     rels = [item_metadata[r] for r in items]

--- a/nltk/sem/drt.py
+++ b/nltk/sem/drt.py
@@ -10,8 +10,6 @@ import operator
 from functools import reduce
 from itertools import chain
 
-from six import string_types
-
 from nltk.sem.logic import (
     APP,
     AbstractVariableExpression,
@@ -1157,7 +1155,7 @@ class DrsDrawer(object):
         :param y: the left side of the current drawing area
         :return: the bottom-rightmost point
         """
-        if isinstance(item, string_types):
+        if isinstance(item, str):
             self.canvas.create_text(x, y, anchor="nw", font=self.canvas.font, text=item)
         elif isinstance(item, tuple):
             # item is the lower-right of a box
@@ -1179,7 +1177,7 @@ class DrsDrawer(object):
         :param y: the left side of the current drawing area
         :return: the bottom-rightmost point
         """
-        if isinstance(item, string_types):
+        if isinstance(item, str):
             return (x + self.canvas.font.measure(item), y + self._get_text_height())
         elif isinstance(item, tuple):
             return item

--- a/nltk/sem/drt.py
+++ b/nltk/sem/drt.py
@@ -40,8 +40,8 @@ from nltk.sem.logic import (
 
 # Import Tkinter-based modules if they are available
 try:
-    from six.moves.tkinter import Canvas, Tk
-    from six.moves.tkinter_font import Font
+    from tkinter import Canvas, Tk
+    from tkinter.font import Font
     from nltk.util import in_idle
 
 except ImportError:
@@ -1426,7 +1426,7 @@ def demo():
 
 def test_draw():
     try:
-        from six.moves.tkinter import Tk
+        from tkinter import Tk
     except ImportError:
         from nose import SkipTest
 

--- a/nltk/sem/drt_glue_demo.py
+++ b/nltk/sem/drt_glue_demo.py
@@ -8,7 +8,7 @@
 # For license information, see LICENSE.TXT
 
 try:
-    from six.moves.tkinter import (
+    from tkinter import (
         Button,
         Frame,
         IntVar,
@@ -18,7 +18,7 @@ try:
         Scrollbar,
         Tk,
     )
-    from six.moves.tkinter_font import Font
+    from tkinter.font import Font
     from nltk.draw.util import CanvasFrame, ShowText
 
 except ImportError:
@@ -407,7 +407,7 @@ class DrtGlueDemo(object):
         )
         TITLE = "About: NLTK DRT Glue Demo"
         try:
-            from six.moves.tkinter_messagebox import Message
+            from tkinter.messagebox import Message
 
             Message(message=ABOUT, title=TITLE).show()
         except:

--- a/nltk/sem/evaluate.py
+++ b/nltk/sem/evaluate.py
@@ -20,8 +20,6 @@ import textwrap
 import re
 import sys
 
-from six import string_types
-
 from nltk.decorators import decorator  # this used in code that is commented out
 
 from nltk.sem.logic import (
@@ -97,7 +95,7 @@ def set2rel(s):
     """
     new = set()
     for elem in s:
-        if isinstance(elem, string_types):
+        if isinstance(elem, str):
             new.add((elem,))
         elif isinstance(elem, int):
             new.add((str(elem)))
@@ -135,7 +133,7 @@ class Valuation(dict):
         """
         super(Valuation, self).__init__()
         for (sym, val) in xs:
-            if isinstance(val, string_types) or isinstance(val, bool):
+            if isinstance(val, str) or isinstance(val, bool):
                 self[sym] = val
             elif isinstance(val, set):
                 self[sym] = set2rel(val)
@@ -162,7 +160,7 @@ class Valuation(dict):
         """Set-theoretic domain of the value-space of a Valuation."""
         dom = []
         for val in self.values():
-            if isinstance(val, string_types):
+            if isinstance(val, str):
                 dom.append(val)
             elif not isinstance(val, bool):
                 dom.extend(
@@ -550,7 +548,7 @@ class Model(object):
         indent = spacer + (spacer * nesting)
         candidates = []
 
-        if isinstance(varex, string_types):
+        if isinstance(varex, str):
             var = Variable(varex)
         else:
             var = varex

--- a/nltk/sem/glue.py
+++ b/nltk/sem/glue.py
@@ -9,8 +9,6 @@
 import os
 from itertools import chain
 
-from six import string_types
-
 import nltk
 from nltk.internals import Counter
 from nltk.tag import UnigramTagger, BigramTagger, TrigramTagger, RegexpTagger
@@ -41,7 +39,7 @@ class GlueFormula(object):
         if not indices:
             indices = set()
 
-        if isinstance(meaning, string_types):
+        if isinstance(meaning, str):
             self.meaning = Expression.fromstring(meaning)
         elif isinstance(meaning, Expression):
             self.meaning = meaning
@@ -51,7 +49,7 @@ class GlueFormula(object):
                 % (meaning, meaning.__class__)
             )
 
-        if isinstance(glue, string_types):
+        if isinstance(glue, str):
             self.glue = linearlogic.LinearLogicParser().parse(glue)
         elif isinstance(glue, linearlogic.Expression):
             self.glue = glue
@@ -732,7 +730,7 @@ class DrtGlueFormula(GlueFormula):
         if not indices:
             indices = set()
 
-        if isinstance(meaning, string_types):
+        if isinstance(meaning, str):
             self.meaning = drt.DrtExpression.fromstring(meaning)
         elif isinstance(meaning, drt.DrtExpression):
             self.meaning = meaning
@@ -742,7 +740,7 @@ class DrtGlueFormula(GlueFormula):
                 % (meaning, meaning.__class__)
             )
 
-        if isinstance(glue, string_types):
+        if isinstance(glue, str):
             self.glue = linearlogic.LinearLogicParser().parse(glue)
         elif isinstance(glue, linearlogic.Expression):
             self.glue = glue

--- a/nltk/sem/hole.py
+++ b/nltk/sem/hole.py
@@ -22,8 +22,6 @@ convert that representation into first-order logic formulas.
 
 from functools import reduce
 
-from six import itervalues
-
 from nltk.parse import load_parser
 
 from nltk.sem.skolemize import skolemize
@@ -141,7 +139,7 @@ class HoleSemantics(object):
 
     def _find_top_nodes(self, node_list):
         top_nodes = node_list.copy()
-        for f in itervalues(self.fragments):
+        for f in self.fragments.values():
             # the label is the first argument of the predicate
             args = f[1]
             for arg in args:

--- a/nltk/sem/linearlogic.py
+++ b/nltk/sem/linearlogic.py
@@ -6,8 +6,6 @@
 # URL: <http://nltk.org/>
 # For license information, see LICENSE.TXT
 
-from six import string_types
-
 from nltk.internals import Counter
 from nltk.sem.logic import LogicParser, APP
 
@@ -97,7 +95,7 @@ class AtomicExpression(Expression):
         :param name: str for the constant name
         :param dependencies: list of int for the indices on which this atom is dependent
         """
-        assert isinstance(name, string_types)
+        assert isinstance(name, str)
         self.name = name
 
         if not dependencies:

--- a/nltk/sem/logic.py
+++ b/nltk/sem/logic.py
@@ -16,8 +16,6 @@ import operator
 from collections import defaultdict
 from functools import reduce, total_ordering
 
-from six import string_types
-
 from nltk.util import Trie
 from nltk.internals import Counter
 
@@ -621,7 +619,7 @@ class Variable(object):
         """
         :param name: the name of the variable
         """
-        assert isinstance(name, string_types), "%s is not a string" % name
+        assert isinstance(name, str), "%s is not a string" % name
         self.name = name
 
     def __eq__(self, other):
@@ -836,7 +834,7 @@ ANY_TYPE = AnyType()
 
 
 def read_type(type_string):
-    assert isinstance(type_string, string_types)
+    assert isinstance(type_string, str)
     type_string = type_string.replace(" ", "")  # remove spaces
 
     if type_string[0] == "<":
@@ -1963,7 +1961,7 @@ def is_indvar(expr):
     :param expr: str
     :return: bool True if expr is of the correct form
     """
-    assert isinstance(expr, string_types), "%s is not a string" % expr
+    assert isinstance(expr, str), "%s is not a string" % expr
     return re.match(r"^[a-df-z]\d*$", expr) is not None
 
 
@@ -1975,7 +1973,7 @@ def is_funcvar(expr):
     :param expr: str
     :return: bool True if expr is of the correct form
     """
-    assert isinstance(expr, string_types), "%s is not a string" % expr
+    assert isinstance(expr, str), "%s is not a string" % expr
     return re.match(r"^[A-Z]\d*$", expr) is not None
 
 
@@ -1987,7 +1985,7 @@ def is_eventvar(expr):
     :param expr: str
     :return: bool True if expr is of the correct form
     """
-    assert isinstance(expr, string_types), "%s is not a string" % expr
+    assert isinstance(expr, str), "%s is not a string" % expr
     return re.match(r"^e\d*$", expr) is not None
 
 

--- a/nltk/sem/relextract.py
+++ b/nltk/sem/relextract.py
@@ -23,9 +23,8 @@ The two serialization outputs are "rtuple" and "clause".
 # todo: get a more general solution to canonicalized symbols for clauses -- maybe use xmlcharrefs?
 
 from collections import defaultdict
+import html
 import re
-
-from six.moves import html_entities
 
 # Dictionary that associates corpora with NE classes
 NE_CLASSES = {
@@ -102,7 +101,7 @@ def _join(lst, sep=" ", untag=False):
         return sep.join(tuple2str(tup) for tup in lst)
 
 
-def descape_entity(m, defs=html_entities.entitydefs):
+def descape_entity(m, defs=html.entities.entitydefs):
     """
     Translate one entity to its ISO Latin value.
     Inspired by example from effbot.org

--- a/nltk/stem/api.py
+++ b/nltk/stem/api.py
@@ -8,11 +8,9 @@
 # For license information, see LICENSE.TXT
 
 from abc import ABCMeta, abstractmethod
-from six import add_metaclass
 
 
-@add_metaclass(ABCMeta)
-class StemmerI(object):
+class StemmerI(metaclass=ABCMeta):
     """
     A processing interface for removing morphological affixes from
     words.  This process is known as stemming.

--- a/nltk/stem/snowball.py
+++ b/nltk/stem/snowball.py
@@ -25,7 +25,6 @@ There is also a demo function: `snowball.demo()`.
 """
 
 import re
-from six.moves import input
 
 from nltk.corpus import stopwords
 from nltk.stem import porter

--- a/nltk/tag/api.py
+++ b/nltk/tag/api.py
@@ -13,15 +13,13 @@ information, such as its part of speech.
 from abc import ABCMeta, abstractmethod
 from itertools import chain
 
-from six import add_metaclass
 
 from nltk.internals import overridden
 from nltk.metrics import accuracy
 from nltk.tag.util import untag
 
 
-@add_metaclass(ABCMeta)
-class TaggerI(object):
+class TaggerI(metaclass=ABCMeta):
     """
     A processing interface for assigning a tag to each token in a list.
     Tags are case sensitive strings that identify some property of each

--- a/nltk/tag/hmm.py
+++ b/nltk/tag/hmm.py
@@ -72,8 +72,6 @@ which includes extensive demonstration code.
 import re
 import itertools
 
-from six.moves import map, zip
-
 try:
     import numpy as np
 except ImportError:

--- a/nltk/tag/hunpos.py
+++ b/nltk/tag/hunpos.py
@@ -15,8 +15,6 @@ A module for interfacing with the HunPos open-source POS-tagger.
 import os
 from subprocess import Popen, PIPE
 
-from six import text_type
-
 from nltk.internals import find_binary, find_file
 from nltk.tag.api import TaggerI
 
@@ -123,7 +121,7 @@ class HunposTagger(TaggerI):
         """
         for token in tokens:
             assert "\n" not in token, "Tokens should not contain newlines"
-            if isinstance(token, text_type):
+            if isinstance(token, str):
                 token = token.encode(self._encoding)
             self._hunpos.stdin.write(token + b"\n")
         # We write a final empty line to tell hunpos that the sentence is finished:

--- a/nltk/tag/stanford.py
+++ b/nltk/tag/stanford.py
@@ -23,8 +23,6 @@ import tempfile
 from subprocess import PIPE
 import warnings
 
-from six import text_type
-
 from nltk.internals import find_file, find_jar, config_java, java, _java_options
 from nltk.tag.api import TaggerI
 
@@ -106,7 +104,7 @@ class StanfordTagger(TaggerI):
         # Write the actual sentences to the temporary input file
         _input_fh = os.fdopen(_input_fh, "wb")
         _input = "\n".join((" ".join(x) for x in sentences))
-        if isinstance(_input, text_type) and encoding:
+        if isinstance(_input, str) and encoding:
             _input = _input.encode(encoding)
         _input_fh.write(_input)
         _input_fh.close()

--- a/nltk/tbl/feature.py
+++ b/nltk/tbl/feature.py
@@ -9,11 +9,9 @@
 # For license information, see  LICENSE.TXT
 
 from abc import ABCMeta, abstractmethod
-from six import add_metaclass
 
 
-@add_metaclass(ABCMeta)
-class Feature:
+class Feature(metaclass=ABCMeta):
     """
     An abstract base class for Features. A Feature is a combination of
     a specific property-computing method and a list of relative positions

--- a/nltk/tbl/rule.py
+++ b/nltk/tbl/rule.py
@@ -9,7 +9,6 @@
 # For license information, see  LICENSE.TXT
 
 from abc import ABCMeta, abstractmethod
-from six import add_metaclass
 
 from nltk.compat import unicode_repr
 from nltk import jsontags
@@ -18,8 +17,7 @@ from nltk import jsontags
 ######################################################################
 # Tag Rules
 ######################################################################
-@add_metaclass(ABCMeta)
-class TagRule:
+class TagRule(metaclass=ABCMeta):
     """
     An interface for tag transformations on a tagged corpus, as
     performed by tbl taggers.  Each transformation finds all tokens

--- a/nltk/tbl/template.py
+++ b/nltk/tbl/template.py
@@ -9,14 +9,12 @@
 # For license information, see  LICENSE.TXT
 
 from abc import ABCMeta, abstractmethod
-from six import add_metaclass
 import itertools as it
 from nltk.tbl.feature import Feature
 from nltk.tbl.rule import Rule
 
 
-@add_metaclass(ABCMeta)
-class BrillTemplateI:
+class BrillTemplateI(metaclass=ABCMeta):
     """
     An interface for generating lists of transformational rules that
     apply at given sentence positions.  ``BrillTemplateI`` is used by

--- a/nltk/test/childes_fixt.py
+++ b/nltk/test/childes_fixt.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 
 def setup_module(module):

--- a/nltk/test/classify_fixt.py
+++ b/nltk/test/classify_fixt.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 
 # most of classify.doctest requires numpy

--- a/nltk/test/compat_fixt.py
+++ b/nltk/test/compat_fixt.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 from nltk.compat import PY3
 
 

--- a/nltk/test/corpus_fixt.py
+++ b/nltk/test/corpus_fixt.py
@@ -1,4 +1,3 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 from nltk.corpus import teardown_module

--- a/nltk/test/data.doctest
+++ b/nltk/test/data.doctest
@@ -20,8 +20,7 @@ takes as its first argument a URL specifying what file should be
 loaded.  The ``nltk:`` protocol loads files from the NLTK data
 distribution:
 
-    >>> from __future__ import print_function
-    >>> tokenizer = nltk.data.load('nltk:tokenizers/punkt/english.pickle')
+     >>> tokenizer = nltk.data.load('nltk:tokenizers/punkt/english.pickle')
     >>> tokenizer.tokenize('Hello.  This is a test.  It works!')
     ['Hello.', 'This is a test.', 'It works!']
 

--- a/nltk/test/data.doctest
+++ b/nltk/test/data.doctest
@@ -20,7 +20,7 @@ takes as its first argument a URL specifying what file should be
 loaded.  The ``nltk:`` protocol loads files from the NLTK data
 distribution:
 
-     >>> tokenizer = nltk.data.load('nltk:tokenizers/punkt/english.pickle')
+    >>> tokenizer = nltk.data.load('nltk:tokenizers/punkt/english.pickle')
     >>> tokenizer.tokenize('Hello.  This is a test.  It works!')
     ['Hello.', 'This is a test.', 'It works!']
 

--- a/nltk/test/discourse_fixt.py
+++ b/nltk/test/discourse_fixt.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 
 # FIXME: the entire discourse.doctest is skipped if Prover9/Mace4 is

--- a/nltk/test/doctest_nose_plugin.py
+++ b/nltk/test/doctest_nose_plugin.py
@@ -112,7 +112,7 @@ class DoctestPluginHelper(object):
 
     def _patchTestCase(self, case):
         if case:
-            case._dt_test.globs["print_function"] = print_function
+            case._dt_test.globs["print_function"] = print
             case._dt_checker = _checker
         return case
 

--- a/nltk/test/doctest_nose_plugin.py
+++ b/nltk/test/doctest_nose_plugin.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function
 import re
 import sys
 import os

--- a/nltk/test/featgram.doctest
+++ b/nltk/test/featgram.doctest
@@ -9,7 +9,7 @@
 
 Grammars can be parsed from strings.
 
-     >>> import nltk
+    >>> import nltk
     >>> from nltk import grammar, parse
     >>> g = """
     ... % start DP

--- a/nltk/test/featgram.doctest
+++ b/nltk/test/featgram.doctest
@@ -9,8 +9,7 @@
 
 Grammars can be parsed from strings.
 
-    >>> from __future__ import print_function
-    >>> import nltk
+     >>> import nltk
     >>> from nltk import grammar, parse
     >>> g = """
     ... % start DP

--- a/nltk/test/featstruct.doctest
+++ b/nltk/test/featstruct.doctest
@@ -4,8 +4,7 @@
 ==================================
  Feature Structures & Unification
 ==================================
-    >>> from __future__ import print_function
-    >>> from nltk.featstruct import FeatStruct
+     >>> from nltk.featstruct import FeatStruct
     >>> from nltk.sem.logic import Variable, VariableExpression, Expression
 
 .. note:: For now, featstruct uses the older lambdalogic semantics

--- a/nltk/test/featstruct.doctest
+++ b/nltk/test/featstruct.doctest
@@ -4,7 +4,7 @@
 ==================================
  Feature Structures & Unification
 ==================================
-     >>> from nltk.featstruct import FeatStruct
+    >>> from nltk.featstruct import FeatStruct
     >>> from nltk.sem.logic import Variable, VariableExpression, Expression
 
 .. note:: For now, featstruct uses the older lambdalogic semantics

--- a/nltk/test/gensim_fixt.py
+++ b/nltk/test/gensim_fixt.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 
 def setup_module(module):

--- a/nltk/test/gluesemantics_malt_fixt.py
+++ b/nltk/test/gluesemantics_malt_fixt.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 
 def setup_module(module):

--- a/nltk/test/inference_fixt.py
+++ b/nltk/test/inference_fixt.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 
 def setup_module(module):

--- a/nltk/test/metrics.doctest
+++ b/nltk/test/metrics.doctest
@@ -8,7 +8,6 @@ Metrics
 The `nltk.metrics` package provides a variety of *evaluation measures*
 which can be used for a wide variety of NLP tasks.
 
-   >>> from __future__ import print_function
    >>> from nltk.metrics import *
 
 ------------------

--- a/nltk/test/nonmonotonic_fixt.py
+++ b/nltk/test/nonmonotonic_fixt.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 
 def setup_module(module):

--- a/nltk/test/portuguese_en_fixt.py
+++ b/nltk/test/portuguese_en_fixt.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 from nltk.compat import PY3
 
 from nltk.corpus import teardown_module

--- a/nltk/test/probability_fixt.py
+++ b/nltk/test/probability_fixt.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 
 # probability.doctest uses HMM which requires numpy;

--- a/nltk/test/runtests.py
+++ b/nltk/test/runtests.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, print_function
 import sys
 import os
 import nose

--- a/nltk/test/segmentation_fixt.py
+++ b/nltk/test/segmentation_fixt.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 
 # skip segmentation.doctest if numpy is not available

--- a/nltk/test/semantics_fixt.py
+++ b/nltk/test/semantics_fixt.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 # reset the variables counter before running tests
 def setup_module(module):

--- a/nltk/test/simple.doctest
+++ b/nltk/test/simple.doctest
@@ -8,8 +8,7 @@ EasyInstall Tests
 This file contains some simple tests that will be run by EasyInstall in
 order to test the installation when NLTK-Data is absent.
 
-    >>> from __future__ import print_function
-
+ 
 ------------
 Tokenization
 ------------

--- a/nltk/test/stem.doctest
+++ b/nltk/test/stem.doctest
@@ -11,7 +11,7 @@ Overview
 Stemmers remove morphological affixes from words, leaving only the
 word stem.
 
-     >>> from nltk.stem import *
+    >>> from nltk.stem import *
 
 Unit tests for the Porter stemmer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/nltk/test/stem.doctest
+++ b/nltk/test/stem.doctest
@@ -11,8 +11,7 @@ Overview
 Stemmers remove morphological affixes from words, leaving only the
 word stem.
 
-    >>> from __future__ import print_function
-    >>> from nltk.stem import *
+     >>> from nltk.stem import *
 
 Unit tests for the Porter stemmer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/nltk/test/tokenize.doctest
+++ b/nltk/test/tokenize.doctest
@@ -1,8 +1,7 @@
 .. Copyright (C) 2001-2019 NLTK Project
 .. For license information, see LICENSE.TXT
 
-    >>> from __future__ import print_function
-    >>> from nltk.tokenize import *
+     >>> from nltk.tokenize import *
 
 Regression Tests: Treebank Tokenizer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/nltk/test/tokenize.doctest
+++ b/nltk/test/tokenize.doctest
@@ -1,7 +1,7 @@
 .. Copyright (C) 2001-2019 NLTK Project
 .. For license information, see LICENSE.TXT
 
-     >>> from nltk.tokenize import *
+    >>> from nltk.tokenize import *
 
 Regression Tests: Treebank Tokenizer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/nltk/test/translate_fixt.py
+++ b/nltk/test/translate_fixt.py
@@ -1,4 +1,3 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 from nltk.corpus import teardown_module

--- a/nltk/test/unit/lm/test_counter.py
+++ b/nltk/test/unit/lm/test_counter.py
@@ -7,8 +7,6 @@
 
 import unittest
 
-import six
-
 from nltk import FreqDist
 from nltk.lm import NgramCounter
 from nltk.util import everygrams
@@ -53,8 +51,8 @@ class NgramCounterTests(unittest.TestCase):
         bigrams = self.trigram_counter[2]
         trigrams = self.trigram_counter[3]
 
-        six.assertCountEqual(self, expected_bigram_contexts, bigrams.conditions())
-        six.assertCountEqual(self, expected_trigram_contexts, trigrams.conditions())
+        self.assertCountEqual(expected_bigram_contexts, bigrams.conditions())
+        self.assertCountEqual(expected_trigram_contexts, trigrams.conditions())
 
     def test_bigram_counts_seen_ngrams(self):
         b_given_a_count = 1
@@ -104,7 +102,7 @@ class NgramCounterTrainingTests(unittest.TestCase):
 
         self.assertFalse(bool(counter[3]))
         self.assertFalse(bool(counter[2]))
-        six.assertCountEqual(self, words, counter[1].keys())
+        self.assertCountEqual(words, counter[1].keys())
 
     def test_train_on_illegal_sentences(self):
         str_sent = ["Check", "this", "out", "!"]
@@ -129,6 +127,6 @@ class NgramCounterTrainingTests(unittest.TestCase):
         bigram_contexts = [("a",), ("c",)]
         trigram_contexts = [("e", "f")]
 
-        six.assertCountEqual(self, unigrams, counter[1].keys())
-        six.assertCountEqual(self, bigram_contexts, counter[2].keys())
-        six.assertCountEqual(self, trigram_contexts, counter[3].keys())
+        self.assertCountEqual(unigrams, counter[1].keys())
+        self.assertCountEqual(bigram_contexts, counter[2].keys())
+        self.assertCountEqual(trigram_contexts, counter[3].keys())

--- a/nltk/test/unit/lm/test_models.py
+++ b/nltk/test/unit/lm/test_models.py
@@ -9,7 +9,6 @@
 import math
 import unittest
 
-from six import add_metaclass
 
 from nltk.lm import (
     Vocabulary,
@@ -77,8 +76,7 @@ class ParametrizeTestsMeta(type):
         return test
 
 
-@add_metaclass(ParametrizeTestsMeta)
-class MleBigramTests(unittest.TestCase):
+class MleBigramTests(unittest.TestCase, metaclass=ParametrizeTestsMeta):
     """Unit tests for MLE ngram model."""
 
     score_tests = [
@@ -157,8 +155,7 @@ class MleBigramTests(unittest.TestCase):
         self.assertAlmostEqual(perplexity, self.model.perplexity(text), places=4)
 
 
-@add_metaclass(ParametrizeTestsMeta)
-class MleTrigramTests(unittest.TestCase):
+class MleTrigramTests(unittest.TestCase, metaclass=ParametrizeTestsMeta):
     """MLE trigram model tests"""
 
     score_tests = [
@@ -182,8 +179,7 @@ class MleTrigramTests(unittest.TestCase):
         self.model.fit(training_text)
 
 
-@add_metaclass(ParametrizeTestsMeta)
-class LidstoneBigramTests(unittest.TestCase):
+class LidstoneBigramTests(unittest.TestCase, metaclass=ParametrizeTestsMeta):
     """Unit tests for Lidstone class"""
 
     score_tests = [
@@ -241,8 +237,7 @@ class LidstoneBigramTests(unittest.TestCase):
         self.assertAlmostEqual(perplexity, self.model.perplexity(text), places=4)
 
 
-@add_metaclass(ParametrizeTestsMeta)
-class LidstoneTrigramTests(unittest.TestCase):
+class LidstoneTrigramTests(unittest.TestCase, metaclass=ParametrizeTestsMeta):
     score_tests = [
         # Logic behind this is the same as for bigram model
         ("d", ["c"], 1.1 / 1.8),
@@ -259,8 +254,7 @@ class LidstoneTrigramTests(unittest.TestCase):
         self.model.fit(training_text)
 
 
-@add_metaclass(ParametrizeTestsMeta)
-class LaplaceBigramTests(unittest.TestCase):
+class LaplaceBigramTests(unittest.TestCase, metaclass=ParametrizeTestsMeta):
     """Unit tests for Laplace class"""
 
     score_tests = [
@@ -320,8 +314,7 @@ class LaplaceBigramTests(unittest.TestCase):
         self.assertAlmostEqual(perplexity, self.model.perplexity(text), places=4)
 
 
-@add_metaclass(ParametrizeTestsMeta)
-class WittenBellInterpolatedTrigramTests(unittest.TestCase):
+class WittenBellInterpolatedTrigramTests(unittest.TestCase, metaclass=ParametrizeTestsMeta):
     def setUp(self):
         vocab, training_text = _prepare_test_data(3)
         self.model = WittenBellInterpolated(3, vocabulary=vocab)
@@ -352,8 +345,7 @@ class WittenBellInterpolatedTrigramTests(unittest.TestCase):
     ]
 
 
-@add_metaclass(ParametrizeTestsMeta)
-class KneserNeyInterpolatedTrigramTests(unittest.TestCase):
+class KneserNeyInterpolatedTrigramTests(unittest.TestCase, metaclass=ParametrizeTestsMeta):
     def setUp(self):
         vocab, training_text = _prepare_test_data(3)
         self.model = KneserNeyInterpolated(3, vocabulary=vocab)

--- a/nltk/test/unit/lm/test_models.py
+++ b/nltk/test/unit/lm/test_models.py
@@ -5,7 +5,6 @@
 # URL: <http://nltk.org/>
 # For license information, see LICENSE.TXT
 
-from __future__ import division
 
 import math
 import unittest

--- a/nltk/test/unit/lm/test_vocabulary.py
+++ b/nltk/test/unit/lm/test_vocabulary.py
@@ -60,8 +60,8 @@ class NgramModelVocabularyTests(unittest.TestCase):
         vocab_counts = ["a", "b", "c", "d", "e", "f", "g", "w", "z"]
         vocab_items = ["a", "b", "d", "e", "<UNK>"]
 
-        six.assertCountEqual(self, vocab_counts, list(self.vocab.counts.keys()))
-        six.assertCountEqual(self, vocab_items, list(self.vocab))
+        self.assertCountEqual(vocab_counts, list(self.vocab.counts.keys()))
+        self.assertCountEqual(vocab_items, list(self.vocab))
 
     def test_update_empty_vocab(self):
         empty = Vocabulary(unk_cutoff=2)

--- a/nltk/test/unit/lm/test_vocabulary.py
+++ b/nltk/test/unit/lm/test_vocabulary.py
@@ -8,7 +8,6 @@
 import unittest
 from collections import Counter
 
-import six
 from nltk.lm import Vocabulary
 
 

--- a/nltk/test/unit/test_2x_compat.py
+++ b/nltk/test/unit/test_2x_compat.py
@@ -3,7 +3,6 @@
 Unit tests for nltk.compat.
 See also nltk/test/compat.doctest.
 """
-from __future__ import absolute_import, unicode_literals
 import unittest
 
 from nltk.text import Text

--- a/nltk/test/unit/test_aline.py
+++ b/nltk/test/unit/test_aline.py
@@ -3,7 +3,6 @@
 Unit tests for nltk.metrics.aline
 """
 
-from __future__ import unicode_literals
 
 import unittest
 

--- a/nltk/test/unit/test_chunk.py
+++ b/nltk/test/unit/test_chunk.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
 import unittest
 
 from nltk import RegexpParser

--- a/nltk/test/unit/test_classify.py
+++ b/nltk/test/unit/test_classify.py
@@ -2,7 +2,6 @@
 """
 Unit tests for nltk.classify. See also: nltk/test/classify.doctest
 """
-from __future__ import absolute_import
 from nose import SkipTest
 from nltk import classify
 

--- a/nltk/test/unit/test_collocations.py
+++ b/nltk/test/unit/test_collocations.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
 import unittest
 
 from nltk.collocations import BigramCollocationFinder

--- a/nltk/test/unit/test_concordance.py
+++ b/nltk/test/unit/test_concordance.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
 
 import unittest
 import contextlib

--- a/nltk/test/unit/test_corpora.py
+++ b/nltk/test/unit/test_corpora.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
 import unittest
 
 from nltk.corpus import (

--- a/nltk/test/unit/test_corpus_views.py
+++ b/nltk/test/unit/test_corpus_views.py
@@ -2,7 +2,6 @@
 """
 Corpus View Regression Tests
 """
-from __future__ import absolute_import, unicode_literals
 import unittest
 import nltk.data
 from nltk.corpus.reader.util import (

--- a/nltk/test/unit/test_disagreement.py
+++ b/nltk/test/unit/test_disagreement.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
 import unittest
 
 from nltk.metrics.agreement import AnnotationTask

--- a/nltk/test/unit/test_hmm.py
+++ b/nltk/test/unit/test_hmm.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
 from nltk.tag import hmm
 
 

--- a/nltk/test/unit/test_json2csv_corpus.py
+++ b/nltk/test/unit/test_json2csv_corpus.py
@@ -15,8 +15,6 @@ package.
 import os
 import unittest
 
-from six.moves import zip
-
 from nltk.compat import TemporaryDirectory
 from nltk.corpus import twitter_samples
 from nltk.twitter.common import json2csv, json2csv_entities

--- a/nltk/test/unit/test_naivebayes.py
+++ b/nltk/test/unit/test_naivebayes.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function, unicode_literals
 
 
 import unittest

--- a/nltk/test/unit/test_nombank.py
+++ b/nltk/test/unit/test_nombank.py
@@ -3,7 +3,6 @@
 Unit tests for nltk.corpus.nombank
 """
 
-from __future__ import unicode_literals
 import unittest
 
 from nltk.corpus import nombank

--- a/nltk/test/unit/test_pos_tag.py
+++ b/nltk/test/unit/test_pos_tag.py
@@ -3,7 +3,6 @@
 Tests for nltk.pos_tag
 """
 
-from __future__ import unicode_literals
 
 import unittest
 

--- a/nltk/test/unit/test_rte_classify.py
+++ b/nltk/test/unit/test_rte_classify.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function, unicode_literals
 
 import unittest
 

--- a/nltk/test/unit/test_seekable_unicode_stream_reader.py
+++ b/nltk/test/unit/test_seekable_unicode_stream_reader.py
@@ -3,7 +3,6 @@
 The following test performs a random series of reads, seeks, and
 tells, and checks that the results are consistent.
 """
-from __future__ import absolute_import, unicode_literals
 import random
 import functools
 from io import BytesIO

--- a/nltk/test/unit/test_senna.py
+++ b/nltk/test/unit/test_senna.py
@@ -3,7 +3,6 @@
 Unit tests for Senna
 """
 
-from __future__ import unicode_literals
 from os import environ, path, sep
 
 import logging

--- a/nltk/test/unit/test_stem.py
+++ b/nltk/test/unit/test_stem.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function, unicode_literals
 
 import os
 import unittest

--- a/nltk/test/unit/test_tag.py
+++ b/nltk/test/unit/test_tag.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
 
 
 def test_basic():

--- a/nltk/test/unit/test_tgrep.py
+++ b/nltk/test/unit/test_tgrep.py
@@ -15,8 +15,6 @@ Unit tests for nltk.tgrep.
 
 import unittest
 
-from six import b
-
 from nltk.tree import ParentedTree
 from nltk import tgrep
 
@@ -65,7 +63,7 @@ class TestSequenceFunctions(unittest.TestCase):
         Test that tokenization handles bytes and strs the same way.
         '''
         self.assertEqual(
-            tgrep.tgrep_tokenize(b('A .. (B !< C . D) | ![<< (E , F) $ G]')),
+            tgrep.tgrep_tokenize(b'A .. (B !< C . D) | ![<< (E , F) $ G]'),
             tgrep.tgrep_tokenize('A .. (B !< C . D) | ![<< (E , F) $ G]'),
         )
 
@@ -268,15 +266,15 @@ class TestSequenceFunctions(unittest.TestCase):
             '(S (NP (DT the) (JJ big) (NN dog)) ' '(VP bit) (NP (DT a) (NN cat)))'
         )
         self.assertEqual(
-            list(tgrep.tgrep_positions(b('NN'), [tree])),
-            list(tgrep.tgrep_positions('NN', [tree])),
+            list(tgrep.tgrep_positions(b'NN', [tree])),
+            list(tgrep.tgrep_positions(b'NN', [tree])),
         )
         self.assertEqual(
-            list(tgrep.tgrep_nodes(b('NN'), [tree])),
+            list(tgrep.tgrep_nodes(b'NN', [tree])),
             list(tgrep.tgrep_nodes('NN', [tree])),
         )
         self.assertEqual(
-            list(tgrep.tgrep_positions(b('NN|JJ'), [tree])),
+            list(tgrep.tgrep_positions(b'NN|JJ', [tree])),
             list(tgrep.tgrep_positions('NN|JJ', [tree])),
         )
 

--- a/nltk/test/unit/test_tgrep.py
+++ b/nltk/test/unit/test_tgrep.py
@@ -12,7 +12,6 @@
 Unit tests for nltk.tgrep.
 '''
 
-from __future__ import absolute_import, print_function, unicode_literals
 
 import unittest
 

--- a/nltk/test/unit/test_tokenize.py
+++ b/nltk/test/unit/test_tokenize.py
@@ -4,7 +4,6 @@ Unit tests for nltk.tokenize.
 See also nltk/test/tokenize.doctest
 """
 
-from __future__ import unicode_literals
 
 import unittest
 

--- a/nltk/test/unit/test_wordnet.py
+++ b/nltk/test/unit/test_wordnet.py
@@ -4,7 +4,6 @@ Unit tests for nltk.corpus.wordnet
 See also nltk/test/wordnet.doctest
 """
 
-from __future__ import unicode_literals
 
 import collections
 import os

--- a/nltk/test/unit/utils.py
+++ b/nltk/test/unit/utils.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 from unittest import TestCase
 from functools import wraps
 from nose.plugins.skip import SkipTest

--- a/nltk/test/util.doctest
+++ b/nltk/test/util.doctest
@@ -5,7 +5,7 @@
 Utility functions
 =================
 
-     >>> from nltk.util import *
+    >>> from nltk.util import *
     >>> from nltk.tree import Tree
 
     >>> print_string("This is a long string, therefore it should break", 25)

--- a/nltk/test/util.doctest
+++ b/nltk/test/util.doctest
@@ -5,8 +5,7 @@
 Utility functions
 =================
 
-    >>> from __future__ import print_function
-    >>> from nltk.util import *
+     >>> from nltk.util import *
     >>> from nltk.tree import Tree
 
     >>> print_string("This is a long string, therefore it should break", 25)

--- a/nltk/test/wordnet.doctest
+++ b/nltk/test/wordnet.doctest
@@ -6,7 +6,6 @@ WordNet Interface
 =================
 
 WordNet is just another NLTK corpus reader, and can be imported like this:
-    >>> from __future__ import print_function, unicode_literals
     >>> from nltk.corpus import wordnet
 
 For more compact code, we recommend:

--- a/nltk/test/wordnet_fixt.py
+++ b/nltk/test/wordnet_fixt.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 
 def teardown_module(module=None):

--- a/nltk/text.py
+++ b/nltk/text.py
@@ -20,8 +20,6 @@ from functools import reduce
 import re
 import sys
 
-from six import text_type
-
 from nltk.lm import MLE
 from nltk.lm.preprocessing import padded_everygram_pipeline
 from nltk.probability import FreqDist
@@ -341,9 +339,9 @@ class Text(object):
             self.name = name
         elif "]" in tokens[:20]:
             end = tokens[:20].index("]")
-            self.name = " ".join(text_type(tok) for tok in tokens[1:end])
+            self.name = " ".join(str(tok) for tok in tokens[1:end])
         else:
-            self.name = " ".join(text_type(tok) for tok in tokens[:8]) + "..."
+            self.name = " ".join(str(tok) for tok in tokens[:8]) + "..."
 
     # ////////////////////////////////////////////////////////////
     # Support item & slice access

--- a/nltk/tgrep.py
+++ b/nltk/tgrep.py
@@ -113,8 +113,6 @@ macro definitions to ``m`` and initialises ``l`` to an empty dictionary.
 import functools
 import re
 
-from six import binary_type, text_type
-
 try:
     import pyparsing
 except ImportError:
@@ -303,7 +301,7 @@ def _tgrep_node_literal_value(node):
     Gets the string value of a given parse tree node, for comparison
     using the tgrep node literal predicates.
     """
-    return node.label() if _istree(node) else text_type(node)
+    return node.label() if _istree(node) else str(node)
 
 
 def _tgrep_macro_use_action(_s, _l, tokens):
@@ -963,7 +961,7 @@ def tgrep_tokenize(tgrep_string):
     Tokenizes a TGrep search string into separate tokens.
     """
     parser = _build_tgrep_parser(False)
-    if isinstance(tgrep_string, binary_type):
+    if isinstance(tgrep_string, bytes):
         tgrep_string = tgrep_string.decode()
     return list(parser.parseString(tgrep_string))
 
@@ -974,7 +972,7 @@ def tgrep_compile(tgrep_string):
     lambda function.
     """
     parser = _build_tgrep_parser(True)
-    if isinstance(tgrep_string, binary_type):
+    if isinstance(tgrep_string, bytes):
         tgrep_string = tgrep_string.decode()
     return list(parser.parseString(tgrep_string, parseAll=True))[0]
 
@@ -1007,7 +1005,7 @@ def tgrep_positions(pattern, trees, search_leaves=True):
     :rtype: iter(tree positions)
     """
 
-    if isinstance(pattern, (binary_type, text_type)):
+    if isinstance(pattern, (bytes, str)):
         pattern = tgrep_compile(pattern)
 
     for tree in trees:
@@ -1034,7 +1032,7 @@ def tgrep_nodes(pattern, trees, search_leaves=True):
     :rtype: iter(tree nodes)
     """
 
-    if isinstance(pattern, (binary_type, text_type)):
+    if isinstance(pattern, (bytes, str)):
         pattern = tgrep_compile(pattern)
 
     for tree in trees:

--- a/nltk/tokenize/api.py
+++ b/nltk/tokenize/api.py
@@ -11,14 +11,12 @@ Tokenizer Interface
 """
 
 from abc import ABCMeta, abstractmethod
-from six import add_metaclass
 
 from nltk.internals import overridden
 from nltk.tokenize.util import string_span_tokenize
 
 
-@add_metaclass(ABCMeta)
-class TokenizerI(object):
+class TokenizerI(metaclass=ABCMeta):
     """
     A processing interface for tokenizing a string.
     Subclasses must define ``tokenize()`` or ``tokenize_sents()`` (or both).

--- a/nltk/tokenize/casual.py
+++ b/nltk/tokenize/casual.py
@@ -36,8 +36,7 @@ domains and tasks. The basic logic is this:
 ######################################################################
 
 import regex  # https://github.com/nltk/nltk/issues/2409
-
-from six.moves import html_entities
+import html
 
 ######################################################################
 # The following strings are components in the regular expression
@@ -238,7 +237,7 @@ def _replace_html_entities(text, keep=(), remove_illegal=True, encoding="utf-8")
             if entity_body in keep:
                 return match.group(0)
             else:
-                number = html_entities.name2codepoint.get(entity_body)
+                number = html.entities.name2codepoint.get(entity_body)
         if number is not None:
             try:
                 return chr(number)

--- a/nltk/tokenize/casual.py
+++ b/nltk/tokenize/casual.py
@@ -37,7 +37,6 @@ domains and tasks. The basic logic is this:
 
 import regex  # https://github.com/nltk/nltk/issues/2409
 
-from six import int2byte, unichr
 from six.moves import html_entities
 
 ######################################################################
@@ -232,7 +231,7 @@ def _replace_html_entities(text, keep=(), remove_illegal=True, encoding="utf-8")
                 # to bytes 80-9F in the Windows-1252 encoding. For more info
                 # see: https://en.wikipedia.org/wiki/ISO/IEC_8859-1#Similar_character_sets
                 if 0x80 <= number <= 0x9F:
-                    return int2byte(number).decode("cp1252")
+                    return bytes((number,)).decode("cp1252")
             except ValueError:
                 number = None
         else:
@@ -242,7 +241,7 @@ def _replace_html_entities(text, keep=(), remove_illegal=True, encoding="utf-8")
                 number = html_entities.name2codepoint.get(entity_body)
         if number is not None:
             try:
-                return unichr(number)
+                return chr(number)
             except ValueError:
                 pass
 

--- a/nltk/tokenize/nist.py
+++ b/nltk/tokenize/nist.py
@@ -15,7 +15,6 @@ which was also ported into Python in
 https://github.com/lium-lst/nmtpy/blob/master/nmtpy/metrics/mtevalbleu.py#L162
 """
 
-from __future__ import unicode_literals
 
 import io
 import re

--- a/nltk/tokenize/nist.py
+++ b/nltk/tokenize/nist.py
@@ -18,7 +18,6 @@ https://github.com/lium-lst/nmtpy/blob/master/nmtpy/metrics/mtevalbleu.py#L162
 
 import io
 import re
-from six import text_type
 
 from nltk.corpus import perluniprops
 from nltk.tokenize.api import TokenizerI
@@ -31,7 +30,6 @@ class NISTTokenizer(TokenizerI):
     paragraph-based tokenization from mteval-14.pl; The sentence-based
     tokenization is consistent with the other tokenizers available in NLTK.
 
-    >>> from six import text_type
     >>> from nltk.tokenize.nist import NISTTokenizer
     >>> nist = NISTTokenizer()
     >>> s = "Good muffins cost $3.88 in New York."
@@ -93,9 +91,9 @@ class NISTTokenizer(TokenizerI):
     ]
 
     # Perluniprops characters used in NIST tokenizer.
-    pup_number = text_type("".join(set(perluniprops.chars("Number"))))  # i.e. \p{N}
-    pup_punct = text_type("".join(set(perluniprops.chars("Punctuation"))))  # i.e. \p{P}
-    pup_symbol = text_type("".join(set(perluniprops.chars("Symbol"))))  # i.e. \p{S}
+    pup_number = str("".join(set(perluniprops.chars("Number"))))  # i.e. \p{N}
+    pup_punct = str("".join(set(perluniprops.chars("Punctuation"))))  # i.e. \p{P}
+    pup_symbol = str("".join(set(perluniprops.chars("Symbol"))))  # i.e. \p{S}
 
     # Python regexes needs to escape some special symbols, see
     # see https://stackoverflow.com/q/45670950/610569
@@ -108,8 +106,8 @@ class NISTTokenizer(TokenizerI):
     #       (ii) de-deuplicate spaces.
     #       In Python, this would do: ' '.join(str.strip().split())
     # Thus, the next two lines were commented out.
-    # Line_Separator = text_type(''.join(perluniprops.chars('Line_Separator'))) # i.e. \p{Zl}
-    # Separator = text_type(''.join(perluniprops.chars('Separator'))) # i.e. \p{Z}
+    # Line_Separator = str(''.join(perluniprops.chars('Line_Separator'))) # i.e. \p{Zl}
+    # Separator = str(''.join(perluniprops.chars('Separator'))) # i.e. \p{Z}
 
     # Pads non-ascii strings with space.
     NONASCII = re.compile("([\x00-\x7f]+)"), r" \1 "
@@ -140,7 +138,7 @@ class NISTTokenizer(TokenizerI):
         return text
 
     def tokenize(self, text, lowercase=False, western_lang=True, return_str=False):
-        text = text_type(text)
+        text = str(text)
         # Language independent regex.
         text = self.lang_independent_sub(text)
         # Language dependent regex.
@@ -155,13 +153,13 @@ class NISTTokenizer(TokenizerI):
         text = " ".join(text.split())
         # Finally, strips heading and trailing spaces
         # and converts output string into unicode.
-        text = text_type(text.strip())
+        text = str(text.strip())
         return text if return_str else text.split()
 
     def international_tokenize(
         self, text, lowercase=False, split_non_ascii=True, return_str=False
     ):
-        text = text_type(text)
+        text = str(text)
         # Different from the 'normal' tokenize(), STRIP_EOL_HYPHEN is applied
         # first before unescaping.
         regexp, substitution = self.STRIP_SKIP

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -108,8 +108,6 @@ import re
 import math
 from collections import defaultdict
 
-from six import string_types
-
 from nltk.compat import unicode_repr
 from nltk.probability import FreqDist
 from nltk.tokenize.api import TokenizerI
@@ -1258,7 +1256,7 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
         given. Repeated calls to this method destroy previous parameters. For
         incremental training, instantiate a separate PunktTrainer instance.
         """
-        if not isinstance(train_text, string_types):
+        if not isinstance(train_text, str):
             return train_text
         return PunktTrainer(
             train_text, lang_vars=self._lang_vars, token_cls=self._Token

--- a/nltk/tokenize/repp.py
+++ b/nltk/tokenize/repp.py
@@ -14,8 +14,6 @@ import sys
 import subprocess
 import tempfile
 
-from six import text_type
-
 from nltk.data import ZipFilePathPointer
 from nltk.internals import find_dir
 
@@ -87,7 +85,7 @@ class ReppTokenizer(TokenizerI):
         ) as input_file:
             # Write sentences to temporary input file.
             for sent in sentences:
-                input_file.write(text_type(sent) + "\n")
+                input_file.write(str(sent) + "\n")
             input_file.close()
             # Generate command to run REPP.
             cmd = self.generate_repp_command(input_file.name)

--- a/nltk/tokenize/stanford.py
+++ b/nltk/tokenize/stanford.py
@@ -13,8 +13,6 @@ import json
 from subprocess import PIPE
 import warnings
 
-from six import text_type
-
 from nltk.internals import find_jar, config_java, java, _java_options
 from nltk.tokenize.api import TokenizerI
 from nltk.parse.corenlp import CoreNLPParser
@@ -99,7 +97,7 @@ class StanfordTokenizer(TokenizerI):
         # Windows is incompatible with NamedTemporaryFile() without passing in delete=False.
         with tempfile.NamedTemporaryFile(mode="wb", delete=False) as input_file:
             # Write the actual sentences to the temporary input file
-            if isinstance(input_, text_type) and encoding:
+            if isinstance(input_, str) and encoding:
                 input_ = input_.encode(encoding)
             input_file.write(input_)
             input_file.flush()

--- a/nltk/tokenize/stanford_segmenter.py
+++ b/nltk/tokenize/stanford_segmenter.py
@@ -17,8 +17,6 @@ import json
 import warnings
 from subprocess import PIPE
 
-from six import text_type
-
 from nltk.internals import (
     find_jar,
     find_file,
@@ -242,7 +240,7 @@ class StanfordSegmenter(TokenizerI):
         # Write the actural sentences to the temporary input file
         _input_fh = os.fdopen(_input_fh, "wb")
         _input = "\n".join((" ".join(x) for x in sentences))
-        if isinstance(_input, text_type) and encoding:
+        if isinstance(_input, str) and encoding:
             _input = _input.encode(encoding)
         _input_fh.write(_input)
         _input_fh.close()

--- a/nltk/tokenize/toktok.py
+++ b/nltk/tokenize/toktok.py
@@ -22,7 +22,6 @@ Model (Doctoral dissertation). Columbus, OH, USA: The Ohio State University.
 """
 
 import re
-from six import text_type
 
 from nltk.tokenize.api import TokenizerI
 
@@ -88,7 +87,7 @@ class ToktokTokenizer(TokenizerI):
 
     # This is the \p{Open_Punctuation} from Perl's perluniprops
     # see http://perldoc.perl.org/perluniprops.html
-    OPEN_PUNCT = text_type(
+    OPEN_PUNCT = str(
         u"([{\u0f3a\u0f3c\u169b\u201a\u201e\u2045\u207d"
         u"\u208d\u2329\u2768\u276a\u276c\u276e\u2770\u2772"
         u"\u2774\u27c5\u27e6\u27e8\u27ea\u27ec\u27ee\u2983"
@@ -100,7 +99,7 @@ class ToktokTokenizer(TokenizerI):
         u"\ufe5d\uff08\uff3b\uff5b\uff5f\uff62"
     )
     # This is the \p{Close_Punctuation} from Perl's perluniprops
-    CLOSE_PUNCT = text_type(
+    CLOSE_PUNCT = str(
         u")]}\u0f3b\u0f3d\u169c\u2046\u207e\u208e\u232a"
         u"\u2769\u276b\u276d\u276f\u2771\u2773\u2775\u27c6"
         u"\u27e7\u27e9\u27eb\u27ed\u27ef\u2984\u2986\u2988"
@@ -112,7 +111,7 @@ class ToktokTokenizer(TokenizerI):
         u"\uff09\uff3d\uff5d\uff60\uff63"
     )
     # This is the \p{Close_Punctuation} from Perl's perluniprops
-    CURRENCY_SYM = text_type(
+    CURRENCY_SYM = str(
         u"$\xa2\xa3\xa4\xa5\u058f\u060b\u09f2\u09f3\u09fb"
         u"\u0af1\u0bf9\u0e3f\u17db\u20a0\u20a1\u20a2\u20a3"
         u"\u20a4\u20a5\u20a6\u20a7\u20a8\u20a9\u20aa\u20ab"
@@ -172,10 +171,10 @@ class ToktokTokenizer(TokenizerI):
     ]
 
     def tokenize(self, text, return_str=False):
-        text = text_type(text)  # Converts input string into unicode.
+        text = str(text)  # Converts input string into unicode.
         for regexp, subsitution in self.TOKTOK_REGEXES:
             text = regexp.sub(subsitution, text)
         # Finally, strips heading and trailing spaces
         # and converts output string into unicode.
-        text = text_type(text.strip())
+        text = str(text.strip())
         return text if return_str else text.split()

--- a/nltk/toolbox.py
+++ b/nltk/toolbox.py
@@ -14,8 +14,6 @@ Toolbox databases and settings files.
 import re, codecs
 from xml.etree.ElementTree import ElementTree, TreeBuilder, Element, SubElement
 
-from six import u
-
 from nltk.compat import StringIO, PY3
 from nltk.data import PathPointer, find
 
@@ -321,11 +319,11 @@ def to_sfm_string(tree, encoding=None, errors="strict", unicode_fields=None):
                     cur_encoding = encoding
                 if re.search(_is_value, value):
                     l.append(
-                        (u("\\%s %s\n") % (mkr, value)).encode(cur_encoding, errors)
+                        ("\\%s %s\n" % (mkr, value)).encode(cur_encoding, errors)
                     )
                 else:
                     l.append(
-                        (u("\\%s%s\n") % (mkr, value)).encode(cur_encoding, errors)
+                        ("\\%s%s\n" % (mkr, value)).encode(cur_encoding, errors)
                     )
             else:
                 if re.search(_is_value, value):

--- a/nltk/tree.py
+++ b/nltk/tree.py
@@ -18,7 +18,6 @@ import re
 import sys
 from abc import ABCMeta, abstractmethod
 
-from six import add_metaclass
 
 from nltk.grammar import Production, Nonterminal
 from nltk.probability import ProbabilisticMixIn
@@ -995,8 +994,7 @@ class ImmutableTree(Tree):
 ######################################################################
 ## Parented trees
 ######################################################################
-@add_metaclass(ABCMeta)
-class AbstractParentedTree(Tree):
+class AbstractParentedTree(Tree, metaclass=ABCMeta):
     """
     An abstract base class for a ``Tree`` that automatically maintains
     pointers to parent nodes.  These parent pointers are updated

--- a/nltk/tree.py
+++ b/nltk/tree.py
@@ -18,7 +18,7 @@ import re
 import sys
 from abc import ABCMeta, abstractmethod
 
-from six import string_types, add_metaclass
+from six import add_metaclass
 
 from nltk.grammar import Production, Nonterminal
 from nltk.probability import ProbabilisticMixIn
@@ -103,7 +103,7 @@ class Tree(list):
             raise TypeError(
                 "%s: Expected a node value and child list " % type(self).__name__
             )
-        elif isinstance(children, string_types):
+        elif isinstance(children, str):
             raise TypeError(
                 "%s() argument 2 should be a list, not a "
                 "string" % type(self).__name__
@@ -374,7 +374,7 @@ class Tree(list):
         :rtype: list(Production)
         """
 
-        if not isinstance(self._label, string_types):
+        if not isinstance(self._label, str):
             raise TypeError(
                 "Productions can only be generated from trees having node labels that are strings"
             )
@@ -647,7 +647,7 @@ class Tree(list):
             then it will return a tree of that type.
         :rtype: Tree
         """
-        if not isinstance(brackets, string_types) or len(brackets) != 2:
+        if not isinstance(brackets, str) or len(brackets) != 2:
             raise TypeError("brackets must be a length-2 string")
         if re.search("\s", brackets):
             raise TypeError("whitespace brackets not allowed")
@@ -860,7 +860,7 @@ class Tree(list):
             return s
 
         # If it doesn't fit on one line, then write it on multi-lines.
-        if isinstance(self._label, string_types):
+        if isinstance(self._label, str):
             s = "%s%s%s" % (parens[0], self._label, nodesep)
         else:
             s = "%s%s%s" % (parens[0], unicode_repr(self._label), nodesep)
@@ -873,7 +873,7 @@ class Tree(list):
                 )
             elif isinstance(child, tuple):
                 s += "\n" + " " * (indent + 2) + "/".join(child)
-            elif isinstance(child, string_types) and not quotes:
+            elif isinstance(child, str) and not quotes:
                 s += "\n" + " " * (indent + 2) + "%s" % child
             else:
                 s += "\n" + " " * (indent + 2) + unicode_repr(child)
@@ -909,11 +909,11 @@ class Tree(list):
                 childstrs.append(child._pformat_flat(nodesep, parens, quotes))
             elif isinstance(child, tuple):
                 childstrs.append("/".join(child))
-            elif isinstance(child, string_types) and not quotes:
+            elif isinstance(child, str) and not quotes:
                 childstrs.append("%s" % child)
             else:
                 childstrs.append(unicode_repr(child))
-        if isinstance(self._label, string_types):
+        if isinstance(self._label, str):
             return "%s%s%s %s%s" % (
                 parens[0],
                 self._label,

--- a/nltk/twitter/api.py
+++ b/nltk/twitter/api.py
@@ -16,7 +16,6 @@ import time as _time
 from abc import ABCMeta, abstractmethod
 from datetime import tzinfo, timedelta, datetime
 
-from six import add_metaclass
 
 from nltk.compat import UTC
 
@@ -51,8 +50,7 @@ class LocalTimezoneOffsetWithUTC(tzinfo):
 LOCAL = LocalTimezoneOffsetWithUTC()
 
 
-@add_metaclass(ABCMeta)
-class BasicTweetHandler(object):
+class BasicTweetHandler(metaclass=ABCMeta):
     """
     Minimal implementation of `TweetHandler`.
 

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -20,7 +20,6 @@ from pprint import pprint
 from collections import defaultdict, deque
 from sys import version_info
 
-from six import class_types
 from six.moves.urllib.request import (
     build_opener,
     install_opener,
@@ -43,7 +42,7 @@ from nltk.collections import *
 def usage(obj, selfname="self"):
     str(obj)  # In case it's lazy, this will load it.
 
-    if not isinstance(obj, class_types):
+    if not isinstance(obj, type):
         obj = obj.__class__
 
     print("%s supports the following operations:" % obj.__name__)

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -20,7 +20,7 @@ from pprint import pprint
 from collections import defaultdict, deque
 from sys import version_info
 
-from six import class_types, string_types, text_type
+from six import class_types
 from six.moves.urllib.request import (
     build_opener,
     install_opener,
@@ -202,7 +202,7 @@ def re_show(regexp, string, left="{", right="}"):
 def filestring(f):
     if hasattr(f, "read"):
         return f.read()
-    elif isinstance(f, string_types):
+    elif isinstance(f, str):
         with open(f, "r") as infile:
             return infile.read()
     else:
@@ -281,7 +281,7 @@ def guess_encoding(data):
         if not enc:
             continue
         try:
-            decoded = text_type(data, enc)
+            decoded = str(data, enc)
             successful_encoding = enc
 
         except (UnicodeError, LookupError):

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -20,7 +20,7 @@ from pprint import pprint
 from collections import defaultdict, deque
 from sys import version_info
 
-from six.moves.urllib.request import (
+from urllib.request import (
     build_opener,
     install_opener,
     getproxies,

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,6 @@ natural language processing.  NLTK requires Python 3.5, 3.6, or 3.7.""",
     ],
     package_data={"nltk": ["test/*.doctest", "VERSION"]},
     install_requires=[
-        "six",
         'singledispatch; python_version < "3.4"',
         "click",
         "joblib",

--- a/tools/find_deprecated.py
+++ b/tools/find_deprecated.py
@@ -7,7 +7,6 @@
 # URL: <http://nltk.org/>
 # For license information, see LICENSE.TXT
 
-from __future__ import print_function
 
 """
 This command-line tool takes a list of python files or directories,

--- a/tools/nltk_term_index.py
+++ b/tools/nltk_term_index.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 
 import re
 import sys

--- a/tools/run_doctests.py
+++ b/tools/run_doctests.py
@@ -4,7 +4,6 @@
 run doctests
 """
 
-from __future__ import print_function
 import sys
 import subprocess
 import os

--- a/tools/svnmime.py
+++ b/tools/svnmime.py
@@ -4,7 +4,6 @@
 # configured to automatically set mime types
 # http://code.google.com/p/support/wiki/FAQ
 
-from __future__ import print_function
 
 import os
 import sys


### PR DESCRIPTION
* Remove all `__future__` imports
* Remove dependency on `six`

See also #2296

There are still remaining changes like the `nltk/compat.py` file and various version-dependent branches. Additionally the documentation needs an update.