### PR TITLE
Removed unecessary keys call

### DIFF
--- a/nltk/chat/util.py
+++ b/nltk/chat/util.py
@@ -54,7 +54,7 @@ class Chat(object):
         self._regex = self._compile_reflections()
 
     def _compile_reflections(self):
-        sorted_refl = sorted(self._reflections.keys(), key=len, reverse=True)
+        sorted_refl = sorted(self._reflections, key=len, reverse=True)
         return re.compile(
             r"\b({0})\b".format("|".join(map(re.escape, sorted_refl))), re.IGNORECASE
         )


### PR DESCRIPTION

It is not necessary to call keys() in the argument to sorted. Iterating over a dict will give you the keys. self._reflections is sufficient.