### PR TITLE
Support OMW 1.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,7 +112,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/nltk_data
-          key: nltk_data_${{ secrets.CACHE_VERSION }}
+          key: new-nltk_data_${{ secrets.CACHE_VERSION }}
 
       - name: Use cached third party tools
         uses: actions/cache@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
         id: restore-cache
         with:
           path: ~/nltk_data
-          key: new-nltk_data_${{ secrets.CACHE_VERSION }}
+          key: nltk_data_${{ secrets.CACHE_VERSION }}
 
       - name: Download nltk data packages on cache miss
         run: |
@@ -112,7 +112,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/nltk_data
-          key: new-nltk_data_${{ secrets.CACHE_VERSION }}
+          key: nltk_data_${{ secrets.CACHE_VERSION }}
 
       - name: Use cached third party tools
         uses: actions/cache@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
         id: restore-cache
         with:
           path: ~/nltk_data
-          key: nltk_data_${{ secrets.CACHE_VERSION }}
+          key: new-nltk_data_${{ secrets.CACHE_VERSION }}
 
       - name: Download nltk data packages on cache miss
         run: |

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -443,37 +443,29 @@ class Synset(_WordNetObject):
     def frame_ids(self):
         return self._frame_ids
 
-    def definition(self, lang="eng"):
-        """Return definition in specified language"""
+    def _doc(self, doc_type, default, lang="eng"):
+        """Helper method for Synset.definition and Synset.examples"""
         corpus = self._wordnet_corpus_reader
         if lang not in corpus.langs():
             return None
         elif lang == "eng":
-            return self._definition
+            return default
         else:
             corpus._load_lang_data(lang)
             of = corpus.ss2of(self)
-            i = corpus.lg_attrs.index("def")
+            i = corpus.lg_attrs.index(doc_type)
             if of in corpus._lang_data[lang][i].keys():
                 return corpus._lang_data[lang][i][of]
             else:
                 return None
 
+    def definition(self, lang="eng"):
+        """Return definition in specified language"""
+        return self._doc("def", self._definition, lang=lang)
+
     def examples(self, lang="eng"):
-        corpus = self._wordnet_corpus_reader
         """Return examples in specified language"""
-        if lang not in corpus.langs():
-            return None
-        elif lang == "eng":
-            return self._examples
-        else:
-            corpus._load_lang_data(lang)
-            of = corpus.ss2of(self)
-            i = corpus.lg_attrs.index("exe")
-            if of in corpus._lang_data[lang][i].keys():
-                return corpus._lang_data[lang][i][of]
-            else:
-                return None
+        return self._doc("exe", self._examples, lang=lang)
 
     def lexname(self):
         return self._lexname

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -1837,59 +1837,38 @@ class WordNetCorpusReader(CorpusReader):
         """return lemmas of the given language as list of words"""
         return self.all_lemma_names(lang=lang)
 
+    def doc(self, file="README", lang="eng"):
+        """Return the contents of readme, license or citation file
+        use lang=lang to get the file for an individual language"""
+        if lang == "eng":
+            reader = self
+        else:
+            reader = self._omw_reader
+            if lang in self.langs():
+                file = f"{os.path.join(self.provenances[lang],file)}"
+        try:
+            with reader.open(file) as fp:
+                return fp.read()
+        except:
+            if lang in self._lang_data:
+                return f"Cannot determine {file} for {lang}"
+            else:
+                return f"Language {lang} is not supported."
+
     def license(self, lang="eng"):
         """Return the contents of LICENSE (for omw)
         use lang=lang to get the license for an individual language"""
-        if lang == "eng":
-            with self.open("LICENSE") as fp:
-                return fp.read()
-        elif lang in self.langs():
-            with self._omw_reader.open(f"{lang}/LICENSE") as fp:
-                return fp.read()
-        elif lang == "omw":
-            # under the assumption you don't mean Omwunra-Toqura
-            with self._omw_reader.open("LICENSE") as fp:
-                return fp.read()
-        elif lang in self._lang_data:
-            raise WordNetError("Cannot determine license for user-provided tab file")
-        else:
-            raise WordNetError("Language is not supported.")
+        return self.doc(file="LICENSE", lang=lang)
 
-    def readme(self, lang="omw"):
+    def readme(self, lang="eng"):
         """Return the contents of README (for omw)
         use lang=lang to get the readme for an individual language"""
-        if lang == "eng":
-            with self.open("README") as fp:
-                return fp.read()
-        elif lang in self.langs():
-            with self._omw_reader.open(f"{lang}/README") as fp:
-                return fp.read()
-        elif lang == "omw":
-            # under the assumption you don't mean Omwunra-Toqura
-            with self._omw_reader.open("README") as fp:
-                return fp.read()
-        elif lang in self._lang_data:
-            raise WordNetError("No README for user-provided tab file")
-        else:
-            raise WordNetError("Language is not supported.")
+        return self.doc(file="README", lang=lang)
 
-    def citation(self, lang="omw"):
+    def citation(self, lang="eng"):
         """Return the contents of citation.bib file (for omw)
         use lang=lang to get the citation for an individual language"""
