### PR TITLE
Add links to GitHub and GitHub issues from the Website

### DIFF
--- a/web/index.rst
+++ b/web/index.rst
@@ -66,8 +66,8 @@ follows:
 Next Steps
 ----------
 
-* `sign up for release announcements <https://groups.google.com/group/nltk>`_
-* `join in the discussion <https://groups.google.com/group/nltk-users>`_
+* `Sign up for release announcements <https://groups.google.com/group/nltk>`_
+* `Join in the discussion <https://groups.google.com/group/nltk-users>`_
 
 
 .. toctree::
@@ -80,6 +80,8 @@ Next Steps
    Module Index <py-modindex>
    Wiki <https://github.com/nltk/nltk/wiki>
    FAQ <https://github.com/nltk/nltk/wiki/FAQ>
+   Open Issues <https://github.com/nltk/nltk/issues>
+   NLTK on GitHub <https://github.com/nltk/nltk>
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Hello!

## Pull request overview
* Add links to [issues](/nltk/nltk/issues) and [GitHub](/nltk/nltk) from the Website
* Title case some sentence starts

### Reasoning
The majority of the traffic that this repository gets is via https://www.nltk.org, which is somewhat surprising as there are only a few links from https://www.nltk.org to www.github.com/nltk/nltk. Let's help users out and create two more - one directly to the list of issues and one to the GitHub itself.

The webpage would become:

![image](https://user-images.githubusercontent.com/37621491/147383331-d1b62586-7925-4926-b87d-30ccaa190a14.png)

- Tom Aarsen