### PR TITLE
Compute Minimum Spanning Tree of unweighted graph using BFS

### DIFF
--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -587,6 +587,7 @@ class Synset(_WordNetObject):
 
     from nltk.util import acyclic_depth_first as acyclic_tree
 
+    from nltk.util import unweighted_minimum_cost_spanning_tree as mst
 
     def tree(self, rel, depth=-1, cut_mark=None):
         """

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -587,7 +587,7 @@ class Synset(_WordNetObject):
 
     from nltk.util import acyclic_depth_first as acyclic_tree
 
-    from nltk.util import unweighted_minimum_cost_spanning_tree as mst
+    from nltk.util import unweighted_minimum_spanning_tree as mst
 
     def tree(self, rel, depth=-1, cut_mark=None):
         """

--- a/nltk/test/wordnet.doctest
+++ b/nltk/test/wordnet.doctest
@@ -727,7 +727,7 @@ A Minimum Spanning Tree (MST) spans all the nodes of a relation subgraph once,
 while guaranteeing that each node is reached through the shortest path possible.
 In unweighted relation graphs like WordNet, a MST can be computed very efficiently
 in linear time, using Breadth-First Search (BFS). Like acyclic_tree(), the new
-"unweighted_minimum_cost_spanning_tree()" function (imported in the Wordnet
+"unweighted_minimum_spanning_tree()" function (imported in the Wordnet
 module as "mst") handles intractable trees, such as the example discussed above:
 "wn.synset('concrete.a.01').mst(lambda s:s.also_sees())".
 
@@ -744,23 +744,6 @@ classified.a.02):
       [Synset('confined.a.02')],
       [Synset('dependent.a.01')],
       [Synset('restricted.a.01'), [Synset('classified.a.02')]]]]
-
-
-Here also, specifying the "cut_mark" parameter increases verbosity, so that the
-cycles are mentioned in the output, together with the level where they occur:
-
-    >>> pprint(wn.synset('bound.a.01').mst(lambda s:s.also_sees(),cut_mark='...'))
-    [Synset('bound.a.01'),
-     [Synset('unfree.a.02'),
-      "Cycle(Synset('bound.a.01'),2,...)",
-      [Synset('confined.a.02'),
-       "Cycle(Synset('restricted.a.01'),3,...)",
-       "Cycle(Synset('unfree.a.02'),3,...)"],
-      [Synset('dependent.a.01'), "Cycle(Synset('unfree.a.02'),3,...)"],
-      [Synset('restricted.a.01'),
-       [Synset('classified.a.02')],
-       "Cycle(Synset('confined.a.02'),3,...)",
-       "Cycle(Synset('unfree.a.02'),3,...)"]]]
 
 
 -------------

--- a/nltk/test/wordnet.doctest
+++ b/nltk/test/wordnet.doctest
@@ -678,6 +678,10 @@ by limiting the "depth" parameter to display a small number of levels:
       [Synset('sincere.a.01'), '...']],
      [Synset('tangible.a.01'), "Cycle(Synset('concrete.a.01'),0,...)"]]
 
+
+2.1 First solution: acyclic_tree()
+..................................
+
 On the other hand, the new acyclic_tree() function is able to also handle
 the intractable cases. The also_sees() acyclic tree of 'concrete.a.01' is
 several hundred lines long, so here is a simpler example, concerning a much
@@ -714,6 +718,49 @@ cycles are mentioned in the output, together with the level where they occur:
        "Cycle(Synset('unfree.a.02'),-4,...)"],
       [Synset('dependent.a.01'), "Cycle(Synset('unfree.a.02'),-4,...)"],
       "Cycle(Synset('restricted.a.01'),-3,...)"]]
