### PR TITLE
Bug fix/accommodate iteratables in everygrams resolves #2562

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -263,6 +263,7 @@
 - Bonifacio de Oliveira <https://github.com/Bonifacio2>
 - Vassilis Palassopoulos <https://github.com/palasso>
 - Ram Rachum <https://github.com/cool-RR>
+- Denali Molitor <https://github.com/dmmolitor>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 ### Contributors to the Porter Stemmer

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -264,6 +264,7 @@
 - Vassilis Palassopoulos <https://github.com/palasso>
 - Ram Rachum <https://github.com/cool-RR>
 - Denali Molitor <https://github.com/dmmolitor>
+- Jacob Moorman <https://github.com/jdmoorman>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 ### Contributors to the Porter Stemmer

--- a/nltk/lm/__init__.py
+++ b/nltk/lm/__init__.py
@@ -73,15 +73,7 @@ While not the most efficient, it is conceptually simple.
     >>> from nltk.util import everygrams
     >>> padded_bigrams = list(pad_both_ends(text[0], n=2))
     >>> list(everygrams(padded_bigrams, max_len=2))
-    [('<s>',),
-     ('a',),
-     ('b',),
-     ('c',),
-     ('</s>',),
-     ('<s>', 'a'),
-     ('a', 'b'),
-     ('b', 'c'),
-     ('c', '</s>')]
+    [('<s>',), ('<s>', 'a'), ('a',), ('a', 'b'), ('b',), ('b', 'c'), ('c',), ('c', '</s>'), ('</s>',)]
 
 We are almost ready to start counting ngrams, just one more step left.
 During training and evaluation our model will rely on a vocabulary that

--- a/nltk/test/lm.doctest
+++ b/nltk/test/lm.doctest
@@ -129,3 +129,19 @@ For speed take only the first 100 sentences of reuters. Shouldn't affect the tes
     >>> lm.fit(train_data, vocab_data)
     >>> lm.score("said", ("",)) < 1
     True
+
+
+
+
+Issue 2562
+---------
+https://github.com/nltk/nltk/issues/2562
+
+
+Test that everygrams works for iterables.
+    >>> from nltk import everygrams
+    >>> sent = 'a b c'.split()
+    >>> list(everygrams(iter(sent)))
+    [('a',), ('a', 'b'), ('a', 'b', 'c'), ('b',), ('b', 'c'), ('c',)]
+    >>> list(everygrams(iter(sent), max_len=2))
+    [('a',), ('a', 'b'), ('b',), ('b', 'c'), ('c',)]

--- a/nltk/test/lm.doctest
+++ b/nltk/test/lm.doctest
@@ -129,19 +129,3 @@ For speed take only the first 100 sentences of reuters. Shouldn't affect the tes
     >>> lm.fit(train_data, vocab_data)
     >>> lm.score("said", ("",)) < 1
     True
-
-
-
-
-Issue 2562
----------
-https://github.com/nltk/nltk/issues/2562
-
-
-Test that everygrams works for iterables.
-    >>> from nltk import everygrams
-    >>> sent = 'a b c'.split()
-    >>> list(everygrams(iter(sent)))
-    [('a',), ('a', 'b'), ('a', 'b', 'c'), ('b',), ('b', 'c'), ('c',)]
-    >>> list(everygrams(iter(sent), max_len=2))
-    [('a',), ('a', 'b'), ('b',), ('b', 'c'), ('c',)]

--- a/nltk/test/unit/lm/test_preprocessing.py
+++ b/nltk/test/unit/lm/test_preprocessing.py
@@ -13,15 +13,15 @@ class TestPreprocessing(unittest.TestCase):
     def test_padded_everygram_pipeline(self):
         expected_train = [
             [
-                 ('<s>',),
-                 ('<s>', 'a'),
-                 ('a',),
-                 ('a', 'b'),
-                 ('b',),
-                 ('b', 'c'),
-                 ('c',),
-                 ('c', '</s>'),
-                 ('</s>',)
+                 ("<s>",),
+                 ("<s>", "a"),
+                 ("a",),
+                 ("a", "b"),
+                 ("b",),
+                 ("b", "c"),
+                 ("c",),
+                 ("c", "</s>"),
+                 ("</s>",)
              ]
         ]
         expected_vocab = ["<s>", "a", "b", "c", "</s>"]

