### PR TITLE
Modernize `nltk.org/howto` pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ coverage.xml
 
 # automatically built files for website
 web/api/*.rst
+web/howto/*.rst
 
 # iPython notebooks
 

--- a/nltk/test/corpus.doctest
+++ b/nltk/test/corpus.doctest
@@ -25,7 +25,7 @@ and new corpus reader classes.  Section `Regression Tests`_
 and associated functions and classes.
 
 .. contents:: **Table of Contents**
-  :depth: 2
+  :depth: 4
   :backlinks: none
 
 ---------------------

--- a/web/_templates/doctest.rst
+++ b/web/_templates/doctest.rst
@@ -1,0 +1,5 @@
+{% for item in range(17 + module_name|length) -%}#{%- endfor %}
+Sample usage for {{ module_name }}
+{% for item in range(17 + module_name|length) -%}#{%- endfor %}
+
+.. include:: ../../nltk/test/{{ module_name }}.doctest

--- a/web/conf.py
+++ b/web/conf.py
@@ -54,6 +54,40 @@ def run_apidoc(app):
     )
 
 
+def generate_howto():
+    """Custom function for generating contents in the ``howto`` folder,
+    based on the ``ntlk/test/*.doctest`` files.
+    """
+    import glob
+    import re
+
+    from jinja2 import Template
+
+    modules = []
+
+    web_folder = os.path.dirname(os.path.abspath(__file__))
+
+    # Load jinja templates
+    with open(os.path.join(web_folder, "_templates", "doctest.rst")) as f:
+        doctest_template = Template(f.read())
+
+    print("Generating HOWTO pages...")
+    # Iterate over .doctest files, and find the module_name.
+    pattern = re.compile(r"(\w+)\.doctest$")
+    for path in glob.glob(os.path.join(web_folder, "..", "nltk", "test", "*.doctest")):
+        match = pattern.search(path)
+        module_name = match.group(1)
+        # Write .rst files based on the doctest_template.
+        doctest_template.stream(module_name=module_name).dump(
+            os.path.join(web_folder, "howto", f"{module_name}.rst")
+        )
+        modules.append(module_name)
+
+    print(f"Generated {len(modules)} HOWTO pages.")
+
+
+generate_howto()
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 

--- a/web/conf.py
+++ b/web/conf.py
@@ -66,6 +66,9 @@ def generate_howto():
     modules = []
 
     web_folder = os.path.dirname(os.path.abspath(__file__))
+    howto_folder = os.path.join(web_folder, "howto")
+    if not os.path.exists(howto_folder):
+        os.makedirs(howto_folder)
 
     # Load jinja template
     with open(os.path.join(web_folder, "_templates", "doctest.rst")) as f:
@@ -82,7 +85,7 @@ def generate_howto():
             continue
         # Write .rst files based on the doctest_template.
         doctest_template.stream(module_name=module_name).dump(
-            os.path.join(web_folder, "howto", f"{module_name}.rst")
+            os.path.join(howto_folder, f"{module_name}.rst")
         )
         modules.append(module_name)
 

--- a/web/conf.py
+++ b/web/conf.py
@@ -67,7 +67,7 @@ def generate_howto():
 
     web_folder = os.path.dirname(os.path.abspath(__file__))
 
-    # Load jinja templates
+    # Load jinja template
     with open(os.path.join(web_folder, "_templates", "doctest.rst")) as f:
         doctest_template = Template(f.read())
 
@@ -77,6 +77,9 @@ def generate_howto():
     for path in glob.glob(os.path.join(web_folder, "..", "nltk", "test", "*.doctest")):
         match = pattern.search(path)
         module_name = match.group(1)
+        # Ignore index.doctest, we already have an index, i.e. howto.rst
+        if module_name == "index":
+            continue
         # Write .rst files based on the doctest_template.
         doctest_template.stream(module_name=module_name).dump(
             os.path.join(web_folder, "howto", f"{module_name}.rst")

--- a/web/howto.rst
+++ b/web/howto.rst
@@ -1,0 +1,8 @@
+Example usage of NLTK modules
+=============================
+
+.. toctree::
+   :titlesonly:
+   :glob:
+
+   howto/*

--- a/web/index.rst
+++ b/web/index.rst
@@ -76,7 +76,7 @@ Next Steps
    :caption: NLTK Documentation
 
    API Reference <api/nltk>
-   Example Usage <https://www.nltk.org/howto>
+   Example Usage <howto>
    Module Index <py-modindex>
    Wiki <https://github.com/nltk/nltk/wiki>
    FAQ <https://github.com/nltk/nltk/wiki/FAQ>


### PR DESCRIPTION
Hello!

### Pull request overview
- Modernize `nltk.org/howto` and `nltk.org/howto/*.html`.
- Automate the updating of `nltk.org/howto` pages. They're now built whenever the rest of the website is.

### Live demo
See https://tomaarsen.com/nltk/howto.html for the result of this PR in action. Feel free to compare to https://www.nltk.org/howto. Keep in mind that the HOWTO's from nltk.org are ~6 years old, so they might have slightly less or different information.

### Background
These HOWTO pages (see https://www.nltk.org/howto) are generated using the `nltk/test/*.doctest` files. They provide a quick and comfortable way of showing how certain core functionality can be used.

This PR tackles one of the last thorns in my eye regarding the website. The page formerly referred to as the `HOWTO` page (later renamed to `Example Usage`) looks very bland, and doesn't fit with the remainder of the website. It feels very separate to the rest of the site. 
This PR tackles this in a simple and concise way, which allows for automated updating of the example usage files. This is a step up from the current method, which requires manual updates - something that hasn't been done for some 6 years (because it's so annoying to update!)

### Details
I realised that our website builder Sphinx is able to render these pages properly if we simply use 
```rst
.. include:: /nltk/test/bleu.doctest
```
The next step was figuring out how to easily and properly use this. A key goal was to ensure that no page URLs need to be updated. If https://www.nltk.org/howto/corpus.html links to the Example Usage of the corpus module right now, then it will still do so after this PR is merged. This means: No unnecessary updating of URLs throughout the projects, and no links to documentation used in e.g. stackoverflow that suddenly don't go anywhere anymore.

To help with this, I've made a function in `web/conf.py`, which generates these howto files. They're based on jinja templates like we were already using for the automatic generation of the API Reference. The new template looks like this:
```rst
{% for item in range(17 + module_name|length) -%}#{%- endfor %}
Sample usage for {{ module_name }}
{% for item in range(17 + module_name|length) -%}#{%- endfor %}

.. include:: ../../nltk/test/{{ module_name }}.doctest
```
Which generates for example:
```rst
####################
Sample usage for ccg
####################

.. include:: ../../nltk/test/ccg.doctest
```

From this point onwards there only needed to be an index page for `nltk.org/howto` to replace the current one, and the Table of Contents needed to point to the new howto page. Simple.

### Screenshots
<details>
<summary>Click here to see some examples of Before and After</summary>

#### Before
![image](https://user-images.githubusercontent.com/37621491/137480889-f77d5942-6db2-4eff-991f-51d4bcb52c04.png)

#### After
![image](https://user-images.githubusercontent.com/37621491/137480910-c790fcef-c1d9-462b-8bf4-3f27662ca9b4.png)

#### Before
![image](https://user-images.githubusercontent.com/37621491/137481074-0221b490-ea5d-4736-8ae7-39e2dd3fcd71.png)

#### After
![image](https://user-images.githubusercontent.com/37621491/137481112-b46ecdc8-272f-4760-b7e4-9d54ccaa38e7.png)

#### Before
![image](https://user-images.githubusercontent.com/37621491/137481312-77976d46-fb39-48b4-9e3b-bf6dd61e661c.png)

#### After
![image](https://user-images.githubusercontent.com/37621491/137481328-13332794-0405-40f3-980c-3b04849f05f6.png)

</details>

### Future changes
Perhaps there are some cases where a code block spans too wide, and a single line is placed on separate lines. In most situations this is the preferred solution, but sometimes we want to be able to see e.g. a pretty-printed drawing fully. I'm not quite sure how to go about fixing this.

### Note
I haven't had time to compare and check every single HOWTO page, and it's important to note that there are now a whopping 543 warnings (as opposed to e.g. 512 before). In some of these cases, the website will render the page oddly, or remove parts. We'll probably want to tackle these at some point.

---

It seems that the common usage of the website will be fully consistent and modernised after this PR!

- Tom Aarsen