### PR TITLE
Fix file handling of CrubadanCorpusReader

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -272,6 +272,7 @@
 - Matt Chaput
 - Danny Sepler <https://github.com/dannysepler>
 - Akshita Bhagia <https://github.com/AkshitaB>
+- Pratap Yadav <https://github.com/prtpydv>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 ### Contributors to the Porter Stemmer

--- a/nltk/corpus/reader/crubadan.py
+++ b/nltk/corpus/reader/crubadan.py
@@ -76,9 +76,10 @@ class CrubadanCorpusReader(CorpusReader):
         if self._LANG_MAPPER_FILE not in self.fileids():
             raise RuntimeError("Could not find language mapper file: " + mapper_file)
 
-        raw = open(mapper_file, "r", encoding="utf-8").read().strip()
+        with open(mapper_file, "r", encoding="utf-8") as raw:
+            strip_raw = raw.read().strip()
 
-        self._lang_mapping_data = [row.split("\t") for row in raw.split("\n")]
+            self._lang_mapping_data = [row.split("\t") for row in strip_raw.split("\n")]
 
     def _load_lang_ngrams(self, lang):
         """ Load single n-gram language file given the ISO 639-3 language code

--- a/nltk/corpus/reader/crubadan.py
+++ b/nltk/corpus/reader/crubadan.py
@@ -95,14 +95,13 @@ class CrubadanCorpusReader(CorpusReader):
             raise RuntimeError("No N-gram file found for requested language.")
 
         counts = FreqDist()
-        f = open(ngram_file, "r", encoding="utf-8")
+        with open(ngram_file, "r", encoding="utf-8") as f:
+            for line in f:
+                data = line.split(" ")
 
-        for line in f:
-            data = line.split(" ")
+                ngram = data[1].strip("\n")
+                freq = int(data[0])
 
-            ngram = data[1].strip("\n")
-            freq = int(data[0])
-
-            counts[ngram] = freq
+                counts[ngram] = freq
 
         return counts


### PR DESCRIPTION
Fixes  [#2633](https://github.com/nltk/nltk/issues/2633)

Hello!
## Pull request overview
This PR is about solving file handling issue in the CrubadanCorpusReader class. 

Two non-public methods ( `_load_lang_mapping_data` and `_load_lang_ngrams`) in the CrubadanCorpusReader class open txt files in the Crubadan corpus without closing them. 
Running some public methods of this class (like `crubadan_to_iso` ) that call either of these non-public methods, issues the following warning:
```
ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/user/nltk_data/corpora/crubadan/ab-3grams.txt' mode='r' encoding='utf-8'>
```
This issue is reported in [#2633](https://github.com/nltk/nltk/issues/2633)
## Bug
### Why does this bug exist?
The two non-public methods `_load_lang_mapping_data` and `_load_lang_ngrams` open and use corpus files without closing them:
https://github.com/nltk/nltk/blob/develop/nltk/corpus/reader/crubadan.py#L68-81
and 
https://github.com/nltk/nltk/blob/develop/nltk/corpus/reader/crubadan.py#L83-105

### How to reproduce?
```python
import unittest

from nltk.classify import textcat
from nltk.corpus import crubadan


def predict_language(text):
    cls = textcat.TextCat()
    lang = cls.guess_language(text)
    return crubadan.iso_to_crubadan(lang)


class Test(unittest.TestCase):
    def test(self):
        print(predict_language('test'))
```
Running this unit test issues ResourceWarning.
```
$ python -m unittest nltk_test.py
/Users/xxx/venv/lib/python3.7/site-packages/nltk/corpus/reader/crubadan.py:79: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/xxx/nltk_data/corpora/crubadan/table.txt' mode='r' encoding='utf-8'>
  raw = open(mapper_file, "r", encoding="utf-8").read().strip()
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/xxx/venv/lib/python3.7/site-packages/nltk/corpus/reader/crubadan.py:48: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/xxx/nltk_data/corpora/crubadan/ab-3grams.txt' mode='r' encoding='utf-8'>
  self._all_lang_freq[lang] = self._load_lang_ngrams(lang)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
/Users/xxx/venv/lib/python3.7/site-packages/nltk/corpus/reader/crubadan.py:48: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/xxx/nltk_data/corpora/crubadan/abn-3grams.txt' mode='r' encoding='utf-8'>
  self._all_lang_freq[lang] = self._load_lang_ngrams(lang)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```

### A fix
Wrapping the file handling statements under a `with` statement as follows ensures the accessed files are closed after use:
```python
    def _load_lang_mapping_data(self):
        """ Load language mappings between codes and description from table.txt """
        if isinstance(self.root, ZipFilePathPointer):
            raise RuntimeError(
                "Please install the 'crubadan' corpus first, use nltk.download()"
            )

        mapper_file = path.join(self.root, self._LANG_MAPPER_FILE)
        if self._LANG_MAPPER_FILE not in self.fileids():
            raise RuntimeError("Could not find language mapper file: " + mapper_file)

        with open(mapper_file, "r", encoding="utf-8") as raw:
            strip_raw = raw.read().strip()

            self._lang_mapping_data = [row.split("\t") for row in strip_raw.split("\n")]
```
```python
    def _load_lang_ngrams(self, lang):
        """ Load single n-gram language file given the ISO 639-3 language code
            and return its FreqDist """

        if lang not in self.langs():
            raise RuntimeError("Unsupported language.")

        crubadan_code = self.iso_to_crubadan(lang)
        ngram_file = path.join(self.root, crubadan_code + "-3grams.txt")

        if not path.isfile(ngram_file):
            raise RuntimeError("No N-gram file found for requested language.")

        counts = FreqDist()
        with open(ngram_file, "r", encoding="utf-8") as f:
            for line in f:
                data = line.split(" ")

                ngram = data[1].strip("\n")
                freq = int(data[0])

                counts[ngram] = freq

        return counts
```
