### PR TITLE
Add a "no dependency" runtime check to tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -123,3 +123,9 @@ setenv =
 commands =
     {toxinidir}/tools/travis/third-party.sh
     {toxinidir}/tools/travis/coverage-pylint.sh
+
+[testenv:py3-runtime-check]
+; nltk should be runnable in an env with nothing installed
+basepython = python3
+deps =
+commands = python -c "import nltk"


### PR DESCRIPTION
I was scratching my head as to how some check didn't catch that "pytest" issue earlier this week. And then I realized, all of the relevant tox targets are unit tests, meaning they all have pytest installed as extras! So this adds a NEW target, which has nothing installed beyond what comes with nltk.

The test passes now but I reverted https://github.com/nltk/nltk/pull/2693 and the test failed