### PR TITLE
Synset path_similarity commutativity

### DIFF
--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -843,6 +843,7 @@ class Synset(_WordNetObject):
             could be found. 1 is returned if a ``Synset`` is compared with
             itself.
         """
+        
         distance = self.shortest_path_distance(
             other, simulate_root=simulate_root
         )

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -843,7 +843,7 @@ class Synset(_WordNetObject):
             could be found. 1 is returned if a ``Synset`` is compared with
             itself.
         """
-        
+    
         distance = self.shortest_path_distance(
             other, simulate_root=simulate_root
         )

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -843,7 +843,7 @@ class Synset(_WordNetObject):
             could be found. 1 is returned if a ``Synset`` is compared with
             itself.
         """
-
+        print("!!!!!!!!!!")
         distance = self.shortest_path_distance(
             other, simulate_root=simulate_root and self._needs_root()
         )

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -843,7 +843,7 @@ class Synset(_WordNetObject):
             could be found. 1 is returned if a ``Synset`` is compared with
             itself.
         """
-    
+
         distance = self.shortest_path_distance(
             other, simulate_root=simulate_root
         )

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -845,7 +845,7 @@ class Synset(_WordNetObject):
         """
 
         distance = self.shortest_path_distance(
-            other, simulate_root=simulate_root
+            other, simulate_root=simulate_root and (self._needs_root() or other._needs_root()) 
         )
         if distance is None or distance < 0:
             return None
@@ -934,13 +934,15 @@ class Synset(_WordNetObject):
             the two senses can be found, None is returned.
 
         """
+        need_root = self._needs_root() or other._needs_root()
 
-        need_root = self._needs_root()
         # Note that to preserve behavior from NLTK2 we set use_min_depth=True
         # It is possible that more accurate results could be obtained by
         # removing this setting and it should be tested later on
         subsumers = self.lowest_common_hypernyms(
-            other, simulate_root=simulate_root and need_root, use_min_depth=True
+            other,
+            simulate_root=simulate_root and need_root,
+            use_min_depth=True
         )
 
         # If no LCS was found return None

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -843,9 +843,8 @@ class Synset(_WordNetObject):
             could be found. 1 is returned if a ``Synset`` is compared with
             itself.
         """
-        print("!!!!!!!!!!")
         distance = self.shortest_path_distance(
-            other, simulate_root=simulate_root and self._needs_root()
+            other, simulate_root=simulate_root
         )
         if distance is None or distance < 0:
             return None

--- a/nltk/test/unit/test_wordnet.py
+++ b/nltk/test/unit/test_wordnet.py
@@ -168,10 +168,14 @@ class WordnNetDemo(unittest.TestCase):
         self.assertEqual(S('germany.n.01').in_region_domains()[23], S('trillion.n.02'))
         self.assertEqual(S('slang.n.02').in_usage_domains()[1], S('airhead.n.01'))
 
+
+
     def test_wordnet_similarities(self):
         # Path based similarities.
         self.assertAlmostEqual(S('cat.n.01').path_similarity(S('cat.n.01')), 1.0)
         self.assertAlmostEqual(S('dog.n.01').path_similarity(S('cat.n.01')), 0.2)
+        self.assertAlmostEqual(S('car.n.01').path_similarity(S('automobile.v.01')),
+                               S('automobile.v.01').path_similarity(S('car.n.01')) )
         self.assertAlmostEqual(
             S('dog.n.01').lch_similarity(S('cat.n.01')), 2.028, places=3
         )

--- a/nltk/test/unit/test_wordnet.py
+++ b/nltk/test/unit/test_wordnet.py
@@ -173,13 +173,15 @@ class WordnNetDemo(unittest.TestCase):
         self.assertAlmostEqual(S('cat.n.01').path_similarity(S('cat.n.01')), 1.0)
         self.assertAlmostEqual(S('dog.n.01').path_similarity(S('cat.n.01')), 0.2)
         self.assertAlmostEqual(S('car.n.01').path_similarity(S('automobile.v.01')),
-                               S('automobile.v.01').path_similarity(S('car.n.01')) )
+                               S('automobile.v.01').path_similarity(S('car.n.01')))
         self.assertAlmostEqual(
             S('dog.n.01').lch_similarity(S('cat.n.01')), 2.028, places=3
         )
         self.assertAlmostEqual(
             S('dog.n.01').wup_similarity(S('cat.n.01')), 0.8571, places=3
         )
+        self.assertAlmostEqual(S('car.n.01').wup_similarity(S('automobile.v.01')),
+                               S('automobile.v.01').wup_similarity(S('car.n.01')))
         # Information Content similarities.
         brown_ic = wnic.ic('ic-brown.dat')
         self.assertAlmostEqual(

--- a/nltk/test/unit/test_wordnet.py
+++ b/nltk/test/unit/test_wordnet.py
@@ -168,8 +168,6 @@ class WordnNetDemo(unittest.TestCase):
         self.assertEqual(S('germany.n.01').in_region_domains()[23], S('trillion.n.02'))
         self.assertEqual(S('slang.n.02').in_usage_domains()[1], S('airhead.n.01'))
 
-
-
     def test_wordnet_similarities(self):
         # Path based similarities.
         self.assertAlmostEqual(S('cat.n.01').path_similarity(S('cat.n.01')), 1.0)


### PR DESCRIPTION
Fixes #2278

We see in this issue, that `path_similarity` is not commutative when comparing a noun and a verb.
This happens because the function `Synset._needs_root()` returns `True` for verbs, but returns `False` for nouns.  According to the docstring, this is because nouns already have a default root.

So, if the graph is not connected, and you do `verb.path_similarity(noun)`, `path_similarity` will call `verb._needs_root()` which returns `True`, which will add a fake root to connect the graph.
If the operation is done in the opposite direction, `noun.path_similarity(verb)`, the graph will also not be connected. But `noun._needs_root()` returns `False` so a fake root is not added.

The same problem appears in the function `synset.wup_similarity`. 
The function `synset.lch_similarity` also calls `synset.needs_root`, but `lch_similarity` checks that both synsets have the same part of speech, so this problem does not appear with this function. 

This PR adds tests to confirm that path_similarity is commutative for nouns and verbs, and updates `path_similarity` and `wup_similarity` so that a fake root is added if either synset needs a fake root.