### PR TITLE
synset_from_sense_key: searching for sense key in index.sense

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -261,6 +261,7 @@
 - Alexandre H. T. Dias <https://github.com/alexandredias3d>
 - Jacob Weightman <https://github.com/jacobdweightman>
 - Bonifacio de Oliveira <https://github.com/Bonifacio2>
+- Jayr A. Pereira <https://github.com/jayralencar/>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 ### Contributors to the Porter Stemmer


### PR DESCRIPTION
I found a little mistake on the method ```synset_from_sense_key```:

On searching for the sense key ```bank%1:06:00::```, for example, it returns the synset ```Synset('bank.n.10')``` (offset: 00169305)  instead of ```Synset('bank.n.10')``` (offset: 02787772), which is the correct. See index.sense excerpt:

...
banjul%1:15:00:: 08946042 1 0
bank%1:04:00:: 00169305 10 0
**bank%1:06:00:: 02787772 9 0**
bank%1:06:01:: 04139859 8 0
bank%1:14:00:: 08420278 2 20
...

To fix it I used the same logic of the method ```lemma_from_key```, using ```_binary_search_file```.