### PR TITLE
Allow empty string in CFG's + more

### DIFF
--- a/nltk/grammar.py
+++ b/nltk/grammar.py
@@ -5,6 +5,7 @@
 #         Edward Loper <edloper@gmail.com>
 #         Jason Narad <jason.narad@gmail.com>
 #         Peter Ljunglöf <peter.ljunglof@heatherleaf.se>
+#         Tom Aarsen <>
 # URL: <https://www.nltk.org/>
 # For license information, see LICENSE.TXT
 #

--- a/nltk/grammar.py
+++ b/nltk/grammar.py
@@ -1531,48 +1531,6 @@ def cfg_demo():
     print()
 
 
-toy_pcfg1 = PCFG.fromstring(
-    """
-    S -> NP VP [1.0]
-    NP -> Det N [0.5] | NP PP [0.25] | 'John' [0.1] | 'I' [0.15]
-    Det -> 'the' [0.8] | 'my' [0.2]
-    N -> 'man' [0.5] | 'telescope' [0.5]
-    VP -> VP PP [0.1] | V NP [0.7] | V [0.2]
-    V -> 'ate' [0.35] | 'saw' [0.65]
-    PP -> P NP [1.0]
-    P -> 'with' [0.61] | 'under' [0.39]
-    """
-)
-
-toy_pcfg2 = PCFG.fromstring(
-    """
-    S    -> NP VP         [1.0]
-    VP   -> V NP          [.59]
-    VP   -> V             [.40]
-    VP   -> VP PP         [.01]
-    NP   -> Det N         [.41]
-    NP   -> Name          [.28]
-    NP   -> NP PP         [.31]
-    PP   -> P NP          [1.0]
-    V    -> 'saw'         [.21]
-    V    -> 'ate'         [.51]
-    V    -> 'ran'         [.28]
-    N    -> 'boy'         [.11]
-    N    -> 'cookie'      [.12]
-    N    -> 'table'       [.13]
-    N    -> 'telescope'   [.14]
-    N    -> 'hill'        [.5]
-    Name -> 'Jack'        [.52]
-    Name -> 'Bob'         [.48]
-    P    -> 'with'        [.61]
-    P    -> 'under'       [.39]
-    Det  -> 'the'         [.41]
-    Det  -> 'a'           [.31]
-    Det  -> 'my'          [.28]
-    """
-)
-
-
 def pcfg_demo():
     """
     A demonstration showing how a ``PCFG`` can be created and used.
@@ -1581,6 +1539,47 @@ def pcfg_demo():
     from nltk import induce_pcfg, treetransforms
     from nltk.corpus import treebank
     from nltk.parse import pchart
+
+    toy_pcfg1 = PCFG.fromstring(
+        """
+        S -> NP VP [1.0]
+        NP -> Det N [0.5] | NP PP [0.25] | 'John' [0.1] | 'I' [0.15]
+        Det -> 'the' [0.8] | 'my' [0.2]
+        N -> 'man' [0.5] | 'telescope' [0.5]
+        VP -> VP PP [0.1] | V NP [0.7] | V [0.2]
+        V -> 'ate' [0.35] | 'saw' [0.65]
+        PP -> P NP [1.0]
+        P -> 'with' [0.61] | 'under' [0.39]
+        """
+    )
+
+    toy_pcfg2 = PCFG.fromstring(
+        """
+        S    -> NP VP         [1.0]
+        VP   -> V NP          [.59]
+        VP   -> V             [.40]
+        VP   -> VP PP         [.01]
+        NP   -> Det N         [.41]
+        NP   -> Name          [.28]
+        NP   -> NP PP         [.31]
+        PP   -> P NP          [1.0]
+        V    -> 'saw'         [.21]
+        V    -> 'ate'         [.51]
+        V    -> 'ran'         [.28]
+        N    -> 'boy'         [.11]
+        N    -> 'cookie'      [.12]
+        N    -> 'table'       [.13]
+        N    -> 'telescope'   [.14]
+        N    -> 'hill'        [.5]
+        Name -> 'Jack'        [.52]
+        Name -> 'Bob'         [.48]
+        P    -> 'with'        [.61]
+        P    -> 'under'       [.39]
+        Det  -> 'the'         [.41]
+        Det  -> 'a'           [.31]
+        Det  -> 'my'          [.28]
+        """
+    )
 
     pcfg_prods = toy_pcfg1.productions()
 

--- a/nltk/grammar.py
+++ b/nltk/grammar.py
@@ -1317,7 +1317,7 @@ def _read_fcfg_production(input, fstruct_reader):
 
 _ARROW_RE = re.compile(r"\s* -> \s*", re.VERBOSE)
 _PROBABILITY_RE = re.compile(r"( \[ [\d\.]+ \] ) \s*", re.VERBOSE)
-_TERMINAL_RE = re.compile(r'( "[^"]+" | \'[^\']+\' ) \s*', re.VERBOSE)
+_TERMINAL_RE = re.compile(r'( "[^"]*" | \'[^\']*\' ) \s*', re.VERBOSE)
 _DISJUNCTION_RE = re.compile(r"\| \s*", re.VERBOSE)
 
 

--- a/nltk/parse/generate.py
+++ b/nltk/parse/generate.py
@@ -42,14 +42,11 @@ def _generate_all(grammar, items, depth):
             for frag1 in _generate_one(grammar, items[0], depth):
                 for frag2 in _generate_all(grammar, items[1:], depth):
                     yield frag1 + frag2
-        except RuntimeError as _error:
-            if _error.message == "maximum recursion depth exceeded":
-                # Helpful error message while still showing the recursion stack.
-                raise RuntimeError(
-                    "The grammar has rule(s) that yield infinite recursion!!"
-                ) from _error
-            else:
-                raise
+        except RecursionError as error:
+            # Helpful error message while still showing the recursion stack.
+            raise RuntimeError(
+                "The grammar has rule(s) that yield infinite recursion!"
+            ) from error
     else:
         yield []
 

--- a/nltk/parse/util.py
+++ b/nltk/parse/util.py
@@ -1,6 +1,7 @@
 # Natural Language Toolkit: Parser Utility Functions
 #
 # Author: Ewan Klein <ewan@inf.ed.ac.uk>
+#         Tom Aarsen <>
 #
 # Copyright (C) 2001-2021 NLTK Project
 # URL: <https://www.nltk.org/>

--- a/nltk/parse/viterbi.py
+++ b/nltk/parse/viterbi.py
@@ -337,8 +337,49 @@ def demo():
     import time
 
     from nltk import tokenize
-    from nltk.grammar import toy_pcfg1, toy_pcfg2
+    from nltk.grammar import PCFG
     from nltk.parse import ViterbiParser
+
+    toy_pcfg1 = PCFG.fromstring(
+        """
+    S -> NP VP [1.0]
+    NP -> Det N [0.5] | NP PP [0.25] | 'John' [0.1] | 'I' [0.15]
+    Det -> 'the' [0.8] | 'my' [0.2]
+    N -> 'man' [0.5] | 'telescope' [0.5]
+    VP -> VP PP [0.1] | V NP [0.7] | V [0.2]
+    V -> 'ate' [0.35] | 'saw' [0.65]
+    PP -> P NP [1.0]
+    P -> 'with' [0.61] | 'under' [0.39]
+    """
+    )
+
+    toy_pcfg2 = PCFG.fromstring(
+        """
+    S    -> NP VP         [1.0]
+    VP   -> V NP          [.59]
+    VP   -> V             [.40]
+    VP   -> VP PP         [.01]
+    NP   -> Det N         [.41]
+    NP   -> Name          [.28]
+    NP   -> NP PP         [.31]
+    PP   -> P NP          [1.0]
+    V    -> 'saw'         [.21]
+    V    -> 'ate'         [.51]
+    V    -> 'ran'         [.28]
+    N    -> 'boy'         [.11]
+    N    -> 'cookie'      [.12]
+    N    -> 'table'       [.13]
+    N    -> 'telescope'   [.14]
+    N    -> 'hill'        [.5]
+    Name -> 'Jack'        [.52]
+    Name -> 'Bob'         [.48]
+    P    -> 'with'        [.61]
+    P    -> 'under'       [.39]
+    Det  -> 'the'         [.41]
+    Det  -> 'a'           [.31]
+    Det  -> 'my'          [.28]
+    """
+    )
 
     # Define two demos.  Each demo has a sentence and a grammar.
     demos = [

--- a/nltk/test/generate.doctest
+++ b/nltk/test/generate.doctest
@@ -65,7 +65,7 @@ The number of sentences of different max depths:
     >>> len(list(generate(grammar)))
     114
 
-Infinite grammars will throw a RecursionError when not bounded by some ``depth`` or ``n``:
+Infinite grammars will throw a RecursionError when not bounded by some ``depth``:
 
     >>> grammar = CFG.fromstring("""
     ... S -> A B

