### PR TITLE
Added Black as pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,3 +6,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: requirements-txt-fixer
+  - repo: https://github.com/ambv/black
+    rev: stable
+    hooks:
+    - id: black


### PR DESCRIPTION
Hello!

### Pull request overview
- Added `black` as a hook to pre-commit, helping developers format, and preventing them from (accidentally) committing code that does not match formatting standards.

Upon committing, black will run (after the other hooks), and if it wants to modify a file, it will prevent the commit from going through, and modify the code. You can then git add again, and re-commit, now with formatted changes.

Note that all of this only works if the user has done `pre-commit install` at some point, like is now recommended for nltk. Only then will pre-commit do anything.

See #2773 for some discussion of adding `black` to pre-commit. Also see #2744 for more discussion on pre-commit itself.

---

- Tom Aarsen
