### PR TITLE
Rewind Wordnet data file after each lookup

### DIFF
--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -1423,6 +1423,7 @@ class WordNetCorpusReader(CorpusReader):
             raise WordNetError(
                 f"No WordNet synset found for pos={pos} at offset={offset}."
             )
+        data_file.seek(0)
         return synset
 
     @deprecated("Use public method synset_from_pos_and_offset() instead")


### PR DESCRIPTION
This fixes #2867. Rewinding Wordnet data files after each lookup may not be absolutely necessary, but it is safer.