### PR TITLE
Deprecate `nltk.usage(obj)` in favor of `help(obj)`

### DIFF
--- a/nltk/test/classify.doctest
+++ b/nltk/test/classify.doctest
@@ -11,16 +11,13 @@
 Classifiers label tokens with category labels (or *class labels*).
 Typically, labels are represented with strings (such as ``"health"``
 or ``"sports"``.  In NLTK, classifiers are defined using classes that
-implement the `ClassifyI` interface:
+implement the `ClassifierI` interface, which supports the following operations:
 
-    >>> import nltk
-    >>> nltk.usage(nltk.classify.ClassifierI)
-    ClassifierI supports the following operations:
-      - self.classify(featureset)
-      - self.classify_many(featuresets)
-      - self.labels()
-      - self.prob_classify(featureset)
-      - self.prob_classify_many(featuresets)
+- self.classify(featureset)
+- self.classify_many(featuresets)
+- self.labels()
+- self.prob_classify(featureset)
+- self.prob_classify_many(featuresets)
 
 NLTK defines several classifier classes:
 
@@ -42,6 +39,7 @@ We define a very simple training corpus with 3 binary features: ['a',
 that the correct answers can be calculated analytically (although we
 haven't done this yet for all tests).
 
+    >>> import nltk
     >>> train = [
     ...     (dict(a=1,b=1,c=1), 'y'),
     ...     (dict(a=1,b=1,c=1), 'x'),

--- a/nltk/test/unit/test_util.py
+++ b/nltk/test/unit/test_util.py
@@ -1,58 +1,6 @@
 import pytest
 
-from nltk.util import everygrams, usage
-
-
-def test_usage_with_self(capsys):
-    class MyClass:
-        def kwargs(self, a=1):
-            ...
-
-        def no_args(self):
-            ...
-
-        def pos_args(self, a, b):
-            ...
-
-        def pos_args_and_kwargs(self, a, b, c=1):
-            ...
-
-    usage(MyClass)
-
-    captured = capsys.readouterr()
-    assert captured.out == (
-        "MyClass supports the following operations:\n"
-        "  - self.kwargs(a=1)\n"
-        "  - self.no_args()\n"
-        "  - self.pos_args(a, b)\n"
-        "  - self.pos_args_and_kwargs(a, b, c=1)\n"
-    )
-
-
-def test_usage_with_cls(capsys):
-    class MyClass:
-        @classmethod
-        def clsmethod(cls):
-            ...
-
-        @classmethod
-        def clsmethod_with_args(cls, a, b, c=1):
-            ...
-
-    usage(MyClass)
-
-    captured = capsys.readouterr()
-    assert captured.out == (
-        "MyClass supports the following operations:\n"
-        "  - cls.clsmethod()\n"
-        "  - cls.clsmethod_with_args(a, b, c=1)\n"
-    )
-
-
-def test_usage_on_builtin():
-    # just check the func passes, since
-    # builtins change each python version
-    usage(dict)
+from nltk.util import everygrams
 
 
 @pytest.fixture

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -37,42 +37,17 @@ from nltk.internals import raise_unorderable_types, slice_bounds
 ######################################################################
 
 
-def usage(obj):
-    str(obj)  # In case it's lazy, this will load it.
+def usage(obj, selfname="self"):
+    """Deprecated in favor of `help(obj)`
 
-    if not isinstance(obj, type):
-        obj = obj.__class__
-
-    print(f"{obj.__name__} supports the following operations:")
-    for (name, method) in sorted(pydoc.allmethods(obj).items()):
-        if name.startswith("_"):
-            continue
-        if getattr(method, "__deprecated__", False):
-            continue
-
-        try:
-            sig = str(inspect.signature(method))
-        except ValueError as e:
-            # builtins sometimes don't support introspection
-            if "builtin" in str(e):
-                continue
-            else:
-                raise
-
-        args = sig.lstrip("(").rstrip(")").split(", ")
-        meth = inspect.getattr_static(obj, name)
-        if isinstance(meth, (classmethod, staticmethod)):
-            name = f"cls.{name}"
-        elif args and args[0] == "self":
-            name = f"self.{name}"
-            args.pop(0)
-        print(
-            textwrap.fill(
-                f"{name}({', '.join(args)})",
-                initial_indent="  - ",
-                subsequent_indent=" " * (len(name) + 5),
-            )
-        )
+    Args:
+        obj (object): The object to inspect, e.g. `nltk.tree.Tree`.
+        selfname (str, optional): Unused. Defaults to "self".
+    """
+    warnings.warn(
+        "nltk.usage(obj) is deprecated; use help(obj).", PendingDeprecationWarning
+    )
+    help(obj)
 
 
 ##########################################################################


### PR DESCRIPTION
Fixes #2807 

Hello!

### Pull request overview
- Started deprecation of `nltk.usage(obj)`. In this PR, it throws a warning and then calls `help(obj)`.
- Removed tests for `nltk.usage`.
- Removed a `classify.doctest` test that used `nltk.usage`, and reworded the documentation there.

See #2807 for discussion on the deprecation.

---

### Changes
My idea is to roll out a somewhat smooth deprecation. Rather than simply removing the function in the next version, it'll start throwing a warning indicating the pending deprecation. Then, because `nltk.usage()` was broken for certain classes (e.g. `nltk.FreqDict`), it now calls `help(obj)` instead.

If this is merged, then another PR can be created some time in the future, for a future version, which fully removes this function.

Please post any discussion regarding whether `nltk.usage` ought to be deprecated or not in #2807, and feel free to comment here on any suggestions about how the deprecation should be rolled out.

### Note
The warning will only be displayed if Python is ran with e.g. a `-Wd` or `-Wall` flag, indicating that warnings must be shown.

- Tom Aarsen
