### PR TITLE
resolve numpy deprecation warning about numpy.float alias

### DIFF
--- a/nltk/cluster/gaac.py
+++ b/nltk/cluster/gaac.py
@@ -48,7 +48,7 @@ class GAAClusterer(VectorSpaceClusterer):
 
         # construct the similarity matrix
         dims = (N, N)
-        dist = numpy.ones(dims, dtype=numpy.float) * numpy.inf
+        dist = numpy.ones(dims, dtype=float) * numpy.inf
         for i in range(N):
             for j in range(i + 1, N):
                 dist[i, j] = cosine_distance(vectors[i], vectors[j])


### PR DESCRIPTION
This PR replaces single use of a deprecated numpy alias with an identical equivalent.

Steps to reproduce:
```python
>>> import numpy
>>> numpy.float
<stdin>:1: DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```
I spotted this code when looking at https://github.com/nltk/nltk/issues/2735, thanks @ihawn
Details: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations