### PR TITLE
Mistake/bleu score.py

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -261,6 +261,7 @@
 - Alexandre H. T. Dias <https://github.com/alexandredias3d>
 - Jacob Weightman <https://github.com/jacobdweightman>
 - Bonifacio de Oliveira <https://github.com/Bonifacio2>
+- Yun Yuan <https://github.com/shushengyuan>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 ### Contributors to the Porter Stemmer

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -631,7 +631,7 @@ class SmoothingFunction:
     def method7(self, p_n, references, hypothesis, hyp_len=None, *args, **kwargs):
         """
         Smoothing method 7:
-        Interpolates methods 5 and 6.
+        Interpolates methods 4 and 5.
         """
         hyp_len = hyp_len if hyp_len else len(hypothesis)
         p_n = self.method4(p_n, references, hypothesis, hyp_len)


### PR DESCRIPTION
i just found a little mistake in nltk/translate/bleu_score.py where the comments of function Smoothing7 is wrong.
It should be
"
| Smoothing method 7:
| Interpolates methods 4 and 5.
"
rather then
"
| Smoothing method 7:
| Interpolates methods 5 and 6.
"