### PR TITLE
Resolved many typos in comments, Exceptions and outputs

### DIFF
--- a/nltk/app/chartparser_app.py
+++ b/nltk/app/chartparser_app.py
@@ -746,7 +746,7 @@ class ChartComparer:
         Frame(buttons, width=20).pack(side="left")
         Button(buttons, text="Swap Charts", command=self._swapcharts).pack(side="left")
 
-        Button(buttons, text="Detatch Output", command=self._detatch_out).pack(
+        Button(buttons, text="Detach Output", command=self._detatch_out).pack(
             side="right"
         )
 

--- a/nltk/app/chartparser_app.py
+++ b/nltk/app/chartparser_app.py
@@ -746,7 +746,7 @@ class ChartComparer:
         Frame(buttons, width=20).pack(side="left")
         Button(buttons, text="Swap Charts", command=self._swapcharts).pack(side="left")
 
-        Button(buttons, text="Detach Output", command=self._detatch_out).pack(
+        Button(buttons, text="Detach Output", command=self._detach_out).pack(
             side="right"
         )
 
@@ -939,7 +939,7 @@ class ChartComparer:
         self._op_label["text"] = " "
         self._out_matrix.inactivate()
 
-    def _detatch_out(self):
+    def _detach_out(self):
         ChartMatrixView(self._root, self._out_chart, title=self._out_label["text"])
 
 

--- a/nltk/app/chunkparser_app.py
+++ b/nltk/app/chunkparser_app.py
@@ -230,7 +230,7 @@ class RegexpChunkApp:
     ]
 
     ##/////////////////////////////////////////////////////////////////
-    ##  Config Parmeters
+    ##  Config Parameters
     ##/////////////////////////////////////////////////////////////////
 
     _EVAL_DELAY = 1
@@ -404,7 +404,7 @@ class RegexpChunkApp:
         top.title("Regexp Chunk Parser App")
         top.bind("<Control-q>", self.destroy)
 
-        # Varaible that restricts how much of the devset we look at.
+        # Variable that restricts how much of the devset we look at.
         self._devset_size = IntVar(top)
         self._devset_size.set(100)
 

--- a/nltk/app/nemo_app.py
+++ b/nltk/app/nemo_app.py
@@ -110,7 +110,7 @@ class FindZone(Zone):
         for color in colors:
             self.txt.tag_remove(color, "1.0", "end")
             self.txt.tag_remove("emph" + color, "1.0", "end")
-        self.rex = re.compile("")  # default value in case of misformed regexp
+        self.rex = re.compile("")  # default value in case of malformed regexp
         self.rex = re.compile(self.fld.get("1.0", "end")[:-1], re.MULTILINE)
         try:
             re.compile("(?P<emph>%s)" % self.fld.get(SEL_FIRST, SEL_LAST))

--- a/nltk/app/wordnet_app.py
+++ b/nltk/app/wordnet_app.py
@@ -38,7 +38,7 @@ Options::
 
     -s or --server-mode
         Do not start a web browser, and do not allow a user to
-        shotdown the server through the web interface.
+        shutdown the server through the web interface.
 """
 # TODO: throughout this package variable names and docstrings need
 # modifying to be compliant with NLTK's coding standards.  Tests also
@@ -78,7 +78,7 @@ firstClient = True
 # gets set by demo().
 server_mode = None
 
-# If set this is a file object for writting log messages.
+# If set this is a file object for writing log messages.
 logfile = None
 
 
@@ -532,7 +532,7 @@ full_hyponym_cont_text = _ul(_li(_italic("(has full hyponym continuation)"))) + 
 def _get_synset(synset_key):
     """
     The synset key is the unique name of the synset, this can be
-    retrived via synset.name()
+    retrieved via synset.name()
     """
     return wn.synset(synset_key)
 
@@ -790,7 +790,7 @@ def page_from_reference(href):
                 except KeyError:
                     pass
     if not body:
-        body = "The word or words '%s' where not found in the dictonary." % word
+        body = "The word or words '%s' where not found in the dictionary." % word
     return body, word
 
 

--- a/nltk/chat/zen.py
+++ b/nltk/chat/zen.py
@@ -278,7 +278,7 @@ responses = (
     # e.g. "you stink!"
     (
         r"you (.*)",
-        ("My path is not of conern to you.", "I am but one, and you but one more."),
+        ("My path is not of concern to you.", "I am but one, and you but one more."),
     ),
     # say goodbye with some extra Zen wisdom.
     (

--- a/nltk/chunk/__init__.py
+++ b/nltk/chunk/__init__.py
@@ -95,8 +95,8 @@ patterns are:
       ``'<NN>+'`` matches one or more repetitions of ``'<NN>'``, not
       ``'<NN'`` followed by one or more repetitions of ``'>'``.
     - Whitespace in tag patterns is ignored.  So
-      ``'<DT> | <NN>'`` is equivalant to ``'<DT>|<NN>'``
-    - In tag patterns, ``'.'`` is equivalant to ``'[^{}<>]'``; so
+      ``'<DT> | <NN>'`` is equivalent to ``'<DT>|<NN>'``
+    - In tag patterns, ``'.'`` is equivalent to ``'[^{}<>]'``; so
       ``'<NN.*>'`` matches any single tag starting with ``'NN'``.
 
 The function ``tag_pattern2re_pattern`` can be used to transform

--- a/nltk/chunk/regexp.py
+++ b/nltk/chunk/regexp.py
@@ -906,8 +906,8 @@ def tag_pattern2re_pattern(tag_pattern):
           ``'<NN>+'`` matches one or more repetitions of ``'<NN>'``, not
           ``'<NN'`` followed by one or more repetitions of ``'>'``.
         - Whitespace in tag patterns is ignored.  So
-          ``'<DT> | <NN>'`` is equivalant to ``'<DT>|<NN>'``
-        - In tag patterns, ``'.'`` is equivalant to ``'[^{}<>]'``; so
+          ``'<DT> | <NN>'`` is equivalent to ``'<DT>|<NN>'``
+        - In tag patterns, ``'.'`` is equivalent to ``'[^{}<>]'``; so
           ``'<NN.*>'`` matches any single tag starting with ``'NN'``.
 
     In particular, ``tag_pattern2re_pattern`` performs the following
@@ -1057,7 +1057,7 @@ class RegexpChunkParser(ChunkParserI):
         :param trace: The level of tracing that should be used when
             parsing a text.  ``0`` will generate no tracing output;
             ``1`` will generate normal tracing output; and ``2`` or
-            highter will generate verbose tracing output.  This value
+            higher will generate verbose tracing output.  This value
             overrides the trace level value that was given to the
             constructor.
         :rtype: Tree
@@ -1263,7 +1263,7 @@ class RegexpParser(ChunkParserI):
         :param trace: The level of tracing that should be used when
             parsing a text.  ``0`` will generate no tracing output;
             ``1`` will generate normal tracing output; and ``2`` or
-            highter will generate verbose tracing output.  This value
+            higher will generate verbose tracing output.  This value
             overrides the trace level value that was given to the
             constructor.
         :return: the chunked output.

--- a/nltk/classify/naivebayes.py
+++ b/nltk/classify/naivebayes.py
@@ -101,7 +101,7 @@ class NaiveBayesClassifier(ClassifierI):
                 # print('Ignoring unseen feature %s' % fname)
                 del featureset[fname]
 
-        # Find the log probabilty of each label, given the features.
+        # Find the log probability of each label, given the features.
         # Start with the log probability of the label itself.
         logprob = {}
         for label in self._labels:

--- a/nltk/cli.py
+++ b/nltk/cli.py
@@ -44,7 +44,7 @@ def tokenize_file(language, preserve_line, processes, encoding, delimiter):
     """ This command tokenizes text stream using nltk.word_tokenize """
     with click.get_text_stream("stdin", encoding=encoding) as fin:
         with click.get_text_stream("stdout", encoding=encoding) as fout:
-            # If it's single process, joblib parallization is slower,
+            # If it's single process, joblib parallelization is slower,
             # so just process line by line normally.
             if processes == 1:
                 for line in tqdm(fin.readlines()):

--- a/nltk/cluster/kmeans.py
+++ b/nltk/cluster/kmeans.py
@@ -46,7 +46,7 @@ class KMeansClusterer(VectorSpaceClusterer):
         :param  num_means:  the number of means to use (may use fewer)
         :type   num_means:  int
         :param  distance:   measure of distance between two vectors
-        :type   distance:   function taking two vectors and returing a float
+        :type   distance:   function taking two vectors and returning a float
         :param  repeats:    number of randomised clustering trials to use
         :type   repeats:    int
         :param  conv_test:  maximum variation in mean differences before

--- a/nltk/collections.py
+++ b/nltk/collections.py
@@ -530,7 +530,7 @@ class LazyZip(LazyMap):
 
 class LazyEnumerate(LazyZip):
     """
-    A lazy sequence whose elements are tuples, each ontaining a count (from
+    A lazy sequence whose elements are tuples, each containing a count (from
     zero) and a value yielded by underlying sequence.  ``LazyEnumerate`` is
     useful for obtaining an indexed list. The tuples are constructed lazily
     -- i.e., when you read a value from the list, ``LazyEnumerate`` will

--- a/nltk/corpus/reader/bracket_parse.py
+++ b/nltk/corpus/reader/bracket_parse.py
@@ -189,7 +189,7 @@ class AlpinoCorpusReader(BracketParseCorpusReader):
     def _normalize(self, t, ordered=False):
         """Normalize the xml sentence element in t.
         The sentence elements <alpino_ds>, although embedded in a few overall
-        xml elements, are seperated by blank lines. That's how the reader can
+        xml elements, are separated by blank lines. That's how the reader can
         deliver them one at a time.
         Each sentence has a few category subnodes that are of no use to us.
         The remaining word nodes may or may not appear in the proper order.

--- a/nltk/corpus/reader/comparative_sents.py
+++ b/nltk/corpus/reader/comparative_sents.py
@@ -63,7 +63,7 @@ class Comparison:
         keyword=None,
     ):
         """
-        :param text: a string (optionally tokenized) containing a comparation.
+        :param text: a string (optionally tokenized) containing a comparison.
         :param comp_type: an integer defining the type of comparison expressed.
             Values can be: 1 (Non-equal gradable), 2 (Equative), 3 (Superlative),
             4 (Non-gradable).

--- a/nltk/corpus/reader/framenet.py
+++ b/nltk/corpus/reader/framenet.py
@@ -58,7 +58,7 @@ def _pretty_longstring(defstr, prefix="", wrap_at=65):
 
     :param defstr: The string to be printed.
     :type defstr: str
-    :return: A nicely formated string representation of the long string.
+    :return: A nicely formatted string representation of the long string.
     :rtype: str
     """
 
@@ -75,7 +75,7 @@ def _pretty_any(obj):
 
     :param obj: The obj to be printed.
     :type obj: AttrDict
-    :return: A nicely formated string representation of the AttrDict object.
+    :return: A nicely formatted string representation of the AttrDict object.
     :rtype: str
     """
 
@@ -98,7 +98,7 @@ def _pretty_semtype(st):
 
     :param st: The semantic type to be printed.
     :type st: AttrDict
-    :return: A nicely formated string representation of the semantic type.
+    :return: A nicely formatted string representation of the semantic type.
     :rtype: str
     """
 
@@ -134,7 +134,7 @@ def _pretty_frame_relation_type(freltyp):
 
     :param freltyp: The frame relation type to be printed.
     :type freltyp: AttrDict
-    :return: A nicely formated string representation of the frame relation type.
+    :return: A nicely formatted string representation of the frame relation type.
     :rtype: str
     """
     outstr = "<frame relation type ({0.ID}): {0.superFrameName} -- {0.name} -> {0.subFrameName}>".format(
@@ -150,7 +150,7 @@ def _pretty_frame_relation(frel):
 
     :param frel: The frame relation to be printed.
     :type frel: AttrDict
-    :return: A nicely formated string representation of the frame relation.
+    :return: A nicely formatted string representation of the frame relation.
     :rtype: str
     """
     outstr = "<{0.type.superFrameName}={0.superFrameName} -- {0.type.name} -> {0.type.subFrameName}={0.subFrameName}>".format(
@@ -166,7 +166,7 @@ def _pretty_fe_relation(ferel):
 
     :param ferel: The FE relation to be printed.
     :type ferel: AttrDict
-    :return: A nicely formated string representation of the FE relation.
+    :return: A nicely formatted string representation of the FE relation.
     :rtype: str
     """
     outstr = "<{0.type.superFrameName}={0.frameRelation.superFrameName}.{0.superFEName} -- {0.type.name} -> {0.type.subFrameName}={0.frameRelation.subFrameName}.{0.subFEName}>".format(
@@ -182,7 +182,7 @@ def _pretty_lu(lu):
 
     :param lu: The lu to be printed.
     :type lu: AttrDict
-    :return: A nicely formated string representation of the lexical unit.
+    :return: A nicely formatted string representation of the lexical unit.
     :rtype: str
     """
 
@@ -346,7 +346,7 @@ def _pretty_annotation(sent, aset_level=False):
     :param sent: An annotation set or exemplar sentence to be printed.
     :param aset_level: If True, 'sent' is actually an annotation set within a sentence.
     :type sent: AttrDict
-    :return: A nicely formated string representation of the exemplar sentence
+    :return: A nicely formatted string representation of the exemplar sentence
     with its target, frame, and FE annotations.
     :rtype: str
     """
@@ -664,7 +664,7 @@ def _pretty_fe(fe):
 
     :param fe: The frame element to be printed.
     :type fe: AttrDict
-    :return: A nicely formated string representation of the frame element.
+    :return: A nicely formatted string representation of the frame element.
     :rtype: str
     """
     fekeys = fe.keys()
@@ -708,7 +708,7 @@ def _pretty_frame(frame):
 
     :param frame: The frame to be printed.
     :type frame: AttrDict
-    :return: A nicely formated string representation of the frame.
+    :return: A nicely formatted string representation of the frame.
     :rtype: str
     """
 
@@ -1570,7 +1570,7 @@ warnings(True) to display corpus consistency warnings when loading data
     def frames_by_lemma(self, pat):
         """
         Returns a list of all frames that contain LUs in which the
-        ``name`` attribute of the LU matchs the given regular expression
+        ``name`` attribute of the LU matches the given regular expression
         ``pat``. Note that LU names are composed of "lemma.POS", where
         the "lemma" part can be made up of either a single lexeme
         (e.g. 'run') or multiple lexemes (e.g. 'a little').
@@ -2178,7 +2178,7 @@ warnings(True) to display corpus consistency warnings when loading data
         :param name: A regular expression pattern used to search the LU
             names. Note that LU names take the form of a dotted
             string (e.g. "run.v" or "a little.adv") in which a
-            lemma preceeds the "." and a POS follows the
+            lemma precedes the "." and a POS follows the
             dot. The lemma may be composed of a single lexeme
             (e.g. "run") or of multiple lexemes (e.g. "a
             little"). If 'name' is not given, then all LUs will
@@ -3305,7 +3305,7 @@ def demo():
     #
     # It is not necessary to explicitly build the indexes by calling
     # buildindexes(). We do this here just for demo purposes. If the
-    # indexes are not built explicitely, they will be built as needed.
+    # indexes are not built explicitly, they will be built as needed.
     #
     print("Building the indexes...")
     fn.buildindexes()

--- a/nltk/corpus/reader/mte.py
+++ b/nltk/corpus/reader/mte.py
@@ -223,7 +223,7 @@ class MTECorpusReader(TaggedCorpusReader):
 
         :param root: The root directory for this corpus. (default points to location in multext config file)
         :param fileids: A list or regexp specifying the fileids in this corpus. (default is oana-en.xml)
-        :param enconding: The encoding of the given files (default is utf8)
+        :param encoding: The encoding of the given files (default is utf8)
         """
         TaggedCorpusReader.__init__(self, root, fileids, encoding)
         self._readme = "00README.txt"

--- a/nltk/corpus/reader/nombank.py
+++ b/nltk/corpus/reader/nombank.py
@@ -59,7 +59,7 @@ class NombankCorpusReader(CorpusReader):
         if isinstance(framefiles, str):
             self._fileids = find_corpus_fileids(root, framefiles)
         self._fileids = list(framefiles)
-        # Initialze the corpus reader.
+        # Initialize the corpus reader.
         CorpusReader.__init__(self, root, framefiles, encoding)
 
         # Record our nom file & nouns file.
@@ -344,7 +344,7 @@ class NombankChainTreePointer(NombankPointer):
 
     def select(self, tree):
         if tree is None:
-            raise ValueError("Parse tree not avaialable")
+            raise ValueError("Parse tree not available")
         return Tree("*CHAIN*", [p.select(tree) for p in self.pieces])
 
 
@@ -362,7 +362,7 @@ class NombankSplitTreePointer(NombankPointer):
 
     def select(self, tree):
         if tree is None:
-            raise ValueError("Parse tree not avaialable")
+            raise ValueError("Parse tree not available")
         return Tree("*SPLIT*", [p.select(tree) for p in self.pieces])
 
 
@@ -429,7 +429,7 @@ class NombankTreePointer(NombankPointer):
 
     def select(self, tree):
         if tree is None:
-            raise ValueError("Parse tree not avaialable")
+            raise ValueError("Parse tree not available")
         return tree[self.treepos(tree)]
 
     def treepos(self, tree):
@@ -438,7 +438,7 @@ class NombankTreePointer(NombankPointer):
         given that it points to the given tree.
         """
         if tree is None:
-            raise ValueError("Parse tree not avaialable")
+            raise ValueError("Parse tree not available")
         stack = [tree]
         treepos = []
 

--- a/nltk/corpus/reader/plaintext.py
+++ b/nltk/corpus/reader/plaintext.py
@@ -23,7 +23,7 @@ class PlaintextCorpusReader(CorpusReader):
     Reader for corpora that consist of plaintext documents.  Paragraphs
     are assumed to be split using blank lines.  Sentences and words can
     be tokenized using the default tokenizers, or by custom tokenizers
-    specificed as parameters to the constructor.
+    specified as parameters to the constructor.
 
     This corpus reader can be customized (e.g., to skip preface
     sections of specific document formats) by creating a subclass and

--- a/nltk/corpus/reader/propbank.py
+++ b/nltk/corpus/reader/propbank.py
@@ -58,7 +58,7 @@ class PropbankCorpusReader(CorpusReader):
         if isinstance(framefiles, str):
             framefiles = find_corpus_fileids(root, framefiles)
         framefiles = list(framefiles)
-        # Initialze the corpus reader.
+        # Initialize the corpus reader.
         CorpusReader.__init__(self, root, [propfile, verbsfile] + framefiles, encoding)
 
         # Record our frame fileids & prop file.
@@ -353,7 +353,7 @@ class PropbankChainTreePointer(PropbankPointer):
 
     def select(self, tree):
         if tree is None:
-            raise ValueError("Parse tree not avaialable")
+            raise ValueError("Parse tree not available")
         return Tree("*CHAIN*", [p.select(tree) for p in self.pieces])
 
 
@@ -372,7 +372,7 @@ class PropbankSplitTreePointer(PropbankPointer):
 
     def select(self, tree):
         if tree is None:
-            raise ValueError("Parse tree not avaialable")
+            raise ValueError("Parse tree not available")
         return Tree("*SPLIT*", [p.select(tree) for p in self.pieces])
 
 
@@ -440,7 +440,7 @@ class PropbankTreePointer(PropbankPointer):
 
     def select(self, tree):
         if tree is None:
-            raise ValueError("Parse tree not avaialable")
+            raise ValueError("Parse tree not available")
         return tree[self.treepos(tree)]
 
     def treepos(self, tree):
@@ -449,7 +449,7 @@ class PropbankTreePointer(PropbankPointer):
         given that it points to the given tree.
         """
         if tree is None:
-            raise ValueError("Parse tree not avaialable")
+            raise ValueError("Parse tree not available")
         stack = [tree]
         treepos = []
 

--- a/nltk/corpus/reader/semcor.py
+++ b/nltk/corpus/reader/semcor.py
@@ -193,7 +193,7 @@ class SemcorCorpusReader(XMLCorpusReader):
                     except Exception:
                         # cannot retrieve the wordnet.Lemma object. possible reasons:
                         #  (a) the wordnet corpus is not downloaded;
-                        #  (b) a nonexistant sense is annotated: e.g., such.s.00 triggers:
+                        #  (b) a nonexistent sense is annotated: e.g., such.s.00 triggers:
                         #  nltk.corpus.reader.wordnet.WordNetError: No synset found for key u'such%5:00:01:specified:00'
                         # solution: just use the lemma name as a string
                         try:

--- a/nltk/corpus/reader/senseval.py
+++ b/nltk/corpus/reader/senseval.py
@@ -135,7 +135,7 @@ class SensevalCorpusView(StreamBackedCorpusView):
                         assert not (cword.text.strip() and len(cword) == 1)
                         # Record the position of the head:
                         position = len(context)
-                        # Addd on the head word itself:
+                        # Add on the head word itself:
                         if cword.text.strip():
                             context.append(cword.text.strip())
                         elif cword[0].tag == "wf":

--- a/nltk/corpus/reader/timit.py
+++ b/nltk/corpus/reader/timit.py
@@ -108,7 +108,7 @@ The 4 functions are as follows.
  - audiodata(item, start=0, end=None)
 
    Given an item, returns a chunk of audio samples formatted into a string.
-   When the fuction is called, if start and end are omitted, the entire
+   When the function is called, if start and end are omitted, the entire
    samples of the recording will be returned.  If only end is omitted,
    samples from the start offset to the end of the recording will be returned.
 

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -560,7 +560,7 @@ class Synset(_WordNetObject):
         UserWarning: Discarded redundant search for Synset('computer.n.01') at depth 2
 
 
-        Include redundant pathes (but only once), avoiding duplicate searches
+        Include redundant paths (but only once), avoiding duplicate searches
         (from 'animal.n.01' to 'entity.n.01'):
 
         >>> dog = wn.synset('dog.n.01')

--- a/nltk/corpus/util.py
+++ b/nltk/corpus/util.py
@@ -129,7 +129,7 @@ class LazyCorpusLoader:
         )
 
     def _unload(self):
-        # If an exception occures during corpus loading then
+        # If an exception occurs during corpus loading then
         # '_unload' method may be unattached, so __getattr__ can be called;
         # we shouldn't trigger corpus loading again in this case.
         pass

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -290,7 +290,7 @@ class PathPointer(metaclass=ABCMeta):
         identified by this pointer, and then following the relative
         path given by ``fileid``.  The path components of ``fileid``
         should be separated by forward slashes, regardless of
-        the underlying file system's path seperator character.
+        the underlying file system's path separator character.
         """
 
 

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -477,7 +477,7 @@ class Downloader:
        installed (i.e., only some of its packages are installed.)"""
 
     # /////////////////////////////////////////////////////////////////
-    # Cosntructor
+    # Constructor
     # /////////////////////////////////////////////////////////////////
 
     def __init__(self, server_index_url=None, download_dir=None):
@@ -938,7 +938,7 @@ class Downloader:
         """A helper function that ensures that self._index is
         up-to-date.  If the index is older than self.INDEX_TIMEOUT,
         then download it again."""
-        # Check if the index is aleady up-to-date.  If so, do nothing.
+        # Check if the index is already up-to-date.  If so, do nothing.
         if not (
             self._index is None
             or url is not None
@@ -1971,7 +1971,7 @@ class DownloaderGUI:
         try:
             ShowText(
                 self.top,
-                "Help: NLTK Dowloader",
+                "Help: NLTK Downloader",
                 self.HELP.strip(),
                 width=75,
                 font="fixed",

--- a/nltk/draw/table.py
+++ b/nltk/draw/table.py
@@ -125,14 +125,14 @@ class MultiListbox(Frame):
             # Clicking or dragging selects:
             lb.bind("<Button-1>", self._select)
             lb.bind("<B1-Motion>", self._select)
-            # Scroll whell scrolls:
+            # Scroll wheel scrolls:
             lb.bind("<Button-4>", lambda e: self._scroll(-1))
             lb.bind("<Button-5>", lambda e: self._scroll(+1))
             lb.bind("<MouseWheel>", lambda e: self._scroll(e.delta))
             # Button 2 can be used to scan:
             lb.bind("<Button-2>", lambda e: self.scan_mark(e.x, e.y))
             lb.bind("<B2-Motion>", lambda e: self.scan_dragto(e.x, e.y))
-            # Dragging outside the window has no effect (diable
+            # Dragging outside the window has no effect (disable
             # the default listbox behavior, which scrolls):
             lb.bind("<B1-Leave>", lambda e: "break")
             # Columns can be resized by dragging them:
@@ -584,7 +584,7 @@ class Table:
     A display widget for a table of values, based on a ``MultiListbox``
     widget.  For many purposes, ``Table`` can be treated as a
     list-of-lists.  E.g., table[i] is a list of the values for row i;
-    and table.append(row) adds a new row with the given lits of
+    and table.append(row) adds a new row with the given list of
     values.  Individual cells can be accessed using table[i,j], which
     refers to the j-th column of the i-th row.  This can be used to
     both read and write values from the table.  E.g.:
@@ -641,7 +641,7 @@ class Table:
             and can be used as an index when reading or writing
             cell values from the table.
         :type rows: list(list)
-        :param rows: A list of row values used to initialze the table.
+        :param rows: A list of row values used to initialize the table.
             Each row value should be a tuple of cell values, one for
             each column in the row.
         :type scrollbar: bool
@@ -779,7 +779,7 @@ class Table:
         """
         Add new rows at the end of the table.
 
-        :param rowvalues: A list of row values used to initialze the
+        :param rowvalues: A list of row values used to initialize the
             table.  Each row value should be a tuple of cell values,
             one for each column in the row.
         """

--- a/nltk/draw/util.py
+++ b/nltk/draw/util.py
@@ -1416,7 +1416,7 @@ class SequenceWidget(CanvasWidget):
     def remove_child(self, child):
         """
         Remove the given child canvas widget.  ``child``'s parent will
-        be set ot None.
+        be set to None.
 
         :type child: CanvasWidget
         :param child: The child canvas widget to remove.
@@ -1588,7 +1588,7 @@ class StackWidget(CanvasWidget):
     def remove_child(self, child):
         """
         Remove the given child canvas widget.  ``child``'s parent will
-        be set ot None.
+        be set to None.
 
         :type child: CanvasWidget
         :param child: The child canvas widget to remove.

--- a/nltk/featstruct.py
+++ b/nltk/featstruct.py
@@ -145,7 +145,7 @@ class FeatStruct(SubstituteBindingsI):
     """:ivar: A flag indicating whether this feature structure is
        frozen or not.  Once this flag is set, it should never be
        un-set; and no further modification should be made to this
-       feature structue."""
+       feature structure."""
 
     ##////////////////////////////////////////////////////////////
     # { Constructor
@@ -2548,7 +2548,7 @@ class FeatStructReader:
         """
         cp = re.escape(close_paren)
         position = match.end()
-        # Special syntax fo empty tuples:
+        # Special syntax of empty tuples:
         m = re.compile(r"\s*/?\s*%s" % cp).match(s, position)
         if m:
             return seq_class(), m.end()

--- a/nltk/grammar.py
+++ b/nltk/grammar.py
@@ -746,7 +746,7 @@ class CFG:
 
     def chomsky_normal_form(self, new_token_padding="@$@", flexible=False):
         """
-        Returns a new Grammer that is in chomsky normal
+        Returns a new Grammar that is in chomsky normal
         :param: new_token_padding
             Customise new rule formation during binarisation
         """

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -618,7 +618,7 @@ def find_file_iter(
         msg = (
             "NLTK was unable to find the %s file!"
             "\nUse software specific "
-            "configuration paramaters" % filename
+            "configuration parameters" % filename
         )
         if env_vars:
             msg += " or set the %s environment variable" % env_vars[0]

--- a/nltk/lazyimport.py
+++ b/nltk/lazyimport.py
@@ -45,7 +45,7 @@ class LazyModule:
 
     """
 
-    # Flag which inidicates whether the LazyModule is initialized or not
+    # Flag which indicates whether the LazyModule is initialized or not
     __lazymodule_init = 0
 
     # Name of the module to load

--- a/nltk/lm/api.py
+++ b/nltk/lm/api.py
@@ -89,7 +89,7 @@ class LanguageModel(metaclass=ABCMeta):
         :param ngrams_fn: If given, defines how sentences in training text are turned to ngram
                           sequences.
         :type ngrams_fn: function or None
-        :param pad_fn: If given, defines how senteces in training text are padded.
+        :param pad_fn: If given, defines how sentences in training text are padded.
         :type pad_fn: function or None
 
         """

--- a/nltk/lm/counter.py
+++ b/nltk/lm/counter.py
@@ -91,7 +91,7 @@ class NgramCounter:
         If `ngram_text` is specified, counts ngrams from it, otherwise waits for
         `update` method to be called explicitly.
 
-        :param ngram_text: Optional text containing senteces of ngrams, as for `update` method.
+        :param ngram_text: Optional text containing sentences of ngrams, as for `update` method.
         :type ngram_text: Iterable(Iterable(tuple(str))) or None
 
         """
@@ -107,7 +107,7 @@ class NgramCounter:
         Expects `ngram_text` to be a sequence of sentences (sequences).
         Each sentence consists of ngrams as tuples of strings.
 
-        :param Iterable(Iterable(tuple(str))) ngram_text: Text containing senteces of ngrams.
+        :param Iterable(Iterable(tuple(str))) ngram_text: Text containing sentences of ngrams.
         :raises TypeError: if the ngrams are not tuples.
 
         """

--- a/nltk/metrics/aline.py
+++ b/nltk/metrics/aline.py
@@ -1237,7 +1237,7 @@ def diff(p, q, f):
 
 def R(p, q):
     """
-    Return relevant features for segment comparsion.
+    Return relevant features for segment comparison.
 
     (Kondrak 2002: 54)
     """

--- a/nltk/parse/featurechart.py
+++ b/nltk/parse/featurechart.py
@@ -249,7 +249,7 @@ class FeatureFundamentalRule(FundamentalRule):
     r"""
     A specialized version of the fundamental rule that operates on
     nonterminals whose symbols are ``FeatStructNonterminal``s.  Rather
-    tha simply comparing the nonterminals for equality, they are
+    than simply comparing the nonterminals for equality, they are
     unified.  Variable bindings from these unifications are collected
     and stored in the chart using a ``FeatureTreeEdge``.  When a
     complete edge is generated, these bindings are applied to all

--- a/nltk/parse/malt.py
+++ b/nltk/parse/malt.py
@@ -36,8 +36,8 @@ def malt_regex_tagger():
             (r"^-?[0-9]+(.[0-9]+)?$", "CD"),  # cardinal numbers
             (r"(The|the|A|a|An|an)$", "DT"),  # articles
             (r"(He|he|She|she|It|it|I|me|Me|You|you)$", "PRP"),  # pronouns
-            (r"(His|his|Her|her|Its|its)$", "PRP$"),  # possesive
-            (r"(my|Your|your|Yours|yours)$", "PRP$"),  # possesive
+            (r"(His|his|Her|her|Its|its)$", "PRP$"),  # possessive
+            (r"(my|Your|your|Yours|yours)$", "PRP$"),  # possessive
             (r"(on|On|in|In|at|At|since|Since)$", "IN"),  # time prepopsitions
             (r"(for|For|ago|Ago|before|Before)$", "IN"),  # time prepopsitions
             (r"(till|Till|until|Until)$", "IN"),  # time prepopsitions

--- a/nltk/parse/transitionparser.py
+++ b/nltk/parse/transitionparser.py
@@ -574,7 +574,7 @@ class TransitionParser(ParserI):
                 )
 
                 # It's best to use decision function as follow BUT it's not supported yet for sparse SVM
-                # Using decision funcion to build the votes array
+                # Using decision function to build the votes array
                 # dec_func = model.decision_function(x_test)[0]
                 # votes = {}
                 # k = 0

--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -1938,7 +1938,7 @@ class ConditionalFreqDist(defaultdict):
         :type conditions: list
         """
         try:
-            import matplotlib.pyplot as plt #import statment fix
+            import matplotlib.pyplot as plt #import statement fix
         except ImportError as e:
             raise ValueError(
                 "The plot function requires matplotlib to be installed."
@@ -2530,7 +2530,7 @@ def gt_demo():
     emma_words = corpus.gutenberg.words("austen-emma.txt")
     fd = FreqDist(emma_words)
     sgt = SimpleGoodTuringProbDist(fd)
-    print("%18s %8s  %14s" % ("word", "freqency", "SimpleGoodTuring"))
+    print("%18s %8s  %14s" % ("word", "frequency", "SimpleGoodTuring"))
     fd_keys_sorted = (
         key for key, value in sorted(fd.items(), key=lambda item: item[1], reverse=True)
     )

--- a/nltk/sem/cooper_storage.py
+++ b/nltk/sem/cooper_storage.py
@@ -95,7 +95,7 @@ def demo():
     sentence = "every girl chases a dog"
     # sentence = "a man gives a bone to every dog"
     print()
-    print("Analyis of sentence '%s'" % sentence)
+    print("Analysis of sentence '%s'" % sentence)
     print("=" * 50)
     trees = cs.parse_with_bindops(sentence, trace=0)
     for tree in trees:

--- a/nltk/sem/drt.py
+++ b/nltk/sem/drt.py
@@ -1088,7 +1088,7 @@ def resolve_anaphora(expression, trail=[]):
 class DrsDrawer:
     BUFFER = 3  # Space between elements
     TOPSPACE = 10  # Space above whole DRS
-    OUTERSPACE = 6  # Space to the left, right, and bottom of the whle DRS
+    OUTERSPACE = 6  # Space to the left, right, and bottom of the while DRS
 
     def __init__(self, drs, size_canvas=True, canvas=None):
         """

--- a/nltk/sem/evaluate.py
+++ b/nltk/sem/evaluate.py
@@ -252,7 +252,7 @@ class Assignment(dict):
     r"""
     A dictionary which represents an assignment of values to variables.
 
-    An assigment can only assign values from its domain.
+    An assignment can only assign values from its domain.
 
     If an unknown expression *a* is passed to a model *M*\ 's
     interpretation function *i*, *i* will first check whether *M*\ 's

--- a/nltk/sentiment/util.py
+++ b/nltk/sentiment/util.py
@@ -230,7 +230,7 @@ def mark_negation(document, double_neg_flip=False, shallow=False):
     :param document: a list of words/tokens, or a tuple (words, label).
     :param shallow: if True, the method will modify the original document in place.
     :param double_neg_flip: if True, double negation is considered affirmation
-        (we activate/deactivate negation scope everytime we find a negation).
+        (we activate/deactivate negation scope every time we find a negation).
     :return: if `shallow == True` the method will modify the original document
         and return it. If `shallow == False` the method will return a modified
         document, leaving the original unmodified.

--- a/nltk/stem/isri.py
+++ b/nltk/stem/isri.py
@@ -1,7 +1,7 @@
 #
 # Natural Language Toolkit: The ISRI Arabic Stemmer
 #
-# Copyright (C) 2001-2021 NLTK Proejct
+# Copyright (C) 2001-2021 NLTK Project
 # Algorithm: Kazem Taghva, Rania Elkhoury, and Jeffrey Coombs (2005)
 # Author: Hosam Algasaier <hosam_hme@yahoo.com>
 # URL: <http://nltk.org/>

--- a/nltk/stem/porter.py
+++ b/nltk/stem/porter.py
@@ -187,7 +187,7 @@ class PorterStemmer(StemmerI):
             else:
                 cv_sequence += "v"
 
-        # Count the number of 'vc' occurences, which is equivalent to
+        # Count the number of 'vc' occurrences, which is equivalent to
         # the number of 'VC' occurrences in Porter's reduced form in the
         # docstring above, which is in turn equivalent to `m`
         return cv_sequence.count("vc")

--- a/nltk/tag/__init__.py
+++ b/nltk/tag/__init__.py
@@ -126,7 +126,7 @@ def _pos_tag(tokens, tagset=None, tagger=None, lang=None):
                     for (token, tag) in tagged_tokens
                 ]
             elif lang == "rus":
-                # Note that the new Russion pos tags from the model contains suffixes,
+                # Note that the new Russian pos tags from the model contains suffixes,
                 # see https://github.com/nltk/nltk/issues/2151#issuecomment-430709018
                 tagged_tokens = [
                     (token, map_tag("ru-rnc-new", tagset, tag.partition("=")[0]))

--- a/nltk/tag/crf.py
+++ b/nltk/tag/crf.py
@@ -101,7 +101,7 @@ class CRFTagger(TaggerI):
              - Has Punctuation ?
              - Has Number ?
              - Suffixes up to length 3
-        Note that : we might include feature over previous word, next word ect.
+        Note that : we might include feature over previous word, next word etc.
 
         :return : a list which contains the features
         :rtype : list(str)

--- a/nltk/tag/hmm.py
+++ b/nltk/tag/hmm.py
@@ -221,7 +221,7 @@ class HiddenMarkovModelTagger(TaggerI):
         :param verbose: boolean flag indicating whether training should be
             verbose or include printed output
         :type verbose: bool
-        :param max_iterations: number of Baum-Welch interations to perform
+        :param max_iterations: number of Baum-Welch iterations to perform
         :type max_iterations: int
         """
         return cls._train(labeled_sequence, test_sequence, unlabeled_sequence, **kwargs)

--- a/nltk/tag/mapping.py
+++ b/nltk/tag/mapping.py
@@ -51,7 +51,7 @@ _UNIVERSAL_TAGS = (
 )
 
 # _MAPPINGS = defaultdict(lambda: defaultdict(dict))
-# the mapping between tagset T1 and T2 returns UNK if appied to an unrecognized tag
+# the mapping between tagset T1 and T2 returns UNK if applied to an unrecognized tag
 _MAPPINGS = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: "UNK")))
 
 

--- a/nltk/tag/sequential.py
+++ b/nltk/tag/sequential.py
@@ -524,7 +524,7 @@ class RegexpTagger(SequentialBackoffTagger):
     :type regexps: list(tuple(str, str))
     :param regexps: A list of ``(regexp, tag)`` pairs, each of
         which indicates that a word matching ``regexp`` should
-        be tagged with ``tag``.  The pairs will be evalutated in
+        be tagged with ``tag``.  The pairs will be evaluated in
         order.  If none of the regexps match a word, then the
         optional backoff tagger is invoked, else it is
         assigned the tag None.

--- a/nltk/tag/tnt.py
+++ b/nltk/tag/tnt.py
@@ -330,7 +330,7 @@ class TnT(TaggerI):
         of a particular tag
         """
 
-        # if this word marks the end of the sentance,
+        # if this word marks the end of the sentence,
         # return the most probable tag
         if sent == []:
             (h, logp) = current_states[0]
@@ -342,7 +342,7 @@ class TnT(TaggerI):
         new_states = []
 
         # if the Capitalisation is requested,
-        # initalise the flag for this word
+        # initialise the flag for this word
         C = False
         if self._C and word[0].isupper():
             C = True

--- a/nltk/test/childes.doctest
+++ b/nltk/test/childes.doctest
@@ -114,14 +114,14 @@ POS tags in the CHILDES are automatically assigned by MOR and POST programs
     ('a', 'det'), ('month', 'n'), ('ago', 'adv')]]
 
 When the argument *stem* is true, the word stems (e.g., 'is' -> 'be-3PS') are
-used instread of the original words.
+used instead of the original words.
 
     >>> valian.words('Valian/01a.xml')[:30]
     ['at', 'Parent', "Lastname's", 'house', 'with', 'Child', 'Lastname', 'and', 'it', 'is', ...
     >>> valian.words('Valian/01a.xml',stem=True)[:30]
     ['at', 'Parent', 'Lastname', 's', 'house', 'with', 'Child', 'Lastname', 'and', 'it', 'be-3S', ...
 
-When the argument *replace* is true, the replaced words are used instread of
+When the argument *replace* is true, the replaced words are used instead of
 the original words.
 
     >>> valian.words('Valian/01a.xml',speaker='CHI')[247]

--- a/nltk/test/corpus.doctest
+++ b/nltk/test/corpus.doctest
@@ -396,7 +396,7 @@ examples illustrate the use of the wordlist corpora:
     >>> names.words('female.txt')
     ['Abagael', 'Abagail', 'Abbe', 'Abbey', 'Abbi', 'Abbie', ...]
 
-The CMU Pronunciation Dictionary corpus contains pronounciation
+The CMU Pronunciation Dictionary corpus contains pronunciation
 transcriptions for over 100,000 words.  It can be accessed as a list
 of entries (where each entry consists of a word, an identifier, and a
 transcription) or as a dictionary from words to lists of

--- a/nltk/test/featstruct.doctest
+++ b/nltk/test/featstruct.doctest
@@ -261,7 +261,7 @@ used to combine sets & tuples:
     [x=(1, 2, 3, 4, 5), z=(3, 4, 5)]
 
 Thus, feature value tuples and sets can be used to build up tuples
-and sets of values over the corse of unification.  For example, when
+and sets of values over the course of unification.  For example, when
 parsing sentences using a semantic feature grammar, feature sets or
 feature tuples can be used to build a list of semantic predicates as
 the sentence is parsed.

--- a/nltk/test/framenet.doctest
+++ b/nltk/test/framenet.doctest
@@ -115,7 +115,7 @@ detailed information about the Frame. See the documentation on the
 
 You can also search for Frames by their Lexical Units (LUs). The
 `frames_by_lemma()` function returns a list of all frames that contain
-LUs in which the 'name' attribute of the LU matchs the given regular
+LUs in which the 'name' attribute of the LU matches the given regular
 expression. Note that LU names are composed of "lemma.POS", where the
 "lemma" part can be made up of either a single lexeme (e.g. 'run') or
 multiple lexemes (e.g. 'a little') (see below).
@@ -207,7 +207,7 @@ You can obtain detailed information on a particular LU by calling the
     'foresee'
 
 Note that LU names take the form of a dotted string (e.g. "run.v" or "a
-little.adv") in which a lemma preceeds the "." and a part of speech
+little.adv") in which a lemma precedes the "." and a part of speech
 (POS) follows the dot. The lemma may be composed of a single lexeme
 (e.g. "run") or of multiple lexemes (e.g. "a little"). The list of
 POSs used in the LUs is:

--- a/nltk/test/meteor.doctest
+++ b/nltk/test/meteor.doctest
@@ -7,7 +7,7 @@
 METEOR tests
 =============
 
-No Allignment test
+No Alignment test
 ------------------
 
     >>> from nltk.translate import meteor

--- a/nltk/test/propbank.doctest
+++ b/nltk/test/propbank.doctest
@@ -161,7 +161,7 @@ at 9353:
     >>> print(inst.predicate.select(inst.tree))
     Traceback (most recent call last):
       . . .
-    ValueError: Parse tree not avaialable
+    ValueError: Parse tree not available
 
 However, if you supply your own version of the treebank corpus (by
 putting it before the nltk-provided version on `nltk.data.path`, or

--- a/nltk/test/toolbox.doctest
+++ b/nltk/test/toolbox.doctest
@@ -66,7 +66,7 @@ Unit test cases for ``toolbox``
     >>> line_nums
     [2, 5, 7]
 
-``StandardFormat.line_num`` doesn't exist before openning or after closing
+``StandardFormat.line_num`` doesn't exist before opening or after closing
 a file or string:
 
     >>> f = toolbox.StandardFormat()

--- a/nltk/test/tree.doctest
+++ b/nltk/test/tree.doctest
@@ -383,7 +383,7 @@ Parented Tree Methods
 ------------------------
 In addition to all the methods defined by the `Tree` class, the
 `ParentedTree` class adds six new methods whose values are
-automatically updated whenver a parented tree is modified: `parent()`,
+automatically updated whenever a parented tree is modified: `parent()`,
 `parent_index()`, `left_sibling()`, `right_sibling()`, `root()`, and
 `treeposition()`.
 
@@ -542,7 +542,7 @@ variable:
 
     >>> all_ptrees = []
 
-Define a helper funciton to create new parented trees:
+Define a helper function to create new parented trees:
 
     >>> def make_ptree(s):
     ...     ptree = ParentedTree.convert(Tree.fromstring(s))
@@ -826,7 +826,7 @@ variable:
 
     >>> all_mptrees = []
 
-Define a helper funciton to create new parented trees:
+Define a helper function to create new parented trees:
 
     >>> def make_mptree(s):
     ...     mptree = MultiParentedTree.convert(Tree.fromstring(s))

--- a/nltk/test/twitter.ipynb
+++ b/nltk/test/twitter.ipynb
@@ -2,13 +2,14 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# Twitter HOWTO"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Overview\n",
     "\n",
@@ -67,11 +68,11 @@
     "   One important thing to remember is that you need to keep your `credentials.txt` file          private. So do **not** share your `twitter-files` folder with anyone else, and do **not**      upload it to a public repository such as GitHub.\n",
     "\n",
     "3. Finally, read through Twitter's [Developer Rules of the Road](https://dev.twitter.com/overview/terms/policy). As far as these rules are concerned, you count as both the application developer and the user."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### <a name=\"twython\">Install Twython</a>\n",
     "\n",
@@ -86,19 +87,19 @@
     "$ easy_install twython\n",
     "```\n",
     "We're now ready to get started. The next section will describe how to use the `Twitter` class to talk to the Twitter API."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "*More detail*:\n",
     "Twitter offers are two main authentication options. OAuth 1 is for user-authenticated API calls, and allows sending status updates, direct messages, etc, whereas OAuth 2 is for application-authenticated calls, where read-only access is sufficient. Although OAuth 2 sounds more appropriate for the kind of tasks envisaged within NLTK, it turns out that access to Twitter's Streaming API requires OAuth 1, which is why it's necessary to obtain *Read and Write* access for your application."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## <a name=\"simple\">Using the simple `Twitter` class</a>\n",
     "\n",
@@ -107,21 +108,19 @@
     "The `Twitter` class is intended as a simple means of interacting with the Twitter data stream. Later on, we'll look at other methods which give more fine-grained control. \n",
     "\n",
     "The Twitter live public stream is a sample (approximately 1%) of all Tweets that are currently being published by users. They can be on any topic and in any language. In your request, you can give keywords which will narrow down the Tweets that get delivered to you. Our first example looks for Tweets which include either the word *love* or *hate*. We limit the call to finding 10 tweets. When you run this code, it will definitely produce different results from those shown below!"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "source": [
-    "from nltk.twitter import Twitter\r\n",
-    "tw = Twitter()\r\n",
-    "tw.tweets(keywords='love, hate', limit=10) #sample from the public stream"
-   ],
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Sana magkakaisa na ang mga Kapamilya at Kapuso.  Spread love, not hate\n",
       " #ShowtimeKapamiIyaDay #ALDubEBforLOVE\n",
@@ -139,31 +138,31 @@
      ]
     }
    ],
-   "metadata": {
-    "collapsed": false,
-    "scrolled": true
-   }
+   "source": [
+    "from nltk.twitter import Twitter\n",
+    "tw = Twitter()\n",
+    "tw.tweets(keywords='love, hate', limit=10) #sample from the public stream"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "The next example filters the live public stream by looking for specific user accounts. In this case, we 'follow' two news organisations, namely `@CNN` and `@BBCNews`. [As advised by Twitter](https://dev.twitter.com/streaming/reference/post/statuses/filter), we use *numeric userIDs* for these accounts. If you run this code yourself, you'll see that Tweets are arriving much more slowly than in the previous example. This is because even big new organisations don't publish Tweets that often.\n",
     "\n",
     "A bit later we will show you how to use Python to convert usernames such as `@CNN` to userIDs such as `759251`, but for now you might find it simpler to use a web service like [TweeterID](http://tweeterid.com) if you want to experiment with following different accounts than the ones shown below."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "source": [
-    "tw = Twitter()\n",
-    "tw.tweets(follow=['759251', '612473'], limit=10) # see what CNN and BBC are talking about"
-   ],
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "RT @CNN: Sunday's #supermoon #eclipse has some excited, but for others, it's an ominous \"blood moon.\" http://t.co/2B1wdQru0q http://t.co/Aw…\n",
       "RT @CNN: Sunday's #supermoon #eclipse has some excited, but for others, it's an ominous \"blood moon.\" http://t.co/2B1wdQru0q http://t.co/Aw…\n",
@@ -179,59 +178,61 @@
      ]
     }
    ],
-   "metadata": {
-    "collapsed": false
-   }
+   "source": [
+    "tw = Twitter()\n",
+    "tw.tweets(follow=['759251', '612473'], limit=10) # see what CNN and BBC are talking about"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Saving Tweets to a File\n",
     "\n",
     "By default, the `Twitter` class will just print out Tweets to your computer terminal. Although it's fun to view the Twitter stream zipping by on your screen, you'll probably want to save some tweets in a file. We can tell the `tweets()` method to save to a file by setting the flag `to_screen` to `False`. \n",
     "\n",
     "The `Twitter` class will look at the value of your environmental variable `TWITTER` to determine which folder to use to save the tweets, and it will put them in a date-stamped file with the prefix `tweets`. "
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "source": [
-    "tw = Twitter()\n",
-    "tw.tweets(to_screen=False, limit=25)"
-   ],
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Writing to /Users/ewan/twitter-files/tweets.20150926-154251.json\n",
       "Written 25 Tweets\n"
      ]
     }
    ],
-   "metadata": {
-    "collapsed": false
-   }
+   "source": [
+    "tw = Twitter()\n",
+    "tw.tweets(to_screen=False, limit=25)"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "So far, we've been taking data from the live public stream. However, it's also possible to retrieve past tweets, for example by searching for specific keywords, and setting `stream=False`:"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "source": [
-    "tw.tweets(keywords='hilary clinton', stream=False, limit=10)"
-   ],
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "“Girls” Creator Lena Dunham Interviews Hilary Clinton About… Lenny Kravitz’s Junk [Video] http://t.co/eY4GgKS3ak\n",
       "“Girls” Creator Lena Dunham Interviews Hilary Clinton About… Lenny Kravitz’s Junk [Video] http://t.co/Pflf7A6Tr6\n",
@@ -252,69 +253,65 @@
      ]
     }
    ],
