### PR TITLE
 Fixed several TreebankWordTokenizer and NLTKWordTokenizer bugs

### DIFF
--- a/nltk/test/tokenize.doctest
+++ b/nltk/test/tokenize.doctest
@@ -73,6 +73,9 @@ Testing treebank's detokenizer
     >>> s = "Well, we couldn't have this predictable, cliche-ridden, \"Touched by an Angel\" (a show creator John Masius worked on) wanna-be if she didn't."
     >>> detokenizer.detokenize(word_tokenize(s))
     'Well, we couldn\'t have this predictable, cliche-ridden, "Touched by an Angel" (a show creator John Masius worked on) wanna-be if she didn\'t.'
+    >>> s = "I wanna watch something"
+    >>> detokenizer.detokenize(word_tokenize(s))
+    'I wanna watch something'
     >>> s = "I cannot cannot work under these conditions!"
     >>> detokenizer.detokenize(word_tokenize(s))
     'I cannot cannot work under these conditions!'

--- a/nltk/test/tokenize.doctest
+++ b/nltk/test/tokenize.doctest
@@ -43,7 +43,7 @@ Some test strings.
     ['It', "'s", 'more', "'n", 'enough', '.']
     >>> s12 = "''Hello, there!''"
     >>> word_tokenize(s12)
-    ["''", "Hello", ",", "there", "!", "''"]
+    ["''", 'Hello', ',', 'there', '!', "''"]
     >>> s13 = "''What a wonderful quote, this is'' - Someone (12 BC)"
     >>> word_tokenize(s13)
     ["''", 'What', 'a', 'wonderful', 'quote', ',', 'this', 'is', "''", '-', 'Someone', '(', '12', 'BC', ')']

--- a/nltk/test/tokenize.doctest
+++ b/nltk/test/tokenize.doctest
@@ -3,10 +3,10 @@
 
     >>> from nltk.tokenize import *
 
-Regression Tests: Treebank Tokenizer
+Regression Tests: NLTKWordTokenizer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Some test strings.
+Tokenizing some test strings.
 
     >>> s1 = "On a $50,000 mortgage of 30 years at 8 percent, the monthly payment would be $366.88."
     >>> word_tokenize(s1)
@@ -41,12 +41,35 @@ Some test strings.
     >>> s11 = "It's more'n enough."
     >>> word_tokenize(s11)
     ['It', "'s", 'more', "'n", 'enough', '.']
-    >>> s12 = "''Hello, there!''"
-    >>> word_tokenize(s12)
-    ["''", 'Hello', ',', 'there', '!', "''"]
-    >>> s13 = "''What a wonderful quote, this is'' - Someone (12 BC)"
-    >>> word_tokenize(s13)
-    ["''", 'What', 'a', 'wonderful', 'quote', ',', 'this', 'is', "''", '-', 'Someone', '(', '12', 'BC', ')']
+
+Gathering the spans of the tokenized strings.
+
+    >>> s = '''Good muffins cost $3.88\nin New (York).  Please (buy) me\ntwo of them.\n(Thanks).'''
+    >>> expected = [(0, 4), (5, 12), (13, 17), (18, 19), (19, 23),
+    ... (24, 26), (27, 30), (31, 32), (32, 36), (36, 37), (37, 38),
+    ... (40, 46), (47, 48), (48, 51), (51, 52), (53, 55), (56, 59),
+    ... (60, 62), (63, 68), (69, 70), (70, 76), (76, 77), (77, 78)]
+    >>> list(NLTKWordTokenizer().span_tokenize(s)) == expected
+    True
+    >>> expected = ['Good', 'muffins', 'cost', '$', '3.88', 'in',
+    ... 'New', '(', 'York', ')', '.', 'Please', '(', 'buy', ')',
+    ... 'me', 'two', 'of', 'them.', '(', 'Thanks', ')', '.']
+    >>> [s[start:end] for start, end in NLTKWordTokenizer().span_tokenize(s)] == expected
+    True
+
+    >>> s = '''I said, "I'd like to buy some ''good muffins" which cost $3.88\n each in New (York)."'''
+    >>> expected = [(0, 1), (2, 6), (6, 7), (8, 9), (9, 10), (10, 12),
+    ... (13, 17), (18, 20), (21, 24), (25, 29), (30, 32), (32, 36),
+    ... (37, 44), (44, 45), (46, 51), (52, 56), (57, 58), (58, 62),
+    ... (64, 68), (69, 71), (72, 75), (76, 77), (77, 81), (81, 82),
+    ... (82, 83), (83, 84)]
+    >>> list(NLTKWordTokenizer().span_tokenize(s)) == expected
+    True
+    >>> expected = ['I', 'said', ',', '"', 'I', "'d", 'like', 'to',
+    ... 'buy', 'some', "''", "good", 'muffins', '"', 'which', 'cost',
+    ... '$', '3.88', 'each', 'in', 'New', '(', 'York', ')', '.', '"']
+    >>> [s[start:end] for start, end in NLTKWordTokenizer().span_tokenize(s)] == expected
+    True
 
 Testing improvement made to the TreebankWordTokenizer
 
