### PR TITLE
Improve StringTokenizer class

### DIFF
--- a/nltk/tokenize/api.py
+++ b/nltk/tokenize/api.py
@@ -10,13 +10,13 @@
 Tokenizer Interface
 """
 
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 
 from nltk.internals import overridden
 from nltk.tokenize.util import string_span_tokenize
 
 
-class TokenizerI(metaclass=ABCMeta):
+class TokenizerI(ABC):
     """
     A processing interface for tokenizing a string.
     Subclasses must define ``tokenize()`` or ``tokenize_sents()`` (or both).
@@ -67,6 +67,11 @@ class StringTokenizer(TokenizerI):
     """A tokenizer that divides a string into substrings by splitting
     on the specified string (defined in subclasses).
     """
+
+    @property
+    @abstractmethod
+    def _string(self):
+        raise NotImplementedError
 
     def tokenize(self, s):
         return s.split(self._string)


### PR DESCRIPTION
- Related issue: #2526 

---

This PR improves the `StringTokenizer` class to provide a better error message for unimplemented abstract methods.

### Before:
```
from nltk.tokenize.api import StringTokenizer
StringTokenizer().tokenize('we')

---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-1-cd1b0f2bbaae> in <module>
      1 from nltk.tokenize.api import StringTokenizer
----> 2 StringTokenizer().tokenize('we')

nltk/tokenize/api.py in tokenize(self, s)
     70
     71     def tokenize(self, s):
---> 72         return s.split(self._string)
     73
     74     def span_tokenize(self, s):

AttributeError: 'StringTokenizer' object has no attribute '_string'
```

### After:
```
from nltk.tokenize.api import StringTokenizer
StringTokenizer().tokenize('this is a test')

---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-1-d5ba88710305> in <module>
      1 from nltk.tokenize.api import StringTokenizer
----> 2 StringTokenizer().tokenize('this is a test')

TypeError: Can't instantiate abstract class StringTokenizer with abstract methods _string
```