### PR TITLE
Fix synset_from_sense_key() (#2442)

### DIFF
--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -1705,7 +1705,7 @@ class WordNetCorpusReader(CorpusReader):
         >>> print(wn.synset_from_sense_key("driving%1:04:03::"))
         Synset('drive.n.06')
         """
-        return lemma_from_key(self, key).synset()
+        return self.lemma_from_key(sense_key).synset()
 
     #############################################################
     # Retrieve synsets and lemmas.

--- a/nltk/test/wordnet.doctest
+++ b/nltk/test/wordnet.doctest
@@ -129,6 +129,11 @@ in NLTK:
     >>> wn.synset_from_pos_and_offset('n', 4543158)
     Synset('wagon.n.01')
 
+Likewise, instantiate a synset from a known sense key:
+    >>> wn.synset_from_sense_key("driving%1:04:03::")
+    Synset('drive.n.06')
+
+
 ------
 Lemmas
 ------


### PR DESCRIPTION
Fix #2442, #2420, #2219 and #2171 by reverting to the synset_from_sense_key() implementation from #2621.

```
from nltk.corpus import wordnet as wn
print(wn.synset_from_sense_key("first%5:00:00:ordinal:00"))
```

> Synset('first.s.02')

_Explanation_: PR #2621 originally fixed sense_key-related problems (#2420, #2171, plus #2219 and #2442). 
But #2889 has inadvertently introduced a non-functional version of synset_from_sense_key(). This problem could have been discovered earlier by running the tests embedded in the documentation string of synset_from_sense_key().
