### PR TITLE
Replaced Travis info with GitHub Actions info in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,19 +158,19 @@ NLTK uses [GitHub Actions](https://github.com/nltk/nltk/actions) for continuous 
 The [`.github/workflows/ci.yaml`](https://github.com/nltk/nltk/blob/develop/.github/workflows/ci.yaml) file configures the CI:
 
  - `on:` section
-   - Ensures that this CI is run on code pushes, pull request, or through the GitHub website via a button.
+   - ensures that this CI is run on code pushes, pull request, or through the GitHub website via a button.
 
  - The `cache_nltk_data` job
-   - Steps:
+   - performs these steps:
      - Downloads the `nltk` source code.
      - Load `nltk_data` via cache.
        - Otherwise, download all the data packages through `nltk.download('all')`.
 
   - The `test` job
-    - Tests against supported Python versions (`3.6`, `3.7`, `3.8`, `3.9`).
-    - Tests on `ubuntu-latest` and `macos-latest`.
-    - Relies on the `cache_nltk_data` job to ensure that `nltk_data` is available.
-    - Steps:
+    - tests against supported Python versions (`3.6`, `3.7`, `3.8`, `3.9`).
+    - tests on `ubuntu-latest` and `macos-latest`.
+    - relies on the `cache_nltk_data` job to ensure that `nltk_data` is available.
+    - performs these steps:
       - Downloads the `nltk` source code.
       - Set up Python using whatever version is being checked in the current execution.
       - Load module dependencies via cache.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,32 +151,32 @@ pytest  # all tests
 
 **Deprecated:** NLTK uses [Cloudbees](https://nltk.ci.cloudbees.com/) for continuous integration.
 
-NLTK uses [Travis](https://travis-ci.org/nltk/nltk/) for continuous integration.
+**Deprecated:** NLTK uses [Travis](https://travis-ci.org/nltk/nltk/) for continuous integration.
 
-The [`.travis.yml`](https://github.com/nltk/nltk/blob/travis/.travis.yml) file configures the server:
+NLTK uses [GitHub Actions](https://github.com/nltk/nltk/actions) for continuous integration. See [here](https://docs.github.com/en/actions) for GitHub's documentation.
 
- - `matrix: include:` section
-   - tests against supported Python versions (3.5, 3.6, 3.7, 3.8, 3.9)
-     - all python versions run the `py-travis` tox test environment in the [`tox.ini`](https://github.com/nltk/nltk/blob/travis/tox.ini#L105) file
-   - tests against Python 3.6 for third-party tools APIs
+The [`.github/workflows/ci.yaml`](https://github.com/nltk/nltk/blob/develop/.github/workflows/ci.yaml) file configures the CI:
 
- - `before_install:` section
-   - checks the Java and Python version calling the `tools/travis/pre-install.sh` script
-   - changes the permission for `tools/travis/coverage-pylint.sh` to allow it to be executable
-   - changes the permission for `tools/travis/third-party.sh` to allow it to be executable
+ - `on:` section
+   - Ensures that this CI is run on code pushes, pull request, or through the GitHub website via a button.
 
- - `install` section
-   - the `tools/travis/install.sh` installs the `pip-req.txt` for NLTK and the necessary python packages for CI testing
-   - install `tox` for testing
+ - The `cache_nltk_data` job
+   - Steps:
+     - Downloads the `nltk` source code.
+     - Load `nltk_data` via cache.
+       - Otherwise, download all the data packages through `nltk.download('all')`.
 
- - `py-travis` tox test environment generally
-   - the `extras = all` dependencies in needed to emulate `pip install nltk[all]`, see https://tox.readthedocs.io/en/latest/config.html#confval-extras=MULTI-LINE-LIST
-   - for the `py-travis-third-party` build, it will run `tools/travis/third-party.sh` to install third-party tools (Stanford NLP tools and CoreNLP and SENNA)
-   - calls `tools/travis/coverage-pylint.sh` shell script that calls `pytest` with [`pytest-cov`](https://pytest-cov.readthedocs.io/) and
-   - calls `pylint` # Currently, disabled because there's lots to clean...
-
-   - before returning a `true` to state that the build is successful
-
+  - The `test` job
+    - Tests against supported Python versions (`3.6`, `3.7`, `3.8`, `3.9`).
+    - Tests on `ubuntu-latest` and `macos-latest`.
+    - Relies on the `cache_nltk_data` job to ensure that `nltk_data` is available.
+    - Steps:
+      - Downloads the `nltk` source code.
+      - Set up Python using whatever version is being checked in the current execution.
+      - Load module dependencies via cache.
+        - Otherwise, install dependencies via `pip install -U -r requirements-ci.txt`.
+      - Load cached `nltk_data` loaded via `cache_nltk_data`.
+      - Run `pytest --numprocesses auto -rsx nltk/test`.
 
 #### To test with `tox` locally
 


### PR DESCRIPTION
Documents changes from #2750.

---

Hello!

### Pull request overview
* Replaced explanation of `.travis.yml` with a short overview of `.github/workflows/ci.yaml`, mentions deprecation of Travis as our CI server.

---

### Note
The CI workflow provided by @purificant runs tests on all *officially supported* versions of Python, i.e. (currently) 3.6, 3.7, 3.8 and 3.9. However, this clashes with our `setup.py` and our `tox.ini`, both of which still mention support for 3.5.

We need to make a call. Some options are:
* We drop 3.5 support. This would be in accordance to the recommendation by the Python team to update away from 3.5.
* We keep 3.5 support, allowing developers to make their own call on which version they use, even when that choice counters the advise from the Python team.

I'm personally very much in favour of the first option. I'd like some feedback on that. I should have some time to work on whichever option is preferred, but the current situation of *"Our setup.py supports Python 3.5, but we don't run tests for it"* is definitely not going to work.

- Tom Aarsen