### PR TITLE
fix: correct minor typo in word_tokenize

### DIFF
--- a/nltk/tokenize/__init__.py
+++ b/nltk/tokenize/__init__.py
@@ -123,7 +123,7 @@ def word_tokenize(text, language="english", preserve_line=False):
     :type text: str
     :param language: the model name in the Punkt corpus
     :type language: str
-    :param preserve_line: An option to keep the preserve the sentence and not sentence tokenize it.
+    :param preserve_line: A flag to decide whether to sentence tokenize the text or not.
     :type preserve_line: bool
     """
     sentences = [text] if preserve_line else sent_tokenize(text, language)


### PR DESCRIPTION
This pull request address [2425](https://github.com/nltk/nltk/issues/2425). It simply refactor the docstring of preserve_line parameter in word_tokenize function to be more meaningful. 