-   "metadata": {
-    "collapsed": false,
-    "scrolled": true
-   }
+   "source": [
+    "tw.tweets(keywords='hilary clinton', stream=False, limit=10)"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## <a name=\"onwards\">Onwards and Upwards</a>\n",
     "\n",
     "In this section, we'll look at how to get more fine-grained control over processing Tweets. To start off, we will import a bunch of stuff from the `twitter` package."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "source": [
-    "from nltk.twitter import Query, Streamer, Twitter, TweetViewer, TweetWriter, credsfromfile"
-   ],
-   "outputs": [],
    "metadata": {
     "collapsed": true
-   }
+   },
+   "outputs": [],
+   "source": [
+    "from nltk.twitter import Query, Streamer, Twitter, TweetViewer, TweetWriter, credsfromfile"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "In the following example, you'll see the line\n",
     "``` python\n",
     "oauth = credsfromfile()\n",
     "```\n",
     "This gets hold of your stored API key information. The function `credsfromfile()` by default looks for a file called `credentials.txt` in the directory set by the environment variable `TWITTER`, reads the contents and returns the result as a dictionary. We then pass this dictionary as an argument when initializing our client code. We'll be using two classes to wrap the clients: `Streamer` and `Query`; the first of these calls [the Streaming API](https://dev.twitter.com/streaming/overview) and the second calls Twitter's [Search API](https://dev.twitter.com/rest/public) (also called the REST API). "
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "*More detail*: For more detail, see this blog post on [The difference between the Twitter Firehose API, the Twitter Search API, and the Twitter Streaming API](http://www.brightplanet.com/2013/06/twitter-firehose-vs-twitter-api-whats-the-difference-and-why-should-you-care/)\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "After initializing a client, we call the `register()` method to specify whether we want to view the data on a terminal or write it to a file. Finally, we call a method which determines the API endpoint to address; in this case, we use `sample()` to get a random sample from the the Streaming API."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 27,
-   "source": [
-    "oauth = credsfromfile()\n",
-    "client = Streamer(**oauth)\n",
-    "client.register(TweetViewer(limit=10))\n",
-    "client.sample()"
-   ],
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "RT @EPVLatino: ¿Y entonces? El gobierno sigue importando carros mientras las plantas Chery los tiene acumulados http://t.co/bBhrawqHe7\n",
       "RT @AbrahamMateoMus: . @menudanochetv aquí se suman nuestros Abrahamers MEXICAN@S!! 👏 \n",
@@ -333,29 +330,31 @@
      ]
     }
    ],
