### PR TITLE
refactor:tokenize the text if the input is string.

### DIFF
--- a/nltk/tag/__init__.py
+++ b/nltk/tag/__init__.py
@@ -90,7 +90,7 @@ from nltk.tag.senna import SennaTagger, SennaChunkTagger, SennaNERTagger
 from nltk.tag.mapping import tagset_mapping, map_tag
 from nltk.tag.crf import CRFTagger
 from nltk.tag.perceptron import PerceptronTagger
-
+from nltk.tokenize import word_tokenize
 from nltk.data import load, find
 
 RUS_PICKLE = (
@@ -115,26 +115,25 @@ def _pos_tag(tokens, tagset=None, tagger=None, lang=None):
             "Currently, NLTK pos_tag only supports English and Russian "
             "(i.e. lang='eng' or lang='rus')"
         )
-    # Throws Error if tokens is of string type
-    elif isinstance(tokens, str):
-        raise TypeError("tokens: expected a list of strings, got a string")
+    # Tokenize the input into tokens, in case it is a string.
+    if isinstance(tokens, str):
+        tokens = word_tokenize(tokens)
 
-    else:
-        tagged_tokens = tagger.tag(tokens)
-        if tagset:  # Maps to the specified tagset.
-            if lang == "eng":
-                tagged_tokens = [
-                    (token, map_tag("en-ptb", tagset, tag))
-                    for (token, tag) in tagged_tokens
-                ]
-            elif lang == "rus":
-                # Note that the new Russian pos tags from the model contains suffixes,
-                # see https://github.com/nltk/nltk/issues/2151#issuecomment-430709018
-                tagged_tokens = [
-                    (token, map_tag("ru-rnc-new", tagset, tag.partition("=")[0]))
-                    for (token, tag) in tagged_tokens
-                ]
-        return tagged_tokens
+    tagged_tokens = tagger.tag(tokens)
+    if tagset:  # Maps to the specified tagset.
+        if lang == "eng":
+            tagged_tokens = [
+                (token, map_tag("en-ptb", tagset, tag))
+                for (token, tag) in tagged_tokens
+            ]
+        elif lang == "rus":
+            # Note that the new Russian pos tags from the model contains suffixes,
+            # see https://github.com/nltk/nltk/issues/2151#issuecomment-430709018
+            tagged_tokens = [
+                (token, map_tag("ru-rnc-new", tagset, tag.partition("=")[0]))
+                for (token, tag) in tagged_tokens
+            ]
+    return tagged_tokens
 
 
 def pos_tag(tokens, tagset=None, lang="eng"):

--- a/nltk/test/unit/test_pos_tag.py
+++ b/nltk/test/unit/test_pos_tag.py
@@ -81,3 +81,32 @@ class TestPosTag(unittest.TestCase):
         text = "모르겠 습니 다"
         expected_but_wrong = [("모르겠", "JJ"), ("습니", "NNP"), ("다", "NN")]
         assert pos_tag(word_tokenize(text)) == expected_but_wrong
+
+    def test_pos_tag_string_eng(self):
+        text = "John's big idea isn't all that bad."
+        expected_tagged = [
+            ("John", "NNP"),
+            ("'s", "POS"),
+            ("big", "JJ"),
+            ("idea", "NN"),
+            ("is", "VBZ"),
+            ("n't", "RB"),
+            ("all", "PDT"),
+            ("that", "DT"),
+            ("bad", "JJ"),
+            (".", "."),
+        ]
+        assert pos_tag(text) == expected_tagged
+
+    def test_pos_tag_string_rus(self):
+        text = "Илья оторопел и дважды перечитал бумажку."
+        expected_tagged = [
+            ("Илья", "S"),
+            ("оторопел", "V"),
+            ("и", "CONJ"),
+            ("дважды", "ADV"),
+            ("перечитал", "V"),
+            ("бумажку", "S"),
+            (".", "NONLEX"),
+        ]
+        assert pos_tag(text, lang="rus") == expected_tagged


### PR DESCRIPTION
The pos_tag method past implementation had a problem with tagging un-tokenized strings. This [issue](https://github.com/nltk/nltk/issues/2648) illustrates the problem.

The suggested changes to solve the problem was raising an error or warning to the user that the pos_tag does not support the type string.

I believe a better approach might be tokenising the string into tokens. 

