### PR TITLE
travis ci, run 3rd party tests on latest python, do not run tests on py3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,14 +29,14 @@ matrix:
     - python: '3.7'
       env: TOXENV="py-travis"
 
-    - python: '3.7' # Only runs checks on 3rd party for latest Python distribution
-      env: TOXENV="py-travis-third-party"
-
     - python: '3.8'
       env: TOXENV="py-travis"
 
     - python: '3.9'
       env: TOXENV="py-travis"
+
+    - python: '3.9' # Only runs checks on 3rd party for latest Python distribution
+      env: TOXENV="py-travis-third-party"
 
 before_install:
   - source tools/travis/pre-install.sh # Checks Java and Python versions.

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,6 @@ addons:
 
 matrix:
   include:
-    - python: '3.5'
-      env: TOXENV="py-travis"
-
     - python: '3.6'
       env: TOXENV="py-travis"
 


### PR DESCRIPTION
- Run 3rd party tests on the latest Python version
- Do not run tests on python 3.5 because it is end of life: https://devguide.python.org/devcycle/#end-of-life-branches