-   "metadata": {
-    "collapsed": false
-   }
+   "source": [
+    "oauth = credsfromfile()\n",
+    "client = Streamer(**oauth)\n",
+    "client.register(TweetViewer(limit=10))\n",
+    "client.sample()"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "The next example is similar, except that we call the `filter()` method with the `track` parameter followed by a string literal. The string is interpreted as a list of search terms where [comma indicates a logical OR](https://dev.twitter.com/streaming/overview/request-parameters#track). The terms are treated as case-insensitive."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 30,
-   "source": [
-    "client = Streamer(**oauth)\n",
-    "client.register(TweetViewer(limit=10))\n",
-    "client.filter(track='refugee, germany')"
-   ],
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "European countries at heart of refugee crisis seek to ease tensions: Hungary announces removal of razor wire f... http://t.co/PavCKddtY2\n",
       "RT @onlinewweman: Germany told students to wear \"modest clothing\" bc they don't want the refugees to have \"misunderstandings.\" That's a wei…\n",
@@ -371,34 +370,31 @@
      ]
     }
    ],
-   "metadata": {
-    "collapsed": false,
-    "scrolled": true
-   }
+   "source": [
+    "client = Streamer(**oauth)\n",
+    "client.register(TweetViewer(limit=10))\n",
+    "client.filter(track='refugee, germany')"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Whereas the Streaming API lets us access near real-time Twitter data, the Search API lets us query for past Tweets. In the following example, the value `tweets` returned by `search_tweets()` is a generator; the expression `next(tweets)` gives us the first Tweet from the generator. \n",
     "\n",
     "Although Twitter delivers Tweets as [JSON](http://www.json.org) objects, the Python client encodes them as dictionaries, and the example pretty-prints a portion of the dictionary corresponding the Tweet in question."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 31,
-   "source": [
-    "client = Query(**oauth)\n",
-    "tweets = client.search_tweets(keywords='nltk', limit=10)\n",
-    "tweet = next(tweets)\n",
-    "from pprint import pprint\n",
-    "pprint(tweet, depth=1)"
-   ],
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "{'contributors': None,\n",
       " 'coordinates': None,\n",
@@ -428,30 +424,33 @@
      ]
     }
    ],
