### PR TITLE
Resolved ReDoS vulnerability in Corpus Reader

### DIFF
--- a/nltk/corpus/reader/comparative_sents.py
+++ b/nltk/corpus/reader/comparative_sents.py
@@ -45,7 +45,7 @@ CLOSE_COMPARISON = re.compile(r"</cs-[1234]>")
 GRAD_COMPARISON = re.compile(r"<cs-[123]>")
 NON_GRAD_COMPARISON = re.compile(r"<cs-4>")
 ENTITIES_FEATS = re.compile(r"(\d)_((?:[\.\w\s/-](?!\d_))+)")
-KEYWORD = re.compile(r"\((?!.*\()(.*)\)$")
+KEYWORD = re.compile(r"\(([^\(]*)\)$")
 
 
 class Comparison:

--- a/nltk/test/corpus.doctest
+++ b/nltk/test/corpus.doctest
@@ -2168,21 +2168,29 @@ Ensure that KEYWORD from `comparative_sents.py` no longer contains a ReDoS vulne
     >>> import re
     >>> import time
     >>> from nltk.corpus.reader.comparative_sents import KEYWORD
-    >>> exec_times = []
-    >>> for i in range(1, 10):
-    ...     start_t = time.perf_counter()
-    ...     payload = "( " + "(" * (i * 4000)
-    ...     output = KEYWORD.findall(payload)
-    ...     exec_times.append(time.perf_counter() - start_t)
-    >>> norm_exec_times = [t / min(exec_times) for t in exec_times]
+    >>> sizes = {
+    ...     "short": 4000,
+    ...     "long": 40000
+    ... }
+    >>> exec_times = {
+    ...     "short": [],
+    ...     "long": [],
+    ... }
+    >>> for size_name, size in sizes.items():
+    ...     for j in range(9):
+    ...         start_t = time.perf_counter()
+    ...         payload = "( " + "(" * size
+    ...         output = KEYWORD.findall(payload)
+    ...         exec_times[size_name].append(time.perf_counter() - start_t)
+    ...     exec_times[size_name] = sorted(exec_times[size_name])[4] # Get the mean
 
 Ideally, the execution time of such a regular expression is linear
-in the length of the input. As such, with norm_exec_times[0] normalized
-to 1, we would expect norm_exec_times[9] to be roughly 10 (times as long).
-With the ReDoS in place, it took roughly 70 times as long.
+in the length of the input. As such, we would expect exec_times["long"]
+to be roughly 10 times as big as exec_times["short"].
+With the ReDoS in place, it took roughly 80 times as long.
 For now, we accept values below 30 (times as long), due to the potential
 for variance. This ensures that the ReDoS has certainly been reduced,
 if not removed.
 
-    >>> norm_exec_times[-1] < 30
+    >>> exec_times["long"] / exec_times["short"] < 30
     True

--- a/nltk/test/corpus.doctest
+++ b/nltk/test/corpus.doctest
@@ -2162,3 +2162,27 @@ access to its tuples() method
     >>> from nltk.corpus import qc
     >>> qc.tuples('test.txt')
     [('NUM:dist', 'How far is it from Denver to Aspen ?'), ('LOC:city', 'What county is Modesto , California in ?'), ...]
+
+Ensure that KEYWORD from `comparative_sents.py` no longer contains a ReDoS vulnerability.
+
+    >>> import re
+    >>> import time
+    >>> from nltk.corpus.reader.comparative_sents import KEYWORD
+    >>> exec_times = []
+    >>> for i in range(1, 10):
+    ...     start_t = time.perf_counter()
+    ...     payload = "( " + "(" * (i * 4000)
+    ...     output = KEYWORD.findall(payload)
+    ...     exec_times.append(time.perf_counter() - start_t)
+    >>> norm_exec_times = [t / min(exec_times) for t in exec_times]
+
+Ideally, the execution time of such a regular expression is linear
+in the length of the input. As such, with norm_exec_times[0] normalized
+to 1, we would expect norm_exec_times[9] to be roughly 10 (times as long).
+With the ReDoS in place, it took roughly 70 times as long.
+For now, we accept values below 30 (times as long), due to the potential
+for variance. This ensures that the ReDoS has certainly been reduced,
+if not removed.
+
+    >>> norm_exec_times[-1] < 30
+    True


