### PR TITLE
Implement get_refs function for DrtLambdaExpression

### DIFF
--- a/nltk/sem/drt.py
+++ b/nltk/sem/drt.py
@@ -717,6 +717,12 @@ class DrtLambdaExpression(DrtExpression, LambdaExpression):
             + ["    " + blank + line for line in term_lines[3:]]
         )
 
+    def get_refs(self, recursive=False):
+        """:see: AbstractExpression.get_refs()"""
+        return (
+                [self.variable] + self.term.get_refs(True) if recursive else [self.variable]
+            )
+
 
 class DrtBinaryExpression(DrtExpression, BinaryExpression):
     def get_refs(self, recursive=False):

--- a/nltk/sem/drt.py
+++ b/nltk/sem/drt.py
@@ -720,8 +720,8 @@ class DrtLambdaExpression(DrtExpression, LambdaExpression):
     def get_refs(self, recursive=False):
         """:see: AbstractExpression.get_refs()"""
         return (
-                [self.variable] + self.term.get_refs(True) if recursive else [self.variable]
-            )
+            [self.variable] + self.term.get_refs(True) if recursive else [self.variable]
+        )
 
 
 class DrtBinaryExpression(DrtExpression, BinaryExpression):


### PR DESCRIPTION
This update implemets get_refs function for a DrtLambdaExpression. This function is called when a simplify() on DrtLambdaExpression is called. It returns a list of bound variables within the object of type DrtLambdaExpression. The issue caused without this function was reported in #2844 . 
Should fix #2844