### PR TITLE
Added warnings if nltk_data `.zip` files exist without any corresponding `.xml` files.

### DIFF
--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -167,6 +167,7 @@ import sys
 import textwrap
 import threading
 import time
+import warnings
 import zipfile
 from hashlib import md5
 from xml.etree import ElementTree
@@ -2448,6 +2449,18 @@ def _find_packages(root):
                     )
 
                 yield pkg_xml, zf, relpath
+
+            elif filename.endswith(".zip"):
+                # Warn user in case a .xml does not exist for a .zip
+                resourcename = os.path.splitext(filename)[0]
+                xmlfilename = os.path.join(dirname, resourcename + ".xml")
+                if not os.path.exists(xmlfilename):
+                    warnings.warn(
+                        f"{filename} exists, but {resourcename + '.xml'} cannot be found! "
+                        f"This could mean that {resourcename} can not be downloaded.",
+                        stacklevel=2,
+                    )
+
         # Don't recurse into svn subdirectories:
         try:
             subdirs.remove(".svn")


### PR DESCRIPTION
Resolves https://github.com/nltk/nltk_data/issues/178

Hello!

## Pull request overview
* Added warnings if `build_index` is ran in `nltk.downloader`, when the root folder contains `.zip` files without any corresponding `.xml` files.

## The issue
As inspired mainly by https://github.com/nltk/nltk_data/issues/178, as well as by https://github.com/nltk/nltk_data/pull/176 and https://github.com/nltk/nltk_data/pull/177, @ekaf has noticed that there are several resources in `nltk_data` that have `.zip` files with data, but no `.xml` to specify what kind of data it is. When there is no `.xml`, these `.zip` files are quietly being ignored. 

We experienced this issue with `omw-1.4.zip` (https://github.com/nltk/nltk_data/pull/176) and `wordnet2021.zip` (https://github.com/nltk/nltk_data/pull/177) recently, and it seems there are more resources with these issues.

This PR adds a warning in these situations. 
Running `make pkg_index` on `nltk_data` now also outputs the following:
```python
[sic]\nltk\downloader.py:2294: UserWarning: listing.csv.zip exists, but listing.csv.xml cannot be found! This could mean that listing.csv can not be downloaded.
  for pkg_xml, zf, subdir in _find_packages(os.path.join(root, "packages")):
[sic]\nltk\downloader.py:2294: UserWarning: omw-1.4.zip exists, but omw-1.4.xml cannot be found! This could mean that omw-1.4 can not be downloaded.
  for pkg_xml, zf, subdir in _find_packages(os.path.join(root, "packages")):
[sic]\nltk\downloader.py:2294: UserWarning: ptb3.zip exists, but ptb3.xml cannot be found! This could mean that ptb3 can not be downloaded.
  for pkg_xml, zf, subdir in _find_packages(os.path.join(root, "packages")):
[sic]\nltk\downloader.py:2294: UserWarning: wordnet2021.zip exists, but wordnet2021.xml cannot be found! This could mean that wordnet2021 can not be downloaded.
  for pkg_xml, zf, subdir in _find_packages(os.path.join(root, "packages")):
```

This should prevent us from accidentally forgetting to add an `.xml` to a new `nltk_data` resource.

## Notes
Ignore my error in the commit message, it's meant to say `.xml` instead of `.csv`. I was distracted by the [`listing.csv`](https://github.com/nltk/nltk_data/blob/gh-pages/packages/corpora/listing.csv) and `listing.csv.zip` files. Are these files even still being used? GitHub is complaining that the `listing.csv` isn't even correct, as the number of columns don't match between all rows.

Furthermore, this PR shows that `ptb3` (i.e. a stub of Penn Treebank 3) can not be downloaded. It seems that `ptb` is now being used, and that `ptb3` is just an old copy of `ptb`:
![image](https://user-images.githubusercontent.com/37621491/145572345-1250a430-2587-4ca5-94ef-1c877f686fc6.png)
Perhaps this means we can just delete `ptb3` from `nltk_data`.

Thank you @ekaf for the suggestion.

- Tom Aarsen