### PR TITLE
Tokenize foreign languages with custom punctuation

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -9,6 +9,7 @@
 
 ## Contributors
 
+- Tom Aarsen
 - Rami Al-Rfou'
 - Mark Amery
 - Greg Aumann

--- a/nltk/test/unit/test_concordance.py
+++ b/nltk/test/unit/test_concordance.py
@@ -24,11 +24,11 @@ class TestConcordance(unittest.TestCase):
     """Text constructed using: http://www.nltk.org/book/ch01.html"""
 
     @classmethod
-    def setup_class(cls):
+    def setUpClass(cls):
         cls.corpus = gutenberg.words('melville-moby_dick.txt')
 
     @classmethod
-    def teardown_class(cls):
+    def tearDownClass(cls):
         pass
 
     def setUp(self):

--- a/nltk/test/unit/test_tokenize.py
+++ b/nltk/test/unit/test_tokenize.py
@@ -423,3 +423,26 @@ class TestTokenize(unittest.TestCase):
         obj._lang_vars = TestPunktTokenizeWordsMock()
         # unpack generator, ensure that no error is raised
         list(obj._tokenize_words('test'))
+
+    def test_punkt_tokenize_custom_lang_vars(self):
+        
+        # Create LangVars including a full stop end character as used in Bengali
+        class BengaliLanguageVars(punkt.PunktLanguageVars):
+            sent_end_chars = ('.', '?', '!', '\u0964')
+        obj = punkt.PunktSentenceTokenizer(lang_vars = BengaliLanguageVars())
+
+        # We now expect these sentences to be split up into the individual sentences
+        sentences = u"উপরাষ্ট্রপতি শ্রী এম ভেঙ্কাইয়া নাইডু সোমবার আই আই টি দিল্লির হীরক জয়ন্তী উদযাপনের উদ্বোধন করেছেন। অনলাইনের মাধ্যমে এই অনুষ্ঠানে কেন্দ্রীয় মানব সম্পদ উন্নয়নমন্ত্রী শ্রী রমেশ পোখরিয়াল ‘নিশাঙ্ক’  উপস্থিত ছিলেন। এই উপলক্ষ্যে উপরাষ্ট্রপতি হীরকজয়ন্তীর লোগো এবং ২০৩০-এর জন্য প্রতিষ্ঠানের লক্ষ্য ও পরিকল্পনার নথি প্রকাশ করেছেন।"
+        expected = ["উপরাষ্ট্রপতি শ্রী এম ভেঙ্কাইয়া নাইডু সোমবার আই আই টি দিল্লির হীরক জয়ন্তী উদযাপনের উদ্বোধন করেছেন।", "অনলাইনের মাধ্যমে এই অনুষ্ঠানে কেন্দ্রীয় মানব সম্পদ উন্নয়নমন্ত্রী শ্রী রমেশ পোখরিয়াল ‘নিশাঙ্ক’  উপস্থিত ছিলেন।", "এই উপলক্ষ্যে উপরাষ্ট্রপতি হীরকজয়ন্তীর লোগো এবং ২০৩০-এর জন্য প্রতিষ্ঠানের লক্ষ্য ও পরিকল্পনার নথি প্রকাশ করেছেন।"]
+        
+        self.assertEqual(obj.tokenize(sentences), expected)
+
+    def test_punkt_tokenize_no_custom_lang_vars(self):
+        
+        obj = punkt.PunktSentenceTokenizer()
+
+        # We expect these sentences to not be split properly, as the Bengali full stop '।' is not included in the default language vars
+        sentences = u"উপরাষ্ট্রপতি শ্রী এম ভেঙ্কাইয়া নাইডু সোমবার আই আই টি দিল্লির হীরক জয়ন্তী উদযাপনের উদ্বোধন করেছেন। অনলাইনের মাধ্যমে এই অনুষ্ঠানে কেন্দ্রীয় মানব সম্পদ উন্নয়নমন্ত্রী শ্রী রমেশ পোখরিয়াল ‘নিশাঙ্ক’  উপস্থিত ছিলেন। এই উপলক্ষ্যে উপরাষ্ট্রপতি হীরকজয়ন্তীর লোগো এবং ২০৩০-এর জন্য প্রতিষ্ঠানের লক্ষ্য ও পরিকল্পনার নথি প্রকাশ করেছেন।"
+        expected = ["উপরাষ্ট্রপতি শ্রী এম ভেঙ্কাইয়া নাইডু সোমবার আই আই টি দিল্লির হীরক জয়ন্তী উদযাপনের উদ্বোধন করেছেন। অনলাইনের মাধ্যমে এই অনুষ্ঠানে কেন্দ্রীয় মানব সম্পদ উন্নয়নমন্ত্রী শ্রী রমেশ পোখরিয়াল ‘নিশাঙ্ক’  উপস্থিত ছিলেন। এই উপলক্ষ্যে উপরাষ্ট্রপতি হীরকজয়ন্তীর লোগো এবং ২০৩০-এর জন্য প্রতিষ্ঠানের লক্ষ্য ও পরিকল্পনার নথি প্রকাশ করেছেন।"]
+        
+        self.assertEqual(obj.tokenize(sentences), expected)

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -218,7 +218,9 @@ class PunktLanguageVars(object):
     _re_word_start = r"[^\(\"\`{\[:;&\#\*@\)}\]\-,]"
     """Excludes some characters from starting word tokens"""
 
