### PR TITLE
Add optional `show` argument to `FreqDist.plot()`

### DIFF
--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -1955,6 +1955,8 @@ class ConditionalFreqDist(defaultdict):
 
         if not conditions:
             conditions = self.conditions()
+        else:
+            conditions = [c for c in conditions if c in self]
         if not samples:
             samples = sorted({v for c in conditions for v in self[c]})
         if "linewidth" not in kwargs:

--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -1916,7 +1916,17 @@ class ConditionalFreqDist(defaultdict):
         """
         return sum(fdist.N() for fdist in self.values())
 
-    def plot(self, *args, **kwargs):
+    def plot(
+        self,
+        *args,
+        samples=None,
+        title="",
+        cumulative=False,
+        percents=False,
+        conditions=None,
+        show=True,
+        **kwargs,
+    ):
         """
         Plot the given samples from the conditional frequency distribution.
         For a cumulative plot, specify cumulative=True.
@@ -1926,8 +1936,14 @@ class ConditionalFreqDist(defaultdict):
         :type samples: list
         :param title: The title for the graph
         :type title: str
+        :param cumulative: Whether the plot is cumulative. (default = False)
+        :type cumulative: bool
+        :param percents: Whether the plot uses percents instead of counts. Only when cumulative is True.
+        :type percents: bool
         :param conditions: The conditions to plot (default is all)
         :type conditions: list
+        :param show: Whether to show the plot, or only return the ax.
+        :type show: bool
         """
         try:
             import matplotlib.pyplot as plt  # import statement fix
@@ -1937,19 +1953,14 @@ class ConditionalFreqDist(defaultdict):
                 "See http://matplotlib.org/"
             ) from e
 
-        cumulative = _get_kwarg(kwargs, "cumulative", False)
-        percents = _get_kwarg(kwargs, "percents", False)
-        conditions = [
-            c for c in _get_kwarg(kwargs, "conditions", self.conditions()) if c in self
-        ]  # conditions should be in self
-        title = _get_kwarg(kwargs, "title", "")
-        samples = _get_kwarg(
-            kwargs, "samples", sorted({v for c in conditions for v in self[c]})
-        )  # this computation could be wasted
+        if not conditions:
+            conditions = self.conditions()
+        if not samples:
+            samples = sorted({v for c in conditions for v in self[c]})
         if "linewidth" not in kwargs:
             kwargs["linewidth"] = 2
         ax = plt.gca()
-        if len(conditions) != 0:
+        if conditions:
             freqs = []
             for condition in conditions:
                 if cumulative:
@@ -1979,7 +1990,9 @@ class ConditionalFreqDist(defaultdict):
                 ax.set_title(title)
             ax.set_xlabel("Samples")
             ax.set_ylabel(ylabel)
-        plt.show()
+
+        if show:
+            plt.show()
 
         return ax
 

--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -244,7 +244,9 @@ class FreqDist(Counter):
             )
         return self.most_common(1)[0][0]
 
-    def plot(self, *args, **kwargs):
+    def plot(
+        self, *args, title="", cumulative=False, percents=False, show=True, **kwargs
+    ):
         """
         Plot samples from the frequency distribution
         displaying the most frequent sample first.  If an integer
@@ -252,10 +254,14 @@ class FreqDist(Counter):
         plotted.  For a cumulative plot, specify cumulative=True.
         (Requires Matplotlib to be installed.)
 
-        :param title: The title for the graph
+        :param title: The title for the graph.
         :type title: str
-        :param cumulative: A flag to specify whether the plot is cumulative (default = False)
-        :type title: bool
+        :param cumulative: Whether the plot is cumulative. (default = False)
+        :type cumulative: bool
+        :param percents: Whether the plot uses percents instead of counts. Only when cumulative is True.
+        :type percents: bool
+        :param show: Whether to show the plot, or only return the ax.
+        :type show: bool
         """
         try:
             import matplotlib.pyplot as plt
@@ -269,8 +275,6 @@ class FreqDist(Counter):
             args = [len(self)]
         samples = [item for item, _ in self.most_common(*args)]
 
-        cumulative = _get_kwarg(kwargs, "cumulative", False)
-        percents = _get_kwarg(kwargs, "percents", False)
         if cumulative:
             freqs = list(self._cumulative_frequencies(samples))
             ylabel = "Cumulative Counts"
@@ -287,9 +291,8 @@ class FreqDist(Counter):
 
         if "linewidth" not in kwargs:
             kwargs["linewidth"] = 2
-        if "title" in kwargs:
-            ax.set_title(kwargs["title"])
-            del kwargs["title"]
+        if title:
+            ax.set_title(title)
 
         ax.plot(freqs, **kwargs)
         ax.set_xticks(range(len(samples)))
@@ -297,7 +300,8 @@ class FreqDist(Counter):
         ax.set_xlabel("Samples")
         ax.set_ylabel(ylabel)
 
-        plt.show()
+        if show:
+            plt.show()
 
         return ax
 

--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -251,7 +251,8 @@ class FreqDist(Counter):
         Plot samples from the frequency distribution
         displaying the most frequent sample first.  If an integer
         parameter is supplied, stop after this many samples have been
-        plotted.  For a cumulative plot, specify cumulative=True.
+        plotted.  For a cumulative plot, specify cumulative=True. Additional
+        *args and **kwargs are passed to matplotlib's plot function.
         (Requires Matplotlib to be installed.)
 
         :param title: The title for the graph.
@@ -1929,7 +1930,8 @@ class ConditionalFreqDist(defaultdict):
     ):
         """
         Plot the given samples from the conditional frequency distribution.
-        For a cumulative plot, specify cumulative=True.
+        For a cumulative plot, specify cumulative=True. Additional *args and
+        **kwargs are passed to matplotlib's plot function.
         (Requires Matplotlib to be installed.)
 
         :param samples: The samples to plot

