### PR TITLE
setup.py: fix python_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ natural language processing.  NLTK requires Python 3.5, 3.6, 3.7, 3.8, or 3.9.""
         "Topic :: Text Processing :: Linguistic",
     ],
     package_data={"nltk": ["test/*.doctest", "VERSION"]},
-    python_requires='>=3.5.*',
+    python_requires='>=3.5',
     install_requires=[
         "click",
         "joblib",


### PR DESCRIPTION
Fix python_requires to specify a valid version.  Apparently, combining
`>=` and `.*` is disallowed, and I'm pretty sure 'just' `>=3.5` means
the same.

To reproduce the problem, you can:

    $ pip install nltk distlib
    $ python -c "import distlib.database; \
      distlib.database.DistributionPath().get_distribution('nltk')"

which yields a (not very readable) error of:

    ValueError: '.*' not allowed for '>=' constraints