### PR TITLE
Skipped broken vocabulary test

### DIFF
--- a/nltk/test/unit/lm/test_vocabulary.py
+++ b/nltk/test/unit/lm/test_vocabulary.py
@@ -138,6 +138,7 @@ class NgramModelVocabularyTests(unittest.TestCase):
             ),
         )
 
+    @unittest.skip(reason = "Test is known to be flaky as it compares (runtime) performance.")
     def test_len_is_constant(self):
         # Given an obviously small and an obviously large vocabulary.
         small_vocab = Vocabulary("abcde")


### PR DESCRIPTION
Fixes the flaky test mentioned in #2722.
Alternative to #2723.

---

Hello!

### Pull request overview
* *Skipped* a single test in `nltk/test/unit/lm/test_vocabulary.py`.

This is a *temporary* solution, allowing other PR's (e.g. #2722 by @goodmami) tests to consistently pass again. In the future, @iliakur can propose a more permanent solution that properly corresponds to the initial goals of the test.
As an alternative, #2723 can be merged with the same purpose: being a temporary fix. 

See #2723 for information on the bug.

---

cc: @stevenbird @goodmami @iliakur 

- Tom Aarsen