### PR TITLE
Renamed omw to omw-1.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
         id: restore-cache
         with:
           path: ~/nltk_data
-          key: try-nltk_data_${{ secrets.CACHE_VERSION }}
+          key: nltk_data_${{ secrets.CACHE_VERSION }}
 
       - name: Download nltk data packages on cache miss
         run: |
@@ -112,7 +112,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/nltk_data
-          key: try-nltk_data_${{ secrets.CACHE_VERSION }}
+          key: nltk_data_${{ secrets.CACHE_VERSION }}
 
       - name: Use cached third party tools
         uses: actions/cache@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
         id: restore-cache
         with:
           path: ~/nltk_data
-          key: nltk_data_${{ secrets.CACHE_VERSION }}
+          key: try-nltk_data_${{ secrets.CACHE_VERSION }}
 
       - name: Download nltk data packages on cache miss
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,7 +112,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/nltk_data
-          key: nltk_data_${{ secrets.CACHE_VERSION }}
+          key: try-nltk_data_${{ secrets.CACHE_VERSION }}
 
       - name: Use cached third party tools
         uses: actions/cache@v2

--- a/nltk/corpus/__init__.py
+++ b/nltk/corpus/__init__.py
@@ -356,7 +356,6 @@ verbnet = LazyCorpusLoader("verbnet", VerbnetCorpusReader, r"(?!\.).*\.xml")
 webtext = LazyCorpusLoader(
     "webtext", PlaintextCorpusReader, r"(?!README|\.).*\.txt", encoding="ISO-8859-2"
 )
-
 wordnet = LazyCorpusLoader(
     "wordnet",
     WordNetCorpusReader,

--- a/nltk/corpus/__init__.py
+++ b/nltk/corpus/__init__.py
@@ -359,17 +359,17 @@ webtext = LazyCorpusLoader(
 wordnet = LazyCorpusLoader(
     "wordnet",
     WordNetCorpusReader,
-    LazyCorpusLoader("omw", CorpusReader, r".*/wn-data-.*\.tab", encoding="utf8"),
+    LazyCorpusLoader("omw-1.4", CorpusReader, r".*/wn-data-.*\.tab", encoding="utf8"),
 )
 wordnet31 = LazyCorpusLoader(
     "wordnet31",
     WordNetCorpusReader,
-    LazyCorpusLoader("omw", CorpusReader, r".*/wn-data-.*\.tab", encoding="utf8"),
+    LazyCorpusLoader("omw-1.4", CorpusReader, r".*/wn-data-.*\.tab", encoding="utf8"),
 )
 wordnet2021 = LazyCorpusLoader(
     "wordnet2021",
     WordNetCorpusReader,
-    LazyCorpusLoader("omw", CorpusReader, r".*/wn-data-.*\.tab", encoding="utf8"),
+    LazyCorpusLoader("omw-1.4", CorpusReader, r".*/wn-data-.*\.tab", encoding="utf8"),
 )
 wordnet_ic = LazyCorpusLoader("wordnet_ic", WordNetICCorpusReader, r".*\.dat")
 words = LazyCorpusLoader(

--- a/nltk/corpus/__init__.py
+++ b/nltk/corpus/__init__.py
@@ -356,6 +356,7 @@ verbnet = LazyCorpusLoader("verbnet", VerbnetCorpusReader, r"(?!\.).*\.xml")
 webtext = LazyCorpusLoader(
     "webtext", PlaintextCorpusReader, r"(?!README|\.).*\.txt", encoding="ISO-8859-2"
 )
+
 wordnet = LazyCorpusLoader(
     "wordnet",
     WordNetCorpusReader,


### PR DESCRIPTION
This PR selects omw-1.4 as the default package to use together with Wordnet. This implements the third point in @tomaarsen's plan from https://github.com/nltk/nltk/issues/2905#issuecomment-988901617, in order to ensure a smooth transition to the new OMW-1.4 data.