--- a/nltk/test/unit/lm/test_preprocessing.py
+++ b/nltk/test/unit/lm/test_preprocessing.py
@@ -13,15 +13,15 @@ class TestPreprocessing(unittest.TestCase):
     def test_padded_everygram_pipeline(self):
         expected_train = [
             [
-                 ("<s>",),
-                 ("<s>", "a"),
-                 ("a",),
-                 ("a", "b"),
-                 ("b",),
-                 ("b", "c"),
-                 ("c",),
-                 ("c", "</s>"),
-                 ("</s>",)
+                ("<s>",),
+                ("<s>", "a"),
+                ("a",),
+                ("a", "b"),
+                ("b",),
+                ("b", "c"),
+                ("c",),
+                ("c", "</s>"),
+                ("</s>",)
              ]
         ]
         expected_vocab = ["<s>", "a", "b", "c", "</s>"]

--- a/nltk/test/unit/lm/test_preprocessing.py
+++ b/nltk/test/unit/lm/test_preprocessing.py
@@ -13,16 +13,16 @@ class TestPreprocessing(unittest.TestCase):
     def test_padded_everygram_pipeline(self):
         expected_train = [
             [
-                ("<s>",),
-                ("a",),
-                ("b",),
-                ("c",),
-                ("</s>",),
-                ("<s>", "a"),
-                ("a", "b"),
-                ("b", "c"),
-                ("c", "</s>"),
-            ]
+                 ('<s>',),
+                 ('<s>', 'a'),
+                 ('a',),
+                 ('a', 'b'),
+                 ('b',),
+                 ('b', 'c'),
+                 ('c',),
+                 ('c', '</s>'),
+                 ('</s>',)
+             ]
         ]
         expected_vocab = ["<s>", "a", "b", "c", "</s>"]
         train_data, vocab_data = padded_everygram_pipeline(2, [["a", "b", "c"]])

--- a/nltk/test/unit/test_util.py
+++ b/nltk/test/unit/test_util.py
@@ -13,29 +13,6 @@ class TestEverygrams(unittest.TestCase):
         """Form test data for tests."""
         self.test_data = 'a b c'.split()
 
-    def test_everygrams_pad_left(self):
-        expected_output = set(
-            [
-                (None),
-                (None, None),
-                (None, None, 'a'),
-                (None),
-                (None, 'a'),
-                (None, 'a', 'b'),
-                ('a',),
-                ('a', 'b'),
-                ('a', 'b', 'c'),
-                ('b',),
-                ('b', 'c'),
-                ('c',),
-            ]
-        )
-        output = list(everygrams(self.test_data, max_len=3, pad_left=True))
-        # Test for expected output.
-        self.assertEqual(set(output), expected_output)
-        # Test that no grams are repeated.
-        self.assertEqual(len(output), len(expected_output))
-
     def test_everygrams(self):
         test_data = 'a b c'.split()
         # Test everygrams with defaults.

--- a/nltk/test/unit/test_util.py
+++ b/nltk/test/unit/test_util.py
@@ -14,46 +14,27 @@ class TestEverygrams(unittest.TestCase):
         self.test_data = 'a b c'.split()
 
     def test_everygrams(self):
-        test_data = 'a b c'.split()
-        # Test everygrams with defaults.
-        expected_output = set(
-            [
-                ('a',),
-                ('a', 'b'),
-                ('a', 'b', 'c'),
-                ('b',),
-                ('b', 'c'),
-                ('c',),
-            ]
-        )
-        output = list(everygrams(self.test_data))
-        # Test for expected output.
-        self.assertEqual(set(output), expected_output)
-        # Test that no grams are repeated.
-        self.assertEqual(len(output), len(expected_output))
-
-        # Test that everygrams works with iterables.
-        output = list(everygrams(iter(test_data)))
-        # Test for expected output.
-        self.assertEqual(set(output), expected_output)
-        # Test that no grams are repeated.
-        self.assertEqual(len(output), len(expected_output))
+        # Test everygrams without padding.
+        expected_output = [
+            ('a',),
+            ('a', 'b'),
+            ('a', 'b', 'c'),
+            ('b',),
+            ('b', 'c'),
+            ('c',),
+        ]
+        output = everygrams(iter(self.test_data))
+        self.assertCountEqual(output, expected_output)
 
         # Test everygrams with a max length of 2.
