### PR TITLE
Stop storing `_hash` as an attribute

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -267,6 +267,7 @@
 - Ram Rachum <https://github.com/cool-RR>
 - Denali Molitor <https://github.com/dmmolitor>
 - Jacob Moorman <https://github.com/jdmoorman>
+- Cory Nezin <https://github.com/corynezin>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 ### Contributors to the Porter Stemmer

--- a/nltk/grammar.py
+++ b/nltk/grammar.py
@@ -290,7 +290,10 @@ class Production(object):
             )
         self._lhs = lhs
         self._rhs = tuple(rhs)
-        self._hash = hash((self._lhs, self._rhs))
+
+    @property
+    def _hash(self):
+        return hash((self._lhs, self._rhs))
 
     def lhs(self):
         """

--- a/nltk/grammar.py
+++ b/nltk/grammar.py
@@ -113,7 +113,6 @@ class Nonterminal(object):
             hashable.
         """
         self._symbol = symbol
-        self._hash = hash(symbol)
 
     def symbol(self):
         """
@@ -142,7 +141,7 @@ class Nonterminal(object):
         return self._symbol < other._symbol
 
     def __hash__(self):
-        return self._hash
+        return hash(self._symbol)
 
     def __repr__(self):
         """
@@ -291,10 +290,6 @@ class Production(object):
         self._lhs = lhs
         self._rhs = tuple(rhs)
 
-    @property
-    def _hash(self):
-        return hash((self._lhs, self._rhs))
-
     def lhs(self):
         """
         Return the left-hand side of this ``Production``.
@@ -379,7 +374,7 @@ class Production(object):
 
         :rtype: int
         """
-        return self._hash
+        return hash((self._lhs, self._rhs))
 
 
 
@@ -1033,7 +1028,6 @@ class FeatureValueType(object):
 
     def __init__(self, value):
         self._value = value
-        self._hash = hash(value)
 
     def __repr__(self):
         return "<%s>" % self._value
@@ -1050,7 +1044,7 @@ class FeatureValueType(object):
         return self._value < other._value
 
     def __hash__(self):
-        return self._hash
+        return hash(self._value)
 
 
 

--- a/nltk/test/parse.doctest
+++ b/nltk/test/parse.doctest
@@ -8,6 +8,8 @@
 Unit tests for the Context Free Grammar class
 ---------------------------------------------
 
+    >>> import pickle
+    >>> import subprocess
     >>> from nltk import Nonterminal, nonterminals, Production, CFG
 
     >>> nt1 = Nonterminal('NP')
@@ -53,6 +55,19 @@ Unit tests for the Context Free Grammar class
     ... P -> 'in'
     ... P -> 'on'
     ... """)
+
+    >>> cmd = """import pickle
+    ... from nltk import Production
+    ... p = Production('S', ['NP', 'VP'])
+    ... print(pickle.dumps(p))
+    ... """
+
+    >>> # Start a subprocess to simulate pickling in another process
+    >>> proc = subprocess.run(['python', '-c', cmd], capture_output=True)
+    >>> p1 = pickle.loads(eval(proc.stdout))
+    >>> p2 = Production('S', ['NP', 'VP'])
+    >>> print(hash(p1) == hash(p2))
+    True
 
 Unit tests for the rd (Recursive Descent Parser) class
 ------------------------------------------------------

--- a/nltk/test/parse.doctest
+++ b/nltk/test/parse.doctest
@@ -63,7 +63,7 @@ Unit tests for the Context Free Grammar class
     ... """
 
     >>> # Start a subprocess to simulate pickling in another process
-    >>> proc = subprocess.run(['python', '-c', cmd], capture_output=True)
+    >>> proc = subprocess.run(['python', '-c', cmd], stdout=subprocess.PIPE)
     >>> p1 = pickle.loads(eval(proc.stdout))
     >>> p2 = Production('S', ['NP', 'VP'])
     >>> print(hash(p1) == hash(p2))


### PR DESCRIPTION
The `_hash` property of `nltk.grammar.Production` is hard coded and record at `__init__` time.  This may help performance a small amount, however it also produces the side effect that an unpickled `Production` will probably not have the same hash as an equal `Production` created in the scope of the current Python process.  For example consider running the two programs:

```python
import pickle
import nltk.grammar

a = nltk.grammar.Production('a', [])
with open('production.pkl', 'wb') as f:
    pickle.dump(a, f)
```

```python
import pickle
import nltk.grammar

a = nltk.grammar.Production('a', [])
with open('production.pkl', 'rb') as f:
    b = pickle.load(f)

print(hash(a), hash(b))
```

We would hope they would be the same, but they are not.  This particularly causes issues when storing dictionaries of Productions and saving them, as we will not find them when we search the dictionary upon loading [as in this SO question](https://stackoverflow.com/questions/63962245/tfidfvectorizer-model-loaded-from-joblib-file-only-works-when-trained-in-same-se/63963023?noredirect=1#comment113108360_63963023).

This PR solves the issue in a backward compatible way by making `_hash` a property.