### PR TITLE
Ensure wheel and sdist contain proper license info

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,14 @@
-include LICENSE.txt NOTICE.txt INSTALL.txt README.txt MANIFEST.in
-include setup.py
-include nltk/test/*.doctest
-include nltk/VERSION
-recursive-include *.txt Makefile
+include *.md
+include *.txt
+include *.ini
+include setup.*
+include ChangeLog
+include Makefile
+include MANIFEST.in
+
+
+graft nltk
+graft tools
+graft web
+
 global-exclude *~

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[metadata]
+license_files =
+    LICENSE.txt
+    AUTHORS.md
+    README.md

--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,7 @@ natural language processing.  NLTK requires Python 3.5, 3.6, 3.7, or 3.8.""",
         "Topic :: Text Processing :: Linguistic",
     ],
     package_data={"nltk": ["test/*.doctest", "VERSION"]},
+    python_requires='>=3.5.*',
     install_requires=[
         "click",
         "joblib",


### PR DESCRIPTION
Explicitly adds licensing related files and notices to a build sdist
or wheel to be comprehensive.

Also setup should fail on non-supported Python versions before
3.5.

This also explicitly adds licensing related files and notices to a
built wheel to be comprehensive.

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>