### PR TITLE
Add `CITATION.cff` to nltk

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ repository-code: "https://github.com/nltk/nltk"
 url: "https://www.nltk.org"
 license: Apache-2.0
 keywords:
-  - "NLP",
+  - "NLP"
   - "CL"
   - "natural language processing"
   - "computational linguistics"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,19 +12,19 @@ repository-code: "https://github.com/nltk/nltk"
 url: "https://www.nltk.org"
 license: Apache-2.0
 preferred-citation:
+  title: >-
+    Natural language processing with Python: analyzing
+    text with the natural language toolkit
   type: book
   authors:
     - given-names: Stephen
       family-names: Bird
       orcid: https://orcid.org/0000-0003-3782-7733
-    - given-names: Edward
-      family-names: Loper
     - given-names: Ewan
       family-names: Klein
       orcid: https://orcid.org/0000-0002-0520-8447
-  title: >-
-    Natural language processing with Python: analyzing
-    text with the natural language toolkit
+    - given-names: Edward
+      family-names: Loper
+  year: 2009
   publisher:
     name: "O'Reilly Media, Inc."
-  year: 2009

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,30 @@
+cff-version: 1.2.0
+title: >-
+  Natural Language Toolkit
+message: >-
+  Please cite this software using the metadata from
+  'preferred-citation'.
+type: software
+authors:
+  - name: "NLTK Team"
+    email: "nltk.team@gmail.com"
+repository-code: "https://github.com/nltk/nltk"
+url: "https://www.nltk.org"
+license: Apache-2.0
+preferred-citation:
+  type: book
+  authors:
+    - given-names: Stephen
+      family-names: Bird
+      orcid: https://orcid.org/0000-0003-3782-7733
+    - given-names: Edward
+      family-names: Loper
+    - given-names: Ewan
+      family-names: Klein
+      orcid: https://orcid.org/0000-0002-0520-8447
+  title: >-
+    Natural language processing with Python: analyzing
+    text with the natural language toolkit
+  publisher:
+    name: "O'Reilly Media, Inc."
+  year: 2009

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -26,8 +26,8 @@ keywords:
   - "text analytics"
 preferred-citation:
   title: >-
-    Natural language processing with Python: analyzing
-    text with the natural language toolkit
+    Natural Language Processing with Python: Analyzing
+    Text with the Natural Language Toolkit
   type: book
   authors:
     - given-names: Steven

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -30,7 +30,7 @@ preferred-citation:
     text with the natural language toolkit
   type: book
   authors:
-    - given-names: Stephen
+    - given-names: Steven
       family-names: Bird
       orcid: https://orcid.org/0000-0003-3782-7733
     - given-names: Ewan

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 title: >-
-  Natural Language Toolkit
+  Natural Language ToolKit (NLTK)
 message: >-
   Please cite this software using the metadata from
   'preferred-citation'.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,6 +11,19 @@ authors:
 repository-code: "https://github.com/nltk/nltk"
 url: "https://www.nltk.org"
 license: Apache-2.0
+keywords:
+  - "NLP",
+  - "CL"
+  - "natural language processing"
+  - "computational linguistics"
+  - "parsing"
+  - "tagging"
+  - "tokenizing"
+  - "syntax"
+  - "linguistics"
+  - "language"
+  - "natural language"
+  - "text analytics"
 preferred-citation:
   title: >-
     Natural language processing with Python: analyzing


### PR DESCRIPTION
Closes #2874

Hello!

### Pull request overview
* Add `CITATION.cff` to nltk.

## `CITATION.cff` file
The schema guide for `CITATION.cff` files can be found [here](https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md). The `CITATION.cff` which I've written consists of two parts:
- The "NLTK" part, which represents a software.
- The "NLTK book" part, which is for the 2009 book.

Most notably, the book part is listed under `preferred-citation`. When the "Cite this repository" button is clicked, this will be the part that it uses to generate the actual citation.

