### PR TITLE
refactor: refactor prettyprinter to be more readable

### DIFF
--- a/nltk/tree/prettyprinter.py
+++ b/nltk/tree/prettyprinter.py
@@ -75,7 +75,7 @@ class TreePrettyPrinter:
             leaves = tree.leaves()
             if (
                 leaves
-                and not any(len(a) == 0 for a in tree.subtrees())
+                and any(len(a) > 0 for a in tree.subtrees())
                 and all(isinstance(a, int) for a in leaves)
             ):
                 sentence = [str(a) for a in leaves]
@@ -207,7 +207,7 @@ class TreePrettyPrinter:
             raise ValueError("All leaves must be integer indices.")
         if len(leaves) != len(set(leaves)):
             raise ValueError("Indices must occur at most once.")
-        if not all(0 <= n < len(sentence) for n in leaves):
+        if not all(n in range(0,len(sentence)) for n in leaves):
             raise ValueError(
                 "All leaves must be in the interval 0..n "
                 "with n=len(sentence)\ntokens: %d indices: "
@@ -291,7 +291,7 @@ class TreePrettyPrinter:
                 matrix[rowidx][i] = ids[m]
                 nodes[ids[m]] = tree[m]
                 # add column to the set of children for its parent
-                if m != ():
+                if len(m) > 0:
                     childcols[m[:-1]].add((rowidx, i))
         assert len(positions) == 0
 

--- a/nltk/tree/prettyprinter.py
+++ b/nltk/tree/prettyprinter.py
@@ -207,7 +207,7 @@ class TreePrettyPrinter:
             raise ValueError("All leaves must be integer indices.")
         if len(leaves) != len(set(leaves)):
             raise ValueError("Indices must occur at most once.")
-        if not all(n in range(0, len(sentence)) for n in leaves):
+        if not all(0 <= n < len(sentence) for n in leaves):
             raise ValueError(
                 "All leaves must be in the interval 0..n "
                 "with n=len(sentence)\ntokens: %d indices: "

--- a/nltk/tree/prettyprinter.py
+++ b/nltk/tree/prettyprinter.py
@@ -77,7 +77,7 @@ class TreePrettyPrinter:
                 leaves
                 and any(len(a) > 0 for a in tree.subtrees())
                 and all(isinstance(a, int) for a in leaves)
-            ): 
+            ):
                 sentence = [str(a) for a in leaves]
             else:
                 # this deals with empty nodes (frontier non-terminals)
@@ -207,7 +207,7 @@ class TreePrettyPrinter:
             raise ValueError("All leaves must be integer indices.")
         if len(leaves) != len(set(leaves)):
             raise ValueError("Indices must occur at most once.")
-        if not all(n in range(0,len(sentence)) for n in leaves):
+        if not all(n in range(0, len(sentence)) for n in leaves):
             raise ValueError(
                 "All leaves must be in the interval 0..n "
                 "with n=len(sentence)\ntokens: %d indices: "

--- a/nltk/tree/prettyprinter.py
+++ b/nltk/tree/prettyprinter.py
@@ -75,7 +75,7 @@ class TreePrettyPrinter:
             leaves = tree.leaves()
             if (
                 leaves
-                and any(len(a) > 0 for a in tree.subtrees())
+                and all(len(a) > 0 for a in tree.subtrees())
                 and all(isinstance(a, int) for a in leaves)
             ):
                 sentence = [str(a) for a in leaves]

--- a/nltk/tree/prettyprinter.py
+++ b/nltk/tree/prettyprinter.py
@@ -77,7 +77,7 @@ class TreePrettyPrinter:
                 leaves
                 and any(len(a) > 0 for a in tree.subtrees())
                 and all(isinstance(a, int) for a in leaves)
-            ):
+            ): 
                 sentence = [str(a) for a in leaves]
             else:
                 # this deals with empty nodes (frontier non-terminals)


### PR DESCRIPTION
This pull request refactors the TreePrettyPrinter class to be more readable and clean. For example, line 78 can be simply expressed as:

` if (... and len(a) > 0 and ..) 
`
instead of  

`if (... and not any(len(a) == 0 and ...) `

I believe it is more confusing to read the latter one. 

Also, there is a lot of magic numbers and variables(i.e, scale = 2) without any comments explaining what they do, which is considered [bad practice](https://en.wikipedia.org/wiki/Magic_number_(programming)#:~:text=7%20References-,Unnamed%20numerical%20constants,numbers%20directly%20in%20source%20code.&text=An%20example%20of%20an%20uninformatively,NUMBER_OF_BITS%20%3D%2016%20is%20more%20descriptive) since it does not explain what it does represents. 


Regards,
Mohaned Mashaly. 


