### PR TITLE
Fix `FileNotFoundError` when the `download_dir` is a non-existing nested folder

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -286,6 +286,7 @@
 - Ahmet Yildirim <https://github.com/RnDevelover>
 - Yuta Nakamura <https://github.com/yutanakamura-tky>
 - Adam Hawley <https://github.com/adamjhawley>
+- Panagiotis Simakis <https://github.com/sp1thas>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -695,9 +695,9 @@ class Downloader:
 
         # Ensure the download_dir exists
         if not os.path.exists(download_dir):
-            os.mkdir(download_dir)
+            os.makedirs(download_dir)
         if not os.path.exists(os.path.join(download_dir, info.subdir)):
-            os.mkdir(os.path.join(download_dir, info.subdir))
+            os.makedirs(os.path.join(download_dir, info.subdir))
 
         # Download the file.  This will raise an IOError if the url
         # is not found.

--- a/nltk/test/unit/test_downloader.py
+++ b/nltk/test/unit/test_downloader.py
@@ -1,0 +1,19 @@
+from nltk import download
+
+
+def test_downloader_using_existing_parent_download_dir(tmp_path):
+    """Test that download works properly when the parent folder of the download_dir exists"""
+
+    download_dir = str(tmp_path.joinpath("another_dir"))
+    download_status = download("mwa_ppdb", download_dir)
+    assert download_status is True
+
+
+def test_downloader_using_non_existing_parent_download_dir(tmp_path):
+    """Test that download works properly when the parent folder of the download_dir does not exist"""
+
+    download_dir = str(
+        tmp_path.joinpath("non-existing-parent-folder", "another-non-existing-folder")
+    )
+    download_status = download("mwa_ppdb", download_dir)
+    assert download_status is True


### PR DESCRIPTION
The purpose of this PR is to resolve #2904 by replacing the `os.mkdir` with `os.makedirs` in order to prevent `FileNotFoundError` when the `download_dir` is a non-existing nested directory (parent direcotry does not exists)