### PR TITLE
Corrected __init__ call for SyntaxCorpusReader subclasses

### DIFF
--- a/nltk/corpus/reader/bracket_parse.py
+++ b/nltk/corpus/reader/bracket_parse.py
@@ -53,9 +53,7 @@ class BracketParseCorpusReader(SyntaxCorpusReader):
             for normalizing or converting the POS tags returned by the
             ``tagged_...()`` methods.
         """
-        # FIXME: Why is it inheritting from SyntaxCorpusReader but initializing
-        #       from CorpusReader?
-        CorpusReader.__init__(self, root, fileids, encoding)
+        SyntaxCorpusReader.__init__(self, root, fileids, encoding)
         self._comment_char = comment_char
         self._detect_blocks = detect_blocks
         self._tagset = tagset

--- a/nltk/corpus/reader/dependency.py
+++ b/nltk/corpus/reader/dependency.py
@@ -23,9 +23,7 @@ class DependencyCorpusReader(SyntaxCorpusReader):
         sent_tokenizer=RegexpTokenizer("\n", gaps=True),
         para_block_reader=read_blankline_block,
     ):
-        # FIXME: Why is it inheritting from SyntaxCorpusReader but initializing
-        #       from CorpusReader?
-        CorpusReader.__init__(self, root, fileids, encoding)
+        SyntaxCorpusReader.__init__(self, root, fileids, encoding)
 
     #########################################################
 

--- a/nltk/corpus/reader/knbc.py
+++ b/nltk/corpus/reader/knbc.py
@@ -58,9 +58,7 @@ class KNBCorpusReader(SyntaxCorpusReader):
         morphs2str is a function to convert morphlist to str for tree representation
         for _parse()
         """
-        # FIXME: Why is it inheritting from SyntaxCorpusReader but initializing
-        #       from CorpusReader?
-        CorpusReader.__init__(self, root, fileids, encoding)
+        SyntaxCorpusReader.__init__(self, root, fileids, encoding)
         self.morphs2str = morphs2str
 
     def _read_block(self, stream):


### PR DESCRIPTION
Resolves #2118

Hello!

### Pull request overview
* Replaced `CorpusReader.__init__(...)` with `SyntaxCorpusReader.__init__(...)` on classes that inherit from `SyntaxCorpusReader`.

## Details
See #2118 for details on the issue.

Beyond that:
```python
>>> 
>>> from nltk.corpus import CorpusReader, SyntaxCorpusReader
>>> CorpusReader.__init__ == SyntaxCorpusReader.__init__
True
```

`SyntaxCorpusReader` inherits from `CorpusReader`, and the former doesn't specify a `__init__`, so both methods are identical. That means, we can just go for the logical option of calling `__init__` on the parent we are actually inheriting from.

- Tom Aarsen