### PR TITLE
Breaking issue - Fix regression from #2819

### DIFF
--- a/nltk/stem/wordnet.py
+++ b/nltk/stem/wordnet.py
@@ -30,7 +30,7 @@ class WordNetLemmatizer:
         hardrock
     """
 
-    def lemmatize(self, word: str, pos: str = wn.NOUN) -> str:
+    def lemmatize(self, word: str, pos: str = "n") -> str:
         """Lemmatize `word` using WordNet's built-in morphy function.
         Returns the input word unchanged if it cannot be found in WordNet.
 


### PR DESCRIPTION
Hello!

### Pull request overview
* Fix breaking issue from #2819 

### The bug
NLTK can no longer be imported without having installed `"wordnet"`, and wordnet cannot be downloaded without `nltk` being imported. This prevents users from using NLTK whatsoever. 
After deleting the `wordnet` and `wordnet_ic` folders from my `nltk_data` folder, and importing NLTK, this is the result:
```python
>>> import nltk
Traceback (most recent call last):
  File "[sic]\nltk\corpus\util.py", line 84, in __load       
    root = nltk.data.find(f"{self.subdir}/{zip_name}")
  File "[sic]\nltk\data.py", line 583, in find
    raise LookupError(resource_not_found)
LookupError: 
**********************************************************************
  Resource wordnet not found.
  Please use the NLTK Downloader to obtain the resource:

  >>> import nltk
  >>> nltk.download('wordnet')
  
  For more information see: https://www.nltk.org/data.html

  Attempted to load corpora/wordnet.zip/wordnet/

  Searched in:
    - '[sic]/nltk_data'
    - '[sic]\\Python39\\nltk_data'
    - '[sic]\\Python39\\share\\nltk_data'
    - '[sic]\\Python39\\lib\\nltk_data'
    - '[sic]\\AppData\\Roaming\\nltk_data'
    - 'C:\\nltk_data'
    - 'D:\\nltk_data'
    - 'E:\\nltk_data'
**********************************************************************


During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "[sic]\nltk\__init__.py", line 153, in <module>
    from nltk.translate import *
  File "[sic]\nltk\translate\__init__.py", line 24, in <module>
    from nltk.translate.meteor_score import meteor_score as meteor
  File "[sic]\nltk\translate\meteor_score.py", line 13, in <module>
    from nltk.stem.porter import PorterStemmer
  File "[sic]\nltk\stem\__init__.py", line 34, in <module>
    from nltk.stem.wordnet import WordNetLemmatizer
  File "[sic]\nltk\stem\wordnet.py", line 12, in <module>
    class WordNetLemmatizer:
  File "[sic]\nltk\stem\wordnet.py", line 33, in WordNetLemmatizer
    def lemmatize(self, word: str, pos: str = wn.NOUN) -> str:
  File "[sic]\nltk\corpus\util.py", line 121, in __getattr__
    self.__load()
  File "[sic]\nltk\corpus\util.py", line 86, in __load
    raise e
  File "[sic]\nltk\corpus\util.py", line 81, in __load
    root = nltk.data.find(f"{self.subdir}/{self.__name}")
  File "[sic]\nltk\data.py", line 583, in find
    raise LookupError(resource_not_found)
LookupError:
**********************************************************************
  Resource wordnet not found.
  Please use the NLTK Downloader to obtain the resource:

  >>> import nltk
  >>> nltk.download('wordnet')

  For more information see: https://www.nltk.org/data.html

  Attempted to load corpora/wordnet

  Searched in:
    - '[sic]/nltk_data'
    - '[sic]\\Python39\\nltk_data'
    - '[sic]\\Python39\\share\\nltk_data'
    - '[sic]\\Python39\\lib\\nltk_data'
    - '[sic]\\AppData\\Roaming\\nltk_data'
    - 'C:\\nltk_data'
    - 'D:\\nltk_data'
    - 'E:\\nltk_data'
**********************************************************************

>>> import nltk
Traceback (most recent call last):
  File "[sic]\nltk\corpus\util.py", line 84, in __load
    root = nltk.data.find(f"{self.subdir}/{zip_name}")
  File "[sic]\nltk\data.py", line 583, in find
    raise LookupError(resource_not_found)
LookupError:
**********************************************************************
  Resource wordnet not found.
  Please use the NLTK Downloader to obtain the resource:

  >>> import nltk
  >>> nltk.download('wordnet')

  For more information see: https://www.nltk.org/data.html

  Attempted to load corpora/wordnet.zip/wordnet/

  Searched in:
    - '[sic]/nltk_data'
    - '[sic]\\Python39\\nltk_data'
    - '[sic]\\Python39\\share\\nltk_data'
    - '[sic]\\Python39\\lib\\nltk_data'
    - '[sic]\\AppData\\Roaming\\nltk_data'
    - 'C:\\nltk_data'
    - 'D:\\nltk_data'
    - 'E:\\nltk_data'
**********************************************************************


During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "[sic]\nltk\__init__.py", line 155, in <module>
    from nltk.stem import *
  File "[sic]\nltk\stem\__init__.py", line 34, in <module>
    from nltk.stem.wordnet import WordNetLemmatizer
  File "[sic]\nltk\stem\wordnet.py", line 12, in <module>
    class WordNetLemmatizer:
  File "[sic]\nltk\stem\wordnet.py", line 33, in WordNetLemmatizer
    def lemmatize(self, word: str, pos: str = wn.NOUN) -> str:
  File "[sic]\nltk\corpus\util.py", line 121, in __getattr__
    self.__load()
  File "[sic]\nltk\corpus\util.py", line 86, in __load
    raise e
  File "[sic]\nltk\corpus\util.py", line 81, in __load
    root = nltk.data.find(f"{self.subdir}/{self.__name}")
  File "[sic]\nltk\data.py", line 583, in find
    raise LookupError(resource_not_found)
LookupError:
**********************************************************************
  Resource wordnet not found.
  Please use the NLTK Downloader to obtain the resource:

  >>> import nltk
  >>> nltk.download('wordnet')

  For more information see: https://www.nltk.org/data.html

  Attempted to load corpora/wordnet

  Searched in:
    - '[sic]/nltk_data'
    - '[sic]\\Python39\\nltk_data'
    - '[sic]\\Python39\\share\\nltk_data'
    - '[sic]\\Python39\\lib\\nltk_data'
    - '[sic]\\AppData\\Roaming\\nltk_data'
    - 'C:\\nltk_data'
    - 'D:\\nltk_data'
    - 'E:\\nltk_data'
**********************************************************************
```

