### PR TITLE
use latest version of pip in CI pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,7 +103,9 @@ jobs:
           key: python-dependencies-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements-ci.txt') }}-${{ env.pythonLocation }}
 
       - name: Install dependencies on cache miss
-        run: pip install --upgrade --requirement requirements-ci.txt
+        run: |
+          pip install --no-cache-dir --upgrade pip
+          pip install --no-cache-dir --upgrade --requirement requirements-ci.txt
         if: steps.restore-cache.outputs.cache-hit != 'true'
 
       - name: Use cached nltk data


### PR DESCRIPTION
Small tweak to CI.

1 Use latest version of pip to install dependencies. There can be some variation depending on which python version is used, this ensures the latest version.
2 Use `--no-cache-dir` during dependency installation, this avoid creating local pip cache which is redundant because it is discarded between runs and because we are caching the entire python environment with all installed dependencies.

This PR should not conflict with https://github.com/nltk/nltk/pull/2820/, however, it's probably a good idea to merge https://github.com/nltk/nltk/pull/2820/ first.