### PR TITLE
Resolve ReDoS opportunity by fixing incorrectly specified regex

### DIFF
--- a/nltk/parse/malt.py
+++ b/nltk/parse/malt.py
@@ -32,7 +32,7 @@ def malt_regex_tagger():
             (r"\)$", ")"),  # round brackets
             (r"\[$", "["),
             (r"\]$", "]"),  # square brackets
-            (r"^-?[0-9]+(.[0-9]+)?$", "CD"),  # cardinal numbers
+            (r"^-?[0-9]+(\.[0-9]+)?$", "CD"),  # cardinal numbers
             (r"(The|the|A|a|An|an)$", "DT"),  # articles
             (r"(He|he|She|she|It|it|I|me|Me|You|you)$", "PRP"),  # pronouns
             (r"(His|his|Her|her|Its|its)$", "PRP$"),  # possessive

--- a/nltk/sem/glue.py
+++ b/nltk/sem/glue.py
@@ -703,7 +703,7 @@ class Glue:
 
         regexp_tagger = RegexpTagger(
             [
-                (r"^-?[0-9]+(.[0-9]+)?$", "CD"),  # cardinal numbers
+                (r"^-?[0-9]+(\.[0-9]+)?$", "CD"),  # cardinal numbers
                 (r"(The|the|A|a|An|an)$", "AT"),  # articles
                 (r".*able$", "JJ"),  # adjectives
                 (r".*ness$", "NN"),  # nouns formed from adjectives

--- a/nltk/tag/brill.py
+++ b/nltk/tag/brill.py
@@ -329,7 +329,7 @@ class BrillTagger(TaggerI):
             )
             print(
                 "TRAIN ({tokencount:7d} tokens) initial {initialerrors:5d} {initialacc:.4f} "
-                "final: {finalerrors:5d} {finalacc:.4f} ".format(**train_stats)
+                "final: {finalerrors:5d} {finalacc:.4f}".format(**train_stats)
             )
             head = "#ID | Score (train) |  #Rules     | Template"
             print(head, "\n", "-" * len(head), sep="")

--- a/nltk/tag/brill_trainer.py
+++ b/nltk/tag/brill_trainer.py
@@ -91,7 +91,7 @@ class BrillTaggerTrainer:
     # Training
 
     def train(self, train_sents, max_rules=200, min_score=2, min_acc=None):
-        """
+        r"""
         Trains the Brill tagger on the corpus *train_sents*,
         producing at most *max_rules* transformations, each of which
         reduces the net number of errors in the corpus by at least
@@ -111,7 +111,7 @@ class BrillTaggerTrainer:
         >>> testing_data = [untag(s) for s in gold_data]
 
         >>> backoff = RegexpTagger([
-        ... (r'^-?[0-9]+(.[0-9]+)?$', 'CD'),   # cardinal numbers
+        ... (r'^-?[0-9]+(\.[0-9]+)?$', 'CD'),  # cardinal numbers
         ... (r'(The|the|A|a|An|an)$', 'AT'),   # articles
         ... (r'.*able$', 'JJ'),                # adjectives
         ... (r'.*ness$', 'NN'),                # nouns formed from adjectives
@@ -125,7 +125,7 @@ class BrillTaggerTrainer:
         >>> baseline = backoff #see NOTE1
 
         >>> baseline.evaluate(gold_data) #doctest: +ELLIPSIS
-        0.2450142...
+        0.2433862...
 
         >>> # Set up templates
         >>> Template._cleartemplates() #clear any templates created in earlier tests
@@ -137,7 +137,7 @@ class BrillTaggerTrainer:
         >>> tagger1 = tt.train(training_data, max_rules=10)
         TBL train (fast) (seqs: 100; tokens: 2417; tpls: 2; min score: 2; min acc: None)
         Finding initial useful rules...
-            Found 845 useful rules.
+            Found 847 useful rules.
         <BLANKLINE>
                    B      |
            S   F   r   O  |        Score = Fixed - Broken
@@ -150,7 +150,7 @@ class BrillTaggerTrainer:
           85  85   0   0  | NN->, if Pos:NN@[-1] & Word:,@[0]
           69  69   0   0  | NN->. if Pos:NN@[-1] & Word:.@[0]
           51  51   0   0  | NN->IN if Pos:NN@[-1] & Word:of@[0]
-          47  63  16 161  | NN->IN if Pos:NNS@[-1]
+          47  63  16 162  | NN->IN if Pos:NNS@[-1]
           33  33   0   0  | NN->TO if Pos:NN@[-1] & Word:to@[0]
           26  26   0   0  | IN->. if Pos:NNS@[-1] & Word:.@[0]
           24  24   0   0  | IN->, if Pos:NNS@[-1] & Word:,@[0]
@@ -162,11 +162,11 @@ class BrillTaggerTrainer:
 
         >>> train_stats = tagger1.train_stats()
         >>> [train_stats[stat] for stat in ['initialerrors', 'finalerrors', 'rulescores']]
-        [1775, 1269, [132, 85, 69, 51, 47, 33, 26, 24, 22, 17]]
+        [1776, 1270, [132, 85, 69, 51, 47, 33, 26, 24, 22, 17]]
 
         >>> tagger1.print_template_statistics(printunused=False)
         TEMPLATE STATISTICS (TRAIN)  2 templates, 10 rules)
-        TRAIN (   2417 tokens) initial  1775 0.2656 final:  1269 0.4750
+        TRAIN (   2417 tokens) initial  1776 0.2652 final:  1270 0.4746
         #ID | Score (train) |  #Rules     | Template
         --------------------------------------------
         001 |   305   0.603 |   7   0.700 | Template(Pos([-1]),Word([0]))
@@ -175,7 +175,7 @@ class BrillTaggerTrainer:
         <BLANKLINE>
 
         >>> tagger1.evaluate(gold_data) # doctest: +ELLIPSIS
-        0.43996...
+        0.43833...
 
         >>> tagged, test_stats = tagger1.batch_tag_incremental(testing_data, gold_data)
 
@@ -185,13 +185,13 @@ class BrillTaggerTrainer:
         True
 
         >>> [test_stats[stat] for stat in ['initialerrors', 'finalerrors', 'rulescores']]
-        [1855, 1376, [100, 85, 67, 58, 27, 36, 27, 16, 31, 32]]
+        [1859, 1380, [100, 85, 67, 58, 27, 36, 27, 16, 31, 32]]
 
         >>> # A high-accuracy tagger
         >>> tagger2 = tt.train(training_data, max_rules=10, min_acc=0.99)
         TBL train (fast) (seqs: 100; tokens: 2417; tpls: 2; min score: 2; min acc: 0.99)
         Finding initial useful rules...
-            Found 845 useful rules.
+            Found 847 useful rules.
         <BLANKLINE>
                    B      |
            S   F   r   O  |        Score = Fixed - Broken
@@ -212,7 +212,7 @@ class BrillTaggerTrainer:
           18  18   0   0  | NN->CC if Pos:NN@[-1] & Word:and@[0]
 
         >>> tagger2.evaluate(gold_data)  # doctest: +ELLIPSIS
-        0.44159544...
+        0.43996743...
         >>> tagger2.rules()[2:4]
         (Rule('001', 'NN', '.', [(Pos([-1]),'NN'), (Word([0]),'.')]), Rule('001', 'NN', 'IN', [(Pos([-1]),'NN'), (Word([0]),'of')]))
 

--- a/nltk/tag/sequential.py
+++ b/nltk/tag/sequential.py
@@ -337,7 +337,7 @@ class UnigramTagger(NgramTagger):
         >>> test_sent = brown.sents(categories='news')[0]
         >>> unigram_tagger = UnigramTagger(brown.tagged_sents(categories='news')[:500])
         >>> for tok, tag in unigram_tagger.tag(test_sent):
-        ...     print("({}, {}), ".format(tok, tag))
+        ...     print("({}, {}), ".format(tok, tag)) # doctest: +NORMALIZE_WHITESPACE
         (The, AT), (Fulton, NP-TL), (County, NN-TL), (Grand, JJ-TL),
         (Jury, NN-TL), (said, VBD), (Friday, NR), (an, AT),
         (investigation, NN), (of, IN), (Atlanta's, NP$), (recent, JJ),
@@ -491,7 +491,7 @@ class AffixTagger(ContextTagger):
 
 @jsontags.register_tag
 class RegexpTagger(SequentialBackoffTagger):
-    """
+    r"""
     Regular Expression Tagger
 
     The RegexpTagger assigns tags to tokens by comparing their
@@ -503,7 +503,7 @@ class RegexpTagger(SequentialBackoffTagger):
         >>> from nltk.tag import RegexpTagger
         >>> test_sent = brown.sents(categories='news')[0]
         >>> regexp_tagger = RegexpTagger(
-        ...     [(r'^-?[0-9]+(.[0-9]+)?$', 'CD'),   # cardinal numbers
+        ...     [(r'^-?[0-9]+(\.[0-9]+)?$', 'CD'),  # cardinal numbers
         ...      (r'(The|the|A|a|An|an)$', 'AT'),   # articles
         ...      (r'.*able$', 'JJ'),                # adjectives
         ...      (r'.*ness$', 'NN'),                # nouns formed from adjectives
@@ -515,7 +515,7 @@ class RegexpTagger(SequentialBackoffTagger):
         ... ])
         >>> regexp_tagger
         <Regexp Tagger: size=9>
-        >>> regexp_tagger.tag(test_sent)
+        >>> regexp_tagger.tag(test_sent) # doctest: +NORMALIZE_WHITESPACE
         [('The', 'AT'), ('Fulton', 'NN'), ('County', 'NN'), ('Grand', 'NN'), ('Jury', 'NN'),
         ('said', 'NN'), ('Friday', 'NN'), ('an', 'AT'), ('investigation', 'NN'), ('of', 'NN'),
         ("Atlanta's", 'NNS'), ('recent', 'NN'), ('primary', 'NN'), ('election', 'NN'),

--- a/nltk/tbl/demo.py
+++ b/nltk/tbl/demo.py
@@ -393,11 +393,11 @@ def _demo_plot(learning_curve_output, teststats, trainstats=None, take=None):
     plt.savefig(learning_curve_output)
 
 
-NN_CD_TAGGER = RegexpTagger([(r"^-?[0-9]+(.[0-9]+)?$", "CD"), (r".*", "NN")])
+NN_CD_TAGGER = RegexpTagger([(r"^-?[0-9]+(\.[0-9]+)?$", "CD"), (r".*", "NN")])
 
 REGEXP_TAGGER = RegexpTagger(
     [
-        (r"^-?[0-9]+(.[0-9]+)?$", "CD"),  # cardinal numbers
+        (r"^-?[0-9]+(\.[0-9]+)?$", "CD"),  # cardinal numbers
         (r"(The|the|A|a|An|an)$", "AT"),  # articles
         (r".*able$", "JJ"),  # adjectives
         (r".*ness$", "NN"),  # nouns formed from adjectives


### PR DESCRIPTION
Hello!

## Pull request overview
* Resolve slight ReDoS in some RegexpTaggers throughout NLTK.
* Modified doctests to accompany the changed regex.

## The regex
The original regex was `^-?[0-9]+(.[0-9]+)?$`, which is vulnerable to a ReDoS due to `[0-9]+` followed by any character (due to `.`), and then again `[0-9]+`. However, this original regex does not seem to match what it was intended for: Matching cardinal numbers. The regex seems to want to match:
* Perhaps a `-`
* A non-zero amount of numbers.
* Perhaps a `.` followed by a non-zero amount of numbers.

This would match e.g. `3`, `-4` and `3.12`. However, the regex actually does not match a dot directly, it matches any number. This means that `-3a12` is also allowed, which we would rather not have. I believe the original designer of the regex meant to use `\.`, but used `.` instead, and did not realise the small mistake.

### ReDoS reproduction:
```python
pattern = re.compile(r"^-?[0-9]+(.[0-9]+)?$")

for length in (2**i for i in range(12, 24)):
    s = "-"
    s += "0" * length
    s += "q"

    t = time.time()
    re.search(pattern, s)
    print(f"Searching took {time.time() - t:.8}s for length {length}.")
```
outputs
```
Searching took 0.17596316s for length 4096.
Searching took 0.66382051s for length 8192.
Searching took 2.8454814s for length 16384.
Searching took 10.864819s for length 32768.
Searching took 44.40001s for length 65536.
Searching took 176.56144s for length 131072.
...
```
After several minutes I stopped the execution.

## The fix
Simply adding a `\` before the `.` should fix the problem.

## The consequences
The regex will no longer be vulnerable to a ReDoS. Beyond that, `-3a12` will no longer be considered a cardinal number in the RegexpTagger examples throughout NLTK. This is desirable behaviour, with one small subjective exception: `3e12` will no longer be considered a cardinal number, even though one could argue that it is. 
If we want to still consider it one, then we can of course go for `^-?[0-9]+([e\.][0-9]+)?$`, but I really don't think it matters. 

### ReDoS reproduction
```python
pattern = re.compile(r"^-?[0-9]+(\.[0-9]+)?$")

for length in (2**i for i in range(12, 24)):
    s = "-"
    s += "0" * length
    s += "q"

    t = time.time()
    re.search(pattern, s)
    print(f"Searching took {time.time() - t:.8}s for length {length}.")
```

now outputs
```
Searching took 0.0s for length 4096.
Searching took 0.0010306835s for length 8192.  
Searching took 0.00096130371s for length 16384.
Searching took 0.0020515919s for length 32768. 
Searching took 0.0029797554s for length 65536. 
Searching took 0.0060167313s for length 131072.
Searching took 0.013041735s for length 262144.
Searching took 0.026050091s for length 524288.
Searching took 0.051049709s for length 1048576.
Searching took 0.09999752s for length 2097152.
Searching took 0.20596671s for length 4194304.
Searching took 0.40702796s for length 8388608.
```
As is correct for a simple regex, the execution time of the regex is linear in the length of the input. This was not the case before.

---

Thanks to @scara31 for making us aware of this vulnerability through proper means.

- Tom Aarsen