### PR TITLE
Use raw string for regex template

### DIFF
--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -220,7 +220,7 @@ class PunktLanguageVars(object):
 
     @property
     def _re_non_word_chars(self):
-        return "(?:[)\";}\]\*:@\'\({\[%s])" % re.escape("".join(set(self.sent_end_chars) - {"."}))
+        return r"(?:[)\";}\]\*:@\'\({\[%s])" % re.escape("".join(set(self.sent_end_chars) - {"."}))
     """Characters that cannot appear within words"""
 
     _re_multi_char_punct = r"(?:\-{2,}|\.{2,}|(?:\.\s){2,}\.)"


### PR DESCRIPTION
This avoids a `DeprecationWarning` when [pydoctor](https://github.com/twisted/pydoctor) parses the source and the environment variable `PYTHONWARNINGS` is set to `always`.

To reproduce:
```
$ rm -rf nltk/tokenize/__pycache__/
$ python -W always
Python 3.8.8 (default, Feb 19 2021, 16:53:21) [GCC] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import nltk.tokenize.punkt
nltk/tokenize/punkt.py:223: DeprecationWarning: invalid escape sequence \]
  return "(?:[)\";}\]\*:@\'\({\[%s])" % re.escape("".join(set(self.sent_end_chars) - {"."}))
>>> 
```
Since the warning is emitted when parsing the code, it will not be emitted if a cached version of the module is available, therefore the `rm`.