-        expected_output = set([('a',), ('a', 'b'), ('b',), ('b', 'c'),('c',),])
-        output = list(everygrams(self.test_data, max_len=2))
-        # Test for expected output.
-        self.assertEqual(set(output), expected_output)
-        # Test that no grams are repeated.
-        self.assertEqual(len(output), len(expected_output))
+        expected_output = [('a',), ('a', 'b'), ('b',), ('b', 'c'),('c',),]
+        output = everygrams(iter(self.test_data), max_len=2)
+        self.assertCountEqual(output, expected_output)
 
-        # Test everygrams with a max length of 2.
-        expected_output = set([('a', 'b'), ('b', 'c'), ('a', 'b', 'c'),])
-        output = list(everygrams(self.test_data, min_len=2))
-        # Test for expected output.
-        self.assertEqual(set(output), expected_output)
-        # Test that no grams are repeated.
-        self.assertEqual(len(output), len(expected_output))
+        # Test everygrams with a min length of 2.
+        expected_output = [('a', 'b'), ('b', 'c'), ('a', 'b', 'c'),]
+        output = everygrams(iter(self.test_data), min_len=2)
+        self.assertCountEqual(list(output), expected_output)
 
     def test_everygrams_pad_right(self):
         expected_output = [
@@ -70,12 +51,8 @@ class TestEverygrams(unittest.TestCase):
             (None, None),
             (None,),
         ]
-        output = list(everygrams(self.test_data, max_len=3, pad_right=True))
-        # Test for expected output.
-        self.assertEqual(set(output), set(expected_output))
-        # Test that no grams are repeated.
-        self.assertEqual(len(output), len(expected_output))
-
+        output = everygrams(iter(self.test_data), max_len=3, pad_right=True)
+        self.assertCountEqual(list(output), expected_output)
 
     def test_everygrams_pad_left(self):
         expected_output = [
@@ -92,29 +69,5 @@ class TestEverygrams(unittest.TestCase):
             ('b', 'c'),
             ('c',),
         ]
-        output = list(everygrams(self.test_data, max_len=3, pad_left=True))
-        # Test for expected output.
-        self.assertEqual(set(output), set(expected_output))
-        # Test that no grams are repeated.
-        self.assertEqual(len(output), len(expected_output))
-
-    def test_everygrams_iterable(self):
-        test_data = 'a b c'.split()
-        # Test everygrams with defaults.
-        expected_output = set(
-            [
-                ('a',),
-                ('a', 'b'),
-                ('a', 'b', 'c'),
-                ('b',),
-                ('b', 'c'),
-                ('c',),
-            ]
-        )
-
-        # Test that everygrams works with iterables.
-        output = list(everygrams(iter(test_data)))
-        # Test for expected output.
-        self.assertEqual(set(output), expected_output)
-        # Test that no grams are repeated.
-        self.assertEqual(len(output), len(expected_output))
+        output = everygrams(iter(self.test_data), max_len=3, pad_left=True)
+        self.assertCountEqual(list(output), expected_output)

--- a/nltk/test/unit/test_util.py
+++ b/nltk/test/unit/test_util.py
@@ -33,7 +33,7 @@ class TestEverygrams(unittest.TestCase):
     def test_everygrams_min_len(self):
         expected_output = [('a', 'b'), ('b', 'c'), ('a', 'b', 'c'),]
         output = everygrams(self.test_data, min_len=2)
-        self.assertCountEqual(list(output), expected_output)
+        self.assertCountEqual(output, expected_output)
 
     def test_everygrams_pad_right(self):
         expected_output = [
@@ -51,7 +51,7 @@ class TestEverygrams(unittest.TestCase):
             (None,),
         ]
         output = everygrams(self.test_data, max_len=3, pad_right=True)
-        self.assertCountEqual(list(output), expected_output)
+        self.assertCountEqual(output, expected_output)
 
     def test_everygrams_pad_left(self):
         expected_output = [
@@ -69,4 +69,4 @@ class TestEverygrams(unittest.TestCase):
             ('c',),
         ]
         output = everygrams(self.test_data, max_len=3, pad_left=True)
-        self.assertCountEqual(list(output), expected_output)
+        self.assertCountEqual(output, expected_output)

