### PR TITLE
Made `nltk/__init__.py` equivalent to `setup.py`

### DIFF
--- a/nltk/__init__.py
+++ b/nltk/__init__.py
@@ -52,7 +52,7 @@ __license__ = "Apache License, Version 2.0"
 # Description of the toolkit, keywords, and the project's primary URL.
 __longdescr__ = """\
 The Natural Language Toolkit (NLTK) is a Python package for
-natural language processing.  NLTK requires Python 2.6 or higher."""
+natural language processing.  NLTK requires Python 3.6, 3.7, 3.8, or 3.9."""
 __keywords__ = [
     "NLP",
     "CL",
@@ -70,7 +70,7 @@ __keywords__ = [
 __url__ = "http://nltk.org/"
 
 # Maintainer, contributors, etc.
-__maintainer__ = "Steven Bird, Edward Loper, Ewan Klein"
+__maintainer__ = "Steven Bird"
 __maintainer_email__ = "stevenbird1@gmail.com"
 __author__ = __maintainer__
 __author_email__ = __maintainer_email__
@@ -84,8 +84,10 @@ __classifiers__ = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 2.6",
-    "Programming Language :: Python :: 2.7",
+    "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Scientific/Engineering :: Human Machine Interfaces",


### PR DESCRIPTION
Fixes #2509

Hello!

### Pull request overview
- Made `nltk/__init__.py` equivalent to `setup.py` in terms of project description, classifiers, etc.

---

### Changes
I simply updated all dunder variables in `nltk/__init__.py` to be equivalent to their corresponding variables in `setup.py`. This includes changes to:
* Long description.
* Maintainer.
* Trove classifiers.

---

### Note
I simply copied the values from `setup.py`, but as a consequence two names are removed from the maintainer list here!

- Tom Aarsen
