### PR TITLE
create method word_as_freq at WordListCorpusReader

### DIFF
--- a/nltk/corpus/reader/wordlist.py
+++ b/nltk/corpus/reader/wordlist.py
@@ -24,6 +24,13 @@ class WordListCorpusReader(CorpusReader):
             if not line.startswith(ignore_lines_startswith)
         ]
 
+    def words_as_freq(self, fileids=None, ignore_lines_startswith="\n"):
+        freq_list = dict()
+        for line in line_tokenize(self.raw(fileids)):
+            if not line.startswith(ignore_lines_startswith):
+                freq_list[line] = freq_list.get(line, 0) + 1
+        return freq_list
+
     def raw(self, fileids=None):
         if fileids is None:
             fileids = self._fileids


### PR DESCRIPTION
Create method `word_as_freq` at `nltk.corpus.reader.wordlist.WordListCorpusReader`

This method will return a `dict(str -> int)` in which the key is the word and the value the respective frequency on the corpus.
This could be intresting for `nltk.corpus.stopwords`, as well, when the developer could call it and (without more codings) apply the `dict` to remove stopwords from the input-texts faster (faster than list)