--- a/nltk/test/generate.doctest
+++ b/nltk/test/generate.doctest
@@ -64,3 +64,15 @@ The number of sentences of different max depths:
     114
     >>> len(list(generate(grammar)))
     114
+
+Infinite grammars will throw a RecursionError when not bounded by some ``depth`` or ``n``:
+
+    >>> grammar = CFG.fromstring("""
+    ... S -> A B
+    ... A -> B
+    ... B -> "b" | A
+    ... """)
+    >>> list(generate(grammar))
+    Traceback (most recent call last):
+    ...
+    RuntimeError: The grammar has rule(s) that yield infinite recursion!

--- a/nltk/test/grammar.doctest
+++ b/nltk/test/grammar.doctest
@@ -46,3 +46,24 @@ Chomsky Normal Form grammar (Test for bug 474)
     >>> g = CFG.fromstring("VP^<TOP> -> VBP NP^<VP-TOP>")
     >>> g.productions()[0].lhs()
     VP^<TOP>
+
+Grammars can contain both empty strings and empty productions:
+
+    >>> from nltk.grammar import CFG
+    >>> from nltk.parse.generate import generate
+    >>> grammar = CFG.fromstring("""
+    ... S -> A B
+    ... A -> 'a'
+    ... # An empty string:
+    ... B -> 'b' | ''
+    ... """)
+    >>> list(generate(grammar))
+    [['a', 'b'], ['a', '']]
+    >>> grammar = CFG.fromstring("""
+    ... S -> A B
+    ... A -> 'a'
+    ... # An empty production:
+    ... B -> 'b' |
+    ... """)
+    >>> list(generate(grammar))
+    [['a', 'b'], ['a']]

