### PR TITLE
Convert lm tests to pytest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,9 @@ venv.bak/
 
 #vscode
 .vscode/
+
+# Direnv
+.envrc
+
+# Mypy
+.mypy_cache

--- a/nltk/test/pytest.ini
+++ b/nltk/test/pytest.ini
@@ -3,7 +3,7 @@ doctest_optionflags=ELLIPSIS NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL
 
 # --doctest-continue-on-failure allows the test to always
 # get to the teardown, if it exists
-addopts = --doctest-glob *.doctest --doctest-continue-on-failure
+addopts = --doctest-glob *.doctest --doctest-continue-on-failure --color=yes --code-highlight=yes
 
 # Other options for creating valid teardowns for doctests:
 # 1. Turn doctests into unittest tests

--- a/nltk/test/unit/lm/test_models.py
+++ b/nltk/test/unit/lm/test_models.py
@@ -5,76 +5,53 @@
 # URL: <http://nltk.org/>
 # For license information, see LICENSE.TXT
 import math
+from operator import itemgetter
+
 import pytest
 
-
 from nltk.lm import (
-    Vocabulary,
     MLE,
-    Lidstone,
-    Laplace,
-    WittenBellInterpolated,
-    KneserNeyInterpolated,
     AbsoluteDiscountingInterpolated,
+    KneserNeyInterpolated,
+    Laplace,
+    Lidstone,
     StupidBackoff,
+    Vocabulary,
+    WittenBellInterpolated,
 )
 from nltk.lm.preprocessing import padded_everygrams
 
 
-def _prepare_test_data(ngram_order):
-    return (
-        Vocabulary(["a", "b", "c", "d", "z", "<s>", "</s>"], unk_cutoff=1),
-        [
-            padded_everygrams(ngram_order, sent)
-            for sent in (list("abcd"), list("egadbe"))
-        ],
-    )
+@pytest.fixture(scope="session")
+def vocabulary():
+    return Vocabulary(["a", "b", "c", "d", "z", "<s>", "</s>"], unk_cutoff=1)
 
 
-class ParametrizedTests(type):
-    """Metaclass for generating parametrized tests."""
-
-    contexts = [
-        ("a",),
-        ("c",),
-        (u"<s>",),
-        ("b",),
-        (u"<UNK>",),
-        ("d",),
-        ("e",),
-        ("r",),
-        ("w",),
-    ]
-
-    def __new__(cls, name, bases, dct):
-        scores = dct.get("score_tests", [])
-        for i, (word, context, expected_score) in enumerate(scores):
-            dct["test_score_{}".format(i)] = cls.add_score_test(
-                word, context, expected_score
-            )
-        return super().__new__(cls, name, bases, dct)
-
-    @pytest.mark.parametrize("context", contexts)
-    def test_sum_to_1(self, context):
-        message = "The context is {}".format(context)
-        s = sum(self.model.score(w, context) for w in self.model.vocab)
-        assert pytest.approx(s, 1e-7) == 1.0, message
-
-    @classmethod
-    def add_score_test(self, word, context, expected_score):
-        message = "word='{}', context={}".format(word, context)
-
-        def test_method(self):
-            score = self.model.score(word, context)
-            assert pytest.approx(score, 1e-4) == expected_score, message
-
-        return test_method
+@pytest.fixture(scope="session")
+def training_data():
+    return [["a", "b", "c", "d"], ["e", "g", "a", "d", "b", "e"]]
 
 
-class TestMleBigram(metaclass=ParametrizedTests):
-    """Unit tests for MLE ngram model."""
+@pytest.fixture(scope="session")
+def bigram_training_data(training_data):
+    return [list(padded_everygrams(2, sent)) for sent in training_data]
 
