### PR TITLE
Resolved ZeroDivisionError in RIBES with dissimilar sentences

### DIFF
--- a/nltk/test/unit/test_ribes.py
+++ b/nltk/test/unit/test_ribes.py
@@ -1,0 +1,246 @@
+from nltk.translate.ribes_score import corpus_ribes, word_rank_alignment
+
+
+def test_ribes_empty_worder():  # worder as in word order
+    # Verifies that these two sentences have no alignment,
+    # and hence have the lowest possible RIBES score.
+    hyp = "This is a nice sentence which I quite like".split()
+    ref = "Okay well that's neat and all but the reference's different".split()
+
+    assert word_rank_alignment(ref, hyp) == []
+
+    list_of_refs = [[ref]]
+    hypotheses = [hyp]
+    assert corpus_ribes(list_of_refs, hypotheses) == 0.0
+
+
+def test_ribes_one_worder():
+    # Verifies that these two sentences have just one match,
+    # and the RIBES score for this sentence with very little
+    # correspondence is 0.
+    hyp = "This is a nice sentence which I quite like".split()
+    ref = "Okay well that's nice and all but the reference's different".split()
+
+    assert word_rank_alignment(ref, hyp) == [3]
+
+    list_of_refs = [[ref]]
+    hypotheses = [hyp]
+    assert corpus_ribes(list_of_refs, hypotheses) == 0.0
+
+
+def test_ribes_two_worder():
+    # Verifies that these two sentences have two matches,
+    # but still get the lowest possible RIBES score due
+    # to the lack of similarity.
+    hyp = "This is a nice sentence which I quite like".split()
+    ref = "Okay well that's nice and all but the reference is different".split()
+
+    assert word_rank_alignment(ref, hyp) == [9, 3]
+
+    list_of_refs = [[ref]]
+    hypotheses = [hyp]
+    assert corpus_ribes(list_of_refs, hypotheses) == 0.0
+
+
+def test_ribes():
+    # Based on the doctest of the corpus_ribes function
+    hyp1 = [
+        "It",
+        "is",
+        "a",
+        "guide",
+        "to",
+        "action",
+        "which",
+        "ensures",
+        "that",
+        "the",
+        "military",
+        "always",
+        "obeys",
+        "the",
+        "commands",
+        "of",
+        "the",
+        "party",
+    ]
+    ref1a = [
+        "It",
+        "is",
+        "a",
+        "guide",
+        "to",
+        "action",
+        "that",
+        "ensures",
+        "that",
+        "the",
+        "military",
+        "will",
+        "forever",
+        "heed",
+        "Party",
+        "commands",
+    ]
+    ref1b = [
+        "It",
+        "is",
+        "the",
+        "guiding",
+        "principle",
+        "which",
+        "guarantees",
+        "the",
+        "military",
+        "forces",
+        "always",
+        "being",
+        "under",
+        "the",
+        "command",
+        "of",
+        "the",
+        "Party",
+    ]
+    ref1c = [
+        "It",
+        "is",
+        "the",
+        "practical",
+        "guide",
+        "for",
+        "the",
+        "army",
+        "always",
+        "to",
+        "heed",
+        "the",
+        "directions",
+        "of",
+        "the",
+        "party",
+    ]
+
+    hyp2 = [
+        "he",
+        "read",
+        "the",
+        "book",
+        "because",
+        "he",
+        "was",
+        "interested",
+        "in",
+        "world",
+        "history",
+    ]
+    ref2a = [
+        "he",
+        "was",
+        "interested",
+        "in",
+        "world",
+        "history",
+        "because",
+        "he",
+        "read",
+        "the",
+        "book",
+    ]
+
+    list_of_refs = [[ref1a, ref1b, ref1c], [ref2a]]
+    hypotheses = [hyp1, hyp2]
+
+    score = corpus_ribes(list_of_refs, hypotheses)
+
+    assert round(score, 4) == 0.3597
+
+
+def test_no_zero_div():
+    # Regression test for Issue 2529, assure that no ZeroDivisionError is thrown.
+    hyp1 = [
+        "It",
+        "is",
+        "a",
+        "guide",
+        "to",
+        "action",
+        "which",
+        "ensures",
+        "that",
+        "the",
+        "military",
+        "always",
+        "obeys",
+        "the",
+        "commands",
+        "of",
+        "the",
+        "party",
+    ]
+    ref1a = [
+        "It",
+        "is",
+        "a",
+        "guide",
+        "to",
+        "action",
+        "that",
+        "ensures",
+        "that",
+        "the",
+        "military",
+        "will",
+        "forever",
+        "heed",
+        "Party",
+        "commands",
+    ]
+    ref1b = [
+        "It",
+        "is",
+        "the",
+        "guiding",
+        "principle",
+        "which",
+        "guarantees",
+        "the",
+        "military",
+        "forces",
+        "always",
+        "being",
+        "under",
+        "the",
+        "command",
+        "of",
+        "the",
+        "Party",
+    ]
+    ref1c = [
+        "It",
+        "is",
+        "the",
+        "practical",
+        "guide",
+        "for",
+        "the",
+        "army",
+        "always",
+        "to",
+        "heed",
+        "the",
+        "directions",
+        "of",
+        "the",
+        "party",
+    ]
+
+    hyp2 = ["he", "read", "the"]
+    ref2a = ["he", "was", "interested", "in", "world", "history", "because", "he"]
+
+    list_of_refs = [[ref1a, ref1b, ref1c], [ref2a]]
+    hypotheses = [hyp1, hyp2]
+
+    score = corpus_ribes(list_of_refs, hypotheses)
+
+    assert round(score, 4) == 0.1688

