### PR TITLE
Fixed incorrect MacIntyre contraction

### DIFF
--- a/nltk/test/tokenize.doctest
+++ b/nltk/test/tokenize.doctest
@@ -38,7 +38,9 @@ Some test strings.
     >>> s10 = "There were 300,000, but that wasn't enough."
     >>> word_tokenize(s10)
     ['There', 'were', '300,000', ',', 'but', 'that', 'was', "n't", 'enough', '.']
-
+    >>> s11 = "It's more'n enough."
+    >>> word_tokenize(s11)
+    ['It', "'s", 'more', "'n", 'enough', '.']
 
 Testing improvement made to the TreebankWordTokenizer
 

--- a/nltk/tokenize/destructive.py
+++ b/nltk/tokenize/destructive.py
@@ -22,7 +22,7 @@ class MacIntyreContractions:
         r"(?i)\b(gon)(?#X)(na)\b",
         r"(?i)\b(got)(?#X)(ta)\b",
         r"(?i)\b(lem)(?#X)(me)\b",
-        r"(?i)\b(mor)(?#X)('n)\b",
+        r"(?i)\b(more)(?#X)('n)\b",
         r"(?i)\b(wan)(?#X)(na)\s",
     ]
     CONTRACTIONS3 = [r"(?i) ('t)(?#X)(is)\b", r"(?i) ('t)(?#X)(was)\b"]
@@ -46,7 +46,7 @@ class NLTKWordTokenizer(TokenizerI):
         (re.compile(r"^\""), r"``"),
         (re.compile(r"(``)"), r" \1 "),
         (re.compile(r"([ \(\[{<])(\"|\'{2})"), r"\1 `` "),
-        (re.compile(r"(?i)(\')(?!re|ve|ll|m|t|s|d)(\w)\b", re.U), r"\1 \2"),
+        (re.compile(r"(?i)(\')(?!re|ve|ll|m|t|s|d|n)(\w)\b", re.U), r"\1 \2"),
     ]
 
     # Ending quotes.


### PR DESCRIPTION
Fixes #2607.

Hello!

---

### Pull Request overview
A MacIntyre contraction used for NLTKWordTokenizer and TreebankWordTokenizer was incorrectly adapted from the original. I modified two regexes that solve this issue, but this change has some other (potentially positive, potentially negative) consequences for the NLTKWordTokenizer. (In short, the NLTKWordTokenizer looks slightly more like TreebankWordTokenizer for specific cases ending with `'n`)

---

### Intro
As I described in https://github.com/nltk/nltk/issues/2607#issuecomment-701323755, and as @nmfzone pointed out, NLTKWordTokenizer and TreebankWordTokenizer incorrectly handle `more'n`. According to the original tokenizer by Robert MacIntyre, `more'n` should be split into `more` and `'n`. However, it was split into `more`, `'` and `n`. Read that issue and the comments before continuing to read this PR.

