### PR TITLE
Fixed AttributeError for Arabic ARLSTem2 stemmer

### DIFF
--- a/nltk/stem/__init__.py
+++ b/nltk/stem/__init__.py
@@ -30,3 +30,5 @@ from nltk.stem.snowball import SnowballStemmer
 from nltk.stem.wordnet import WordNetLemmatizer
 from nltk.stem.rslp import RSLPStemmer
 from nltk.stem.cistem import Cistem
+from nltk.stem.arlstem import ARLSTem
+from nltk.stem.arlstem2 import ARLSTem2

--- a/nltk/stem/arlstem2.py
+++ b/nltk/stem/arlstem2.py
@@ -130,7 +130,7 @@ class ARLSTem2(StemmerI):
             if fm is not None:
                 return fm
             # strip the adjective affixes
-            adj = self.adject(token)
+            adj = self.adjective(token)
             if adj is not None:
                 return adj
             # strip the suffixes that are common to nouns and verbs

--- a/nltk/test/stem.doctest
+++ b/nltk/test/stem.doctest
@@ -75,3 +75,32 @@ The 'english' stemmer is better than the original 'porter' stemmer.
 .. note::
 
     Extra stemmer tests can be found in `nltk.test.unit.test_stem`.
+
+Unit tests for ARLSTem Stemmer
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    >>> from nltk.stem.arlstem import ARLSTem
+
+Create a Stemmer instance.
+
+    >>> stemmer = ARLSTem()
+
+Stem a word.
+
+    >>> stemmer.stem('يعمل')
+    'عمل'
+
+Unit tests for ARLSTem2 Stemmer
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    >>> from nltk.stem.arlstem2 import ARLSTem2
+
+Create a Stemmer instance.
+
+    >>> stemmer = ARLSTem2()
+
+Stem a word.
+
+    >>> stemmer.stem('يعمل')
+    'عمل'
+


### PR DESCRIPTION
Closes #2718 

Hello!

---
## Pull request overview
This PR is about fixing an AttributeError when using the ARLSTem2 stemmer in `nltk/stem/arlstem2.py`. 
- It fixes #2718. 
- It adds some unittests to ensure that #2718 doesn't happen again.
- It adds easier importing of `ARLSTem2` and `ARLSTem`.

---

## Bug:
The following line calls a method that does not exist on this class.
https://github.com/nltk/nltk/blob/b8e6705ebb08b5b9232d182e25129b635e9fd3f4/nltk/stem/arlstem2.py#L133

However, the method `adjective` *does* exist. It is my, and @LMech 's understanding that this method ought to be used here instead.

---

## Error log:
```python
Traceback (most recent call last):
  File "c:/GitHub/NLTK/nltk/nltk_2718.py", line 4, in <module>        
    word = stemmer.stem('يعمل')
  File "c:\GitHub\NLTK\nltk\nltk\stem\arlstem2.py", line 162, in stem 
    token = self.stem1(token)
  File "c:\GitHub\NLTK\nltk\nltk\stem\arlstem2.py", line 133, in stem1
    adj = self.adject(token)
AttributeError: 'ARLSTem2' object has no attribute 'adject'
```

---

## The fix
Replaced `adject` with `adjective`. Note that I cannot confirm whether this produces the intended behaviour, as I do not know any Arabic. 
Furthermore, I added unittests for `ARLSTem2` and `ARLSTem` in `nltk/test/stem.doctest`, but I can't be sure whether the stem I used to test there is actually correct. It's more to test that it doesn't throw an Exception, than to test the accuracy or performance. Perhaps @LMech can help verify that this stem is correct.
EDIT: LMech stepped in and verified that the stem seem to make sense!

Lastly, I added 
```python
from nltk.stem.arlstem import ARLSTem
from nltk.stem.arlstem2 import ARLSTem2
```
to `nltk/stem/__init__.py`. As a result, these two stemmers can be imported like
```python
from nltk.stem import ARLSTem, ARLSTem2
```
rather than
```python
from nltk.stem.arlstem import ARLSTem
from nltk.stem.arlstem2 import ARLSTem2
```
Note that all other stemmers were already added to the `nltk/stem/__init__.py`, meaning that they could be imported in the convenient way already.

---

- Tom Aarsen (Formerly CubieDev on GitHub)