### PR TITLE
Warn about nonexistent OMW offsets

### DIFF
--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -1532,9 +1532,7 @@ class WordNetCorpusReader(CorpusReader):
             self._synset_offset_cache[pos][offset] = synset
         else:
             synset = None
-            raise WordNetError(
-                f"No WordNet synset found for pos={pos} at offset={offset}."
-            )
+            warnings.warn(f"No WordNet synset found for pos={pos} at offset={offset}.")
         data_file.seek(0)
         return synset
 


### PR DESCRIPTION
Fixes #2973: instead of raising a fatal error when an offset is not found in WordNet, only raise a warning, so that batch processing can continue. This is especially handy with OMW, which is known to contain some references to nonexistent offsets (cf. https://github.com/omwn/omw-data/issues/24#issuecomment-974789720).

```
from nltk.corpus import wordnet as wn

print(wn.synsets('osim', lang='hrv'))
```

With this PR, a list of offfsets is returned, with None instead of eventual incorrect offsets, in addition to any correct offset:

`[Synset('apart.r.01'), None]`

Meanwhile, a non-fatal warning is wriiten to the standard error stream, with details about the nonexistent synset offset:

```
nltk/corpus/reader/wordnet.py:1536: UserWarning: No WordNet synset found for pos=a at offset=2002046.
  f"No WordNet synset found for pos={pos} at offset={offset}."
```


Note: maybe it could be worthwile to go through the 12 calls of the WordNetError class in wordnet.py, to see if some other of the raised errors could also be replaced by a non-fatal call of warnings.warn(). 