### PR TITLE
refactor: refactor sentiment analyzer by removing dead and slow perfomance code

### DIFF
--- a/nltk/sentiment/sentiment_analyzer.py
+++ b/nltk/sentiment/sentiment_analyzer.py
@@ -47,10 +47,10 @@ class SentimentAnalyzer:
         all_words = []
         if labeled is None:
             labeled = documents and isinstance(documents[0], tuple)
-        if labeled == True:
-            for words, sentiment in documents:
-                all_words.extend(words)
-        elif labeled == False:
+        if labeled is True:
+            for words in documents:
+                all_words.extend(words[0])
+        elif labeled is False:
             for words in documents:
                 all_words.extend(words)
         return all_words
@@ -218,7 +218,7 @@ class SentimentAnalyzer:
             classifier = self.classifier
         print(f"Evaluating {type(classifier).__name__} results...")
         metrics_results = {}
-        if accuracy == True:
+        if accuracy is True:
             accuracy_score = eval_accuracy(classifier, test_set)
             metrics_results["Accuracy"] = accuracy_score
 
@@ -232,22 +232,22 @@ class SentimentAnalyzer:
             test_results[observed].add(i)
 
         for label in labels:
-            if precision == True:
+            if precision is True:
                 precision_score = eval_precision(
                     gold_results[label], test_results[label]
                 )
                 metrics_results[f"Precision [{label}]"] = precision_score
-            if recall == True:
+            if recall is True:
                 recall_score = eval_recall(gold_results[label], test_results[label])
                 metrics_results[f"Recall [{label}]"] = recall_score
-            if f_measure == True:
+            if f_measure is True:
                 f_measure_score = eval_f_measure(
                     gold_results[label], test_results[label]
                 )
                 metrics_results[f"F-measure [{label}]"] = f_measure_score
 
         # Print evaluation results (in alphabetical order)
-        if verbose == True:
+        if verbose is True:
             for result in sorted(metrics_results):
                 print(f"{result}: {metrics_results[result]}")
 

--- a/nltk/sentiment/sentiment_analyzer.py
+++ b/nltk/sentiment/sentiment_analyzer.py
@@ -47,10 +47,10 @@ class SentimentAnalyzer:
         all_words = []
         if labeled is None:
             labeled = documents and isinstance(documents[0], tuple)
-        if labeled is True:
+        if labeled:
             for words in documents:
                 all_words.extend(words[0])
-        elif labeled is False:
+        elif labeled:
             for words in documents:
                 all_words.extend(words)
         return all_words
@@ -218,7 +218,7 @@ class SentimentAnalyzer:
             classifier = self.classifier
         print(f"Evaluating {type(classifier).__name__} results...")
         metrics_results = {}
-        if accuracy is True:
+        if accuracy:
             accuracy_score = eval_accuracy(classifier, test_set)
             metrics_results["Accuracy"] = accuracy_score
 
@@ -232,22 +232,22 @@ class SentimentAnalyzer:
             test_results[observed].add(i)
 
         for label in labels:
-            if precision is True:
+            if precision:
                 precision_score = eval_precision(
                     gold_results[label], test_results[label]
                 )
                 metrics_results[f"Precision [{label}]"] = precision_score
-            if recall is True:
+            if recall:
                 recall_score = eval_recall(gold_results[label], test_results[label])
                 metrics_results[f"Recall [{label}]"] = recall_score
-            if f_measure is True:
+            if f_measure:
                 f_measure_score = eval_f_measure(
                     gold_results[label], test_results[label]
                 )
                 metrics_results[f"F-measure [{label}]"] = f_measure_score
 
         # Print evaluation results (in alphabetical order)
-        if verbose is True:
+        if verbose:
             for result in sorted(metrics_results):
                 print(f"{result}: {metrics_results[result]}")
 

--- a/nltk/sentiment/sentiment_analyzer.py
+++ b/nltk/sentiment/sentiment_analyzer.py
@@ -50,7 +50,7 @@ class SentimentAnalyzer:
         if labeled:
             for words in documents:
                 all_words.extend(words[0])
-        elif labeled:
+        elif not labeled:
             for words in documents:
                 all_words.extend(words)
         return all_words

--- a/nltk/sentiment/sentiment_analyzer.py
+++ b/nltk/sentiment/sentiment_analyzer.py
@@ -48,8 +48,8 @@ class SentimentAnalyzer:
         if labeled is None:
             labeled = documents and isinstance(documents[0], tuple)
         if labeled:
-            for words in documents:
-                all_words.extend(words[0])
+            for words, _sentiment in documents:
+                all_words.extend(words)
         elif not labeled:
             for words in documents:
                 all_words.extend(words)


### PR DESCRIPTION
The pull request refactors the sentiment analyser class by generally doing the following points:

- Removing dead code like sentiment value in for loop(which made my curious why it is defined in all_words while not used) 
- Replace '==' in checking boolean values with the variable value. For example refactor if value == False with if not value: (performance reasons) 

A single if statement or even dozens won not be that bad, but hundred of if's statement, this may cause some minor performance issues. The below numbers illustrates better. 

`python -m timeit -s "variable=False" "if variable == True: pass"
`
output: 

> 10000000 loops, best of 5: 28.7 nsec per loop

`python -m timeit -s "variable=True" "if variable is True: pass"`

> 10000000 loops, best of 5: 21 nsec per loop

`python -m timeit -s "variable=True" "if variable: pass"`

> 20000000 loops, best of 5: 13.6 nsec per loop

I believe this may affect the performance of the sentiment analyser in a minor way.