### PR TITLE
Skip ReDoS test - performance testing isn't viable with cloud computing

### DIFF
--- a/nltk/test/corpus.doctest
+++ b/nltk/test/corpus.doctest
@@ -2192,5 +2192,5 @@ For now, we accept values below 30 (times as long), due to the potential
 for variance. This ensures that the ReDoS has certainly been reduced,
 if not removed.
 
-    >>> exec_times["long"] / exec_times["short"] < 30
+    >>> exec_times["long"] / exec_times["short"] < 30 # doctest: +SKIP
     True


### PR DESCRIPTION
Hello!

### Pull request overview
* Skipped ReDoS test introduced in #2816

### The issue
I'll keep this short - the GitHub actions run [here](https://github.com/nltk/nltk/runs/3756143856) from dacda6f50057e1de560483f5e432b5ccb0dd5876 failed due to this test being inconsistent. This PR is very similar to #2728. 

GitHub uses cloud computing for their CI, and it's not meant to be super consistent. If some other task on the physical machine that runs our test happens to require more resources at a given moment, then we simply can't rely on time-based performance results. This is something that @iliakur has also experienced with #2760.

A potential fix would be to somehow use some hack to keep track of function calls of built-in methods, and compare those. That said, I don't believe this is possible (or reasonable to build for just 2 tests).

So, for the time being, this test should be skipped. I really hoped that I had built in enough room for error, but it seems that perhaps there is no such thing as enough room for error.

- Tom Aarsen