### PR TITLE
Initialize WordNet IC total counts with smoothing value

### DIFF
--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -1988,6 +1988,8 @@ class WordNetCorpusReader(CorpusReader):
 
         # Initialize the counts with the smoothing value
         if smoothing > 0.0:
+            for pp in POS_LIST:
+                ic[pp][0] = smoothing
             for ss in self.all_synsets():
                 pos = ss._pos
                 if pos == ADJ_SAT:

--- a/nltk/test/wordnet.doctest
+++ b/nltk/test/wordnet.doctest
@@ -605,6 +605,16 @@ Patch-1 https://github.com/nltk/nltk/pull/2065  Adding 3 functions (relations) t
     >>> wn.synsets("slang")[1].in_usage_domains()[18]
     Synset('can-do.s.01')
 
+Issue 2721: WordNetCorpusReader.ic() does not add smoothing to N
+
+    >>> class FakeCorpus:
+    ...     def words(self): return ['word']
+    ...
+    >>> fake_ic = wn.ic(FakeCorpus(), False, 1.0)
+    >>> word = wn.synset('word.n.01')
+    >>> information_content(word, fake_ic) > 0
+    True
+
 
 ------------------------------------------------
 Endlessness vs. intractability in relation trees


### PR DESCRIPTION
This fixes #2721. When the total counts for a part of speech don't include the smoothing value, we can get concept probabilities greater than 1.0, and therefore the information_content() can be less than 0. This PR initializes the total for each part of speech to the smoothing value.