--- a/nltk/test/unit/test_util.py
+++ b/nltk/test/unit/test_util.py
@@ -8,9 +8,7 @@ from nltk.util import everygrams
 
 
 class TestEverygrams(unittest.TestCase):
-    # test_data = 'a b c'.split()
 
-    # @classmethod
     def setUp(self):
         """Form test data for tests."""
         self.test_data = 'a b c'.split()

--- a/nltk/test/unit/test_util.py
+++ b/nltk/test/unit/test_util.py
@@ -11,10 +11,9 @@ class TestEverygrams(unittest.TestCase):
 
     def setUp(self):
         """Form test data for tests."""
-        self.test_data = 'a b c'.split()
+        self.test_data = iter('a b c'.split())
 
-    def test_everygrams(self):
-        # Test everygrams without padding.
+    def test_everygrams_without_padding(self):
         expected_output = [
             ('a',),
             ('a', 'b'),
@@ -23,17 +22,17 @@ class TestEverygrams(unittest.TestCase):
             ('b', 'c'),
             ('c',),
         ]
-        output = everygrams(iter(self.test_data))
+        output = everygrams(self.test_data)
         self.assertCountEqual(output, expected_output)
 
-        # Test everygrams with a max length of 2.
+    def test_everygrams_max_len(self):
         expected_output = [('a',), ('a', 'b'), ('b',), ('b', 'c'),('c',),]
-        output = everygrams(iter(self.test_data), max_len=2)
+        output = everygrams(self.test_data, max_len=2)
         self.assertCountEqual(output, expected_output)
 
-        # Test everygrams with a min length of 2.
+    def test_everygrams_min_len(self):
         expected_output = [('a', 'b'), ('b', 'c'), ('a', 'b', 'c'),]
-        output = everygrams(iter(self.test_data), min_len=2)
+        output = everygrams(self.test_data, min_len=2)
         self.assertCountEqual(list(output), expected_output)
 
     def test_everygrams_pad_right(self):
@@ -51,7 +50,7 @@ class TestEverygrams(unittest.TestCase):
             (None, None),
             (None,),
         ]
-        output = everygrams(iter(self.test_data), max_len=3, pad_right=True)
+        output = everygrams(self.test_data, max_len=3, pad_right=True)
         self.assertCountEqual(list(output), expected_output)
 
     def test_everygrams_pad_left(self):
@@ -69,5 +68,5 @@ class TestEverygrams(unittest.TestCase):
             ('b', 'c'),
             ('c',),
         ]
-        output = everygrams(iter(self.test_data), max_len=3, pad_left=True)
+        output = everygrams(self.test_data, max_len=3, pad_left=True)
         self.assertCountEqual(list(output), expected_output)

