### PR TITLE
Fix CoreNLP request

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -277,6 +277,7 @@
 - Danny Sepler <https://github.com/dannysepler>
 - Akshita Bhagia <https://github.com/AkshitaB>
 - Pratap Yadav <https://github.com/prtpydv>
+- Hiroki Teranishi <https://github.com/chantera>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 

--- a/nltk/parse/corenlp.py
+++ b/nltk/parse/corenlp.py
@@ -244,6 +244,7 @@ class GenericCoreNLPParser(ParserI, TokenizerI, TaggerI):
             self.url,
             params={"properties": json.dumps(default_properties)},
             data=data.encode(self.encoding),
+            headers={"Content-Type": "text/plain; charset={}".format(self.encoding)},
             timeout=timeout,
         )
 


### PR DESCRIPTION
This PR fixes CoreNLP API calls.

# Issue

The following code causes 500 Internal Server Error.

```py
from nltk.parse.corenlp import CoreNLPParser, CoreNLPServer

server = CoreNLPServer()
with server:
    parser = CoreNLPParser()
    s = "The broader Standard & Poor's 500 Index <.SPX> was 0.46 points lower, or 0.05 %, at 997.02."
    tree = next(parser.raw_parse(s))  # => `requests.exceptions.HTTPError: 500 Server Error`
```

This is because POST data is not properly encoded in [nltk/corenlp.py](https://github.com/nltk/nltk/blob/3.5/nltk/parse/corenlp.py#L246).

```py
response = self.session.post(
    self.url,
    params={"properties": json.dumps(default_properties)},
    data=data.encode(self.encoding),  # this is expected to be URL-encoded
    timeout=timeout,
)
```

When giving `str` or `bytes` data to `requests.Session.post`, it is expected to be URL-encoded and thus is not encoded internally ([requests/models.py](https://github.com/psf/requests/blob/v2.25.1/requests/models.py#L91)).

Consequently, an illegal character could be passed to the server, which causes `java.lang.IllegalArgumentException` in `java.net.URLDecoder` ([CoreNLP/StanfordCoreNLPServer.java](https://github.com/stanfordnlp/CoreNLP/blob/v4.2.0/src/edu/stanford/nlp/pipeline/StanfordCoreNLPServer.java#L330)).

# Fix

To fix this, one possible solution is to apply URL-encoding to POST data.

```py
from requests.compat import quote_plus

response = self.session.post(
    self.url,
    params={"properties": json.dumps(default_properties)},
    data=quote_plus(data, encoding=self.encoding),
    timeout=timeout,
)
```

More simply, we can tell the server that POST data is not URL-encoded, as implemented in [stanza/client.py](https://github.com/stanfordnlp/stanza/blob/v1.1.1/stanza/server/client.py#L432).
To do this, I added `Content-Type: plain/text` to the header (the default type is `application/x-www-form-urlencoded`).
As a result, the data is not URL-decoded in the server and this no longer causes the error.