### PR TITLE
Resolve IndexError in `sent_tokenize`

### DIFF
--- a/nltk/test/tokenize.doctest
+++ b/nltk/test/tokenize.doctest
@@ -310,6 +310,11 @@ Testing mutable default arguments for https://github.com/nltk/nltk/pull/2067
     >>> type(pst._lang_vars)
     <class 'nltk.tokenize.punkt.PunktLanguageVars'>
 
+Testing that inputs can start with dots.
+
+    >>> pst = PunktSentenceTokenizer(lang_vars=None)
+    >>> pst.tokenize(". This input starts with a dot. This used to cause issues.")
+    ['.', 'This input starts with a dot.', 'This used to cause issues.']
 
 Regression Tests: align_tokens
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -1379,7 +1379,7 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
             # Find the word before the current match
             split = text[: match.start()].rsplit(maxsplit=1)
             before_start = len(split[0]) if len(split) == 2 else 0
-            before_words[match] = split[-1]
+            before_words[match] = split[-1] if split else ""
             matches.append(match)
 
         return [


### PR DESCRIPTION
Closes #2921

Hello!

## Pull request overview
* Prevent `IndexError` when the `sent_tokenize` input starts with a dot.
* Wrote tests to prevent this from failing again.

## Details
It is possible that `split` is empty whenever `.` is matched, which can happen whenever the input of `sent_tokenize` starts with a `.`, in the following snippet:
https://github.com/nltk/nltk/blob/dd1494ea0b88ea92a95034777863828e6552fde2/nltk/tokenize/punkt.py#L1380-L1382

This PR ought to resolve this issue. 

- Tom Aarsen