### PR TITLE
Fixed broken vocabulary test

### DIFF
--- a/nltk/test/unit/lm/test_vocabulary.py
+++ b/nltk/test/unit/lm/test_vocabulary.py
@@ -150,4 +150,6 @@ class NgramModelVocabularyTests(unittest.TestCase):
         large_vocab_len_time = timeit("len(large_vocab)", globals=locals())
 
         # The timing should be the same order of magnitude.
-        self.assertAlmostEqual(small_vocab_len_time, large_vocab_len_time, places=1)
+        self.assertLess(large_vocab_len_time, 10 * small_vocab_len_time, 
+            "Computing the length of a small Vocabulary should take within the same order of magnitude as computing the length of a large Vocabulary.")
+

--- a/nltk/test/unit/lm/test_vocabulary.py
+++ b/nltk/test/unit/lm/test_vocabulary.py
@@ -150,8 +150,8 @@ class NgramModelVocabularyTests(unittest.TestCase):
         large_vocab_len_time = timeit("len(large_vocab)", globals=locals())
 
         # The timing should be the same order of magnitude.
-        self.assertLess(large_vocab_len_time, 10 * small_vocab_len_time, 
-            "Computing the length of a small Vocabulary should take within the same order of magnitude as computing the length of a large Vocabulary.")
-        self.assertLess(small_vocab_len_time, 10 * large_vocab_len_time, 
-            "Computing the length of a small Vocabulary should take within the same order of magnitude as computing the length of a large Vocabulary.")
+        self.assertLess(large_vocab_len_time, 2 * small_vocab_len_time, 
+            "Computing the length of a small Vocabulary should take roughly as long as computing the length of a large Vocabulary.")
+        self.assertLess(small_vocab_len_time, 2 * large_vocab_len_time, 
+            "Computing the length of a small Vocabulary should take roughly as long as computing the length of a large Vocabulary.")
 

--- a/nltk/test/unit/lm/test_vocabulary.py
+++ b/nltk/test/unit/lm/test_vocabulary.py
@@ -152,4 +152,6 @@ class NgramModelVocabularyTests(unittest.TestCase):
         # The timing should be the same order of magnitude.
         self.assertLess(large_vocab_len_time, 10 * small_vocab_len_time, 
             "Computing the length of a small Vocabulary should take within the same order of magnitude as computing the length of a large Vocabulary.")
+        self.assertLess(small_vocab_len_time, 10 * large_vocab_len_time, 
+            "Computing the length of a small Vocabulary should take within the same order of magnitude as computing the length of a large Vocabulary.")
 


### PR DESCRIPTION
Fixes the flaky test mentioned in #2722.

Hello!

# Pull request overview
* Fixed a single test in `nltk/test/unit/lm/test_vocabulary.py`

## The bug
Previously, the following line would not correctly do as the comment states:
https://github.com/nltk/nltk/blob/e4444c9b15762e6d86f5f6c4f5faadb87632c72a/nltk/test/unit/lm/test_vocabulary.py#L152-L153

In particular, the broken test didn't check whether the timings are in indeed the same order of magnitude. 

As per the [assertAlmostEqual documentation](https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertAlmostEqual), `assertAlmostEqual(a, b, places)` checks that `round(a-b, places) == 0`. Then, as can be seen in [this failing Travis CI](https://travis-ci.org/github/nltk/nltk/jobs/773245334#L2097-L2117) run, `0.0400...` and `0.4656...` are not equal within 1 place.

This makes sense, as `round(0.0400... - 0.4656..., 1) => round(-0.065217..., 1) => -0.1`, and this is not equal to `0.0`.

## The fix
So, if we truly want to (roughly) check whether the two are in the same order of magnitude, then one simple way to do so is to ensure that `a < b * 10`, and `b < a * 10`. So, this only holds if `a` is not more than 10 times as large as `b`, and not more than 10 times smaller than `b`.

This is implemented through
```python
        # The timing should be the same order of magnitude.
        self.assertLess(large_vocab_len_time, 10 * small_vocab_len_time, 
            "Computing the length of a small Vocabulary should take within the same order of magnitude as computing the length of a large Vocabulary.")
        self.assertLess(small_vocab_len_time, 10 * large_vocab_len_time, 
            "Computing the length of a small Vocabulary should take within the same order of magnitude as computing the length of a large Vocabulary.")
```

---

This test should pass, and should conform to the desired behaviour described in the test comment, unlike the current test.
Upon merging, the tests from #2722 should pass again.

cc: @stevenbird @goodmami @iliakur 

- Tom Aarsen