### PR TITLE
Run CI tests on Windows, too

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,10 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   cache_nltk_data:
     name: cache nltk_data
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -15,12 +18,12 @@ jobs:
         id: restore-cache
         with:
           path: ~/nltk_data
-          key: nltk_data
+          key: nltk_data_${{ secrets.CACHE_VERSION }}
 
       - name: Download nltk data packages on cache miss
         run: |
           pip install regex # dependencies needed to download nltk data
-          python -c "import nltk; nltk.download('all')"
+          python -c "import nltk; from pathlib import Path; path = Path('~/nltk_data').expanduser(); path.mkdir(exist_ok=True); nltk.download('all', download_dir=path)"
         shell: bash
         if: steps.restore-cache.outputs.cache-hit != 'true'
 
@@ -30,7 +33,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -57,7 +60,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/nltk_data
-          key: nltk_data
+          key: nltk_data_${{ secrets.CACHE_VERSION }}
 
       - name: Run pytest
         run: pytest --numprocesses auto -rsx nltk/test


### PR DESCRIPTION
Hello!

### Pull request overview
- Made CI tests run on Windows too. This involves:
  - Ensuring that `nltk.download()` data is placed in `~/nltk_data`.
- Added `${{ secrets.CACHE_VERSION }}` to cache key. **This requires setting `CACHE_VERSION` in Settings -> Secrets to e.g. `v1`.** This is the only way to "reset" the cache in case of a broken cache. The `CACHE_VERSION` in Secrets can be edited to e.g. `v2`, and a new cache will be created and used instead.

---

### Adding Windows support
We cannot simply add `windows-latest` to the `test` job. If we did, then the step to use the cached `nltk.download()` data will fail or return no data, and then a bunch of the `pytest` tests will fail due to lacking the required `nltk.download()` files.

So, we need to add a cache for `windows-latest` as well. 

Simply adding `windows-latest` to the `cache_nltk_data` job doesn't do it either - as `nltk.download('all')` will place the files in `~/nltk_data` for Ubuntu and MacOS, but in `C:\Users\...\AppData\Roaming\nltk_data` for Windows. So, either:
* The download location is fixed.
* The location where to read the cache is OS specific.

I went with the first option, and replaced
```
python -c "import nltk; nltk.download('all')"
```
with
```
python -c "import nltk; from pathlib import Path; path = Path('~/nltk_data').expanduser(); path.mkdir(exist_ok=True); nltk.download('all', download_dir=path)"
```
This ensures the folder exists (which is required to prevent an Exception on windows), and then places the downloaded files on `~/nltk_data`, regardless of OS.

---

### CACHE_VERSION Secret
During testing, the cache was frequently wrong. However, the only way to "clear" a cache in GitHub Actions is to use a different cache key instead, forcing it to make a new cache instead of using the old broken one. However, pushing a new `ci.yaml` with a modified key every time we want to reset the cache is not convenient at all. (There are other ways, but they involve not pushing code for 7 days, or filling up the cache with an additional 5+ GB, after which GitHub Actions clears the cache for exceeding their limit)

That's why it's recommended to use a Secret which can be modified on the fly, after which the CI can just be re-run with a button on the Actions tab on GitHub. 

For this, someone with Secrets privileges has to go to Settings -> Secrets, or follow this link: https://github.com/nltk/nltk/settings/secrets/actions. Once there, click on New Repository Secrets, and set `CACHE_VERSION` as the name, with `v1` as the value. Whenever there is an issue with the cache, we can clear it by updating the Secret to e.g. `v2` (or just a randomly generated string, it doesn't matter).

However, the cache is only likely to have issues if we mess with the CI, which should rarely happen.

---

### Further improvements
Something we should still tackle is adding `pre-commit` to the CI. I believe this can be done by simply adding
```yaml
- uses: pre-commit/actions@v2.0.0
```
But I've yet to really look into it. See https://github.com/nltk/nltk/issues/2775#issuecomment-894076955 for more information.

---

Also, my actual changes were iteratively tried in my `add_windows_ci` branch, and not this `add_windows_ci_reduced` branch. However, I didn't want to create this PR with 19 unnecessary commits, so I just created a new branch from develop instead. For those interested, see https://github.com/tomaarsen/nltk/tree/add_windows_ci for the individual attempts I made.

@purificant This PR might interest you, given that you worked on the CI file.

- Tom Aarsen