-    score_tests = [
+
+@pytest.fixture(scope="session")
+def trigram_training_data(training_data):
+    return [list(padded_everygrams(3, sent)) for sent in training_data]
+
+
+@pytest.fixture
+def mle_bigram_model(vocabulary, bigram_training_data):
+    model = MLE(2, vocabulary=vocabulary)
+    model.fit(bigram_training_data)
+    return model
+
+
+@pytest.mark.parametrize(
+    "word, context, expected_score",
+    [
         ("d", ["c"], 1),
         # Unseen ngrams should yield 0
         ("d", ["e"], 0),
@@ -85,74 +62,79 @@ class TestMleBigram(metaclass=ParametrizedTests):
         ("a", None, 2.0 / 14),
         # count('y') = 3
         ("y", None, 3.0 / 14),
+    ],
+)
+def test_mle_bigram_scores(mle_bigram_model, word, context, expected_score):
+    assert pytest.approx(mle_bigram_model.score(word, context), 1e-4) == expected_score
+
+
+def test_mle_bigram_logscore_for_zero_score(mle_bigram_model):
+    assert math.isinf(mle_bigram_model.logscore("d", ["e"]))
+
+
+def test_mle_bigram_entropy_perplexity_seen(mle_bigram_model):
+    # ngrams seen during training
+    trained = [
+        ("<s>", "a"),
+        ("a", "b"),
+        ("b", "<UNK>"),
+        ("<UNK>", "a"),
+        ("a", "d"),
+        ("d", "</s>"),
     ]
-
-    @classmethod
-    def setup_method(self):
-        vocab, training_text = _prepare_test_data(2)
-        self.model = MLE(2, vocabulary=vocab)
-        self.model.fit(training_text)
-
-    def test_logscore_zero_score(self):
-        # logscore of unseen ngrams should be -inf
-        logscore = self.model.logscore("d", ["e"])
-        assert math.isinf(logscore)
-
-    def test_entropy_perplexity_seen(self):
-        # ngrams seen during training
-        trained = [
-            ("<s>", "a"),
-            ("a", "b"),
-            ("b", "<UNK>"),
-            ("<UNK>", "a"),
-            ("a", "d"),
-            ("d", "</s>"),
-        ]
-        # Ngram = Log score
-        # <s>, a    = -1
-        # a, b      = -1
-        # b, UNK    = -1
-        # UNK, a    = -1.585
-        # a, d      = -1
-        # d, </s>   = -1
-        # TOTAL logscores   = -6.585
-        # - AVG logscores   = 1.0975
-        H = 1.0975
-        perplexity = 2.1398
-        assert pytest.approx(self.model.entropy(trained), 1e-4) == H
-        assert pytest.approx(self.model.perplexity(trained), 1e-4) == perplexity
-
-    def test_entropy_perplexity_unseen(self):
-        # In MLE, even one unseen ngram should make entropy and perplexity infinite
-        untrained = [("<s>", "a"), ("a", "c"), ("c", "d"), ("d", "</s>")]
-
-        assert math.isinf(self.model.entropy(untrained))
-        assert math.isinf(self.model.perplexity(untrained))
-
-    def test_entropy_perplexity_unigrams(self):
-        # word = score, log score
-        # <s>   = 0.1429, -2.8074
-        # a     = 0.1429, -2.8074
-        # c     = 0.0714, -3.8073
-        # UNK   = 0.2143, -2.2224
-        # d     = 0.1429, -2.8074
-        # c     = 0.0714, -3.8073
-        # </s>  = 0.1429, -2.8074
-        # TOTAL logscores = -21.6243
-        # - AVG logscores = 3.0095
-        H = 3.0095
-        perplexity = 8.0529
-
-        text = [("<s>",), ("a",), ("c",), ("-",), ("d",), ("c",), ("</s>",)]
-
-        assert pytest.approx(self.model.entropy(text), 1e-4) == H
-        assert pytest.approx(self.model.perplexity(text), 1e-4) == perplexity
+    # Ngram = Log score
+    # <s>, a    = -1
+    # a, b      = -1
+    # b, UNK    = -1
+    # UNK, a    = -1.585
+    # a, d      = -1
+    # d, </s>   = -1
+    # TOTAL logscores   = -6.585
+    # - AVG logscores   = 1.0975
+    H = 1.0975
+    perplexity = 2.1398
+    assert pytest.approx(mle_bigram_model.entropy(trained), 1e-4) == H
+    assert pytest.approx(mle_bigram_model.perplexity(trained), 1e-4) == perplexity
 
 
-class TestMleTrigram(metaclass=ParametrizedTests):
-    """MLE trigram model tests"""
+def test_mle_bigram_entropy_perplexity_unseen(mle_bigram_model):
+    # In MLE, even one unseen ngram should make entropy and perplexity infinite
+    untrained = [("<s>", "a"), ("a", "c"), ("c", "d"), ("d", "</s>")]
 
-    score_tests = [
+    assert math.isinf(mle_bigram_model.entropy(untrained))
+    assert math.isinf(mle_bigram_model.perplexity(untrained))
+
+
+def test_mle_bigram_entropy_perplexity_unigrams(mle_bigram_model):
+    # word = score, log score
+    # <s>   = 0.1429, -2.8074
+    # a     = 0.1429, -2.8074
+    # c     = 0.0714, -3.8073
+    # UNK   = 0.2143, -2.2224
+    # d     = 0.1429, -2.8074
+    # c     = 0.0714, -3.8073
+    # </s>  = 0.1429, -2.8074
+    # TOTAL logscores = -21.6243
+    # - AVG logscores = 3.0095
+    H = 3.0095
+    perplexity = 8.0529
+
+    text = [("<s>",), ("a",), ("c",), ("-",), ("d",), ("c",), ("</s>",)]
+
+    assert pytest.approx(mle_bigram_model.entropy(text), 1e-4) == H
+    assert pytest.approx(mle_bigram_model.perplexity(text), 1e-4) == perplexity
+
+
+@pytest.fixture
+def mle_trigram_model(trigram_training_data, vocabulary):
+    model = MLE(order=3, vocabulary=vocabulary)
+    model.fit(trigram_training_data)
+    return model
+
+
+@pytest.mark.parametrize(
+    "word, context, expected_score",
+    [
         # count(d | b, c) = 1
         # count(b, c) = 1
         ("d", ("b", "c"), 1),
@@ -165,19 +147,22 @@ class TestMleTrigram(metaclass=ParametrizedTests):
         ("z", None, 0),
         # out of vocabulary should use "UNK" score
         ("y", None, 3.0 / 18),
-    ]
-
-    @classmethod
-    def setup_method(self):
-        vocab, training_text = _prepare_test_data(3)
-        self.model = MLE(3, vocabulary=vocab)
-        self.model.fit(training_text)
+    ],
+)
+def test_mle_trigram_scores(mle_trigram_model, word, context, expected_score):
+    assert pytest.approx(mle_trigram_model.score(word, context), 1e-4) == expected_score
 
 
-class TestLidstoneBigram(metaclass=ParametrizedTests):
-    """Unit tests for Lidstone class"""
+@pytest.fixture
+def lidstone_bigram_model(bigram_training_data, vocabulary):
+    model = Lidstone(0.1, order=2, vocabulary=vocabulary)
+    model.fit(bigram_training_data)
+    return model
 
-    score_tests = [
+
+@pytest.mark.parametrize(
+    "word, context, expected_score",
+    [
         # count(d | c) = 1
         # *count(d | c) = 1.1
         # Count(w | c for w in vocab) = 1
@@ -197,44 +182,50 @@ class TestLidstoneBigram(metaclass=ParametrizedTests):
         # count("<UNK>") = 3
         # *count("<UNK>") = 3.1
         ("y", None, 3.1 / 14.8),
+    ],
+)
+def test_lidstone_bigram_score(lidstone_bigram_model, word, context, expected_score):
+    assert (
+        pytest.approx(lidstone_bigram_model.score(word, context), 1e-4)
+        == expected_score
+    )
+
+
+def test_lidstone_entropy_perplexity(lidstone_bigram_model):
+    text = [
+        ("<s>", "a"),
+        ("a", "c"),
+        ("c", "<UNK>"),
+        ("<UNK>", "d"),
+        ("d", "c"),
+        ("c", "</s>"),
     ]
-
-    @classmethod
-    def setup_method(self):
-        vocab, training_text = _prepare_test_data(2)
-        self.model = Lidstone(0.1, 2, vocabulary=vocab)
-        self.model.fit(training_text)
-
-    def test_gamma(self):
-        assert 0.1 == self.model.gamma
-
-    def test_entropy_perplexity(self):
-        text = [
-            ("<s>", "a"),
-            ("a", "c"),
-            ("c", "<UNK>"),
-            ("<UNK>", "d"),
-            ("d", "c"),
-            ("c", "</s>"),
-        ]
-        # Unlike MLE this should be able to handle completely novel ngrams
-        # Ngram = score, log score
-        # <s>, a    = 0.3929, -1.3479
-        # a, c      = 0.0357, -4.8074
-        # c, UNK    = 0.0(5), -4.1699
-        # UNK, d    = 0.0263,  -5.2479
-        # d, c      = 0.0357, -4.8074
-        # c, </s>   = 0.0(5), -4.1699
-        # TOTAL logscore: −24.5504
-        # - AVG logscore: 4.0917
-        H = 4.0917
-        perplexity = 17.0504
-        assert pytest.approx(self.model.entropy(text), 1e-4) == H
-        assert pytest.approx(self.model.perplexity(text), 1e-4) == perplexity
+    # Unlike MLE this should be able to handle completely novel ngrams
+    # Ngram = score, log score
+    # <s>, a    = 0.3929, -1.3479
+    # a, c      = 0.0357, -4.8074
+    # c, UNK    = 0.0(5), -4.1699
+    # UNK, d    = 0.0263,  -5.2479
+    # d, c      = 0.0357, -4.8074
+    # c, </s>   = 0.0(5), -4.1699
+    # TOTAL logscore: −24.5504
+    # - AVG logscore: 4.0917
+    H = 4.0917
+    perplexity = 17.0504
+    assert pytest.approx(lidstone_bigram_model.entropy(text), 1e-4) == H
+    assert pytest.approx(lidstone_bigram_model.perplexity(text), 1e-4) == perplexity
 
 
-class TestLidstoneTrigram(metaclass=ParametrizedTests):
-    score_tests = [
+@pytest.fixture
+def lidstone_trigram_model(trigram_training_data, vocabulary):
+    model = Lidstone(0.1, order=3, vocabulary=vocabulary)
+    model.fit(trigram_training_data)
+    return model
+
+
+@pytest.mark.parametrize(
+    "word, context, expected_score",
+    [
         # Logic behind this is the same as for bigram model
         ("d", ["c"], 1.1 / 1.8),
         # if we choose a word that hasn't appeared after (b, c)
@@ -242,19 +233,25 @@ class TestLidstoneTrigram(metaclass=ParametrizedTests):
         # Trigram score now
         ("d", ["b", "c"], 1.1 / 1.8),
         ("e", ["b", "c"], 0.1 / 1.8),
-    ]
+    ],
+)
+def test_lidstone_trigram_score(lidstone_trigram_model, word, context, expected_score):
+    assert (
+        pytest.approx(lidstone_trigram_model.score(word, context), 1e-4)
+        == expected_score
+    )
 
-    @classmethod
-    def setup_method(self):
-        vocab, training_text = _prepare_test_data(3)
-        self.model = Lidstone(0.1, 3, vocabulary=vocab)
-        self.model.fit(training_text)
+
+@pytest.fixture
+def laplace_bigram_model(bigram_training_data, vocabulary):
+    model = Laplace(2, vocabulary=vocabulary)
+    model.fit(bigram_training_data)
+    return model
 
 
-class TestLaplaceBigram(metaclass=ParametrizedTests):
-    """Unit tests for Laplace class"""
-
-    score_tests = [
+@pytest.mark.parametrize(
+    "word, context, expected_score",
+    [
         # basic sanity-check:
         # count(d | c) = 1
         # *count(d | c) = 2
@@ -275,51 +272,53 @@ class TestLaplaceBigram(metaclass=ParametrizedTests):
         # count("<UNK>") = 3
         # *count("<UNK>") = 4
         ("y", None, 4.0 / 22),
+    ],
+)
+def test_laplace_bigram_score(laplace_bigram_model, word, context, expected_score):
+    assert (
+        pytest.approx(laplace_bigram_model.score(word, context), 1e-4) == expected_score
+    )
+
+
+def test_laplace_bigram_entropy_perplexity(laplace_bigram_model):
+    text = [
+        ("<s>", "a"),
+        ("a", "c"),
+        ("c", "<UNK>"),
+        ("<UNK>", "d"),
+        ("d", "c"),
+        ("c", "</s>"),
     ]
-
-    @classmethod
-    def setup_method(self):
-        vocab, training_text = _prepare_test_data(2)
-        self.model = Laplace(2, vocabulary=vocab)
-        self.model.fit(training_text)
-
-    def test_gamma(self):
-        # Make sure the gamma is set to 1
-        assert 1 == self.model.gamma
-
-    def test_entropy_perplexity(self):
-        text = [
-            ("<s>", "a"),
-            ("a", "c"),
-            ("c", "<UNK>"),
-            ("<UNK>", "d"),
-            ("d", "c"),
-            ("c", "</s>"),
-        ]
-        # Unlike MLE this should be able to handle completely novel ngrams
-        # Ngram = score, log score
-        # <s>, a    = 0.2, -2.3219
-        # a, c      = 0.1, -3.3219
-        # c, UNK    = 0.(1), -3.1699
-        # UNK, d    = 0.(09), 3.4594
-        # d, c      = 0.1 -3.3219
-        # c, </s>   = 0.(1), -3.1699
-        # Total logscores: −18.7651
-        # - AVG logscores: 3.1275
-        H = 3.1275
-        perplexity = 8.7393
-        assert pytest.approx(self.model.entropy(text), 1e-4) == H
-        assert pytest.approx(self.model.perplexity(text), 1e-4) == perplexity
+    # Unlike MLE this should be able to handle completely novel ngrams
+    # Ngram = score, log score
+    # <s>, a    = 0.2, -2.3219
+    # a, c      = 0.1, -3.3219
+    # c, UNK    = 0.(1), -3.1699
+    # UNK, d    = 0.(09), 3.4594
+    # d, c      = 0.1 -3.3219
+    # c, </s>   = 0.(1), -3.1699
+    # Total logscores: −18.7651
+    # - AVG logscores: 3.1275
+    H = 3.1275
+    perplexity = 8.7393
+    assert pytest.approx(laplace_bigram_model.entropy(text), 1e-4) == H
+    assert pytest.approx(laplace_bigram_model.perplexity(text), 1e-4) == perplexity
 
 
-class TestWittenBellInterpolatedTrigram(metaclass=ParametrizedTests):
-    @classmethod
-    def setup_method(self):
-        vocab, training_text = _prepare_test_data(3)
-        self.model = WittenBellInterpolated(3, vocabulary=vocab)
-        self.model.fit(training_text)
+def test_laplace_gamma(laplace_bigram_model):
+    assert laplace_bigram_model.gamma == 1
 
-    score_tests = [
+
+@pytest.fixture
+def wittenbell_trigram_model(trigram_training_data, vocabulary):
+    model = WittenBellInterpolated(3, vocabulary=vocabulary)
+    model.fit(trigram_training_data)
+    return model
+
+
+@pytest.mark.parametrize(
+    "word, context, expected_score",
+    [
         # For unigram scores by default revert to regular MLE
         # Total unigrams: 18
         # Vocab Size = 7
@@ -345,7 +344,16 @@ class TestWittenBellInterpolatedTrigram(metaclass=ParametrizedTests):
         # P(c|zb)
         # The ngram 'zbc' was not seen, so we use P(c|b). See issue #2332.
         ("c", ["z", "b"], ((1 - 0.5) * 0.5 + 0.5 * 1 / 18)),
-    ]
+    ],
+)
+def test_wittenbell_trigram_score(
+    wittenbell_trigram_model, word, context, expected_score
+):
+    assert (
+        pytest.approx(wittenbell_trigram_model.score(word, context), 1e-4)
+        == expected_score
+    )
+
 
 ###############################################################################
 #                              Notation Explained                             #
@@ -358,14 +366,16 @@ class TestWittenBellInterpolatedTrigram(metaclass=ParametrizedTests):
 # 1. unique(ngram): Count unique instances (types) of an ngram.
 
 
-class TestKneserNeyInterpolatedTrigram(metaclass=ParametrizedTests):
-    @classmethod
-    def setup_method(self):
-        vocab, training_text = _prepare_test_data(3)
-        self.model = KneserNeyInterpolated(3, discount=0.75, vocabulary=vocab)
-        self.model.fit(training_text)
+@pytest.fixture
+def kneserney_trigram_model(trigram_training_data, vocabulary):
+    model = KneserNeyInterpolated(order=3, discount=0.75, vocabulary=vocabulary)
+    model.fit(trigram_training_data)
+    return model
 
-    score_tests = [
+
+@pytest.mark.parametrize(
+    "word, context, expected_score",
+    [
         # P(c) = count('*c') / unique('**')
         #      = 1 / 14
         ("c", None, 1.0 / 14),
@@ -397,17 +407,27 @@ class TestKneserNeyInterpolatedTrigram(metaclass=ParametrizedTests):
         # P(c|zb)
         # The ngram 'zbc' was not seen, so we use P(c|b). See issue #2332.
         ("c", ["z", "b"], (0.125 + 0.75 * (1 / 14))),
-    ]
+    ],
+)
+def test_kneserney_trigram_score(
+    kneserney_trigram_model, word, context, expected_score
+):
+    assert (
+        pytest.approx(kneserney_trigram_model.score(word, context), 1e-4)
+        == expected_score
+    )
 
 
-class TestAbsoluteDiscountingTrigram(metaclass=ParametrizedTests):
-    @classmethod
-    def setup_method(self):
-        vocab, training_text = _prepare_test_data(3)
-        self.model = AbsoluteDiscountingInterpolated(3, discount=0.75, vocabulary=vocab)
-        self.model.fit(training_text)
+@pytest.fixture
+def absolute_discounting_trigram_model(trigram_training_data, vocabulary):
+    model = AbsoluteDiscountingInterpolated(order=3, vocabulary=vocabulary)
+    model.fit(trigram_training_data)
+    return model
 
-    score_tests = [
+
+@pytest.mark.parametrize(
+    "word, context, expected_score",
+    [
         # For unigram scores revert to uniform
         # P(c) = count('c') / count('**')
         ("c", None, 1.0 / 18),
@@ -436,17 +456,27 @@ class TestAbsoluteDiscountingTrigram(metaclass=ParametrizedTests):
         # P(c|zb)
         # The ngram 'zbc' was not seen, so we use P(c|b). See issue #2332.
         ("c", ["z", "b"], (0.125 + 0.75 * (2 / 2) * (1 / 18))),
-    ]
+    ],
+)
+def test_absolute_discounting_trigram_score(
+    absolute_discounting_trigram_model, word, context, expected_score
+):
+    assert (
+        pytest.approx(absolute_discounting_trigram_model.score(word, context), 1e-4)
+        == expected_score
+    )
 
 
-class TestStupidBackoffTrigram(metaclass=ParametrizedTests):
-    @classmethod
-    def setup_method(self):
-        vocab, training_text = _prepare_test_data(3)
-        self.model = StupidBackoff(order=3, alpha=0.4, vocabulary=vocab)
-        self.model.fit(training_text)
+@pytest.fixture
+def stupid_backoff_trigram_model(trigram_training_data, vocabulary):
+    model = StupidBackoff(order=3, vocabulary=vocabulary)
+    model.fit(trigram_training_data)
+    return model
 
-    score_tests = [
+
+@pytest.mark.parametrize(
+    "word, context, expected_score",
+    [
         # For unigram scores revert to uniform
         # total bigrams = 18
         ("c", None, 1.0 / 18),
@@ -463,67 +493,116 @@ class TestStupidBackoffTrigram(metaclass=ParametrizedTests):
         # The ngram 'z b c' was not seen, so we backoff to
         # the score of the ngram 'b c' * smoothing factor
         ("c", ["z", "b"], (0.4 * (1 / 2))),
+    ],
+)
+def test_stupid_backoff_trigram_score(
+    stupid_backoff_trigram_model, word, context, expected_score
+):
+    assert (
+        pytest.approx(stupid_backoff_trigram_model.score(word, context), 1e-4)
+        == expected_score
+    )
+
+
+###############################################################################
+#               Probability Distributions Should Sum up to Unity              #
+###############################################################################
+
+
+@pytest.fixture(scope="session")
+def kneserney_bigram_model(bigram_training_data, vocabulary):
+    model = KneserNeyInterpolated(order=2, vocabulary=vocabulary)
+    model.fit(bigram_training_data)
+    return model
+
+
+@pytest.mark.parametrize(
+    "model_fixture",
+    [
+        "mle_bigram_model",
+        "mle_trigram_model",
+        "lidstone_bigram_model",
+        "laplace_bigram_model",
+        "wittenbell_trigram_model",
+        "absolute_discounting_trigram_model",
+        "kneserney_bigram_model",
+        pytest.param(
+            "stupid_backoff_trigram_model",
+            marks=pytest.mark.xfail(reason="Stupid Backoff is not a valid distibution"),
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "context",
+    [("a",), ("c",), (u"<s>",), ("b",), (u"<UNK>",), ("d",), ("e",), ("r",), ("w",)],
+    ids=itemgetter(0),
+)
+def test_sums_to_1(model_fixture, context, request):
+    model = request.getfixturevalue(model_fixture)
+    scores_for_context = sum(model.score(w, context) for w in model.vocab)
+    assert pytest.approx(scores_for_context, 1e-7) == 1.0
+
+
+###############################################################################
+#                               Generating Text                               #
+###############################################################################
+
+
+def test_generate_one_no_context(mle_trigram_model):
+    assert mle_trigram_model.generate(random_seed=3) == "<UNK>"
+
+
+def test_generate_one_from_limiting_context(mle_trigram_model):
+    # We don't need random_seed for contexts with only one continuation
+    assert mle_trigram_model.generate(text_seed=["c"]) == "d"
+    assert mle_trigram_model.generate(text_seed=["b", "c"]) == "d"
+    assert mle_trigram_model.generate(text_seed=["a", "c"]) == "d"
+
+
+def test_generate_one_from_varied_context(mle_trigram_model):
+    # When context doesn't limit our options enough, seed the random choice
+    assert mle_trigram_model.generate(text_seed=("a", "<s>"), random_seed=2) == "a"
+
+
+def test_generate_cycle(mle_trigram_model):
+    # Add a cycle to the model: bd -> b, db -> d
+    more_training_text = [padded_everygrams(mle_trigram_model.order, list("bdbdbd"))]
+
+    mle_trigram_model.fit(more_training_text)
+    # Test that we can escape the cycle
+    assert mle_trigram_model.generate(7, text_seed=("b", "d"), random_seed=5) == [
+        "b",
+        "d",
+        "b",
+        "d",
+        "b",
+        "d",
+        "</s>",
     ]
 
 
-class TestNgramModelTextGeneration:
-    """Using MLE model, generate some text."""
+def test_generate_with_text_seed(mle_trigram_model):
+    assert mle_trigram_model.generate(5, text_seed=("<s>", "e"), random_seed=3) == [
+        "<UNK>",
+        "a",
+        "d",
+        "b",
+        "<UNK>",
+    ]
 
-    @classmethod
-    def setup_method(self):
-        vocab, training_text = _prepare_test_data(3)
-        self.model = MLE(3, vocabulary=vocab)
-        self.model.fit(training_text)
 
-    def test_generate_one_no_context(self):
-        assert self.model.generate(random_seed=3) == "<UNK>"
+def test_generate_oov_text_seed(mle_trigram_model):
+    assert mle_trigram_model.generate(
+        text_seed=("aliens",), random_seed=3
+    ) == mle_trigram_model.generate(text_seed=("<UNK>",), random_seed=3)
 
-    def test_generate_one_limiting_context(self):
-        # We don't need random_seed for contexts with only one continuation
-        assert self.model.generate(text_seed=["c"]) == "d"
-        assert self.model.generate(text_seed=["b", "c"]) == "d"
-        assert self.model.generate(text_seed=["a", "c"]) == "d"
 
-    def test_generate_one_varied_context(self):
-        # When context doesn't limit our options enough, seed the random choice
-        assert self.model.generate(text_seed=("a", "<s>"), random_seed=2) == "a"
+def test_generate_None_text_seed(mle_trigram_model):
+    # should crash with type error when we try to look it up in vocabulary
+    with pytest.raises(TypeError):
+        mle_trigram_model.generate(text_seed=(None,))
 
-    def test_generate_cycle(self):
-        # Add a cycle to the model: bd -> b, db -> d
-        more_training_text = [padded_everygrams(self.model.order, list("bdbdbd"))]
-
-        self.model.fit(more_training_text)
-        # Test that we can escape the cycle
-        assert self.model.generate(7, text_seed=("b", "d"), random_seed=5) == [
-            "b",
-            "d",
-            "b",
-            "d",
-            "b",
-            "d",
-            "</s>",
-        ]
-
-    def test_generate_with_text_seed(self):
-        assert self.model.generate(5, text_seed=("<s>", "e"), random_seed=3) == [
-            "<UNK>",
-            "a",
-            "d",
-            "b",
-            "<UNK>",
-        ]
-
-    def test_generate_oov_text_seed(self):
-        assert self.model.generate(
-            text_seed=("aliens",), random_seed=3
-        ) == self.model.generate(text_seed=("<UNK>",), random_seed=3)
-
-    def test_generate_None_text_seed(self):
-        # should crash with type error when we try to look it up in vocabulary
-        with pytest.raises(TypeError):
-            self.model.generate(text_seed=(None,))
-
-        # This will work
-        assert self.model.generate(
-            text_seed=None, random_seed=3
-        ) == self.model.generate(random_seed=3)
+    # This will work
+    assert mle_trigram_model.generate(
+        text_seed=None, random_seed=3
+    ) == mle_trigram_model.generate(random_seed=3)


### PR DESCRIPTION
Builds on #2709 so plz merge that first.

@dannysepler take a look at `nltk/test/unit/lm/test_models.py`. I know you were interested in how to convert those tests to pytest.

@manujosephv I noticed that kneser-ney trigram model does not sum up to unity at the level of bigrams. However a bigram model does (I added it explicitly to the tests). This is as expected, right?