### PR TITLE
Fixed issue on platforms that use `\r\n` line-endings when writing CSV files

### DIFF
--- a/nltk/twitter/common.py
+++ b/nltk/twitter/common.py
@@ -137,9 +137,9 @@ def outf_writer_compat(outfile, encoding, errors, gzip_compress=False):
 
 def _outf_writer(outfile, encoding, errors, gzip_compress=False):
     if gzip_compress:
-        outf = gzip.open(outfile, "wt", encoding=encoding, errors=errors)
+        outf = gzip.open(outfile, "wt", newline="", encoding=encoding, errors=errors)
     else:
-        outf = open(outfile, "w", encoding=encoding, errors=errors)
+        outf = open(outfile, "w", newline="", encoding=encoding, errors=errors)
     writer = csv.writer(outf)
     return (writer, outf)
 


### PR DESCRIPTION
Hello!

### Pull request overview
- Currently, tests in `test_json2csv_corpus.py` that use `files_are_identical` fail on Windows.
  This issue is caused by `csv.writer` on files opened without specifying `newline=""`. This PR fixes this issue.

Relevant documentation: https://docs.python.org/3/library/csv.html#id3

---

### Overview
When I boot to my Windows install, and run the NLTK tests, I get the following (truncated) output:

```python
========================================================== short test summary info ========================================================== 
FAILED nltk/test/unit/test_json2csv_corpus.py::test_textoutput - AssertionError: assert False
FAILED nltk/test/unit/test_json2csv_corpus.py::test_tweet_metadata - AssertionError: assert False
FAILED nltk/test/unit/test_json2csv_corpus.py::test_user_metadata - AssertionError: assert False
FAILED nltk/test/unit/test_json2csv_corpus.py::test_tweet_hashtag - AssertionError: assert False
FAILED nltk/test/unit/test_json2csv_corpus.py::test_tweet_usermention - AssertionError: assert False
FAILED nltk/test/unit/test_json2csv_corpus.py::test_tweet_media - AssertionError: assert False
FAILED nltk/test/unit/test_json2csv_corpus.py::test_tweet_url - AssertionError: assert False
FAILED nltk/test/unit/test_json2csv_corpus.py::test_userurl - AssertionError: assert False
FAILED nltk/test/unit/test_json2csv_corpus.py::test_tweet_place - AssertionError: assert False
FAILED nltk/test/unit/test_json2csv_corpus.py::test_tweet_place_boundingbox - AssertionError: assert False
FAILED nltk/test/unit/test_json2csv_corpus.py::test_retweet_original_tweet - AssertionError: assert False
==================================== 11 failed, 361 passed, 39 skipped, 9 xfailed, 7 warnings in 28.15s =====================================
```

<details>
<summary>See the full output here</summary>

