### PR TITLE
docs: fix simple typo, emtpy -> empty

### DIFF
--- a/nltk/corpus/reader/xmldocs.py
+++ b/nltk/corpus/reader/xmldocs.py
@@ -225,7 +225,7 @@ class XMLCorpusView(StreamBackedCorpusView):
     _XML_TAG_NAME = re.compile(r"<\s*/?\s*([^\s>]+)")
 
     #: A regular expression used to find all start-tags, end-tags, and
-    #: emtpy-elt tags in an XML file.  This regexp is more lenient than
+    #: empty-elt tags in an XML file.  This regexp is more lenient than
     #: the XML spec -- e.g., it allows spaces in some places where the
     #: spec does not.
     _XML_PIECE = re.compile(

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -1479,7 +1479,7 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
                 yield sentence
                 sentence = ""
 
-        # If the last sentence is emtpy, discard it.
+        # If the last sentence is empty, discard it.
         if sentence:
             yield sentence
 


### PR DESCRIPTION
There is a small typo in nltk/corpus/reader/xmldocs.py, nltk/tokenize/punkt.py.

Should read `empty` rather than `emtpy`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md