### PR TITLE
cache improvements, enable gensim tests, more verbose test output for skipped and failed tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,15 +12,17 @@ jobs:
 
       - name: Cache nltk data
         uses: actions/cache@v2
+        id: restore-cache
         with:
           path: ~/nltk_data
           key: nltk_data
 
-      - name: Download nltk data packages
+      - name: Download nltk data packages on cache miss
         run: |
           pip install regex # dependencies needed to download nltk data
           python -c "import nltk; nltk.download('all')"
         shell: bash
+        if: steps.restore-cache.outputs.cache-hit != 'true'
 
   test:
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
@@ -42,12 +44,14 @@ jobs:
 
       - name: Cache dependencies
         uses: actions/cache@v2
+        id: restore-cache
         with:
           path: ${{ env.pythonLocation }}
           key: python-dependencies-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements-ci.txt') }}-${{ env.pythonLocation }}
       
-      - name: Install dependencies
+      - name: Install dependencies on cache miss
         run: pip install --upgrade --requirement requirements-ci.txt
+        if: steps.restore-cache.outputs.cache-hit != 'true'
 
       - name: Use cached nltk data
         uses: actions/cache@v2
@@ -56,5 +60,5 @@ jobs:
           key: nltk_data
 
       - name: Run pytest
-        run: pytest --numprocesses auto nltk/test
+        run: pytest --numprocesses auto -rsx nltk/test
         shell: bash

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,3 +1,4 @@
+gensim<4.0.0
 matplotlib
 pytest
 pytest-mock


### PR DESCRIPTION
A few small updates to Github Actions CI:

- enable more verbose output for skipped and failed tests with `pytest -rsx`, this is useful when a test is skipped due to a missing dependency or third party package
- enable test that requires gensim package
- skip cache regeneration step on cache hit, this further speeds up the build with warm cache