--- a/nltk/test/parse.doctest
+++ b/nltk/test/parse.doctest
@@ -545,7 +545,43 @@ Unit tests for the Probabilistic CFG class
 
     >>> from nltk.corpus import treebank
     >>> from itertools import islice
-    >>> from nltk.grammar import PCFG, induce_pcfg, toy_pcfg1, toy_pcfg2
+    >>> from nltk.grammar import PCFG, induce_pcfg
+    >>> toy_pcfg1 = PCFG.fromstring("""
+    ...     S -> NP VP [1.0]
+    ...     NP -> Det N [0.5] | NP PP [0.25] | 'John' [0.1] | 'I' [0.15]
+    ...     Det -> 'the' [0.8] | 'my' [0.2]
+    ...     N -> 'man' [0.5] | 'telescope' [0.5]
+    ...     VP -> VP PP [0.1] | V NP [0.7] | V [0.2]
+    ...     V -> 'ate' [0.35] | 'saw' [0.65]
+    ...     PP -> P NP [1.0]
+    ...     P -> 'with' [0.61] | 'under' [0.39]
+    ...     """)
+
+    >>> toy_pcfg2 = PCFG.fromstring("""
+    ...     S    -> NP VP         [1.0]
+    ...     VP   -> V NP          [.59]
+    ...     VP   -> V             [.40]
+    ...     VP   -> VP PP         [.01]
+    ...     NP   -> Det N         [.41]
+    ...     NP   -> Name          [.28]
+    ...     NP   -> NP PP         [.31]
+    ...     PP   -> P NP          [1.0]
+    ...     V    -> 'saw'         [.21]
+    ...     V    -> 'ate'         [.51]
+    ...     V    -> 'ran'         [.28]
+    ...     N    -> 'boy'         [.11]
+    ...     N    -> 'cookie'      [.12]
+    ...     N    -> 'table'       [.13]
+    ...     N    -> 'telescope'   [.14]
+    ...     N    -> 'hill'        [.5]
+    ...     Name -> 'Jack'        [.52]
+    ...     Name -> 'Bob'         [.48]
+    ...     P    -> 'with'        [.61]
+    ...     P    -> 'under'       [.39]
+    ...     Det  -> 'the'         [.41]
+    ...     Det  -> 'a'           [.31]
+    ...     Det  -> 'my'          [.28]
+    ...     """)
 
 Create a set of PCFG productions.
 


### PR DESCRIPTION
Resolves #1890

Hello!

# Pull request overview
* Allow for empty strings as terminals in CFG's + doctests.
* Fixed issue with infinite recursion in `nltk.parse.generate` + doctest.
* Moved unnecessary PCFG's into the relevant methods, so they don't get created whenever someone does `import nltk`.

