### PR TITLE
Resolved serious ReDoS in PunktSentenceTokenizer

### DIFF
--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -1377,9 +1377,9 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
             if matches and match.end() > before_start:
                 continue
             # Find the word before the current match
-            all_before, before_word = text[: match.start()].rsplit(maxsplit=1)
-            before_start = len(all_before)
-            before_words[match] = before_word
+            split = text[: match.start()].rsplit(maxsplit=1)
+            before_start = len(split[0]) if len(split) == 2 else 0
+            before_words[match] = split[-1]
             matches.append(match)
 
         return [

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -189,7 +189,7 @@ class PunktLanguageVars:
     constructors.
     """
 
-    __slots__ = ("_re_period_context", "_re_word_tokenizer")
+    __slots__ = ("_re_period_context", "_re_word_tokenizer", "_re_last_word")
 
     def __getstate__(self):
         # All modifications to the class are performed by inheritance.
@@ -266,7 +266,6 @@ class PunktLanguageVars:
         return self._word_tokenizer_re().findall(s)
 
     _period_context_fmt = r"""
-        \S*                          # some word material
         %(SentEndChars)s             # a potential sentence ending
         (?=(?P<after_tok>
             %(NonWord)s              # either other punctuation
@@ -292,6 +291,16 @@ class PunktLanguageVars:
                 re.UNICODE | re.VERBOSE,
             )
             return self._re_period_context
+
+    def last_word_re(self):
+        """Compiles and returns a regular expression to return the sequence
+        of non-whitespace characters in a string starting from the right.
+        It returns an empty match if the text ends with whitespace."""
+        try:
+            return self._re_last_word
+        except:
+            self._re_last_word = re.compile(r"\S*$")
+            return self._re_last_word
 
 
 _re_non_punct = re.compile(r"[^\W\d]", re.UNICODE)
@@ -1284,8 +1293,7 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
         See format_debug_decision() to help make this output readable.
         """
 
-        for match in self._lang_vars.period_context_re().finditer(text):
-            decision_text = match.group() + match.group("after_tok")
+        for match, decision_text in self._match_potential_end_contexts(text):
             tokens = self._tokenize_words(decision_text)
             tokens = list(self._annotate_first_pass(tokens))
             while tokens and not tokens[0].tok.endswith(self._lang_vars.sent_end_chars):
@@ -1333,10 +1341,68 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
         """
         return [text[s:e] for s, e in self.span_tokenize(text, realign_boundaries)]
 
+    def _match_potential_end_contexts(self, text):
+        """
+        Given a text, find the matches of potential sentence breaks,
+        alongside the contexts surrounding these sentence breaks.
+
+        Since the fix for the ReDOS discovered in issue #2866, we no longer match
+        the word before a potential end of sentence token. Instead, we use a separate
+        regex for this. As a consequence, `finditer`'s desire to find non-overlapping
+        matches no longer aids us in finding the single longest match.
+        Where previously, we could use::
+
+            >>> pst = PunktSentenceTokenizer()
+            >>> text = "Very bad acting!!! I promise."
+            >>> list(pst._lang_vars.period_context_re().finditer(text)) # doctest: +SKIP
+            [<re.Match object; span=(9, 18), match='acting!!!'>]
+
+        Now we have to find the word before (i.e. 'acting') separately, and `finditer`
+        returns::
+
+            >>> pst = PunktSentenceTokenizer()
+            >>> text = "Very bad acting!!! I promise."
+            >>> list(pst._lang_vars.period_context_re().finditer(text)) # doctest: +NORMALIZE_WHITESPACE
+            [<re.Match object; span=(15, 16), match='!'>,
+            <re.Match object; span=(16, 17), match='!'>,
+            <re.Match object; span=(17, 18), match='!'>]
+
+        So, we need to find the word before the match from right to left, and then manually remove
+        the overlaps. That is what this method does::
+
+            >>> pst = PunktSentenceTokenizer()
+            >>> text = "Very bad acting!!! I promise."
+            >>> pst._match_potential_end_contexts(text)
+            [(<re.Match object; span=(17, 18), match='!'>, 'acting!!! I')]
+
+        :param text: String of one or more sentences
+        :type text: str
+        :return: List of match-context tuples.
+        :rtype: List[Tuple[re.Match, str]]
+        """
+        before_words = {}
+        matches = []
+        for match in reversed(list(self._lang_vars.period_context_re().finditer(text))):
+            # Ignore matches that have already been captured by matches to the right of this match
+            if matches and match.end() > before_words[matches[-1]].start():
+                continue
+            # Find the word before the current match
+            before_words[match] = self._lang_vars.last_word_re().search(
+                text[: match.start()]
+            )
+            matches.append(match)
+
+        return [
+            (
+                match,
+                before_words[match].group() + match.group() + match.group("after_tok"),
+            )
+            for match in matches[::-1]
+        ]
+
     def _slices_from_text(self, text):
         last_break = 0
-        for match in self._lang_vars.period_context_re().finditer(text):
-            context = match.group() + match.group("after_tok")
+        for match, context in self._match_potential_end_contexts(text):
             if self.text_contains_sentbreak(context):
                 yield slice(last_break, match.end())
                 if match.group("next_tok"):


### PR DESCRIPTION
Resolves #2866 

Hello!

### Pull request overview
* Resolved serious Regular Expression Denial of Service (ReDoS) issue in PunktSentenceTokenizer.
  * This has severe consequences for the commonly used `sent_tokenize` and `word_tokenize`.

## The consequences of the ReDoS
The ReDoS is described in #2866, where an example of a malicious string is given. The consequences can be seen with this script:
```python
n = 8
for length in [10**i for i in range(2, n)]:
    text = "a" * length
    start_t = time.time()
    word_tokenize(text)
    print(f"A length of {length:<{n}} takes {time.time() - start_t:.4f}s")
```
Which outputs:
```
A length of 100      takes 0.0060s
A length of 1000     takes 0.0060s
A length of 10000    takes 0.6320s
A length of 100000   takes 56.3322s
...
```
This is before I canceled the execution of the program after running it for several hours.

## Potential malicious inputs
Any long sequence of any non-whitespace characters except `.`, `?` or `!` will be malicious input to the regex. A quick example is simply:
```python
"a" * 100000
```
It takes `word_tokenize` 56.3322 seconds to tokenize this input.

## The details of the ReDoS
The ReDoS is caused by this regex: 
https://github.com/nltk/nltk/blob/ad3c84c792453a44f2d195e5263e72b315774478/nltk/tokenize/punkt.py#L268-L278

After being formatted with the default values, this becomes:
```python
_period_context_fmt = r"""
\S*                             # some word material
[\.\?!]                         # a potential sentence ending
(?=(?P<after_tok>
    (?:[)\";}\]\*:@\'\({\[!\?]  # either other punctuation
    |
    \s+(?P<next_tok>\S+)        # or whitespace and some other token
))"""
```
The vulnerability is already at the very start of the regex. The following regex is also vulnerable:
```python
_period_context_fmt = r"""
\S*                             # some word material
[\.\?!]                         # a potential sentence ending
"""
```
The issue is that the Python regex engine will start matching tokens with `\S*` (i.e. any non-whitespace), and only recognize that it failed to find a `.`, `?` or a `! ` when it either reaches a whitespace character. So, with an input of a thousand characters of `"a"`, then the regex engine will start matching from the very first `"a"`, and only recognize that it won't be able to match this way after matching the full 1000 `"a"`'s. Then, it will backtrack all the way back to the first `"a"`, skip it, and try the entire thing again from the second `"a"`, now matching 999 characters before realising this won't work. This will continue until finally realising that the regex will not match the string at all. 
Given an input string of length `n`, this will take `(n^2 + n) / 2` steps. With other words, `word_tokenize` becomes at least O(n^2) time complexity, while a performance of O(n) should be reachable for most regex problems.

## The fix
The fix seems elementary:
* Remove `\S*` from the regex, then the regex engine will only start trying to match when it actually finds a potential end of sentence token (i.e. `.`, `!` or `?` by default).
* Then, use a simply regex like `\S*$` to match the final word before the end of sentence token.

And this works very well, with one small but crucial detail: `re.finditer` will find all *non-overlapping* matches, and we've now reduced the size of each match. See the consequences with this example:
#### On the `develop` branch
```python
>>> pst = PunktSentenceTokenizer()
>>> text = "Very bad acting!!! I promise."
>>> list(pst._lang_vars.period_context_re().finditer(text)) # doctest: +SKIP
[<re.Match object; span=(9, 18), match='acting!!!'>]
```
#### After removing `\S*` from the regex
```python
>>> pst = PunktSentenceTokenizer()
>>> text = "Very bad acting!!! I promise."
>>> list(pst._lang_vars.period_context_re().finditer(text)) # doctest: +NORMALIZE_WHITESPACE
[<re.Match object; span=(15, 16), match='!'>,
<re.Match object; span=(16, 17), match='!'>,
<re.Match object; span=(17, 18), match='!'>]
```
In short, we need to manually remove these overlapping cases. This is what the new `_match_potential_end_contexts` method is for. I can't come up with a regex-only solution for this problem.

## Results
Upon running the script again, but now with the fix in place, we get:
```python
A length of 100      takes 0.0070s
A length of 1000     takes 0.0010s
A length of 10000    takes 0.0060s
A length of 100000   takes 0.0400s
A length of 1000000  takes 0.3520s
A length of 10000000 takes 3.4641s
```
As you can see, the performance is significantly better, and more in tune with the expected O(n).

Beyond that, the performance of normal sentences (i.e. with dots) is in line with the original performance.

If all is well, then only the performance is (positively) impacted.

## Note
I believe that this PR does **not** require re-training of the Punkt models.

- Tom Aarsen