### PR TITLE
Resolved NameError bug in raising Exception for RegexpTagger

### DIFF
--- a/nltk/tag/sequential.py
+++ b/nltk/tag/sequential.py
@@ -20,6 +20,7 @@ backoff tagger for any other SequentialBackoffTagger.
 import ast
 import re
 from abc import abstractmethod
+from typing import List, Optional, Tuple
 
 from nltk import jsontags
 from nltk.classify import NaiveBayesClassifier
@@ -533,21 +534,18 @@ class RegexpTagger(SequentialBackoffTagger):
 
     json_tag = "nltk.tag.sequential.RegexpTagger"
 
-    def __init__(self, regexps, backoff=None):
-        """ """
+    def __init__(
+        self, regexps: List[Tuple[str, str]], backoff: Optional[TaggerI] = None
+    ):
         super().__init__(backoff)
-        try:
-            self._regexps = [
-                (
-                    re.compile(regexp),
-                    tag,
-                )
-                for regexp, tag in regexps
-            ]
-        except Exception as e:
-            raise Exception(
-                "Invalid RegexpTagger regexp:", str(e), "regexp:", regexp, "tag:", tag
-            ) from e
+        self._regexps = []
+        for regexp, tag in regexps:
+            try:
+                self._regexps.append((re.compile(regexp), tag))
+            except Exception as e:
+                raise Exception(
+                    f"Invalid RegexpTagger regexp: {e}\n- regexp: {regexp!r}\n- tag: {tag!r}"
+                ) from e
 
     def encode_json_obj(self):
         return [(regexp.pattern, tag) for regexp, tag in self._regexps], self.backoff


### PR DESCRIPTION
Resolves #2817

Hello!

### Pull request overview
* Resolved `NameError` that would be thrown if RegexpTagger encountered an Exception.
* Added Python 3.5+ typing to the RegexpTagger constructor.

### The bug
The bug in question was mentioned in #2817, but was perhaps not made clear enough, as this issue also advocates for checking whether the input is of the right type, which is not something I believe in (See the bottom of this PR for more info). However, I would like to reiterate that there is actually a bug here. In short, whenever RegexpTagger is initialised with a value of `regexps` that throws an Exception, then *another* unplanned Exception is thrown with the following traceback:
```
[sic]

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "[sic]\nltk_2817.py", line 8, in <module>
    tagger = RegexpTagger(regexps)
  File "[sic]\nltk\tag\sequential.py", line 549, in __init__
    "Invalid RegexpTagger regexp:", str(e), "regexp:", regexp, "tag:", tag
NameError: name 'regexp' is not defined
```

The code in question is this:
https://github.com/nltk/nltk/blob/43f3e3096ade1a2564a20a66172d53bd140ac983/nltk/tag/sequential.py#L536-L550

This exact Exception is thrown because `regexp` nor `tag` can be accessed from within the `except` branch of the `try-except`. Note:  This doesn't only occur when the list is empty (in fact, no Exception is thrown when the list is empty). These variables simply cannot be accessed, ever.

### How to reproduce
```python
from nltk.tag import RegexpTagger
# Note: The last regular expression is faulty - the slash before the i doesn't work
regexps = [(r'^-?[0-]', 'CD'), (r'(The|the|A|a|An|an)$', 'AT'), ("\i{,2}", "CD")]
tagger = RegexpTagger(regexps)
```
This outputs:
```
Traceback (most recent call last):
  File "[sic]\nltk\tag\sequential.py", line 540, in __init__
    self._regexps = [
  File "[sic]\nltk\tag\sequential.py", line 542, in <listcomp>
    re.compile(regexp),
  File "[sic]\Python39\lib\re.py", line 252, in compile
    return _compile(pattern, flags)
  File "[sic]\Python39\lib\re.py", line 304, in _compile
    p = sre_compile.compile(pattern, flags)
  File "[sic]\Python39\lib\sre_compile.py", line 764, in compile 
    p = sre_parse.parse(p, flags)
  File "[sic]\Python39\lib\sre_parse.py", line 948, in parse     
    p = _parse_sub(source, state, flags & SRE_FLAG_VERBOSE, 0)
  File "[sic]\Python39\lib\sre_parse.py", line 443, in _parse_sub
    itemsappend(_parse(source, state, verbose, nested + 1,
  File "[sic]\Python39\lib\sre_parse.py", line 525, in _parse    
    code = _escape(source, this, state)
  File "[sic]\Python39\lib\sre_parse.py", line 426, in _escape   
    raise source.error("bad escape %s" % escape, len(escape))
re.error: bad escape \i at position 0

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "[sic]\nltk_2817.py", line 8, in <module>
    tagger = RegexpTagger(regexps)
  File "[sic]\nltk\tag\sequential.py", line 549, in __init__
    "Invalid RegexpTagger regexp:", str(e), "regexp:", regexp, "tag:", tag
NameError: name 'regexp' is not defined
```
We get this same uninformative `NameError` regardless of how valid or invalid the thrown Exception is.
Here we would like to get a useful Exception that shows which `regexp` and `tag` caused the issue.

### The fix
I've turned the list comprehension into a regular for loop, and moved the try-except into the for loop. This way, the variables are always known, so we can produce useful Exceptions. I've *slightly* modified the Exception, and added Python 3.5+ typing to the constructor.

Now, the aforementioned program outputs the following useful exception:
```
[sic]

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "[sic]\nltk_2817.py", line 8, in <module>
    tagger = RegexpTagger(regexps)
  File "[sic]\nltk\tag\sequential.py", line 546, in __init__
    raise Exception(
Exception: Invalid RegexpTagger regexp: bad escape \i at position 0
- regexp: '\\i{,2}'
- tag: 'CD'
```

---

### Other changes
I've also added Python 3.5+ typing to the RegexpTagger construct, to guide developers their IDE's to suggest the right input type.

---

Thank you to @12mohaned for raising this issue. Regarding your issue - many Python developers believe in "Garbage in - garbage out". If the documentation is clear, and a user fails to follow it, then that is their problem. **That said**, you also pointed out a real bug, which is that NLTK fails to construct a string used in throwing the Exception.

Your example of 
```python
regexps = [(r'^-?[0-]', 'CD'), (r'(The|the|A|a|An|an)$', 'AT'), (r'.*able$',)]
```
now throws:
```
Traceback (most recent call last):
  File "[sic]\nltk_2817.py", line 9, in <module>
    tagger = RegexpTagger(regexps)
  File "[sic]\nltk\tag\sequential.py", line 542, in __init__
    for regexp, tag in regexps:
ValueError: not enough values to unpack (expected 2, got 1)
```
Which should indicate to the developers that they're doing something wrong.

- Tom Aarsen