In case you're interested, this is the original `tokenizer.sed` by Robert MacIntyre here (converted to .txt so I could upload it here):
[tokenizer.sed.txt](https://github.com/nltk/nltk/files/5305250/tokenizer.sed.txt)

### The issue
The contraction that handles `more'n` accidentally handles `mor'n` instead (line 25): 
https://github.com/nltk/nltk/blob/5023d6b933ef1a5b1f25fba1d5ed11a8a43a47e4/nltk/tokenize/destructive.py#L13-L29

I have resolved this issue by making the following change:
```python
r"(?i)\b(more)(?#X)('n)\b",
            ^
```

However, though this solved the issue for the TreebankWordTokenizer, the issue persisted in NLTKWordTokenizer.
This is because of line 49 here:
https://github.com/nltk/nltk/blob/5023d6b933ef1a5b1f25fba1d5ed11a8a43a47e4/nltk/tokenize/destructive.py#L44-L50

This regex will place a space inbetween any `'` and what comes behind, *unless* what comes behind is whitespace or any item in the following list: `re`, `ve`, `ll`, `m`, `t`, `s` and `d`. So, `would've` or `she'll` stay the same, so that they can be handled by `ENDING_QUOTES`. However, the `n` from `more'n` is not in that list, and is converted to `more' n`. Then, one of the `PUNCTUATION` regexes will convert that further to `more ' n`, and the contraction regex will no longer catch it to convert it to `more` and `'n`. 
One fix for this is adding `n` to the list of characters for which to not add spaces. This is what I've done. This has some consequences for inputs such as `"word'n"`:

### Consequences for NLTKWordTokenizer
Old: 
```python
>>> from nltk.tokenize import word_tokenize
>>> word_tokenize("It's more'n enough.")
['It', "'s", 'more', "'", 'n', 'enough', '.'] # wrong, `'` and `n` should be grouped together
>>> word_tokenize("It's ore'n enough.")
['It', "'s", 'mor', "'", 'n', 'enough', '.'] # different from new, debatably better
>>> word_tokenize("It's wrong'n enough.")
['It', "'s", 'wrong', "'", 'n', 'enough', '.'] # different from new, debatably better
>>> word_tokenize("It's 'n enough.")
['It', "'s", "'", 'n', 'enough', '.'] # different from new, debatably better
>>> word_tokenize("It's more'd enough.")
['It', "'s", 'more', "'d", 'enough', '.'] # unaffected by this PR
>>> word_tokenize("It's mor's enough.")
['It', "'s", 'mor', "'s", 'enough', '.'] # unaffected by this PR
>>> word_tokenize("It's 'd enough.")
['It', "'s", "'d", 'enough', '.'] # unaffected by this PR
```
New:
```python
>>> from nltk.tokenize import word_tokenize
>>> word_tokenize("It's more'n enough.")
['It', "'s", 'more', "'n", 'enough', '.'] # correct
>>> word_tokenize("It's ore'n enough.")
['It', "'s", "mor'n", 'enough', '.'] # different from old, debatably better
>>> word_tokenize("It's wrong'n enough.")
['It', "'s", "wrong'n", 'enough', '.'] # different from old, debatably better
>>> word_tokenize("It's 'n enough.")
['It', "'s", "'n", 'enough', '.'] # different from old, debatably better
>>> word_tokenize("It's more'd enough.")
['It', "'s", 'more', "'d", 'enough', '.'] # unaffected by this PR
>>> word_tokenize("It's mor's enough.")
['It', "'s", 'mor', "'s", 'enough', '.'] # unaffected by this PR
>>> word_tokenize("It's 'd enough.")
['It', "'s", "'d", 'enough', '.'] # unaffected by this PR
```
In words, `'n` is now preserved and left untouched, just like `'s` and `'d`, etc. (see the last three examples)
i.e. `(.*)'n` will stay as `["$1'n"]`, with one exception: `more'n -> ["more", "'n"]`. 
These new results are identical to the `TreebankWordTokenizer.tokenize()` results with the same inputs.

### Consequences for TreebankWordTokenizer
Old: 
```python
>>> from nltk.tokenize import TreebankWordTokenizer as word_tokenizer
>>> wt = word_tokenizer()
>>> wt.tokenize("It's more'n enough.")
['It', "'s", "more'n", 'enough', '.'] # wrong, direct consequence of wrong contraction rule
>>> wt.tokenize("It's ore'n enough.")
['It', "'s", 'mor', "'n", 'enough', '.'] # wrong, direct consequence of wrong contraction rule
>>> wt.tokenize("It's wrong'n enough.")
['It', "'s", 'wrong', "'", 'n', 'enough', '.'] # unaffected by this PR
>>> wt.tokenize("It's 'n enough.")
['It', "'s", "'", 'n', 'enough', '.'] # unaffected by this PR
>>> wt.tokenize("It's more'd enough.")
['It', "'s", 'more', "'d", 'enough', '.'] # unaffected by this PR
>>> wt.tokenize("It's mor's enough.")
['It', "'s", 'mor', "'s", 'enough', '.'] # unaffected by this PR
>>> wt.tokenize("It's 'd enough.")
['It', "'s", "'d", 'enough', '.'] # unaffected by this PR
```
New:
```python
>>> from nltk.tokenize import TreebankWordTokenizer as word_tokenizer
>>> wt = word_tokenizer()
>>> wt.tokenize("It's more'n enough.")
['It', "'s", 'more', "'n", 'enough', '.'] # correct
>>> wt.tokenize("It's ore'n enough.")
['It', "'s", "mor'n", 'enough', '.'] # correct
>>> wt.tokenize("It's wrong'n enough.")
['It', "'s", "wrong'n", 'enough', '.'] # unaffected by this PR
>>> wt.tokenize("It's 'n enough.")
['It', "'s", "'n", 'enough', '.'] # unaffected by this PR
>>> wt.tokenize("It's more'd enough.")
['It', "'s", 'more', "'d", 'enough', '.'] # unaffected by this PR
>>> wt.tokenize("It's mor's enough.")
['It', "'s", 'mor', "'s", 'enough', '.'] # unaffected by this PR
>>> wt.tokenize("It's 'd enough.")
['It', "'s", "'d", 'enough', '.'] # unaffected by this PR
```
Unlike for `NLTKWordTokenizer`, this PR has no sideeffects beyond the intended effect of fixing the one issue for `more'n`. 

---

### Tests
I added the following test, which previously failed, but passes with these changes.
```python
    >>> s11 = "It's more'n enough."
    >>> word_tokenize(s11)
    ['It', "'s", 'more', "'n", 'enough', '.']
```

---

Merging this PR should close issue #2607

Whether this PR should be merged depends on your preferences regarding the consequences for `NLTKWordTokenizer`. Perhaps alternative solutions without these sideeffects are possible too, if the sideeffects are deemed undesirable. However, the sideeffects might be a happy accident, depending on your preferences on the matter.

If the cure is deemed worse than the sickness, then you should still merge the changes to the contraction regex on line 25 of `nltk/tokenize/destructive.py`, as this will fix the `TreebankWordTokenizer` with no other sideeffects. (As some of the aforementioned regexes will make it impossible for either the old or the new contraction regex to be matched, for the `NLTKWordTokenizer`)

- Tom Aarsen