+
+
+2.1 Better solution: mst()
+..........................
+
+A Minimum Spanning Tree (MST) spans all the nodes of a relation graph once,
+while guaranteeing that each node is reached through the shortest path possible.
+In unweighted relation graphs like WordNet, a MST can be computed very
+efficiently using Breadth-First Search (BFS). Like acyclic_tree(), the new
+"unweighted_minimum_cost_spanning_tree()" function (imported in the Wordnet
+module as "mst") handles untractable trees, as the example discussed above:
+"wn.synset('concrete.a.01').mst(lambda s:s.also_sees())".
+
+But, while the also_sees() acyclic_tree of 'bound.a.01' reaches 
+'classified.a.02' through four links, using depth-first search as seen above
+(bound.a.01 > unfree.a.02 > confined.a.02 > restricted.a.01 > classified.a.02),
+in the following MST, the path to 'classified.a.02' is the shortest possible,
+consisting only in three links (bound.a.01 > unfree.a.02 > restricted.a.01 > 
+classified.a.02):
+
+    >>> pprint(wn.synset('bound.a.01').mst(lambda s:s.also_sees()))
+    [Synset('bound.a.01'),
+     [Synset('unfree.a.02'),
+      [Synset('confined.a.02')],
+      [Synset('dependent.a.01')],
+      [Synset('restricted.a.01'), [Synset('classified.a.02')]]]]
+
+
+Here also, specifying the "cut_mark" parameter increases verbosity, so that the
+cycles are mentioned in the output, together with the level where they occur:
+
+    >>> pprint(wn.synset('bound.a.01').mst(lambda s:s.also_sees(),cut_mark='...'))
+    [Synset('bound.a.01'),
+     [Synset('unfree.a.02'),
+      "Cycle(Synset('bound.a.01'),2,...)",
+      [Synset('confined.a.02'),
+       "Cycle(Synset('restricted.a.01'),3,...)",
+       "Cycle(Synset('unfree.a.02'),3,...)"],
+      [Synset('dependent.a.01'), "Cycle(Synset('unfree.a.02'),3,...)"],
+      [Synset('restricted.a.01'),
+       [Synset('classified.a.02')],
+       "Cycle(Synset('confined.a.02'),3,...)",
+       "Cycle(Synset('unfree.a.02'),3,...)"]]]
 
 
 -------------

--- a/nltk/test/wordnet.doctest
+++ b/nltk/test/wordnet.doctest
@@ -720,18 +720,18 @@ cycles are mentioned in the output, together with the level where they occur:
       "Cycle(Synset('restricted.a.01'),-3,...)"]]
 
 
-2.1 Better solution: mst()
+2.2 Better solution: mst()
 ..........................
 
-A Minimum Spanning Tree (MST) spans all the nodes of a relation graph once,
+A Minimum Spanning Tree (MST) spans all the nodes of a relation subgraph once,
 while guaranteeing that each node is reached through the shortest path possible.
-In unweighted relation graphs like WordNet, a MST can be computed very
-efficiently using Breadth-First Search (BFS). Like acyclic_tree(), the new
+In unweighted relation graphs like WordNet, a MST can be computed very efficiently
+in linear time, using Breadth-First Search (BFS). Like acyclic_tree(), the new
 "unweighted_minimum_cost_spanning_tree()" function (imported in the Wordnet
-module as "mst") handles untractable trees, as the example discussed above:
+module as "mst") handles intractable trees, such as the example discussed above:
 "wn.synset('concrete.a.01').mst(lambda s:s.also_sees())".
 
