### PR TITLE
deprecate: deprecate get and set node methods

### DIFF
--- a/nltk/tree/tree.py
+++ b/nltk/tree/tree.py
@@ -17,8 +17,7 @@ syntax trees and morphological trees.
 
 import re
 import sys
-import warnings
-
+from nltk.internals import deprecated
 from nltk.grammar import Nonterminal, Production
 
 ######################################################################
@@ -202,22 +201,13 @@ class Tree(list):
     # ////////////////////////////////////////////////////////////
     # Basic tree operations
     # ////////////////////////////////////////////////////////////
-
+    @deprecated("_get_node() is deprecated, use label() instead") 
     def _get_node(self):
         """Outdated method to access the node value; use the label() method instead."""
-        warnings.warn(
-            "_get_node() is deprecated, use label() instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
 
+    @deprecated("_set_node() is deprecated, use set_label() instead") 
     def _set_node(self, value):
         """Outdated method to set the node value; use the set_label() method instead."""
-        warnings.warn(
-            "_set_node() is deprecated, use set_label() instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
 
     node = property(_get_node, _set_node)
 

--- a/nltk/tree/tree.py
+++ b/nltk/tree/tree.py
@@ -18,6 +18,7 @@ syntax trees and morphological trees.
 import re
 import sys
 import warnings
+
 from nltk.grammar import Nonterminal, Production
 
 ######################################################################
@@ -201,18 +202,22 @@ class Tree(list):
     # ////////////////////////////////////////////////////////////
     # Basic tree operations
     # ////////////////////////////////////////////////////////////
-    
+
     def _get_node(self):
         """Outdated method to access the node value; use the label() method instead."""
-        warnings.warn("_get_node() is deprecated, use label() instead", 
-        DeprecationWarning,
-        stacklevel=2)
+        warnings.warn(
+            "_get_node() is deprecated, use label() instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     def _set_node(self, value):
         """Outdated method to set the node value; use the set_label() method instead."""
-        warnings.warn("_set_node() is deprecated, use set_label() instead", 
-        DeprecationWarning,
-        stacklevel=2)
+        warnings.warn(
+            "_set_node() is deprecated, use set_label() instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     node = property(_get_node, _set_node)
 

--- a/nltk/tree/tree.py
+++ b/nltk/tree/tree.py
@@ -202,11 +202,11 @@ class Tree(list):
     # ////////////////////////////////////////////////////////////
     # Basic tree operations
     # ////////////////////////////////////////////////////////////
-    @deprecated("_get_node() is deprecated, use label() instead")
+    @deprecated("Use label() instead")
     def _get_node(self):
         """Outdated method to access the node value; use the label() method instead."""
 
-    @deprecated("_set_node() is deprecated, use set_label() instead")
+    @deprecated("Use set_label() instead")
     def _set_node(self, value):
         """Outdated method to set the node value; use the set_label() method instead."""
 

--- a/nltk/tree/tree.py
+++ b/nltk/tree/tree.py
@@ -17,8 +17,9 @@ syntax trees and morphological trees.
 
 import re
 import sys
-from nltk.internals import deprecated
+
 from nltk.grammar import Nonterminal, Production
+from nltk.internals import deprecated
 
 ######################################################################
 ## Trees
@@ -201,11 +202,11 @@ class Tree(list):
     # ////////////////////////////////////////////////////////////
     # Basic tree operations
     # ////////////////////////////////////////////////////////////
-    @deprecated("_get_node() is deprecated, use label() instead") 
+    @deprecated("_get_node() is deprecated, use label() instead")
     def _get_node(self):
         """Outdated method to access the node value; use the label() method instead."""
 
-    @deprecated("_set_node() is deprecated, use set_label() instead") 
+    @deprecated("_set_node() is deprecated, use set_label() instead")
     def _set_node(self, value):
         """Outdated method to set the node value; use the set_label() method instead."""
 

--- a/nltk/tree/tree.py
+++ b/nltk/tree/tree.py
@@ -6,6 +6,7 @@
 #         Peter Ljunglöf <peter.ljunglof@gu.se>
 #         Nathan Bodenstab <bodenstab@cslu.ogi.edu> (tree transforms)
 #         Eric Kafe <kafe.eric@gmail.com> (Tree.fromlist())
+#         Mohaned mashaly<mohaned.mashaly12@gmail.com> (Deprecating methods)
 # URL: <https://www.nltk.org/>
 # For license information, see LICENSE.TXT
 
@@ -16,7 +17,7 @@ syntax trees and morphological trees.
 
 import re
 import sys
-
+import warnings
 from nltk.grammar import Nonterminal, Production
 
 ######################################################################
@@ -200,14 +201,18 @@ class Tree(list):
     # ////////////////////////////////////////////////////////////
     # Basic tree operations
     # ////////////////////////////////////////////////////////////
-
+    
     def _get_node(self):
         """Outdated method to access the node value; use the label() method instead."""
-        raise NotImplementedError("Use label() to access a node label.")
+        warnings.warn("_get_node() is deprecated, use label() instead", 
+        DeprecationWarning,
+        stacklevel=2)
 
     def _set_node(self, value):
         """Outdated method to set the node value; use the set_label() method instead."""
-        raise NotImplementedError("Use set_label() method to set a node label.")
+        warnings.warn("_set_node() is deprecated, use set_label() instead", 
+        DeprecationWarning,
+        stacklevel=2)
 
     node = property(_get_node, _set_node)
 


### PR DESCRIPTION
This pull request deprecates _get_node() and _set_node() methods, it was similar to this [PR](https://github.com/nltk/nltk/pull/2898), but I forgot to amend the required changes instead, I accidentally removed the methods. Sorry for the inconvenience @stevenbird .