### PR TITLE
Enhancement: Add ZWJ sequences Emoji and Skin Tone Modifier Emoji support to TweetTokenizer 

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -280,6 +280,7 @@
 - Hiroki Teranishi <https://github.com/chantera>
 - Ruben Cartuyvels <https://github.com/rubencart>
 - Dalton Pearson <https://github.com/daltonpearson>
+- Saibo Geng <https://github.com/Saibo-creator>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 

--- a/nltk/test/unit/test_tokenize.py
+++ b/nltk/test/unit/test_tokenize.py
@@ -334,6 +334,54 @@ class TestTokenize:
         result = tokenizer.tokenize(test2)
         assert result == expected
 
+    def test_emoji_tokenizer(self):
+        """
+        Test a string that contains Emoji ZWJ Sequences and skin tone modifier
+        """
+        tokenizer = TweetTokenizer()
+
+        # A Emoji ZWJ Sequences, they together build as a single emoji, should not be split.
+        test1 = "👨‍👩‍👧‍👧"
+        expected = ["👨‍👩‍👧‍👧"]
+        result = tokenizer.tokenize(test1)
+        assert result == expected
+
+        # A Emoji with skin tone modifier, the two characters build a single emoji, should not be split.
+        test2 = "👨🏿"
+        expected = ["👨🏿"]
+        result = tokenizer.tokenize(test2)
+        assert result == expected
+
+        # A string containing both skin tone modifier and ZWJ Sequences
+        test3 = "🤔 🙈 me así, se😌 ds 💕👭👙 hello 👩🏾‍🎓 emoji hello 👨‍👩‍👦‍👦 how are 😊 you today🙅🏽🙅🏽"
+        expected = [
+            "🤔",
+            "🙈",
+            "me",
+            "así",
+            ",",
+            "se",
+            "😌",
+            "ds",
+            "💕",
+            "👭",
+            "👙",
+            "hello",
+            "👩🏾\u200d🎓",
+            "emoji",
+            "hello",
+            "👨\u200d👩\u200d👦\u200d👦",
+            "how",
+            "are",
+            "😊",
+            "you",
+            "today",
+            "🙅🏽",
+            "🙅🏽",
+        ]
+        result = tokenizer.tokenize(test3)
+        assert result == expected
+
     def test_pad_asterisk(self):
         """
         Test padding of asterisk for word tokenization.

--- a/nltk/tokenize/casual.py
+++ b/nltk/tokenize/casual.py
@@ -420,7 +420,9 @@ def merge_emoji_skin_tone_modifiers(words: List[str]):
     words_after_merge = []
     i = len(words) - 1
     while i >= 0:
-        if words[i] in SKIN_TONE_MODIFIERS:
+        # i!=0 to handle corner case where first word is a skin tone modifier
+        # this corner case should be rare as it's a not legal use of skin tone modifier
+        if words[i] in SKIN_TONE_MODIFIERS and i != 0:
             words_after_merge.append(words[i - 1] + words[i])
             i -= 2
         else:
@@ -432,7 +434,9 @@ def merge_emoji_skin_tone_modifiers(words: List[str]):
 def merge_zwj_element_for_emojis(words: List[str]):
     i = len(words) - 1
     while i > 0:
-        if words[i] == ZWJ_ELEMENT:
+        # i!=0 and i != len(words) - 1 to handle corner case where first or last word is a skin tone modifier
+        # those two corner cases should be rare as they are not legal use of zwj element
+        if words[i] == ZWJ_ELEMENT and i != 0 and i != len(words) - 1:
             # merge the two tokens surrounding zwj element
             words[i - 1] = words[i - 1] + words[i] + words[i + 1]
             # delete the merged two tokens


### PR DESCRIPTION
Resolves #2829
Enable TweetTokenizer to handle Emoji containing ZWJ element or Skin Tone Modifier, i.e. tokenize them as a single token instead of several.