### PR TITLE
Fix nltk.NgramAssocMeasures.likelihood_ratio multiplier

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -278,6 +278,7 @@
 - Akshita Bhagia <https://github.com/AkshitaB>
 - Pratap Yadav <https://github.com/prtpydv>
 - Hiroki Teranishi <https://github.com/chantera>
+- Ruben Cartuyvels <https://github.com/rubencart>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 

--- a/nltk/metrics/association.py
+++ b/nltk/metrics/association.py
@@ -145,7 +145,7 @@ class NgramAssocMeasures(metaclass=ABCMeta):
         """Scores ngrams using likelihood ratios as in Manning and Schutze 5.3.4.
         """
         cont = cls._contingency(*marginals)
-        return cls._n * sum(
+        return 2 * sum(
             obs * _ln(obs / (exp + _SMALL) + _SMALL)
             for obs, exp in zip(cont, cls._expected_values(cont))
         )

--- a/nltk/test/unit/test_metrics.py
+++ b/nltk/test/unit/test_metrics.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+import unittest
+
+from nltk.metrics import BigramAssocMeasures, TrigramAssocMeasures, QuadgramAssocMeasures
+
+## Test the likelihood ratio metric
+
+_DELTA = 1e-8
+
+
+class TestLikelihoodRatio(unittest.TestCase):
+    def test_lr_bigram(self):
+        self.assertAlmostEqual(
+            BigramAssocMeasures.likelihood_ratio(2, (4, 4), 20),
+            2.4142743368419755,
+            delta=_DELTA
+        )
+        self.assertAlmostEqual(
+            BigramAssocMeasures.likelihood_ratio(1, (1, 1), 1),
+            0.0,
+            delta=_DELTA
+        )
+        self.assertRaises(
+            ValueError,
+            BigramAssocMeasures.likelihood_ratio,
+            *(0, (2, 2), 2),
+        )
+
+    def test_lr_trigram(self):
+        self.assertAlmostEqual(
+            TrigramAssocMeasures.likelihood_ratio(1, (1, 1, 1), (1, 1, 1), 2),
+            5.545177444479562,
+            delta=_DELTA
+        )
+        self.assertAlmostEqual(
+            TrigramAssocMeasures.likelihood_ratio(1, (1, 1, 1), (1, 1, 1), 1),
+            0.0,
+            delta=_DELTA
+        )
+        self.assertRaises(
+            ValueError,
+            TrigramAssocMeasures.likelihood_ratio,
+            *(1, (1, 1, 2), (1, 1, 2), 2)
+        )
+
+    def test_lr_quadgram(self):
+        self.assertAlmostEqual(
+            QuadgramAssocMeasures.likelihood_ratio(1, (1, 1, 1, 1), (1, 1, 1, 1, 1, 1), (1, 1, 1, 1), 2),
+            8.317766166719343,
+            delta=_DELTA
+        )
+        self.assertAlmostEqual(
+            QuadgramAssocMeasures.likelihood_ratio(1, (1, 1, 1, 1), (1, 1, 1, 1, 1, 1), (1, 1, 1, 1), 1),
+            0.0,
+            delta=_DELTA
+        )
+        self.assertRaises(
+            ValueError,
+            QuadgramAssocMeasures.likelihood_ratio,
+            *(1, (1, 1, 1, 1), (1, 1, 1, 1, 1, 2), (1, 1, 1, 1), 1),
+        )


### PR DESCRIPTION
Fixes https://github.com/nltk/nltk/issues/2691.

Searching for likelihood_ratio in the tests/ dir pointed me to the following locations. Lines 232-233 in tests/metrics.doctest (`N = 8` in line 224):
```python
>>> bam.likelihood_ratio(150, (12593, 932), N)
1291...
```
But actually running this gives me the following error.
```python
Traceback (most recent call last):
  File "/cw/liir/NoCsBack/testliir/rubenc/miniconda3/envs/tsenv/lib/python3.8/site-packages/IPython/core/interactiveshell.py", line 3427, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-147-79b1533611d8>", line 1, in <module>
    nltk.BigramAssocMeasures.likelihood_ratio(150, (12593, 932), 8)
  File "/cw/liir/NoCsBack/testliir/rubenc/miniconda3/envs/tsenv/lib/python3.8/site-packages/nltk/metrics/association.py", line 148, in likelihood_ratio
    return cls._n * sum(
  File "/cw/liir/NoCsBack/testliir/rubenc/miniconda3/envs/tsenv/lib/python3.8/site-packages/nltk/metrics/association.py", line 149, in <genexpr>
    obs * _ln(obs / (exp + _SMALL) + _SMALL)
ValueError: math domain error
```

Line 272: `tam.likelihood_ratio(n_w1_w2_w3, pair_counts, uni_counts2, N) > tam.likelihood_ratio(n_w1_w2_w3, pair_counts, uni_counts, N)` is unaffected, since the inequality will still hold after multiplying both sides with a constant.

I tried to run (unit)tests, but `tox -e py37` fails with the following error.
```python
Traceback (most recent call last):
  File "/Users/rubencartuyvels/Documents/phd/eth/nltk/venv/bin/tox", line 6, in <module>
    from tox import cmdline
  File "/Users/rubencartuyvels/Documents/phd/eth/nltk/venv/lib/python3.7/site-packages/tox/__init__.py", line 32, in <module>
    from .session import cmdline  # isort:skip
  File "/Users/rubencartuyvels/Documents/phd/eth/nltk/venv/lib/python3.7/site-packages/tox/session/__init__.py", line 22, in <module>
    from tox.config import INTERRUPT_TIMEOUT, SUICIDE_TIMEOUT, TERMINATE_TIMEOUT, parseconfig
  File "/Users/rubencartuyvels/Documents/phd/eth/nltk/venv/lib/python3.7/site-packages/tox/config/__init__.py", line 24, in <module>
    from packaging import requirements
  File "/Users/rubencartuyvels/Documents/phd/eth/nltk/venv/lib/python3.7/site-packages/packaging/requirements.py", line 10, in <module>
    from pyparsing import (  # noqa: N817
  File "/Users/rubencartuyvels/Documents/phd/eth/nltk/venv/lib/python3.7/site-packages/pyparsing.py", line 5672, in <module>
    _escapedPunc = Word(_bslash, r"\[]-*.$+^?()~ ", exact=2).setParseAction(lambda s, l, t: t[0][1])
  File "/Users/rubencartuyvels/Documents/phd/eth/nltk/venv/lib/python3.7/site-packages/pyparsing.py", line 1563, in setParseAction
    self.parseAction = list(map(_trim_arity, list(fns)))
  File "/Users/rubencartuyvels/Documents/phd/eth/nltk/venv/lib/python3.7/site-packages/pyparsing.py", line 1310, in _trim_arity
    this_line = extract_stack(limit=2)[-1]
  File "/Users/rubencartuyvels/Documents/phd/eth/nltk/venv/lib/python3.7/site-packages/pyparsing.py", line 1294, in extract_stack
    frame_summary = traceback.extract_stack(limit=-offset + limit - 1)[offset]
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.7/lib/python3.7/traceback.py", line 211, in extract_stack
    stack = StackSummary.extract(walk_stack(f), limit=limit)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.7/lib/python3.7/traceback.py", line 363, in extract
    f.line
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.7/lib/python3.7/traceback.py", line 285, in line
    self._line = linecache.getline(self.filename, self.lineno).strip()
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.7/lib/python3.7/linecache.py", line 16, in getline
    lines = getlines(filename, module_globals)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.7/lib/python3.7/linecache.py", line 48, in getlines
    for mod in sys.modules.values():
RuntimeError: dictionary changed size during iteration
```
Let me know if anything else is expected from me 🙂 .

EDIT: I misunderstood something, lines 232-233 in tests/metrics.doctest actually do run without error and they give the correct result. Running unit tests with pytest works as well and no tests fail.