### PR TITLE
Fix exception causes in collections.py

### DIFF
--- a/nltk/collections.py
+++ b/nltk/collections.py
@@ -171,8 +171,8 @@ class AbstractLazySequence(object):
             # Use iterate_from to extract it.
             try:
                 return next(self.iterate_from(i))
-            except StopIteration:
-                raise IndexError("index out of range")
+            except StopIteration as e:
+                raise IndexError("index out of range") from e
 
     def __iter__(self):
         """Return an iterator that generates the tokens in the corpus
@@ -464,8 +464,8 @@ class LazyMap(AbstractLazySequence):
             # Calculate the value
             try:
                 val = next(self.iterate_from(index))
-            except StopIteration:
-                raise IndexError("index out of range")
+            except StopIteration as e:
+                raise IndexError("index out of range") from e
             # Update the cache
             if self._cache is not None:
                 if len(self._cache) > self._cache_size:


### PR DESCRIPTION
I recently went over [Matplotlib](https://github.com/matplotlib/matplotlib/pull/16706), [Pandas](https://github.com/pandas-dev/pandas/pull/32322) and [NumPy](https://github.com/numpy/numpy/pull/15731), fixing a small mistake in the way that Python 3's exception chaining is used. If you're interested, I can do it here too. I've done it on just one file right now. 

The mistake is this: In some parts of the code, an exception is being caught and replaced with a more user-friendly error. In these cases the syntax `raise new_error from old_error` needs to be used.

Python 3's exception chaining means it shows not only the traceback of the current exception, but that of the original exception (and possibly more.) This is regardless of `raise from`. The usage of `raise from` tells Python to put a more accurate message between the tracebacks. Instead of this: 

    During handling of the above exception, another exception occurred:

You'll get this: 

    The above exception was the direct cause of the following exception:

The first is inaccurate, because it signifies a bug in the exception-handling code itself, which is a separate situation than wrapping an exception.

Let me know what you think! 