### PR TITLE
Minor improvements to the CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,12 @@ sudo: false
 language: python
 
 cache:
-  apt: true
+  pip: true
   directories:
   - $HOME/.cache/pip
   - $HOME/.ccache
   - $HOME/.pip-cache
   - $HOME/third
-  - $HOME/nltk_data
 
 dist: xenial
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,6 +145,15 @@ pytest unit/translate/test_nist.py  # unittest
 pytest  # all tests
 ```
 
+(For moderately faster tests, you can install [pytest-xdist](https://pypi.org/project/pytest-xdist/) locally and run your tests in parallel.)
+
+```
+pip install pytest-xdist
+
+# Run tests using 3 subprocesses
+pytest  -n3 nltk/test/
+```
+
 
 ## Continuous Integration
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,11 +161,11 @@ pytest  -n3 nltk/test/
 
 NLTK uses [Travis](https://travis-ci.org/nltk/nltk/) for continuous integration. 
 
-The [`.travis.yml`](https://github.com/nltk/nltk/blob/travis/.travis.yml) file configures the server:
+The [`.travis.yml`](https://github.com/nltk/nltk/blob/develop/.travis.yml) file configures the server:
 
  - `matrix: include:` section 
    - tests against supported Python versions (3.5, 3.6, 3.7, 3.8)
-     - all python versions run the `py-travis` tox test environment in the [`tox.ini`](https://github.com/nltk/nltk/blob/travis/tox.ini#L105) file
+     - all python versions run the `py-travis` tox test environment in the [`tox.ini`](https://github.com/nltk/nltk/blob/develop/tox.ini#L97) file
    - tests against Python 3.6 for third-party tools APIs
 
  - `before_install:` section 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,7 +138,7 @@ the desired feature.
 
 You can use `pytest` to run your tests, no matter which type of test it is:
 
-```
+```shell
 cd nltk/test
 pytest util.doctest  # doctest
 pytest unit/translate/test_nist.py  # unittest
@@ -147,7 +147,7 @@ pytest  # all tests
 
 (For moderately faster tests, you can install [pytest-xdist](https://pypi.org/project/pytest-xdist/) locally and run your tests in parallel.)
 
-```
+```shell
 pip install pytest-xdist
 
 # Run tests using 3 subprocesses
@@ -193,7 +193,7 @@ Then run `tox -e py37`.
 
 For example, using `pipenv`:
 
-```
+```shell
 git clone https://github.com/nltk/nltk.git
 cd nltk
 pipenv install -r pip-req.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,7 +151,7 @@ pytest  # all tests
 pip install pytest-xdist
 
 # Run tests using 3 subprocesses
-pytest  -n3 nltk/test/
+pytest  -n3
 ```
 
 

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -80,7 +80,7 @@ echo "---- Running tests ----"
 
 # Coverage
 rm -f coverage_scrubbed.xml
-pytest --cov=nltk --cov-report xml nltk/test/
+pytest --cov=nltk --cov-report xml
 iconv -c -f utf-8 -t utf-8 coverage.xml > coverage_scrubbed.xml
 
 # Create a default pylint configuration file.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,9 +1,18 @@
 [pytest]
-doctest_optionflags=ELLIPSIS NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL
+norecursedirs=.tox
+
+testpaths = nltk/test
+
+doctest_optionflags=
+    ELLIPSIS
+    NORMALIZE_WHITESPACE
+    IGNORE_EXCEPTION_DETAIL
 
 # --doctest-continue-on-failure allows the test to always
 # get to the teardown, if it exists
-addopts = --doctest-glob *.doctest --doctest-continue-on-failure
+addopts =
+    --doctest-glob *.doctest
+    --doctest-continue-on-failure
 
 # Other options for creating valid teardowns for doctests:
 # 1. Turn doctests into unittest tests

--- a/tools/travis/coverage-pylint.sh
+++ b/tools/travis/coverage-pylint.sh
@@ -15,7 +15,7 @@ pip -V
 
 echo "$(pwd)"  # Know which directory tox is running this shell from.
 
-#coverage
+# Coverage
 rm -f coverage_scrubbed.xml
 pytest --cov=nltk --cov-report xml
 iconv -c -f utf-8 -t utf-8 coverage.xml > coverage_scrubbed.xml

--- a/tox.ini
+++ b/tox.ini
@@ -46,16 +46,16 @@ deps =
     pytest-mock
     twython
 
-commands =
-    pytest
-
 [testenv:py35-nodeps]
 basepython = python3.5
 deps =
     nose >= 1.2.1
     pytest
     pytest-mock
-commands = pytest
+commands =
+    ; "nodeps" testenvs require a new commands list that doesn't
+    ; install scipy and scikit-learn
+    pytest
 
 [testenv:py36-nodeps]
 basepython = python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -28,13 +28,12 @@ deps =
     python-crfsuite
     regex
 
-changedir = nltk/test
 commands =
     ; scipy and scikit-learn requires numpy even to run setup.py so
     ; they can't be installed in one command
     pip install scipy scikit-learn
 
-    ; pytest --cov=nltk --cov-report html:{envdir}/docs nltk/test/
+    ; pytest --cov=nltk --cov-report html:{envdir}/docs
     pytest
 
 [testenv:pypy]

--- a/web/dev/local_testing.rst
+++ b/web/dev/local_testing.rst
@@ -49,7 +49,7 @@ only under single interpreter, but it may be easier to have numpy and other
 libraries installed this way. In order to run tests without tox, make sure
 to ``pip install -r test-requirements.txt`` and run ``pytest``::
 
-    pytest nltk/test/
+    pytest
 
 
 Writing tests


### PR DESCRIPTION
One of @iliakur's comments on my original diff, which I really liked.

The alternative is to add this to the `pytest.ini` so that tests always run parallel -- but I don't like the experience of `pytest path/to/file.py` still running parallel.