### PR TITLE
Fixes issue #2314 (Infinite loop in Wordnet closure and tree)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -91,6 +91,7 @@
 - Edward Ivanovic
 - Thomas Jakobsen
 - Nick Johnson
+- Eric Kafe
 - Piotr Kasprzyk
 - Angelos Katharopoulos
 - Sudharshan Kaushik

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -583,6 +583,9 @@ class Synset(_WordNetObject):
                 yield synset
 
 
+    from nltk.util import acyclic_depth_first as acyclic_tree
+
+
     def tree(self, rel, depth=-1, cut_mark=None):
         """
         Return the full relation tree, including self,
@@ -626,8 +629,8 @@ class Synset(_WordNetObject):
                [Synset('physical_entity.n.01'), [Synset('entity.n.01')]]]]]]]]]
         """
 
-        from nltk.util import acyclic_depth_first
-        return acyclic_depth_first(self, rel, depth, cut_mark)
+        from nltk.util import acyclic_branches_depth_first
+        return acyclic_branches_depth_first(self, rel, depth, cut_mark)
 
 
     def hypernym_paths(self):

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -559,22 +559,23 @@ class Synset(_WordNetObject):
         >>> print(list(computer.closure(topic)))
 
         UserWarning: Discarded redundant search ([(Synset('computer.n.01'), 2)])
+
         [Synset('computer_science.n.01')]
 
 
+        However, still search pathes once (from 'animal.n.01' to 'entity.n.01'):
+
         >>> dog = wn.synset('dog.n.01')
-        >>> topic = lambda s:s.hypernyms()
-        >>> pprint(computer.tree(hyp))
-        >>> print(list(dog.tree(hyp)))
+        >>> hyp = lambda s:s.hypernyms()
+        >>> print(list(dog.closure(hyp)))
 
-        [Synset('canine.n.02'), Synset('domestic_animal.n.01'),
-        Synset('carnivore.n.01'), Synset('animal.n.01'),
-        Synset('placental.n.01'), Synset('organism.n.01'),
-        Synset('mammal.n.01'), Synset('living_thing.n.01'),
-        Synset('vertebrate.n.01'), Synset('whole.n.02'),
-        Synset('chordate.n.01'), Synset('object.n.01'),
-        Synset('physical_entity.n.01'), Synset('entity.n.01')]
+        UserWarning: Discarded redundant search ([(Synset('animal.n.01'), 7)])
 
+        [Synset('domestic_animal.n.01'), Synset('animal.n.01'), Synset('organism.n.01'),
+        Synset('living_thing.n.01'), Synset('whole.n.02'), Synset('object.n.01'),
+        Synset('physical_entity.n.01'), Synset('entity.n.01'), Synset('canine.n.02'),
+        Synset('carnivore.n.01'), Synset('placental.n.01'), Synset('mammal.n.01'),
+        Synset('vertebrate.n.01'), Synset('chordate.n.01')]
         """
 
         from nltk.util import acyclic_breadth_first
@@ -593,14 +594,14 @@ class Synset(_WordNetObject):
         >>> pprint(computer.tree(topic))
 
         UserWarning: Discarded redundant search ([(Synset('computer.n.01'), -3)])
+
         [Synset('computer.n.01'), [Synset('computer_science.n.01')]]
 
 
         But keep duplicate branches (from 'animal.n.01' to 'entity.n.01'):
 
         >>> dog = wn.synset('dog.n.01')
-        >>> topic = lambda s:s.hypernyms()
-        >>> pprint(computer.tree(hyp))
+        >>> hyp = lambda s:s.hypernyms()
         >>> pprint(dog.tree(hyp))
 
         [Synset('dog.n.01'),
@@ -624,11 +625,10 @@ class Synset(_WordNetObject):
              [Synset('whole.n.02'),
               [Synset('object.n.01'),
                [Synset('physical_entity.n.01'), [Synset('entity.n.01')]]]]]]]]]
-
         """
 
         from nltk.util import acyclic_depth_first
-        return acyclic_depth_first(self, rel, depth)
+        return acyclic_depth_first(self, rel, depth, cut_mark)
 
 
     def hypernym_paths(self):

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -557,10 +557,9 @@ class Synset(_WordNetObject):
         >>> computer = wn.synset('computer.n.01')
         >>> topic = lambda s:s.topic_domains()
         >>> print(list(computer.closure(topic)))
+        [Synset('computer_science.n.01')]
 
         UserWarning: Discarded redundant search ([(Synset('computer.n.01'), 2)])
-
-        [Synset('computer_science.n.01')]
 
 
         However, still search pathes once (from 'animal.n.01' to 'entity.n.01'):
@@ -568,14 +567,13 @@ class Synset(_WordNetObject):
         >>> dog = wn.synset('dog.n.01')
         >>> hyp = lambda s:s.hypernyms()
         >>> print(list(dog.closure(hyp)))
