### PR TITLE
Speedup two tests

### DIFF
--- a/nltk/classify/rte_classify.py
+++ b/nltk/classify/rte_classify.py
@@ -152,13 +152,19 @@ def rte_featurize(rte_pairs):
     return [(rte_features(pair), pair.value) for pair in rte_pairs]
 
 
-def rte_classifier(algorithm):
+def rte_classifier(algorithm, sample_N=None):
     from nltk.corpus import rte as rte_corpus
 
     train_set = rte_corpus.pairs(["rte1_dev.xml", "rte2_dev.xml", "rte3_dev.xml"])
     test_set = rte_corpus.pairs(["rte1_test.xml", "rte2_test.xml", "rte3_test.xml"])
+
+    if sample_N is not None:
+        train_set = train_set[:sample_N]
+        test_set = test_set[:sample_N]
+
     featurized_train_set = rte_featurize(train_set)
     featurized_test_set = rte_featurize(test_set)
+
     # Train the classifier
     print("Training classifier...")
     if algorithm in ["megam", "BFGS"]:  # MEGAM based algorithms.

--- a/nltk/test/conftest.py
+++ b/nltk/test/conftest.py
@@ -15,12 +15,15 @@ def mock_plot(mocker):
         pass
 
 
-@pytest.fixture(scope="session", autouse=True)
-def teardown_loaded_corpora(request):
+@pytest.fixture(scope="module", autouse=True)
+def teardown_loaded_corpora():
     """
     After each test session ends (either doctest or unit test),
     unload any loaded corpora
     """
+
+    yield  # first, wait for the test to end
+
     import nltk.corpus
 
     for name in dir(nltk.corpus):

--- a/nltk/test/gensim.doctest
+++ b/nltk/test/gensim.doctest
@@ -22,7 +22,7 @@ Train the model
 Here we train a word embedding using the Brown Corpus:
 
     >>> from nltk.corpus import brown
-    >>> train_set = brown.sents()[:10_000]
+    >>> train_set = brown.sents()[:10000]
     >>> model = gensim.models.Word2Vec(train_set)
 
 It might take some time to train the model. So, after it is trained, it can be saved as follows:

--- a/nltk/test/gensim.doctest
+++ b/nltk/test/gensim.doctest
@@ -22,7 +22,8 @@ Train the model
 Here we train a word embedding using the Brown Corpus:
 
     >>> from nltk.corpus import brown
-    >>> model = gensim.models.Word2Vec(brown.sents())
+    >>> train_set = brown.sents()[:10_000]
+    >>> model = gensim.models.Word2Vec(train_set)
 
 It might take some time to train the model. So, after it is trained, it can be saved as follows:
 

--- a/nltk/test/unit/test_rte_classify.py
+++ b/nltk/test/unit/test_rte_classify.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import unittest
+import pytest
 
 from nltk.corpus import rte as rte_corpus
 from nltk.classify.rte_classify import RTEFeatureExtractor, rte_features, rte_classifier
@@ -56,7 +56,7 @@ word_overlap    => 1
 """
 
 
-class RTEClassifierTest(unittest.TestCase):
+class TestRTEClassifier:
     # Test the feature extraction method.
     def test_rte_feature_extraction(self):
         pairs = rte_corpus.pairs(['rte1_dev.xml'])[:6]
@@ -68,24 +68,27 @@ class RTEClassifierTest(unittest.TestCase):
         expected_output = expected_from_rte_feature_extration.strip().split('\n')
         # Remove null strings.
         expected_output = list(filter(None, expected_output))
-        self.assertEqual(test_output, expected_output)
+        assert test_output == expected_output
 
     # Test the RTEFeatureExtractor object.
     def test_feature_extractor_object(self):
         rtepair = rte_corpus.pairs(['rte3_dev.xml'])[33]
         extractor = RTEFeatureExtractor(rtepair)
-        self.assertEqual(extractor.hyp_words, {'member', 'China', 'SCO.'})
-        self.assertEqual(extractor.overlap('word'), set())
-        self.assertEqual(extractor.overlap('ne'), {'China'})
-        self.assertEqual(extractor.hyp_extra('word'), {'member'})
+
+        assert extractor.hyp_words == {'member', 'China', 'SCO.'}
+        assert extractor.overlap('word') == set()
+        assert extractor.overlap('ne') == {'China'}
+        assert extractor.hyp_extra('word') == {'member'}
 
     # Test the RTE classifier training.
     def test_rte_classification_without_megam(self):
-        clf = rte_classifier('IIS')
-        clf = rte_classifier('GIS')
+        # Use a sample size for unit testing, since we
+        # don't need to fully train these classifiers
+        clf = rte_classifier('IIS', sample_N=100)
+        clf = rte_classifier('GIS', sample_N=100)
 
-    @unittest.skip("Skipping tests with dependencies on MEGAM")
+    @pytest.mark.skip("Skipping tests with dependencies on MEGAM")
     def test_rte_classification_with_megam(self):
         nltk.config_megam('/usr/local/bin/megam')
-        clf = rte_classifier('megam')
-        clf = rte_classifier('BFGS')
+        clf = rte_classifier('megam', sample_N=100)
+        clf = rte_classifier('BFGS', sample_N=100)


### PR DESCRIPTION
Philosophically, I don't think unit tests should be responsible for loading whole corpora. Ideally, they should load mock datasets. But for now we can downsample their input size to make them a bit faster.

`rte_classify`: ~60s to 4s
`gensim.doctest`: 45s to 25s

This is not to say this diff shaves 80 seconds off of the whole test suite. It's more around the lines of 30 or 40 seconds.