### PR TITLE
Missing ic argument in res, jcn and lin similarity functions of wordnet

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -288,6 +288,7 @@
 - Adam Hawley <https://github.com/adamjhawley>
 - Panagiotis Simakis <https://github.com/sp1thas>
 - Richard Wang <https://github.com/richarddwang>
+- Alexandre Perez-Lebel <https://github.com/aperezlebel>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -2353,15 +2353,15 @@ def wup_similarity(synset1, synset2, verbose=False, simulate_root=True):
 
 
 def res_similarity(synset1, synset2, ic, verbose=False):
-    return synset1.res_similarity(synset2, verbose)
+    return synset1.res_similarity(synset2, ic, verbose)
 
 
 def jcn_similarity(synset1, synset2, ic, verbose=False):
-    return synset1.jcn_similarity(synset2, verbose)
+    return synset1.jcn_similarity(synset2, ic, verbose)
 
 
 def lin_similarity(synset1, synset2, ic, verbose=False):
-    return synset1.lin_similarity(synset2, verbose)
+    return synset1.lin_similarity(synset2, ic, verbose)
 
 
 path_similarity.__doc__ = Synset.path_similarity.__doc__

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -2341,27 +2341,29 @@ class WordNetICCorpusReader(CorpusReader):
 
 
 def path_similarity(synset1, synset2, verbose=False, simulate_root=True):
-    return synset1.path_similarity(synset2, verbose, simulate_root)
+    return synset1.path_similarity(
+        synset2, verbose=verbose, simulate_root=simulate_root
+    )
 
 
 def lch_similarity(synset1, synset2, verbose=False, simulate_root=True):
-    return synset1.lch_similarity(synset2, verbose, simulate_root)
+    return synset1.lch_similarity(synset2, verbose=verbose, simulate_root=simulate_root)
 
 
 def wup_similarity(synset1, synset2, verbose=False, simulate_root=True):
-    return synset1.wup_similarity(synset2, verbose, simulate_root)
+    return synset1.wup_similarity(synset2, verbose=verbose, simulate_root=simulate_root)
 
 
 def res_similarity(synset1, synset2, ic, verbose=False):
-    return synset1.res_similarity(synset2, ic, verbose)
+    return synset1.res_similarity(synset2, ic, verbose=verbose)
 
 
 def jcn_similarity(synset1, synset2, ic, verbose=False):
-    return synset1.jcn_similarity(synset2, ic, verbose)
+    return synset1.jcn_similarity(synset2, ic, verbose=verbose)
 
 
 def lin_similarity(synset1, synset2, ic, verbose=False):
-    return synset1.lin_similarity(synset2, ic, verbose)
+    return synset1.lin_similarity(synset2, ic, verbose=verbose)
 
 
 path_similarity.__doc__ = Synset.path_similarity.__doc__


### PR DESCRIPTION
Hello,

I just ran into a little bug when using `res_similarity`, `jcn_similarity` and `lin_similarity` functions. The `ic` argument is not passed to the corresponding methods of the Synset class.

Example:
```python
import nltk
from nltk.corpus import wordnet as wn
from nltk.corpus.reader.wordnet import jcn_similarity, lin_similarity, res_similarity

nltk.download('wordnet')

# Random synsets
s1 = wn.synset_from_pos_and_offset('n', 7579787)
s2 = wn.synset_from_pos_and_offset('n', 2226429)

ic = {}
res_similarity(s1, s2, ic)
jcn_similarity(s1, s2, ic)
lin_similarity(s1, s2, ic)
```
Throws:
`TypeError: 'bool' object is not subscriptable`
