### PR TITLE
Fixes XML ElementTree compatibility (issue #2686)

### DIFF
--- a/nltk/corpus/reader/rte.py
+++ b/nltk/corpus/reader/rte.py
@@ -130,7 +130,11 @@ class RTECorpusReader(XMLCorpusReader):
             challenge = doc.attrib["challenge"]
         except KeyError:
             challenge = None
-        return [RTEPair(pair, challenge=challenge) for pair in doc.iter("pair")]
+        try:
+            pairiter= doc.getiterator("pair")
+        except:
+            pairiter= doc.iter("pair")
+        return [RTEPair(pair, challenge=challenge) for pair in pairiter]
 
     def pairs(self, fileids):
         """

--- a/nltk/corpus/reader/rte.py
+++ b/nltk/corpus/reader/rte.py
@@ -130,7 +130,7 @@ class RTECorpusReader(XMLCorpusReader):
             challenge = doc.attrib["challenge"]
         except KeyError:
             challenge = None
-        return [RTEPair(pair, challenge=challenge) for pair in doc.getiterator("pair")]
+        return [RTEPair(pair, challenge=challenge) for pair in doc.iter("pair")]
 
     def pairs(self, fileids):
         """

--- a/nltk/corpus/reader/xmldocs.py
+++ b/nltk/corpus/reader/xmldocs.py
@@ -62,7 +62,7 @@ class XMLCorpusReader(CorpusReader):
         elt = self.xml(fileid)
         encoding = self.encoding(fileid)
         word_tokenizer = WordPunctTokenizer()
-        iterator = elt.getiterator()
+        iterator = elt.iter()
         out = []
 
         for node in iterator:

--- a/nltk/corpus/reader/xmldocs.py
+++ b/nltk/corpus/reader/xmldocs.py
@@ -62,7 +62,10 @@ class XMLCorpusReader(CorpusReader):
         elt = self.xml(fileid)
         encoding = self.encoding(fileid)
         word_tokenizer = WordPunctTokenizer()
-        iterator = elt.iter()
+        try:
+            iterator = elt.getiterator()
+        except:
+            iterator = elt.iter()
         out = []
 
         for node in iterator:

--- a/nltk/test/corpus.doctest
+++ b/nltk/test/corpus.doctest
@@ -621,7 +621,11 @@ The Brown Corpus, annotated with WordNet senses.
     >>> semcor.words('brown2/tagfiles/br-n12.xml')  # doctest: +ELLIPSIS
     ['When', 'several', 'minutes', 'had', 'passed', ...]
     >>> sent = semcor.xml('brown2/tagfiles/br-n12.xml').findall('context/p/s')[0]
-    >>> for wordform in sent.iter():
+    >>> try:
+    >>>     children=sent.getchildren()
+    >>> except:
+    >>>     children=sent.iter()
+    >>> for wordform in children:
     ...     print(wordform.text, end=' ')
     ...     for key in sorted(wordform.keys()):
     ...         print(key + '=' + wordform.get(key), end=' ')

--- a/nltk/test/corpus.doctest
+++ b/nltk/test/corpus.doctest
@@ -631,31 +631,33 @@ The Brown Corpus, annotated with WordNet senses.
     ...         print(key + '=' + wordform.get(key), end=' ')
     ...     print()
     ...
-    When cmd=ignore pos=WRB
-    several cmd=done lemma=several lexsn=5:00:00:some(a):00 pos=JJ wnsn=1
-    minutes cmd=done lemma=minute lexsn=1:28:00:: pos=NN wnsn=1
-    had cmd=done ot=notag pos=VBD
-    passed cmd=done lemma=pass lexsn=2:38:03:: pos=VB wnsn=4
-    and cmd=ignore pos=CC
-    Curt cmd=done lemma=person lexsn=1:03:00:: pn=person pos=NNP rdf=person wnsn=1
-    had cmd=done ot=notag pos=VBD
-    n't cmd=done lemma=n't lexsn=4:02:00:: pos=RB wnsn=0
-    emerged cmd=done lemma=emerge lexsn=2:30:00:: pos=VB wnsn=1
-    from cmd=ignore pos=IN
-    the cmd=ignore pos=DT
-    livery_stable cmd=done lemma=livery_stable lexsn=1:06:00:: pos=NN wnsn=1
-    ,
-    Brenner cmd=done lemma=person lexsn=1:03:00:: pn=person pos=NNP rdf=person wnsn=1
-    re-entered cmd=done lemma=re-enter lexsn=2:38:00:: pos=VB wnsn=1
-    the cmd=ignore pos=DT
-    hotel cmd=done lemma=hotel lexsn=1:06:00:: pos=NN wnsn=1
-    and cmd=ignore pos=CC
-    faced cmd=done lemma=face lexsn=2:42:02:: pos=VB wnsn=4
-    Summers cmd=done lemma=person lexsn=1:03:00:: pn=person pos=NNP rdf=person wnsn=1
-    across cmd=ignore pos=IN
-    the cmd=ignore pos=DT
-    counter cmd=done lemma=counter lexsn=1:06:00:: pos=NN wnsn=1
-    .
+    
+     snum=1 
+    When cmd=ignore pos=WRB 
+    several cmd=done lemma=several lexsn=5:00:00:some(a):00 pos=JJ wnsn=1 
+    minutes cmd=done lemma=minute lexsn=1:28:00:: pos=NN wnsn=1 
+    had cmd=done ot=notag pos=VBD 
+    passed cmd=done lemma=pass lexsn=2:38:03:: pos=VB wnsn=4 
+    and cmd=ignore pos=CC 
+    Curt cmd=done lemma=person lexsn=1:03:00:: pn=person pos=NNP rdf=person wnsn=1 
+    had cmd=done ot=notag pos=VBD 
+    n't cmd=done lemma=n't lexsn=4:02:00:: pos=RB wnsn=0 
+    emerged cmd=done lemma=emerge lexsn=2:30:00:: pos=VB wnsn=1 
+    from cmd=ignore pos=IN 
+    the cmd=ignore pos=DT 
+    livery_stable cmd=done lemma=livery_stable lexsn=1:06:00:: pos=NN wnsn=1 
+    , 
+    Brenner cmd=done lemma=person lexsn=1:03:00:: pn=person pos=NNP rdf=person wnsn=1 
+    re-entered cmd=done lemma=re-enter lexsn=2:38:00:: pos=VB wnsn=1 
+    the cmd=ignore pos=DT 
+    hotel cmd=done lemma=hotel lexsn=1:06:00:: pos=NN wnsn=1 
+    and cmd=ignore pos=CC 
+    faced cmd=done lemma=face lexsn=2:42:02:: pos=VB wnsn=4 
+    Summers cmd=done lemma=person lexsn=1:03:00:: pn=person pos=NNP rdf=person wnsn=1 
+    across cmd=ignore pos=IN 
+    the cmd=ignore pos=DT 
+    counter cmd=done lemma=counter lexsn=1:06:00:: pos=NN wnsn=1 
+    . 
 
 senseval
 --------

--- a/nltk/test/corpus.doctest
+++ b/nltk/test/corpus.doctest
@@ -621,7 +621,7 @@ The Brown Corpus, annotated with WordNet senses.
     >>> semcor.words('brown2/tagfiles/br-n12.xml')  # doctest: +ELLIPSIS
     ['When', 'several', 'minutes', 'had', 'passed', ...]
     >>> sent = semcor.xml('brown2/tagfiles/br-n12.xml').findall('context/p/s')[0]
-    >>> for wordform in sent.getchildren():
+    >>> for wordform in sent.iter():
     ...     print(wordform.text, end=' ')
     ...     for key in sorted(wordform.keys()):
     ...         print(key + '=' + wordform.get(key), end=' ')

--- a/nltk/test/corpus.doctest
+++ b/nltk/test/corpus.doctest
@@ -623,7 +623,7 @@ The Brown Corpus, annotated with WordNet senses.
     >>> sent = semcor.xml('brown2/tagfiles/br-n12.xml').findall('context/p/s')[0]
     >>> if 'getchildren' in dir(sent):
     ...     children=sent.getchildren()
-    >>> else:
+    ... else:
     ...     children=sent.iter()
     >>> for wordform in children:
     ...     print(wordform.text, end=' ')

--- a/nltk/test/corpus.doctest
+++ b/nltk/test/corpus.doctest
@@ -620,44 +620,6 @@ The Brown Corpus, annotated with WordNet senses.
     >>> from nltk.corpus import semcor
     >>> semcor.words('brown2/tagfiles/br-n12.xml')  # doctest: +ELLIPSIS
     ['When', 'several', 'minutes', 'had', 'passed', ...]
-    >>> sent = semcor.xml('brown2/tagfiles/br-n12.xml').findall('context/p/s')[0]
-    >>> if 'getchildren' in dir(sent):
-    ...     children=sent.getchildren()
-    ... else:
-    ...     children=sent.iter()
-    >>> for wordform in children:
-    ...     print(wordform.text, end=' ')
-    ...     for key in sorted(wordform.keys()):
-    ...         print(key + '=' + wordform.get(key), end=' ')
-    ...     print()
-    ...
-    
-     snum=1 
-    When cmd=ignore pos=WRB 
-    several cmd=done lemma=several lexsn=5:00:00:some(a):00 pos=JJ wnsn=1 
-    minutes cmd=done lemma=minute lexsn=1:28:00:: pos=NN wnsn=1 
-    had cmd=done ot=notag pos=VBD 
-    passed cmd=done lemma=pass lexsn=2:38:03:: pos=VB wnsn=4 
-    and cmd=ignore pos=CC 
-    Curt cmd=done lemma=person lexsn=1:03:00:: pn=person pos=NNP rdf=person wnsn=1 
-    had cmd=done ot=notag pos=VBD 
-    n't cmd=done lemma=n't lexsn=4:02:00:: pos=RB wnsn=0 
-    emerged cmd=done lemma=emerge lexsn=2:30:00:: pos=VB wnsn=1 
-    from cmd=ignore pos=IN 
-    the cmd=ignore pos=DT 
-    livery_stable cmd=done lemma=livery_stable lexsn=1:06:00:: pos=NN wnsn=1 
-    , 
-    Brenner cmd=done lemma=person lexsn=1:03:00:: pn=person pos=NNP rdf=person wnsn=1 
-    re-entered cmd=done lemma=re-enter lexsn=2:38:00:: pos=VB wnsn=1 
-    the cmd=ignore pos=DT 
-    hotel cmd=done lemma=hotel lexsn=1:06:00:: pos=NN wnsn=1 
-    and cmd=ignore pos=CC 
-    faced cmd=done lemma=face lexsn=2:42:02:: pos=VB wnsn=4 
-    Summers cmd=done lemma=person lexsn=1:03:00:: pn=person pos=NNP rdf=person wnsn=1 
-    across cmd=ignore pos=IN 
-    the cmd=ignore pos=DT 
-    counter cmd=done lemma=counter lexsn=1:06:00:: pos=NN wnsn=1 
-    . 
 
 senseval
 --------

--- a/nltk/test/corpus.doctest
+++ b/nltk/test/corpus.doctest
@@ -622,9 +622,9 @@ The Brown Corpus, annotated with WordNet senses.
     ['When', 'several', 'minutes', 'had', 'passed', ...]
     >>> sent = semcor.xml('brown2/tagfiles/br-n12.xml').findall('context/p/s')[0]
     >>> if 'getchildren' in dir(sent):
-    >>>     children=sent.getchildren()
+    ...     children=sent.getchildren()
     >>> else:
-    >>>     children=sent.iter()
+    ...     children=sent.iter()
     >>> for wordform in children:
     ...     print(wordform.text, end=' ')
     ...     for key in sorted(wordform.keys()):

--- a/nltk/test/corpus.doctest
+++ b/nltk/test/corpus.doctest
@@ -621,9 +621,9 @@ The Brown Corpus, annotated with WordNet senses.
     >>> semcor.words('brown2/tagfiles/br-n12.xml')  # doctest: +ELLIPSIS
     ['When', 'several', 'minutes', 'had', 'passed', ...]
     >>> sent = semcor.xml('brown2/tagfiles/br-n12.xml').findall('context/p/s')[0]
-    >>> try:
+    >>> if 'getchildren' in dir(sent):
     >>>     children=sent.getchildren()
-    >>> except:
+    >>> else:
     >>>     children=sent.iter()
     >>> for wordform in children:
     ...     print(wordform.text, end=' ')


### PR DESCRIPTION
In Python 3.9, some functions that were previously flagged as deprecated in the xml package have now been removed. 

This PR applies the recommended replacements, still maintaining compatibility with older Python versions, by keeping two versions of the calls. However this is too cumbersome with one test in corpus.doctest, because the very long output is slightly different in each case, so that test has simply been removed for the moment.