### PR TITLE
return demo_sent_subjectivity instead of print

### DIFF
--- a/nltk/sentiment/util.py
+++ b/nltk/sentiment/util.py
@@ -713,7 +713,8 @@ def demo_sent_subjectivity(text):
 
     # Tokenize and convert to lower case
     tokenized_text = [word.lower() for word in word_tokenizer.tokenize(text)]
-    print(sentim_analyzer.classify(tokenized_text))
+    return sentim_analyzer.classify(tokenized_text)
+  
 
 
 def demo_liu_hu_lexicon(sentence, plot=False):


### PR DESCRIPTION
I simply changed the output format of the demo_sent_subjectivity to return instead of print to avoid the program to have to run longer because it prints out each. result to the console.