### PR TITLE
LazyIteratorList in nltk.collections throws StopIteration exception when getting list length

### DIFF
--- a/nltk/collections.py
+++ b/nltk/collections.py
@@ -594,10 +594,13 @@ class LazyIteratorList(AbstractLazySequence):
         while i < len(self._cache):
             yield self._cache[i]
             i += 1
-        while True:
-            v = next(self._it)
-            self._cache.append(v)
-            yield v
+        try:
+            while True:
+                v = next(self._it)
+                self._cache.append(v)
+                yield v
+        except StopIteration as e:
+            pass
 
     def __add__(self, other):
         """Return a list concatenating self with other."""

--- a/nltk/collections.py
+++ b/nltk/collections.py
@@ -598,7 +598,6 @@ class LazyIteratorList(AbstractLazySequence):
             v = next(self._it)
             self._cache.append(v)
             yield v
-            i += 1
 
     def __add__(self, other):
         """Return a list concatenating self with other."""

--- a/nltk/collections.py
+++ b/nltk/collections.py
@@ -305,7 +305,7 @@ class LazyConcatenation(AbstractLazySequence):
 
     def __len__(self):
         if len(self._offsets) <= len(self._list):
-            for tok in self.iterate_from(self._offsets[-1]):
+            for _ in self.iterate_from(self._offsets[-1]):
                 pass
         return self._offsets[-1]
 
@@ -580,7 +580,7 @@ class LazyIteratorList(AbstractLazySequence):
     def __len__(self):
         if self._len:
             return self._len
-        for x in self.iterate_from(len(self._cache)):
+        for _ in self.iterate_from(len(self._cache)):
             pass
         self._len = len(self._cache)
         return self._len

--- a/nltk/collections.py
+++ b/nltk/collections.py
@@ -599,7 +599,7 @@ class LazyIteratorList(AbstractLazySequence):
                 v = next(self._it)
                 self._cache.append(v)
                 yield v
-        except StopIteration as e:
+        except StopIteration:
             pass
 
     def __add__(self, other):

--- a/nltk/collections.py
+++ b/nltk/collections.py
@@ -327,7 +327,7 @@ class LazyConcatenation(AbstractLazySequence):
             if sublist_index == (len(self._offsets) - 1):
                 assert (
                     index + len(sublist) >= self._offsets[-1]
-                ), "offests not monotonic increasing!"
+                ), "offsets not monotonic increasing!"
                 self._offsets.append(index + len(sublist))
             else:
                 assert self._offsets[sublist_index + 1] == index + len(

--- a/nltk/test/collections.doctest
+++ b/nltk/test/collections.doctest
@@ -18,3 +18,14 @@ Trie can be pickled:
     >>> s = pickle.dumps(trie)
     >>> pickle.loads(s)
     {'a': {True: None}}
+
+LazyIteratorList
+----------------
+
+Fetching the length of a LazyIteratorList object does not throw a StopIteration exception:
+
+    >>> lil = LazyIteratorList(i for i in range(1, 11))
+    >>> lil[-1]
+    10
+    >>> len(lil)
+    10


### PR DESCRIPTION
Fixes #2616.

Hello!

---
## Pull request overview
This PR is about solving a StopIteration exception when calling `iterate_from` on a `LazyIteratorList` object in `nltk.collections`. 
This object is used in `nltk.corpus.framenet`, and causes the following program to throw a StopIteration exception:
```python
from nltk.corpus import framenet as fn
list(fn.annotations())
```
(Alternatively, `len` instead of `list` also causes this error)
This error is reported in #2616.

---

## Bug:
### Why does this bug exist?
Both `len(lil)` and `list(lil)` with `lil` as a `LazyIteratorList` object call `iterate_from()`:
https://github.com/nltk/nltk/blob/385fb3f22031ebfa87b5c5571f32008f967264fa/nltk/collections.py#L580-L601

Lines 597 through 601 contains an infinite loop, endlessly grabbing the next from an iterator and yielding it. However, this iterator might be finite, causing a StopIteration exception to be thrown. This is not necessarily an issue, if it is caught elsewhere, however the call from `__len__` in line 583 does not handle this exception. Other calls to this method (e.g. from the superclass) don't catch this exception either.

### How to reproduce?
```python
from nltk.collections import LazyIteratorList
lil = LazyIteratorList(i for i in range(1, 11))
print(list(lil))
print(len(lil))
print(lil[-1])
```
Every single one of the last three lines will throw a StopIteration exception.

### A fix
Wrapping lines 597 to 601 with a try-except with `pass` will terminate the iteration like expected, when the end is reached. Both `len()` and `list()` will work properly now. I added two tests to `collections.doctest` that failed previously. 
I chose to not add a test for `list(fn.annotations())` as it requires expansion of all annotations, and there are several hundreds of thousands of them. This test would cost several minutes, and is not required, as the real issue is with `LazyIteratorList`. However, this does work again. The list of framenet annotations can be fully expanded without an exception now.

---

### Other changes
* Remove an unnecessary incremention of `i` in line 601 of `iterate_from` that was leftover from a previous implementation.
* I replaced two unused variables in for loops with `_`.
* Fixed a typo in an assertion statement.

---

- Tom Aarsen