+        [Synset('canine.n.02'), Synset('domestic_animal.n.01'), Synset('carnivore.n.01'),
+        Synset('animal.n.01'), Synset('placental.n.01'), Synset('organism.n.01'),
+        Synset('mammal.n.01'), Synset('living_thing.n.01'), Synset('vertebrate.n.01'),
+        Synset('whole.n.02'), Synset('chordate.n.01'), Synset('object.n.01'),
+        Synset('physical_entity.n.01'), Synset('entity.n.01')]
 
         UserWarning: Discarded redundant search ([(Synset('animal.n.01'), 7)])
-
-        [Synset('domestic_animal.n.01'), Synset('animal.n.01'), Synset('organism.n.01'),
-        Synset('living_thing.n.01'), Synset('whole.n.02'), Synset('object.n.01'),
-        Synset('physical_entity.n.01'), Synset('entity.n.01'), Synset('canine.n.02'),
-        Synset('carnivore.n.01'), Synset('placental.n.01'), Synset('mammal.n.01'),
-        Synset('vertebrate.n.01'), Synset('chordate.n.01')]
         """
 
         from nltk.util import acyclic_breadth_first
@@ -592,10 +590,9 @@ class Synset(_WordNetObject):
         >>> computer = wn.synset('computer.n.01')
         >>> topic = lambda s:s.topic_domains()
         >>> pprint(computer.tree(topic))
+        [Synset('computer.n.01'), [Synset('computer_science.n.01')]]
 
         UserWarning: Discarded redundant search ([(Synset('computer.n.01'), -3)])
-
-        [Synset('computer.n.01'), [Synset('computer_science.n.01')]]
 
 
         But keep duplicate branches (from 'animal.n.01' to 'entity.n.01'):
@@ -603,7 +600,6 @@ class Synset(_WordNetObject):
         >>> dog = wn.synset('dog.n.01')
         >>> hyp = lambda s:s.hypernyms()
         >>> pprint(dog.tree(hyp))
-
         [Synset('dog.n.01'),
          [Synset('canine.n.02'),
           [Synset('carnivore.n.01'),

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -562,7 +562,8 @@ class Synset(_WordNetObject):
         UserWarning: Discarded redundant search ([(Synset('computer.n.01'), 2)])
 
 
-        However, still search pathes once (from 'animal.n.01' to 'entity.n.01'):
+        Include redundant pathes (but only once), avoiding duplicate searches
+        (from 'animal.n.01' to 'entity.n.01'):
 
         >>> dog = wn.synset('dog.n.01')
         >>> hyp = lambda s:s.hypernyms()
@@ -577,7 +578,9 @@ class Synset(_WordNetObject):
         """
 
         from nltk.util import acyclic_breadth_first
-        return acyclic_breadth_first(self, rel, depth)
+        for synset in acyclic_breadth_first(self, rel, depth):
+            if synset != self:
+                yield synset
 
 
     def tree(self, rel, depth=-1, cut_mark=None):

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -559,7 +559,7 @@ class Synset(_WordNetObject):
         >>> print(list(computer.closure(topic)))
         [Synset('computer_science.n.01')]
 
-        UserWarning: Discarded redundant search ([(Synset('computer.n.01'), 2)])
+        UserWarning: Discarded redundant search for Synset('computer.n.01') at depth 2
 
 
         Include redundant pathes (but only once), avoiding duplicate searches
@@ -574,7 +574,7 @@ class Synset(_WordNetObject):
         Synset('whole.n.02'), Synset('chordate.n.01'), Synset('object.n.01'),
         Synset('physical_entity.n.01'), Synset('entity.n.01')]
 
-        UserWarning: Discarded redundant search ([(Synset('animal.n.01'), 7)])
+        UserWarning: Discarded redundant search for Synset('animal.n.01') at depth 7
         """
 
         from nltk.util import acyclic_breadth_first
@@ -595,7 +595,7 @@ class Synset(_WordNetObject):
         >>> pprint(computer.tree(topic))
         [Synset('computer.n.01'), [Synset('computer_science.n.01')]]
 
-        UserWarning: Discarded redundant search ([(Synset('computer.n.01'), -3)])
+        UserWarning: Discarded redundant search for Synset('computer.n.01') at depth -3
 
 
         But keep duplicate branches (from 'animal.n.01' to 'entity.n.01'):

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -547,31 +547,89 @@ class Synset(_WordNetObject):
                 self._min_depth = 1 + min(h.min_depth() for h in hypernyms)
         return self._min_depth
 
-    def closure(self, rel, depth=-1):
-        """Return the transitive closure of source under the rel
-        relationship, breadth-first
 
