### PR TITLE
POS tagger throws IndexError when passed empty string

### DIFF
--- a/nltk/tag/__init__.py
+++ b/nltk/tag/__init__.py
@@ -108,7 +108,7 @@ def _get_tagger(lang=None):
 
 
 def _pos_tag(tokens, tagset=None, tagger=None, lang=None):
-    # Currently only supoorts English and Russian.
+    # Currently only supports English and Russian.
     if lang not in ["eng", "rus"]:
         raise NotImplementedError(
             "Currently, NLTK pos_tag only supports English and Russian "

--- a/nltk/tag/perceptron.py
+++ b/nltk/tag/perceptron.py
@@ -277,7 +277,7 @@ class PerceptronTagger(TaggerI):
             return "!HYPHEN"
         elif word.isdigit() and len(word) == 4:
             return "!YEAR"
-        elif word and word[0].isdigit():
+        elif word[0].isdigit():
             return "!DIGITS"
         else:
             return word.lower()
@@ -296,7 +296,7 @@ class PerceptronTagger(TaggerI):
         # It's useful to have a constant feature, which acts sort of like a prior
         add("bias")
         add("i suffix", word[-3:])
-        add("i pref1", word[0] if word else "")
+        add("i pref1", word[0])
         add("i-1 tag", prev)
         add("i-2 tag", prev2)
         add("i tag+i-2 tag", prev, prev2)

--- a/nltk/tag/perceptron.py
+++ b/nltk/tag/perceptron.py
@@ -275,11 +275,12 @@ class PerceptronTagger(TaggerI):
         """
         if "-" in word and word[0] != "-":
             return "!HYPHEN"
-        if word.isdigit() and len(word) == 4:
+        elif word.isdigit() and len(word) == 4:
             return "!YEAR"
-        if word and word[0].isdigit():
+        elif word and word[0].isdigit():
             return "!DIGITS"
-        return word.lower()
+        else:
+            return word.lower()
 
     def _get_features(self, i, word, context, prev, prev2):
         """Map tokens into a feature representation, implemented as a

--- a/nltk/tag/perceptron.py
+++ b/nltk/tag/perceptron.py
@@ -277,7 +277,7 @@ class PerceptronTagger(TaggerI):
             return "!HYPHEN"
         elif word.isdigit() and len(word) == 4:
             return "!YEAR"
-        elif word[0].isdigit():
+        elif word and word[0].isdigit():
             return "!DIGITS"
         else:
             return word.lower()
@@ -296,7 +296,7 @@ class PerceptronTagger(TaggerI):
         # It's useful to have a constant feature, which acts sort of like a prior
         add("bias")
         add("i suffix", word[-3:])
-        add("i pref1", word[0])
+        add("i pref1", word[0] if word else "")
         add("i-1 tag", prev)
         add("i-2 tag", prev2)
         add("i tag+i-2 tag", prev, prev2)

--- a/nltk/tag/perceptron.py
+++ b/nltk/tag/perceptron.py
@@ -275,12 +275,11 @@ class PerceptronTagger(TaggerI):
         """
         if "-" in word and word[0] != "-":
             return "!HYPHEN"
-        elif word.isdigit() and len(word) == 4:
+        if word.isdigit() and len(word) == 4:
             return "!YEAR"
-        elif word and word[0].isdigit():
+        if word and word[0].isdigit():
             return "!DIGITS"
-        else:
-            return word.lower()
+        return word.lower()
 
     def _get_features(self, i, word, context, prev, prev2):
         """Map tokens into a feature representation, implemented as a

--- a/nltk/test/tag.doctest
+++ b/nltk/test/tag.doctest
@@ -31,3 +31,14 @@ and does not fail with:
     >>> from nltk.tag import RegexpTagger
     >>> patterns = [(str(i), 'NNP',) for i in range(200)]
     >>> tagger = RegexpTagger(patterns)
+
+Regression Testing for issue #2483
+==================================
+
+Ensure that tagging with pos_tag (PerceptronTagger) does not throw an IndexError
+when attempting tagging an empty string. What it must return instead is not 
+strictly defined.
+
+    >>> from nltk.tag import pos_tag
+    >>> pos_tag(['', 'is', 'a', 'beautiful', 'day'])
+    [...]


### PR DESCRIPTION
Fixes #2483.

Hello!

---
## Pull request overview
This PR is about removing an IndexError that is thrown when an empty string is passed to either:
- `pos_tag()` in `nltk`
- `PerceptronTagger().tag()` in `nltk.tag.perceptron`
- `PerceptronTagger().train()` in `nltk.tag.perceptron`
- `PerceptronTagger().normalize()` in `nltk.tag.perceptron`

This error is reported in #2483.

---

## Bug:
### Why does this bug exist?
The first three functions (and methods) all call `PerceptronTagger().normalize()` for each "word" they are given. However, line 280 in that function checks the first character of that word:
https://github.com/nltk/nltk/blob/385fb3f22031ebfa87b5c5571f32008f967264fa/nltk/tag/perceptron.py#L267-L283
This will throw an IndexError when the passed word is an empty string.

### How to reproduce?
There are multiple functions affected, listed from most to least important. I'll provide ways to reproduce the issue for only the two most used functions:
```python
from nltk import pos_tag
words = ['', 'is', 'a', 'beautiful', 'day']
pos_tag(words)
```
```python
from nltk.tag.perceptron import PerceptronTagger
words = ['', 'is', 'a', 'beautiful', 'day']
tagger = PerceptronTagger()
tagger.tag(words)
```
For both of these, the last line will throw an IndexError.

### A fix
The fix, as proposed in f3ae03bcdfc3e57250bac511e3667d5ce421ce27 is to convert `elif word[0].isdigit():` to `elif word and word[0].isdigit()`, which causes the latter part to only be evaluated if `word` is non-empty.
This is only part of the fix however, as `pos_tag` and `PerceptionTagger().tag()` will still throw IndexErrors when extracting features from the word for use in the tagging. In particular, when getting the first character of the word. This is also resolved in the aforementioned commit by using an empty string if the word is an empty string.

### The consequences
With the pos_tagger that is shipped in nltk, an empty string is tagged as a `NN` with roughly `0.99` confidence. To me, this is way preferable over throwing an IndexError. If this really is undesired, an exception should be thrown explaining that empty strings should not be used.

### Tests
I added a test which previously failed, testing the first program listed in the "How to reproduce?" section.

---

### Notes
I also:
* Fixed a typo in a comment.
* Accidentally committed to the wrong branch in `CubieDev/nltk` and reverted afterward. As a result this PR has some commits that cancel each other out. This doesn't affect anything.

---

- Tom Aarsen