### The "Cite this repository" button
Here's a quick screenshot of it:
![image](https://user-images.githubusercontent.com/37621491/140758822-82949334-c885-4bdb-9124-da33439750d5.png)

And after clicking on it:
![image](https://user-images.githubusercontent.com/37621491/140759308-f20b681d-9d07-4085-a0e0-c888d52065b2.png)


It can be seen on my `feature/citation` branch of my fork: https://github.com/tomaarsen/nltk/tree/feature/citation

### The NLTK software part
I'm open to discussions about this - citations are very important, and I would like to get a common agreement on the CITATION.cff. The next snippet is about the "Software" section of the citation, which provides information about NLTK as a software, but is not used in the BibTeX or APA citation.
```yaml
cff-version: 1.2.0
title: >-
  Natural Language Toolkit
message: >-
  Please cite this software using the metadata from
  'preferred-citation'.
type: software
authors:
  - name: "NLTK Team"
    email: "nltk.team@gmail.com"
repository-code: "https://github.com/nltk/nltk"
url: "https://www.nltk.org"
license: Apache-2.0
keywords:
  - "NLP",
  - "CL"
  - "natural language processing"
  - "computational linguistics"
  - "parsing"
  - "tagging"
  - "tokenizing"
  - "syntax"
  - "linguistics"
  - "language"
  - "natural language"
  - "text analytics"
```
* `title`: I've opted for `Natural Language Toolkit`. `nltk` or `NLTK` are alternatives.
* `message`: This is one of the default options, which lets users know to use the citation for the book instead.
* `authors`: Here I've gone with the info as can be found in the setup.py file, as opposed to mentioning specific users. That said, we may want to list *both* individual users *and* then "NLTK Team" or "NLTK Contributors", as suggested in the third code block [here](https://github.com/citation-file-format/citation-file-format/blob/1.2.0/schema-guide.md#authors).
  For example:
  ```yaml
  authors:
    - given-names: Steven
      family-names: Bird
    - given-names: Liling
      family-names: Tan
    - name: "NLTK Team"
      email: "nltk.team@gmail.com"
  ```
* `license`: I've listed Apache-2.0, as the code is licensed under that. That said, there are other licences for e.g. the documentation. We can also supply a list of licenses here. 

The remainder of this section speaks for itself.

### The NLTK book part
This section specifies the part of the CITATION.cff which is actually used in the citation generation. The snippet is as follows:
```yaml
preferred-citation:
  title: >-
    Natural language processing with Python: analyzing
    text with the natural language toolkit
  type: book
  authors:
    - given-names: Steven
      family-names: Bird
      orcid: https://orcid.org/0000-0003-3782-7733
    - given-names: Ewan
      family-names: Klein
      orcid: https://orcid.org/0000-0002-0520-8447
    - given-names: Edward
      family-names: Loper
  year: 2009
  publisher:
    name: "O'Reilly Media, Inc."
```
* `title`:  The full title of the book
* `type`: A book, as opposed to software.
* `authors`: Listed in the same order as the authors of the book, and the citations as provided by Google Scholar. I've provided ORCID ID's of Ewan Klein and Steven Bird. Obviously, these can be removed. Beyond that, more information can be added here about each author, but I left it fairly minimal. Also, one more thing to note: The order of authors from this PR, from Google Scholar, and from the book itself *differ* from the order of authors on the current README.
  This is definitely something to look into!
* `year`: Speaks for itself. I decided to not include the month or date, as they don't seem to be included in the BibTeX that  Google Scholar provides. 
* `publisher`: "O'Reilly Media, Inc." differs slightly from the citation that Google Scholar provides, which is " O'Reilly Media, Inc." (with an extra space before). This is also something to consider, as it affects the generated APA or BibTeX citation.

## Generated citations:
### APA
Generated by Google Scholar:
```
Bird, S., Klein, E., & Loper, E. (2009). Natural language processing with Python: analyzing text with the natural language toolkit. " O'Reilly Media, Inc.".
```
Generated by GitHub from https://github.com/tomaarsen/nltk/tree/feature/citation according to this CITATION.cff:
```
Bird, S., Klein, E., & Loper, E. (2009). Natural language processing with Python: analyzing text with the natural language toolkit. O'Reilly Media, Inc.
```

These are nearly identical - the difference is that the Google Scholar citation includes an additional space for the publisher, alongside extra quotes. 

### BibTeX
Generated by Google Scholar:
```
@book{bird2009natural,
  title={Natural language processing with Python: analyzing text with the natural language toolkit},
  author={Bird, Steven and Klein, Ewan and Loper, Edward},
  year={2009},
  publisher={" O'Reilly Media, Inc."}
}
```
Generated by GitHub from https://github.com/tomaarsen/nltk/tree/feature/citation according to this CITATION.cff:
```
@book{Bird_Natural_language_processing_2009,
author = {Bird, Steven and Klein, Ewan and Loper, Edward},
publisher = {O'Reilly Media, Inc.},
title = {{Natural language processing with Python: analyzing text with the natural language toolkit}},
year = {2009}
}
```
Yet again these are nearly identical, with the same difference in publisher. Beyond that, the order is different, which should not matter. The label with which these can be referenced also differs, but that's also not a big deal.

For context, this is the citation that is currently suggested to be used according to the README:
```
Bird, Steven, Edward Loper and Ewan Klein (2009).
Natural Language Processing with Python.  O'Reilly Media Inc.
```
(Some notes: the differing order of authors, and the shrunk title)

### Note
This entire PR assumes that we still wish for citations to cite the book, rather than the software.

- Tom Aarsen