-            >>> from nltk.corpus import wordnet as wn
-            >>> dog = wn.synset('dog.n.01')
-            >>> hyp = lambda s:s.hypernyms()
-            >>> list(dog.closure(hyp))
-            [Synset('canine.n.02'), Synset('domestic_animal.n.01'),
-            Synset('carnivore.n.01'), Synset('animal.n.01'),
-            Synset('placental.n.01'), Synset('organism.n.01'),
-            Synset('mammal.n.01'), Synset('living_thing.n.01'),
-            Synset('vertebrate.n.01'), Synset('whole.n.02'),
-            Synset('chordate.n.01'), Synset('object.n.01'),
-            Synset('physical_entity.n.01'), Synset('entity.n.01')]
+    def closure(self, rel, depth=-1):
+        """
+        Return the transitive closure of source under the rel
+        relationship, breadth-first, discarding cycles:
+
+        >>> from nltk.corpus import wordnet as wn
+        >>> computer = wn.synset('computer.n.01')
+        >>> topic = lambda s:s.topic_domains()
+        >>> print(list(computer.closure(topic)))
+
+        UserWarning: Discarded redundant search ([(Synset('computer.n.01'), 2)])
+        [Synset('computer_science.n.01')]
+
+
+        >>> dog = wn.synset('dog.n.01')
+        >>> topic = lambda s:s.hypernyms()
+        >>> pprint(computer.tree(hyp))
+        >>> print(list(dog.tree(hyp)))
+
+        [Synset('canine.n.02'), Synset('domestic_animal.n.01'),
+        Synset('carnivore.n.01'), Synset('animal.n.01'),
+        Synset('placental.n.01'), Synset('organism.n.01'),
+        Synset('mammal.n.01'), Synset('living_thing.n.01'),
+        Synset('vertebrate.n.01'), Synset('whole.n.02'),
+        Synset('chordate.n.01'), Synset('object.n.01'),
+        Synset('physical_entity.n.01'), Synset('entity.n.01')]
 
         """
-        from nltk.util import breadth_first
 
-        synset_offsets = []
-        for synset in breadth_first(self, rel, depth):
-            if synset._offset != self._offset:
-                if synset._offset not in synset_offsets:
-                    synset_offsets.append(synset._offset)
-                    yield synset
+        from nltk.util import acyclic_breadth_first
+        return acyclic_breadth_first(self, rel, depth)
+
+
+    def tree(self, rel, depth=-1, cut_mark=None):
+        """
+        Return the full relation tree, including self,
+        discarding cycles:
+
+        >>> from nltk.corpus import wordnet as wn
+        >>> from pprint import pprint
+        >>> computer = wn.synset('computer.n.01')
+        >>> topic = lambda s:s.topic_domains()
+        >>> pprint(computer.tree(topic))
+
+        UserWarning: Discarded redundant search ([(Synset('computer.n.01'), -3)])
+        [Synset('computer.n.01'), [Synset('computer_science.n.01')]]
+
+
+        But keep duplicate branches (from 'animal.n.01' to 'entity.n.01'):
+
+        >>> dog = wn.synset('dog.n.01')
+        >>> topic = lambda s:s.hypernyms()
+        >>> pprint(computer.tree(hyp))
+        >>> pprint(dog.tree(hyp))
+
+        [Synset('dog.n.01'),
+         [Synset('canine.n.02'),
+          [Synset('carnivore.n.01'),
+           [Synset('placental.n.01'),
+            [Synset('mammal.n.01'),
+             [Synset('vertebrate.n.01'),
+              [Synset('chordate.n.01'),
+               [Synset('animal.n.01'),
+                [Synset('organism.n.01'),
+                 [Synset('living_thing.n.01'),
+                  [Synset('whole.n.02'),
+                   [Synset('object.n.01'),
+                    [Synset('physical_entity.n.01'),
+                     [Synset('entity.n.01')]]]]]]]]]]]]],
+         [Synset('domestic_animal.n.01'),
+          [Synset('animal.n.01'),
+           [Synset('organism.n.01'),
+            [Synset('living_thing.n.01'),
+             [Synset('whole.n.02'),
+              [Synset('object.n.01'),
+               [Synset('physical_entity.n.01'), [Synset('entity.n.01')]]]]]]]]]
+
+        """
+
+        from nltk.util import acyclic_depth_first
+        return acyclic_depth_first(self, rel, depth)
+
 
     def hypernym_paths(self):
         """
@@ -753,42 +811,6 @@ class Synset(_WordNetObject):
 
         return None if math.isinf(path_distance) else path_distance
 
-    def tree(self, rel, depth=-1, cut_mark=None):
-        """
-        >>> from nltk.corpus import wordnet as wn
-        >>> dog = wn.synset('dog.n.01')
-        >>> hyp = lambda s:s.hypernyms()
-        >>> from pprint import pprint
-        >>> pprint(dog.tree(hyp))
-        [Synset('dog.n.01'),
-         [Synset('canine.n.02'),
-          [Synset('carnivore.n.01'),
-           [Synset('placental.n.01'),
-            [Synset('mammal.n.01'),
-             [Synset('vertebrate.n.01'),
-              [Synset('chordate.n.01'),
-               [Synset('animal.n.01'),
-                [Synset('organism.n.01'),
-                 [Synset('living_thing.n.01'),
-                  [Synset('whole.n.02'),
-                   [Synset('object.n.01'),
-                    [Synset('physical_entity.n.01'),
-                     [Synset('entity.n.01')]]]]]]]]]]]]],
-         [Synset('domestic_animal.n.01'),
-          [Synset('animal.n.01'),
-           [Synset('organism.n.01'),
-            [Synset('living_thing.n.01'),
-             [Synset('whole.n.02'),
-              [Synset('object.n.01'),
-               [Synset('physical_entity.n.01'), [Synset('entity.n.01')]]]]]]]]]
-        """
-
-        tree = [self]
-        if depth != 0:
-            tree += [x.tree(rel, depth - 1, cut_mark) for x in rel(self)]
-        elif cut_mark:
-            tree += [cut_mark]
-        return tree
 
     # interface to similarity methods
     def path_similarity(self, other, verbose=False, simulate_root=True):

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -244,25 +244,22 @@ def acyclic_breadth_first(tree, children=iter, maxdepth=-1):
     children should be a function taking as argument a tree node
     and returning an iterator of the node's children.
     """
