### PR TITLE
Skip inconsistent test

### DIFF
--- a/nltk/tag/__init__.py
+++ b/nltk/tag/__init__.py
@@ -58,8 +58,8 @@ of ``None``.
 
 We evaluate a tagger on data that was not seen during training:
 
-    >>> tagger.evaluate(brown.tagged_sents(categories='news')[500:600]) # doctest: +SKIP
-    0.73...
+    >>> tagger.evaluate(brown.tagged_sents(categories='news')[500:600])
+    0.7...
 
 For more information, please consult chapter 5 of the NLTK Book.
 """

--- a/nltk/tag/__init__.py
+++ b/nltk/tag/__init__.py
@@ -58,7 +58,7 @@ of ``None``.
 
 We evaluate a tagger on data that was not seen during training:
 
-    >>> tagger.evaluate(brown.tagged_sents(categories='news')[500:600])
+    >>> tagger.evaluate(brown.tagged_sents(categories='news')[500:600]) # doctest: +SKIP
     0.73...
 
 For more information, please consult chapter 5 of the NLTK Book.


### PR DESCRIPTION
Hello!

---
### Summary of PR:
Tagging Doctest has ~1.8% chance to fail, despite working correctly. This PR skips this test.

---

I was checking out PR #2597, and noticed the tests were failing for it, even though the tests passed when I proposed the changes.
The corresponding Travis CI [logs](https://travis-ci.org/github/nltk/nltk/builds/726705964) state that it only failed for Python 3.5, while the other four test versions worked. So I dug deeper and found the single test that had failed:
```
1) FAIL: Doctest: nltk.tag
----------------------------------------------------------------------
   Traceback (most recent call last):
    /opt/python/3.5.6/lib/python3.5/doctest.py line 2190 in runTest
      raise self.failureException(self.format_failure(new.getvalue()))
   AssertionError: Failed doctest test for nltk.tag
     File "/home/travis/build/nltk/nltk/nltk/tag/__init__.py", line 8, in tag
   
   ----------------------------------------------------------------------
   File "/home/travis/build/nltk/nltk/nltk/tag/__init__.py", line 61, in nltk.tag
   Failed example:
       tagger.evaluate(brown.tagged_sents(categories='news')[500:600])
   Expected:
       0.73...
   Got:
       0.7406290392072382
```
Naturally I expected this to be because of the pushed changes, but I was unable to reproduce this error.

I dusted off my old Python 3.5 install and dug into the code. The doctest that failed can be found here:
https://github.com/nltk/nltk/blob/54221dec0bae2642d1642d182d8a381c88b86bd0/nltk/tag/__init__.py#L42-L62

The program I used to replicate this doctest is as follows:
```python
from nltk.corpus import brown
from nltk.tag import UnigramTagger

tagger = UnigramTagger(brown.tagged_sents(categories='news')[:500])
out = tagger.evaluate(brown.tagged_sents(categories='news')[500:600])

print(out)
```
And some sample outputs when running this on Python 3.5:
```python
0.7393364928909952
0.7345971563981043
0.7350280051701853
0.7337354588539423
0.7345971563981043
0.7341663076260233
0.7350280051701853
0.7389056441189142
0.7393364928909952
0.7380439465747523
...
```
Note: Inconsistent results.

And when running this on Python 3.6 (there are similar results on Python 3.7 and 3.8):
```python
0.7345971563981043
0.7345971563981043
0.7345971563981043
0.7345971563981043
0.7345971563981043
0.7345971563981043
0.7345971563981043
0.7345971563981043
0.7345971563981043
0.7345971563981043
...
```
Note: Consistent results.

I dug deeper, and found out that this inconsistency for Python 3.5 occurs when training a [ContextTagger](https://github.com/nltk/nltk/blob/develop/nltk/tag/sequential.py#L108). A `ConditionalFreqDist()` is created, with `FreqDist` objects. These are used to, for each token, find the most common tag. (i.e. finding learning that "do" is most frequently a verb)
However, it may occur that the frequency of two tags for a specific token is the same, and then [Counter's most_common](https://docs.python.org/3.5/library/collections.html#collections.Counter.most_common) function is used, which will pick between equally valid options arbitrarily, explaining the difference between the trained models for Python 3.5.
This arbitrary choice is potentially no longer arbitrary starting from Python 3.6 because `dict`'s got an update and were now often insertion ordered, rather than arbitrary like before. This change was an implementation detail which became a fixed property from Python 3.7 onwards.

Regardless, because of this arbitrariness for Python 3.5, we can train models in the doctest which perform better than the expected result. The distribution after 1000 iterations of the above program is the following, with the blue line representing the value `0.74`:
![eval_dist_3](https://user-images.githubusercontent.com/37621491/94206793-8f565180-fec6-11ea-8931-5ede4dff0cd2.png)

Out of a 1000 iterations, the result was within `0.73...` 982 times, and above `0.74` 18 times. So, there is a ~1.8% chance that this test will randomly fail, despite the `UnigramTagger` working correctly, and doubtlessly frustrating the hell out of any dev that just pushed changes only to see the tests fail completely out of nowhere.

Considering this test will also break on any change in the brown corpus, even when the UnigramTagger works flawlessly, I suggest skipping this doctest. The commit alongside this PR does so.

Alternative solutions are to replace `0.73...` with `0.7...` to keep the test in place without there being any chance of it failing arbitrarily.

### Important note:
This means that the tests for #2597 *do* in fact pass, and those tests should be re-run after this PR is merged, or after another solution for this bug is implemented. Have another look at it after resolving this issue!

This bug has been fun to hunt.

- Tom Aarsen