```python
============================================================ test session starts ============================================================
platform win32 -- Python 3.9.4, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: C:\GitHub\nltk
plugins: cov-2.12.1, mock-3.6.1
collected 420 items

nltk\test\unit\test_aline.py ..                                                                                                        [  0%]
nltk\test\unit\test_brill.py s.                                                                                                        [  0%]
nltk\test\unit\test_cfd_mutation.py ...                                                                                                [  1%] 
nltk\test\unit\test_cfg2chomsky.py ..                                                                                                  [  2%]
nltk\test\unit\test_chunk.py .                                                                                                         [  2%]
nltk\test\unit\test_classify.py ss                                                                                                     [  2%] 
nltk\test\unit\test_collocations.py ...                                                                                                [  3%] 
nltk\test\unit\test_concordance.py ....                                                                                                [  4%]
nltk\test\unit\test_corenlp.py ssssss                                                                                                  [  5%] 
nltk\test\unit\test_corpora.py ...........ssssssss                                                                                     [ 10%]
nltk\test\unit\test_corpus_views.py ..                                                                                                 [ 10%]
nltk\test\unit\test_data.py ..                                                                                                         [ 11%] 
nltk\test\unit\test_disagreement.py ....                                                                                               [ 12%]
nltk\test\unit\test_freqdist.py .                                                                                                      [ 12%]
nltk\test\unit\test_hmm.py ...                                                                                                         [ 13%] 
nltk\test\unit\test_json2csv_corpus.py FFFFFFFFFFF.                                                                                    [ 16%]
nltk\test\unit\test_json_serialization.py ......                                                                                       [ 17%]
nltk\test\unit\test_metrics.py ...                                                                                                     [ 18%] 
nltk\test\unit\test_naivebayes.py .                                                                                                    [ 18%] 
nltk\test\unit\test_nombank.py ...                                                                                                     [ 19%]
nltk\test\unit\test_pl196x.py .                                                                                                        [ 19%] 
nltk\test\unit\test_pos_tag.py ......                                                                                                  [ 20%]
nltk\test\unit\test_ribes.py .....                                                                                                     [ 22%]
nltk\test\unit\test_rte_classify.py ...s                                                                                               [ 23%]
nltk\test\unit\test_seekable_unicode_stream_reader.py ......                                                                           [ 24%]
nltk\test\unit\test_senna.py ssss                                                                                                      [ 25%] 
nltk\test\unit\test_stem.py ..........                                                                                                 [ 27%]
nltk\test\unit\test_tag.py .                                                                                                           [ 28%] 
nltk\test\unit\test_tgrep.py .............................                                                                             [ 35%]
nltk\test\unit\test_tokenize.py ssssssssssssssss                                                                                       [ 38%]
nltk\test\unit\test_twitter_auth.py ..........                                                                                         [ 41%]
nltk\test\unit\test_util.py .....                                                                                                      [ 42%]
nltk\test\unit\test_wordnet.py .............                                                                                           [ 45%]
nltk\test\unit\lm\test_counter.py ...............                                                                                      [ 49%]
nltk\test\unit\lm\test_models.py ............................................................x.......x.......x.......x.......x.......x [ 73%]
.......x.......x.......x.......                                                                                                        [ 80%]
nltk\test\unit\lm\test_preprocessing.py .                                                                                              [ 80%] 
nltk\test\unit\lm\test_vocabulary.py .....s..............                                                                              [ 85%]
nltk\test\unit\translate\test_bleu.py ............                                                                                     [ 88%]
nltk\test\unit\translate\test_gdfa.py .                                                                                                [ 88%]
nltk\test\unit\translate\test_ibm1.py ...                                                                                              [ 89%] 
nltk\test\unit\translate\test_ibm2.py ...                                                                                              [ 90%]
nltk\test\unit\translate\test_ibm3.py ...                                                                                              [ 90%]
nltk\test\unit\translate\test_ibm4.py ...                                                                                              [ 91%] 
nltk\test\unit\translate\test_ibm5.py ....                                                                                             [ 92%]
nltk\test\unit\translate\test_ibm_model.py ............                                                                                [ 95%]
nltk\test\unit\translate\test_meteor.py .                                                                                              [ 95%] 
nltk\test\unit\translate\test_nist.py .                                                                                                [ 95%]
nltk\test\unit\translate\test_stack_decoder.py ..................                                                                      [100%]

================================================================= FAILURES ================================================================== 
______________________________________________________________ test_textoutput ______________________________________________________________ 

tmp_path = WindowsPath('C:/Users/Tom/AppData/Local/Temp/pytest-of-Tom/pytest-3/test_textoutput0')
infile = ['{"in_reply_to_status_id": null, "contributors": null, "filter_level": "low", "coordinates": null, "id_str": "5938910...ls": []}, "source": "<a href=\\"http://tapbots.com/tweetbot\\" rel=\\"nofollow\\">Tweetbot for i\\u039fS</a>"}\n', ...]

    def test_textoutput(tmp_path, infile):
        ref_fn = subdir / 'tweets.20150430-223406.text.csv.ref'
        outfn = tmp_path / 'tweets.20150430-223406.text.csv'
        json2csv(infile, outfn, ['text'], gzip_compress=False)
>       assert files_are_identical(outfn, ref_fn)
E       AssertionError: assert False
E        +  where False = files_are_identical(WindowsPath('C:/Users/Tom/AppData/Local/Temp/pytest-of-Tom/pytest-3/test_textoutput0/tweets.20150430-223406.text.csv'), WindowsPath('C:/GitHub/nltk/nltk/test/unit/files/tweets.20150430-223406.text.csv.ref'))

nltk\test\unit\test_json2csv_corpus.py:42: AssertionError
____________________________________________________________ test_tweet_metadata ____________________________________________________________ 

tmp_path = WindowsPath('C:/Users/Tom/AppData/Local/Temp/pytest-of-Tom/pytest-3/test_tweet_metadata0')
infile = ['{"in_reply_to_status_id": null, "contributors": null, "filter_level": "low", "coordinates": null, "id_str": "5938910...ls": []}, "source": "<a href=\\"http://tapbots.com/tweetbot\\" rel=\\"nofollow\\">Tweetbot for i\\u039fS</a>"}\n', ...]

    def test_tweet_metadata(tmp_path, infile):
        ref_fn = subdir / 'tweets.20150430-223406.tweet.csv.ref'
        fields = [
            'created_at',
            'favorite_count',
            'id',
            'in_reply_to_status_id',
            'in_reply_to_user_id',
            'retweet_count',
            'retweeted',
            'text',
            'truncated',
            'user.id',
        ]

        outfn = tmp_path / 'tweets.20150430-223406.tweet.csv'
        json2csv(infile, outfn, fields, gzip_compress=False)
>       assert files_are_identical(outfn, ref_fn)
E       AssertionError: assert False
E        +  where False = files_are_identical(WindowsPath('C:/Users/Tom/AppData/Local/Temp/pytest-of-Tom/pytest-3/test_tweet_metadata0/tweets.20150430-223406.tweet.csv'), WindowsPath('C:/GitHub/nltk/nltk/test/unit/files/tweets.20150430-223406.tweet.csv.ref'))

nltk\test\unit\test_json2csv_corpus.py:62: AssertionError
____________________________________________________________ test_user_metadata _____________________________________________________________ 

tmp_path = WindowsPath('C:/Users/Tom/AppData/Local/Temp/pytest-of-Tom/pytest-3/test_user_metadata0')
infile = ['{"in_reply_to_status_id": null, "contributors": null, "filter_level": "low", "coordinates": null, "id_str": "5938910...ls": []}, "source": "<a href=\\"http://tapbots.com/tweetbot\\" rel=\\"nofollow\\">Tweetbot for i\\u039fS</a>"}\n', ...]

    def test_user_metadata(tmp_path, infile):
        ref_fn = subdir / 'tweets.20150430-223406.user.csv.ref'
        fields = ['id', 'text', 'user.id', 'user.followers_count', 'user.friends_count']

        outfn = tmp_path / 'tweets.20150430-223406.user.csv'
        json2csv(infile, outfn, fields, gzip_compress=False)
>       assert files_are_identical(outfn, ref_fn)
E       AssertionError: assert False
E        +  where False = files_are_identical(WindowsPath('C:/Users/Tom/AppData/Local/Temp/pytest-of-Tom/pytest-3/test_user_metadata0/tweets.20150430-223406.user.csv'), WindowsPath('C:/GitHub/nltk/nltk/test/unit/files/tweets.20150430-223406.user.csv.ref'))

nltk\test\unit\test_json2csv_corpus.py:71: AssertionError
____________________________________________________________ test_tweet_hashtag _____________________________________________________________ 

tmp_path = WindowsPath('C:/Users/Tom/AppData/Local/Temp/pytest-of-Tom/pytest-3/test_tweet_hashtag0')
infile = ['{"in_reply_to_status_id": null, "contributors": null, "filter_level": "low", "coordinates": null, "id_str": "5938910...ls": []}, "source": "<a href=\\"http://tapbots.com/tweetbot\\" rel=\\"nofollow\\">Tweetbot for i\\u039fS</a>"}\n', ...]

    def test_tweet_hashtag(tmp_path, infile):
        ref_fn = subdir / 'tweets.20150430-223406.hashtag.csv.ref'
        outfn = tmp_path / 'tweets.20150430-223406.hashtag.csv'
        json2csv_entities(
            infile,
            outfn,
            ['id', 'text'],
            'hashtags',
            ['text'],
            gzip_compress=False,
        )
>       assert files_are_identical(outfn, ref_fn)
E       AssertionError: assert False
E        +  where False = files_are_identical(WindowsPath('C:/Users/Tom/AppData/Local/Temp/pytest-of-Tom/pytest-3/test_tweet_hashtag0/tweets.20150430-223406.hashtag.csv'), WindowsPath('C:/GitHub/nltk/nltk/test/unit/files/tweets.20150430-223406.hashtag.csv.ref'))

nltk\test\unit\test_json2csv_corpus.py:85: AssertionError
__________________________________________________________ test_tweet_usermention ___________________________________________________________ 

tmp_path = WindowsPath('C:/Users/Tom/AppData/Local/Temp/pytest-of-Tom/pytest-3/test_tweet_usermention0')
infile = ['{"in_reply_to_status_id": null, "contributors": null, "filter_level": "low", "coordinates": null, "id_str": "5938910...ls": []}, "source": "<a href=\\"http://tapbots.com/tweetbot\\" rel=\\"nofollow\\">Tweetbot for i\\u039fS</a>"}\n', ...]

    def test_tweet_usermention(tmp_path, infile):
        ref_fn = subdir / 'tweets.20150430-223406.usermention.csv.ref'
        outfn = tmp_path / 'tweets.20150430-223406.usermention.csv'
        json2csv_entities(
            infile,
            outfn,
            ['id', 'text'],
            'user_mentions',
            ['id', 'screen_name'],
            gzip_compress=False,
        )
>       assert files_are_identical(outfn, ref_fn)
E       AssertionError: assert False
E        +  where False = files_are_identical(WindowsPath('C:/Users/Tom/AppData/Local/Temp/pytest-of-Tom/pytest-3/test_tweet_usermention0/tweets.20150430-223406.usermention.csv'), WindowsPath('C:/GitHub/nltk/nltk/test/unit/files/tweets.20150430-223406.usermention.csv.ref'))

nltk\test\unit\test_json2csv_corpus.py:99: AssertionError
_____________________________________________________________ test_tweet_media ______________________________________________________________ 

tmp_path = WindowsPath('C:/Users/Tom/AppData/Local/Temp/pytest-of-Tom/pytest-3/test_tweet_media0')
infile = ['{"in_reply_to_status_id": null, "contributors": null, "filter_level": "low", "coordinates": null, "id_str": "5938910...ls": []}, "source": "<a href=\\"http://tapbots.com/tweetbot\\" rel=\\"nofollow\\">Tweetbot for i\\u039fS</a>"}\n', ...]

    def test_tweet_media(tmp_path, infile):
        ref_fn = subdir / 'tweets.20150430-223406.media.csv.ref'
        outfn = tmp_path / 'tweets.20150430-223406.media.csv'
        json2csv_entities(
            infile,
            outfn,
            ['id'],
            'media',
            ['media_url', 'url'],
            gzip_compress=False,
        )

>       assert files_are_identical(outfn, ref_fn)
E       AssertionError: assert False
E        +  where False = files_are_identical(WindowsPath('C:/Users/Tom/AppData/Local/Temp/pytest-of-Tom/pytest-3/test_tweet_media0/tweets.20150430-223406.media.csv'), WindowsPath('C:/GitHub/nltk/nltk/test/unit/files/tweets.20150430-223406.media.csv.ref'))

nltk\test\unit\test_json2csv_corpus.py:114: AssertionError
______________________________________________________________ test_tweet_url _______________________________________________________________ 

tmp_path = WindowsPath('C:/Users/Tom/AppData/Local/Temp/pytest-of-Tom/pytest-3/test_tweet_url0')
infile = ['{"in_reply_to_status_id": null, "contributors": null, "filter_level": "low", "coordinates": null, "id_str": "5938910...ls": []}, "source": "<a href=\\"http://tapbots.com/tweetbot\\" rel=\\"nofollow\\">Tweetbot for i\\u039fS</a>"}\n', ...]

    def test_tweet_url(tmp_path, infile):
        ref_fn = subdir / 'tweets.20150430-223406.url.csv.ref'
        outfn = tmp_path / 'tweets.20150430-223406.url.csv'
        json2csv_entities(
            infile,
            outfn,
            ['id'],
            'urls',
            ['url', 'expanded_url'],
            gzip_compress=False,
        )

>       assert files_are_identical(outfn, ref_fn)
E       AssertionError: assert False
E        +  where False = files_are_identical(WindowsPath('C:/Users/Tom/AppData/Local/Temp/pytest-of-Tom/pytest-3/test_tweet_url0/tweets.20150430-223406.url.csv'), WindowsPath('C:/GitHub/nltk/nltk/test/unit/files/tweets.20150430-223406.url.csv.ref'))

nltk\test\unit\test_json2csv_corpus.py:129: AssertionError
_______________________________________________________________ test_userurl ________________________________________________________________ 

tmp_path = WindowsPath('C:/Users/Tom/AppData/Local/Temp/pytest-of-Tom/pytest-3/test_userurl0')
infile = ['{"in_reply_to_status_id": null, "contributors": null, "filter_level": "low", "coordinates": null, "id_str": "5938910...ls": []}, "source": "<a href=\\"http://tapbots.com/tweetbot\\" rel=\\"nofollow\\">Tweetbot for i\\u039fS</a>"}\n', ...]

    def test_userurl(tmp_path, infile):
        ref_fn = subdir / 'tweets.20150430-223406.userurl.csv.ref'
        outfn = tmp_path / 'tweets.20150430-223406.userurl.csv'
        json2csv_entities(
            infile,
            outfn,
            ['id', 'screen_name'],
            'user.urls',
            ['url', 'expanded_url'],
            gzip_compress=False,
        )

>       assert files_are_identical(outfn, ref_fn)
E       AssertionError: assert False
E        +  where False = files_are_identical(WindowsPath('C:/Users/Tom/AppData/Local/Temp/pytest-of-Tom/pytest-3/test_userurl0/tweets.20150430-223406.userurl.csv'), WindowsPath('C:/GitHub/nltk/nltk/test/unit/files/tweets.20150430-223406.userurl.csv.ref'))

nltk\test\unit\test_json2csv_corpus.py:144: AssertionError
_____________________________________________________________ test_tweet_place ______________________________________________________________ 

tmp_path = WindowsPath('C:/Users/Tom/AppData/Local/Temp/pytest-of-Tom/pytest-3/test_tweet_place0')
infile = ['{"in_reply_to_status_id": null, "contributors": null, "filter_level": "low", "coordinates": null, "id_str": "5938910...ls": []}, "source": "<a href=\\"http://tapbots.com/tweetbot\\" rel=\\"nofollow\\">Tweetbot for i\\u039fS</a>"}\n', ...]

    def test_tweet_place(tmp_path, infile):
        ref_fn = subdir / 'tweets.20150430-223406.place.csv.ref'
        outfn = tmp_path / 'tweets.20150430-223406.place.csv'
        json2csv_entities(
            infile,
            outfn,
            ['id', 'text'],
            'place',
            ['name', 'country'],
            gzip_compress=False,
        )

>       assert files_are_identical(outfn, ref_fn)
E       AssertionError: assert False
E        +  where False = files_are_identical(WindowsPath('C:/Users/Tom/AppData/Local/Temp/pytest-of-Tom/pytest-3/test_tweet_place0/tweets.20150430-223406.place.csv'), WindowsPath('C:/GitHub/nltk/nltk/test/unit/files/tweets.20150430-223406.place.csv.ref'))

nltk\test\unit\test_json2csv_corpus.py:159: AssertionError
_______________________________________________________ test_tweet_place_boundingbox ________________________________________________________ 

tmp_path = WindowsPath('C:/Users/Tom/AppData/Local/Temp/pytest-of-Tom/pytest-3/test_tweet_place_boundingbox0')
infile = ['{"in_reply_to_status_id": null, "contributors": null, "filter_level": "low", "coordinates": null, "id_str": "5938910...ls": []}, "source": "<a href=\\"http://tapbots.com/tweetbot\\" rel=\\"nofollow\\">Tweetbot for i\\u039fS</a>"}\n', ...]

    def test_tweet_place_boundingbox(tmp_path, infile):
        ref_fn = subdir / 'tweets.20150430-223406.placeboundingbox.csv.ref'
        outfn = tmp_path / 'tweets.20150430-223406.placeboundingbox.csv'
        json2csv_entities(
            infile,
            outfn,
            ['id', 'name'],
            'place.bounding_box',
            ['coordinates'],
            gzip_compress=False,
        )

>       assert files_are_identical(outfn, ref_fn)
E       AssertionError: assert False
E        +  where False = files_are_identical(WindowsPath('C:/Users/Tom/AppData/Local/Temp/pytest-of-Tom/pytest-3/test_tweet_place_boundingbox0/tweets.20150430-223406.placeboundingbox.csv'), WindowsPath('C:/GitHub/nltk/nltk/test/unit/files/tweets.20150430-223406.placeboundingbox.csv.ref'))

nltk\test\unit\test_json2csv_corpus.py:174: AssertionError
________________________________________________________ test_retweet_original_tweet ________________________________________________________ 

tmp_path = WindowsPath('C:/Users/Tom/AppData/Local/Temp/pytest-of-Tom/pytest-3/test_retweet_original_tweet0')
infile = ['{"in_reply_to_status_id": null, "contributors": null, "filter_level": "low", "coordinates": null, "id_str": "5938910...ls": []}, "source": "<a href=\\"http://tapbots.com/tweetbot\\" rel=\\"nofollow\\">Tweetbot for i\\u039fS</a>"}\n', ...]

    def test_retweet_original_tweet(tmp_path, infile):
        ref_fn = subdir / 'tweets.20150430-223406.retweet.csv.ref'
        outfn = tmp_path / 'tweets.20150430-223406.retweet.csv'
        json2csv_entities(
            infile,
            outfn,
            ['id'],
            'retweeted_status',
            [
                'created_at',
                'favorite_count',
                'id',
                'in_reply_to_status_id',
                'in_reply_to_user_id',
                'retweet_count',
                'text',
                'truncated',
                'user.id',
            ],
            gzip_compress=False,
        )

>       assert files_are_identical(outfn, ref_fn)
E       AssertionError: assert False
E        +  where False = files_are_identical(WindowsPath('C:/Users/Tom/AppData/Local/Temp/pytest-of-Tom/pytest-3/test_retweet_original_tweet0/tweets.20150430-223406.retweet.csv'), WindowsPath('C:/GitHub/nltk/nltk/test/unit/files/tweets.20150430-223406.retweet.csv.ref'))

nltk\test\unit\test_json2csv_corpus.py:199: AssertionError
============================================================= warnings summary ============================================================== 
nltk/test/unit/test_tokenize.py::TestTokenize::test_tweet_tokenizer
  C:\GitHub\nltk\nltk\test\unit\test_tokenize.py:21: DeprecationWarning:
  The StanfordTokenizer will be deprecated in version 3.2.5.
  Please use nltk.parse.corenlp.CoreNLPTokenizer instead.'
    seg = StanfordSegmenter()

nltk/test/unit/translate/test_bleu.py::TestBLEU::test_partial_matches_hypothesis_longer_than_reference
nltk/test/unit/translate/test_bleu.py::TestBLEUFringeCases::test_case_where_n_is_bigger_than_hypothesis_length
nltk/test/unit/translate/test_bleu.py::TestBLEUFringeCases::test_case_where_n_is_bigger_than_hypothesis_length
nltk/test/unit/translate/test_bleu.py::TestBLEUFringeCases::test_reference_or_hypothesis_shorter_than_fourgrams
  C:\GitHub\nltk\nltk\translate\bleu_score.py:515: UserWarning:
  The hypothesis contains 0 counts of 4-gram overlaps.
  Therefore the BLEU score evaluates to 0, independently of
  how many N-gram overlaps of lower order it contains.
  Consider using lower n-gram order or use SmoothingFunction()
    warnings.warn(_msg)

nltk/test/unit/translate/test_bleu.py::TestBLEUFringeCases::test_reference_or_hypothesis_shorter_than_fourgrams
  C:\GitHub\nltk\nltk\translate\bleu_score.py:515: UserWarning:
  The hypothesis contains 0 counts of 2-gram overlaps.
  Therefore the BLEU score evaluates to 0, independently of
  how many N-gram overlaps of lower order it contains.
  Consider using lower n-gram order or use SmoothingFunction()
    warnings.warn(_msg)

nltk/test/unit/translate/test_bleu.py::TestBLEUFringeCases::test_reference_or_hypothesis_shorter_than_fourgrams
  C:\GitHub\nltk\nltk\translate\bleu_score.py:515: UserWarning:
  The hypothesis contains 0 counts of 3-gram overlaps.
  Therefore the BLEU score evaluates to 0, independently of
  how many N-gram overlaps of lower order it contains.
  Consider using lower n-gram order or use SmoothingFunction()
    warnings.warn(_msg)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
========================================================== short test summary info ========================================================== 
FAILED nltk/test/unit/test_json2csv_corpus.py::test_textoutput - AssertionError: assert False
FAILED nltk/test/unit/test_json2csv_corpus.py::test_tweet_metadata - AssertionError: assert False
FAILED nltk/test/unit/test_json2csv_corpus.py::test_user_metadata - AssertionError: assert False
FAILED nltk/test/unit/test_json2csv_corpus.py::test_tweet_hashtag - AssertionError: assert False
FAILED nltk/test/unit/test_json2csv_corpus.py::test_tweet_usermention - AssertionError: assert False
FAILED nltk/test/unit/test_json2csv_corpus.py::test_tweet_media - AssertionError: assert False
FAILED nltk/test/unit/test_json2csv_corpus.py::test_tweet_url - AssertionError: assert False
FAILED nltk/test/unit/test_json2csv_corpus.py::test_userurl - AssertionError: assert False
FAILED nltk/test/unit/test_json2csv_corpus.py::test_tweet_place - AssertionError: assert False
FAILED nltk/test/unit/test_json2csv_corpus.py::test_tweet_place_boundingbox - AssertionError: assert False
FAILED nltk/test/unit/test_json2csv_corpus.py::test_retweet_original_tweet - AssertionError: assert False
==================================== 11 failed, 361 passed, 39 skipped, 9 xfailed, 7 warnings in 28.15s =====================================
```