+    traversed = set()
     queue = deque([(tree, 0)])
-    traversed = {tree}
-    cycles = []
     while queue:
         node, depth = queue.popleft()
         yield node
-
+        traversed.add(node)
         if depth != maxdepth:
             try:
                 for child in children(node):
                     if child not in traversed:
                         queue.append((child, depth + 1))
-                        traversed.add(child)
                     else:
-                        cycles.append((child, depth + 1))
+                        warnings.warn('Discarded redundant search for {0} at depth {1}'.format(child, depth + 1), stacklevel=2)
             except TypeError:
                 pass
-    if cycles:
-        warnings.warn('Discarded redundant search {0}'.format(str(cycles)))
+
 
 def acyclic_depth_first(tree, children=iter, depth=-1, cut_mark=None, traversed=None):
     """Traverse the nodes of a tree in depth-first order,
@@ -276,7 +273,6 @@ def acyclic_depth_first(tree, children=iter, depth=-1, cut_mark=None, traversed=
     if traversed is None:
         traversed = {tree}
     out_tree = [tree]
-    cycles = []
     if depth != 0:
         try:
             for child in children(tree):
@@ -284,13 +280,11 @@ def acyclic_depth_first(tree, children=iter, depth=-1, cut_mark=None, traversed=
 #                   Recurse with a different "traversed" set for each child:
                     out_tree += [acyclic_depth_first(child, children, depth - 1, cut_mark, traversed.union({child}))]
                 else:
-                    cycles.append((child, depth - 1))
+                    warnings.warn('Discarded redundant search for {0} at depth {1}'.format(child, depth - 1), stacklevel=3)
         except TypeError:
             pass
     elif cut_mark:
         out_tree += [cut_mark]
-    if cycles:
-        warnings.warn('Discarded redundant search {0}'.format(str(cycles)))
     return out_tree
 
 

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -229,6 +229,69 @@ def breadth_first(tree, children=iter, maxdepth=-1):
             except TypeError:
                 pass
 
+##########################################################################
+# Breadth-First / Depth-first Searches with Cycle Detection
+##########################################################################
+
+import warnings
+
+def acyclic_breadth_first(self, children=iter, maxdepth=-1):
+    """Traverse the nodes of a tree in breadth-first order,
+    discarding eventual cycles ().
+
+    The first argument should be the tree root;
+    children should be a function taking as argument a tree node
+    and returning an iterator of the node's children.
+    """
+    queue = [(self, 0)]
+    traversed = {self}
+    cycles = []
+    while queue:
+        node, depth = queue.pop()
+        if node != self:
+            yield node
+
+        if depth != maxdepth:
+            try:
+                for c in children(node):
+                    if c not in traversed:
+                        queue.append((c, depth + 1))
+                        traversed.add(c)
+                    else:
+                        cycles.append((c, depth + 1))
+            except TypeError:
+                pass
+    if cycles:
+        warnings.warn('Discarded redundant search (%s)' % cycles)
+
+
+def acyclic_depth_first(self, children=iter, depth=-1, cut_mark=None, traversed=None):
+    """Traverse the nodes of a tree in depth-first order,
+    discarding eventual cycles ().
+
+    The first argument should be the tree root;
+    children should be a function taking as argument a tree node
+    and returning an iterator of the node's children.
+    """
+    if traversed is None:
+        traversed = {self}
+    tree = [self]
+    cycles = []
+    if depth != 0:
+        try:
+            for c in children(self):
+                if c not in traversed:
+                    tree += [acyclic_depth_first(c, children, depth - 1, cut_mark, traversed.union({c}))]
+                else:
+                    cycles.append((c, depth - 1))
+        except TypeError:
+            pass
+    elif cut_mark:
+        tree += [cut_mark]
+    if cycles:
+        warnings.warn('Discarded redundant search (%s)' % cycles)
+    return tree
+
 
 ##########################################################################
 # Guess Character Encoding

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -229,6 +229,7 @@ def breadth_first(tree, children=iter, maxdepth=-1):
             except TypeError:
                 pass
 
+
 ##########################################################################
 # Breadth-First / Depth-first Searches with Cycle Detection
 ##########################################################################
@@ -247,7 +248,7 @@ def acyclic_breadth_first(self, children=iter, maxdepth=-1):
     traversed = {self}
     cycles = []
     while queue:
-        node, depth = queue.pop()
+        node, depth = queue.pop(0)
         if node != self:
             yield node
 

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -273,9 +273,10 @@ def acyclic_depth_first(tree, children=iter, depth=-1, cut_mark=None, traversed=
     Catches all cycles:
 
     >>> import nltk
+    >>> from nltk.util import acyclic_depth_first as acyclic_tree
     >>> wn=nltk.corpus.wordnet
     >>> from pprint import pprint
-    >>> pprint(wn.synset('dog.n.01').acyclic_tree(lambda s:s.hypernyms(),cut_mark='...'))
+    >>> pprint(acyclic_tree(wn.synset('dog.n.01'), lambda s:s.hypernyms(),cut_mark='...'))
     [Synset('dog.n.01'),
      [Synset('canine.n.02'),
       [Synset('carnivore.n.01'),
@@ -327,9 +328,10 @@ def acyclic_branches_depth_first(tree, children=iter, depth=-1, cut_mark=None, t
     but keeping cycles from different branches:
 
     >>> import nltk
+    >>> from nltk.util import acyclic_branches_depth_first as tree
     >>> wn=nltk.corpus.wordnet
     >>> from pprint import pprint
-    >>> pprint(wn.synset('certified.a.01').tree(lambda s:s.also_sees(),cut_mark='...',depth=4))
+    >>> pprint(tree(wn.synset('certified.a.01'), lambda s:s.also_sees(), cut_mark='...', depth=4))
     [Synset('certified.a.01'),
      [Synset('authorized.a.01'),
       [Synset('lawful.a.01'),

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -212,7 +212,7 @@ def filestring(f):
 
 def breadth_first(tree, children=iter, maxdepth=-1):
     """Traverse the nodes of a tree in breadth-first order.
