### PR TITLE
Dropped support for Python 3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 NLTK -- the Natural Language Toolkit -- is a suite of open source Python
 modules, data sets, and tutorials supporting research and development in Natural
-Language Processing. NLTK requires Python version 3.5, 3.6, 3.7, 3.8, or 3.9.
+Language Processing. NLTK requires Python version 3.6, 3.7, 3.8, or 3.9.
 
 For documentation, please visit [nltk.org](http://www.nltk.org/).
 

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
     },
     long_description="""\
 The Natural Language Toolkit (NLTK) is a Python package for
-natural language processing.  NLTK requires Python 3.5, 3.6, 3.7, 3.8, or 3.9.""",
+natural language processing.  NLTK requires Python 3.6, 3.7, 3.8, or 3.9.""",
     license="Apache License, Version 2.0",
     keywords=[
         "NLP",
@@ -92,7 +92,6 @@ natural language processing.  NLTK requires Python 3.5, 3.6, 3.7, 3.8, or 3.9.""
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
@@ -108,7 +107,7 @@ natural language processing.  NLTK requires Python 3.5, 3.6, 3.7, 3.8, or 3.9.""
         "Topic :: Text Processing :: Linguistic",
     ],
     package_data={"nltk": ["test/*.doctest", "VERSION"]},
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     install_requires=[
         "click",
         "joblib",

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    py{35,36,37,38,39}
+    py{36,37,38,39}
     pypy
-    py{35,36,37,38,39}-nodeps
-    py{35,36,37,38,39}-jenkins
+    py{36,37,38,39}-nodeps
+    py{36,37,38,39}-jenkins
     py-travis
 
 [testenv]
@@ -50,13 +50,6 @@ deps =
 commands =
     pytest
 
-[testenv:py35-nodeps]
-basepython = python3.5
-deps =
-    pytest
-    pytest-mock
-commands = pytest
-
 [testenv:py36-nodeps]
 basepython = python3.6
 deps =
@@ -89,14 +82,6 @@ commands = pytest
 # control Python2/3 versions using jenkins' user-defined matrix instead.
 # Available Python versions: http://repository-cloudbees.forge.cloudbees.com/distributions/ci-addons/python/fc25/
 
-[testenv:py3.5.4-jenkins]
-basepython = python3
-commands = {toxinidir}/jenkins.sh
-setenv =
-	STANFORD_MODELS = {homedir}/third/stanford-parser/
-	STANFORD_PARSER = {homedir}/third/stanford-parser/
-	STANFORD_POSTAGGER = {homedir}/third/stanford-postagger/
-
 [testenv:py3.6.4-jenkins]
 basepython = python3
 commands = {toxinidir}/jenkins.sh
@@ -104,7 +89,6 @@ setenv =
 	STANFORD_MODELS = {homedir}/third/stanford-parser/
 	STANFORD_PARSER = {homedir}/third/stanford-parser/
 	STANFORD_POSTAGGER = {homedir}/third/stanford-postagger/
-
 
 [testenv:py-travis]
 extras = all

--- a/web/install.rst
+++ b/web/install.rst
@@ -1,7 +1,7 @@
 Installing NLTK
 ===============
 
-NLTK requires Python versions 3.5, 3.6, 3.7, 3.8, or 3.9
+NLTK requires Python versions 3.6, 3.7, 3.8, or 3.9
 
 For Windows users, it is strongly recommended that you go through this guide to install Python 3 successfully https://docs.python-guide.org/starting/install3/win/#install3-windows
 


### PR DESCRIPTION
See previous discussion at #2761

---

Hello!

### Pull request overview
* Set `python_requires` in `setup.py` to `>=3.6` instead of `>=3.5`.
* Removed mention of supporting Python 3.5 in documentation.
* Removed py35 tests in tox.

---

### Note
I left mentions of Python 3.5 in the tools folder, e.g. in `run_doctests.py`:
https://github.com/nltk/nltk/blob/6411fabf05a75e2beb82b29fed614dbd12688f7f/tools/run_doctests.py#L10-L16

This folder seems mostly outdated and unused, also containing references back to jenkins and travis. One of the files, `run_doctests.py`, is not the proper way that doctests should be ran regardless. I didn't worry about these cases too much.

Furthermore, I did not update the following instance in CONTRIBUTING.md:
> matrix: include: section
>    tests against supported Python versions (3.5, 3.6, 3.7, 3.8, 3.9)

As this would unnecessarily create a merge conflict with #2761. Right now, both can be merged without any conflicts. If it is decided to merge this, but not #2761, then this line must still be updated.

Also, a new release should probably be created soon after dropping Python 3.5.

- Tom Aarsen