-    _re_non_word_chars = r"(?:[?!)\";}\]\*:@\'\({\[])"
+    @property
+    def _re_non_word_chars(self):
+        return "(?:[)\";}\]\*:@\'\({\[%s])" % re.escape("".join(set(self.sent_end_chars) - {"."}))
     """Characters that cannot appear within words"""
 
     _re_multi_char_punct = r"(?:\-{2,}|\.{2,}|(?:\.\s){2,}\.)"


### PR DESCRIPTION
# Issue 
I discovered this undesired behaviour in issue #2586. It is about tokenization of a foreign language using custom sentence full stop characters. The following code was provided in the aforementioned issue, and slightly edited by me (Python 3.7):
```python
# -*- coding: UTF-8 -*-
from nltk.tokenize.punkt import PunktSentenceTokenizer, PunktLanguageVars

class BengaliLangVars(PunktLanguageVars):
    sent_end_chars = ('.', '?', '!', '\u0964')

tokenizer = PunktSentenceTokenizer(lang_vars = BengaliLangVars())
text = u"উপরাষ্ট্রপতি শ্রী এম ভেঙ্কাইয়া নাইডু সোমবার আই আই টি দিল্লির হীরক জয়ন্তী উদযাপনের উদ্বোধন করেছেন। অনলাইনের মাধ্যমে এই অনুষ্ঠানে কেন্দ্রীয় মানব সম্পদ উন্নয়নমন্ত্রী শ্রী রমেশ পোখরিয়াল ‘নিশাঙ্ক’  উপস্থিত ছিলেন। এই উপলক্ষ্যে উপরাষ্ট্রপতি হীরকজয়ন্তীর লোগো এবং ২০৩০-এর জন্য প্রতিষ্ঠানের লক্ষ্য ও পরিকল্পনার নথি প্রকাশ করেছেন।"
sentences = tokenizer.tokenize(text)
for sent_i, sentence in enumerate(sentences):
    print(f"Sentence {sent_i + 1}: {repr(sentence)}")
```
Note that the text is three sentences in what appears to be Bangali, with three full stops that appear in that language (। or u0964).
This program outputs:
#### Program output 1
```python
Sentence 1: 'উপরাষ্ট্রপতি শ্রী এম ভেঙ্কাইয়া নাইডু সোমবার আই আই টি দিল্লির হীরক জয়ন্তী উদযাপনের উদ্বোধন করেছেন। অনলাইনের মাধ্যমে এই অনুষ্ঠানে কেন্দ্রীয় মানব সম্পদ উন্নয়নমন্ত্রী শ্রী রমেশ পোখরিয়া
ল ‘নিশাঙ্ক’  উপস্থিত ছিলেন। এই উপলক্ষ্যে উপরাষ্ট্রপতি হীরকজয়ন্তীর লোগো এবং ২০৩০-এর জন্য প্রতিষ্ঠানের লক্ষ্য ও পরিকল্পনার নথি প্রকাশ করেছেন।'
```
It cannot be argued that the actual result is the desired behaviour. This is either a bug, or a feature that should be implemented, that isn't yet. The program should correctly consider `u0964` (which is ।) to be the end of a sentence, and should then split this text up into multiple sentences.
With the small modification implemented in this pull request, the program outputs like one would expect:
#### Program output 2
```python
Sentence 1: 'উপরাষ্ট্রপতি শ্রী এম ভেঙ্কাইয়া নাইডু সোমবার আই আই টি দিল্লির হীরক জয়ন্তী উদযাপনের উদ্বোধন করেছেন।'
Sentence 2: 'অনলাইনের মাধ্যমে এই অনুষ্ঠানে কেন্দ্রীয় মানব সম্পদ উন্নয়নমন্ত্রী শ্রী রমেশ পোখরিয়াল ‘নিশাঙ্ক’  উপস্থিত ছিলেন।'
Sentence 3: 'এই উপলক্ষ্যে উপরাষ্ট্রপতি হীরকজয়ন্তীর লোগো এবং ২০৩০-এর জন্য প্রতিষ্ঠানের লক্ষ্য ও পরিকল্পনার নথি প্রকাশ করেছেন।'
```

