### PR TITLE
Fix LC cutoff policy of text tiling

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -287,6 +287,7 @@
 - Yuta Nakamura <https://github.com/yutanakamura-tky>
 - Adam Hawley <https://github.com/adamjhawley>
 - Panagiotis Simakis <https://github.com/sp1thas>
+- Richard Wang <https://github.com/richarddwang>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 

--- a/nltk/tokenize/texttiling.py
+++ b/nltk/tokenize/texttiling.py
@@ -291,9 +291,8 @@ class TextTilingTokenizer(TokenizerI):
         avg = sum(depth_scores) / len(depth_scores)
         stdev = numpy.std(depth_scores)
 
-        # SB: what is the purpose of this conditional?
         if self.cutoff_policy == LC:
-            cutoff = avg - stdev / 2.0
+            cutoff = avg - stdev
         else:
             cutoff = avg - stdev / 2.0
 


### PR DESCRIPTION
According to the paper (Hearst, Marti A.. “Text Tiling: Segmenting Text into Multi-paragraph Subtopic Passages.” Comput. Linguistics 23 (1997): 33-64.) that the NLTK TextTiling algorithm is probably based on, 

> One version of this function entails drawing a boundary only if the depth score exceeds s_hat - sigma (the liberal measure, LC). This function can be varied to achieve correspondingly varying precision/recall trade-offs. A higher precision but lower recall can be found by setting the limit to be depth scores exceeding s_hat - sigma/2 (the conservative measure, HC) instead of s_hat - sigma

I believe LC/HC uses a threshold which is (s_hat - sigma)/(s_hat - sigma/2) respectively. 