### PR TITLE
Remove usage of thread.isAlive

### DIFF
--- a/nltk/inference/api.py
+++ b/nltk/inference/api.py
@@ -533,7 +533,7 @@ class ParallelProverBuilder(Prover, ModelBuilder):
         tp_thread.start()
         mb_thread.start()
 
-        while tp_thread.isAlive() and mb_thread.isAlive():
+        while tp_thread.is_alive() and mb_thread.is_alive():
             # wait until either the prover or the model builder is done
             pass
 
@@ -578,7 +578,7 @@ class ParallelProverBuilderCommand(BaseProverCommand, BaseModelBuilderCommand):
         tp_thread.start()
         mb_thread.start()
 
-        while tp_thread.isAlive() and mb_thread.isAlive():
+        while tp_thread.is_alive() and mb_thread.is_alive():
             # wait until either the prover or the model builder is done
             pass
 


### PR DESCRIPTION
The thread.isAlive method was removed in Python 3.9; see https://bugs.python.org/issue37804. It was an alias for thread.is_alive, so use that instead.