### PR TITLE
numpy deprecated np.int, replace with identical int

### DIFF
--- a/nltk/tag/hmm.py
+++ b/nltk/tag/hmm.py
@@ -393,7 +393,7 @@ class HiddenMarkovModelTagger(TaggerI):
         P, O, X, S = self._cache
 
         V = np.zeros((T, N), np.float32)
-        B = -np.ones((T, N), np.int)
+        B = -np.ones((T, N), int)
 
         V[0] = P + O[:, S[unlabeled_sequence[0]]]
         for t in range(1, T):


### PR DESCRIPTION
numpy 1.20 deprecated `np.int`, details here: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
This PR replaces use of `np.int` with identical `int`.

Deprecation warning message as seen in CI:
```
probability.doctest: 410 warnings
  /home/runner/work/nltk/nltk/nltk/tag/hmm.py:396: DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    B = -np.ones((T, N), np.int)
```