@@ -58,9 +81,6 @@ Testing improvement made to the TreebankWordTokenizer
     >>> expected = ['The', 'unicode', '201C', 'and', '201D', '\u201c', 'LEFT', '(', 'RIGHT', ')', 'DOUBLE', 'QUOTATION', 'MARK', '\u201d', 'is', 'also', 'OPEN_PUNCT', 'and', 'CLOSE_PUNCT', '.']
     >>> word_tokenize(sx2) == expected
     True
-    >>> sx3 = "''Hello'\""
-    >>> list(TreebankWordTokenizer().span_tokenize(sx3))
-    [(0, 2), (2, 7), (7, 8), (8, 9)]
 
 
 Testing treebank's detokenizer
@@ -76,9 +96,6 @@ Testing treebank's detokenizer
     >>> s = "Well, we couldn't have this predictable, cliche-ridden, \"Touched by an Angel\" (a show creator John Masius worked on) wanna-be if she didn't."
     >>> detokenizer.detokenize(word_tokenize(s))
     'Well, we couldn\'t have this predictable, cliche-ridden, "Touched by an Angel" (a show creator John Masius worked on) wanna-be if she didn\'t.'
-    >>> s = "I wanna watch something"
-    >>> detokenizer.detokenize(word_tokenize(s))
-    'I wanna watch something'
     >>> s = "I cannot cannot work under these conditions!"
     >>> detokenizer.detokenize(word_tokenize(s))
     'I cannot cannot work under these conditions!'

--- a/nltk/test/tokenize.doctest
+++ b/nltk/test/tokenize.doctest
@@ -58,6 +58,9 @@ Testing improvement made to the TreebankWordTokenizer
     >>> expected = ['The', 'unicode', '201C', 'and', '201D', '\u201c', 'LEFT', '(', 'RIGHT', ')', 'DOUBLE', 'QUOTATION', 'MARK', '\u201d', 'is', 'also', 'OPEN_PUNCT', 'and', 'CLOSE_PUNCT', '.']
     >>> word_tokenize(sx2) == expected
     True
+    >>> sx3 = "''Hello'\""
+    >>> list(TreebankWordTokenizer().span_tokenize(sx3))
+    [(0, 2), (2, 7), (7, 8), (8, 9)]
 
 
 Testing treebank's detokenizer

--- a/nltk/test/tokenize.doctest
+++ b/nltk/test/tokenize.doctest
@@ -41,6 +41,12 @@ Some test strings.
     >>> s11 = "It's more'n enough."
     >>> word_tokenize(s11)
     ['It', "'s", 'more', "'n", 'enough', '.']
+    >>> s12 = "''Hello, there!''"
+    >>> word_tokenize(s12)
+    ["''", "Hello", ",", "there", "!", "''"]
+    >>> s13 = "''What a wonderful quote, this is'' - Someone (12 BC)"
+    >>> word_tokenize(s13)
+    ["''", 'What', 'a', 'wonderful', 'quote', ',', 'this', 'is', "''", '-', 'Someone', '(', '12', 'BC', ')']
 
 Testing improvement made to the TreebankWordTokenizer
 

--- a/nltk/tokenize/__init__.py
+++ b/nltk/tokenize/__init__.py
@@ -88,7 +88,7 @@ from nltk.tokenize.sonority_sequencing import SyllableTokenizer
 from nltk.tokenize.stanford_segmenter import StanfordSegmenter
 from nltk.tokenize.texttiling import TextTilingTokenizer
 from nltk.tokenize.toktok import ToktokTokenizer
-from nltk.tokenize.treebank import TreebankWordTokenizer
+from nltk.tokenize.treebank import TreebankWordDetokenizer, TreebankWordTokenizer
 from nltk.tokenize.util import regexp_span_tokenize, string_span_tokenize
 
 

