### PR TITLE
Fix punkt tokenizer complexity for very long tokens

### DIFF
--- a/nltk/test/tokenize.doctest
+++ b/nltk/test/tokenize.doctest
@@ -198,7 +198,7 @@ Two instances of PunktSentenceTokenizer should not share PunktParameters.
     >>> pst2 = PunktSentenceTokenizer()
     >>> pst._params is pst2._params
     False
-    
+
 Testing mutable default arguments for https://github.com/nltk/nltk/pull/2067
 
     >>> from nltk.tokenize.punkt import PunktBaseClass, PunktTrainer, PunktSentenceTokenizer
@@ -214,7 +214,7 @@ Testing mutable default arguments for https://github.com/nltk/nltk/pull/2067
     >>> pst = PunktSentenceTokenizer(lang_vars=None)
     >>> type(pst._lang_vars)
     <class 'nltk.tokenize.punkt.PunktLanguageVars'>
-    
+
 
 Regression Tests: align_tokens
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/nltk/test/unit/test_tokenize.py
+++ b/nltk/test/unit/test_tokenize.py
@@ -5,6 +5,7 @@ See also nltk/test/tokenize.doctest
 """
 
 
+import timeit
 import unittest
 
 from nose import SkipTest
@@ -13,6 +14,7 @@ from nose.tools import assert_equal
 from nltk.tokenize import (
     punkt,
     word_tokenize,
+    sent_tokenize,
     TweetTokenizer,
     StanfordSegmenter,
     TreebankWordTokenizer,
@@ -42,7 +44,7 @@ class TestTokenize(unittest.TestCase):
             'français',
         ]
         self.assertEqual(tokens, expected)
-        
+
     def test_sonority_sequencing_syllable_tokenizer(self):
         """
         Test SyllableTokenizer tokenizer.
@@ -108,23 +110,23 @@ class TestTokenize(unittest.TestCase):
         expected = ['(', '393', ')', "928 -3010"]
         result = tokenizer.tokenize(test2)
         self.assertEqual(result, expected)
-        
+
     def test_pad_asterisk(self):
         """
         Test padding of asterisk for word tokenization.
         """
         text = "This is a, *weird sentence with *asterisks in it."
-        expected = ['This', 'is', 'a', ',', '*', 'weird', 'sentence', 
+        expected = ['This', 'is', 'a', ',', '*', 'weird', 'sentence',
                     'with', '*', 'asterisks', 'in', 'it', '.']
         self.assertEqual(word_tokenize(text), expected)
-        
+
     def test_pad_dotdot(self):
         """
         Test padding of dotdot* for word tokenization.
         """
         text = "Why did dotdot.. not get tokenized but dotdotdot... did? How about manydots....."
-        expected = ['Why', 'did', 'dotdot', '..', 'not', 'get', 
-                    'tokenized', 'but', 'dotdotdot', '...', 'did', '?', 
+        expected = ['Why', 'did', 'dotdot', '..', 'not', 'get',
+                    'tokenized', 'but', 'dotdotdot', '...', 'did', '?',
                     'How', 'about', 'manydots', '.....']
         self.assertEqual(word_tokenize(text), expected)
 
@@ -382,15 +384,23 @@ class TestTokenize(unittest.TestCase):
         """
         Test word_tokenize function
         """
-        
+
         sentence = "The 'v', I've been fooled but I'll seek revenge."
-        expected = ['The', "'", 'v', "'", ',', 'I', "'ve", 'been', 'fooled', 
+        expected = ['The', "'", 'v', "'", ',', 'I', "'ve", 'been', 'fooled',
                     'but', 'I', "'ll", 'seek', 'revenge', '.']
         self.assertEqual(word_tokenize(sentence), expected)
-        
+
         sentence = "'v' 're'"
         expected = ["'", 'v', "'", "'re", "'"]
         self.assertEqual(word_tokenize(sentence), expected)
+
+    def test_word_tokenize_complexity(self):
+        """
+        Test word_tokenize function complexity
+        """
+        sentence = "a" * 30000
+        elapsed = timeit.timeit(lambda: word_tokenize(sentence), number=1)
+        assert elapsed < 3, "It should take less than 3 seconds to tokenize a long word"
 
     def test_punkt_pair_iter(self):
 


### PR DESCRIPTION
This change prevents N^2 complexity for inputs with very long tokens (N being the length of the longest token). Instead of using `finditer` with regex that starts from any point in the string, we use match method that starts only at the string beginning and moves from one opportunity to another (either end of next blank sequence of previous break).

**Why should we bother changing complexity**
I've discovered that while processing some real world conversational data. The current implementation choked on some strings having tokens 60k characters long (yes, over time, users will find all sorts of bottlenecks in the real system 🤷‍♂️), taking > 8s to tokenise that that string. Reducing to complexity to this brings the execution below few millis. I can't remember exact numbers, but can create some benchmark if it's bringing extra value here.

**What was N^2 exactly?**
Used regex can start at any position in the string. If we have a token
like 01234567890123...9, \S* starts matching 0 and matches everything till
the last 9 and then figures out that it does not have potential sentence
ending character.

Since finditer returns matches starting at any position, it tries matching with character 1, matches everything till the end and then does not find potential sentence ending, ... It does that matching N times, each time going through N/2 characters (on average).

**Complexity test**
I've found regression tests like the one I wrote useful. If you are ok with it, I can improve the robustness.