### PR TITLE
performance test for vocabulary len being independent of its size

### DIFF
--- a/nltk/test/unit/lm/test_vocabulary.py
+++ b/nltk/test/unit/lm/test_vocabulary.py
@@ -7,6 +7,7 @@
 
 import unittest
 from collections import Counter
+from timeit import timeit
 
 from nltk.lm import Vocabulary
 
@@ -136,3 +137,17 @@ class NgramModelVocabularyTests(unittest.TestCase):
                 unk_cutoff=2,
             ),
         )
+
+    def test_len_is_constant(self):
+        # Given an obviously small and an obviously large vocabulary.
+        small_vocab = Vocabulary("abcde")
+        from nltk.corpus.europarl_raw import english
+
+        large_vocab = Vocabulary(english.words())
+
+        # If we time calling `len` on them.
+        small_vocab_len_time = timeit("len(small_vocab)", globals=locals())
+        large_vocab_len_time = timeit("len(large_vocab)", globals=locals())
+
+        # The timing should be the same order of magnitude.
+        self.assertAlmostEqual(small_vocab_len_time, large_vocab_len_time, places=1)


### PR DESCRIPTION
Small follow-up to recent work by @palasso.

I'm still not sure how robust this test will be to executing on other machines to be honest.

It also takes 2ish seconds on my computer, which means it'll add some overhead to the test suite overall. Not a big deal for CI, but may impact local development. At the same time, I personally don't actually run *all* the NLTK tests when I'm working on the `lm` module but only its tests.

If we at any point switch to `pytest` for managing tests, I could mark it (and some others) with a label so that they can be ignored when speed of test execution matters.