### PR TITLE
Remove redundant doctest option flags

### DIFF
--- a/nltk/test/chat80.doctest
+++ b/nltk/test/chat80.doctest
@@ -51,7 +51,7 @@ By analogy with NLTK corpora, ``chat80`` defines a number of 'items'
 which correspond to the relations.
 
     >>> from nltk.sem import chat80
-    >>> print(chat80.items) # doctest: +ELLIPSIS
+    >>> print(chat80.items)
     ('borders', 'circle_of_lat', 'circle_of_long', 'city', ...)
 
 The fields in the table are mapped to binary predicates. The first
@@ -108,7 +108,7 @@ the extraction.
     >>> concepts = chat80.clause2concepts('cities.pl', 'city', schema)
     >>> concepts
     [Concept('city'), Concept('country_of'), Concept('population_of')]
-    >>> for c in concepts: # doctest: +NORMALIZE_WHITESPACE
+    >>> for c in concepts:
     ...     print("%s:\n\t%s" % (c.prefLabel, c.extension[:4]))
     city:
         ['athens', 'bangkok', 'barcelona', 'berlin']

--- a/nltk/test/chunk.doctest
+++ b/nltk/test/chunk.doctest
@@ -147,7 +147,7 @@ Create and score a series of chunk parsers, successively more complex.
     >>> chunkscore.incorrect()
     []
 
-    >>> chunk_parser.rules() # doctest: +NORMALIZE_WHITESPACE
+    >>> chunk_parser.rules()
     [<ChunkRule: '<.*>+'>, <StripRule: '<VBD|IN|\\.>'>,
      <SplitRule: '<DT><NN>', '<DT><NN>'>]
 

--- a/nltk/test/collocations.doctest
+++ b/nltk/test/collocations.doctest
@@ -19,7 +19,7 @@ measured using Pointwise Mutual Information.
     >>> fourgram_measures = nltk.collocations.QuadgramAssocMeasures()
     >>> finder = BigramCollocationFinder.from_words(
     ...     nltk.corpus.genesis.words('english-web.txt'))