</details>

All of these failed tests are caused by `files_are_identical(pathA, pathB)` returning False, while they do return True on Ubuntu and MacOS. 
The files that are being compared all only differ in one way, which is best described with an example:
Sample of the newly generated file:
```
id,retweeted_status.created_at,retweeted_status.favorite_count,retweeted_status.id,retweeted_status.in_reply_to_status_id,retweeted_status.in_reply_to_user_id,retweeted_status.retweet_count,retweeted_status.text,retweeted_status.truncated,retweeted_status.user.id

593891099434983425,Thu Apr 30 21:11:02 +0000 2015,3,593885295323521025,,,11,Indirect cost of the UK being in the EU is estimated to be costing Britain £170 billion per year! #BetterOffOut #UKIP,False,929903647

593891099388846080,Thu Apr 30 19:25:17 +0000 2015,68,593858679256002560,,,225,The economy was growing 3 times faster on the day David Cameron became Prime Minister than it is today.. #BBCqt http://t.co/yKornG2YDo,False,168090600

593891100429045760,Thu Apr 30 15:50:02 +0000 2015,6,593804511371776000,,,3,the UKIP east lothian candidate looks about 16 and still has an msn addy http://t.co/7eIU0c5Fm1,False,317875569

593891100768784384,Thu Apr 30 14:06:14 +0000 2015,114,593778387065384960,,,581,UKIP's housing spokesman rakes in £800k in housing benefit from migrants.  http://t.co/GVwb9Rcb4w http://t.co/c1AZxcLhbH,False,262604305

```
Sample of the desired, reference file:
```
id,retweeted_status.created_at,retweeted_status.favorite_count,retweeted_status.id,retweeted_status.in_reply_to_status_id,retweeted_status.in_reply_to_user_id,retweeted_status.retweet_count,retweeted_status.text,retweeted_status.truncated,retweeted_status.user.id
593891099434983425,Thu Apr 30 21:11:02 +0000 2015,3,593885295323521025,,,11,Indirect cost of the UK being in the EU is estimated to be costing Britain £170 billion per year! #BetterOffOut #UKIP,False,929903647
593891099388846080,Thu Apr 30 19:25:17 +0000 2015,68,593858679256002560,,,225,The economy was growing 3 times faster on the day David Cameron became Prime Minister than it is today.. #BBCqt http://t.co/yKornG2YDo,False,168090600
593891100429045760,Thu Apr 30 15:50:02 +0000 2015,6,593804511371776000,,,3,the UKIP east lothian candidate looks about 16 and still has an msn addy http://t.co/7eIU0c5Fm1,False,317875569
593891100768784384,Thu Apr 30 14:06:14 +0000 2015,114,593778387065384960,,,581,UKIP's housing spokesman rakes in £800k in housing benefit from migrants.  http://t.co/GVwb9Rcb4w http://t.co/c1AZxcLhbH,False,262604305
```