-   "metadata": {
-    "collapsed": false
-   }
+   "source": [
+    "client = Query(**oauth)\n",
+    "tweets = client.search_tweets(keywords='nltk', limit=10)\n",
+    "tweet = next(tweets)\n",
+    "from pprint import pprint\n",
+    "pprint(tweet, depth=1)"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Twitter's own documentation [provides a useful overview of all the fields in the JSON object](https://dev.twitter.com/overview/api/tweets) and it may be helpful to look at this [visual map of a Tweet object](http://www.scribd.com/doc/30146338/map-of-a-tweet).\n",
     "\n",
     "Since each Tweet is converted into a Python dictionary, it's straightforward to just show a selected field, such as the value of the `'text'` key."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 32,
-   "source": [
-    "for tweet in tweets:\n",
-    "    print(tweet['text'])"
-   ],
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Slammer an immigration lawyer seattle wa protection if purusha this morning polaric deportation?: Nltk\n",
       "Python Text Processing with NLTK 2.0 Cookbook / Jacob Perkins\n",
@@ -468,55 +467,49 @@
      ]
     }
    ],
-   "metadata": {
-    "collapsed": false
-   }
+   "source": [
+    "for tweet in tweets:\n",
+    "    print(tweet['text'])"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 11,
-   "source": [
-    "client = Query(**oauth)\n",
-    "client.register(TweetWriter())\n",
-    "client.user_tweets('timoreilly', 10)"
-   ],
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Writing to /Users/ewan/twitter-files/tweets.20150926-154337.json\n"
      ]
     }
    ],
-   "metadata": {
-    "collapsed": false
-   }
+   "source": [
+    "client = Query(**oauth)\n",
+    "client.register(TweetWriter())\n",
+    "client.user_tweets('timoreilly', 10)"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Given a list of user IDs, the following example shows how to retrieve the screen name and other information about the users."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 12,
-   "source": [
-    "userids = ['759251', '612473', '15108702', '6017542', '2673523800']\n",
-    "client = Query(**oauth)\n",
-    "user_info = client.user_info_from_id(userids)\n",
-    "for info in user_info:\n",
-    "    name = info['screen_name']\n",
-    "    followers = info['followers_count']\n",
-    "    following = info['friends_count']\n",
-    "    print(\"{}, followers: {}, following: {}\".format(name, followers, following))"
-   ],
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "CNN, followers: 19806095, following: 1102\n",
       "BBCNews, followers: 4935491, following: 105\n",
@@ -526,29 +519,34 @@
      ]
     }
    ],
-   "metadata": {
-    "collapsed": false
-   }
+   "source": [
+    "userids = ['759251', '612473', '15108702', '6017542', '2673523800']\n",
+    "client = Query(**oauth)\n",
+    "user_info = client.user_info_from_id(userids)\n",
+    "for info in user_info:\n",
+    "    name = info['screen_name']\n",
+    "    followers = info['followers_count']\n",
+    "    following = info['friends_count']\n",
+    "    print(\"{}, followers: {}, following: {}\".format(name, followers, following))"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "A list of user IDs can also be used as input to the Streaming API client."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 13,
-   "source": [
-    "client = Streamer(**oauth)\r\n",
-    "client.register(TweetViewer(limit=10))\r\n",
-    "client.statuses.filter(follow=userids)"
-   ],
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "RT @CNN: Sunday's #supermoon #eclipse has some excited, but for others, it's an ominous \"blood moon.\" http://t.co/2B1wdQru0q http://t.co/Aw…\n",
       "RT @bbcweather: Cameras at the ready for #supermoon #eclipse on 27/28th Sept, next one won't be until 2033! http://t.co/SPucnmBqaD http://t…\n",
@@ -565,107 +563,108 @@
      ]
     }
    ],
-   "metadata": {
-    "collapsed": false
-   }
+   "source": [
+    "client = Streamer(**oauth)\n",
+    "client.register(TweetViewer(limit=10))\n",
+    "client.statuses.filter(follow=userids)"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "To store data that Twitter sents by the Streaming API, we register a `TweetWriter` instance."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 14,
-   "source": [
-    "client = Streamer(**oauth)\r\n",
-    "client.register(TweetWriter(limit=10))\r\n",
-    "client.statuses.sample()"
-   ],
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Writing to /Users/ewan/twitter-files/tweets.20150926-154408.json\n",
       "Written 10 Tweets\n"
      ]
     }
    ],
-   "metadata": {
-    "collapsed": false
-   }
-  },
-  {
-   "cell_type": "markdown",
    "source": [
-    "Here's the full signature of the `Tweetwriter`'s `__init__()` method:\r\n",
-    "```python\r\n",
-    "def __init__(self, limit=2000, upper_date_limit=None, lower_date_limit=None,\r\n",
-    "                 fprefix='tweets', subdir='twitter-files', repeat=False,\r\n",
-    "                 gzip_compress=False):                \r\n",
-    "```\r\n",
-    "If the `repeat` parameter is set to `True`, then the writer will write up to the value of `limit` in file `file1`, then open a new file `file2` and write to it until the limit is reached, and so on indefinitely. The parameter `gzip_compress` can be used to compress the files once they have been written."
-   ],
-   "metadata": {}
+    "client = Streamer(**oauth)\n",
+    "client.register(TweetWriter(limit=10))\n",
+    "client.statuses.sample()"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here's the full signature of the `Tweetwriter`'s `__init__()` method:\n",
+    "```python\n",
+    "def __init__(self, limit=2000, upper_date_limit=None, lower_date_limit=None,\n",
+    "                 fprefix='tweets', subdir='twitter-files', repeat=False,\n",
+    "                 gzip_compress=False):                \n",
+    "```\n",
+    "If the `repeat` parameter is set to `True`, then the writer will write up to the value of `limit` in file `file1`, then open a new file `file2` and write to it until the limit is reached, and so on indefinitely. The parameter `gzip_compress` can be used to compress the files once they have been written."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## <a name=\"corpus_reader\">Using a Tweet Corpus</a>\n",
     "\n",
     "NLTK's Twitter corpus currently contains a sample of 20k Tweets (named '`twitter_samples`')\n",
     "retrieved from the Twitter Streaming API, together with another 10k which are divided according to sentiment into negative and positive."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 15,
-   "source": [
-    "from nltk.corpus import twitter_samples\r\n",
-    "twitter_samples.fileids()"
-   ],
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "['negative_tweets.json', 'positive_tweets.json', 'tweets.20150430-223406.json']"
       ]
      },
+     "execution_count": 15,
      "metadata": {},
-     "execution_count": 15
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {
-    "collapsed": false
-   }
+   "source": [
+    "from nltk.corpus import twitter_samples\n",
+    "twitter_samples.fileids()"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "We follow standard practice in storing full Tweets as line-separated\n",
     "JSON. These data structures can be accessed via `tweets.docs()`. However, in general it\n",
     "is more practical to focus just on the text field of the Tweets, which\n",
     "are accessed via the `strings()` method."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 16,
-   "source": [
-    "strings = twitter_samples.strings('tweets.20150430-223406.json')\r\n",
-    "for string in strings[:15]:\r\n",
-    "    print(string)"
-   ],
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "RT @KirkKus: Indirect cost of the UK being in the EU is estimated to be costing Britain £170 billion per year! #BetterOffOut #UKIP\n",
       "VIDEO: Sturgeon on post-election deals http://t.co/BTJwrpbmOY\n",
@@ -685,31 +684,30 @@
      ]
     }
    ],
-   "metadata": {
-    "collapsed": false,
-    "scrolled": true
-   }
+   "source": [
+    "strings = twitter_samples.strings('tweets.20150430-223406.json')\n",
+    "for string in strings[:15]:\n",
+    "    print(string)"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "The default tokenizer for Tweets (`casual.py`) is specialised for 'casual' text, and\n",
     "the `tokenized()` method returns a list of lists of tokens."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 17,
-   "source": [
-    "tokenized = twitter_samples.tokenized('tweets.20150430-223406.json')\r\n",
-    "for toks in tokenized[:5]:\r\n",
-    "    print(toks)"
-   ],
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "['RT', '@KirkKus', ':', 'Indirect', 'cost', 'of', 'the', 'UK', 'being', 'in', 'the', 'EU', 'is', 'estimated', 'to', 'be', 'costing', 'Britain', '£', '170', 'billion', 'per', 'year', '!', '#BetterOffOut', '#UKIP']\n",
       "['VIDEO', ':', 'Sturgeon', 'on', 'post-election', 'deals', 'http://t.co/BTJwrpbmOY']\n",
@@ -719,57 +717,60 @@
      ]
     }
    ],
-   "metadata": {
-    "collapsed": false
-   }
+   "source": [
+    "tokenized = twitter_samples.tokenized('tweets.20150430-223406.json')\n",
+    "for toks in tokenized[:5]:\n",
+    "    print(toks)"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false
+   },
    "source": [
     "### Extracting Parts of a Tweet\n",
     "\n",
     "If we want to carry out other kinds of analysis on Tweets, we have to work directly with the file rather than via the corpus reader. For demonstration purposes, we will use the same file as the one in the preceding section, namely  `tweets.20150430-223406.json`. The `abspath()` method of the corpus gives us the full pathname of the relevant file. If your NLTK data is installed in the default location on a Unix-like system, this pathname will be `'/usr/share/nltk_data/corpora/twitter_samples/tweets.20150430-223406.json'`."
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "source": [
-    "from nltk.corpus import twitter_samples\r\n",
-    "input_file = twitter_samples.abspath(\"tweets.20150430-223406.json\")"
-   ],
-   "outputs": [],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "outputs": [],
+   "source": [
+    "from nltk.corpus import twitter_samples\n",
+    "input_file = twitter_samples.abspath(\"tweets.20150430-223406.json\")"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "The function `json2csv()` takes as input a file-like object consisting of Tweets as line-delimited JSON objects and returns a file in CSV format. The third parameter of the function lists the fields that we want to extract from the JSON. One of the simplest examples is to extract just the text of the Tweets (though of course it would have been even simpler to use the `strings()` method of the corpus reader)."
-   ],
    "metadata": {
     "collapsed": true
-   }
+   },
+   "source": [
+    "The function `json2csv()` takes as input a file-like object consisting of Tweets as line-delimited JSON objects and returns a file in CSV format. The third parameter of the function lists the fields that we want to extract from the JSON. One of the simplest examples is to extract just the text of the Tweets (though of course it would have been even simpler to use the `strings()` method of the corpus reader)."
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "source": [
-    "from nltk.twitter.common import json2csv\r\n",
-    "with open(input_file) as fp:\r\n",
-    "    json2csv(fp, 'tweets_text.csv', ['text'])"
-   ],
-   "outputs": [],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "outputs": [],
+   "source": [
+    "from nltk.twitter.common import json2csv\n",
+    "with open(input_file) as fp:\n",
+    "    json2csv(fp, 'tweets_text.csv', ['text'])"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "We've passed the filename `'tweets_text.csv'` as the second argument of `json2csv()`. Unless you provide a complete pathname, the file will be created in the directory where you are currently executing Python.\n",
     "\n",
@@ -782,44 +783,42 @@
     "RT @GregLauder: the UKIP east lothian candidate looks about 16 and still has an msn addy http://t.co/7eIU0c5Fm1\n",
     "RT @thesundaypeople: UKIP's housing spokesman rakes in £800k in housing benefit from migrants.  http://t.co/GVwb9Rcb4w http://t.co/c1AZxcLh…\n",
     "```"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "However, in some applications you may want to work with Tweet metadata, e.g., the creation date and the user. As mentioned earlier, all the fields of a Tweet object are described in [the official Twitter API](https://dev.twitter.com/overview/api/tweets). \n",
     "\n",
     "The third argument of `json2csv()` can specified so that the function selects relevant parts of the metadata. For example, the following will generate a CSV file including most of the metadata together with the id of the user who has published it."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "source": [
-    "with open(input_file) as fp:\r\n",
-    "    json2csv(fp, 'tweets.20150430-223406.tweet.csv',\r\n",
-    "            ['created_at', 'favorite_count', 'id', 'in_reply_to_status_id', \r\n",
-    "            'in_reply_to_user_id', 'retweet_count', 'retweeted', \r\n",
-    "            'text', 'truncated', 'user.id'])"
-   ],
-   "outputs": [],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "outputs": [],
+   "source": [
+    "with open(input_file) as fp:\n",
+    "    json2csv(fp, 'tweets.20150430-223406.tweet.csv',\n",
+    "            ['created_at', 'favorite_count', 'id', 'in_reply_to_status_id', \n",
+    "            'in_reply_to_user_id', 'retweet_count', 'retweeted', \n",
+    "            'text', 'truncated', 'user.id'])"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "source": [
-    "for line in open('tweets.20150430-223406.tweet.csv').readlines()[:5]:\r\n",
-    "    print(line)"
-   ],
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "created_at,favorite_count,id,in_reply_to_status_id,in_reply_to_user_id,retweet_count,retweeted,text,truncated,user.id\n",
       "\n",
@@ -834,146 +833,103 @@
      ]
     }
    ],
