### PR TITLE
Added Tree.fromlist()

### DIFF
--- a/nltk/test/tree.doctest
+++ b/nltk/test/tree.doctest
@@ -273,17 +273,13 @@ The class method `Tree.fromlist()` can be used to parse trees
 that are expressed as nested lists, such as those produced by
 the tree() function from the wordnet module.
 
-    >>> wn=nltk.corpus.wordnet
+    >>> from nltk.corpus import wordnet as wn
     >>> t=Tree.fromlist(wn.synset('dog.n.01').tree(lambda s:s.hypernyms()))
-
     >>> print(t.height())
     14
-
     >>> print(t.leaves())
     ["Synset('entity.n.01')", "Synset('entity.n.01')"]
-
     >>> t.pretty_print()
-
                       Synset('dog.n.01')                  
              _________________|__________________          
     Synset('canine.n.                            |        

--- a/nltk/test/tree.doctest
+++ b/nltk/test/tree.doctest
@@ -266,6 +266,67 @@ It will not remove a top-level empty bracketing with multiple children:
     >>> print(Tree.fromstring('((A a) (B b))'))
     ( (A a) (B b))
 
+
+Tree.fromlist()
+---------------
+The class method `Tree.fromlist()` can be used to parse trees
+that are expressed as nested lists, such as those produced by
+the tree() function from the wordnet module.
+
+    >>> wn=nltk.corpus.wordnet
+    >>> t=Tree.fromlist(wn.synset('dog.n.01').tree(lambda s:s.hypernyms()))
+
+    >>> print(t.height())
+    14
+
+    >>> print(t.leaves())
+    ["Synset('entity.n.01')", "Synset('entity.n.01')"]
+
+    >>> t.pretty_print()
+
+                      Synset('dog.n.01')                  
+             _________________|__________________          
+    Synset('canine.n.                            |        
+           02')                                  |        
+            |                                    |         
+     Synset('carnivor                            |        
+         e.n.01')                                |        
+            |                                    |         
+     Synset('placenta                            |        
+         l.n.01')                                |        
+            |                                    |         
+    Synset('mammal.n.                            |        
+           01')                                  |        
+            |                                    |         
+     Synset('vertebra                            |        
+        te.n.01')                                |        
+            |                                    |         
+    Synset('chordate.                     Synset('domestic
+          n.01')                           _animal.n.01') 
+            |                                    |         
+    Synset('animal.n.                    Synset('animal.n.
+           01')                                 01')      
+            |                                    |         
+    Synset('organism.                    Synset('organism.
+          n.01')                               n.01')     
+            |                                    |         
+     Synset('living_t                     Synset('living_t
+       hing.n.01')                          hing.n.01')   
+            |                                    |         
+     Synset('whole.n.                     Synset('whole.n.
+           02')                                 02')      
+            |                                    |         
+    Synset('object.n.                    Synset('object.n.
+           01')                                 01')      
+            |                                    |         
+     Synset('physical                     Synset('physical
+      _entity.n.01')                       _entity.n.01') 
+            |                                    |         
+    Synset('entity.n.                    Synset('entity.n.
+           01')                                 01')      
+
+
+
 Parented Trees
 ==============
 `ParentedTree` is a subclass of `Tree` that automatically maintains

--- a/nltk/tree.py
+++ b/nltk/tree.py
@@ -6,6 +6,7 @@
 #         Steven Bird <stevenbird1@gmail.com>
 #         Peter Ljunglöf <peter.ljunglof@gu.se>
 #         Nathan Bodenstab <bodenstab@cslu.ogi.edu> (tree transforms)
+#         Eric Kafe <kafe.eric@gmail.com> (Tree.fromlist())
 # URL: <http://nltk.org/>
 # For license information, see LICENSE.TXT
 
@@ -736,6 +737,25 @@ class Tree(list):
             offset = 13
         msg += '\n%s"%s"\n%s^' % (" " * 16, s, " " * (17 + offset))
         raise ValueError(msg)
+
+    @classmethod
+    def fromlist(cls, l):
+        """
+        :type l: list
+        :param l: a tree represented as nested lists
+
+        :return: A tree corresponding to the list representation ``l``.
+        :rtype: Tree
+
+        Convert nested lists to a NLTK Tree
+        """
+        if type(l)==list and len(l)>0:
+            label = repr(l[0])
+            if len(l)>1:
+                return Tree(label, [cls.fromlist(child) for child in l[1:]])
+            else:
+                return label
+
 
     # ////////////////////////////////////////////////////////////
     # Visualization & String Representation
@@ -1696,6 +1716,7 @@ def sinica_parse(s):
 #    s = re.sub(r'\w+:', '', s)       # remove role tags
 
 #    return s
+
 
 ######################################################################
 ## Demonstration


### PR DESCRIPTION
Solves issue #2684

The new class method Tree.fromlist() can be used to parse trees that are expressed as nested lists, such as those produced by the tree() function from the wordnet module.

This allows to use nice functionality provided by the NLTK Tree class:

    >>> from nltk.corpus import wordnet as wn
    >>> t=Tree.fromlist(wn.synset('dog.n.01').tree(lambda s:s.hypernyms()))
    >>> print(t.height())
    14
    >>> print(t.leaves())
    ["Synset('entity.n.01')", "Synset('entity.n.01')"]
    >>> t.pretty_print()
                      Synset('dog.n.01')                  
             _________________|__________________          
    Synset('canine.n.                            |        
           02')                                  |        
            |                                    |         
     Synset('carnivor                            |        
         e.n.01')                                |        
            |                                    |         
     Synset('placenta                            |        
         l.n.01')                                |        
            |                                    |         
    Synset('mammal.n.                            |        
           01')                                  |        
            |                                    |         
     Synset('vertebra                            |        
        te.n.01')                                |        
            |                                    |         
    Synset('chordate.                     Synset('domestic
          n.01')                           _animal.n.01') 
            |                                    |         
    Synset('animal.n.                    Synset('animal.n.
           01')                                 01')      
            |                                    |         
    Synset('organism.                    Synset('organism.
          n.01')                               n.01')     
            |                                    |         
     Synset('living_t                     Synset('living_t
       hing.n.01')                          hing.n.01')   
            |                                    |         
     Synset('whole.n.                     Synset('whole.n.
           02')                                 02')      
            |                                    |         
    Synset('object.n.                    Synset('object.n.
           01')                                 01')      
            |                                    |         
     Synset('physical                     Synset('physical
      _entity.n.01')                       _entity.n.01') 
            |                                    |         
    Synset('entity.n.                    Synset('entity.n.
           01')                                 01')      
    >>> t.draw()
![dog](https://user-images.githubusercontent.com/4782556/113500676-25c39980-9520-11eb-80c9-4d0624b8b0c8.png)