--- a/nltk/test/unit/test_util.py
+++ b/nltk/test/unit/test_util.py
@@ -4,11 +4,7 @@ Unit tests for nltk.util.
 """
 
 import unittest
-from nltk.util import (
-    pad_sequence,
-    ngrams,
-    everygrams,
-)
+from nltk.util import everygrams
 
 
 class TestEverygrams(unittest.TestCase):

--- a/nltk/test/unit/test_util.py
+++ b/nltk/test/unit/test_util.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests for nltk.util.
+"""
+
+import unittest
+from nltk.util import (
+    pad_sequence,
+    ngrams,
+    everygrams,
+)
+
+
+class TestEverygrams(unittest.TestCase):
+    # test_data = 'a b c'.split()
+
+    # @classmethod
+    def setUp(self):
+        """Form test data for tests."""
+        self.test_data = 'a b c'.split()
+
+    def test_everygrams_pad_left(self):
+        expected_output = set(
+            [
+                (None),
+                (None, None),
+                (None, None, 'a'),
+                (None),
+                (None, 'a'),
+                (None, 'a', 'b'),
+                ('a',),
+                ('a', 'b'),
+                ('a', 'b', 'c'),
+                ('b',),
+                ('b', 'c'),
+                ('c',),
+            ]
+        )
+        output = list(everygrams(self.test_data, max_len=3, pad_left=True))
+        # Test for expected output.
+        self.assertEqual(set(output), expected_output)
+        # Test that no grams are repeated.
+        self.assertEqual(len(output), len(expected_output))
+
+    def test_everygrams(self):
+        test_data = 'a b c'.split()
+        # Test everygrams with defaults.
+        expected_output = set(
+            [
+                ('a',),
+                ('a', 'b'),
+                ('a', 'b', 'c'),
+                ('b',),
+                ('b', 'c'),
+                ('c',),
+            ]
+        )
+        output = list(everygrams(self.test_data))
+        # Test for expected output.
+        self.assertEqual(set(output), expected_output)
+        # Test that no grams are repeated.
+        self.assertEqual(len(output), len(expected_output))
+
+        # Test that everygrams works with iterables.
+        output = list(everygrams(iter(test_data)))
+        # Test for expected output.
+        self.assertEqual(set(output), expected_output)
+        # Test that no grams are repeated.
+        self.assertEqual(len(output), len(expected_output))
+
+        # Test everygrams with a max length of 2.
+        expected_output = set([('a',), ('a', 'b'), ('b',), ('b', 'c'),('c',),])
+        output = list(everygrams(self.test_data, max_len=2))
+        # Test for expected output.
+        self.assertEqual(set(output), expected_output)
+        # Test that no grams are repeated.
+        self.assertEqual(len(output), len(expected_output))
+
+        # Test everygrams with a max length of 2.
+        expected_output = set([('a', 'b'), ('b', 'c'), ('a', 'b', 'c'),])
+        output = list(everygrams(self.test_data, min_len=2))
+        # Test for expected output.
+        self.assertEqual(set(output), expected_output)
+        # Test that no grams are repeated.
+        self.assertEqual(len(output), len(expected_output))
+
+    def test_everygrams_pad_right(self):
+        expected_output = [
+            ('a',),
+            ('a', 'b'),
+            ('a', 'b', 'c'),
+            ('b',),
+            ('b', 'c'),
+            ('b', 'c', None),
+            ('c',),
+            ('c', None),
+            ('c', None, None),
+            (None,),
+            (None, None),
+            (None,),
+        ]
+        output = list(everygrams(self.test_data, max_len=3, pad_right=True))
+        # Test for expected output.
+        self.assertEqual(set(output), set(expected_output))
+        # Test that no grams are repeated.
+        self.assertEqual(len(output), len(expected_output))
+
+
+    def test_everygrams_pad_left(self):
+        expected_output = [
+            (None,),
+            (None, None),
+            (None, None, 'a'),
+            (None,),
+            (None, 'a'),
+            (None, 'a', 'b'),
+            ('a',),
+            ('a', 'b'),
+            ('a', 'b', 'c'),
+            ('b',),
+            ('b', 'c'),
+            ('c',),
+        ]
+        output = list(everygrams(self.test_data, max_len=3, pad_left=True))
+        # Test for expected output.
+        self.assertEqual(set(output), set(expected_output))
+        # Test that no grams are repeated.
+        self.assertEqual(len(output), len(expected_output))
+
+    def test_everygrams_iterable(self):
+        test_data = 'a b c'.split()
+        # Test everygrams with defaults.
+        expected_output = set(
+            [
+                ('a',),
+                ('a', 'b'),
+                ('a', 'b', 'c'),
+                ('b',),
+                ('b', 'c'),
+                ('c',),
+            ]
+        )
+
+        # Test that everygrams works with iterables.
+        output = list(everygrams(iter(test_data)))
+        # Test for expected output.
+        self.assertEqual(set(output), expected_output)
+        # Test that no grams are repeated.
+        self.assertEqual(len(output), len(expected_output))

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -574,7 +574,8 @@ def everygrams(sequence, min_len=1, max_len=-1, pad_left=False, pad_right=False,
         >>> list(everygrams(sent, max_len=2))
         [('a',), ('a', 'b'), ('b',), ('b', 'c'), ('c',)]
 
-    :param sequence: the source data to be converted into ngrams
+    :param sequence: the source data to be converted into ngrams. If max_len is
+        not provided, this sequence will be loaded into memory
     :type sequence: sequence or iter
     :param min_len: minimum length of the ngrams, aka. n-gram order/degree of ngram
     :type  min_len: int

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -496,14 +496,14 @@ def ngrams(sequence, n, **kwargs):
     :param sequence: the source data to be converted into ngrams
     :type sequence: sequence or iter
     :param n: the degree of the ngrams
-    :type n: int    
-    :param pad_left: whether the ngrams should be left-padded	
-    :type pad_left: bool	
-    :param pad_right: whether the ngrams should be right-padded	
-    :type pad_right: bool	
-    :param left_pad_symbol: the symbol to use for left padding (default is None)	
-    :type left_pad_symbol: any	
-    :param right_pad_symbol: the symbol to use for right padding (default is None)	
+    :type n: int
+    :param pad_left: whether the ngrams should be left-padded
+    :type pad_left: bool
+    :param pad_right: whether the ngrams should be right-padded
+    :type pad_right: bool
+    :param left_pad_symbol: the symbol to use for left padding (default is None)
+    :type left_pad_symbol: any
+    :param right_pad_symbol: the symbol to use for right padding (default is None)
     :type right_pad_symbol: any
     :rtype: sequence or iter
     """

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -496,7 +496,15 @@ def ngrams(sequence, n, **kwargs):
     :param sequence: the source data to be converted into ngrams
     :type sequence: sequence or iter
     :param n: the degree of the ngrams
-    :type n: int
+    :type n: int    
+    :param pad_left: whether the ngrams should be left-padded	
+    :type pad_left: bool	
+    :param pad_right: whether the ngrams should be right-padded	
+    :type pad_right: bool	
+    :param left_pad_symbol: the symbol to use for left padding (default is None)	
+    :type left_pad_symbol: any	
+    :param right_pad_symbol: the symbol to use for right padding (default is None)	
+    :type right_pad_symbol: any
     :rtype: sequence or iter
     """
     sequence = pad_sequence(sequence, n, **kwargs)

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -593,25 +593,17 @@ def everygrams(sequence, min_len=1, max_len=-1, pad_left=False, pad_right=False,
     # Sliding window to store grams.
     history = list(islice(sequence, max_len))
 
-    # Prevent ngrams with only the padding symbol.
-    if pad_left:
-        min_len_start = max_len
-    else:
-        min_len_start = min_len
-
     # Yield ngrams from sequence.
     while history:
-        for ngram_len in range(min_len_start, len(history)+1):
+        for ngram_len in range(min_len, len(history)+1):
             yield tuple(history[:ngram_len])
-            min_len_start = max(min_len, min_len_start - 1)
 
         # Append element to history if sequence has more items.
         try:
             history.append(next(sequence))
         except StopIteration:
             # Prevent ngrams with only the padding symbol.
-            if pad_right:
-                return
+            pass
 
         del history[0]
 

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -610,7 +610,6 @@ def everygrams(sequence, min_len=1, max_len=-1, pad_left=False, pad_right=False,
         try:
             history.append(next(sequence))
         except StopIteration:
-            # Prevent ngrams with only the padding symbol.
             pass
 
         del history[0]

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -592,7 +592,7 @@ def everygrams(
         >>> list(everygrams(sent, max_len=2))
         [('a',), ('a', 'b'), ('b',), ('b', 'c'), ('c',)]
 
-    :param sequence: the source data to be converted into trigrams
+    :param sequence: the source data to be converted into ngrams
     :type sequence: sequence or iter
     :param min_len: minimum length of the ngrams, aka. n-gram order/degree of ngram
     :type  min_len: int

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -508,13 +508,15 @@ def ngrams(sequence, n, **kwargs):
     :rtype: sequence or iter
     """
     sequence = pad_sequence(sequence, n, **kwargs)
-
+    
+    # Creates the sliding window, of n no. of items.
+    # `iterables` is a tuple of iterables where each iterable is a window of n items.
     iterables = tee(sequence, n)
 
-    for i, sub_iterable in enumerate(iterables):
-        for _ in range(i):
-            next(sub_iterable, None)
-    return zip(*iterables)
+    for i, sub_iterable in enumerate(iterables): # For each window,
+        for _ in range(i):                       # iterate through every order of ngrams
+            next(sub_iterable, None)             # generate the ngrams within the window.
+    return zip(*iterables) # Unpack and flattens the iterables.
 
 
 def bigrams(sequence, **kwargs):


### PR DESCRIPTION
This is a PR for [issue 2562](https://github.com/nltk/nltk/issues/2562). It modifies the everygrams function to work with iterables. It modifies the necessary tests to accommodate the difference in order output of the grams.