-   "metadata": {
-    "collapsed": false
-   }
+   "source": [
+    "for line in open('tweets.20150430-223406.tweet.csv').readlines()[:5]:\n",
+    "    print(line)"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "The first nine elements of the list are attributes of the Tweet, while the last one, `user.id`, takes the user object associated with the Tweet, and retrieves the attributes in the list (in this case only the id). The object for the Twitter user is described in the  [Twitter API for users](https://dev.twitter.com/overview/api/users)."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "The rest of the metadata of the Tweet are the so-called [entities](https://dev.twitter.com/overview/api/entities) and [places](https://dev.twitter.com/overview/api/places). The following examples show how to get each of those entities. They all include the id of the Tweet as the first argument, and some of them include also the text for clarity."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 22,
-   "source": [
-    "from nltk.twitter.common import json2csv_entities\r\n",
-    "with open(input_file) as fp:\r\n",
-    "    json2csv_entities(fp, 'tweets.20150430-223406.hashtags.csv',\r\n",
-    "                        ['id', 'text'], 'hashtags', ['text'])\r\n",
-    "    \r\n",
-    "with open(input_file) as fp:\r\n",
-    "    json2csv_entities(fp, 'tweets.20150430-223406.user_mentions.csv',\r\n",
-    "                        ['id', 'text'], 'user_mentions', ['id', 'screen_name'])\r\n",
-    "    \r\n",
-    "with open(input_file) as fp:\r\n",
-    "    json2csv_entities(fp, 'tweets.20150430-223406.media.csv',\r\n",
-    "                        ['id'], 'media', ['media_url', 'url'])\r\n",
-    "    \r\n",
-    "with open(input_file) as fp:\r\n",
-    "    json2csv_entities(fp, 'tweets.20150430-223406.urls.csv',\r\n",
-    "                        ['id'], 'urls', ['url', 'expanded_url'])\r\n",
-    "    \r\n",
-    "with open(input_file) as fp:\r\n",
-    "    json2csv_entities(fp, 'tweets.20150430-223406.place.csv',\r\n",
-    "                        ['id', 'text'], 'place', ['name', 'country'])\r\n",
-    "\r\n",
-    "with open(input_file) as fp:\r\n",
-    "    json2csv_entities(fp, 'tweets.20150430-223406.place_bounding_box.csv',\r\n",
-    "                        ['id', 'name'], 'place.bounding_box', ['coordinates'])"
-   ],
-   "outputs": [],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "outputs": [],
+   "source": [
+    "from nltk.twitter.common import json2csv_entities\n",
+    "with open(input_file) as fp:\n",
+    "    json2csv_entities(fp, 'tweets.20150430-223406.hashtags.csv',\n",
+    "                        ['id', 'text'], 'hashtags', ['text'])\n",
+    "    \n",
+    "with open(input_file) as fp:\n",
+    "    json2csv_entities(fp, 'tweets.20150430-223406.user_mentions.csv',\n",
+    "                        ['id', 'text'], 'user_mentions', ['id', 'screen_name'])\n",
+    "    \n",
+    "with open(input_file) as fp:\n",
+    "    json2csv_entities(fp, 'tweets.20150430-223406.media.csv',\n",
+    "                        ['id'], 'media', ['media_url', 'url'])\n",
+    "    \n",
+    "with open(input_file) as fp:\n",
+    "    json2csv_entities(fp, 'tweets.20150430-223406.urls.csv',\n",
+    "                        ['id'], 'urls', ['url', 'expanded_url'])\n",
+    "    \n",
+    "with open(input_file) as fp:\n",
+    "    json2csv_entities(fp, 'tweets.20150430-223406.place.csv',\n",
+    "                        ['id', 'text'], 'place', ['name', 'country'])\n",
+    "\n",
+    "with open(input_file) as fp:\n",
+    "    json2csv_entities(fp, 'tweets.20150430-223406.place_bounding_box.csv',\n",
+    "                        ['id', 'name'], 'place.bounding_box', ['coordinates'])"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Additionally, when a Tweet is actually a retweet, the original tweet can be also fetched from the same file, as follows:"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 23,
-   "source": [
-    "with open(input_file) as fp:\r\n",
-    "    json2csv_entities(fp, 'tweets.20150430-223406.original_tweets.csv',\r\n",
-    "                        ['id'], 'retweeted_status', ['created_at', 'favorite_count', \r\n",
-    "                        'id', 'in_reply_to_status_id', 'in_reply_to_user_id', 'retweet_count',\r\n",
-    "                        'text', 'truncated', 'user.id'])"
-   ],
-   "outputs": [],
    "metadata": {
     "collapsed": false
-   }
+   },
+   "outputs": [],
+   "source": [
+    "with open(input_file) as fp:\n",
+    "    json2csv_entities(fp, 'tweets.20150430-223406.original_tweets.csv',\n",
+    "                        ['id'], 'retweeted_status', ['created_at', 'favorite_count', \n",
+    "                        'id', 'in_reply_to_status_id', 'in_reply_to_user_id', 'retweet_count',\n",
+    "                        'text', 'truncated', 'user.id'])"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
-    "Here the first id corresponds to the retweeted Tweet, and the second id to the original Tweet.\r\n",
-    "\r\n",
-    "### Using Dataframes\r\n",
-    "\r\n",
-    "Sometimes it's convenient to manipulate CSV files as tabular data, and this is made easy with the [Pandas](http://pandas.pydata.org/) data analysis library. `pandas` is not currently one of the dependencies of NLTK, and you will probably have to install it specially.\r\n",
-    "\r\n",
+    "Here the first id corresponds to the retweeted Tweet, and the second id to the original Tweet.\n",
+    "\n",
+    "### Using Dataframes\n",
+    "\n",
+    "Sometimes it's convenient to manipulate CSV files as tabular data, and this is made easy with the [Pandas](http://pandas.pydata.org/) data analysis library. `pandas` is not currently one of the dependencies of NLTK, and you will probably have to install it specially.\n",
+    "\n",
     "Here is an example of how to read a CSV file into a `pandas` dataframe. We use the `head()` method of a dataframe to just show the first 5 rows."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 24,
-   "source": [
-    "import pandas as pd\r\n",
-    "tweets = pd.read_csv('tweets.20150430-223406.tweet.csv', index_col=2, header=0, encoding=\"utf8\")\r\n",
-    "tweets.head(5)"
-   ],
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
-      "text/plain": [
-       "                                        created_at  favorite_count  \\\n",
-       "id                                                                   \n",
-       "593891099434983425  Thu Apr 30 21:34:06 +0000 2015               0   \n",
-       "593891099548094465  Thu Apr 30 21:34:06 +0000 2015               0   \n",
-       "593891099388846080  Thu Apr 30 21:34:06 +0000 2015               0   \n",
-       "593891100429045760  Thu Apr 30 21:34:06 +0000 2015               0   \n",
-       "593891100768784384  Thu Apr 30 21:34:07 +0000 2015               0   \n",
-       "\n",
-       "                    in_reply_to_status_id  in_reply_to_user_id  retweet_count  \\\n",
-       "id                                                                              \n",
-       "593891099434983425                    NaN                  NaN              0   \n",
-       "593891099548094465                    NaN                  NaN              0   \n",
-       "593891099388846080                    NaN                  NaN              0   \n",
-       "593891100429045760                    NaN                  NaN              0   \n",
-       "593891100768784384                    NaN                  NaN              0   \n",
-       "\n",
-       "                   retweeted  \\\n",
-       "id                             \n",
-       "593891099434983425     False   \n",
-       "593891099548094465     False   \n",
-       "593891099388846080     False   \n",
-       "593891100429045760     False   \n",
-       "593891100768784384     False   \n",
-       "\n",
-       "                                                                 text  \\\n",
-       "id                                                                      \n",
-       "593891099434983425  RT @KirkKus: Indirect cost of the UK being in ...   \n",
-       "593891099548094465  VIDEO: Sturgeon on post-election deals http://...   \n",
-       "593891099388846080  RT @LabourEoin: The economy was growing 3 time...   \n",
-       "593891100429045760  RT @GregLauder: the UKIP east lothian candidat...   \n",
-       "593891100768784384  RT @thesundaypeople: UKIP's housing spokesman ...   \n",
-       "\n",
-       "                   truncated     user.id  \n",
-       "id                                        \n",
-       "593891099434983425     False   107794703  \n",
-       "593891099548094465     False   557422508  \n",
-       "593891099388846080     False  3006692193  \n",
-       "593891100429045760     False   455154030  \n",
-       "593891100768784384     False   187547338  "
-      ],
       "text/html": [
        "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
@@ -1067,32 +1023,75 @@
        "  </tbody>\n",
        "</table>\n",
        "</div>"
+      ],
+      "text/plain": [
+       "                                        created_at  favorite_count  \\\n",
+       "id                                                                   \n",
+       "593891099434983425  Thu Apr 30 21:34:06 +0000 2015               0   \n",
+       "593891099548094465  Thu Apr 30 21:34:06 +0000 2015               0   \n",
+       "593891099388846080  Thu Apr 30 21:34:06 +0000 2015               0   \n",
+       "593891100429045760  Thu Apr 30 21:34:06 +0000 2015               0   \n",
+       "593891100768784384  Thu Apr 30 21:34:07 +0000 2015               0   \n",
+       "\n",
+       "                    in_reply_to_status_id  in_reply_to_user_id  retweet_count  \\\n",
+       "id                                                                              \n",
+       "593891099434983425                    NaN                  NaN              0   \n",
+       "593891099548094465                    NaN                  NaN              0   \n",
+       "593891099388846080                    NaN                  NaN              0   \n",
+       "593891100429045760                    NaN                  NaN              0   \n",
+       "593891100768784384                    NaN                  NaN              0   \n",
+       "\n",
+       "                   retweeted  \\\n",
+       "id                             \n",
+       "593891099434983425     False   \n",
+       "593891099548094465     False   \n",
+       "593891099388846080     False   \n",
+       "593891100429045760     False   \n",
+       "593891100768784384     False   \n",
+       "\n",
+       "                                                                 text  \\\n",
+       "id                                                                      \n",
+       "593891099434983425  RT @KirkKus: Indirect cost of the UK being in ...   \n",
+       "593891099548094465  VIDEO: Sturgeon on post-election deals http://...   \n",
+       "593891099388846080  RT @LabourEoin: The economy was growing 3 time...   \n",
+       "593891100429045760  RT @GregLauder: the UKIP east lothian candidat...   \n",
+       "593891100768784384  RT @thesundaypeople: UKIP's housing spokesman ...   \n",
+       "\n",
+       "                   truncated     user.id  \n",
+       "id                                        \n",
+       "593891099434983425     False   107794703  \n",
+       "593891099548094465     False   557422508  \n",
+       "593891099388846080     False  3006692193  \n",
+       "593891100429045760     False   455154030  \n",
+       "593891100768784384     False   187547338  "
       ]
      },
+     "execution_count": 24,
      "metadata": {},
-     "execution_count": 24
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {
-    "collapsed": false
-   }
+   "source": [
+    "import pandas as pd\n",
+    "tweets = pd.read_csv('tweets.20150430-223406.tweet.csv', index_col=2, header=0, encoding=\"utf8\")\n",
+    "tweets.head(5)"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Using the dataframe it is easy, for example, to first select Tweets with a specific user ID and then retrieve their `'text'` value."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 25,
-   "source": [
-    "tweets.loc[tweets['user.id'] == 557422508]['text']"
-   ],
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "id\n",
@@ -1101,60 +1100,36 @@
        "Name: text, dtype: object"
       ]
      },
+     "execution_count": 25,
      "metadata": {},
-     "execution_count": 25
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {
-    "collapsed": false
-   }
+   "source": [
+    "tweets.loc[tweets['user.id'] == 557422508]['text']"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Expanding a list of Tweet IDs\n",
     "\n",
     "Because the Twitter Terms of Service place severe restrictions on the distribution of Tweets by third parties, a workaround is to instead distribute just the Tweet IDs, which are not subject to the same restrictions. The method `expand_tweetids()` sends a request to the Twitter API to return the full Tweet (in Twitter's terminology, a *hydrated* Tweet) that corresponds to a given Tweet ID. \n",
     "\n",
     "Since Tweets can be deleted by users, it's possible that certain IDs will only retrieve a null value. For this reason, it's safest to use a `try`/`except` block when retrieving values from the fetched Tweet. "
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 26,
-   "source": [
-    "from io import StringIO\r\n",
-    "ids_f =\\\r\n",
-    "    StringIO(\"\"\"\\\r\n",
-    "    588665495492124672\r\n",
-    "    588665495487909888\r\n",
-    "    588665495508766721\r\n",
-    "    588665495513006080\r\n",
-    "    588665495517200384\r\n",
-    "    588665495487811584\r\n",
-    "    588665495525588992\r\n",
-    "    588665495487844352\r\n",
-    "    88665495492014081\r\n",
-    "    588665495512948737\"\"\")\r\n",
-    "    \r\n",
-    "oauth = credsfromfile()\r\n",
-    "client = Query(**oauth)\r\n",
-    "hydrated = client.expand_tweetids(ids_f)\r\n",
-    "\r\n",
-    "    \r\n",
-    "for tweet in hydrated:            \r\n",
-    "        id_str = tweet['id_str']\r\n",
-    "        print('id: {}'.format(id_str))\r\n",
-    "        text = tweet['text']\r\n",
-    "        if text.startswith('@null'):\r\n",
-    "            text = \"[Tweet not available]\"\r\n",
-    "        print(text + '\\n')"
-   ],
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Counted 10 Tweet IDs in <_io.StringIO object at 0x107234558>.\n",
       "id: 588665495508766721\n",
@@ -1188,16 +1163,41 @@
      ]
     }
    ],
-   "metadata": {
-    "collapsed": false
-   }
+   "source": [
+    "from io import StringIO\n",
+    "ids_f =\\\n",
+    "    StringIO(\"\"\"\\\n",
+    "    588665495492124672\n",
+    "    588665495487909888\n",
+    "    588665495508766721\n",
+    "    588665495513006080\n",
+    "    588665495517200384\n",
+    "    588665495487811584\n",
+    "    588665495525588992\n",
+    "    588665495487844352\n",
+    "    88665495492014081\n",
+    "    588665495512948737\"\"\")\n",
+    "    \n",
+    "oauth = credsfromfile()\n",
+    "client = Query(**oauth)\n",
+    "hydrated = client.expand_tweetids(ids_f)\n",
+    "\n",
+    "    \n",
+    "for tweet in hydrated:            \n",
+    "        id_str = tweet['id_str']\n",
+    "        print('id: {}'.format(id_str))\n",
+    "        text = tweet['text']\n",
+    "        if text.startswith('@null'):\n",
+    "            text = \"[Tweet not available]\"\n",
+    "        print(text + '\\n')"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "Although we provided the list of IDs as a string in the above example, the standard use case is to pass a file-like object as the argument to `expand_tweetids()`. "
-   ],
-   "metadata": {}
+   ]
   }
  ],
  "metadata": {
@@ -1221,5 +1221,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 0
 }

--- a/nltk/test/twitter.ipynb
+++ b/nltk/test/twitter.ipynb
@@ -2,14 +2,13 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "# Twitter HOWTO"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Overview\n",
     "\n",
@@ -68,11 +67,11 @@
     "   One important thing to remember is that you need to keep your `credentials.txt` file          private. So do **not** share your `twitter-files` folder with anyone else, and do **not**      upload it to a public repository such as GitHub.\n",
     "\n",
     "3. Finally, read through Twitter's [Developer Rules of the Road](https://dev.twitter.com/overview/terms/policy). As far as these rules are concerned, you count as both the application developer and the user."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### <a name=\"twython\">Install Twython</a>\n",
     "\n",
