### PR TITLE
Use global regex for TweetTokenizer's remove_handles

### DIFF
--- a/nltk/tokenize/casual.py
+++ b/nltk/tokenize/casual.py
@@ -177,6 +177,10 @@ EMOTICON_RE = regex.compile(EMOTICONS, regex.VERBOSE | regex.I | regex.UNICODE)
 # These are for regularizing HTML entities to Unicode:
 ENT_RE = regex.compile(r"&(#?(x?))([^&;\s]+);")
 
+# For stripping away handles from a tweet:
+HANDLES_RE = regex.compile(
+    r"(?<![A-Za-z0-9_!@#\$%&*])@(([A-Za-z0-9_]){20}(?!@))|(?<![A-Za-z0-9_!@#\$%&*])@(([A-Za-z0-9_]){1,19})(?![A-Za-z0-9_]*@)"
+)
 
 ######################################################################
 # Functions for converting html entities
@@ -322,11 +326,8 @@ def remove_handles(text):
     """
     Remove Twitter username handles from text.
     """
-    pattern = regex.compile(
-        r"(?<![A-Za-z0-9_!@#\$%&*])@(([A-Za-z0-9_]){20}(?!@))|(?<![A-Za-z0-9_!@#\$%&*])@(([A-Za-z0-9_]){1,19})(?![A-Za-z0-9_]*@)"
-    )
     # Substitute handles with ' ' to ensure that text on either side of removed handles are tokenized correctly
-    return pattern.sub(" ", text)
+    return HANDLES_RE.sub(" ", text)
 
 
 ######################################################################


### PR DESCRIPTION
Hello!

### Pull request overview
- Prevent `regex.compile(r"[sic]")` from being compiled on every call of the `remove_handles` function. Now, the regex is only compiled once.
   This has caused a small performance improvement of `TweetTokenizer`'s `tokenize` if `strip_handles=True`.

#### Summary
A small change results in a small performance increase. The rest of this PR is details on the change and the consequences, as well as an alternative.

---

### Changes
For context, this is the `remove_handles` function currently.
https://github.com/nltk/nltk/blob/f989fe65d421e7ea4d1037a00f07eaeee3ad6a29/nltk/tokenize/casual.py#L321-L329
It will be called on every use of `tokenize()` for the `TweetTokenizer` if `strip_handles=True`. This function will then re-compile the regex every time it is called. Compilation of such a somewhat big regex can be somewhat intensive, and ought to be done just once.

So, I've created `HANDLES_RE`, which is compiled once globally, just like the other large regexes in the file.

### Performance impact
I ran the following program to see the performance impact:
```python
from nltk.tokenize.casual import remove_handles
from nltk.corpus import twitter_samples
import cProfile

tweets = twitter_samples.strings()[:100]

def run():
    for tweet in tweets:
        remove_handles(tweet)

cProfile.run("run()", "remove_handles_[sic].prof")
```
I used `snakeviz` to quickly visualize the profile file. 

#### Old performance
![image](https://user-images.githubusercontent.com/37621491/131916820-a91b2ed4-a5ef-40b2-ad87-f0e465ab62f6.png)

#### New performance
![image](https://user-images.githubusercontent.com/37621491/131916877-ec84611c-4dc3-497a-b541-e24283ce77ac.png)

#### Comparison
It is not directly visible in the graph of the old performance, but the light green section towards the top right is the `sub` method of `_regex.Pattern`. This is the same as the orange section in the new performance. I didn't modify the execution of this method, and as a result this method took roughly 0.0003 seconds in both situations. As you can see, in the current situation, the `compile` method takes by far the majority of the computation time of this function. It represents roughly 78% of the computation time in my tests. 

This is reduced to a negligible amount in the updated version.

**However**, this comes at the cost that the regex is compiled once every time the module is loaded, even when the remove_handles function is not used (i.e. when `strip_handles` in `TweetTokenizer()` is left as the default: `False`). This is the trade-off at play. 
This one regex compilation is also not included in the cProfile test, as this regex is compiled at the import. However, it should be 100x as small as with the old situation, as we compile it once instead of a 100 times.

---

#### Alternative
An alternative is something along the lines of:
```python
HANDLES_RE = None

[sic]

def remove_handles(text):
    """
    Remove Twitter username handles from text.
    """
    if HANDLES_RE is None:
        HANDLES_RE = regex.compile(
            r"(?<![A-Za-z0-9_!@#\$%&*])@(([A-Za-z0-9_]){20}(?!@))|(?<![A-Za-z0-9_!@#\$%&*])@(([A-Za-z0-9_]){1,19})(?![A-Za-z0-9_]*@)"
        )
    # Substitute handles with ' ' to ensure that text on either side of removed handles are tokenized correctly
    return HANDLES_RE.sub(" ", text)
```
This kind of stuff is really common with classes, but I'm not a fan of it when dealing with globals. To me, a global should only be used if they're a constant. Regardless, this is an option to prevent having to compile a regex unnecessarily. 

---

### Note
There is another similar function called `reduce_lengthening`, as can be seen here:
https://github.com/nltk/nltk/blob/f989fe65d421e7ea4d1037a00f07eaeee3ad6a29/nltk/tokenize/casual.py#L312-L318
This function is very similar, but the regex isn't as computationally intensive to compile. The compilation there only takes roughly a third, instead of over 75%. To contrast, `remove_handles`'s compilation takes an equivalent of 13 times as long as `reduce_lengthening`'s compilation, relative to each function's `sub` call.
Because of that, I didn't implement the performance improvement there. 

However, this would be easy to implement if desired.

Also, this might conflict with #2791, but I can handle fixing the merge conflict if it shows up.

- Tom Aarsen
