### PR TITLE
Allow commits with `/nocache` to not use the cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,12 +37,12 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Cache nltk data
+        if: ${{ !contains(github.event.head_commit.message, '/nocache') }}
         uses: actions/cache@v2
         id: restore-cache
         with:
           path: ~/nltk_data
           key: nltk_data_${{ secrets.CACHE_VERSION }}
-        if: !contains(github.event.head_commit.message, '/nocache')
 
       - name: Download nltk data packages on cache miss
         run: |
@@ -60,12 +60,12 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Cache third party tools
+        if: ${{ !contains(github.event.head_commit.message, '/nocache') }}
         uses: actions/cache@v2
         id: restore-cache
         with:
           path: ~/third
           key: third_${{ secrets.CACHE_VERSION }}
-        if: !contains(github.event.head_commit.message, '/nocache')
 
       - name: Download third party data
         run: |
@@ -98,12 +98,12 @@ jobs:
         if: runner.os == 'Linux'
 
       - name: Cache dependencies
+        if: ${{ !contains(github.event.head_commit.message, '/nocache') }}
         uses: actions/cache@v2
         id: restore-cache
         with:
           path: ${{ env.pythonLocation }}
           key: python-dependencies-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements-ci.txt') }}-${{ env.pythonLocation }}
-        if: !contains(github.event.head_commit.message, '/nocache')
 
       - name: Install dependencies on cache miss
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,7 @@ jobs:
         with:
           path: ~/nltk_data
           key: nltk_data_${{ secrets.CACHE_VERSION }}
+        if: !contains(github.event.head_commit.message, '/nocache')
 
       - name: Download nltk data packages on cache miss
         run: |
@@ -64,6 +65,7 @@ jobs:
         with:
           path: ~/third
           key: third_${{ secrets.CACHE_VERSION }}
+        if: !contains(github.event.head_commit.message, '/nocache')
 
       - name: Download third party data
         run: |
@@ -101,6 +103,7 @@ jobs:
         with:
           path: ${{ env.pythonLocation }}
           key: python-dependencies-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements-ci.txt') }}-${{ env.pythonLocation }}
+        if: !contains(github.event.head_commit.message, '/nocache')
 
       - name: Install dependencies on cache miss
         run: |


### PR DESCRIPTION
Hello!

## Pull request overview
* If a commit message contains `/nocache`, then it will not use the existing cache. 

## Details
From now on, a commit message containing `/nocache` will cause a CI run *without* the existing cache. Note that this *does not* refresh the cache, it just ignores the cache for that commit only. On the `develop` branch, it is recommended (for admins) to go to `Secrets > CACHE_VERSION` and change the value, after which you can go to Actions and "Restart this workflow". No new commit required here.

However, this does not work on PRs. That's what this PR is for. If any PR in the future is failing because of cache issues (which would only be if `nltk_data` was updated very recently), then an empty commit can be pushed with `git commit --allow-empty -m "Restarting CI without cache: /nocache"`. This should cause a CI run without a cache.

- Tom Aarsen