--- a/nltk/tokenize/destructive.py
+++ b/nltk/tokenize/destructive.py
@@ -24,7 +24,7 @@ class MacIntyreContractions:
         r"(?i)\b(got)(?#X)(ta)\b",
         r"(?i)\b(lem)(?#X)(me)\b",
         r"(?i)\b(more)(?#X)('n)\b",
-        r"(?i)\b(wan)(?#X)(na)\s",
+        r"(?i)\b(wan)(?#X)(na)(?=\s)",
     ]
     CONTRACTIONS3 = [r"(?i) ('t)(?#X)(is)\b", r"(?i) ('t)(?#X)(was)\b"]
     CONTRACTIONS4 = [r"(?i)\b(whad)(dd)(ya)\b", r"(?i)\b(wha)(t)(cha)\b"]

--- a/nltk/tokenize/destructive.py
+++ b/nltk/tokenize/destructive.py
@@ -53,8 +53,8 @@ class NLTKWordTokenizer(TokenizerI):
     # Ending quotes.
     ENDING_QUOTES = [
         (re.compile("([»”’])", re.U), r" \1 "),
+        (re.compile(r"''"), " '' "),
         (re.compile(r'"'), " '' "),
-        (re.compile(r"(\S)(\'\')"), r"\1 \2 "),
         (re.compile(r"([^' ])('[sS]|'[mM]|'[dD]|') "), r"\1 \2 "),
         (re.compile(r"([^' ])('ll|'LL|'re|'RE|'ve|'VE|n't|N'T) "), r"\1 \2 "),
     ]

--- a/nltk/tokenize/destructive.py
+++ b/nltk/tokenize/destructive.py
@@ -1,7 +1,8 @@
 # Natural Language Toolkit: NLTK's very own tokenizer.
 #
 # Copyright (C) 2001-2021 NLTK Project
-# Author:
+# Author: Liling Tan
+#         Tom Aarsen <> (modifications)
 # URL: <https://www.nltk.org>
 # For license information, see LICENSE.TXT
 

--- a/nltk/tokenize/destructive.py
+++ b/nltk/tokenize/destructive.py
@@ -9,6 +9,7 @@
 import re
 
 from nltk.tokenize.api import TokenizerI
+from nltk.tokenize.util import align_tokens
 
 
 class MacIntyreContractions:
@@ -146,3 +147,55 @@ class NLTKWordTokenizer(TokenizerI):
         #     text = regexp.sub(r' \1 \2 \3 ', text)
 
         return text if return_str else text.split()
+
+    def span_tokenize(self, text):
+        r"""
+        Uses the post-hoc nltk.tokens.align_tokens to return the offset spans.
+            >>> from nltk.tokenize import NLTKWordTokenizer
+            >>> s = '''Good muffins cost $3.88\nin New (York).  Please (buy) me\ntwo of them.\n(Thanks).'''
+            >>> expected = [(0, 4), (5, 12), (13, 17), (18, 19), (19, 23),
+            ... (24, 26), (27, 30), (31, 32), (32, 36), (36, 37), (37, 38),
+            ... (40, 46), (47, 48), (48, 51), (51, 52), (53, 55), (56, 59),
+            ... (60, 62), (63, 68), (69, 70), (70, 76), (76, 77), (77, 78)]
+            >>> list(NLTKWordTokenizer().span_tokenize(s)) == expected
+            True
+            >>> expected = ['Good', 'muffins', 'cost', '$', '3.88', 'in',
+            ... 'New', '(', 'York', ')', '.', 'Please', '(', 'buy', ')',
+            ... 'me', 'two', 'of', 'them.', '(', 'Thanks', ')', '.']
+            >>> [s[start:end] for start, end in NLTKWordTokenizer().span_tokenize(s)] == expected
+            True
+            Additional example
+            >>> from nltk.tokenize import NLTKWordTokenizer
+            >>> s = '''I said, "I'd like to buy some ''good muffins" which cost $3.88\n each in New (York)."'''
+            >>> expected = [(0, 1), (2, 6), (6, 7), (8, 9), (9, 10), (10, 12),
+            ... (13, 17), (18, 20), (21, 24), (25, 29), (30, 32), (32, 36),
+            ... (37, 44), (44, 45), (46, 51), (52, 56), (57, 58), (58, 62),
+            ... (64, 68), (69, 71), (72, 75), (76, 77), (77, 81), (81, 82),
+            ... (82, 83), (83, 84)]
+            >>> list(NLTKWordTokenizer().span_tokenize(s)) == expected
+            True
+            >>> expected = ['I', 'said', ',', '"', 'I', "'d", 'like', 'to',
+            ... 'buy', 'some', "''", "good", 'muffins', '"', 'which', 'cost',
+            ... '$', '3.88', 'each', 'in', 'New', '(', 'York', ')', '.', '"']
+            >>> [s[start:end] for start, end in NLTKWordTokenizer().span_tokenize(s)] == expected
+            True
+        """
+        raw_tokens = self.tokenize(text)
+
+        # Convert converted quotes back to original double quotes
+        # Do this only if original text contains double quote(s) or double
+        # single-quotes (because '' might be transformed to `` if it is
+        # treated as starting quotes).
+        if ('"' in text) or ("''" in text):
+            # Find double quotes and converted quotes
+            matched = [m.group() for m in re.finditer(r"``|'{2}|\"", text)]
+
+            # Replace converted quotes back to double quotes
+            tokens = [
+                matched.pop(0) if tok in ['"', "``", "''"] else tok
+                for tok in raw_tokens
+            ]
+        else:
+            tokens = raw_tokens
+
+        yield from align_tokens(tokens, text)