-        if lang == "eng":
-            with self.open("citation.bib") as fp:
-                return fp.read()
-        elif lang in self.langs():
-            with self._omw_reader.open(f"{self.provenances[lang]}/citation.bib") as fp:
-                return fp.read()
-        elif lang == "omw":
-            # under the assumption you don't mean Omwunra-Toqura
-            with self._omw_reader.open("citation.bib") as fp:
-                return fp.read()
-        elif lang in self._lang_data:
-            raise WordNetError("citation not known for user-provided tab file")
-        else:
-            raise WordNetError("Language is not supported.")
+        return self.doc(file="citation.bib", lang=lang)
 
     #############################################################
     # Misc

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -1280,7 +1280,6 @@ class WordNetCorpusReader(CorpusReader):
 
     def omw_prov(self):
         """Return a provenance dictionary of the languages in  Multilingual Wordnet"""
-        langs = ["eng"]
         provdict = {}
         provdict["eng"] = ""
         fileids = self._omw_reader.fileids()

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -1775,11 +1775,32 @@ class WordNetCorpusReader(CorpusReader):
             lemma = iter(set(lemma))
             return lemma
 
-    def all_synsets(self, pos=None):
+    def all_omw_synsets(self, pos=None, lang=None):
+        if lang not in self.langs():
+            return None
+        self._load_lang_data(lang)
+        for of in self._lang_data[lang][0].keys():
+            try:
+                ss = self.of2ss(of)
+                yield ss
+            except:
+                # A few OMW offsets don't exist in Wordnet 3.0.
+                # Additionally, when mapped to later Wordnets,
+                # increasing numbers of synsets are lost in the mapping.
+                #    warnings.warn(f"Language {lang}: no synset found for {of}")
+                pass
+
+    def all_synsets(self, pos=None, lang="eng"):
         """Iterate over all synsets with a given part of speech tag.
         If no pos is specified, all synsets for all parts of speech
         will be loaded.
         """
+        if lang == "eng":
+            return self.all_eng_synsets(pos=pos)
+        else:
+            return self.all_omw_synsets(pos=pos, lang=lang)
+
+    def all_eng_synsets(self, pos=None):
         if pos is None:
             pos_tags = self._FILEMAP.keys()
         else:

--- a/nltk/test/wordnet.doctest
+++ b/nltk/test/wordnet.doctest
@@ -48,19 +48,20 @@ The WordNet corpus reader gives access to the Open Multilingual
 WordNet, using ISO-639 language codes.
 
     >>> sorted(wn.langs())
-    ['als', 'arb', 'bul', 'cat', 'cmn', 'dan', 'ell', 'eng', 'eus', 'fas',
-    'fin', 'fra', 'glg', 'heb', 'hrv', 'ind', 'ita', 'jpn', 'nld', 'nno',
-    'nob', 'pol', 'por', 'qcn', 'slv', 'spa', 'swe', 'tha', 'zsm']
+    ['als', 'arb', 'bul', 'cat', 'cmn', 'dan', 'ell', 'eng', 'eus',
+    'fin', 'fra', 'glg', 'heb', 'hrv', 'ind', 'isl', 'ita', 'ita_iwn',
+    'jpn', 'lit', 'nld', 'nno', 'nob', 'pol', 'por', 'ron', 'slk',
+    'slv', 'spa', 'swe', 'tha', 'zsm']
     >>> wn.synsets(b'\xe7\x8a\xac'.decode('utf-8'), lang='jpn')
     [Synset('dog.n.01'), Synset('spy.n.01')]
 
     >>> wn.synset('spy.n.01').lemma_names('jpn')
-    ['いぬ', 'スパイ', '回者', '回し者', '密偵', '工作員',
-    '廻者', '廻し者', '探', '探り', '犬', '秘密捜査員',
-    'まわし者', '諜報員', '諜者', '間者', '間諜', '隠密']
+    ['いぬ', 'まわし者', 'スパイ', '回し者', '回者', '密偵',
+    '工作員', '廻し者', '廻者', '探', '探り', '犬', '秘密捜査員',
+    '諜報員', '諜者', '間者', '間諜', '隠密']
 
     >>> wn.synset('dog.n.01').lemma_names('ita')
-    ['cane', 'Canis_familiaris']
+    ['Canis_familiaris', 'cane']
     >>> wn.lemmas('cane', lang='ita')
     [Lemma('dog.n.01.cane'), Lemma('cramp.n.02.cane'), Lemma('hammer.n.01.cane'), Lemma('bad_person.n.01.cane'),
     Lemma('incompetent.n.01.cane')]
@@ -77,7 +78,7 @@ WordNet, using ISO-639 language codes.
     >>> dog_lemma.lang()
     'por'
     >>> len(list(wordnet.all_lemma_names(pos='n', lang='jpn')))
-    64797
+    66031
 
 -------
 Synsets


### PR DESCRIPTION
This PR adapts the multilingual functions in wordnet.py to use the new OMW-data 1.4 (https://github.com/nltk/nltk_data/pull/171), the recent release of the Open Multilingual Wordnet.
 
The directory structure of the new nltk_data/corpora/omw package has a slightly different layout, where each folder name indicates the provenance of any number of wordnets included in the corresponding folder.

For English and Italian, OMW now includes wordnets from two different provenances, so the lang parameter needs to eventually encode the provenance, in cases where more wordnets exist for the same language.

Also, in addition to lemmas, some wordnets in OMW 1.4 now also include definitions (def) and examples (exe).

This PR supports both the new and the old omw formats.