### PR TITLE
replace travis badge with github actions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Natural Language Toolkit (NLTK)
 [![PyPI](https://img.shields.io/pypi/v/nltk.svg)](https://pypi.python.org/pypi/nltk)
-[![Travis](https://travis-ci.org/nltk/nltk.svg?branch=develop)](https://travis-ci.org/nltk/nltk)
+![CI](https://github.com/nltk/nltk/actions/workflows/ci.yaml/badge.svg?branch=develop)
 
 NLTK -- the Natural Language Toolkit -- is a suite of open source Python
 modules, data sets, and tutorials supporting research and development in Natural


### PR DESCRIPTION
This PR replaces Travis badge with Github Actions badge. The new badge is pinned for builds in `develop` branch.

The change is:
![travis](https://user-images.githubusercontent.com/4669013/133898506-4456a3fe-1116-45ba-addd-bb003fe17c65.png)
=>
![github_actions](https://user-images.githubusercontent.com/4669013/133898503-00ffd57a-6a16-40ca-ac0c-c3bcb9bea371.png)

"ci-workflow" text comes from the name of the workflow in https://github.com/nltk/nltk/blob/1d87106312be12b8510890be42c329c00e1b425f/.github/workflows/ci.yaml#L1

Ideas are welcome if we should rename that to something else.