-But, while the also_sees() acyclic_tree of 'bound.a.01' reaches 
+But, while the also_sees() acyclic_tree of 'bound.a.01' reaches
 'classified.a.02' through four links, using depth-first search as seen above
 (bound.a.01 > unfree.a.02 > confined.a.02 > restricted.a.01 > classified.a.02),
 in the following MST, the path to 'classified.a.02' is the shortest possible,

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -364,6 +364,68 @@ def acyclic_branches_depth_first(tree, children=iter, depth=-1, cut_mark=None, t
     return out_tree
 
 
+def ms2tree(node, dic):
+    """Convert Minimum Spanning Tree dictionary 'dic' to nested list"""
+    if type(node)==str:
+        return node
+    else:
+        return [node] + [ms2tree(child, dic) for child in dic[node]]
+
+
+def unweighted_minimum_cost_spanning_tree(tree, children=iter, maxdepth=-1, cut_mark=None):
+    """
+    Output a Minimum Spanning Tree (MST) of an unweighted graph,
+    by traversing the nodes of a tree in breadth-first order,
+    discarding eventual cycles.
+
+    The first argument should be the tree root;
+    children should be a function taking as argument a tree node
+    and returning an iterator of the node's children.
+
+    Use maxdepth parameter to limit the depth, and cut_mark
+    to mention discarded cycles in the output.
+
+    >>> import nltk
+    >>> from nltk.util import unweighted_minimum_cost_spanning_tree as mst
+    >>> wn=nltk.corpus.wordnet
+    >>> from pprint import pprint
+    >>> pprint(mst(wn.synset('bound.a.01'), lambda s:s.also_sees()))
+    [Synset('bound.a.01'),
+     [Synset('unfree.a.02'),
+      [Synset('confined.a.02')],
+      [Synset('dependent.a.01')],
+      [Synset('restricted.a.01'), [Synset('classified.a.02')]]]]
+    """
+#   traversed is the set of traversed nodes
+    traversed = set()
+    queue = deque([(0, tree)])
+#   qset is the set of queued nodes
+    qset = {tree}
+    umcst = {} # mst dictionary
+    while queue:
+        depth, node = queue.popleft()
+        if node not in umcst.keys():
+#           Create a dictionary item for node, with an empty list of children:
+            umcst[node]=[]
+        if depth != maxdepth and node not in traversed:
+            traversed.add(node)
+            for child in children(node):
+                if child in qset: # queue nodes only once
+                    warnings.warn('Discarded redundant search for {0} at depth {1}'.format(child, depth+1), stacklevel=2)
+                    if cut_mark:
+#                       Mention this cycle in the output:
+                        umcst[node].append('Cycle({0},{1},{2})'.format(child, depth+1, cut_mark))
+                else:
+#                   Add child to the MST and the queue:
+                    umcst[node].append(child)
+                    queue.append((depth+1, child))
+                    qset.add(child)
+        elif cut_mark:
+#           Mention this cut in the output:
+            umcst[node].append(cut_mark)
+    return ms2tree(tree, umcst)
+
+
 ##########################################################################
 # Guess Character Encoding
 ##########################################################################

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -364,10 +364,11 @@ def acyclic_branches_depth_first(tree, children=iter, depth=-1, cut_mark=None, t
     return out_tree
 
 
-def dic2tree(node, dic):
-    """Convert dictionary 'dic' to tree suitable for pprint,
-    starting at root 'node', with subtrees as nested lists"""
-    return [node] + [dic2tree(child, dic) for child in dic[node]]
+def acyclic_dic2tree(node, dic):
+    """Convert acyclic dictionary 'dic', where the keys are nodes, and the
+    values are lists of children, to output tree suitable for pprint(),
+    starting at root 'node', with subtrees as nested lists."""
+    return [node] + [acyclic_dic2tree(child, dic) for child in dic[node]]
 
 
 def unweighted_minimum_spanning_tree(tree, children=iter):
@@ -405,7 +406,7 @@ def unweighted_minimum_spanning_tree(tree, children=iter):
                     mstdic[node].append(child)     # Add child to the MST
                     queue.append(child)            # Add child to queue
                     agenda.add(child)
-    return dic2tree(tree, mstdic)
+    return acyclic_dic2tree(tree, mstdic)
 
 
 ##########################################################################

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -382,7 +382,7 @@ def unweighted_minimum_spanning_tree(tree, children=iter):
     and returning an iterator of the node's children.
 
     >>> import nltk
-    >>> from nltk.util import unweighted_minimum_cost_spanning_tree as mst
+    >>> from nltk.util import unweighted_minimum_spanning_tree as mst
     >>> wn=nltk.corpus.wordnet
     >>> from pprint import pprint
     >>> pprint(mst(wn.synset('bound.a.01'), lambda s:s.also_sees()))

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -372,7 +372,7 @@ def ms2tree(node, dic):
         return [node] + [ms2tree(child, dic) for child in dic[node]]
 
 
-def unweighted_minimum_cost_spanning_tree(tree, children=iter, maxdepth=-1, cut_mark=None):
+def unweighted_minimum_spanning_tree(tree, children=iter):
     """
     Output a Minimum Spanning Tree (MST) of an unweighted graph,
     by traversing the nodes of a tree in breadth-first order,
@@ -381,9 +381,6 @@ def unweighted_minimum_cost_spanning_tree(tree, children=iter, maxdepth=-1, cut_
     The first argument should be the tree root;
     children should be a function taking as argument a tree node
     and returning an iterator of the node's children.
-
-    Use maxdepth parameter to limit the depth, and cut_mark
-    to mention discarded cycles in the output.
 
     >>> import nltk
     >>> from nltk.util import unweighted_minimum_cost_spanning_tree as mst
@@ -396,34 +393,21 @@ def unweighted_minimum_cost_spanning_tree(tree, children=iter, maxdepth=-1, cut_
       [Synset('dependent.a.01')],
       [Synset('restricted.a.01'), [Synset('classified.a.02')]]]]
     """
-#   traversed is the set of traversed nodes
-    traversed = set()
-    queue = deque([(0, tree)])
-#   qset is the set of queued nodes
-    qset = {tree}
-    umcst = {} # mst dictionary
+    traversed = set()             # Empty set of traversed nodes
+    queue = deque([tree])         # Initialize queue
+    agenda = {tree}               # Set of all nodes ever queued
+    mstdic = {}                   # Empty MST dictionary
     while queue:
-        depth, node = queue.popleft()
-        if node not in umcst.keys():
-#           Create a dictionary item for node, with an empty list of children:
-            umcst[node]=[]
-        if depth != maxdepth and node not in traversed:
+        node = queue.popleft()    # Node is not yet in the MST dictionary,
+        mstdic[node]=[]           # so add it with an empty list of children
+        if node not in traversed: # Avoid cycles
             traversed.add(node)
             for child in children(node):
-                if child in qset: # queue nodes only once
-                    warnings.warn('Discarded redundant search for {0} at depth {1}'.format(child, depth+1), stacklevel=2)
-                    if cut_mark:
-#                       Mention this cycle in the output:
-                        umcst[node].append('Cycle({0},{1},{2})'.format(child, depth+1, cut_mark))
-                else:
-#                   Add child to the MST and the queue:
-                    umcst[node].append(child)
-                    queue.append((depth+1, child))
-                    qset.add(child)
-        elif cut_mark:
-#           Mention this cut in the output:
-            umcst[node].append(cut_mark)
-    return ms2tree(tree, umcst)
+                if child not in agenda:            # Queue nodes only once
+                    mstdic[node].append(child)     # Add child to the MST
+                    queue.append(child)            # Add child to queue
+                    agenda.add(child)
+    return ms2tree(tree, mstdic)
 
 
 ##########################################################################

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -366,10 +366,7 @@ def acyclic_branches_depth_first(tree, children=iter, depth=-1, cut_mark=None, t
 
 def ms2tree(node, dic):
     """Convert Minimum Spanning Tree dictionary 'dic' to nested list"""
-    if type(node)==str:
-        return node
-    else:
-        return [node] + [ms2tree(child, dic) for child in dic[node]]
+    return [node] + [ms2tree(child, dic) for child in dic[node]]
 
 
 def unweighted_minimum_spanning_tree(tree, children=iter):

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -364,9 +364,10 @@ def acyclic_branches_depth_first(tree, children=iter, depth=-1, cut_mark=None, t
     return out_tree
 
 
-def ms2tree(node, dic):
-    """Convert Minimum Spanning Tree dictionary 'dic' to nested list"""
-    return [node] + [ms2tree(child, dic) for child in dic[node]]
+def dic2tree(node, dic):
+    """Convert dictionary 'dic' to tree suitable for pprint,
+    starting at root 'node', with subtrees as nested lists"""
+    return [node] + [dic2tree(child, dic) for child in dic[node]]
 
 
 def unweighted_minimum_spanning_tree(tree, children=iter):
@@ -404,7 +405,7 @@ def unweighted_minimum_spanning_tree(tree, children=iter):
                     mstdic[node].append(child)     # Add child to the MST
                     queue.append(child)            # Add child to queue
                     agenda.add(child)
-    return ms2tree(tree, mstdic)
+    return dic2tree(tree, mstdic)
 
 
 ##########################################################################


### PR DESCRIPTION
This PR provides a better solution to  the problem of intractable trees first mentioned in connection to  issue #2314, which was solved sub-optimally using Depth-first Search in PR #2612, and  complements the corresponding wordnet.doctest  section from PR #2640.
 
A Minimum Spanning Tree (MST) spans all the nodes of a relation graph once, while guaranteeing that each node is reached through the shortest path possible. In unweighted relation graphs like WordNet, a MST can be computed very efficiently in linear time, using Breadth-First Search (BFS). 

Like the acyclic_tree() function introduced in PR #2612, the new "unweighted_minimum_spanning_tree()" function (imported in the Wordnet module as "mst") handles the intractable trees discussed in PR #2640, for ex. "wn.synset('concrete.a.01').mst(lambda s:s.also_sees())".

But the MST is a better solution, because the also_sees() acyclic_tree of for ex. 'bound.a.01' is unnecessarily deep, and thus less optimal than the corresponding MST, since  depth-first search reaches 'classified.a.02' through a longer path, consisting in four links (bound.a.01 > unfree.a.02 > confined.a.02 > restricted.a.01 > classified.a.02):

![bound-dfs](https://user-images.githubusercontent.com/4782556/113478415-fca3fa00-9488-11eb-94a6-d6957a909e40.png)
By contrast, the following MST is better, because the path to 'classified.a.02' is the shortest possible, consisting only in three links (bound.a.01 > unfree.a.02 > restricted.a.01 > classified.a.02):
```
    >>> pprint(wn.synset('bound.a.01').mst(lambda s:s.also_sees()))
    [Synset('bound.a.01'),
     [Synset('unfree.a.02'),
      [Synset('confined.a.02')],
      [Synset('dependent.a.01')],
      [Synset('restricted.a.01'), [Synset('classified.a.02')]]]]
```

![bound-bfs](https://user-images.githubusercontent.com/4782556/113478452-3248e300-9489-11eb-90cf-136dfbd52116.png)