--- a/nltk/translate/ribes_score.py
+++ b/nltk/translate/ribes_score.py
@@ -279,11 +279,9 @@ def kendall_tau(worder, normalize=True):
     :rtype: float
     """
     worder_len = len(worder)
-    # If the length of the word order list is less than 2,
-    # then num_possible_pairs will be 0. This produces a ZeroDivisionError.
-    # So, instead, we want to return the lowest possible score.
-    # From worder_len as 2 or higher, `choose(worder_len, 2)` will no longer
-    # be 0.
+    # With worder_len < 2, `choose(worder_len, 2)` will be 0.
+    # As we divide by this, it will give a ZeroDivisionError.
+    # To avoid this, we can just return the lowest possible score.
     if worder_len < 2:
         tau = -1
     else:

--- a/nltk/translate/ribes_score.py
+++ b/nltk/translate/ribes_score.py
@@ -36,7 +36,7 @@ def sentence_ribes(references, hypothesis, alpha=0.25, beta=0.10):
     to http://www.kecl.ntt.co.jp/icl/lirg/ribes/ for the official script.
 
     :param references: a list of reference sentences
-    :type reference: list(list(str))
+    :type references: list(list(str))
     :param hypothesis: a hypothesis sentence
     :type hypothesis: list(str)
     :param alpha: hyperparameter used as a prior for the unigram precision.
@@ -258,7 +258,7 @@ def kendall_tau(worder, normalize=True):
     Calculates the Kendall's Tau correlation coefficient given the *worder*
     list of word alignments from word_rank_alignment(), using the formula:
 
-        tau = 2 * num_increasing_pairs / num_possible pairs -1
+        tau = 2 * num_increasing_pairs / num_possible_pairs -1
 
     Note that the no. of increasing pairs can be discontinuous in the *worder*
     list and each each increasing sequence can be tabulated as choose(len(seq), 2)
@@ -273,21 +273,29 @@ def kendall_tau(worder, normalize=True):
 
     :param worder: The worder list output from word_rank_alignment
     :type worder: list(int)
-    :param normalize: Flag to indicate normalization
+    :param normalize: Flag to indicate normalization to between 0.0 and 1.0.
     :type normalize: boolean
     :return: The Kendall's Tau correlation coefficient.
     :rtype: float
     """
     worder_len = len(worder)
-    # Extract the groups of increasing/monotonic sequences.
-    increasing_sequences = find_increasing_sequences(worder)
-    # Calculate no. of increasing_pairs in *worder* list.
-    num_increasing_pairs = sum(choose(len(seq), 2) for seq in increasing_sequences)
-    # Calculate no. of possible pairs.
-    num_possible_pairs = choose(worder_len, 2)
-    # Kendall's Tau computation.
-    tau = 2 * num_increasing_pairs / num_possible_pairs - 1
-    if normalize:  # If normalized, the tau output falls between 0.0 to 1.0
+    # If the length of the word order list is less than 2,
+    # then num_possible_pairs will be 0. This produces a ZeroDivisionError.
+    # So, instead, we want to return the lowest possible score.
+    # From worder_len as 2 or higher, `choose(worder_len, 2)` will no longer
+    # be 0.
+    if worder_len < 2:
+        tau = -1
+    else:
+        # Extract the groups of increasing/monotonic sequences.
+        increasing_sequences = find_increasing_sequences(worder)
+        # Calculate no. of increasing_pairs in *worder* list.
+        num_increasing_pairs = sum(choose(len(seq), 2) for seq in increasing_sequences)
+        # Calculate no. of possible pairs.
+        num_possible_pairs = choose(worder_len, 2)
+        # Kendall's Tau computation.
+        tau = 2 * num_increasing_pairs / num_possible_pairs - 1
+    if normalize: # If normalized, the tau output falls between 0.0 to 1.0
         return (tau + 1) / 2
     else:  # Otherwise, the tau outputs falls between -1.0 to +1.0
         return tau


### PR DESCRIPTION
Fixes #2529, fixes #2433, and fixes one of the two issues mentioned in #1785. 
The second issue in this #1785 has not been taken care of - however it's a consistency change rather than a genuine bug.

---

Hello!

### Pull request overview
* Ensured that a ZeroDivisionError is not thrown when sentences passed to `corpus_ribes` or `sentence_ribes` are dissimilar or too short, by modifying `kendall_tau`.
* Added tests to show that this no longer throws an Exception.
* Modified documentation slightly and applied typo fixes.

---

### The bug & the fix
RIBES relies on `kendall_tau`, which is computed as such:
https://github.com/nltk/nltk/blob/6c07b5e99389b47e13c5e70fa07b37ef29ea8f73/nltk/translate/ribes_score.py#L261

The current implementation does not check whether `num_possible_pairs` is 0 or not. When this is the case, the lowest possible score should be returned.

For reference, the entire function in question:
https://github.com/nltk/nltk/blob/6c07b5e99389b47e13c5e70fa07b37ef29ea8f73/nltk/translate/ribes_score.py#L256-L293

Here, `worder` is a list of integers representing a word order. The dangerous denominator `num_possible_pairs` is created using `choose(worder_len, 2)`. However, if the `worder` list contains no or just one element, then `choose(worder_len, 2)` is 0. With this 0 is then divided, resulting in an exception.

So, in these cases, the lowest possible score should just be returned.

That is what this PR changes. 

---

### Additional changes
I've added 5 tests. The first three use dissimilar sentences I came up with, which would have previously thrown an Exception due to being too dissimilar (i.e. the `worder` list was too small). The fourth test is taken from the docstring of `corpus_ribes`, and the last test originates from #2529.

Beyond that there are some small documentation changes.

P.s. I've been enjoying keeping busy during some of my days off by helping maintain this repo. :)

- Tom Aarsen