## Bug backstory

I've looked into what's preventing the sentence from splitting like you would expect it to. The root of this issue is the method `word_tokenize` of the `PunktLanguageVars` class, which tokenizes a string to split off punctuation other than periods. After splitting, each split token is checked on whether it contains a sentence break. This is done in two main ways:
* Is the split off token an element of the `sent_end_chars` tuple? If so, the token contains a sentence break.
* Does the token end with a dot? If so, the the token contains a sentence break.

However, `word_tokenize` only splits off the following punctuation: `)";}]*:@'({[`. This is *fine* for most cases, but if we specifically want to tokenize sentences based on additional punctuation, then we need to split off this newly introduced punctuation too. Then, the first rule of checking whether there is a sentence break will correctly mark the token as a sentence break.

Without this change implemented, none of the rules detecting sentence breaks will detect that e.g. `করেছেন।` has a sentence break, even if `।` is in the `sent_end_chars` tuple.

# Changes

The fix for this is elementary, we can simply modify a section of the regex to also look for all all punctuation in `sent_end_chars` other than the dot. This is implemented in commit a000e9b9c946d1d28a7625fd29f946a8aae8e394. The new method is implemented in the same way `_re_sent_end_chars` is, just a few lines above. Note that if `sent_end_chars` is not overridden, the produces regex is identical to the original one.

I added two simple tests in commit 86705ae8152f257ed47f5acf5f87f29b838b3fc0, the first does not have a custom LangVars, and expects the first of the two program outputs as a result. The second test does include a custom LangVars, and expects the text to be split according to the second of the two program outputs.

Lastly, when running tests, I discovered that two methods in the `TestConcordance` class of `nltk/test/unit/test_concordance.py` were not being called by unittest's internal calls like was clearly intended, as they were called `setup_class` and `teardown_class` instead of `setUpClass` and `tearDownClass` respectively. Because of this, the body of `setup_class` was never run on my machine, and the `corpus` attribute that's created there cannot be used in the `setUp` method without throwing an AttributeError. This small method rename is implemented in commit 45793601e11b0bd3c837e08ba6cbc6624efa27d9.

---

Let me know if any more work is needed on this.