@@ -87,19 +86,19 @@
     "$ easy_install twython\n",
     "```\n",
     "We're now ready to get started. The next section will describe how to use the `Twitter` class to talk to the Twitter API."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "*More detail*:\n",
     "Twitter offers are two main authentication options. OAuth 1 is for user-authenticated API calls, and allows sending status updates, direct messages, etc, whereas OAuth 2 is for application-authenticated calls, where read-only access is sufficient. Although OAuth 2 sounds more appropriate for the kind of tasks envisaged within NLTK, it turns out that access to Twitter's Streaming API requires OAuth 1, which is why it's necessary to obtain *Read and Write* access for your application."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## <a name=\"simple\">Using the simple `Twitter` class</a>\n",
     "\n",
@@ -108,19 +107,21 @@
     "The `Twitter` class is intended as a simple means of interacting with the Twitter data stream. Later on, we'll look at other methods which give more fine-grained control. \n",
     "\n",
     "The Twitter live public stream is a sample (approximately 1%) of all Tweets that are currently being published by users. They can be on any topic and in any language. In your request, you can give keywords which will narrow down the Tweets that get delivered to you. Our first example looks for Tweets which include either the word *love* or *hate*. We limit the call to finding 10 tweets. When you run this code, it will definitely produce different results from those shown below!"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false,
-    "scrolled": true
-   },
+   "source": [
+    "from nltk.twitter import Twitter\r\n",
+    "tw = Twitter()\r\n",
+    "tw.tweets(keywords='love, hate', limit=10) #sample from the public stream"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Sana magkakaisa na ang mga Kapamilya at Kapuso.  Spread love, not hate\n",
       " #ShowtimeKapamiIyaDay #ALDubEBforLOVE\n",
@@ -138,31 +139,31 @@
      ]
     }
    ],
-   "source": [
-    "from nltk.twitter import Twitter\n",
-    "tw = Twitter()\n",
-    "tw.tweets(keywords='love, hate', limit=10) #sample from the public stream"
-   ]
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "The next example filters the live public stream by looking for specific user accounts. In this case, we 'follow' two news organisations, namely `@CNN` and `@BBCNews`. [As advised by Twitter](https://dev.twitter.com/streaming/reference/post/statuses/filter), we use *numeric userIDs* for these accounts. If you run this code yourself, you'll see that Tweets are arriving much more slowly than in the previous example. This is because even big new organisations don't publish Tweets that often.\n",
     "\n",
     "A bit later we will show you how to use Python to convert usernames such as `@CNN` to userIDs such as `759251`, but for now you might find it simpler to use a web service like [TweeterID](http://tweeterid.com) if you want to experiment with following different accounts than the ones shown below."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "source": [
+    "tw = Twitter()\n",
+    "tw.tweets(follow=['759251', '612473'], limit=10) # see what CNN and BBC are talking about"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "RT @CNN: Sunday's #supermoon #eclipse has some excited, but for others, it's an ominous \"blood moon.\" http://t.co/2B1wdQru0q http://t.co/Aw…\n",
       "RT @CNN: Sunday's #supermoon #eclipse has some excited, but for others, it's an ominous \"blood moon.\" http://t.co/2B1wdQru0q http://t.co/Aw…\n",
@@ -178,61 +179,59 @@
      ]
     }
    ],
-   "source": [
-    "tw = Twitter()\n",
-    "tw.tweets(follow=['759251', '612473'], limit=10) # see what CNN and BBC are talking about"
-   ]
+   "metadata": {
+    "collapsed": false
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### Saving Tweets to a File\n",
     "\n",
     "By default, the `Twitter` class will just print out Tweets to your computer terminal. Although it's fun to view the Twitter stream zipping by on your screen, you'll probably want to save some tweets in a file. We can tell the `tweets()` method to save to a file by setting the flag `to_screen` to `False`. \n",
     "\n",
     "The `Twitter` class will look at the value of your environmental variable `TWITTER` to determine which folder to use to save the tweets, and it will put them in a date-stamped file with the prefix `tweets`. "
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "source": [
+    "tw = Twitter()\n",
+    "tw.tweets(to_screen=False, limit=25)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Writing to /Users/ewan/twitter-files/tweets.20150926-154251.json\n",
       "Written 25 Tweets\n"
      ]
     }
    ],
-   "source": [
-    "tw = Twitter()\n",
-    "tw.tweets(to_screen=False, limit=25)"
-   ]
+   "metadata": {
+    "collapsed": false
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "So far, we've been taking data from the live public stream. However, it's also possible to retrieve past tweets, for example by searching for specific keywords, and setting `stream=False`:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false,
-    "scrolled": true
-   },
+   "source": [
+    "tw.tweets(keywords='hilary clinton', stream=False, limit=10)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "“Girls” Creator Lena Dunham Interviews Hilary Clinton About… Lenny Kravitz’s Junk [Video] http://t.co/eY4GgKS3ak\n",
       "“Girls” Creator Lena Dunham Interviews Hilary Clinton About… Lenny Kravitz’s Junk [Video] http://t.co/Pflf7A6Tr6\n",
@@ -253,65 +252,69 @@
      ]
     }
    ],
-   "source": [
-    "tw.tweets(keywords='hilary clinton', stream=False, limit=10)"
-   ]
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## <a name=\"onwards\">Onwards and Upwards</a>\n",
     "\n",
     "In this section, we'll look at how to get more fine-grained control over processing Tweets. To start off, we will import a bunch of stuff from the `twitter` package."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
    "source": [
     "from nltk.twitter import Query, Streamer, Twitter, TweetViewer, TweetWriter, credsfromfile"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {
+    "collapsed": true
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "In the following example, you'll see the line\n",
     "``` python\n",
     "oauth = credsfromfile()\n",
     "```\n",
     "This gets hold of your stored API key information. The function `credsfromfile()` by default looks for a file called `credentials.txt` in the directory set by the environment variable `TWITTER`, reads the contents and returns the result as a dictionary. We then pass this dictionary as an argument when initializing our client code. We'll be using two classes to wrap the clients: `Streamer` and `Query`; the first of these calls [the Streaming API](https://dev.twitter.com/streaming/overview) and the second calls Twitter's [Search API](https://dev.twitter.com/rest/public) (also called the REST API). "
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "*More detail*: For more detail, see this blog post on [The difference between the Twitter Firehose API, the Twitter Search API, and the Twitter Streaming API](http://www.brightplanet.com/2013/06/twitter-firehose-vs-twitter-api-whats-the-difference-and-why-should-you-care/)\n"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "After initializing a client, we call the `register()` method to specify whether we want to view the data on a terminal or write it to a file. Finally, we call a method which determines the API endpoint to address; in this case, we use `sample()` to get a random sample from the the Streaming API."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 27,
-   "metadata": {
-    "collapsed": false
-   },
+   "source": [
+    "oauth = credsfromfile()\n",
+    "client = Streamer(**oauth)\n",
+    "client.register(TweetViewer(limit=10))\n",
+    "client.sample()"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "RT @EPVLatino: ¿Y entonces? El gobierno sigue importando carros mientras las plantas Chery los tiene acumulados http://t.co/bBhrawqHe7\n",
       "RT @AbrahamMateoMus: . @menudanochetv aquí se suman nuestros Abrahamers MEXICAN@S!! 👏 \n",
@@ -330,31 +333,29 @@
      ]
     }
    ],
-   "source": [
-    "oauth = credsfromfile()\n",
-    "client = Streamer(**oauth)\n",
-    "client.register(TweetViewer(limit=10))\n",
-    "client.sample()"
-   ]
+   "metadata": {
+    "collapsed": false
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "The next example is similar, except that we call the `filter()` method with the `track` parameter followed by a string literal. The string is interpreted as a list of search terms where [comma indicates a logical OR](https://dev.twitter.com/streaming/overview/request-parameters#track). The terms are treated as case-insensitive."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 30,
-   "metadata": {
-    "collapsed": false,
-    "scrolled": true
-   },
+   "source": [
+    "client = Streamer(**oauth)\n",
+    "client.register(TweetViewer(limit=10))\n",
+    "client.filter(track='refugee, germany')"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "European countries at heart of refugee crisis seek to ease tensions: Hungary announces removal of razor wire f... http://t.co/PavCKddtY2\n",
       "RT @onlinewweman: Germany told students to wear \"modest clothing\" bc they don't want the refugees to have \"misunderstandings.\" That's a wei…\n",
@@ -370,31 +371,34 @@
      ]
     }
    ],
-   "source": [
-    "client = Streamer(**oauth)\n",
-    "client.register(TweetViewer(limit=10))\n",
-    "client.filter(track='refugee, germany')"
-   ]
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Whereas the Streaming API lets us access near real-time Twitter data, the Search API lets us query for past Tweets. In the following example, the value `tweets` returned by `search_tweets()` is a generator; the expression `next(tweets)` gives us the first Tweet from the generator. \n",
     "\n",
     "Although Twitter delivers Tweets as [JSON](http://www.json.org) objects, the Python client encodes them as dictionaries, and the example pretty-prints a portion of the dictionary corresponding the Tweet in question."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 31,
-   "metadata": {
-    "collapsed": false
-   },
+   "source": [
+    "client = Query(**oauth)\n",
+    "tweets = client.search_tweets(keywords='nltk', limit=10)\n",
+    "tweet = next(tweets)\n",
+    "from pprint import pprint\n",
+    "pprint(tweet, depth=1)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "{'contributors': None,\n",
       " 'coordinates': None,\n",
@@ -424,33 +428,30 @@
      ]
     }
    ],
-   "source": [
-    "client = Query(**oauth)\n",
-    "tweets = client.search_tweets(keywords='nltk', limit=10)\n",
-    "tweet = next(tweets)\n",
-    "from pprint import pprint\n",
-    "pprint(tweet, depth=1)"
-   ]
+   "metadata": {
+    "collapsed": false
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Twitter's own documentation [provides a useful overview of all the fields in the JSON object](https://dev.twitter.com/overview/api/tweets) and it may be helpful to look at this [visual map of a Tweet object](http://www.scribd.com/doc/30146338/map-of-a-tweet).\n",
     "\n",
     "Since each Tweet is converted into a Python dictionary, it's straightforward to just show a selected field, such as the value of the `'text'` key."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 32,
-   "metadata": {
-    "collapsed": false
-   },
+   "source": [
+    "for tweet in tweets:\n",
+    "    print(tweet['text'])"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Slammer an immigration lawyer seattle wa protection if purusha this morning polaric deportation?: Nltk\n",
       "Python Text Processing with NLTK 2.0 Cookbook / Jacob Perkins\n",
@@ -467,58 +468,41 @@
      ]
     }
    ],
-   "source": [
-    "for tweet in tweets:\n",
-    "    print(tweet['text'])"
-   ]
+   "metadata": {
+    "collapsed": false
+   }
   },
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "collapsed": false
-   },
+   "source": [
+    "client = Query(**oauth)\n",
+    "client.register(TweetWriter())\n",
+    "client.user_tweets('timoreilly', 10)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Writing to /Users/ewan/twitter-files/tweets.20150926-154337.json\n"
      ]
     }
    ],
-   "source": [
-    "client = Query(**oauth)\n",
-    "client.register(TweetWriter())\n",
-    "client.user_tweets('timoreilly', 10)"
-   ]
+   "metadata": {
+    "collapsed": false
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Given a list of user IDs, the following example shows how to retrieve the screen name and other information about the users."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CNN, followers: 19806095, following: 1102\n",
-      "BBCNews, followers: 4935491, following: 105\n",
-      "ReutersLive, followers: 307337, following: 55\n",
-      "BreakingNews, followers: 7949242, following: 541\n",
-      "AJELive, followers: 1117, following: 19\n"
-     ]
-    }
-   ],
    "source": [
     "userids = ['759251', '612473', '15108702', '6017542', '2673523800']\n",
     "client = Query(**oauth)\n",
@@ -528,25 +512,43 @@
     "    followers = info['followers_count']\n",
     "    following = info['friends_count']\n",
     "    print(\"{}, followers: {}, following: {}\".format(name, followers, following))"
-   ]
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "CNN, followers: 19806095, following: 1102\n",
+      "BBCNews, followers: 4935491, following: 105\n",
+      "ReutersLive, followers: 307337, following: 55\n",
+      "BreakingNews, followers: 7949242, following: 541\n",
+      "AJELive, followers: 1117, following: 19\n"
+     ]
+    }
+   ],
+   "metadata": {
+    "collapsed": false
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "A list of user IDs can also be used as input to the Streaming API client."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {
-    "collapsed": false
-   },
+   "source": [
+    "client = Streamer(**oauth)\r\n",
+    "client.register(TweetViewer(limit=10))\r\n",
+    "client.statuses.filter(follow=userids)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "RT @CNN: Sunday's #supermoon #eclipse has some excited, but for others, it's an ominous \"blood moon.\" http://t.co/2B1wdQru0q http://t.co/Aw…\n",
       "RT @bbcweather: Cameras at the ready for #supermoon #eclipse on 27/28th Sept, next one won't be until 2033! http://t.co/SPucnmBqaD http://t…\n",
@@ -563,108 +565,107 @@
      ]
     }
    ],
-   "source": [
-    "client = Streamer(**oauth)\n",
-    "client.register(TweetViewer(limit=10))\n",
-    "client.statuses.filter(follow=userids)"
-   ]
+   "metadata": {
+    "collapsed": false
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "To store data that Twitter sents by the Streaming API, we register a `TweetWriter` instance."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {
-    "collapsed": false
-   },
+   "source": [
+    "client = Streamer(**oauth)\r\n",
+    "client.register(TweetWriter(limit=10))\r\n",
+    "client.statuses.sample()"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Writing to /Users/ewan/twitter-files/tweets.20150926-154408.json\n",
       "Written 10 Tweets\n"
      ]
     }
    ],
-   "source": [
-    "client = Streamer(**oauth)\n",
-    "client.register(TweetWriter(limit=10))\n",
-    "client.statuses.sample()"
-   ]
+   "metadata": {
+    "collapsed": false
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
-    "Here's the full signature of the `Tweetwriter`'s `__init__()` method:\n",
-    "```python\n",
-    "def __init__(self, limit=2000, upper_date_limit=None, lower_date_limit=None,\n",
-    "                 fprefix='tweets', subdir='twitter-files', repeat=False,\n",
-    "                 gzip_compress=False):                \n",
-    "```\n",
+    "Here's the full signature of the `Tweetwriter`'s `__init__()` method:\r\n",
+    "```python\r\n",
+    "def __init__(self, limit=2000, upper_date_limit=None, lower_date_limit=None,\r\n",
+    "                 fprefix='tweets', subdir='twitter-files', repeat=False,\r\n",
+    "                 gzip_compress=False):                \r\n",
+    "```\r\n",
     "If the `repeat` parameter is set to `True`, then the writer will write up to the value of `limit` in file `file1`, then open a new file `file2` and write to it until the limit is reached, and so on indefinitely. The parameter `gzip_compress` can be used to compress the files once they have been written."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## <a name=\"corpus_reader\">Using a Tweet Corpus</a>\n",
     "\n",
     "NLTK's Twitter corpus currently contains a sample of 20k Tweets (named '`twitter_samples`')\n",
     "retrieved from the Twitter Streaming API, together with another 10k which are divided according to sentiment into negative and positive."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {
-    "collapsed": false
-   },
+   "source": [
+    "from nltk.corpus import twitter_samples\r\n",
+    "twitter_samples.fileids()"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "['negative_tweets.json', 'positive_tweets.json', 'tweets.20150430-223406.json']"
       ]
      },
-     "execution_count": 15,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 15
     }
    ],
-   "source": [
-    "from nltk.corpus import twitter_samples\n",
-    "twitter_samples.fileids()"
-   ]
+   "metadata": {
+    "collapsed": false
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "We follow standard practice in storing full Tweets as line-separated\n",
     "JSON. These data structures can be accessed via `tweets.docs()`. However, in general it\n",
     "is more practical to focus just on the text field of the Tweets, which\n",
     "are accessed via the `strings()` method."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {
-    "collapsed": false,
-    "scrolled": true
-   },
+   "source": [
+    "strings = twitter_samples.strings('tweets.20150430-223406.json')\r\n",
+    "for string in strings[:15]:\r\n",
+    "    print(string)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "RT @KirkKus: Indirect cost of the UK being in the EU is estimated to be costing Britain £170 billion per year! #BetterOffOut #UKIP\n",
       "VIDEO: Sturgeon on post-election deals http://t.co/BTJwrpbmOY\n",
@@ -684,30 +685,31 @@
      ]
     }
    ],
