### PR TITLE
Fix the twitter test

### DIFF
--- a/nltk/test/unit/test_json2csv_corpus.py
+++ b/nltk/test/unit/test_json2csv_corpus.py
@@ -18,9 +18,12 @@ from nltk.twitter.common import json2csv, json2csv_entities
 
 
 def files_are_identical(pathA, pathB):
-    """ Compare two files, ignoring carriage returns """
-    f1 = pathA.read_bytes().splitlines()
-    f2 = pathB.read_bytes().splitlines()
+    """
+    Compare two files, ignoring carriage returns,
+    leading whitespace, and trailing whitespace
+    """
+    f1 = [l.strip() for l in pathA.read_bytes().splitlines()]
+    f2 = [l.strip() for l in pathB.read_bytes().splitlines()]
     return f1 == f2
 
 


### PR DESCRIPTION
https://github.com/nltk/nltk/pull/2753 broke the twitter tests, which https://github.com/nltk/nltk/pull/2754 graciously offered to fix. I'd rather just make the tests more flexible, because the pre-commit hooks will continue to strip the trailing whitespace the next time those files are edited.