### PR TITLE
Handle wordnet synsets that were lost in mapping

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,7 @@ jobs:
         id: restore-cache
         with:
           path: ~/third
-          key: new-third_${{ secrets.CACHE_VERSION }}
+          key: third_${{ secrets.CACHE_VERSION }}
 
       - name: Download third party data
         run: |
@@ -118,7 +118,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/third
-          key: new-third_${{ secrets.CACHE_VERSION }}
+          key: third_${{ secrets.CACHE_VERSION }}
         if: runner.os == 'Linux'
 
       - name: Run pytest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,7 @@ jobs:
         id: restore-cache
         with:
           path: ~/third
-          key: third_${{ secrets.CACHE_VERSION }}
+          key: new-third_${{ secrets.CACHE_VERSION }}
 
       - name: Download third party data
         run: |
@@ -118,7 +118,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/third
-          key: third_${{ secrets.CACHE_VERSION }}
+          key: new-third_${{ secrets.CACHE_VERSION }}
         if: runner.os == 'Linux'
 
       - name: Run pytest

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -1527,7 +1527,6 @@ class WordNetCorpusReader(CorpusReader):
         data_file_line = data_file.readline()
         # If valid, the offset equals the 8-digit 0-padded integer found at the start of the line:
         line_offset = data_file_line[:8]
-        #        if line_offset.isalnum() and offset == int(line_offset):
         if (
             line_offset.isalnum()
             and line_offset == f"{'0'*(8-len(str(offset)))}{str(offset)}"

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -493,7 +493,7 @@ class Synset(_WordNetObject):
         """Return all the lemma objects associated with the synset"""
         if lang == "eng":
             return self._lemmas
-        else:
+        elif self._name:
             self._wordnet_corpus_reader._load_lang_data(lang)
             lemmark = []
             lemmy = self.lemma_names(lang)
@@ -1517,6 +1517,7 @@ class WordNetCorpusReader(CorpusReader):
         >>> print(wn.synset_from_pos_and_offset('n', 1740))
         Synset('entity.n.01')
         """
+
         # Check to see if the synset is in the cache
         if offset in self._synset_offset_cache[pos]:
             return self._synset_offset_cache[pos][offset]
@@ -1526,12 +1527,16 @@ class WordNetCorpusReader(CorpusReader):
         data_file_line = data_file.readline()
         # If valid, the offset equals the 8-digit 0-padded integer found at the start of the line:
         line_offset = data_file_line[:8]
-        if line_offset.isalnum() and offset == int(line_offset):
+        #        if line_offset.isalnum() and offset == int(line_offset):
+        if (
+            line_offset.isalnum()
+            and line_offset == f"{'0'*(8-len(str(offset)))}{str(offset)}"
+        ):
             synset = self._synset_from_pos_and_line(pos, data_file_line)
             assert synset._offset == offset
             self._synset_offset_cache[pos][offset] = synset
         else:
-            synset = None
+            synset = Synset(self)
             warnings.warn(f"No WordNet synset found for pos={pos} at offset={offset}.")
         data_file.seek(0)
         return synset

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -1517,7 +1517,6 @@ class WordNetCorpusReader(CorpusReader):
         >>> print(wn.synset_from_pos_and_offset('n', 1740))
         Synset('entity.n.01')
         """
-
         # Check to see if the synset is in the cache
         if offset in self._synset_offset_cache[pos]:
             return self._synset_offset_cache[pos][offset]


### PR DESCRIPTION
This PR fixes #2984 so that, when a wordsense has been lost in a wordnet mapping, the remaining senses of the word can still be retrieved. For ex: instead of raising a fatal error, the following retrieves the French senses of 'perceptible' in WordNet 3.1:

> from nltk.corpus import wordnet31 as wn
> print(wn.synsets('perceptible', lang='fra'))

[Synset('detectable.s.02'), Synset('None'), Synset('perceptible.a.01')]