### PR TITLE
Add function to retrieve wordnet synonyms

### DIFF
--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -1880,7 +1880,7 @@ class WordNetCorpusReader(CorpusReader):
     def synonyms(self, word, lang="eng"):
         """return nested list with the synonyms of the different senses of word in the given language"""
         return [
-            list(set(ss.lemma_names(lang=lang)) - {word})
+            sorted(list(set(ss.lemma_names(lang=lang)) - {word}))
             for ss in self.synsets(word, lang=lang)
         ]
 

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -1879,6 +1879,13 @@ class WordNetCorpusReader(CorpusReader):
         """return lemmas of the given language as list of words"""
         return self.all_lemma_names(lang=lang)
 
+    def synonyms(self, word, lang="eng"):
+        """return nested list with the synonyms of the different senses of word in the given language"""
+        return [
+            list(set(ss.lemma_names(lang=lang)) - {word})
+            for ss in self.synsets(word, lang=lang)
+        ]
+
     def doc(self, file="README", lang="eng"):
         """Return the contents of readme, license or citation file
         use lang=lang to get the file for an individual language"""

--- a/nltk/test/wordnet.doctest
+++ b/nltk/test/wordnet.doctest
@@ -80,6 +80,14 @@ WordNet, using ISO-639 language codes.
     >>> len(list(wordnet.all_lemma_names(pos='n', lang='jpn')))
     66031
 
+The synonyms of a word are returned as a nested list of synonyms of the different senses of
+the input word in the given language, since these different senses are not mutual synonyms:
+    >>> wn.synonyms('car')
+    [['auto', 'automobile', 'motorcar', 'machine'], ['railway_car', 'railroad_car', 'railcar'], ['gondola'], ['elevator_car'], ['cable_car']]
+    >>> wn.synonyms('coche', lang='spa')
+    [['máquina', 'turismo', 'auto', 'carro', 'vehículo', 'automóvil'], ['automotor', 'vagón'], ['vagón_de_pasajeros', 'vagón']]
+
+
 -------
 Synsets
 -------

--- a/nltk/test/wordnet.doctest
+++ b/nltk/test/wordnet.doctest
@@ -83,9 +83,9 @@ WordNet, using ISO-639 language codes.
 The synonyms of a word are returned as a nested list of synonyms of the different senses of
 the input word in the given language, since these different senses are not mutual synonyms:
     >>> wn.synonyms('car')
-    [['auto', 'automobile', 'motorcar', 'machine'], ['railway_car', 'railroad_car', 'railcar'], ['gondola'], ['elevator_car'], ['cable_car']]
+    [['auto', 'automobile', 'machine', 'motorcar'], ['railcar', 'railroad_car', 'railway_car'], ['gondola'], ['elevator_car'], ['cable_car']]
     >>> wn.synonyms('coche', lang='spa')
-    [['máquina', 'turismo', 'auto', 'carro', 'vehículo', 'automóvil'], ['automotor', 'vagón'], ['vagón_de_pasajeros', 'vagón']]
+    [['auto', 'automóvil', 'carro', 'máquina', 'turismo', 'vehículo'], ['automotor', 'vagón'], ['vagón', 'vagón_de_pasajeros']]
 
 
 -------


### PR DESCRIPTION
Users struggle to find the synonyms of a word (#2976) because the wordnet.py module still does not provide a convenient way to retrieve synonyms, although it claims to:
"Using synsets, helps find conceptual relationships between words such as hypernyms, hyponyms, synonyms, antonyms etc." (sic).

To remedy this deficiency, the present PR adds a function that returns a nested list with the synonyms of the different senses of a word in the given language. Collapsing the different senses into one big list is not recommendable, since the different senses are not mutual synonyms.

>from nltk.corpus import wordnet as wn
> print(wn.synonyms('car'))

[['automobile', 'machine', 'auto', 'motorcar'], ['railcar', 'railway_car', 'railroad_car'], ['gondola'], ['elevator_car'], ['cable_car']]

> print(wn.synonyms('coche', lang='spa'))

[['vehículo', 'auto', 'carro', 'automóvil', 'máquina', 'turismo'], ['vagón', 'automotor'], ['vagón', 'vagón_de_pasajeros']]
