### PR TITLE
feat: allow SentimentIntensityAnalyzer to preprocess hashtags

### DIFF
--- a/nltk/sentiment/vader.py
+++ b/nltk/sentiment/vader.py
@@ -6,6 +6,7 @@
 #         Pierpaolo Pantone <24alsecondo@gmail.com> (modifications)
 #         George Berry <geb97@cornell.edu> (modifications)
 #         Malavika Suresh <malavika.suresh0794@gmail.com> (modifications)
+#         Mohaned Mashaly <>(modifications)
 # URL: <http://nltk.org/>
 # For license information, see LICENSE.TXT
 #
@@ -269,6 +270,7 @@ class SentiText:
         if not isinstance(text, str):
             text = str(text.encode("utf-8"))
         self.text = text
+        self.text = self.remove_hashtag(text)
         self.PUNC_LIST = punc_list
         self.REGEX_REMOVE_PUNCTUATION = regex_remove_punctuation
         self.words_and_emoticons = self._words_and_emoticons()
@@ -326,6 +328,15 @@ class SentiText:
         if 0 < cap_differential < len(words):
             is_different = True
         return is_different
+
+    def remove_hashtag(self, text):
+        """
+        Remove hastag (#) symbol
+        from the text
+        :param: text
+        :returns: rext after removing hashtags
+        """
+        return re.sub("#", "", text)
 
 
 class SentimentIntensityAnalyzer:

--- a/nltk/test/unit/Pipfile
+++ b/nltk/test/unit/Pipfile
@@ -1,0 +1,11 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+
+[dev-packages]
+
+[requires]
+python_version = "3.9"

--- a/nltk/test/unit/test_remove_hashtags_senti_text.py
+++ b/nltk/test/unit/test_remove_hashtags_senti_text.py
@@ -1,0 +1,44 @@
+"""
+Tests for nltk.sentiment.vader.remove_hashtag
+"""
+
+import unittest
+
+from nltk.sentiment import SentimentIntensityAnalyzer
+
+
+class TestRemoveHashtag(unittest.TestCase):
+    def setUp(self):
+        self.sentiment_analyser = SentimentIntensityAnalyzer()
+
+    def test_remove_hashtag_multiple(self):
+        """
+        Test against multiple hashtags
+        """
+        case = "Strings with hashtag ###stupid ##useless ##BAD"
+        expected = {"neg": 0.777, "neu": 0.223, "pos": 0.0, "compound": -0.8868}
+        assert self.sentiment_analyser.polarity_scores(case) == expected
+
+    def test_remove_hashtag_space(self):
+        """
+        Test against hashtag with spaces
+        """
+        case = "I feel very # happy # today"
+        expected = {"neg": 0.0, "neu": 0.429, "pos": 0.571, "compound": 0.6115}
+        assert self.sentiment_analyser.polarity_scores(case) == expected
+
+    def test_remove_hashtag_postfix(self):
+        """
+        Test hashtags that comes after the text
+        """
+        case = "I feel very # happy# today#"
+        expected = {"neg": 0.0, "neu": 0.429, "pos": 0.571, "compound": 0.6115}
+        assert self.sentiment_analyser.polarity_scores(case) == expected
+
+    def test_remove_hashtag_infix(self):
+        """
+        Test hashtags that comes in the middle of the text
+        """
+        case = "Strings with hashtag stup#id useless BA#D"
+        expected = {"neg": 0.777, "neu": 0.223, "pos": 0.0, "compound": -0.8868}
+        assert self.sentiment_analyser.polarity_scores(case) == expected


### PR DESCRIPTION
This pull request address [issue](https://github.com/nltk/nltk/issues/2637). Hashtags affects the sentiment of text which affects the overall score and output in-accurate results.

This pull request does the following: 

- Add remove_hashtag function in the preprocessing pipeline to remove hashtags, in order to deal with words properly.

Regards.