-    >>> finder.nbest(bigram_measures.pmi, 10)  # doctest: +NORMALIZE_WHITESPACE
+    >>> finder.nbest(bigram_measures.pmi, 10)
     [('Allon', 'Bacuth'), ('Ashteroth', 'Karnaim'), ('Ben', 'Ammi'),
      ('En', 'Mishpat'), ('Jegar', 'Sahadutha'), ('Salt', 'Sea'),
      ('Whoever', 'sheds'), ('appoint', 'overseers'), ('aromatic', 'resin'),
@@ -30,7 +30,7 @@ infrequent.  Therefore it is useful to apply filters, such as ignoring all
 bigrams which occur less than three times in the corpus:
 
     >>> finder.apply_freq_filter(3)
-    >>> finder.nbest(bigram_measures.pmi, 10)  # doctest: +NORMALIZE_WHITESPACE
+    >>> finder.nbest(bigram_measures.pmi, 10)
     [('Beer', 'Lahai'), ('Lahai', 'Roi'), ('gray', 'hairs'),
      ('ewe', 'lambs'), ('Most', 'High'), ('many', 'colors'),
      ('burnt', 'offering'), ('Paddan', 'Aram'), ('east', 'wind'),
@@ -40,7 +40,7 @@ We may similarly find collocations among tagged words:
 
     >>> finder = BigramCollocationFinder.from_words(
     ...     nltk.corpus.brown.tagged_words('ca01', tagset='universal'))
-    >>> finder.nbest(bigram_measures.pmi, 5)  # doctest: +NORMALIZE_WHITESPACE
+    >>> finder.nbest(bigram_measures.pmi, 5)
     [(('1,119', 'NUM'), ('votes', 'NOUN')),
      (('1962', 'NUM'), ("governor's", 'NOUN')),
      (('637', 'NUM'), ('E.', 'NOUN')),
@@ -51,7 +51,7 @@ Or tags alone:
 
     >>> finder = BigramCollocationFinder.from_words(t for w, t in
     ...     nltk.corpus.brown.tagged_words('ca01', tagset='universal'))
-    >>> finder.nbest(bigram_measures.pmi, 10)  # doctest: +NORMALIZE_WHITESPACE
+    >>> finder.nbest(bigram_measures.pmi, 10)
     [('PRT', 'VERB'), ('PRON', 'VERB'), ('ADP', 'DET'), ('.', 'PRON'), ('DET', 'ADJ'),
      ('CONJ', 'PRON'), ('ADP', 'NUM'), ('NUM', '.'), ('ADV', 'ADV'), ('VERB', 'ADV')]
 
@@ -63,7 +63,7 @@ Or spanning intervening words:
     >>> finder.apply_freq_filter(2)
     >>> ignored_words = nltk.corpus.stopwords.words('english')
     >>> finder.apply_word_filter(lambda w: len(w) < 3 or w.lower() in ignored_words)
-    >>> finder.nbest(bigram_measures.likelihood_ratio, 10) # doctest: +NORMALIZE_WHITESPACE
+    >>> finder.nbest(bigram_measures.likelihood_ratio, 10)
     [('chief', 'chief'), ('became', 'father'), ('years', 'became'),
      ('hundred', 'years'), ('lived', 'became'), ('king', 'king'),
      ('lived', 'years'), ('became', 'became'), ('chief', 'chiefs'),
@@ -79,7 +79,7 @@ consider all ngrams in a text as candidate collocations:
     >>> tokens = nltk.wordpunct_tokenize(text)
     >>> finder = BigramCollocationFinder.from_words(tokens)
     >>> scored = finder.score_ngrams(bigram_measures.raw_freq)
-    >>> sorted(bigram for bigram, score in scored)  # doctest: +NORMALIZE_WHITESPACE
+    >>> sorted(bigram for bigram, score in scored)
     [(',', 'I'), ('I', 'am'), ('I', 'do'), ('Sam', 'I'), ('am', '!'),
      ('and', 'ham'), ('do', 'not'), ('eggs', 'and'), ('green', 'eggs'),
      ('ham', ','), ('like', 'green'), ('like', 'them'), ('not', 'like'),
@@ -121,7 +121,7 @@ Now spanning intervening words:
     
 A closer look at the finder's ngram frequencies:
 
-    >>> sorted(finder.ngram_fd.items(), key=lambda t: (-t[1], t[0]))[:10]  # doctest: +NORMALIZE_WHITESPACE
+    >>> sorted(finder.ngram_fd.items(), key=lambda t: (-t[1], t[0]))[:10]
     [(('I', 'do', 'like'), 2), (('I', 'do', 'not'), 2), (('I', 'not', 'like'), 2),
      (('do', 'not', 'like'), 2), ((',', 'I', 'do'), 1), ((',', 'I', 'not'), 1),
      ((',', 'do', 'not'), 1), (('I', 'am', '!'), 1), (('Sam', 'I', '!'), 1),

--- a/nltk/test/concordance.doctest
+++ b/nltk/test/concordance.doctest
@@ -15,7 +15,7 @@ concordance, and then placing "monstrous" in parentheses:
 >>> corpus = gutenberg.words('melville-moby_dick.txt')
 >>> text = Text(corpus)
 
->>> text.concordance("monstrous") # doctest:+NORMALIZE_WHITESPACE
+>>> text.concordance("monstrous")
 Displaying 11 of 11 matches:
 ong the former , one was of a most monstrous size . ... This came towards us ,
 ON OF THE PSALMS . " Touching that monstrous bulk of the whale or ork we have r
@@ -29,7 +29,7 @@ ere to enter upon those still more monstrous stories of them which are to be fo
 ght have been rummaged out of this monstrous cabinet there is no telling . But
 of Whale - Bones ; for Whales of a monstrous size are oftentimes cast up dead u
 
->>> text.concordance("monstrous") # doctest:+ELLIPSIS, +NORMALIZE_WHITESPACE
+>>> text.concordance("monstrous")
 Displaying 11 of 11 matches:
 ong the former , one was of a most monstrous size . ... This came towards us ,
 ON OF THE PSALMS . " Touching that monstrous bulk of the whale or ork we have r
@@ -38,7 +38,7 @@ ll over with a heathenish array of monstrous clubs and spears . Some were thick
 
 We can also search for a multi-word phrase by passing a list of strings:
 
->>> text.concordance(["monstrous", "size"]) # doctest:+NORMALIZE_WHITESPACE
+>>> text.concordance(["monstrous", "size"])
 Displaying 2 of 2 matches:
 the former , one was of a most monstrous size . ... This came towards us , op
 Whale - Bones ; for Whales of a monstrous size are oftentimes cast up dead upo

--- a/nltk/test/corpus.doctest
+++ b/nltk/test/corpus.doctest
@@ -57,9 +57,9 @@ Most corpora consist of a set of files, each containing a document (or
 other pieces of text).  A list of identifiers for these files is
 accessed via the ``fileids()`` method of the corpus reader:
 
-    >>> nltk.corpus.treebank.fileids() # doctest: +ELLIPSIS
+    >>> nltk.corpus.treebank.fileids()
     ['wsj_0001.mrg', 'wsj_0002.mrg', 'wsj_0003.mrg', 'wsj_0004.mrg', ...]
-    >>> nltk.corpus.inaugural.fileids() # doctest: +ELLIPSIS
+    >>> nltk.corpus.inaugural.fileids()
     ['1789-Washington.txt', '1793-Washington.txt', '1797-Adams.txt', ...]
 
 Each corpus reader provides a variety of methods to read data from the
@@ -68,13 +68,13 @@ corpora support methods to read the corpus as raw text, a list of
 words, a list of sentences, or a list of paragraphs.
 
     >>> from nltk.corpus import inaugural
-    >>> inaugural.raw('1789-Washington.txt') # doctest: +ELLIPSIS
+    >>> inaugural.raw('1789-Washington.txt')
     'Fellow-Citizens of the Senate ...'
     >>> inaugural.words('1789-Washington.txt')
     ['Fellow', '-', 'Citizens', 'of', 'the', ...]
-    >>> inaugural.sents('1789-Washington.txt') # doctest: +ELLIPSIS
+    >>> inaugural.sents('1789-Washington.txt')
     [['Fellow', '-', 'Citizens'...], ['Among', 'the', 'vicissitudes'...]...]
-    >>> inaugural.paras('1789-Washington.txt') # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> inaugural.paras('1789-Washington.txt')
     [[['Fellow', '-', 'Citizens'...]],
      [['Among', 'the', 'vicissitudes'...],
       ['On', 'the', 'one', 'hand', ',', 'I'...]...]...]
@@ -133,17 +133,17 @@ than just bare word strings.
     ['The', 'Fulton', 'County', 'Grand', 'Jury', ...]
     >>> print(brown.tagged_words())
     [('The', 'AT'), ('Fulton', 'NP-TL'), ...]
-    >>> print(brown.sents()) # doctest: +ELLIPSIS
+    >>> print(brown.sents())
     [['The', 'Fulton', 'County'...], ['The', 'jury', 'further'...], ...]
-    >>> print(brown.tagged_sents()) # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> print(brown.tagged_sents())
     [[('The', 'AT'), ('Fulton', 'NP-TL')...],
      [('The', 'AT'), ('jury', 'NN'), ('further', 'RBR')...]...]
-    >>> print(brown.paras(categories='reviews')) # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> print(brown.paras(categories='reviews'))
     [[['It', 'is', 'not', 'news', 'that', 'Nathan', 'Milstein'...],
       ['Certainly', 'not', 'in', 'Orchestra', 'Hall', 'where'...]],
      [['There', 'was', 'about', 'that', 'song', 'something', ...],
       ['Not', 'the', 'noblest', 'performance', 'we', 'have', ...], ...], ...]
-    >>> print(brown.tagged_paras(categories='reviews')) # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> print(brown.tagged_paras(categories='reviews'))
     [[[('It', 'PPS'), ('is', 'BEZ'), ('not', '*'), ...],
       [('Certainly', 'RB'), ('not', '*'), ('in', 'IN'), ...]],
      [[('There', 'EX'), ('was', 'BEDZ'), ('about', 'IN'), ...],
@@ -163,11 +163,11 @@ Indian text annotated with part-of-speech tags:
 Several tagged corpora support access to a simplified, universal tagset, e.g. where all nouns
 tags are collapsed to a single category ``NOUN``:
 
-    >>> print(brown.tagged_sents(tagset='universal')) # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> print(brown.tagged_sents(tagset='universal'))
     [[('The', 'DET'), ('Fulton', 'NOUN'), ('County', 'NOUN'), ('Grand', 'ADJ'), ('Jury', 'NOUN'), ...],
      [('The', 'DET'), ('jury', 'NOUN'), ('further', 'ADV'), ('said', 'VERB'), ('in', 'ADP'), ...]...]
     >>> from nltk.corpus import conll2000, switchboard
-    >>> print(conll2000.tagged_words(tagset='universal')) # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> print(conll2000.tagged_words(tagset='universal'))
     [('Confidence', 'NOUN'), ('in', 'ADP'), ...]
 
 Use ``nltk.app.pos_concordance()`` to access a GUI for searching tagged corpora.
@@ -180,11 +180,11 @@ flat trees.  The CoNLL 2000 Corpus includes phrasal chunks; and the
 CoNLL 2002 Corpus includes named entity chunks.
 
     >>> from nltk.corpus import conll2000, conll2002
-    >>> print(conll2000.sents()) # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> print(conll2000.sents())
     [['Confidence', 'in', 'the', 'pound', 'is', 'widely', ...],
      ['Chancellor', 'of', 'the', 'Exchequer', ...], ...]
     >>> for tree in conll2000.chunked_sents()[:2]:
-    ...     print(tree) # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    ...     print(tree)
     (S
       (NP Confidence/NN)
       (PP in/IN)
@@ -198,10 +198,10 @@ CoNLL 2002 Corpus includes named entity chunks.
       (PP of/IN)
       (NP the/DT Exchequer/NNP)
       ...)
-    >>> print(conll2002.sents()) # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> print(conll2002.sents())
     [['Sao', 'Paulo', '(', 'Brasil', ')', ',', ...], ['-'], ...]
     >>> for tree in conll2002.chunked_sents()[:2]:
-    ...     print(tree) # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    ...     print(tree)
     (S
       (LOC Sao/NC Paulo/VMI)
       (/Fpa
@@ -227,10 +227,10 @@ to the entire chunk).
     ['The', 'Fulton', 'County', 'Grand', 'Jury', ...]
     >>> semcor.chunks()
     [['The'], ['Fulton', 'County', 'Grand', 'Jury'], ...]
-    >>> semcor.sents() # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> semcor.sents()
     [['The', 'Fulton', 'County', 'Grand', 'Jury', 'said', ...],
     ['The', 'jury', 'further', 'said', ...], ...]
-    >>> semcor.chunk_sents() # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> semcor.chunk_sents()
     [[['The'], ['Fulton', 'County', 'Grand', 'Jury'], ['said'], ...
     ['.']], [['The'], ['jury'], ['further'], ['said'], ... ['.']], ...]
     >>> list(map(str, semcor.tagged_chunks(tag='both')[:3]))
@@ -247,7 +247,7 @@ corpus defines the `parsed_docs` method, which returns the documents
 in a given item as `IEERDocument` objects:
 
     >>> from nltk.corpus import ieer
-    >>> ieer.fileids() # doctest: +NORMALIZE_WHITESPACE
+    >>> ieer.fileids()
     ['APW_19980314', 'APW_19980424', 'APW_19980429',
      'NYT_19980315', 'NYT_19980403', 'NYT_19980407']
     >>> docs = ieer.parsed_docs('APW_19980314')
@@ -261,7 +261,7 @@ in a given item as `IEERDocument` objects:
     03/14/1998 10:36:00
     >>> print(docs[0].headline)
     (DOCUMENT Kenyans protest tax hikes)
-    >>> print(docs[0].text) # doctest: +ELLIPSIS
+    >>> print(docs[0].text)
     (DOCUMENT
       (LOCATION NAIROBI)
       ,
@@ -288,13 +288,13 @@ NLTK data package includes a 10% sample of the Penn Treebank (in
 Reading the Penn Treebank (Wall Street Journal sample):
 
     >>> from nltk.corpus import treebank
-    >>> print(treebank.fileids()) # doctest: +ELLIPSIS
+    >>> print(treebank.fileids())
     ['wsj_0001.mrg', 'wsj_0002.mrg', 'wsj_0003.mrg', 'wsj_0004.mrg', ...]
     >>> print(treebank.words('wsj_0003.mrg'))
     ['A', 'form', 'of', 'asbestos', 'once', 'used', ...]
     >>> print(treebank.tagged_words('wsj_0003.mrg'))
     [('A', 'DT'), ('form', 'NN'), ('of', 'IN'), ...]
-    >>> print(treebank.parsed_sents('wsj_0003.mrg')[0]) # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> print(treebank.parsed_sents('wsj_0003.mrg')[0])
     (S
       (S-TPC-1
         (NP-SBJ
@@ -382,18 +382,18 @@ examples illustrate the use of the wordlist corpora:
     >>> from nltk.corpus import names, stopwords, words
     >>> words.fileids()
     ['en', 'en-basic']
-    >>> words.words('en') # doctest: +ELLIPSIS
+    >>> words.words('en')
     ['A', 'a', 'aa', 'aal', 'aalii', 'aam', 'Aani', 'aardvark', 'aardwolf', ...]
 
-    >>> stopwords.fileids() # doctest: +ELLIPSIS
+    >>> stopwords.fileids()
     ['arabic', 'azerbaijani', 'danish', 'dutch', 'english', 'finnish', 'french', ...]
-    >>> sorted(stopwords.words('portuguese')) # doctest: +ELLIPSIS
+    >>> sorted(stopwords.words('portuguese'))
     ['a', 'ao', 'aos', 'aquela', 'aquelas', 'aquele', 'aqueles', ...]
     >>> names.fileids()
     ['female.txt', 'male.txt']
-    >>> names.words('male.txt') # doctest: +ELLIPSIS
+    >>> names.words('male.txt')
     ['Aamir', 'Aaron', 'Abbey', 'Abbie', 'Abbot', 'Abbott', ...]
-    >>> names.words('female.txt') # doctest: +ELLIPSIS
+    >>> names.words('female.txt')
     ['Abagael', 'Abagail', 'Abbe', 'Abbey', 'Abbi', 'Abbie', ...]
 
 The CMU Pronunciation Dictionary corpus contains pronounciation
@@ -404,7 +404,7 @@ transcriptions.  Transcriptions are encoded as tuples of phoneme
 strings.
 
     >>> from nltk.corpus import cmudict
-    >>> print(cmudict.entries()[653:659]) # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> print(cmudict.entries()[653:659])
     [('acetate', ['AE1', 'S', 'AH0', 'T', 'EY2', 'T']),
     ('acetic', ['AH0', 'S', 'EH1', 'T', 'IH0', 'K']),
     ('acetic', ['AH0', 'S', 'IY1', 'T', 'IH0', 'K']),
@@ -413,7 +413,7 @@ strings.
     ('acetone', ['AE1', 'S', 'AH0', 'T', 'OW2', 'N'])]
     >>> # Load the entire cmudict corpus into a Python dictionary:
     >>> transcr = cmudict.dict()
-    >>> print([transcr[w][0] for w in 'Natural Language Tool Kit'.lower().split()]) # doctest: +NORMALIZE_WHITESPACE
+    >>> print([transcr[w][0] for w in 'Natural Language Tool Kit'.lower().split()])
     [['N', 'AE1', 'CH', 'ER0', 'AH0', 'L'],
      ['L', 'AE1', 'NG', 'G', 'W', 'AH0', 'JH'],
      ['T', 'UW1', 'L'],
@@ -450,12 +450,12 @@ and their categories (in both directions).  Access the categories using the ``ca
 method, e.g.:
 
     >>> from nltk.corpus import brown, movie_reviews, reuters
-    >>> brown.categories() # doctest: +NORMALIZE_WHITESPACE
+    >>> brown.categories()
     ['adventure', 'belles_lettres', 'editorial', 'fiction', 'government', 'hobbies', 'humor',
     'learned', 'lore', 'mystery', 'news', 'religion', 'reviews', 'romance', 'science_fiction']
     >>> movie_reviews.categories()
     ['neg', 'pos']
-    >>> reuters.categories() # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    >>> reuters.categories()
     ['acq', 'alum', 'barley', 'bop', 'carcass', 'castor-oil', 'cocoa',
     'coconut', 'coconut-oil', 'coffee', 'copper', 'copra-cake', 'corn',
     'cotton', 'cotton-oil', 'cpi', 'cpu', 'crude', 'dfl', 'dlr', ...]
@@ -474,7 +474,7 @@ of documents, allowing us to map from (one or more) documents to (one or more) c
 
 We can go back the other way using the optional argument of the ``fileids()`` method:
 
-    >>> reuters.fileids('barley') # doctest: +ELLIPSIS
+    >>> reuters.fileids('barley')
     ['test/15618', 'test/15649', 'test/15676', 'test/15728', 'test/15871', ...]
 
 Both the ``categories()`` and ``fileids()`` methods return a sorted list containing
@@ -486,7 +486,7 @@ of a corpus by specifying one or more fileids, we can identify one or more categ
 
     >>> brown.tagged_words(categories='news')
     [('The', 'AT'), ('Fulton', 'NP-TL'), ...]
-    >>> brown.sents(categories=['editorial','reviews']) # doctest: +NORMALIZE_WHITESPACE
+    >>> brown.sents(categories=['editorial','reviews'])
     [['Assembly', 'session', 'brought', 'much', 'good'], ['The', 'General',
     'Assembly', ',', 'which', 'adjourns', 'today', ',', 'has', 'performed',
     'in', 'an', 'atmosphere', 'of', 'crisis', 'and', 'struggle', 'from',
@@ -557,7 +557,7 @@ prepositional phrase attachment decisions.  Each instance in the
 corpus is encoded as a ``PPAttachment`` object:
 
     >>> from nltk.corpus import ppattach
-    >>> ppattach.attachments('training') # doctest: +NORMALIZE_WHITESPACE
+    >>> ppattach.attachments('training')
     [PPAttachment(sent='0', verb='join', noun1='board',
                   prep='as', noun2='director', attachment='V'),
      PPAttachment(sent='1', verb='is', noun1='chairman',
@@ -618,7 +618,7 @@ semcor
 The Brown Corpus, annotated with WordNet senses.
 
     >>> from nltk.corpus import semcor
-    >>> semcor.words('brown2/tagfiles/br-n12.xml')  # doctest: +ELLIPSIS
+    >>> semcor.words('brown2/tagfiles/br-n12.xml')
     ['When', 'several', 'minutes', 'had', 'passed', ...]
 
 senseval
@@ -634,7 +634,7 @@ context.
     >>> senseval.fileids()
     ['hard.pos', 'interest.pos', 'line.pos', 'serve.pos']
     >>> senseval.instances('hard.pos')
-    ... # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    ...
     [SensevalInstance(word='hard-a',
         position=20,
         context=[('``', '``'), ('he', 'PRP'), ...('hard', 'JJ'), ...],
@@ -688,22 +688,22 @@ as XML files.  These corpora are returned as ElementTree objects:
 
     >>> from nltk.corpus import shakespeare
     >>> from xml.etree import ElementTree
-    >>> shakespeare.fileids() # doctest: +ELLIPSIS
+    >>> shakespeare.fileids()
     ['a_and_c.xml', 'dream.xml', 'hamlet.xml', 'j_caesar.xml', ...]
     >>> play = shakespeare.xml('dream.xml')
-    >>> print(play) # doctest: +ELLIPSIS
+    >>> print(play)
     <Element 'PLAY' at ...>
     >>> print('%s: %s' % (play[0].tag, play[0].text))
     TITLE: A Midsummer Night's Dream
     >>> personae = [persona.text for persona in
     ...             play.findall('PERSONAE/PERSONA')]
-    >>> print(personae) # doctest: +ELLIPSIS
+    >>> print(personae)
     ['THESEUS, Duke of Athens.', 'EGEUS, father to Hermia.', ...]
     >>> # Find and print speakers not listed as personae
     >>> names = [persona.split(',')[0] for persona in personae]
     >>> speakers = set(speaker.text for speaker in
     ...                play.findall('*/*/*/SPEAKER'))
-    >>> print(sorted(speakers.difference(names))) # doctest: +NORMALIZE_WHITESPACE
+    >>> print(sorted(speakers.difference(names)))
     ['ALL', 'COBWEB', 'DEMETRIUS', 'Fairy', 'HERNIA', 'LYSANDER',
      'Lion', 'MOTH', 'MUSTARDSEED', 'Moonshine', 'PEASEBLOSSOM',
      'Prologue', 'Pyramus', 'Thisbe', 'Wall']
@@ -791,13 +791,13 @@ down into small speech samples, each of which is available as a wave
 file, a phonetic transcription, and a tokenized word list.
 
     >>> from nltk.corpus import timit
-    >>> print(timit.utteranceids()) # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> print(timit.utteranceids())
     ['dr1-fvmh0/sa1', 'dr1-fvmh0/sa2', 'dr1-fvmh0/si1466',
     'dr1-fvmh0/si2096', 'dr1-fvmh0/si836', 'dr1-fvmh0/sx116',
     'dr1-fvmh0/sx206', 'dr1-fvmh0/sx26', 'dr1-fvmh0/sx296', ...]
 
     >>> item = timit.utteranceids()[5]
-    >>> print(timit.phones(item)) # doctest: +NORMALIZE_WHITESPACE
+    >>> print(timit.phones(item))
     ['h#', 'k', 'l', 'ae', 's', 'pcl', 'p', 'dh', 'ax',
      's', 'kcl', 'k', 'r', 'ux', 'ix', 'nx', 'y', 'ax',
      'l', 'eh', 'f', 'tcl', 't', 'hh', 'ae', 'n', 'dcl',
@@ -825,9 +825,9 @@ the phonemes to produce a single tree structure:
 The start time and stop time of each phoneme, word, and sentence are
 also available:
 
-    >>> print(timit.phone_times(item)) # doctest: +ELLIPSIS
+    >>> print(timit.phone_times(item))
     [('h#', 0, 2190), ('k', 2190, 3430), ('l', 3430, 4326), ...]
-    >>> print(timit.word_times(item)) # doctest: +ELLIPSIS
+    >>> print(timit.word_times(item))
     [('clasp', 2190, 8804), ('the', 8804, 9734), ...]
     >>> print(timit.sent_times(item))
     [('Clasp the screw in your left hand.', 0, 32154)]
@@ -843,7 +843,7 @@ speaker and sentence identifier for a given speech sample:
     dr1-fvmh0
     >>> print(timit.sentid(item))
     sx116
-    >>> print(timit.spkrinfo(timit.spkrid(item))) # doctest: +NORMALIZE_WHITESPACE
+    >>> print(timit.spkrinfo(timit.spkrid(item)))
     SpeakerInfo(id='VMH0',
                 sex='F',
                 dr='1',
@@ -856,7 +856,7 @@ speaker and sentence identifier for a given speech sample:
                 comments='BEST NEW ENGLAND ACCENT SO FAR')
 
     >>> # List the speech samples from the same speaker:
-    >>> timit.utteranceids(spkrid=timit.spkrid(item)) # doctest: +ELLIPSIS
+    >>> timit.utteranceids(spkrid=timit.spkrid(item))
     ['dr1-fvmh0/sa1', 'dr1-fvmh0/sa2', 'dr1-fvmh0/si1466', ...]
 
 twitter_samples
@@ -875,13 +875,13 @@ JSON. These data structures can be accessed via `tweets.docs()`. However, in gen
 is more practical to focus just on the text field of the Tweets, which
 are accessed via the `strings()` method.
 
-    >>> twitter_samples.strings('tweets.20150430-223406.json')[:5] # doctest: +ELLIPSIS
+    >>> twitter_samples.strings('tweets.20150430-223406.json')[:5]
     ['RT @KirkKus: Indirect cost of the UK being in the EU is estimated to be costing Britain \xa3170 billion per year! #BetterOffOut #UKIP', ...]
 
 The default tokenizer for Tweets is specialised for 'casual' text, and
 the `tokenized()` method returns a list of lists of tokens.
 
-    >>> twitter_samples.tokenized('tweets.20150430-223406.json')[:5] # doctest: +ELLIPSIS
+    >>> twitter_samples.tokenized('tweets.20150430-223406.json')[:5]
     [['RT', '@KirkKus', ':', 'Indirect', 'cost', 'of', 'the', 'UK', 'being', 'in', ...],
      ['VIDEO', ':', 'Sturgeon', 'on', 'post-election', 'deals', 'http://t.co/BTJwrpbmOY'], ...]
 
@@ -892,10 +892,10 @@ RTE1, RTE2 and RTE3 datasets (dev and test data), and consists of a
 list of XML-formatted 'text'/'hypothesis' pairs.
 
     >>> from nltk.corpus import rte
-    >>> print(rte.fileids()) # doctest: +ELLIPSIS
+    >>> print(rte.fileids())
     ['rte1_dev.xml', 'rte1_test.xml', 'rte2_dev.xml', ..., 'rte3_test.xml']
     >>> rtepairs = rte.pairs(['rte2_test.xml', 'rte3_test.xml'])
-    >>> print(rtepairs)  # doctest: +ELLIPSIS
+    >>> print(rtepairs)
     [<RTEPair: gid=2-8>, <RTEPair: gid=2-9>, <RTEPair: gid=2-15>, ...]
 
 In the gold standard test sets, each pair is labeled according to
@@ -904,7 +904,7 @@ entailment value is mapped to an integer 1 (True) or 0 (False).
 
     >>> rtepairs[5]
     <RTEPair: gid=2-23>
-    >>> rtepairs[5].text # doctest: +NORMALIZE_WHITESPACE
+    >>> rtepairs[5].text
     'His wife Strida won a seat in parliament after forging an alliance
     with the main anti-Syrian coalition in the recent election.'
     >>> rtepairs[5].hyp
@@ -917,7 +917,7 @@ The RTE corpus also supports an ``xml()`` method which produces ElementTrees.
     >>> xmltree = rte.xml('rte3_dev.xml')
     >>> xmltree # doctest: +SKIP
     <Element entailment-corpus at ...>
-    >>> xmltree[7].findtext('t') # doctest: +NORMALIZE_WHITESPACE
+    >>> xmltree[7].findtext('t')
     "Mrs. Bush's approval ratings have remained very high, above 80%,
     even as her husband's have recently dropped below 50%."
 
@@ -954,12 +954,12 @@ The primary object in the lexicon is a class record, which is stored
 as an ElementTree xml object.  The class record for a given class
 identifier is returned by the `vnclass()` method:
 
-    >>> verbnet.vnclass('remove-10.1') # doctest: +ELLIPSIS
+    >>> verbnet.vnclass('remove-10.1')
     <Element 'VNCLASS' at ...>
 
 The `vnclass()` method also accepts "short" identifiers, such as '10.1':
 
-    >>> verbnet.vnclass('10.1') # doctest: +ELLIPSIS
+    >>> verbnet.vnclass('10.1')
     <Element 'VNCLASS' at ...>
 
 See the Verbnet documentation, or the Verbnet files, for information
@@ -1037,7 +1037,7 @@ chat rooms, which have been anonymized, POS-tagged and dialogue-act tagged.
     ['now', 'im', 'left', 'with', 'this', 'gay', ...]
     >>> print(nltk.corpus.nps_chat.tagged_words())
     [('now', 'RB'), ('im', 'PRP'), ('left', 'VBD'), ...]
-    >>> print(nltk.corpus.nps_chat.tagged_posts()) # doctest: +NORMALIZE_WHITESPACE
+    >>> print(nltk.corpus.nps_chat.tagged_posts())
     [[('now', 'RB'), ('im', 'PRP'), ('left', 'VBD'), ('with', 'IN'),
     ('this', 'DT'), ('gay', 'JJ'), ('name', 'NN')], [(':P', 'UH')], ...]
 
@@ -1045,7 +1045,7 @@ We can access the XML elements corresponding to individual posts.  These element
 have ``class`` and ``user`` attributes that we can access using ``p.attrib['class']``
 and ``p.attrib['user']``.  They also have text content, accessed using ``p.text``.
 
-    >>> print(nltk.corpus.nps_chat.xml_posts()) # doctest: +ELLIPSIS
+    >>> print(nltk.corpus.nps_chat.xml_posts())
     [<Element 'Post' at 0...>, <Element 'Post' at 0...>, ...]
     >>> posts = nltk.corpus.nps_chat.xml_posts()
     >>> sorted(nltk.FreqDist(p.attrib['class'] for p in posts).keys())
@@ -1102,15 +1102,15 @@ in the NLTK data distribution.  Here is a small sample of those
 corpus reader instances:
 
     >>> import nltk
-    >>> nltk.corpus.brown # doctest: +ELLIPSIS
+    >>> nltk.corpus.brown
     <CategorizedTaggedCorpusReader ...>
-    >>> nltk.corpus.treebank # doctest: +ELLIPSIS
+    >>> nltk.corpus.treebank
     <BracketParseCorpusReader ...>
-    >>> nltk.corpus.names # doctest: +ELLIPSIS
+    >>> nltk.corpus.names
     <WordListCorpusReader ...>
-    >>> nltk.corpus.genesis # doctest: +ELLIPSIS
+    >>> nltk.corpus.genesis
     <PlaintextCorpusReader ...>
-    >>> nltk.corpus.inaugural # doctest: +ELLIPSIS
+    >>> nltk.corpus.inaugural
     <PlaintextCorpusReader ...>
 
 This sample illustrates that different corpus reader classes are used
@@ -1156,7 +1156,7 @@ uses a different sentence tokenizer as follows:
     >>> my_genesis = nltk.corpus.PlaintextCorpusReader(
     ...     genesis_dir, r'.*\.txt', sent_tokenizer=my_sent_tokenizer)
     >>> # Use the new corpus reader object.
-    >>> print(my_genesis.sents('english-kjv.txt')[0]) # doctest: +NORMALIZE_WHITESPACE
+    >>> print(my_genesis.sents('english-kjv.txt')[0])
     ['In', 'the', 'beginning', 'God', 'created', 'the', 'heaven',
      'and', 'the', 'earth']
 
@@ -1218,7 +1218,7 @@ directory (or in subdirectories of that root directory).  The absolute
 path to the root directory is stored in the ``root`` property:
 
     >>> import os
-    >>> str(nltk.corpus.genesis.root).replace(os.path.sep,'/') # doctest: +ELLIPSIS
+    >>> str(nltk.corpus.genesis.root).replace(os.path.sep,'/')
     '.../nltk_data/corpora/genesis'
 
 Each file within the corpus is identified by a platform-independent
@@ -1240,22 +1240,22 @@ metadata files.  For corpora with diverse file types, the ``fileids()``
 method will often take one or more optional arguments, which can be
 used to get a list of the files with a specific file type:
 
-    >>> nltk.corpus.timit.fileids() # doctest: +ELLIPSIS
+    >>> nltk.corpus.timit.fileids()
     ['dr1-fvmh0/sa1.phn', 'dr1-fvmh0/sa1.txt', 'dr1-fvmh0/sa1.wav', ...]
-    >>> nltk.corpus.timit.fileids('phn') # doctest: +ELLIPSIS
+    >>> nltk.corpus.timit.fileids('phn')
     ['dr1-fvmh0/sa1.phn', 'dr1-fvmh0/sa2.phn', 'dr1-fvmh0/si1466.phn', ...]
 
 In some corpora, the files are divided into distinct categories.  For
 these corpora, the ``fileids()`` method takes an optional argument,
 which can be used to get a list of the files within a specific category:
 
-    >>> nltk.corpus.brown.fileids('hobbies') # doctest: +ELLIPSIS
+    >>> nltk.corpus.brown.fileids('hobbies')
     ['ce01', 'ce02', 'ce03', 'ce04', 'ce05', 'ce06', 'ce07', ...]
 
 The ``abspath()`` method can be used to find the absolute path to a
 corpus file, given its file identifier:
 
-    >>> str(nltk.corpus.brown.abspath('ce06')).replace(os.path.sep,'/') # doctest: +ELLIPSIS
+    >>> str(nltk.corpus.brown.abspath('ce06')).replace(os.path.sep,'/')
     '.../corpora/brown/ce06'
 
 The ``abspaths()`` method can be used to find the absolute paths for
@@ -1327,7 +1327,7 @@ content, some corpora use different identifiers instead.  For example,
 the data access methods for the ``timit`` corpus uses *utterance
 identifiers* to select which corpus items should be returned:
 
-    >>> nltk.corpus.timit.utteranceids() # doctest: +ELLIPSIS
+    >>> nltk.corpus.timit.utteranceids()
     ['dr1-fvmh0/sa1', 'dr1-fvmh0/sa2', 'dr1-fvmh0/si1466', ...]
     >>> nltk.corpus.timit.words('dr1-fvmh0/sa2')
     ["don't", 'ask', 'me', 'to', 'carry', 'an', 'oily', 'rag', 'like', 'that']
@@ -1335,7 +1335,7 @@ identifiers* to select which corpus items should be returned:
 Attempting to call ``timit``\ 's data access methods with a file
 identifier will result in an exception:
 
-    >>> nltk.corpus.timit.fileids() # doctest: +ELLIPSIS
+    >>> nltk.corpus.timit.fileids()
     ['dr1-fvmh0/sa1.phn', 'dr1-fvmh0/sa1.txt', 'dr1-fvmh0/sa1.wav', ...]
     >>> nltk.corpus.timit.words('dr1-fvmh0/sa1.txt') # doctest: +SKIP
     Traceback (most recent call last):
@@ -1347,7 +1347,7 @@ method, which expects a roleset identifier, not a file identifier:
 
     >>> roleset = nltk.corpus.propbank.roleset('eat.01')
     >>> from xml.etree import ElementTree as ET
-    >>> print(ET.tostring(roleset).decode('utf8')) # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> print(ET.tostring(roleset).decode('utf8'))
     <roleset id="eat.01" name="consume" vncls="39.1">
       <roles>
         <role descr="consumer, eater" n="0">...</role>...
@@ -1461,12 +1461,12 @@ entire corpus).  The method's implementation converts this argument to
 a list of path names using the `abspaths()` method, which handles all
 three value types (string, list, and None):
 
-    >>> print(str(nltk.corpus.brown.abspaths()).replace('\\\\','/')) # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> print(str(nltk.corpus.brown.abspaths()).replace('\\\\','/'))
     [FileSystemPathPointer('.../corpora/brown/ca01'),
      FileSystemPathPointer('.../corpora/brown/ca02'), ...]
-    >>> print(str(nltk.corpus.brown.abspaths('ce06')).replace('\\\\','/')) # doctest: +ELLIPSIS
+    >>> print(str(nltk.corpus.brown.abspaths('ce06')).replace('\\\\','/'))
     [FileSystemPathPointer('.../corpora/brown/ce06')]
-    >>> print(str(nltk.corpus.brown.abspaths(['ce06', 'ce07'])).replace('\\\\','/')) # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> print(str(nltk.corpus.brown.abspaths(['ce06', 'ce07'])).replace('\\\\','/'))
     [FileSystemPathPointer('.../corpora/brown/ce06'),
      FileSystemPathPointer('.../corpora/brown/ce07')]
 
@@ -1699,15 +1699,15 @@ By default, they apply to all documents in the corpus.
     True
     >>> corpus.words()
     ['This', 'is', 'the', 'first', 'sentence', '.', ...]
-    >>> corpus.sents() # doctest: +ELLIPSIS
+    >>> corpus.sents()
     [['This', 'is', 'the', 'first', ...], ['Here', 'is', 'another'...], ...]
-    >>> corpus.paras() # doctest: +ELLIPSIS
+    >>> corpus.paras()
     [[['This', ...], ['Here', ...], ...], [['This', ...], ...], ...]
-    >>> corpus.tagged_words() # doctest: +ELLIPSIS
+    >>> corpus.tagged_words()
     [('This', 'DET'), ('is', 'VERB'), ('the', 'DET'), ...]
-    >>> corpus.tagged_sents() # doctest: +ELLIPSIS
+    >>> corpus.tagged_sents()
     [[('This', 'DET'), ('is', 'VERB'), ...], [('Here', 'DET'), ...], ...]
-    >>> corpus.tagged_paras() # doctest: +ELLIPSIS
+    >>> corpus.tagged_paras()
     [[[('This', 'DET'), ...], ...], [[('This', 'DET'), ...], ...], ...]
     >>> corpus.raw()[:40]
     'This/det is/verb the/det first/adj sente'
@@ -1726,24 +1726,24 @@ By default, they apply to all documents in the corpus.
 The Brown Corpus uses the tagged corpus reader:
 
     >>> from nltk.corpus import brown
-    >>> brown.fileids() # doctest: +ELLIPSIS
+    >>> brown.fileids()
     ['ca01', 'ca02', 'ca03', 'ca04', 'ca05', 'ca06', 'ca07', ...]
-    >>> brown.categories() # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> brown.categories()
     ['adventure', 'belles_lettres', 'editorial', 'fiction', 'government', 'hobbies', 'humor',
     'learned', 'lore', 'mystery', 'news', 'religion', 'reviews', 'romance', 'science_fiction']
-    >>> print(repr(brown.root).replace('\\\\','/')) # doctest: +ELLIPSIS
+    >>> print(repr(brown.root).replace('\\\\','/'))
     FileSystemPathPointer('.../corpora/brown')
     >>> brown.words()
     ['The', 'Fulton', 'County', 'Grand', 'Jury', ...]
-    >>> brown.sents() # doctest: +ELLIPSIS
+    >>> brown.sents()
     [['The', 'Fulton', 'County', 'Grand', ...], ...]
-    >>> brown.paras() # doctest: +ELLIPSIS
+    >>> brown.paras()
     [[['The', 'Fulton', 'County', ...]], [['The', 'jury', ...]], ...]
-    >>> brown.tagged_words() # doctest: +ELLIPSIS
+    >>> brown.tagged_words()
     [('The', 'AT'), ('Fulton', 'NP-TL'), ...]
-    >>> brown.tagged_sents() # doctest: +ELLIPSIS
+    >>> brown.tagged_sents()
     [[('The', 'AT'), ('Fulton', 'NP-TL'), ('County', 'NN-TL'), ...], ...]
-    >>> brown.tagged_paras() # doctest: +ELLIPSIS
+    >>> brown.tagged_paras()
     [[[('The', 'AT'), ...]], [[('The', 'AT'), ...]], ...]
 
 Verbnet Corpus Reader
@@ -1761,7 +1761,7 @@ Make sure we're picking up the right number of elements:
 
 Selecting classids based on various selectors:
 
-    >>> verbnet.classids(lemma='take') # doctest: +NORMALIZE_WHITESPACE
+    >>> verbnet.classids(lemma='take')
     ['bring-11.3', 'characterize-29.2', 'convert-26.6.2', 'cost-54.2',
     'fit-54.3', 'performance-26.7-2', 'steal-10.5']
     >>> verbnet.classids(wordnetid='lead%2:38:01')

--- a/nltk/test/crubadan.doctest
+++ b/nltk/test/crubadan.doctest
@@ -8,7 +8,7 @@ Crubadan is an NLTK corpus reader for ngram files provided
 by the Crubadan project. It supports several languages.
 
     >>> from nltk.corpus import crubadan
-    >>> crubadan.langs() # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
+    >>> crubadan.langs()
     ['abk', 'abn',..., 'zpa', 'zul']
 
 ----------------------------------------

--- a/nltk/test/data.doctest
+++ b/nltk/test/data.doctest
@@ -30,7 +30,7 @@ not work!
 
 The ``nltk:`` protocol is used by default if no protocol is specified:
 
-    >>> nltk.data.load('tokenizers/punkt/english.pickle') # doctest: +ELLIPSIS
+    >>> nltk.data.load('tokenizers/punkt/english.pickle')
     <nltk.tokenize.punkt.PunktSentenceTokenizer object at ...>
 
 But it is also possible to load resources from ``http:``, ``ftp:``,
@@ -38,9 +38,9 @@ and ``file:`` URLs, e.g. ``cfg = nltk.data.load('http://example.com/path/to/toy.
 
     >>> # Load a grammar using an absolute path.
     >>> url = 'file:%s' % nltk.data.find('grammars/sample_grammars/toy.cfg')
-    >>> url.replace('\\', '/') # doctest: +ELLIPSIS
+    >>> url.replace('\\', '/')
     'file:...toy.cfg'
-    >>> print(nltk.data.load(url)) # doctest: +ELLIPSIS
+    >>> print(nltk.data.load(url))
     Grammar with 14 productions (start state = S)
         S -> NP VP
         PP -> P NP
@@ -55,7 +55,7 @@ currently supported by the data module are described by the dictionary
 `nltk.data.FORMATS`:
 
     >>> for format, descr in sorted(nltk.data.FORMATS.items()):
-    ...     print('{0:<7} {1:}'.format(format, descr)) # doctest: +NORMALIZE_WHITESPACE
+    ...     print('{0:<7} {1:}'.format(format, descr))
     cfg     A context free grammar.
     fcfg    A feature CFG.
     fol     A list of first order logic expressions, parsed with
@@ -113,7 +113,7 @@ override the load method's default processing behavior.  For example,
 to get the raw contents of any file, simply use ``format="raw"``:
 
     >>> s = nltk.data.load('grammars/sample_grammars/toy.cfg', 'text') 
-    >>> print(s) # doctest: +ELLIPSIS
+    >>> print(s)
     S -> NP VP
     PP -> P NP
     NP -> Det N | NP PP
@@ -144,7 +144,7 @@ sample grammars.
 
     >>> # Load the edited grammar, & display it.
     >>> cfg = nltk.data.load('file:///' + os.path.abspath('toy.cfg'))
-    >>> print(cfg) # doctest: +ELLIPSIS
+    >>> print(cfg)
     Grammar with 14 productions (start state = S)
         S -> DP VP
         PP -> P DP
@@ -171,7 +171,7 @@ ValueError exception.  It will *not* overwrite the file:
 
     >>> os.path.isfile('./toy.cfg')
     True
-    >>> nltk.data.retrieve('grammars/sample_grammars/toy.cfg') # doctest: +ELLIPSIS
+    >>> nltk.data.retrieve('grammars/sample_grammars/toy.cfg')
     Traceback (most recent call last):
       . . .
     ValueError: File '...toy.cfg' already exists!
@@ -193,7 +193,7 @@ types define the `open()` method, which can be used to read the string
 contents of the file.
 
     >>> path = nltk.data.find('corpora/abc/rural.txt')
-    >>> str(path) # doctest: +ELLIPSIS
+    >>> str(path)
     '...rural.txt'
     >>> print(path.open().read(60).decode())
     PM denies knowledge of AWB kickbacks
@@ -281,7 +281,7 @@ The `retrieve()` function accepts all url types:
     ...         'nltk:grammars/sample_grammars/toy.cfg',
     ...         'grammars/sample_grammars/toy.cfg']
     >>> for i, url in enumerate(urls):
-    ...     nltk.data.retrieve(url, 'toy-%d.cfg' % i) # doctest: +ELLIPSIS
+    ...     nltk.data.retrieve(url, 'toy-%d.cfg' % i)
     Retrieving 'https://raw.githubusercontent.com/nltk/nltk/develop/nltk/test/toy.cfg', saving to 'toy-0.cfg'
     Retrieving 'file:...toy.cfg', saving to 'toy-1.cfg'
     Retrieving 'nltk:grammars/sample_grammars/toy.cfg', saving to 'toy-2.cfg'
@@ -304,7 +304,7 @@ internal use by NLTK's corpus readers.
     >>> ll = nltk.data.LazyLoader('grammars/sample_grammars/toy.cfg')
 
     >>> # Show that it's not loaded yet:
-    >>> object.__repr__(ll) # doctest: +ELLIPSIS
+    >>> object.__repr__(ll)
     '<nltk.data.LazyLoader object at ...>'
 
     >>> # printing it is enough to cause it to be loaded:
@@ -312,7 +312,7 @@ internal use by NLTK's corpus readers.
     <Grammar with 14 productions>
 
     >>> # Show that it's now been loaded:
-    >>> object.__repr__(ll) # doctest: +ELLIPSIS
+    >>> object.__repr__(ll)
     '<nltk.grammar.CFG object at ...>'
 
 
@@ -320,7 +320,7 @@ internal use by NLTK's corpus readers.
     >>> ll = nltk.data.LazyLoader('grammars/sample_grammars/toy.cfg')
     >>> ll.start()
     S
-    >>> object.__repr__(ll) # doctest: +ELLIPSIS
+    >>> object.__repr__(ll)
     '<nltk.grammar.CFG object at ...>'
 
 Buffered Gzip Reading and Writing

--- a/nltk/test/dependency.doctest
+++ b/nltk/test/dependency.doctest
@@ -94,7 +94,7 @@ Using the dependency-parsed version of the Penn Treebank corpus sample.
 
     >>> from nltk.corpus import dependency_treebank
     >>> t = dependency_treebank.parsed_sents()[0]
-    >>> print(t.to_conll(3))  # doctest: +NORMALIZE_WHITESPACE
+    >>> print(t.to_conll(3))
     Pierre      NNP     2
     Vinken      NNP     8
     ,   ,       2
@@ -231,7 +231,7 @@ of MALT parser, it's set to `'null'`.
 >>> dg.root['word'], dg.root['address']
 ('shot', 2)
 
->>> print(dg.to_conll(10))  # doctest: +NORMALIZE_WHITESPACE
+>>> print(dg.to_conll(10))
 1   I       _       NN      NN      _       2       nn      _       _
 2   shot    _       NN      NN      _       0       null    _       _
 3   an      _       AT      AT      _       2       dep     _       _

--- a/nltk/test/discourse.doctest
+++ b/nltk/test/discourse.doctest
@@ -40,7 +40,7 @@ As you will see, each sentence receives an identifier `s`\ :subscript:`i`.
 We might also want to check what grammar the ``DiscourseTester`` is
 using (by default, ``book_grammars/discourse.fcfg``):
 
-    >>> dt.grammar() # doctest: +ELLIPSIS
+    >>> dt.grammar()
     % start S
     # Grammar Rules
     S[SEM = <app(?subj,?vp)>] -> NP[NUM=?n,SEM=?subj] VP[NUM=?n,SEM=?vp]
@@ -96,7 +96,7 @@ the ``readings()`` method. Again, each thread is assigned an
 identifier of the form `d`\ :sub:`i`. Following the identifier is a
 list of the readings that constitute that thread.
 
-    >>> dt.readings(threaded=True) # doctest: +NORMALIZE_WHITESPACE
+    >>> dt.readings(threaded=True)
     d0: ['s0-r0', 's1-r0']
     d1: ['s0-r0', 's1-r1']
     d2: ['s0-r1', 's1-r0']
@@ -198,7 +198,7 @@ couple of them.
     <BLANKLINE>
     s2-r0: boxer(John)
     s2-r1: boxerdog(John)
-    >>> dt.readings(threaded=True) # doctest: +NORMALIZE_WHITESPACE
+    >>> dt.readings(threaded=True)
     d0: ['s0-r0', 's1-r0', 's2-r0']
     d1: ['s0-r0', 's1-r0', 's2-r1']
     d2: ['s0-r0', 's1-r1', 's2-r0']
@@ -248,7 +248,7 @@ us to check:
 
 So let's retract the inconsistent sentence:
 
-    >>> dt.retract_sentence('No person dances', verbose=True) # doctest: +NORMALIZE_WHITESPACE
+    >>> dt.retract_sentence('No person dances', verbose=True)
     Current sentences are
     s0: A student dances
     s1: Every student is a person
@@ -353,7 +353,7 @@ Let's build a new discourse, and look at the readings of the component sentences
 
 This gives us a lot of threads:
 
-    >>> dt.readings(threaded=True) # doctest: +NORMALIZE_WHITESPACE
+    >>> dt.readings(threaded=True)
     d0: ['s0-r0', 's1-r0', 's2-r0', 's3-r0']
     d1: ['s0-r0', 's1-r1', 's2-r0', 's3-r0']
     d2: ['s0-r1', 's1-r0', 's2-r0', 's3-r0']
@@ -381,7 +381,7 @@ The background information allows us to reject three of the threads as
 inconsistent. To see what remains, use the ``filter=True`` parameter
 on ``readings()``.
 
-    >>> dt.readings(filter=True) # doctest: +NORMALIZE_WHITESPACE
+    >>> dt.readings(filter=True)
     d1: ['s0-r0', 's1-r1', 's2-r0', 's3-r0']
 
 The ``models()`` method gives us more information about the surviving thread.

--- a/nltk/test/framenet.doctest
+++ b/nltk/test/framenet.doctest
@@ -89,7 +89,7 @@ function passing in the frame number:
     202
     >>> f.name
     'Arrest'
-    >>> f.definition # doctest: +ELLIPSIS
+    >>> f.definition
     "Authorities charge a Suspect, who is under suspicion of having committed a crime..."
     >>> len(f.lexUnit)
     11
@@ -120,7 +120,7 @@ expression. Note that LU names are composed of "lemma.POS", where the
 "lemma" part can be made up of either a single lexeme (e.g. 'run') or
 multiple lexemes (e.g. 'a little') (see below).
 
-    >>> PrettyList(sorted(fn.frames_by_lemma(r'(?i)a little'), key=itemgetter('ID'))) # doctest: +ELLIPSIS
+    >>> PrettyList(sorted(fn.frames_by_lemma(r'(?i)a little'), key=itemgetter('ID')))
     [<frame ID=189 name=Quanti...>, <frame ID=2001 name=Degree>]
 
 -------------
@@ -239,7 +239,7 @@ of these documents can be obtained by calling the `docs()` function:
     >>> d = fn.docs('BellRinging')[0]
     >>> d.corpname
     'PropBank'
-    >>> d.sentence[49] # doctest: +ELLIPSIS
+    >>> d.sentence[49]
     full-text sentence (...) in BellRinging:
     <BLANKLINE>
     <BLANKLINE>
@@ -261,7 +261,7 @@ of these documents can be obtained by calling the `docs()` function:
      (Desir=Desiring, Cause_t=Cause_to_make_noise, Cause=Cause_motion, Comple=Completeness)
     <BLANKLINE>
 
-    >>> d.sentence[49].annotationSet[1] # doctest: +ELLIPSIS
+    >>> d.sentence[49].annotationSet[1]
     annotation set (...):
     <BLANKLINE>
     [status] MANUAL

--- a/nltk/test/grammar.doctest
+++ b/nltk/test/grammar.doctest
@@ -22,7 +22,7 @@ Grammars can be parsed from strings:
     <Grammar with 14 productions>
     >>> grammar.start()
     S
-    >>> grammar.productions() # doctest: +NORMALIZE_WHITESPACE
+    >>> grammar.productions()
     [S -> NP VP, PP -> P NP, NP -> Det N, NP -> NP PP, VP -> V NP, VP -> VP PP,
     Det -> 'a', Det -> 'the', N -> 'dog', N -> 'cat', V -> 'chased', V -> 'sat',
     P -> 'on', P -> 'in']

--- a/nltk/test/inference.doctest
+++ b/nltk/test/inference.doctest
@@ -76,7 +76,7 @@ If the ``prove()`` method has not been called,
 then the prover command will be unable to display a proof.
 
     >>> prover = ResolutionProverCommand(c, [p1,p2])
-    >>> print(prover.proof()) # doctest: +ELLIPSIS
+    >>> print(prover.proof())
     Traceback (most recent call last):
       File "...", line 1212, in __run
         compileflags, 1) in test.globs
@@ -121,7 +121,7 @@ That means that ``proof()`` will be unavailable until ``prove()`` is called and
 a call to ``prove()`` will execute the theorem prover.
 
     >>> prover.retract_assumptions([read_expr('man(socrates)')])
-    >>> print(prover.proof()) # doctest: +ELLIPSIS
+    >>> print(prover.proof())
     Traceback (most recent call last):
       File "...", line 1212, in __run
         compileflags, 1) in test.globs
@@ -156,7 +156,7 @@ Install these into an appropriate location; the
 following locations:
 
     >>> p = Prover9()
-    >>> p.binary_locations() # doctest: +NORMALIZE_WHITESPACE
+    >>> p.binary_locations()
     ['/usr/local/bin/prover9',
      '/usr/local/bin/prover9/bin',
      '/usr/local/bin',
@@ -299,7 +299,7 @@ statements as new assumptions.
     >>> prover.add_assumptions(new)
     >>> print(prover.prove())
     True
-    >>> print(prover.proof()) # doctest: +ELLIPSIS
+    >>> print(prover.proof())
     ============================== prooftrans ============================
     Prover9 (...) version ...
     Process ... was started by ... on ...

--- a/nltk/test/logic.doctest
+++ b/nltk/test/logic.doctest
@@ -17,16 +17,16 @@ Overview
 
 The default inventory of logical constants is the following:
 
-    >>> boolean_ops() # doctest: +NORMALIZE_WHITESPACE
+    >>> boolean_ops()
     negation           -
     conjunction        &
     disjunction        |
     implication        ->
     equivalence        <->
-    >>> equality_preds() # doctest: +NORMALIZE_WHITESPACE
+    >>> equality_preds()
     equality           =
     inequality         !=
-    >>> binding_ops() # doctest: +NORMALIZE_WHITESPACE
+    >>> binding_ops()
     existential        exists
     universal          all
     lambda             \
@@ -727,7 +727,7 @@ typecheck()
     >>> c = a & b
     >>> c.first.type
     ?
-    >>> c.typecheck() # doctest: +ELLIPSIS
+    >>> c.typecheck()
     {...}
     >>> c.first.type
     t
@@ -736,7 +736,7 @@ typecheck()
     >>> b = tlp.parse('P(x) & Q(x)')
     >>> a.type
     ?
-    >>> typecheck([a,b]) # doctest: +ELLIPSIS
+    >>> typecheck([a,b])
     {...}
     >>> a.type
     t
@@ -862,9 +862,9 @@ Type error during parsing
 
     >>> a = tlp.parse(r'-P(x)')
     >>> b = tlp.parse(r'-P(x,y)')
-    >>> a.typecheck() # doctest: +ELLIPSIS
+    >>> a.typecheck()
     {...}
-    >>> b.typecheck() # doctest: +ELLIPSIS
+    >>> b.typecheck()
     {...}
     >>> try: typecheck([a,b])
     ... except InconsistentTypeHierarchyException as e: print(e)
@@ -873,7 +873,7 @@ Type error during parsing
     >>> a = tlp.parse(r'P(x)')
     >>> b = tlp.parse(r'P(x,y)')
     >>> signature = {'P': '<e,t>'}
-    >>> a.typecheck(signature) # doctest: +ELLIPSIS
+    >>> a.typecheck(signature)
     {...}
     >>> try: typecheck([a,b], signature)
     ... except InconsistentTypeHierarchyException as e: print(e)

--- a/nltk/test/portuguese.doctest_latin1
+++ b/nltk/test/portuguese.doctest_latin1
@@ -74,7 +74,7 @@ remover o conteúdo que antecede o sinal de mais:
     ...         return t
     >>> twords = nltk.corpus.floresta.tagged_words()
     >>> twords = [(w.lower(),simplify_tag(t)) for (w,t) in twords]
-    >>> twords[:10] # doctest: +NORMALIZE_WHITESPACE
+    >>> twords[:10]
     [('um', 'art'), ('revivalismo', 'n'), ('refrescante', 'adj'), ('o', 'art'), ('7_e_meio', 'prop'),
     ('\xe9', 'v-fin'), ('um', 'art'), ('ex-libris', 'n'), ('de', 'prp'), ('a', 'art')]
    
@@ -100,21 +100,21 @@ freqüência:
 
     >>> tags = [simplify_tag(tag) for (word,tag) in floresta.tagged_words()]
     >>> fd = nltk.FreqDist(tags)
-    >>> fd.sorted()[:20] # doctest: +NORMALIZE_WHITESPACE
+    >>> fd.sorted()[:20]
     ['n', 'prp', 'art', 'v-fin', ',', 'prop', 'adj', 'adv', '.', 'conj-c', 'v-inf',
     'pron-det', 'v-pcp', 'num', 'pron-indp', 'pron-pers', '\xab', '\xbb', 'conj-s', '}']
 
 Também podemos ler o corpus agrupado por enunciados:
 
-    >>> floresta.sents() # doctest: +NORMALIZE_WHITESPACE
+    >>> floresta.sents()
     [['Um', 'revivalismo', 'refrescante'], ['O', '7_e_Meio', '\xe9', 'um', 'ex-libris',
     'de', 'a', 'noite', 'algarvia', '.'], ...]
-    >>> floresta.tagged_sents() # doctest: +NORMALIZE_WHITESPACE
+    >>> floresta.tagged_sents()
     [[('Um', '>N+art'), ('revivalismo', 'H+n'), ('refrescante', 'N<+adj')],
     [('O', '>N+art'), ('7_e_Meio', 'H+prop'), ('\xe9', 'P+v-fin'), ('um', '>N+art'),
     ('ex-libris', 'H+n'), ('de', 'H+prp'), ('a', '>N+art'), ('noite', 'H+n'),
     ('algarvia', 'N<+adj'), ('.', '.')], ...]
-    >>> floresta.parsed_sents() # doctest: +NORMALIZE_WHITESPACE
+    >>> floresta.parsed_sents()
     [Tree('UTT+np', [Tree('>N+art', ['Um']), Tree('H+n', ['revivalismo']),
     Tree('N<+adj', ['refrescante'])]), Tree('STA+fcl', [Tree('SUBJ+np',
     [Tree('>N+art', ['O']), Tree('H+prop', ['7_e_Meio'])]), Tree('P+v-fin', ['\xe9']),

--- a/nltk/test/portuguese_en.doctest
+++ b/nltk/test/portuguese_en.doctest
@@ -243,7 +243,7 @@ We can access this corpus as a sequence of words or tagged words as follows:
     >>> import nltk.corpus
     >>> nltk.corpus.mac_morpho.words()
     ['Jersei', 'atinge', 'm\xe9dia', 'de', 'Cr$', '1,4', ...]
-    >>> nltk.corpus.mac_morpho.sents() # doctest: +NORMALIZE_WHITESPACE
+    >>> nltk.corpus.mac_morpho.sents()
     [['Jersei', 'atinge', 'm\xe9dia', 'de', 'Cr$', '1,4', 'milh\xe3o',
     'em', 'a', 'venda', 'de', 'a', 'Pinhal', 'em', 'S\xe3o', 'Paulo'],
     ['Programe', 'sua', 'viagem', 'a', 'a', 'Exposi\xe7\xe3o', 'Nacional',
@@ -253,7 +253,7 @@ We can access this corpus as a sequence of words or tagged words as follows:
 
 We can also access it in sentence chunks.
 
-    >>> nltk.corpus.mac_morpho.tagged_sents() # doctest: +NORMALIZE_WHITESPACE
+    >>> nltk.corpus.mac_morpho.tagged_sents()
     [[('Jersei', 'N'), ('atinge', 'V'), ('m\xe9dia', 'N'), ('de', 'PREP'),
       ('Cr$', 'CUR'), ('1,4', 'NUM'), ('milh\xe3o', 'N'), ('em', 'PREP|+'),
       ('a', 'ART'), ('venda', 'N'), ('de', 'PREP|+'), ('a', 'ART'),
@@ -316,24 +316,24 @@ List the 20 most frequent tags, in order of decreasing frequency:
 
     >>> tags = [simplify_tag(tag) for (word,tag) in floresta.tagged_words()]
     >>> fd = nltk.FreqDist(tags)
-    >>> fd.keys()[:20] # doctest: +NORMALIZE_WHITESPACE
+    >>> fd.keys()[:20]
     ['n', 'prp', 'art', 'v-fin', ',', 'prop', 'adj', 'adv', '.',
      'conj-c', 'v-inf', 'pron-det', 'v-pcp', 'num', 'pron-indp',
      'pron-pers', '\xab', '\xbb', 'conj-s', '}']
 
 We can also access the corpus grouped by sentence:
 
-    >>> floresta.sents() # doctest: +NORMALIZE_WHITESPACE
+    >>> floresta.sents()
     [['Um', 'revivalismo', 'refrescante'],
      ['O', '7_e_Meio', '\xe9', 'um', 'ex-libris', 'de', 'a', 'noite',
       'algarvia', '.'], ...]
-    >>> floresta.tagged_sents() # doctest: +NORMALIZE_WHITESPACE
+    >>> floresta.tagged_sents()
     [[('Um', '>N+art'), ('revivalismo', 'H+n'), ('refrescante', 'N<+adj')],
      [('O', '>N+art'), ('7_e_Meio', 'H+prop'), ('\xe9', 'P+v-fin'),
       ('um', '>N+art'), ('ex-libris', 'H+n'), ('de', 'H+prp'),
       ('a', '>N+art'), ('noite', 'H+n'), ('algarvia', 'N<+adj'), ('.', '.')],
      ...]
-    >>> floresta.parsed_sents() # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    >>> floresta.parsed_sents()
     [Tree('UTT+np', [Tree('>N+art', ['Um']), Tree('H+n', ['revivalismo']),
                      Tree('N<+adj', ['refrescante'])]),
      Tree('STA+fcl',

--- a/nltk/test/propbank.doctest
+++ b/nltk/test/propbank.doctest
@@ -12,7 +12,7 @@ the verb, and the location and identity of its arguments:
 
     >>> from nltk.corpus import propbank
     >>> pb_instances = propbank.instances()
-    >>> print(pb_instances) # doctest: +NORMALIZE_WHITESPACE
+    >>> print(pb_instances)
     [<PropbankInstance: wsj_0001.mrg, sent 0, word 8>,
      <PropbankInstance: wsj_0001.mrg, sent 1, word 10>, ...]
 
@@ -41,7 +41,7 @@ The following examples show the types of these arguments:
     'rise.01'
     >>> inst.predicate
     PropbankTreePointer(16, 0)
-    >>> inst.arguments # doctest: +NORMALIZE_WHITESPACE
+    >>> inst.arguments
     ((PropbankTreePointer(0, 2), 'ARG1'),
      (PropbankTreePointer(13, 1), 'ARGM-DIS'),
      (PropbankTreePointer(17, 1), 'ARG4-to'),
@@ -104,7 +104,7 @@ that is both discontinuous and contains a chain:
     >>> argloc.pieces
     [<PropbankSplitTreePointer: 22:1,24:0,25:1>, PropbankTreePointer(27, 0)]
     >>> argloc.pieces[0].pieces
-    ... # doctest: +NORMALIZE_WHITESPACE
+    ...
     [PropbankTreePointer(22, 1), PropbankTreePointer(24, 0),
      PropbankTreePointer(25, 1)]
     >>> print(argloc.select(inst.tree))
@@ -121,7 +121,7 @@ descriptions of the argument roles, along with examples.
 
     >>> expose_01 = propbank.roleset('expose.01')
     >>> turn_01 = propbank.roleset('turn.01')
-    >>> print(turn_01) # doctest: +ELLIPSIS
+    >>> print(turn_01)
     <Element 'roleset' at ...>
     >>> for role in turn_01.findall("roles/role"):
     ...     print(role.attrib['n'], role.attrib['descr'])
@@ -148,7 +148,7 @@ at 9353:
     >>> inst = pb_instances[9352]
     >>> inst.fileid
     'wsj_0199.mrg'
-    >>> print(inst.tree) # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    >>> print(inst.tree)
     (S (NP-SBJ (NNP Trinity)) (VP (VBD said) (SBAR (-NONE- 0) ...))
     >>> print(inst.predicate.select(inst.tree))
     (VB begin)

--- a/nltk/test/relextract.doctest
+++ b/nltk/test/relextract.doctest
@@ -29,7 +29,7 @@ representation of document NYT_19980315.064:
     >>> from nltk.corpus import ieer
     >>> docs = ieer.parsed_docs('NYT_19980315')
     >>> tree = docs[1].text
-    >>> print(tree) # doctest: +ELLIPSIS
+    >>> print(tree)
     (DOCUMENT
     ...
       ``It's
@@ -116,7 +116,7 @@ stored as left and right context respectively.
 
     >>> reldicts = relextract.semi_rel2reldict(pairs)
     >>> for k, v in sorted(reldicts[0].items()):
-    ...     print(k, '=>', v) # doctest: +ELLIPSIS
+    ...     print(k, '=>', v)
     filler => of messages to their own ``Cyberia'' ...
     lcon => transactions.'' Each week, they post
     objclass => ORGANIZATION
@@ -157,7 +157,7 @@ signature <ORG, LOC>.
     >>> for fileid in ieer.fileids():
     ...     for doc in ieer.parsed_docs(fileid):
     ...         for rel in relextract.extract_rels('ORG', 'LOC', doc, corpus='ieer', pattern = IN):
-    ...             print(relextract.rtuple(rel))  # doctest: +ELLIPSIS
+    ...             print(relextract.rtuple(rel))
     [ORG: 'Christian Democrats'] ', the leading political forces in' [LOC: 'Italy']
     [ORG: 'AP'] ') _ Lebanese guerrillas attacked Israeli forces in southern' [LOC: 'Lebanon']
     [ORG: 'Security Council'] 'adopted Resolution 425. Huge yellow banners hung across intersections in' [LOC: 'Beirut']
@@ -209,7 +209,7 @@ of roles that a PERSON can occupy in an ORGANIZATION.
     >>> for fileid in ieer.fileids():
     ...     for doc in ieer.parsed_docs(fileid):
     ...         for rel in relextract.extract_rels('PER', 'ORG', doc, corpus='ieer', pattern=ROLES):
-    ...             print(relextract.rtuple(rel)) # doctest: +ELLIPSIS
+    ...             print(relextract.rtuple(rel))
     [PER: 'Kivutha Kibwana'] ', of the' [ORG: 'National Convention Assembly']
     [PER: 'Boban Boskovic'] ', chief executive of the' [ORG: 'Plastika']
     [PER: 'Annan'] ', the first sub-Saharan African to head the' [ORG: 'United Nations']
@@ -233,7 +233,7 @@ presented as something that looks more like a clause in a logical language.
     >>> rels = [rel for doc in conll2002.chunked_sents('esp.train')
     ...         for rel in relextract.extract_rels('ORG', 'LOC', doc, corpus='conll2002', pattern = DE)]
     >>> for r in rels[:10]:
-    ...     print(relextract.clause(r, relsym='DE'))    # doctest: +NORMALIZE_WHITESPACE
+    ...     print(relextract.clause(r, relsym='DE'))
     DE('tribunal_supremo', 'victoria')
     DE('museo_de_arte', 'alcorc\xf3n')
     DE('museo_de_bellas_artes', 'a_coru\xf1a')

--- a/nltk/test/semantics.doctest
+++ b/nltk/test/semantics.doctest
@@ -398,7 +398,7 @@ Satisfier Tests
     >>> g.purge()
     >>> g.add('x', 'b1')
     {'x': 'b1'}
-    >>> for f in formulas: # doctest: +NORMALIZE_WHITESPACE
+    >>> for f in formulas:
     ...     try:
     ...         print("'%s' gets value: %s" % (f, m.evaluate(f, g)))
     ...     except Undefined:
@@ -424,7 +424,7 @@ Satisfier Tests
     'exists y. (love(adam, y) & love(y, x))' gets value: True
 
     >>> from nltk.sem import Expression
-    >>> for fmla in formulas: # doctest: +NORMALIZE_WHITESPACE
+    >>> for fmla in formulas:
     ...     p = Expression.fromstring(fmla)
     ...     g.purge()
     ...     print("Satisfiers of '%s':\n\t%s" % (p, sorted(m.satisfiers(p, 'x', g))))

--- a/nltk/test/sentiwordnet.doctest
+++ b/nltk/test/sentiwordnet.doctest
@@ -28,7 +28,7 @@ SentiSynsets
 Lookup
 ------
 
-    >>> list(swn.senti_synsets('slow')) # doctest: +NORMALIZE_WHITESPACE
+    >>> list(swn.senti_synsets('slow'))
     [SentiSynset('decelerate.v.01'), SentiSynset('slow.v.02'),
     SentiSynset('slow.v.03'), SentiSynset('slow.a.01'),
     SentiSynset('slow.a.02'), SentiSynset('dense.s.04'),

--- a/nltk/test/simple.doctest
+++ b/nltk/test/simple.doctest
@@ -16,7 +16,7 @@ Tokenization
     >>> from nltk.tokenize import wordpunct_tokenize
     >>> s = ("Good muffins cost $3.88\nin New York.  Please buy me\n"
     ...      "two of them.\n\nThanks.")
-    >>> wordpunct_tokenize(s) # doctest: +NORMALIZE_WHITESPACE
+    >>> wordpunct_tokenize(s)
     ['Good', 'muffins', 'cost', '$', '3', '.', '88', 'in', 'New', 'York', '.',
     'Please', 'buy', 'me', 'two', 'of', 'them', '.', 'Thanks', '.']
 

--- a/nltk/test/stem.doctest
+++ b/nltk/test/stem.doctest
@@ -32,7 +32,7 @@ Test the stemmer on various pluralised words.
 
     >>> singles = [stemmer.stem(plural) for plural in plurals]
 
-    >>> print(' '.join(singles))  # doctest: +NORMALIZE_WHITESPACE
+    >>> print(' '.join(singles))
     caress fli die mule deni die agre own humbl size meet
     state siez item sensat tradit refer colon plot
 

--- a/nltk/test/translate.doctest
+++ b/nltk/test/translate.doctest
@@ -21,7 +21,7 @@ Corpus Reader
     I
     declare
     >>> als = comtrans.aligned_sents('alignment-en-fr.txt')[0]
-    >>> als  # doctest: +NORMALIZE_WHITESPACE
+    >>> als
     AlignedSent(['Resumption', 'of', 'the', 'session'],
     ['Reprise', 'de', 'la', 'session'],
     Alignment([(0, 0), (1, 1), (2, 2), (3, 3)]))
@@ -43,7 +43,7 @@ Aligned sentences are simply a mapping between words in a sentence:
 Usually we look at them from the perspective of a source to a target language,
 but they are easily inverted:
 
-    >>> als.invert() # doctest: +NORMALIZE_WHITESPACE
+    >>> als.invert()
     AlignedSent(['Reprise', 'de', 'la', 'session'],
     ['Resumption', 'of', 'the', 'session'],
     Alignment([(0, 0), (1, 1), (2, 2), (3, 3)]))

--- a/nltk/test/wordnet.doctest
+++ b/nltk/test/wordnet.doctest
@@ -19,7 +19,7 @@ Words
 Look up a word using ``synsets()``; this function has an optional ``pos`` argument
 which lets you constrain the part of speech of the word:
 
-    >>> wn.synsets('dog') # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    >>> wn.synsets('dog')
     [Synset('dog.n.01'), Synset('frump.n.01'), Synset('dog.n.03'), Synset('cad.n.01'),
     Synset('frank.n.02'), Synset('pawl.n.01'), Synset('andiron.n.01'), Synset('chase.v.01')]
     >>> wn.synsets('dog', pos=wn.VERB)
@@ -46,14 +46,14 @@ A synset is identified with a 3-part name of the form: word.pos.nn:
 The WordNet corpus reader gives access to the Open Multilingual
 WordNet, using ISO-639 language codes.
 
-    >>> sorted(wn.langs()) # doctest: +NORMALIZE_WHITESPACE
+    >>> sorted(wn.langs())
     ['als', 'arb', 'bul', 'cat', 'cmn', 'dan', 'ell', 'eng', 'eus', 'fas',
     'fin', 'fra', 'glg', 'heb', 'hrv', 'ind', 'ita', 'jpn', 'nld', 'nno',
     'nob', 'pol', 'por', 'qcn', 'slv', 'spa', 'swe', 'tha', 'zsm']
     >>> wn.synsets(b'\xe7\x8a\xac'.decode('utf-8'), lang='jpn')
     [Synset('dog.n.01'), Synset('spy.n.01')]
 
-    wn.synset('spy.n.01').lemma_names('jpn') # doctest: +NORMALIZE_WHITESPACE
+    wn.synset('spy.n.01').lemma_names('jpn')
     ['\u3044\u306c', '\u307e\u308f\u3057\u8005', '\u30b9\u30d1\u30a4', '\u56de\u3057\u8005',
     '\u56de\u8005', '\u5bc6\u5075', '\u5de5\u4f5c\u54e1', '\u5efb\u3057\u8005',
     '\u5efb\u8005', '\u63a2', '\u63a2\u308a', '\u72ac', '\u79d8\u5bc6\u635c\u67fb\u54e1',
@@ -61,10 +61,10 @@ WordNet, using ISO-639 language codes.
 
     >>> wn.synset('dog.n.01').lemma_names('ita')
     ['cane', 'Canis_familiaris']
-    >>> wn.lemmas('cane', lang='ita') # doctest: +NORMALIZE_WHITESPACE
+    >>> wn.lemmas('cane', lang='ita')
     [Lemma('dog.n.01.cane'), Lemma('cramp.n.02.cane'), Lemma('hammer.n.01.cane'), Lemma('bad_person.n.01.cane'),
     Lemma('incompetent.n.01.cane')]
-    >>> sorted(wn.synset('dog.n.01').lemmas('dan')) # doctest: +NORMALIZE_WHITESPACE
+    >>> sorted(wn.synset('dog.n.01').lemmas('dan'))
     [Lemma('dog.n.01.hund'), Lemma('dog.n.01.k\xf8ter'),
     Lemma('dog.n.01.vovhund'), Lemma('dog.n.01.vovse')]
 
@@ -88,7 +88,7 @@ Synsets
     >>> dog = wn.synset('dog.n.01')
     >>> dog.hypernyms()
     [Synset('canine.n.02'), Synset('domestic_animal.n.01')]
-    >>> dog.hyponyms()  # doctest: +ELLIPSIS
+    >>> dog.hyponyms()
     [Synset('basenji.n.01'), Synset('corgi.n.01'), Synset('cur.n.01'), Synset('dalmatian.n.02'), ...]
     >>> dog.member_holonyms()
     [Synset('canis.n.01'), Synset('pack.n.06')]
@@ -217,13 +217,13 @@ The old behavior can be achieved by setting simulate_root to be False.
 A score of 1 represents identity i.e. comparing a sense with itself
 will return 1.
 
-    >>> dog.path_similarity(cat)  # doctest: +ELLIPSIS
+    >>> dog.path_similarity(cat)
     0.2...
 
-    >>> hit.path_similarity(slap)  # doctest: +ELLIPSIS
+    >>> hit.path_similarity(slap)
     0.142...
 
-    >>> wn.path_similarity(hit, slap)  # doctest: +ELLIPSIS
+    >>> wn.path_similarity(hit, slap)
     0.142...
 
     >>> print(hit.path_similarity(slap, simulate_root=False))
@@ -240,13 +240,13 @@ of the taxonomy in which the senses occur. The relationship is given
 as -log(p/2d) where p is the shortest path length and d the taxonomy
 depth.
 
-    >>> dog.lch_similarity(cat)  # doctest: +ELLIPSIS
+    >>> dog.lch_similarity(cat)
     2.028...
 
-    >>> hit.lch_similarity(slap)  # doctest: +ELLIPSIS
+    >>> hit.lch_similarity(slap)
     1.312...
 
-    >>> wn.lch_similarity(hit, slap)  # doctest: +ELLIPSIS
+    >>> wn.lch_similarity(hit, slap)
     1.312...
 
     >>> print(hit.lch_similarity(slap, simulate_root=False))
@@ -271,7 +271,7 @@ shortest path to the root node is the longest will be selected. Where
 the LCS has multiple paths to the root, the longer path is used for
 the purposes of the calculation.
 
-    >>> dog.wup_similarity(cat)  # doctest: +ELLIPSIS
+    >>> dog.wup_similarity(cat)
     0.857...
 
     >>> hit.wup_similarity(slap)
@@ -309,9 +309,9 @@ information content, the result is dependent on the corpus used to
 generate the information content and the specifics of how the
 information content was created.
 
-    >>> dog.res_similarity(cat, brown_ic)  # doctest: +ELLIPSIS
+    >>> dog.res_similarity(cat, brown_ic)
     7.911...
-    >>> dog.res_similarity(cat, genesis_ic)  # doctest: +ELLIPSIS
+    >>> dog.res_similarity(cat, genesis_ic)
     7.204...
 
 ``synset1.jcn_similarity(synset2, ic):``
@@ -321,9 +321,9 @@ Information Content (IC) of the Least Common Subsumer (most specific
 ancestor node) and that of the two input Synsets. The relationship is
 given by the equation 1 / (IC(s1) + IC(s2) - 2 * IC(lcs)).
 
-    >>> dog.jcn_similarity(cat, brown_ic)  # doctest: +ELLIPSIS
+    >>> dog.jcn_similarity(cat, brown_ic)
     0.449...
-    >>> dog.jcn_similarity(cat, genesis_ic)  # doctest: +ELLIPSIS
+    >>> dog.jcn_similarity(cat, genesis_ic)
     0.285...
 
 ``synset1.lin_similarity(synset2, ic):``
@@ -333,7 +333,7 @@ Information Content (IC) of the Least Common Subsumer (most specific
 ancestor node) and that of the two input Synsets. The relationship is
 given by the equation 2 * IC(lcs) / (IC(s1) + IC(s2)).
 
-    >>> dog.lin_similarity(cat, semcor_ic)  # doctest: +ELLIPSIS
+    >>> dog.lin_similarity(cat, semcor_ic)
     0.886...
 
 
@@ -359,7 +359,7 @@ Iterate over all the noun synsets:
 
 Get all synsets for this word, possibly restricted by POS:
 
-    >>> wn.synsets('dog') # doctest: +ELLIPSIS
+    >>> wn.synsets('dog')
     [Synset('dog.n.01'), Synset('frump.n.01'), Synset('dog.n.03'), Synset('cad.n.01'), ...]
     >>> wn.synsets('dog', pos='v')
     [Synset('chase.v.01')]
@@ -388,7 +388,7 @@ Look up forms not in WordNet, with the help of Morphy:
     deny
     >>> wn.synsets('denied', wn.NOUN)
     []
-    >>> wn.synsets('denied', wn.VERB) # doctest: +NORMALIZE_WHITESPACE
+    >>> wn.synsets('denied', wn.VERB)
     [Synset('deny.v.01'), Synset('deny.v.02'), Synset('deny.v.03'), Synset('deny.v.04'),
     Synset('deny.v.05'), Synset('traverse.v.03'), Synset('deny.v.07')]
 
@@ -423,13 +423,13 @@ Compute transitive closures of synsets
     True
     >>> list(dog.closure(hyper, depth=1)) == dog.hypernyms()
     True
-    >>> list(dog.closure(hypo)) # doctest: +NORMALIZE_WHITESPACE, +ELLIPSIS
+    >>> list(dog.closure(hypo))
     [Synset('basenji.n.01'), Synset('corgi.n.01'), Synset('cur.n.01'),
      Synset('dalmatian.n.02'), Synset('great_pyrenees.n.01'),
      Synset('griffon.n.02'), Synset('hunting_dog.n.01'), Synset('lapdog.n.01'),
      Synset('leonberg.n.01'), Synset('mexican_hairless.n.01'),
      Synset('newfoundland.n.01'), Synset('pooch.n.01'), Synset('poodle.n.01'), ...]
-    >>> list(dog.closure(hyper)) # doctest: +NORMALIZE_WHITESPACE
+    >>> list(dog.closure(hyper))
     [Synset('canine.n.02'), Synset('domestic_animal.n.01'), Synset('carnivore.n.01'), Synset('animal.n.01'),
     Synset('placental.n.01'), Synset('organism.n.01'), Synset('mammal.n.01'), Synset('living_thing.n.01'),
     Synset('vertebrate.n.01'), Synset('whole.n.02'), Synset('chordate.n.01'), Synset('object.n.01'),
@@ -455,7 +455,7 @@ Bug 160: wup_similarity breaks when the two synsets have no common hypernym
 
     >>> t = wn.synsets('picasso')[0]
     >>> m = wn.synsets('male')[1]
-    >>> t.wup_similarity(m)  # doctest: +ELLIPSIS
+    >>> t.wup_similarity(m)
     0.631...
 
     Issue #2278: wup_similarity not commutative when comparing a noun and a verb.
@@ -470,14 +470,14 @@ Bug 21: "instance of" not included in LCS (very similar to bug 160)
     >>> a = wn.synsets("writings")[0]
     >>> b = wn.synsets("scripture")[0]
     >>> brown_ic = wordnet_ic.ic('ic-brown.dat')
-    >>> a.jcn_similarity(b, brown_ic)  # doctest: +ELLIPSIS
+    >>> a.jcn_similarity(b, brown_ic)
     0.175...
 
 Bug 221: Verb root IC is zero
 
     >>> from nltk.corpus.reader.wordnet import information_content
     >>> s = wn.synsets('say', wn.VERB)[0]
-    >>> information_content(s, brown_ic)  # doctest: +ELLIPSIS
+    >>> information_content(s, brown_ic)
     4.623...
 
 Bug 161: Comparison between WN keys/lemmas should not be case sensitive
@@ -503,7 +503,7 @@ Bug 382: JCN Division by zero error
     >>> shlep = wn.synset('shlep.v.02')
     >>> from nltk.corpus import wordnet_ic
     >>> brown_ic =  wordnet_ic.ic('ic-brown.dat')
-    >>> tow.jcn_similarity(shlep, brown_ic)  # doctest: +ELLIPSIS
+    >>> tow.jcn_similarity(shlep, brown_ic)
     1...e+300
 
 Bug 428: Depth is zero for instance nouns
@@ -525,7 +525,7 @@ Bug 470: shortest_path_distance ignored instance hypernyms
 
     >>> google = wordnet.synsets("google")[0]
     >>> earth = wordnet.synsets("earth")[0]
-    >>> google.wup_similarity(earth)  # doctest: +ELLIPSIS
+    >>> google.wup_similarity(earth)
     0.1...
 
 Bug 484: similarity metrics returned -1 instead of None for no LCS
@@ -557,17 +557,17 @@ Bug 482: Some nouns not being lemmatised by WordNetLemmatizer().lemmatize
 
 Bug 284: instance hypernyms not used in similarity calculations
 
-    >>> wn.synset('john.n.02').lch_similarity(wn.synset('dog.n.01'))  # doctest: +ELLIPSIS
+    >>> wn.synset('john.n.02').lch_similarity(wn.synset('dog.n.01'))
     1.335...
-    >>> wn.synset('john.n.02').wup_similarity(wn.synset('dog.n.01'))  # doctest: +ELLIPSIS
+    >>> wn.synset('john.n.02').wup_similarity(wn.synset('dog.n.01'))
     0.571...
-    >>> wn.synset('john.n.02').res_similarity(wn.synset('dog.n.01'), brown_ic)  # doctest: +ELLIPSIS
+    >>> wn.synset('john.n.02').res_similarity(wn.synset('dog.n.01'), brown_ic)
     2.224...
-    >>> wn.synset('john.n.02').jcn_similarity(wn.synset('dog.n.01'), brown_ic)  # doctest: +ELLIPSIS
+    >>> wn.synset('john.n.02').jcn_similarity(wn.synset('dog.n.01'), brown_ic)
     0.075...
-    >>> wn.synset('john.n.02').lin_similarity(wn.synset('dog.n.01'), brown_ic)  # doctest: +ELLIPSIS
+    >>> wn.synset('john.n.02').lin_similarity(wn.synset('dog.n.01'), brown_ic)
     0.252...
-    >>> wn.synset('john.n.02').hypernym_paths()  # doctest: +ELLIPSIS
+    >>> wn.synset('john.n.02').hypernym_paths()
     [[Synset('entity.n.01'), ..., Synset('john.n.02')]]
 
 Issue 541: add domains to wordnet


### PR DESCRIPTION
There's no reason for these anymore, since they're in the `pytest.ini` by default. (I "skipped" `SKIP`, since it's not in the pytest.ini)

I did this by the following. On a mac, so this syntax may or may not work on your computer.
```
$ cd nltk/test
$ ls | grep doctest | grep -v "portuguese" | xargs sed -i '' '/SKIP/! s/[[:space:]]*# doctest:[[:space:]]*.*//'
```

portuguese had some characters that didn't play well with sed, so removed those by hand