The core of the bug can be found in this line:
```python
  File "[sic]\nltk\stem\wordnet.py", line 33, in WordNetLemmatizer
    def lemmatize(self, word: str, pos: str = wn.NOUN) -> str:
  File "[sic]\nltk\corpus\util.py", line 121, in __getattr__
    self.__load()
```

My recent changes from #2819 has converted
```python
from nltk.corpus import wordnet
from nltk.corpus.reader.wordnet import NOUN

...

   def lemmatize(self, word, pos=NOUN):
...
```
to
```python
from nltk.corpus import wordnet as wn

...

   def lemmatize(self, word: str, pos: str = wn.NOUN) -> str:
...
```

This change seems innocuous, with no real consequences whatsoever - but it seems that using `wn.NOUN` forces the `WordNetCorpusReader` to load. This is not a problem if `wordnet` is already downloaded. But, if it isn't, then an exception gets thrown, telling the user to download `wordnet`.
However, this cannot be done when `import nltk` throws an exception, and then
```python
>>> import nltk
>>> nltk.download("wordnet")
```
cannot be executed.

### The fix
Simply replace `wn.NOUN` with `"n"`, which is clearer (people recognise strings, but not `wn.NOUN`), but removes the "mental link" to the wordnet global variables. Perhaps there's a way to use `NOUN` again without loading the corpus loader.

---

By the way, the reason the tests never picked this up, is because `nltk_data` is cached. As a result, loading `wordnet` doesn't give issues. However, if the cache ever needed renewing, then it would start complaining.

I must say that I never imagined these consequences. 

- Tom Aarsen