--- a/nltk/tokenize/treebank.py
+++ b/nltk/tokenize/treebank.py
@@ -86,8 +86,8 @@ class TreebankWordTokenizer(TokenizerI):
 
     # ending quotes
     ENDING_QUOTES = [
+        (re.compile(r"''"), " '' "),
         (re.compile(r'"'), " '' "),
-        (re.compile(r"(\S)(\'\')"), r"\1 \2 "),
         (re.compile(r"([^' ])('[sS]|'[mM]|'[dD]|') "), r"\1 \2 "),
         (re.compile(r"([^' ])('ll|'LL|'re|'RE|'ve|'VE|n't|N'T) "), r"\1 \2 "),
     ]

--- a/nltk/tokenize/treebank.py
+++ b/nltk/tokenize/treebank.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2001-2021 NLTK Project
 # Author: Edward Loper <edloper@gmail.com>
 #         Michael Heilman <mheilman@cmu.edu> (re-port from http://www.cis.upenn.edu/~treebank/tokenizer.sed)
+#         Tom Aarsen <> (modifications)
 #
 # URL: <https://www.nltk.org>
 # For license information, see LICENSE.TXT


### PR DESCRIPTION
Resolves #1750, resolves #2076, resolves #2876

Hello!

### Pull request overview
* (Bug 1) Correct tokenisation error when using `''` (two single quotes) as starting quotes.
* (Bug 2) Resolved issue with `'wanna'` in MacIntyreContractions for TreebankWordTokenizer and NLTKWordTokenizer. 
* Implement `span_tokenize` in NLTKWordTokenizer, just like in TreebankWordTokenizer.
* Allow TreebankWordDetokenizer to be imported with `from nltk.tokenize import TreebankWordDetokenizer`.

## Bug 1
Relevant issues: #1750 and #2076
### Reproduction
```python
from nltk.tokenize import TreebankWordTokenizer
tokenizer = TreebankWordTokenizer()
text = "''Hello'\""
print(list(tokenizer.span_tokenize(text)))
```
produces
```python
Traceback (most recent call last):
  File "[sic]\nltk\tokenize\util.py", line 290, in align_tokens
    start = sentence.index(token, point)
ValueError: substring not found

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "[sic]\nltk_1750.py", line 42, in <module>
    print(list(tokenizer.span_tokenize(text)))
  File "[sic]\nltk\tokenize\treebank.py", line 190, in span_tokenize
    yield from align_tokens(tokens, text)
  File "[sic]\nltk\tokenize\util.py", line 292, in align_tokens
    raise ValueError(f'substring "{token}" not found in "{sentence}"') from e
ValueError: substring "''" not found in "''Hello'""
```
### Details & The fix
The true cause here is that the `span_tokenize` method expects tokens with quotes to be exclusively `''`, `"` or ``:
https://github.com/nltk/nltk/blob/ec1d49da924a69dcaaac8fceb64a34fcd3f9f1e0/nltk/tokenize/treebank.py#L183-L186

This is because `span_tokenize` assumes that the tokenized output will always split off these quotes into separate tokens. However, this is not the case currently. For example:
```python
from nltk.tokenize import TreebankWordTokenizer
tokenizer = TreebankWordTokenizer()
text = "''Hello''"
print(tokenizer.tokenize(text))
```
produces
```python
["''Hello", "''"]
```
This is the true underlying bug. This bug exists in both TreebankWordTokenizer and NLTKWordTokenizer!
The cause is the following ENDING_QUOTES rule:
https://github.com/nltk/nltk/blob/ec1d49da924a69dcaaac8fceb64a34fcd3f9f1e0/nltk/tokenize/treebank.py#L90

