### PR TITLE
Fix check for existing trigram_model in Text.generate()

### DIFF
--- a/nltk/text.py
+++ b/nltk/text.py
@@ -567,7 +567,7 @@ class Text(object):
         self._tokenized_sents = [
             sent.split(" ") for sent in sent_tokenize(" ".join(self.tokens))
         ]
-        if not hasattr(self, "trigram_model"):
+        if not hasattr(self, "_trigram_model"):
             print("Building ngram index...", file=sys.stderr)
             self._trigram_model = self._train_default_ngram_lm(
                 self._tokenized_sents, n=3


### PR DESCRIPTION
When generating text with `nlt.text.Text.generate()` a trigram model is created if one doesn't already exist, but the check to see if one exists has a small bug.

The check looks for the model at `self.trigram_model`, but it should look at `self._trigram_model`. This is defined two lines down. Since this check is never successful, it always creates a new model each time `generate()` is called.

This MR fixes this issue and speeds up multiple calls of `generate()`.