### PR TITLE
FIX OverflowError in TweetTokenizer

### DIFF
--- a/nltk/tokenize/casual.py
+++ b/nltk/tokenize/casual.py
@@ -241,7 +241,7 @@ def _replace_html_entities(text, keep=(), remove_illegal=True, encoding="utf-8")
         if number is not None:
             try:
                 return chr(number)
-            except ValueError:
+            except ValueError, OverflowError:
                 pass
 
         return "" if remove_illegal else match.group(0)

--- a/nltk/tokenize/casual.py
+++ b/nltk/tokenize/casual.py
@@ -241,7 +241,7 @@ def _replace_html_entities(text, keep=(), remove_illegal=True, encoding="utf-8")
         if number is not None:
             try:
                 return chr(number)
-            except ValueError, OverflowError:
+            except (ValueError, OverflowError):
                 pass
 
         return "" if remove_illegal else match.group(0)


### PR DESCRIPTION
In python 3.7, `chr()` can raise `OverflowError` when value >= 0x80000000 (or < -0x80000000). This is encountered in https://github.com/nltk/nltk/issues/2557