-    (No need to check for cycles.)
+    (No check for cycles.)
     The first argument should be the tree root;
     children should be a function taking as argument a tree node
     and returning an iterator of the node's children.
@@ -236,62 +236,63 @@ def breadth_first(tree, children=iter, maxdepth=-1):
 
 import warnings
 
-def acyclic_breadth_first(self, children=iter, maxdepth=-1):
+def acyclic_breadth_first(tree, children=iter, maxdepth=-1):
     """Traverse the nodes of a tree in breadth-first order,
-    discarding eventual cycles ().
+    discarding eventual cycles.
 
     The first argument should be the tree root;
     children should be a function taking as argument a tree node
     and returning an iterator of the node's children.
     """
-    queue = [(self, 0)]
-    traversed = {self}
+    queue = [(tree, 0)]
+    traversed = {tree}
     cycles = []
     while queue:
         node, depth = queue.pop(0)
-        if node != self:
-            yield node
+        yield node
 
         if depth != maxdepth:
             try:
-                for c in children(node):
-                    if c not in traversed:
-                        queue.append((c, depth + 1))
-                        traversed.add(c)
+                for child in children(node):
+                    if child not in traversed:
+                        queue.append((child, depth + 1))
+                        traversed.add(child)
                     else:
-                        cycles.append((c, depth + 1))
+                        cycles.append((child, depth + 1))
             except TypeError:
                 pass
     if cycles:
-        warnings.warn('Discarded redundant search (%s)' % cycles)
+        warnings.warn('Discarded redundant search {0}'.format(str(cycles)))
 
 
-def acyclic_depth_first(self, children=iter, depth=-1, cut_mark=None, traversed=None):
+def acyclic_depth_first(tree, children=iter, depth=-1, cut_mark=None, traversed=None):
     """Traverse the nodes of a tree in depth-first order,
-    discarding eventual cycles ().
+    discarding eventual cycles within the same branch, but keep
+    duplicate pathes in different branches.
 
     The first argument should be the tree root;
     children should be a function taking as argument a tree node
     and returning an iterator of the node's children.
     """
     if traversed is None:
-        traversed = {self}
-    tree = [self]
+        traversed = {tree}
+    out_tree = [tree]
     cycles = []
     if depth != 0:
         try:
-            for c in children(self):
-                if c not in traversed:
-                    tree += [acyclic_depth_first(c, children, depth - 1, cut_mark, traversed.union({c}))]
+            for child in children(tree):
+                if child not in traversed:
+#                   Recurse with a different "traversed" set for each child:
+                    out_tree += [acyclic_depth_first(child, children, depth - 1, cut_mark, traversed.union({child}))]
                 else:
-                    cycles.append((c, depth - 1))
+                    cycles.append((child, depth - 1))
         except TypeError:
             pass
     elif cut_mark:
-        tree += [cut_mark]
+        out_tree += [cut_mark]
     if cycles:
