### PR TITLE
Resolved typo in api.py, 'peraser' -> 'parser'

### DIFF
--- a/nltk/chunk/api.py
+++ b/nltk/chunk/api.py
@@ -40,7 +40,7 @@ class ChunkParserI(ParserI):
         Score the accuracy of the chunker against the gold standard.
         Remove the chunking the gold standard text, rechunk it using
         the chunker, and return a ``ChunkScore`` object
-        reflecting the performance of this chunk peraser.
+        reflecting the performance of this chunk parser.
 
         :type gold: list(Tree)
         :param gold: The list of chunked sentences to score the chunker on.


### PR DESCRIPTION
Discovered this when closing #2614.

This PR speaks for itself.