-   "source": [
-    "strings = twitter_samples.strings('tweets.20150430-223406.json')\n",
-    "for string in strings[:15]:\n",
-    "    print(string)"
-   ]
+   "metadata": {
+    "collapsed": false,
+    "scrolled": true
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "The default tokenizer for Tweets (`casual.py`) is specialised for 'casual' text, and\n",
     "the `tokenized()` method returns a list of lists of tokens."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {
-    "collapsed": false
-   },
+   "source": [
+    "tokenized = twitter_samples.tokenized('tweets.20150430-223406.json')\r\n",
+    "for toks in tokenized[:5]:\r\n",
+    "    print(toks)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "['RT', '@KirkKus', ':', 'Indirect', 'cost', 'of', 'the', 'UK', 'being', 'in', 'the', 'EU', 'is', 'estimated', 'to', 'be', 'costing', 'Britain', '£', '170', 'billion', 'per', 'year', '!', '#BetterOffOut', '#UKIP']\n",
       "['VIDEO', ':', 'Sturgeon', 'on', 'post-election', 'deals', 'http://t.co/BTJwrpbmOY']\n",
@@ -717,60 +719,57 @@
      ]
     }
    ],
-   "source": [
-    "tokenized = twitter_samples.tokenized('tweets.20150430-223406.json')\n",
-    "for toks in tokenized[:5]:\n",
-    "    print(toks)"
-   ]
+   "metadata": {
+    "collapsed": false
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": false
-   },
    "source": [
     "### Extracting Parts of a Tweet\n",
     "\n",
     "If we want to carry out other kinds of analysis on Tweets, we have to work directly with the file rather than via the corpus reader. For demonstration purposes, we will use the same file as the one in the preceding section, namely  `tweets.20150430-223406.json`. The `abspath()` method of the corpus gives us the full pathname of the relevant file. If your NLTK data is installed in the default location on a Unix-like system, this pathname will be `'/usr/share/nltk_data/corpora/twitter_samples/tweets.20150430-223406.json'`."
-   ]
+   ],
+   "metadata": {
+    "collapsed": false
+   }
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "source": [
+    "from nltk.corpus import twitter_samples\r\n",
+    "input_file = twitter_samples.abspath(\"tweets.20150430-223406.json\")"
+   ],
+   "outputs": [],
    "metadata": {
     "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "from nltk.corpus import twitter_samples\n",
-    "input_file = twitter_samples.abspath(\"tweets.20150430-223406.json\")"
-   ]
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
    "source": [
     "The function `json2csv()` takes as input a file-like object consisting of Tweets as line-delimited JSON objects and returns a file in CSV format. The third parameter of the function lists the fields that we want to extract from the JSON. One of the simplest examples is to extract just the text of the Tweets (though of course it would have been even simpler to use the `strings()` method of the corpus reader)."
-   ]
+   ],
+   "metadata": {
+    "collapsed": true
+   }
   },
   {
    "cell_type": "code",
    "execution_count": 3,
+   "source": [
+    "from nltk.twitter.common import json2csv\r\n",
+    "with open(input_file) as fp:\r\n",
+    "    json2csv(fp, 'tweets_text.csv', ['text'])"
+   ],
+   "outputs": [],
    "metadata": {
     "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "from nltk.twitter.common import json2csv\n",
-    "with open(input_file) as fp:\n",
-    "    json2csv(fp, 'tweets_text.csv', ['text'])"
-   ]
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "We've passed the filename `'tweets_text.csv'` as the second argument of `json2csv()`. Unless you provide a complete pathname, the file will be created in the directory where you are currently executing Python.\n",
     "\n",
@@ -783,42 +782,44 @@
     "RT @GregLauder: the UKIP east lothian candidate looks about 16 and still has an msn addy http://t.co/7eIU0c5Fm1\n",
     "RT @thesundaypeople: UKIP's housing spokesman rakes in £800k in housing benefit from migrants.  http://t.co/GVwb9Rcb4w http://t.co/c1AZxcLh…\n",
     "```"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "However, in some applications you may want to work with Tweet metadata, e.g., the creation date and the user. As mentioned earlier, all the fields of a Tweet object are described in [the official Twitter API](https://dev.twitter.com/overview/api/tweets). \n",
     "\n",
     "The third argument of `json2csv()` can specified so that the function selects relevant parts of the metadata. For example, the following will generate a CSV file including most of the metadata together with the id of the user who has published it."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 4,
+   "source": [
+    "with open(input_file) as fp:\r\n",
+    "    json2csv(fp, 'tweets.20150430-223406.tweet.csv',\r\n",
+    "            ['created_at', 'favorite_count', 'id', 'in_reply_to_status_id', \r\n",
+    "            'in_reply_to_user_id', 'retweet_count', 'retweeted', \r\n",
+    "            'text', 'truncated', 'user.id'])"
+   ],
+   "outputs": [],
    "metadata": {
     "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "with open(input_file) as fp:\n",
-    "    json2csv(fp, 'tweets.20150430-223406.tweet.csv',\n",
-    "            ['created_at', 'favorite_count', 'id', 'in_reply_to_status_id', \n",
-    "            'in_reply_to_user_id', 'retweet_count', 'retweeted', \n",
-    "            'text', 'truncated', 'user.id'])"
-   ]
+   }
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "source": [
+    "for line in open('tweets.20150430-223406.tweet.csv').readlines()[:5]:\r\n",
+    "    print(line)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "created_at,favorite_count,id,in_reply_to_status_id,in_reply_to_user_id,retweet_count,retweeted,text,truncated,user.id\n",
       "\n",
@@ -833,103 +834,146 @@
      ]
     }
    ],
-   "source": [
-    "for line in open('tweets.20150430-223406.tweet.csv').readlines()[:5]:\n",
-    "    print(line)"
-   ]
+   "metadata": {
+    "collapsed": false
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "The first nine elements of the list are attributes of the Tweet, while the last one, `user.id`, takes the user object associated with the Tweet, and retrieves the attributes in the list (in this case only the id). The object for the Twitter user is described in the  [Twitter API for users](https://dev.twitter.com/overview/api/users)."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "The rest of the metadata of the Tweet are the so-called [entities](https://dev.twitter.com/overview/api/entities) and [places](https://dev.twitter.com/overview/api/places). The following examples show how to get each of those entities. They all include the id of the Tweet as the first argument, and some of them include also the text for clarity."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 22,
+   "source": [
+    "from nltk.twitter.common import json2csv_entities\r\n",
+    "with open(input_file) as fp:\r\n",
+    "    json2csv_entities(fp, 'tweets.20150430-223406.hashtags.csv',\r\n",
+    "                        ['id', 'text'], 'hashtags', ['text'])\r\n",
+    "    \r\n",
+    "with open(input_file) as fp:\r\n",
+    "    json2csv_entities(fp, 'tweets.20150430-223406.user_mentions.csv',\r\n",
+    "                        ['id', 'text'], 'user_mentions', ['id', 'screen_name'])\r\n",
+    "    \r\n",
+    "with open(input_file) as fp:\r\n",
+    "    json2csv_entities(fp, 'tweets.20150430-223406.media.csv',\r\n",
+    "                        ['id'], 'media', ['media_url', 'url'])\r\n",
+    "    \r\n",
+    "with open(input_file) as fp:\r\n",
+    "    json2csv_entities(fp, 'tweets.20150430-223406.urls.csv',\r\n",
+    "                        ['id'], 'urls', ['url', 'expanded_url'])\r\n",
+    "    \r\n",
+    "with open(input_file) as fp:\r\n",
+    "    json2csv_entities(fp, 'tweets.20150430-223406.place.csv',\r\n",
+    "                        ['id', 'text'], 'place', ['name', 'country'])\r\n",
+    "\r\n",
+    "with open(input_file) as fp:\r\n",
+    "    json2csv_entities(fp, 'tweets.20150430-223406.place_bounding_box.csv',\r\n",
+    "                        ['id', 'name'], 'place.bounding_box', ['coordinates'])"
+   ],
+   "outputs": [],
    "metadata": {
     "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "from nltk.twitter.common import json2csv_entities\n",
-    "with open(input_file) as fp:\n",
-    "    json2csv_entities(fp, 'tweets.20150430-223406.hashtags.csv',\n",
-    "                        ['id', 'text'], 'hashtags', ['text'])\n",
-    "    \n",
-    "with open(input_file) as fp:\n",
-    "    json2csv_entities(fp, 'tweets.20150430-223406.user_mentions.csv',\n",
-    "                        ['id', 'text'], 'user_mentions', ['id', 'screen_name'])\n",
-    "    \n",
-    "with open(input_file) as fp:\n",
-    "    json2csv_entities(fp, 'tweets.20150430-223406.media.csv',\n",
-    "                        ['id'], 'media', ['media_url', 'url'])\n",
-    "    \n",
-    "with open(input_file) as fp:\n",
-    "    json2csv_entities(fp, 'tweets.20150430-223406.urls.csv',\n",
-    "                        ['id'], 'urls', ['url', 'expanded_url'])\n",
-    "    \n",
-    "with open(input_file) as fp:\n",
-    "    json2csv_entities(fp, 'tweets.20150430-223406.place.csv',\n",
-    "                        ['id', 'text'], 'place', ['name', 'country'])\n",
-    "\n",
-    "with open(input_file) as fp:\n",
-    "    json2csv_entities(fp, 'tweets.20150430-223406.place_bounding_box.csv',\n",
-    "                        ['id', 'name'], 'place.bounding_box', ['coordinates'])"
-   ]
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Additionally, when a Tweet is actually a retweet, the original tweet can be also fetched from the same file, as follows:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 23,
+   "source": [
+    "with open(input_file) as fp:\r\n",
+    "    json2csv_entities(fp, 'tweets.20150430-223406.original_tweets.csv',\r\n",
+    "                        ['id'], 'retweeted_status', ['created_at', 'favorite_count', \r\n",
+    "                        'id', 'in_reply_to_status_id', 'in_reply_to_user_id', 'retweet_count',\r\n",
+    "                        'text', 'truncated', 'user.id'])"
+   ],
+   "outputs": [],
    "metadata": {
     "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "with open(input_file) as fp:\n",
-    "    json2csv_entities(fp, 'tweets.20150430-223406.original_tweets.csv',\n",
-    "                        ['id'], 'retweeted_status', ['created_at', 'favorite_count', \n",
-    "                        'id', 'in_reply_to_status_id', 'in_reply_to_user_id', 'retweet_count',\n",
-    "                        'text', 'truncated', 'user.id'])"
-   ]
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
-    "Here the first id corresponds to the retweeted Tweet, and the second id to the original Tweet.\n",
-    "\n",
-    "### Using Dataframes\n",
-    "\n",
-    "Sometimes it's convenient to manipulate CSV files as tabular data, and this is made easy with the [Pandas](http://pandas.pydata.org/) data analysis library. `pandas` is not currrently one of the dependencies of NLTK, and you will probably have to install it specially.\n",
-    "\n",
+    "Here the first id corresponds to the retweeted Tweet, and the second id to the original Tweet.\r\n",
+    "\r\n",
+    "### Using Dataframes\r\n",
+    "\r\n",
+    "Sometimes it's convenient to manipulate CSV files as tabular data, and this is made easy with the [Pandas](http://pandas.pydata.org/) data analysis library. `pandas` is not currently one of the dependencies of NLTK, and you will probably have to install it specially.\r\n",
+    "\r\n",
     "Here is an example of how to read a CSV file into a `pandas` dataframe. We use the `head()` method of a dataframe to just show the first 5 rows."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 24,
-   "metadata": {
-    "collapsed": false
-   },
+   "source": [
+    "import pandas as pd\r\n",
+    "tweets = pd.read_csv('tweets.20150430-223406.tweet.csv', index_col=2, header=0, encoding=\"utf8\")\r\n",
+    "tweets.head(5)"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
+      "text/plain": [
+       "                                        created_at  favorite_count  \\\n",
+       "id                                                                   \n",
+       "593891099434983425  Thu Apr 30 21:34:06 +0000 2015               0   \n",
+       "593891099548094465  Thu Apr 30 21:34:06 +0000 2015               0   \n",
+       "593891099388846080  Thu Apr 30 21:34:06 +0000 2015               0   \n",
+       "593891100429045760  Thu Apr 30 21:34:06 +0000 2015               0   \n",
+       "593891100768784384  Thu Apr 30 21:34:07 +0000 2015               0   \n",
+       "\n",
+       "                    in_reply_to_status_id  in_reply_to_user_id  retweet_count  \\\n",
+       "id                                                                              \n",
+       "593891099434983425                    NaN                  NaN              0   \n",
+       "593891099548094465                    NaN                  NaN              0   \n",
+       "593891099388846080                    NaN                  NaN              0   \n",
+       "593891100429045760                    NaN                  NaN              0   \n",
+       "593891100768784384                    NaN                  NaN              0   \n",
+       "\n",
+       "                   retweeted  \\\n",
+       "id                             \n",
+       "593891099434983425     False   \n",
+       "593891099548094465     False   \n",
+       "593891099388846080     False   \n",
+       "593891100429045760     False   \n",
+       "593891100768784384     False   \n",
+       "\n",
+       "                                                                 text  \\\n",
+       "id                                                                      \n",
+       "593891099434983425  RT @KirkKus: Indirect cost of the UK being in ...   \n",
+       "593891099548094465  VIDEO: Sturgeon on post-election deals http://...   \n",
+       "593891099388846080  RT @LabourEoin: The economy was growing 3 time...   \n",
+       "593891100429045760  RT @GregLauder: the UKIP east lothian candidat...   \n",
+       "593891100768784384  RT @thesundaypeople: UKIP's housing spokesman ...   \n",
+       "\n",
+       "                   truncated     user.id  \n",
+       "id                                        \n",
+       "593891099434983425     False   107794703  \n",
+       "593891099548094465     False   557422508  \n",
+       "593891099388846080     False  3006692193  \n",
+       "593891100429045760     False   455154030  \n",
+       "593891100768784384     False   187547338  "
+      ],
       "text/html": [
        "<div>\n",
        "<table border=\"1\" class=\"dataframe\">\n",
@@ -1023,75 +1067,32 @@
        "  </tbody>\n",
        "</table>\n",
        "</div>"
-      ],
-      "text/plain": [
-       "                                        created_at  favorite_count  \\\n",
-       "id                                                                   \n",
-       "593891099434983425  Thu Apr 30 21:34:06 +0000 2015               0   \n",
-       "593891099548094465  Thu Apr 30 21:34:06 +0000 2015               0   \n",
-       "593891099388846080  Thu Apr 30 21:34:06 +0000 2015               0   \n",
-       "593891100429045760  Thu Apr 30 21:34:06 +0000 2015               0   \n",
-       "593891100768784384  Thu Apr 30 21:34:07 +0000 2015               0   \n",
-       "\n",
-       "                    in_reply_to_status_id  in_reply_to_user_id  retweet_count  \\\n",
-       "id                                                                              \n",
-       "593891099434983425                    NaN                  NaN              0   \n",
-       "593891099548094465                    NaN                  NaN              0   \n",
-       "593891099388846080                    NaN                  NaN              0   \n",
-       "593891100429045760                    NaN                  NaN              0   \n",
-       "593891100768784384                    NaN                  NaN              0   \n",
-       "\n",
-       "                   retweeted  \\\n",
-       "id                             \n",
-       "593891099434983425     False   \n",
-       "593891099548094465     False   \n",
-       "593891099388846080     False   \n",
-       "593891100429045760     False   \n",
-       "593891100768784384     False   \n",
-       "\n",
-       "                                                                 text  \\\n",
-       "id                                                                      \n",
-       "593891099434983425  RT @KirkKus: Indirect cost of the UK being in ...   \n",
-       "593891099548094465  VIDEO: Sturgeon on post-election deals http://...   \n",
-       "593891099388846080  RT @LabourEoin: The economy was growing 3 time...   \n",
-       "593891100429045760  RT @GregLauder: the UKIP east lothian candidat...   \n",
-       "593891100768784384  RT @thesundaypeople: UKIP's housing spokesman ...   \n",
-       "\n",
-       "                   truncated     user.id  \n",
-       "id                                        \n",
-       "593891099434983425     False   107794703  \n",
-       "593891099548094465     False   557422508  \n",
-       "593891099388846080     False  3006692193  \n",
-       "593891100429045760     False   455154030  \n",
-       "593891100768784384     False   187547338  "
       ]
      },
-     "execution_count": 24,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 24
     }
    ],
-   "source": [
-    "import pandas as pd\n",
-    "tweets = pd.read_csv('tweets.20150430-223406.tweet.csv', index_col=2, header=0, encoding=\"utf8\")\n",
-    "tweets.head(5)"
-   ]
+   "metadata": {
+    "collapsed": false
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Using the dataframe it is easy, for example, to first select Tweets with a specific user ID and then retrieve their `'text'` value."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 25,
-   "metadata": {
-    "collapsed": false
-   },
+   "source": [
+    "tweets.loc[tweets['user.id'] == 557422508]['text']"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "id\n",
@@ -1100,36 +1101,60 @@
        "Name: text, dtype: object"
       ]
      },
-     "execution_count": 25,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 25
     }
    ],
-   "source": [
-    "tweets.loc[tweets['user.id'] == 557422508]['text']"
-   ]
+   "metadata": {
+    "collapsed": false
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Expanding a list of Tweet IDs\n",
     "\n",
     "Because the Twitter Terms of Service place severe restrictions on the distribution of Tweets by third parties, a workaround is to instead distribute just the Tweet IDs, which are not subject to the same restrictions. The method `expand_tweetids()` sends a request to the Twitter API to return the full Tweet (in Twitter's terminology, a *hydrated* Tweet) that corresponds to a given Tweet ID. \n",
     "\n",
     "Since Tweets can be deleted by users, it's possible that certain IDs will only retrieve a null value. For this reason, it's safest to use a `try`/`except` block when retrieving values from the fetched Tweet. "
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 26,
-   "metadata": {
-    "collapsed": false
-   },
+   "source": [
+    "from io import StringIO\r\n",
+    "ids_f =\\\r\n",
+    "    StringIO(\"\"\"\\\r\n",
+    "    588665495492124672\r\n",
+    "    588665495487909888\r\n",
+    "    588665495508766721\r\n",
+    "    588665495513006080\r\n",
+    "    588665495517200384\r\n",
+    "    588665495487811584\r\n",
+    "    588665495525588992\r\n",
+    "    588665495487844352\r\n",
+    "    88665495492014081\r\n",
+    "    588665495512948737\"\"\")\r\n",
+    "    \r\n",
+    "oauth = credsfromfile()\r\n",
+    "client = Query(**oauth)\r\n",
+    "hydrated = client.expand_tweetids(ids_f)\r\n",
+    "\r\n",
+    "    \r\n",
+    "for tweet in hydrated:            \r\n",
+    "        id_str = tweet['id_str']\r\n",
+    "        print('id: {}'.format(id_str))\r\n",
+    "        text = tweet['text']\r\n",
+    "        if text.startswith('@null'):\r\n",
+    "            text = \"[Tweet not available]\"\r\n",
+    "        print(text + '\\n')"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Counted 10 Tweet IDs in <_io.StringIO object at 0x107234558>.\n",
       "id: 588665495508766721\n",
@@ -1163,41 +1188,16 @@
      ]
     }
    ],
-   "source": [
-    "from io import StringIO\n",
-    "ids_f =\\\n",
-    "    StringIO(\"\"\"\\\n",
-    "    588665495492124672\n",
-    "    588665495487909888\n",
-    "    588665495508766721\n",
-    "    588665495513006080\n",
-    "    588665495517200384\n",
-    "    588665495487811584\n",
-    "    588665495525588992\n",
-    "    588665495487844352\n",
-    "    88665495492014081\n",
-    "    588665495512948737\"\"\")\n",
-    "    \n",
-    "oauth = credsfromfile()\n",
-    "client = Query(**oauth)\n",
-    "hydrated = client.expand_tweetids(ids_f)\n",
-    "\n",
-    "    \n",
-    "for tweet in hydrated:            \n",
-    "        id_str = tweet['id_str']\n",
-    "        print('id: {}'.format(id_str))\n",
-    "        text = tweet['text']\n",
-    "        if text.startswith('@null'):\n",
-    "            text = \"[Tweet not available]\"\n",
-    "        print(text + '\\n')"
-   ]
+   "metadata": {
+    "collapsed": false
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Although we provided the list of IDs as a string in the above example, the standard use case is to pass a file-like object as the argument to `expand_tweetids()`. "
-   ]
+   ],
+   "metadata": {}
   }
  ],
  "metadata": {
@@ -1221,5 +1221,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 2
 }

--- a/nltk/test/unit/lm/test_models.py
+++ b/nltk/test/unit/lm/test_models.py
@@ -141,7 +141,7 @@ def mle_trigram_model(trigram_training_data, vocabulary):
         # count(d | c) = 1
         # count(c) = 1
         ("d", ["c"], 1),
-        # total number of tokens is 18, of which "a" occured 2 times
+        # total number of tokens is 18, of which "a" occurred 2 times
         ("a", None, 2.0 / 18),
         # in vocabulary but unseen
         ("z", None, 0),
@@ -330,14 +330,14 @@ def wittenbell_trigram_model(trigram_training_data, vocabulary):
         # out of vocabulary should use "UNK" score
         # count("<UNK>") = 3
         ("y", None, 3.0 / 18),
-        # 2 words follow b and b occured a total of 2 times
+        # 2 words follow b and b occurred a total of 2 times
         # gamma(['b']) = 2 / (2 + 2) = 0.5
         # mle.score('c', ['b']) = 0.5
         # mle('c') = 1 / 18 = 0.055
         # (1 - gamma) * mle + gamma * mle('c') ~= 0.27 + 0.055
         ("c", ["b"], (1 - 0.5) * 0.5 + 0.5 * 1 / 18),
         # building on that, let's try 'a b c' as the trigram
-        # 1 word follows 'a b' and 'a b' occured 1 time
+        # 1 word follows 'a b' and 'a b' occurred 1 time
         # gamma(['a', 'b']) = 1 / (1 + 1) = 0.5
         # mle("c", ["a", "b"]) = 1
         ("c", ["a", "b"], (1 - 0.5) + 0.5 * ((1 - 0.5) * 0.5 + 0.5 * 1 / 18)),
@@ -528,7 +528,7 @@ def kneserney_bigram_model(bigram_training_data, vocabulary):
         "kneserney_bigram_model",
         pytest.param(
             "stupid_backoff_trigram_model",
-            marks=pytest.mark.xfail(reason="Stupid Backoff is not a valid distibution"),
+            marks=pytest.mark.xfail(reason="Stupid Backoff is not a valid distribution"),
         ),
     ],
 )

--- a/nltk/test/unit/test_disagreement.py
+++ b/nltk/test/unit/test_disagreement.py
@@ -91,7 +91,7 @@ class TestDisagreement(unittest.TestCase):
     def test_advanced2(self):
         '''
         Same more advanced example, but with 1 rating removed.
-        Again, removal of that 1 rating shoudl not matter.
+        Again, removal of that 1 rating should not matter.
         '''
         data = [('A', '1', '1'),
                 ('B', '1', '1'),

--- a/nltk/test/unit/translate/test_bleu.py
+++ b/nltk/test/unit/translate/test_bleu.py
@@ -192,7 +192,7 @@ class TestBLEUFringeCases(unittest.TestCase):
         assert sentence_bleu(references, hypothesis) == 0
 
     def test_reference_or_hypothesis_shorter_than_fourgrams(self):
-        # Tese case where the length of reference or hypothesis
+        # Test case where the length of reference or hypothesis
         # is shorter than 4.
         references = ['let it go'.split()]
         hypothesis = 'let go it'.split()

--- a/nltk/tgrep.py
+++ b/nltk/tgrep.py
@@ -385,7 +385,7 @@ def _tgrep_nltk_tree_pos_action(_s, _l, tokens):
     which returns true if the node is located at a specific tree
     position.
     """
-    # recover the tuple from the parsed sting
+    # recover the tuple from the parsed string
     node_tree_position = tuple(int(x) for x in tokens if x.isdigit())
     # capture the node's tree position
     return (
@@ -999,7 +999,7 @@ def tgrep_positions(pattern, trees, search_leaves=True):
     :type pattern: str or output of tgrep_compile()
     :param trees: a sequence of NLTK trees (usually ParentedTrees)
     :type trees: iter(ParentedTree) or iter(Tree)
-    :param search_leaves: whether ot return matching leaf nodes
+    :param search_leaves: whether to return matching leaf nodes
     :type search_leaves: bool
     :rtype: iter(tree positions)
     """
@@ -1026,7 +1026,7 @@ def tgrep_nodes(pattern, trees, search_leaves=True):
     :type pattern: str or output of tgrep_compile()
     :param trees: a sequence of NLTK trees (usually ParentedTrees)
     :type trees: iter(ParentedTree) or iter(Tree)
-    :param search_leaves: whether ot return matching leaf nodes
+    :param search_leaves: whether to return matching leaf nodes
     :type search_leaves: bool
     :rtype: iter(tree nodes)
     """

--- a/nltk/tokenize/legality_principle.py
+++ b/nltk/tokenize/legality_principle.py
@@ -65,7 +65,7 @@ class LegalitySyllableTokenizer(TokenizerI):
         """
         :param tokenized_source_text: List of valid tokens in the language
         :type tokenized_source_text: list(str)
-        :param vowels: Valid vowels in language or IPA represenation
+        :param vowels: Valid vowels in language or IPA representation
         :type vowels: str
         :param legal_frequency_threshold: Lowest frequency of all onsets to be considered a legal onset
         :type legal_frequency_threshold: float

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -1176,7 +1176,7 @@ class PunktTrainer(PunktBaseClass):
 
     def _is_potential_sent_starter(self, cur_tok, prev_tok):
         """
-        Returns True given a token and the token that preceds it if it
+        Returns True given a token and the token that precedes it if it
         seems clear that the token is beginning a sentence.
         """
         # If a token (i) is preceded by a sentece break that is
@@ -1586,7 +1586,7 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
                     return REASON_NUMBER_WITH_ORTHOGRAPHIC_HEURISTIC
 
             # Special heuristic for initials: if orthogrpahic
-            # heuristc is unknown, and next word is always
+            # heuristic is unknown, and next word is always
             # capitalized, then mark as abbrev (eg: J. Bach).
             if (
                 is_sent_starter == "unknown"

--- a/nltk/tokenize/sonority_sequencing.py
+++ b/nltk/tokenize/sonority_sequencing.py
@@ -18,7 +18,7 @@ universal syllabification algorithm, but that does not mean it performs equally
 across languages. Bartlett et al. (2009) is a good benchmark for English accuracy
 if utilizing IPA (pg. 311).
 
-Importantly, if a custom hiearchy is supplied and vowels span across more than
+Importantly, if a custom hierarchy is supplied and vowels span across more than
 one level, they should be given separately to the `vowels` class attribute.
 
 References:
@@ -105,7 +105,7 @@ class SyllableTokenizer(TokenizerI):
                     )
                     syllables_values.append((c, max(self.phoneme_map.values())))
                     self.vowels += c
-                else:  # If it's a punctuation, assing -1.
+                else:  # If it's a punctuation, assign -1.
                     syllables_values.append((c, -1))
         return syllables_values
 

--- a/nltk/tokenize/stanford_segmenter.py
+++ b/nltk/tokenize/stanford_segmenter.py
@@ -124,7 +124,7 @@ class StanfordSegmenter(TokenizerI):
 
     def default_config(self, lang):
         """
-        Attempt to intialize Stanford Word Segmenter for the specified language
+        Attempt to initialize Stanford Word Segmenter for the specified language
         using the STANFORD_SEGMENTER and STANFORD_MODELS environment variables
         """
 

--- a/nltk/tokenize/toktok.py
+++ b/nltk/tokenize/toktok.py
@@ -171,8 +171,8 @@ class ToktokTokenizer(TokenizerI):
 
     def tokenize(self, text, return_str=False):
         text = str(text)  # Converts input string into unicode.
-        for regexp, subsitution in self.TOKTOK_REGEXES:
-            text = regexp.sub(subsitution, text)
+        for regexp, substitution in self.TOKTOK_REGEXES:
+            text = regexp.sub(substitution, text)
         # Finally, strips heading and trailing spaces
         # and converts output string into unicode.
         text = str(text.strip())

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -58,7 +58,7 @@ def sentence_bleu(
     value 0. This is because the precision for the order of n-grams without
     overlap is 0, and the geometric mean in the final BLEU score computation
     multiplies the 0 with the precision of other n-grams. This results in 0
-    (independently of the precision of the othe n-gram orders). The following
+    (independently of the precision of the other n-gram orders). The following
     example has zero 3-gram and 4-gram overlaps:
 
     >>> round(sentence_bleu([reference1, reference2, reference3], hypothesis2),4) # doctest: +ELLIPSIS

--- a/nltk/translate/gdfa.py
+++ b/nltk/translate/gdfa.py
@@ -19,9 +19,9 @@ def grow_diag_final_and(srclen, trglen, e2f, f2e):
             these criteria: (i) neighbor alignments points are not in the
             intersection and (ii) neighbor alignments are in the union.
 
-    Step 3: Add all other alignment points thats not in the intersection, not in
+    Step 3: Add all other alignment points that are not in the intersection, not in
             the neighboring alignments that met the criteria but in the original
-            foward/backward alignment outputs.
+            forward/backward alignment outputs.
 
         >>> forw = ('0-0 2-1 9-2 21-3 10-4 7-5 11-6 9-7 12-8 1-9 3-10 '
         ...         '4-11 17-12 17-13 25-14 13-15 24-16 11-17 28-18')

--- a/nltk/translate/meteor_score.py
+++ b/nltk/translate/meteor_score.py
@@ -264,11 +264,11 @@ def allign_words(hypothesis, reference, stemmer=PorterStemmer(), wordnet=wordnet
 def _count_chunks(matches):
     """
     Counts the fewest possible number of chunks such that matched unigrams
-    of each chunk are adjacent to each other. This is used to caluclate the
+    of each chunk are adjacent to each other. This is used to calculate the
     fragmentation part of the metric.
 
     :param matches: list containing a mapping of matched words (output of allign_words)
-    :return: Number of chunks a sentence is divided into post allignment
+    :return: Number of chunks a sentence is divided into post alignment
     :rtype: int
     """
     i = 0
@@ -332,7 +332,7 @@ def single_meteor_score(
     :param beta: parameter for controlling shape of penalty as a
                  function of as a function of fragmentation.
     :type beta: float
-    :param gamma: relative weight assigned to fragmentation penality.
+    :param gamma: relative weight assigned to fragmentation penalty.
     :type gamma: float
     :return: The sentence-level METEOR score.
     :rtype: float
@@ -410,7 +410,7 @@ def meteor_score(
     :param beta: parameter for controlling shape of penalty as a function
                  of as a function of fragmentation.
     :type beta: float
-    :param gamma: relative weight assigned to fragmentation penality.
+    :param gamma: relative weight assigned to fragmentation penalty.
     :type gamma: float
     :return: The sentence-level METEOR score.
     :rtype: float

--- a/nltk/tree.py
+++ b/nltk/tree.py
@@ -502,7 +502,7 @@ class Tree(list):
         :type  expandUnary: bool
         :param childChar: A string separating the head node from its children in an artificial node (default = "|")
         :type  childChar: str
-        :param parentChar: A sting separating the node label from its parent annotation (default = "^")
+        :param parentChar: A string separating the node label from its parent annotation (default = "^")
         :type  parentChar: str
         :param unaryChar: A string joining two non-terminals in a unary production (default = "+")
         :type  unaryChar: str

--- a/nltk/twitter/common.py
+++ b/nltk/twitter/common.py
@@ -191,7 +191,7 @@ def json2csv_entities(
     :param error: Behaviour for encoding errors, see\
     https://docs.python.org/3/library/codecs.html#codec-base-classes
 
-    :param gzip_compress: if `True`, ouput files are compressed with gzip
+    :param gzip_compress: if `True`, output files are compressed with gzip
     """
 
     (writer, outf) = _outf_writer(outfile, encoding, errors, gzip_compress)

--- a/nltk/twitter/twitterclient.py
+++ b/nltk/twitter/twitterclient.py
@@ -474,7 +474,7 @@ class TweetWriter(TweetHandlerI):
         written. If `True`, the length of each file will be set by the value\
         of `limit`. See also :py:func:`handle`.
 
-        :param gzip_compress: if `True`, ouput files are compressed with gzip.
+        :param gzip_compress: if `True`, output files are compressed with gzip.
         """
         self.fprefix = fprefix
         self.subdir = guess_path(subdir)

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -299,7 +299,7 @@ def acyclic_depth_first(tree, children=iter, depth=-1, cut_mark=None, traversed=
 def acyclic_branches_depth_first(tree, children=iter, depth=-1, cut_mark=None, traversed=None):
     """Traverse the nodes of a tree in depth-first order,
     discarding eventual cycles within the same branch,
-    but keep duplicate pathes in different branches.
+    but keep duplicate paths in different branches.
     Add cut_mark (when defined) if cycles were truncated.
 
     The first argument should be the tree root;
@@ -936,7 +936,7 @@ def set_proxy(proxy, user=None, password=""):
         opener.add_handler(ProxyBasicAuthHandler(password_manager))
         opener.add_handler(ProxyDigestAuthHandler(password_manager))
 
-    # Overide the existing url opener
+    # Override the existing url opener
     install_opener(opener)
 
 
@@ -1019,7 +1019,7 @@ def pairwise(iterable):
     return zip(a, b)
 
 ######################################################################
-# Parallization.
+# Parallelization.
 ######################################################################
 
 


### PR DESCRIPTION
Hello!

### Pull request overview
* Resolved many typos in comments, Exceptions and outputs, using the `codespell` module.

---

### Note
Despite the `codespell` module working quite well, it cannot properly be automated (i.e. in per-commit or GitHub Actions CI), as it attempts to "fix" non-English text, URLs, tests and more.

- Tom Aarsen