-        warnings.warn('Discarded redundant search (%s)' % cycles)
-    return tree
+        warnings.warn('Discarded redundant search {0}'.format(str(cycles)))
+    return out_tree
 
 
 ##########################################################################

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -244,11 +244,11 @@ def acyclic_breadth_first(tree, children=iter, maxdepth=-1):
     children should be a function taking as argument a tree node
     and returning an iterator of the node's children.
     """
-    queue = [(tree, 0)]
+    queue = deque([(tree, 0)])
     traversed = {tree}
     cycles = []
     while queue:
-        node, depth = queue.pop(0)
+        node, depth = queue.popleft()
         yield node
 
         if depth != maxdepth:
@@ -263,7 +263,6 @@ def acyclic_breadth_first(tree, children=iter, maxdepth=-1):
                 pass
     if cycles:
         warnings.warn('Discarded redundant search {0}'.format(str(cycles)))
-
 
 def acyclic_depth_first(tree, children=iter, depth=-1, cut_mark=None, traversed=None):
     """Traverse the nodes of a tree in depth-first order,

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -264,11 +264,33 @@ def acyclic_breadth_first(tree, children=iter, maxdepth=-1):
 def acyclic_depth_first(tree, children=iter, depth=-1, cut_mark=None, traversed=None):
     """Traverse the nodes of a tree in depth-first order,
     discarding eventual cycles within any branch,
-    adding cut_mark (when defined) if cycles were truncated.
+    adding cut_mark (when specified) if cycles were truncated.
 
     The first argument should be the tree root;
     children should be a function taking as argument a tree node
     and returning an iterator of the node's children.
+
+    Catches all cycles:
+
+    >>> import nltk
+    >>> wn=nltk.corpus.wordnet
+    >>> from pprint import pprint
+    >>> pprint(wn.synset('dog.n.01').acyclic_tree(lambda s:s.hypernyms(),cut_mark='...'))
+    [Synset('dog.n.01'),
+     [Synset('canine.n.02'),
+      [Synset('carnivore.n.01'),
+       [Synset('placental.n.01'),
+        [Synset('mammal.n.01'),
+         [Synset('vertebrate.n.01'),
+          [Synset('chordate.n.01'),
+           [Synset('animal.n.01'),
+            [Synset('organism.n.01'),
+             [Synset('living_thing.n.01'),
+              [Synset('whole.n.02'),
+               [Synset('object.n.01'),
+                [Synset('physical_entity.n.01'),
+                 [Synset('entity.n.01')]]]]]]]]]]]]],
+     [Synset('domestic_animal.n.01'), "Cycle(Synset('animal.n.01'),-3,...)"]]
     """
     if traversed is None:
         traversed = {tree}
