### PR TITLE
Fix for Issue #2582, name `save_file` is not defined

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -9,6 +9,7 @@
 
 ## Contributors
 
+- Tom Aarsen
 - Rami Al-Rfou'
 - Mark Amery
 - Greg Aumann

--- a/nltk/sentiment/sentiment_analyzer.py
+++ b/nltk/sentiment/sentiment_analyzer.py
@@ -190,6 +190,7 @@ class SentimentAnalyzer(object):
         """
         print("Saving", filename, file=sys.stderr)
         with open(filename, 'wb') as storage_file:
+            import pickle
             # The protocol=2 parameter is for python2 compatibility
             pickle.dump(content, storage_file, protocol=2)
 

--- a/nltk/sentiment/util.py
+++ b/nltk/sentiment/util.py
@@ -685,7 +685,7 @@ def demo_subjectivity(trainer, save_analyzer=False, n_instances=None, output=Non
     results = sentim_analyzer.evaluate(test_set)
 
     if save_analyzer == True:
-        save_file(sentim_analyzer, "sa_subjectivity.pickle")
+        sentim_analyzer.save_file(sentim_analyzer, "sa_subjectivity.pickle")
 
     if output:
         extr = [f.__name__ for f in sentim_analyzer.feat_extractors]


### PR DESCRIPTION
## Issue
`NameError: name 'save_file' is not defined` when calling `demo_sent_subjectivity`, or when calling `demo_subjectivity` with optional parameter `save_analyzer=True`.

The issue #2582 provides full code and a stack trace, copied here for clarity, provided by @jweissenberger. This pull request fixes this issue.
### Full code
```python
import nltk
nltk.download('subjectivity')

from nltk.sentiment.util import demo_sent_subjectivity

demo_sent_subjectivity("This is a test sentence")
```
### Stacktrace
```
Cannot find the sentiment analyzer you want to load.
Training a new one using NaiveBayesClassifier.
Training classifier
Most Informative Features
            contains(--) = True             subj : obj    =     61.0 : 1.0
        contains(film's) = True             subj : obj    =     33.7 : 1.0
       contains(decides) = True              obj : subj   =     28.3 : 1.0
      contains(discover) = True              obj : subj   =     26.3 : 1.0
    contains(girlfriend) = True              obj : subj   =     25.0 : 1.0
          contains(town) = True              obj : subj   =     23.4 : 1.0
  contains(entertaining) = True             subj : obj    =     22.2 : 1.0
     contains(detective) = True              obj : subj   =     21.0 : 1.0
        contains(mother) = True              obj : subj   =     20.1 : 1.0
         contains(finds) = True              obj : subj   =     19.9 : 1.0
Evaluating NaiveBayesClassifier results...
Traceback (most recent call last):
  File "/Users/<my_username>/anaconda3/envs/outpost/lib/python3.7/site-packages/nltk/sentiment/util.py", line 717, in demo_sent_subjectivity
    sentim_analyzer = load("sa_subjectivity.pickle")
  File "/Users/<my_username>/anaconda3/envs/outpost/lib/python3.7/site-packages/nltk/data.py", line 752, in load
    opened_resource = _open(resource_url)
  File "/Users/<my_username>/anaconda3/envs/outpost/lib/python3.7/site-packages/nltk/data.py", line 877, in _open
    return find(path_, path + [""]).open()
  File "/Users/<my_username>/anaconda3/envs/outpost/lib/python3.7/site-packages/nltk/data.py", line 562, in find
    resource_zipname = resource_name.split("/")[1]
IndexError: list index out of range

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/<my_username>/anaconda3/envs/outpost/lib/python3.7/site-packages/nltk/sentiment/util.py", line 721, in demo_sent_subjectivity
    sentim_analyzer = demo_subjectivity(NaiveBayesClassifier.train, True)
  File "/Users/<my_username>/anaconda3/envs/outpost/lib/python3.7/site-packages/nltk/sentiment/util.py", line 688, in demo_subjectivity
    save_file(sentim_analyzer, "sa_subjectivity.pickle")
NameError: name 'save_file' is not defined
```

## Bug backstory and changes
The function `save_file` was removed from `nltk/sentiment/util.py` in commit 1a12f305d555cdee56ea9f4b900e13dd2d652a1b. In its place, the *method* `save_file` was introduced in `nltk/sentiment/sentiment_analyzer.py` in commit c52e47737ed06473590cb0d5fd64b6899b5c6c21.
One reference of `save_file` was updated to `self.save_file` in this last commit, but the other reference (the one that now throws a NameError) was left untouched. It simply needs a `SentimentAnalyzer` object to be able to call `save_file`. 
This object was added in commit df53b488d91050c52e82352e69a52fd3da1dd75b.

Beyond messing this up, the `save_file` function was carelessly copied from `nltk/sentiment/util.py` to `nltk/sentiment/sentiment_analyzer.py` and quickly turned into a method, while ignoring the dependency on the `pickle` module, which is imported in the former file, but not in the latter. This led to *yet another* NameError: `NameError: name 'pickle' is not defined`.
The required pickle import was added in commit 829f8434b32e7f87eaa1ced4903dfb0ccf26f18a.

---

Let me know if any more work is needed on this.