### PR TITLE
Fixed broken inaugural test case

### DIFF
--- a/nltk/test/corpus.doctest
+++ b/nltk/test/corpus.doctest
@@ -94,7 +94,7 @@ If the reader methods are called without any arguments, they will
 typically load all documents in the corpus.
 
     >>> len(inaugural.words())
-    149797
+    152901
 
 If a corpus contains a README file, it can be accessed with a ``readme()`` method:
 


### PR DESCRIPTION
Hello!

## Pull request overview
* Fixed broken test case for `inaugural.words()` in `corpus.doctest`.

## Description
As you can see from e.g. [this CI run](https://github.com/nltk/nltk/runs/4427635395?check_suite_focus=true), the CI currently fails because the number of words in the inaugural corpus was not updated alongside https://github.com/nltk/nltk_data/pull/169.
This PR simply updates this value.

I'll merge this if the tests pass.

- Tom Aarsen