@@ -283,7 +305,7 @@ def acyclic_depth_first(tree, children=iter, depth=-1, cut_mark=None, traversed=
                 else:
                     warnings.warn('Discarded redundant search for {0} at depth {1}'.format(child, depth - 1), stacklevel=3)
                     if cut_mark:
-                        out_tree += [cut_mark]
+                        out_tree += ['Cycle({0},{1},{2})'.format(child, depth - 1, cut_mark)]
         except TypeError:
             pass
     elif cut_mark:
@@ -300,6 +322,33 @@ def acyclic_branches_depth_first(tree, children=iter, depth=-1, cut_mark=None, t
     The first argument should be the tree root;
     children should be a function taking as argument a tree node
     and returning an iterator of the node's children.
+
+    Catches only only cycles within the same branch,
+    but keeping cycles from different branches:
+
+    >>> import nltk
+    >>> wn=nltk.corpus.wordnet
+    >>> from pprint import pprint
+    >>> pprint(wn.synset('certified.a.01').tree(lambda s:s.also_sees(),cut_mark='...',depth=4))
+    [Synset('certified.a.01'),
+     [Synset('authorized.a.01'),
+      [Synset('lawful.a.01'),
+       [Synset('legal.a.01'),
+        "Cycle(Synset('lawful.a.01'),0,...)",
+        [Synset('legitimate.a.01'), '...']],
+       [Synset('straight.a.06'),
+        [Synset('honest.a.01'), '...'],
+        "Cycle(Synset('lawful.a.01'),0,...)"]],
+      [Synset('legitimate.a.01'),
+       "Cycle(Synset('authorized.a.01'),1,...)",
+       [Synset('legal.a.01'),
+        [Synset('lawful.a.01'), '...'],
+        "Cycle(Synset('legitimate.a.01'),0,...)"],
+       [Synset('valid.a.01'),
+        "Cycle(Synset('legitimate.a.01'),0,...)",
+        [Synset('reasonable.a.01'), '...']]],
+      [Synset('official.a.01'), "Cycle(Synset('authorized.a.01'),1,...)"]],
+     [Synset('documented.a.01')]]
     """
     if traversed is None:
         traversed = {tree}
@@ -309,11 +358,11 @@ def acyclic_branches_depth_first(tree, children=iter, depth=-1, cut_mark=None, t
             for child in children(tree):
                 if child not in traversed:
 #                   Recurse with a different "traversed" set for each child:
-                    out_tree += [acyclic_depth_first(child, children, depth - 1, cut_mark, traversed.union({child}))]
+                    out_tree += [acyclic_branches_depth_first(child, children, depth - 1, cut_mark, traversed.union({child}))]
                 else:
                     warnings.warn('Discarded redundant search for {0} at depth {1}'.format(child, depth - 1), stacklevel=3)
                     if cut_mark:
-                        out_tree += [cut_mark]
+                        out_tree += ['Cycle({0},{1},{2})'.format(child, depth - 1, cut_mark)]
         except TypeError:
             pass
     elif cut_mark:


### PR DESCRIPTION
This fixes issue #2314 (Infinite loop in Wordnet closure and tree)

## 1. The Problem

The origin of the bugs mentioned in issue #2314  is that the "nltk_data/corpora/wordnet/data.verb" database file contains two endless cycles: one hyponyms() cycle between 'restrain.v.01' and 'inhibit.v.04', and one topic_domains() cycle between 'computer.n.01' and 'computer_science.n.01'.

As a consequence of these cycles in the database, the closure() function in the WordNet module loops forever on the hyponyms of both 'restrain.v.01' and 'inhibit.v.04', and the topic_domains of both 'computer.n.01' and 'computer_science.n.01', these combinations yielding 4 failing calls:

```
>>> wn=nltk.corpus.wordnet
>>> print(list(wn.synset('restrain.v.01').closure(lambda s:s.hyponyms())))
>>> print(list(wn.synset('inhibit.v.04').closure(lambda s:s.hyponyms())))
>>> print(list(wn.synset('computer.n.01').closure(lambda s:s.topic_domains())))
>>> print(list(wn.synset('computer_science.n.01').closure(lambda s:s.topic_domains())))
```
Likewise, the tree() function throws a RecursionError for any of the 4 corresponding calls. 

```
>>> from pprint import pprint
>>> pprint(wn.synset('restrain.v.01').tree(lambda s:s.hyponyms()))
>>> pprint(wn.synset('inhibit.v.04').tree(lambda s:s.hyponyms()))
>>> pprint(wn.synset('computer.n.01').tree(lambda s:s.topic_domains()))
>>> pprint(wn.synset('computer_science.n.01').tree(lambda s:s.topic_domains()))
```

So 8 calls fail in total, in addition to a few thousand symmetric links from the verb_groups, attributes and also_sees relations.

One solution is to patch the database (as was already done in the past), but this does not prevent similar bugs in future db versions.

PR #2610 by @CubieDev proposes to handle the errors entirely within the WordNet module.

On the other hand, the present PR proposes to handle the problem more generally in nltk/util.py, considering that the source of the problem with the current "closure" function is that it calls a "breadth_first" function imported from nltk.util, where the comment ("No need to check for cycles") is unfortunate, since there really is a need to check for cycles, in order to avoid eventual endless loops. Cyclicity  also occurs in other graphs than Wordnet, so a general-purpose solution outside of the Wordnet module could be useful to check other graphs as well. 

Also, due to the potential severity of this bug, it is preferrable to raise a warning than just to ignore the cycles silently.

## 2. Fixing Closure

This fix implements an "acyclic_breadth_first" function in nltk/util.py, that detects and discards cycles. It is just a clone of the already existing "breadth_first" function, with a few additional lines to handle the cycles. Then wordnet.py needs only a simple wrapper to implement relation closure:

```
    def closure(self, rel, depth=-1):
        """
        Return the transitive closure of source under the rel
        relationship, breadth-first, discarding cycles:

        >>> from nltk.corpus import wordnet as wn
        >>> computer = wn.synset('computer.n.01')
        >>> topic = lambda s:s.topic_domains()
        >>> print(list(computer.closure(topic)))
        [Synset('computer_science.n.01')]

        UserWarning: Discarded redundant search ([(Synset('computer.n.01'), 2)])


        Include redundant pathes (but only once), avoiding duplicate searches
        (from 'animal.n.01' to 'entity.n.01'):

        >>> dog = wn.synset('dog.n.01')
        >>> hyp = lambda s:s.hypernyms()
        >>> print(list(dog.closure(hyp)))
        [Synset('canine.n.02'), Synset('domestic_animal.n.01'), Synset('carnivore.n.01'),
        Synset('animal.n.01'), Synset('placental.n.01'), Synset('organism.n.01'),
        Synset('mammal.n.01'), Synset('living_thing.n.01'), Synset('vertebrate.n.01'),
        Synset('whole.n.02'), Synset('chordate.n.01'), Synset('object.n.01'),
        Synset('physical_entity.n.01'), Synset('entity.n.01')]

        UserWarning: Discarded redundant search ([(Synset('animal.n.01'), 7)])
        """

        from nltk.util import acyclic_breadth_first
        for synset in acyclic_breadth_first(self, rel, depth):
            if synset != self:
                yield synset

```

The current implementation of Wordnet closure does not include the caller synset in the output (unlike the 'tree' fumction), and this behaviour is maintained here.

Please note the  duplicate path (from 'animal.n.01' to 'entity.n.01') in the hypernyms of 'dog.n.01', which has not received much attention previously. Pruning this path indiscriminately would be incorrect, since it occurs legitimately in two different branches of the tree, so we want to keep both instances of it in the output of "tree" (but search it just once in "closure").

## 3. Fixing Tree

Maybe the case is weaker for implementing an "acyclic_depth_first" search function that detects cycles in nltk/util.py,
and the proposal in PR #2610 by @CubieDev to keep it within the WordNet module is a good alternative, although the coding style should be sufficiently explicit, in order to be able to report the eventual cycles, instead of ignoring them silently.

In the present PR, the Wordnet "tree" wrapper can simply be:

```
    def tree(self, rel, depth=-1, cut_mark=None):
        """
        Return the full relation tree, including self,
        discarding cycles:

        >>> from nltk.corpus import wordnet as wn
        >>> from pprint import pprint
        >>> computer = wn.synset('computer.n.01')
        >>> topic = lambda s:s.topic_domains()
        >>> pprint(computer.tree(topic))
        [Synset('computer.n.01'), [Synset('computer_science.n.01')]]

        UserWarning: Discarded redundant search ([(Synset('computer.n.01'), -3)])


        But keep duplicate branches (from 'animal.n.01' to 'entity.n.01'):

        >>> dog = wn.synset('dog.n.01')
        >>> hyp = lambda s:s.hypernyms()
        >>> pprint(dog.tree(hyp))
        [Synset('dog.n.01'),
         [Synset('canine.n.02'),
          [Synset('carnivore.n.01'),
           [Synset('placental.n.01'),
            [Synset('mammal.n.01'),
             [Synset('vertebrate.n.01'),
              [Synset('chordate.n.01'),
               [Synset('animal.n.01'),
                [Synset('organism.n.01'),
                 [Synset('living_thing.n.01'),
                  [Synset('whole.n.02'),
                   [Synset('object.n.01'),
                    [Synset('physical_entity.n.01'),
                     [Synset('entity.n.01')]]]]]]]]]]]]],
         [Synset('domestic_animal.n.01'),
          [Synset('animal.n.01'),
           [Synset('organism.n.01'),
            [Synset('living_thing.n.01'),
             [Synset('whole.n.02'),
              [Synset('object.n.01'),
               [Synset('physical_entity.n.01'), [Synset('entity.n.01')]]]]]]]]]
        """

        from nltk.util import acyclic_branches_depth_first
        return acyclic_branches_depth_first(self, rel, depth, cut_mark)
```

The new function acyclic_branches_depth_first() traverses the nodes of a tree in depth-first order, discarding eventual cycles within the same branch, but keeping duplicate pathes in different branches. The branches are kept separate by recursing with a different "traversed" set for each child.

## 4. Tree-size  Limitation

But the worst problem by far, is the also_sees() relation (2692 links between Synsets), which has both 2490 symmetric links, and 202 non-symmetric links that involve Synsets that also have at least a symmetric link. This combination is particularly toxic, because it produces a huge Strongly Connected Component (SCC), counting 758 synsets, where any member of the SCC is transitively connected to all other members. I am not sure how to estimate the size of such a tree, but only guessing that it could approximately be the average number of children per node, raised to the 758 power. Then the full also_sees() tree, starting at any member of this SCC, for ex. 'concrete.a.01', could not fit on a single computer, no matter how efficiently trees are represented or computed.

So the proposed approach obviously cannot handle such harder cases, where the trees grow to an unmanageable size, and  the computation only terminates in reasonable time if the "depth" parameter is limited:

```
>>> import nltk
>>> wn=nltk.corpus.wordnet
>>> from pprint import pprint
>>> pprint(wn.synset('certified.a.01').tree(lambda s:s.also_sees(),cut_mark='...',depth=4))
[Synset('certified.a.01'),
 [Synset('authorized.a.01'),
  [Synset('lawful.a.01'),
   [Synset('legal.a.01'),
    "Cycle(Synset('lawful.a.01'),0,...)",
    [Synset('legitimate.a.01'), '...']],
   [Synset('straight.a.06'),
    [Synset('honest.a.01'), '...'],
    "Cycle(Synset('lawful.a.01'),0,...)"]],
  [Synset('legitimate.a.01'),
   "Cycle(Synset('authorized.a.01'),1,...)",
   [Synset('legal.a.01'),
    [Synset('lawful.a.01'), '...'],
    "Cycle(Synset('legitimate.a.01'),0,...)"],
   [Synset('valid.a.01'),
    "Cycle(Synset('legitimate.a.01'),0,...)",
    [Synset('reasonable.a.01'), '...']]],
  [Synset('official.a.01'), "Cycle(Synset('authorized.a.01'),1,...)"]],
 [Synset('documented.a.01')]]
```

To handle such cases, global pruning is needed, which is now implemented in a new "acyclic_tree" function. This uses depth first search to compute an arbitrary spanning tree. Alternatively, breadth-first search could compute a minimum spanning tree (MST), which may not necessarily be worthwile, since it would require some overhead in order to assemble a tree structure. The proposed solution can cope with all cycles, but has the drawback that it truncates some legitimate duplicate pathes:

```
>>> import nltk
>>> wn=nltk.corpus.wordnet
>>> from pprint import pprint
>>> pprint(wn.synset('dog.n.01').acyclic_tree(lambda s:s.hypernyms(),cut_mark='...'))
[Synset('dog.n.01'),
 [Synset('canine.n.02'),
  [Synset('carnivore.n.01'),
   [Synset('placental.n.01'),
    [Synset('mammal.n.01'),
     [Synset('vertebrate.n.01'),
      [Synset('chordate.n.01'),
       [Synset('animal.n.01'),
        [Synset('organism.n.01'),
         [Synset('living_thing.n.01'),
          [Synset('whole.n.02'),
           [Synset('object.n.01'),
            [Synset('physical_entity.n.01'),
             [Synset('entity.n.01')]]]]]]]]]]]]],
 [Synset('domestic_animal.n.01'), "Cycle(Synset('animal.n.01'),-3,...)"]]
```