These issues exist with tests for `json2csv`, which is this:
https://github.com/nltk/nltk/blob/1244ab9fc4b130ae20127267d49eea506e30a9ae/nltk/twitter/common.py#L87-L129

This file gets its writer from `_outf_writer`:
https://github.com/nltk/nltk/blob/1244ab9fc4b130ae20127267d49eea506e30a9ae/nltk/twitter/common.py#L138-L144

The issue comes from this second function. According to the `csv` documentation [here](https://docs.python.org/3/library/csv.html#id3), when opening (or creating) a file to be written in by the `csv` writer, then if `newline=''` is *not* specified, newlines embedded inside quoted fields will not be interpreted correctly, and on platforms that use `\r\n` linendings on write an extra `\r` will be added. It should always be safe to specify `newline=''`, since the csv module does its own (universal) newline handling.

In short, the solution is to specify `newline=""` within both `open` functions. After this fix, the tests run correctly again, just like on Ubuntu and MacOS. Naturally, the tests also pass on those OSes.
The output for `pytest` is now:
```
========================================== 372 passed, 39 skipped, 9 xfailed, 7 warnings in 28.36s ==========================================
```

---

### What now?
We should take this as an opportunity to consider whether we also want to support CI tests for Windows. Currently, the tests are ran on `ubuntu-latest` and `macos-latest`. We might want to also add `windows-latest`. I can add this functionality if it is desired.

---

- Tom Aarsen