### PR TITLE
Hotfix/pytest production dependancy

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -278,6 +278,7 @@
 - Akshita Bhagia <https://github.com/AkshitaB>
 - Pratap Yadav <https://github.com/prtpydv>
 - Hiroki Teranishi <https://github.com/chantera>
+- Dalton Pearson <https://github.com/daltonpearson>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 

--- a/nltk/app/__init__.py
+++ b/nltk/app/__init__.py
@@ -48,9 +48,9 @@ else:
     else:
         from nltk.app.wordfreq_app import app as wordfreq
 
-# skip doctests from this package
-import pytest
 
-@pytest.mark.skip("nltk.app examples are not doctests")
 def setup_module(module):
-    pass
+    # skip doctests from this package
+    import pytest
+
+    pytest.skip("nltk.app examples are not doctests")

--- a/nltk/parse/corenlp.py
+++ b/nltk/parse/corenlp.py
@@ -20,8 +20,6 @@ from nltk.tokenize.api import TokenizerI
 from nltk.parse.dependencygraph import DependencyGraph
 from nltk.tree import Tree
 
-import pytest
-
 _stanford_url = "http://stanfordnlp.github.io/CoreNLP/"
 
 
@@ -748,8 +746,11 @@ def transform(sentence):
         )
 
 
-@pytest.mark.skip("Skipping all CoreNLP tests.")
 def setup_module(module):
+    import pytest
+
+    pytest.skip("Skipping all CoreNLP tests.")
+
     global server
 
     try:
@@ -767,6 +768,9 @@ def setup_module(module):
         )
 
 
-@pytest.mark.skip("Skipping all CoreNLP tests.")
 def teardown_module(module):
+    import pytest
+
+    pytest.skip("Skipping all CoreNLP tests.")
+
     server.stop()

--- a/nltk/parse/stanford.py
+++ b/nltk/parse/stanford.py
@@ -10,7 +10,6 @@
 import tempfile
 import os
 import warnings
-import pytest
 from subprocess import PIPE
 
 from nltk.internals import (
@@ -473,8 +472,10 @@ class StanfordNeuralDependencyParser(GenericStanfordParser):
         return DependencyGraph(result, top_relation_label="ROOT")
 
 
-@pytest.mark.skip("doctests from nltk.parse.stanford are skipped because it's deprecated")
 def setup_module(module):
+    import pytest
+
+    pytest.skip("doctests from nltk.parse.stanford are skipped because it's deprecated")
 
     try:
         StanfordParser(


### PR DESCRIPTION
A simple fix to remove the need to install pytest when using nltk in production. Solves issue: https://github.com/nltk/nltk/issues/2690