### PR TITLE
Fixes Issue #2420 (WordNet sense keys mismatch)

### DIFF
--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -1532,26 +1532,17 @@ class WordNetCorpusReader(CorpusReader):
                      Only used if sense is in an adjective satellite synset
         head_id:     uniquely identifies sense in a lexicographer file when paired with head_word
                      Only used if head_word is present (2 digit int)
+
+        >>> import nltk
+        >>> from nltk.corpus import wordnet as wn
+        >>> print(wn.synset_from_sense_key("drive%1:04:03::"))
+        Synset('drive.n.06')
+
+        >>> print(wn.synset_from_sense_key("driving%1:04:03::"))
+        Synset('drive.n.06')
         """
-        sense_key_regex = re.compile(r"(.*)\%(.*):(.*):(.*):(.*):(.*)")
-        synset_types = {1: NOUN, 2: VERB, 3: ADJ, 4: ADV, 5: ADJ_SAT}
-        lemma, ss_type, _, lex_id, _, _ = sense_key_regex.match(sense_key).groups()
+        return self.lemma_from_key(sense_key).synset()
 
-        # check that information extracted from sense_key is valid
-        error = None
-        if not lemma:
-            error = "lemma"
-        elif int(ss_type) not in synset_types:
-            error = "ss_type"
-        elif int(lex_id) < 0 or int(lex_id) > 99:
-            error = "lex_id"
-        if error:
-            raise WordNetError(
-                "valid {} could not be extracted from the sense key".format(error)
-            )
-
-        synset_id = ".".join([lemma, synset_types[int(ss_type)], lex_id])
-        return self.synset(synset_id)
 
     #############################################################
     # Retrieve synsets and lemmas.


### PR DESCRIPTION
Fixes Issues #2420 (WordNet sense keys mismatch) and #2171 (Wordnet: synset_from_sense_key returns the wrong Synset)


## The bug
For 25% of all sense keys, the synset_from_sense_key() function returns a wrong synset, or fails with an IndexError:

```
import nltk
print("NLTK v. %s" % nltk.__version__)
from nltk.corpus import wordnet as wn
print("WordNet v. %s" % wn.get_version())

n = 0
wrong_ss = 0
no_ss = 0

for ss in wn.all_synsets():
    for lm in ss._lemmas:
        n += 1
        try:
            if ss != wn.synset_from_sense_key(lm._key):
                wrong_ss += 1
        except:
            no_ss += 1
#            print('%s not found' % lm._key)

errors = wrong_ss + no_ss
print("%s/%s errors (%s/100): %s wrong, %s not found" % 
   (errors, n, round(100.0*errors/n, 3), wrong_ss, no_ss))
```

```
NLTK v. 3.5
WordNet v. 3.0
51751/206978 errors (25.003/100): 50416 wrong, 1335 not found
```


## Why does this bug occur?

The synset_from_sense_key() function in the wordnet.py module is severely flawed, because it incorrectly uses the "lex_id" extracted from the sense key, to construct synset_ids that turn out to be bogus, since an index into the list of offsets for the corresponding lemma is expected instead. 

At first glance, it seems remarkable that 75% of the results are correct by pure chance, when the lex_id and the expected index have nothing to do with each other. But this result is actually not impressive at all, since 80% of the words in WordNet 3.0 are monosemous, i.e. they occur only in one synset, in which case it should not be possible to pick a wrong synset.


## Reproducing the bug

This retrieves an incorrect synset (Synset('campaign.n.02'), instead of the correct Synset('drive.n.06')):

```
print(wn.synset_from_sense_key("drive%1:04:03::"))
print(wn.synset_from_sense_key("drive%1:04:03::").definition())
print(wn.synset_from_sense_key("drive%1:04:03::").offset())
```

This raises an "IndexError: list index out of range", because lex_ids are neither consecutive nor necessarily numbered starting at 0 (their default value):

```
print(wn.synset_from_sense_key("driving%1:04:03::"))
```

Thanks to @etienne-v for raising this issue


## The fix

Rely on the lemma_from_key() function to provide the correct synset:

```
    def synset_from_sense_key(self, sense_key):
        """
        >>> import nltk
        >>> from nltk.corpus import wordnet as wn
        >>> print(wn.synset_from_sense_key("drive%1:04:03::"))
        Synset('drive.n.06')

        >>> print(wn.synset_from_sense_key("driving%1:04:03::"))
        Synset('drive.n.06')
        """
        return self.lemma_from_key(sense_key).synset()
```


## The effect

After applying this PR, the number of wrong synsets drops to zero, but 8 ill-formed sense keys remain, pertaining to a different well-known problem (upper-case and lower-case forms of the same lemma are expected to share a common sense key):

```
NLTK v. 3.5
WordNet v. 3.0
ddc%1:06:01:: not found
ddi%1:06:01:: not found
earth%1:15:01:: not found
earth%1:17:02:: not found
moon%1:17:03:: not found
sun%1:17:02:: not found
kb%1:23:01:: not found
kb%1:23:03:: not found
8/206978 errors (0.004/100): 0 wrong, 8 not found
```