# Empty strings as terminals in CFG's
This corresponds with #1890. Here, it shows that the following grammar throws an exception:
```python
from nltk.grammar import CFG
grammar = CFG.fromstring("""
S -> A B
A -> 'a'
B -> 'b' | ''
""")
```
fails with
```python
ValueError: Unable to parse line 5: B -> 'b' | ''
Unterminated string
```
However, this is definitely not a case of an Unterminated string. The crux here is this regex:
https://github.com/nltk/nltk/blob/68e4e589eb62750993aabef5554548973fe1e280/nltk/grammar.py#L1320
Simply said, it requires either: `"[^"]+"` or `'[^']+' `, which requires 1 or more tokens to be inside of quotes. However, I don't believe there is a reason this should be "1 or more". Replacing the `+` with `*` will solve the above problem.

### Consequences
As a result, people can now do, e.g.:
```python
from nltk.grammar import CFG
from nltk.parse.generate import generate
grammar = CFG.fromstring("""
S -> A B
A -> 'a'
# An empty string:
B -> 'b' | ''
""")
print(list(generate(grammar)))
```
now produces
```python
[['a', 'b'], ['a', '']]
```
(This previously crashed)

Do note that similar functionality was already possible, but with empty *productions*, not empty *strings as productions*:
```python
grammar = CFG.fromstring("""
S -> A B
A -> 'a'
# An empty production:
B -> 'b' |
""")
print(list(generate(grammar)))
```
has always produced:
```python
[['a', 'b'], ['a']]
```

I've created doctests for these consequences.

# Fixed issue with RecursionError in `generate`
`nltk.parse.generate` can be used with infinite grammars as long as `depth` is provided:
```python
grammar = CFG.fromstring("""
S -> A | A S
A -> "a"
""")
print(list(generate(grammar, depth=10)))
```
produces
```python
[['a'], ['a', 'a'], ['a', 'a', 'a'], ['a', 'a', 'a', 'a'], ['a', 'a', 'a', 'a', 'a'], ['a', 'a', 'a', 'a', 'a', 'a'], ['a', 'a', 'a', 'a', 'a', 'a', 'a'], ['a', 'a', 'a', 'a', 'a', 'a', 'a', 'a']]
```

However, if it's not provided, the output is this:
```python
Traceback (most recent call last):
...
  File "[sic]\nltk\parse\generate.py", line 42, in _generate_all
    for frag1 in _generate_one(grammar, items[0], depth):
  File "[sic]\nltk\parse\generate.py", line 61, in _generate_one
    yield from _generate_all(grammar, prod.rhs(), depth - 1)
  File "[sic]\nltk\parse\generate.py", line 43, in _generate_all
    for frag2 in _generate_all(grammar, items[1:], depth):
  File "[sic]\nltk\parse\generate.py", line 46, in _generate_all
    if _error.message == "maximum recursion depth exceeded":
AttributeError: 'RecursionError' object has no attribute 'message'
```
This is definitely not the traceback we expect! The issue is here: https://github.com/nltk/nltk/blob/68e4e589eb62750993aabef5554548973fe1e280/nltk/parse/generate.py#L45-L52

I've resolved this by catching `RecursionError` instead, instead of relying on a `message` of the error object. Now the output is:
```python
Traceback (most recent call last):
...
  File "[sic]\nltk\parse\generate.py", line 42, in _generate_all
    for frag1 in _generate_one(grammar, items[0], depth):
  File "[sic]\nltk\parse\generate.py", line 61, in _generate_one
    yield from _generate_all(grammar, prod.rhs(), depth - 1)
  File "[sic]\nltk\parse\generate.py", line 43, in _generate_all
    for frag2 in _generate_all(grammar, items[1:], depth):
RuntimeError: The grammar has rule(s) that yield infinite recursion!
```

That's more like what we would expect to see. I've made a doctest for this.

# Moved unnecessary PCFG's into the relevant methods
In `nltk.grammar`, these two pcfg's were being made:
https://github.com/nltk/nltk/blob/68e4e589eb62750993aabef5554548973fe1e280/nltk/grammar.py#L1534-L1573

These are used elsewhere in `demo` functions, and in doctests. However, they are being compiled whenever a user performs `import nltk`, while a user will never use these variables. As a result, I've copied them into the places that require them. This way, importing nltk will be very slightly faster. 

---

Feel free to look at the .doctest files to see some more examples of these changes.

- Tom Aarsen