### PR TITLE
Wordnet Synset similarities for all pos 

### DIFF
--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -456,7 +456,7 @@ class Synset(_WordNetObject):
             return False
         else:
             return True
-            
+
     def lemma_names(self, lang="eng"):
         """Return all the lemma_names associated with the synset"""
         if lang == "eng":

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -452,14 +452,11 @@ class Synset(_WordNetObject):
         return self._lexname
 
     def _needs_root(self):
-        if self._pos == NOUN:
-            if self._wordnet_corpus_reader.get_version() == "1.6":
-                return True
-            else:
-                return False
-        elif self._pos == VERB:
+        if self._pos == NOUN and self._wordnet_corpus_reader.get_version() != "1.6":
+            return False
+        else:
             return True
-
+            
     def lemma_names(self, lang="eng"):
         """Return all the lemma_names associated with the synset"""
         if lang == "eng":

--- a/nltk/test/unit/test_wordnet.py
+++ b/nltk/test/unit/test_wordnet.py
@@ -173,9 +173,9 @@ class WordnNetDemo(unittest.TestCase):
         self.assertAlmostEqual(S('cat.n.01').path_similarity(S('cat.n.01')), 1.0)
         self.assertAlmostEqual(S('dog.n.01').path_similarity(S('cat.n.01')), 0.2)
         self.assertAlmostEqual(S('car.n.01').path_similarity(S('automobile.v.01')),
-                               S('automobile.v.01').path_similarity(S('car.n.01'))
-                               S('big.a.01').path_similarity(S('apple.n.01'))
-                               S('white.a.01').path_similarity(S('grey.a.01')))
+                               S('automobile.v.01').path_similarity(S('car.n.01')))
+        self.assertAlmostEqual(S('big.a.01').path_similarity(S('dog.n.01')),
+                               S('dog.n.01').path_similarity(S('big.a.01')))
         self.assertAlmostEqual(
             S('dog.n.01').lch_similarity(S('cat.n.01')), 2.028, places=3
         )
@@ -183,9 +183,9 @@ class WordnNetDemo(unittest.TestCase):
             S('dog.n.01').wup_similarity(S('cat.n.01')), 0.8571, places=3
         )
         self.assertAlmostEqual(S('car.n.01').wup_similarity(S('automobile.v.01')),
-                               S('automobile.v.01').wup_similarity(S('car.n.01'))
-                               S('big.a.01').wup_similarity(S('apple.n.01'))
-                               S('white.a.01').wup_similarity(S('grey.a.01')))
+                               S('automobile.v.01').wup_similarity(S('car.n.01')))
+        self.assertAlmostEqual(S('big.a.01').wup_similarity(S('dog.n.01')),
+                               S('dog.n.01').wup_similarity(S('big.a.01')))
         # Information Content similarities.
         brown_ic = wnic.ic('ic-brown.dat')
         self.assertAlmostEqual(

--- a/nltk/test/unit/test_wordnet.py
+++ b/nltk/test/unit/test_wordnet.py
@@ -173,7 +173,9 @@ class WordnNetDemo(unittest.TestCase):
         self.assertAlmostEqual(S('cat.n.01').path_similarity(S('cat.n.01')), 1.0)
         self.assertAlmostEqual(S('dog.n.01').path_similarity(S('cat.n.01')), 0.2)
         self.assertAlmostEqual(S('car.n.01').path_similarity(S('automobile.v.01')),
-                               S('automobile.v.01').path_similarity(S('car.n.01')))
+                               S('automobile.v.01').path_similarity(S('car.n.01'))
+                               S('big.a.01').path_similarity(S('apple.n.01'))
+                               S('white.a.01').path_similarity(S('grey.a.01')))
         self.assertAlmostEqual(
             S('dog.n.01').lch_similarity(S('cat.n.01')), 2.028, places=3
         )
@@ -181,7 +183,9 @@ class WordnNetDemo(unittest.TestCase):
             S('dog.n.01').wup_similarity(S('cat.n.01')), 0.8571, places=3
         )
         self.assertAlmostEqual(S('car.n.01').wup_similarity(S('automobile.v.01')),
-                               S('automobile.v.01').wup_similarity(S('car.n.01')))
+                               S('automobile.v.01').wup_similarity(S('car.n.01'))
+                               S('big.a.01').wup_similarity(S('apple.n.01'))
+                               S('white.a.01').wup_similarity(S('grey.a.01')))
         # Information Content similarities.
         brown_ic = wnic.ic('ic-brown.dat')
         self.assertAlmostEqual(

--- a/nltk/test/unit/test_wordnet.py
+++ b/nltk/test/unit/test_wordnet.py
@@ -176,6 +176,8 @@ class WordnNetDemo(unittest.TestCase):
                                S('automobile.v.01').path_similarity(S('car.n.01')))
         self.assertAlmostEqual(S('big.a.01').path_similarity(S('dog.n.01')),
                                S('dog.n.01').path_similarity(S('big.a.01')))
+        self.assertAlmostEqual(S('big.a.01').path_similarity(S('long.a.01')),
+                               S('long.a.01').path_similarity(S('big.a.01')))                    
         self.assertAlmostEqual(
             S('dog.n.01').lch_similarity(S('cat.n.01')), 2.028, places=3
         )
@@ -186,6 +188,10 @@ class WordnNetDemo(unittest.TestCase):
                                S('automobile.v.01').wup_similarity(S('car.n.01')))
         self.assertAlmostEqual(S('big.a.01').wup_similarity(S('dog.n.01')),
                                S('dog.n.01').wup_similarity(S('big.a.01')))
+        self.assertAlmostEqual(S('big.a.01').wup_similarity(S('long.a.01')),
+                               S('long.a.01').wup_similarity(S('big.a.01')))
+        self.assertAlmostEqual(S('big.a.01').lch_similarity(S('long.a.01')),
+                               S('long.a.01').lch_similarity(S('big.a.01')))
         # Information Content similarities.
         brown_ic = wnic.ic('ic-brown.dat')
         self.assertAlmostEqual(


### PR DESCRIPTION
fixes #2651 
This issue is that `wup_similarity`, `path_similairy` and `lch_similarity` return `None` for pos other than noun and verb. This is because the function `Synset.needs_root` return `None` for pos other than nouns and verbs. 
This PR fixes the 'needs_root' function and takes care of all pos. Thus the `Synset` similarity functions can work for all pos, which is demonstrated by the added tests.  