### PR TITLE
Added docstring for WordNetLemmatizer lemmatize

### DIFF
--- a/nltk/stem/wordnet.py
+++ b/nltk/stem/wordnet.py
@@ -6,8 +6,7 @@
 # URL: <http://nltk.org/>
 # For license information, see LICENSE.TXT
 
-from nltk.corpus import wordnet
-from nltk.corpus.reader.wordnet import NOUN
+from nltk.corpus import wordnet as wn
 
 
 class WordNetLemmatizer:
@@ -31,11 +30,19 @@ class WordNetLemmatizer:
         hardrock
     """
 
-    def __init__(self):
-        pass
+    def lemmatize(self, word: str, pos: str = wn.NOUN) -> str:
+        """Lemmatize `word` using WordNet's built-in morphy function.
+        Returns the input word unchanged if it cannot be found in WordNet.
 
-    def lemmatize(self, word, pos=NOUN):
-        lemmas = wordnet._morphy(word, pos)
+        :param word: The input word to lemmatize.
+        :type word: str
+        :param pos: The Part Of Speech tag. Valid options are `"n"` for nouns,
+            `"v"` for verbs, `"a"` for adjectives, `"r"` for adverbs and `"s"`
+            for satellite adjectives.
+        :param pos: str
+        :return: The lemma of `word`, for the given `pos`.
+        """
+        lemmas = wn._morphy(word, pos)
         return min(lemmas, key=len) if lemmas else word
 
     def __repr__(self):


### PR DESCRIPTION
Resolves #2818

Hello!

### Pull request overview
- Added documentation to `WordNetLemmatizer`'s `lemmatize` method. (Including Python 3.5+ typing)
- Modified import slightly, to use `from nltk.corpus import wordnet as wn` as is commonly used in practice.

The changes speak for themselves with this PR. Feel free to suggest modifications to the docstring.

- Tom Aarsen