--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -252,14 +252,14 @@ class FreqDist(Counter):
         displaying the most frequent sample first.  If an integer
         parameter is supplied, stop after this many samples have been
         plotted.  For a cumulative plot, specify cumulative=True. Additional
-        *args and **kwargs are passed to matplotlib's plot function.
+        **kwargs are passed to matplotlib's plot function.
         (Requires Matplotlib to be installed.)
 
         :param title: The title for the graph.
         :type title: str
         :param cumulative: Whether the plot is cumulative. (default = False)
         :type cumulative: bool
-        :param percents: Whether the plot uses percents instead of counts. Only when cumulative is True.
+        :param percents: Whether the plot uses percents instead of counts. (default = False)
         :type percents: bool
         :param show: Whether to show the plot, or only return the ax.
         :type show: bool
@@ -278,14 +278,16 @@ class FreqDist(Counter):
 
         if cumulative:
             freqs = list(self._cumulative_frequencies(samples))
-            ylabel = "Cumulative Counts"
-            if percents:
-                freqs = [f / freqs[len(freqs) - 1] * 100 for f in freqs]
-                ylabel = "Cumulative Percents"
+            ylabel = "Cumulative "
         else:
             freqs = [self[sample] for sample in samples]
-            ylabel = "Counts"
-        # percents = [f * 100 for f in freqs]  only in ProbDist?
+            ylabel = ""
+
+        if percents:
+            freqs = [f / self.N() * 100 for f in freqs]
+            ylabel += "Percents"
+        else:
+            ylabel += "Counts"
 
         ax = plt.gca()
         ax.grid(True, color="silver")
@@ -1940,7 +1942,7 @@ class ConditionalFreqDist(defaultdict):
         :type title: str
         :param cumulative: Whether the plot is cumulative. (default = False)
         :type cumulative: bool
-        :param percents: Whether the plot uses percents instead of counts. Only when cumulative is True.
+        :param percents: Whether the plot uses percents instead of counts. (default = False)
         :type percents: bool
         :param conditions: The conditions to plot (default is all)
         :type conditions: list
@@ -1969,17 +1971,26 @@ class ConditionalFreqDist(defaultdict):
             for condition in conditions:
                 if cumulative:
                     # freqs should be a list of list where each sub list will be a frequency of a condition
-                    freqs.append(list(self[condition]._cumulative_frequencies(samples)))
-                    ylabel = "Cumulative Counts"
-                    legend_loc = "lower right"
-                    if percents:
-                        freqs[-1] = [f / freqs[len(freqs) - 1] * 100 for f in freqs]
-                        ylabel = "Cumulative Percents"
+                    freq = list(self[condition]._cumulative_frequencies(samples))
                 else:
-                    freqs.append([self[condition][sample] for sample in samples])
-                    ylabel = "Counts"
-                    legend_loc = "upper right"
-                # percents = [f * 100 for f in freqs] only in ConditionalProbDist?
+                    freq = [self[condition][sample] for sample in samples]
+
+                if percents:
+                    freq = [f / self[condition].N() * 100 for f in freq]
+
+                freqs.append(freq)
+
+            if cumulative:
+                ylabel = "Cumulative "
+                legend_loc = "lower right"
+            else:
+                ylabel = ""
+                legend_loc = "upper right"
+
+            if percents:
+                ylabel += "Percents"
+            else:
+                ylabel += "Counts"
 
             i = 0
             for freq in freqs:


### PR DESCRIPTION
Closes #2663 

Hello!

### Pull request overview
- Added `show` argument to FreqDist's `plot` method. 
- Made optional function arguments explicit, allowing IDE's to autocomplete these.
  - E.g. put `cumulative=False` in the function header, instead of only showing in the function comments that this is a parameter.

---

### Adding `show` to FreqDist's `plot`
As mentioned by #2663, the following line will automatically plot the frequency distribution:
https://github.com/nltk/nltk/blob/3d7960008dd9f3802a318f5ed20fa4a63584721e/nltk/probability.py#L302

This is great - it's exactly what the FreqDist's `plot` function implies, but it prevents the plot from being modified in any way. What if the user wishes to just `.savefig` these instead of showing them? Or if they want to use `.tight_layout` before plotting? They would need to let the function plot, close the plot, and work with the `ax` that was returned.

However, instead of simply removing this line and changing the functionality of this method (like suggested in #2663), I've opted to add a simple parameter `show`, which is True by default. If `show` is `True`, then `plt.show()` will be executed, and the distribution will be plotted exactly like before. If it is `False`, then it's not plotted. Like always, the `ax` will be returned, allowing it to be modified before the user themselves calls `plt.show()`.

---

### Made optional function arguments explicit
Currently, the method signature is this:
https://github.com/nltk/nltk/blob/3d7960008dd9f3802a318f5ed20fa4a63584721e/nltk/probability.py#L249
And certain arguments are extracted like this:
https://github.com/nltk/nltk/blob/3d7960008dd9f3802a318f5ed20fa4a63584721e/nltk/probability.py#L274-L275
These arguments are briefly mentioned in the method's docstring. These two lines extracts the values (if they exists, otherwise it takes the third parameter, the default) and removes them from the `kwargs` dict. 

Afterwards, `**kwargs` is used in `matplotlib`'s plotting function. 

I've now changed that to list these arguments in the method signature, so that IDE's can autocomplete and autosuggest these arguments.  Beyond that, this change does not impact the functionality of this method at all.

---

### Note
This PR should not change the execution of existing programs. All it does is add the functionality of optionally not plotting, and improve how arguments are taken. 

@stevenbird Whether you want to include this in NLTK 3.6.3 is up to you.

- Tom Aarsen