### PR DESCRIPTION
Hello!

### Pull request overview
- Resolved Regular Expression Denial Of Service vulnerability in the CorpusReader for the Comparative Sentences Dataset.
- Added performance tests hinting that the ReDoS is removed.

#### Background
[Wikipedia page for ReDoS](https://en.wikipedia.org/wiki/ReDoS).

### The ReDoS
The regular expression vulnerable to a ReDoS is compiled here:
https://github.com/nltk/nltk/blob/23f4b1c4b4006b0cb3ec278e801029557cec4e82/nltk/corpus/reader/comparative_sents.py#L48
And only used once, right here:
https://github.com/nltk/nltk/blob/23f4b1c4b4006b0cb3ec278e801029557cec4e82/nltk/corpus/reader/comparative_sents.py#L259

### Regex breakdown

In full:
```python
\((?!.*\()(.*)\)$
```
It consists of 4 segments, described here:

<table>
<tr>
<th>
Regex section
</th>
<th>
Explanation
</th>
</tr>

<tr>
<td>

```python
\(
```

</td>
<td>

Match the character `(` exactly.

</td>
</tr>
<tr>
<td>

```python
(?!.*\()
```

</td>
<td>

Negative lookahead. Makes sure that `.*\(` can **not** be matched. In short, this means that the remainder of the match (after the previous segment) can **not** contain another `(`.

</td>
</tr>
<tr>
<td>

```python
(.*)
```

</td>
<td>
Matches any number of characters, and places them in a group for extraction.
</td>
</tr>
<tr>
<td>

```python
\)$
```

</td>
<td>

Match the character `)` exactly, and ensure that this is the end of the line.

</td>
</tr>
</table>

### What does this regex try to do?
It tries to find information within the brackets in each line in e.g.
```
1_its 2_models 3_fast-forward 3_rewind (more)
 1_4.5 gb 2_0.7 gb (nicer)
1_mirror 2_silver 3_finish (more)
 1_dvd players 3_quality 2_this (better)
 1_panasonics 1_toshibas 1_sonys (cheaper)
```
i.e. extract `more`, `nicer`, `more`, `better`, `cheaper`. This is what segments 1, 3 and 4 do. Segment 2 ensures that the starting `(` is the most right-most `(` in the entire input. This way, in e.g.
```
1_its 2_models (3_fast-forward) 3_rewind (more)
```
Only `more` is extracted.

The ReDoS comes from the combination of the two `.*`'s, and likely results from naive backtracking in Python's regular expression engine.

### The fix
The new regex looks like so:
```python
KEYWORD = re.compile(r"\(([^\(]*)\)$")
```
It's fairly similar to the previous regex. Segments 1 and 4 are reused, while segment 2 is removed, and segment 3 is modified.
Segment 3 is now:
```
([^\(]*)
```
This regular expression will now, rather than match anything, match anything *except `(`*. Because the `$` at the end anchors us at the end of the line, this is still guaranteed to only get the last case of e.g. `... (more)`.

I've quickly tested this new regex with all lines in the Comparative Sentences Dataset, and it finds just as many matches as the old regex. I believe it's identical in output, and only differs in performance.

---

### Tests
In order to help convince that this has actually resolved the issue, I've created a doctest in corpus.doctest. It will:
* Perform `KEYWORD.findall(payload)` 9 times with a malicious payload of 4000 characters. Then, take the mean execution time between these 9 calls. This is dubbed the short mean.
* Perform `KEYWORD.findall(payload)` 9 times with a malicious payload of 40000 (!) characters. Then, take the mean execution time between these 9 calls. This is dubbed the long mean.
* If the regular expression execution time is linear to the size of the input (as it should be in such a relatively simple regex), then the long mean should be roughly 10 times as big as the short mean.
  To play it safe, we ensure that the long mean is at most 30 times as big. A value of 30 seems to work fine.
  When the ReDoS was still intact, the long mean would be rougly 80 times as big, which definitely indicates that the regex is not linear in execution time.

---

Thank you for reporting this vulnerability through our team email. 

- Tom Aarsen