`(\S)(\'\')` requires a non-whitespace character before the `''`. Only then will it separate the quote and what comes before - and crucially: only then will it place a space on the right-hand side of the `''`. I don't believe this non-whitespace character requirement to matter. We can remove it, and create:
```python
    (re.compile(r"''"), " '' "),
```
Upon making this change, the last mentioned program outputs:
```python
["''", "Hello", "''"]
```
And the issues reported for `span_tokenize` disappear like expected. 

### Undesired consequences of the fix
This PR improves tokenization by separating these quotes in a better way, but it does have an undesired consequence: TreebankWordDetokenizer doesn't work as well as a result. Or rather, TreebankWordDetokenizer works identically, but the output of the tokenizer has changed somewhat. This is a consequence:
```python
from nltk.tokenize.treebank import TreebankWordDetokenizer
detokenizer = TreebankWordDetokenizer()
print(detokenizer.detokenize(["''", "Hello", "''"]))
```
produces
```
" Hello"
```
This is because the Detokenizer doesn't consider `''` as a start of quotation, but only as the end. After all, if we let it detokenize `["one", "''", "two"]`, how would it know whether `one" two` or `one "two` is correct? It defaults to `one" two`, as `"` is generally an ending quote, with "``" as a beginning quote.

### Notes for Bug 1
This PR modifies both NLTKWordTokenizer *and* TreebankWordTokenizer. I recognise that it might be preferable to keep the latter true to the original (as much as possible). If we want to do that, then I can simply revert the changes there. But do note that then the issues for `span_tokenize` will not be solved.
These issues can also be solved in different ways, though. We can also direct users to the (new) NLTKWordTokenizer's `span_tokenize` which this PR adds, but I'm not a great fan of that. 

---

## Bug 2
Relevant issue: #2876
### Reproduction
```python
from nltk.tokenize.treebank import TreebankWordTokenizer, TreebankWordDetokenizer

tokens = TreebankWordTokenizer().tokenize("I wanna watch something")
print(tokens)
sentence = TreebankWordDetokenizer().detokenize(tokens)
print(sentence)
```
produces
```
I wannawatch something
```

### Details & The fix
This issue originates from the last line of this set of CONTRACTION regexes:
https://github.com/nltk/nltk/blob/ec1d49da924a69dcaaac8fceb64a34fcd3f9f1e0/nltk/tokenize/destructive.py#L19-L28

Where the rule requires the phrase to end in a whitespace with `\s` (which is one character big), rather than `\b` (word boundary, 0 characters big). The issue is that the Detokenizer considers the whitespace (e.g. a space) to be a part of the regex rule match. This is then replaced, while it shouldn't be. 

A simple solution is to just use `\b`. However, this will fail for the edge case of `wanna-be`, where `wanna` should not be split.

So, another solution is to still check for `\s`, but don't include it in the match. This can be done with a positive lookahead:
```python
    r"(?i)\b(wan)(?#X)(na)(?=\s)", 
```
After this fix, both `wanna watch` and `wanna-be` work properly. There is a test for both of these cases.

---

## Added `span_tokenize` to NLTKWordTokenizer
As NLTKWordTokenizer is merely NLTK's improved version of TreebankWordTokenizer, it kind of surprised me that NLTKWordTokenizer didn't already provide all methods that TreebankWordTokenizer has. Because both classes are so similar, both methods are identical. 
However, if we choose not to update TreebankWordTokenizer, then `span_tokenize` for TreebankWordTokenizer will be broken, while the one for NLTKWordTokenizer should still work. I took the doctests from TreebankWordTokenizer's `span_tokenize`, and added them in `tokenize.doctest` too.

## Improved accessibility of TreebankWordDetokenizer
Currently, TreebankWordDetokenizer can only be imported with:
```python
from nltk.tokenize.treebank import TreebankWordDetokenizer 
```
I've added TreebankWordDetokenizer to `nltk/tokenize/__init__.py`, allowing users to import it like so:
```python
from nltk.tokenize import TreebankWordDetokenizer 
# or even
from nltk import TreebankWordDetokenizer 
```

## Future changes
Create some common interface for NLTKWordTokenizer and TreebankWordTokenizer. There is a good bit of code reuse, especially the new `span_tokenize`.

- Tom Aarsen