### PR TITLE
Minor improvements to CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,12 @@ sudo: false
 language: python
 
 cache:
-  apt: true
+  pip: true
   directories:
   - $HOME/.cache/pip
   - $HOME/.ccache
   - $HOME/.pip-cache
   - $HOME/third
-  - $HOME/nltk_data
 
 dist: xenial
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,9 +1,18 @@
 [pytest]
-doctest_optionflags=ELLIPSIS NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL
+norecursedirs=.tox
+
+testpaths = nltk/test
+
+doctest_optionflags=
+    ELLIPSIS
+    NORMALIZE_WHITESPACE
+    IGNORE_EXCEPTION_DETAIL
 
 # --doctest-continue-on-failure allows the test to always
 # get to the teardown, if it exists
-addopts = --doctest-glob *.doctest --doctest-continue-on-failure
+addopts =
+    --doctest-glob *.doctest
+    --doctest-continue-on-failure
 
 # Other options for creating valid teardowns for doctests:
 # 1. Turn doctests into unittest tests

--- a/tox.ini
+++ b/tox.ini
@@ -28,13 +28,12 @@ deps =
     python-crfsuite
     regex
 
-changedir = nltk/test
 commands =
     ; scipy and scikit-learn requires numpy even to run setup.py so
     ; they can't be installed in one command
     pip install scipy scikit-learn
 
-    ; pytest --cov=nltk --cov-report html:{envdir}/docs nltk/test/
+    ; pytest --cov=nltk --cov-report html:{envdir}/docs
     pytest
 
 [testenv:pypy]


### PR DESCRIPTION
Apparently apt-cache is not supported, and they recommend using a pip cache. https://github.com/travis-ci/docs-travis-ci-com/commit/bd8b56d501dbb47f76d139831c99f55ac69d1314

Also moved pytest.ini to base-level (so you can run `pytest` from anywhere in the repo)