### PR TITLE
Final py3.9 deprecation

### DIFF
--- a/nltk/util.py
+++ b/nltk/util.py
@@ -49,19 +49,15 @@ def usage(obj, selfname="self"):
         if getattr(method, "__deprecated__", False):
             continue
 
-        getargspec = inspect.getfullargspec
-        args, varargs, varkw, defaults = getargspec(method)[:4]
-        if (
-            args
-            and args[0] == "self"
-            and (defaults is None or len(args) > len(defaults))
-        ):
-            args = args[1:]
+        signature = inspect.signature(method)
+        params = list(signature.parameters.values())
+        if params and params[0].name == "self" and params[0].default is params[0].empty:
+            params = params[1:]
             name = f"{selfname}.{name}"
-        argspec = inspect.formatargspec(args, varargs, varkw, defaults)
+        params = ", ".join(p.name for p in params)
         print(
             textwrap.fill(
-                f"{name}{argspec}",
+                f"{name}({params})",
                 initial_indent="  - ",
                 subsequent_indent=" " * (len(name) + 5),
             )
@@ -210,7 +206,6 @@ def breadth_first(tree, children=iter, maxdepth=-1):
                 pass
 
 
-
 ##########################################################################
 # Graph Drawing
 ##########################################################################
@@ -240,7 +235,10 @@ def edge_closure(tree, children=iter, maxdepth=-1, verbose=False):
                         queue.append((child, depth + 1))
                     else:
                         if verbose:
-                            warnings.warn('Discarded redundant search for {0} at depth {1}'.format(child, depth + 1), stacklevel=2)
+                            warnings.warn(
+                                f"Discarded redundant search for {child} at depth {depth + 1}",
+                                stacklevel=2,
+                            )
                     edge = (node, child)
                     if edge not in edges:
                         yield edge
@@ -276,10 +274,10 @@ def edges2dot(edges, shapes=None, attr=None):
     if not attr:
         attr = dict()
 
-    dot_string = 'digraph G {\n'
+    dot_string = "digraph G {\n"
 
     for pair in attr.items():
-        dot_string += f'{pair[0]} = {pair[1]};\n'
+        dot_string += f"{pair[0]} = {pair[1]};\n"
 
     for edge in edges:
         for shape in shapes.items():
@@ -288,7 +286,7 @@ def edges2dot(edges, shapes=None, attr=None):
                     dot_string += f'"{edge[node]}" [shape = {shape[1]}];\n'
         dot_string += f'"{edge[0]}" -> "{edge[1]}";\n'
 
-    dot_string += '}\n'
+    dot_string += "}\n"
     return dot_string
 
 
@@ -321,14 +319,17 @@ def unweighted_minimum_spanning_digraph(tree, children=iter, shapes=None, attr=N
 
     """
     return edges2dot(
-        edge_closure(tree, lambda node:unweighted_minimum_spanning_dict(tree, children)[node]),
-        shapes, attr)
+        edge_closure(
+            tree, lambda node: unweighted_minimum_spanning_dict(tree, children)[node]
+        ),
+        shapes,
+        attr,
+    )
 
 
 ##########################################################################
 # Breadth-First / Depth-first Searches with Cycle Detection
 ##########################################################################
-
 
 
 def acyclic_breadth_first(tree, children=iter, maxdepth=-1):
@@ -567,7 +568,6 @@ def unweighted_minimum_spanning_tree(tree, children=iter):
       [Synset('restricted.a.01'), [Synset('classified.a.02')]]]]
     """
     return acyclic_dic2tree(tree, unweighted_minimum_spanning_dict(tree, children))
-
 
 
 ##########################################################################


### PR DESCRIPTION
Closes #2689. All the other deprecations have been taken care of here https://github.com/nltk/nltk/pull/2698

There's some extra noise in this diff, but that's all to get pre-commit passing (you may notice the same changes here https://github.com/nltk/nltk/pull/2784)