### PR TITLE
specify minimum regex version that supports regex.Pattern

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ natural language processing.  NLTK requires Python 3.6, 3.7, 3.8, or 3.9.""",
     install_requires=[
         "click",
         "joblib",
-        "regex",
+        "regex>=2021.8.3",
         "tqdm",
     ],
     extras_require=extras_require,


### PR DESCRIPTION
See excellent explanation by @tomaarsen here: https://github.com/nltk/nltk/pull/2834

This PR increases minimum required version of a dependency to solve a use case like https://github.com/nltk/nltk/issues/2833
