### PR TITLE
Fix some tests in Wordnet-related DocStrings

### DIFF
--- a/nltk/corpus/reader/sentiwordnet.py
+++ b/nltk/corpus/reader/sentiwordnet.py
@@ -19,12 +19,12 @@ http://sentiwordnet.isti.cnr.it/
     >>> print(swn.senti_synset('breakdown.n.03'))
     <breakdown.n.03: PosScore=0.0 NegScore=0.25>
     >>> list(swn.senti_synsets('slow'))
-    [SentiSynset('decelerate.v.01'), SentiSynset('slow.v.02'),
-    SentiSynset('slow.v.03'), SentiSynset('slow.a.01'),
-    SentiSynset('slow.a.02'), SentiSynset('dense.s.04'),
-    SentiSynset('slow.a.04'), SentiSynset('boring.s.01'),
-    SentiSynset('dull.s.08'), SentiSynset('slowly.r.01'),
-    SentiSynset('behind.r.03')]
+    [SentiSynset('decelerate.v.01'), SentiSynset('slow.v.02'),\
+ SentiSynset('slow.v.03'), SentiSynset('slow.a.01'),\
+ SentiSynset('slow.a.02'), SentiSynset('dense.s.04'),\
+ SentiSynset('slow.a.04'), SentiSynset('boring.s.01'),\
+ SentiSynset('dull.s.08'), SentiSynset('slowly.r.01'),\
+ SentiSynset('behind.r.03')]
     >>> happy = swn.senti_synsets('happy', 'a')
     >>> happy0 = list(happy)[0]
     >>> happy0.pos_score()

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -585,11 +585,11 @@ class Synset(_WordNetObject):
         >>> dog = wn.synset('dog.n.01')
         >>> hyp = lambda s:s.hypernyms()
         >>> print(list(dog.closure(hyp)))
-        [Synset('canine.n.02'), Synset('domestic_animal.n.01'), Synset('carnivore.n.01'),
-        Synset('animal.n.01'), Synset('placental.n.01'), Synset('organism.n.01'),
-        Synset('mammal.n.01'), Synset('living_thing.n.01'), Synset('vertebrate.n.01'),
-        Synset('whole.n.02'), Synset('chordate.n.01'), Synset('object.n.01'),
-        Synset('physical_entity.n.01'), Synset('entity.n.01')]
+        [Synset('canine.n.02'), Synset('domestic_animal.n.01'), Synset('carnivore.n.01'),\
+ Synset('animal.n.01'), Synset('placental.n.01'), Synset('organism.n.01'),\
+ Synset('mammal.n.01'), Synset('living_thing.n.01'), Synset('vertebrate.n.01'),\
+ Synset('whole.n.02'), Synset('chordate.n.01'), Synset('object.n.01'),\
+ Synset('physical_entity.n.01'), Synset('entity.n.01')]
 
         UserWarning: Discarded redundant search for Synset('animal.n.01') at depth 7
         """
@@ -2235,24 +2235,23 @@ class WordNetCorpusReader(CorpusReader):
         >>> from nltk.corpus import wordnet as wn
         >>> print(wn.digraph([wn.synset('dog.n.01')]))
         digraph G {
-        "Synset('dog.n.01')" -> "Synset('domestic_animal.n.01')";
-        "Synset('organism.n.01')" -> "Synset('living_thing.n.01')";
-        "Synset('mammal.n.01')" -> "Synset('vertebrate.n.01')";
-        "Synset('placental.n.01')" -> "Synset('mammal.n.01')";
         "Synset('animal.n.01')" -> "Synset('organism.n.01')";
-        "Synset('vertebrate.n.01')" -> "Synset('chordate.n.01')";
-        "Synset('chordate.n.01')" -> "Synset('animal.n.01')";
         "Synset('canine.n.02')" -> "Synset('carnivore.n.01')";
-        "Synset('living_thing.n.01')" -> "Synset('whole.n.02')";
-        "Synset('physical_entity.n.01')" -> "Synset('entity.n.01')";
         "Synset('carnivore.n.01')" -> "Synset('placental.n.01')";
-        "Synset('object.n.01')" -> "Synset('physical_entity.n.01')";
-        "Synset('whole.n.02')" -> "Synset('object.n.01')";
+        "Synset('chordate.n.01')" -> "Synset('animal.n.01')";
         "Synset('dog.n.01')" -> "Synset('canine.n.02')";
+        "Synset('dog.n.01')" -> "Synset('domestic_animal.n.01')";
         "Synset('domestic_animal.n.01')" -> "Synset('animal.n.01')";
+        "Synset('living_thing.n.01')" -> "Synset('whole.n.02')";
+        "Synset('mammal.n.01')" -> "Synset('vertebrate.n.01')";
+        "Synset('object.n.01')" -> "Synset('physical_entity.n.01')";
+        "Synset('organism.n.01')" -> "Synset('living_thing.n.01')";
+        "Synset('physical_entity.n.01')" -> "Synset('entity.n.01')";
+        "Synset('placental.n.01')" -> "Synset('mammal.n.01')";
+        "Synset('vertebrate.n.01')" -> "Synset('chordate.n.01')";
+        "Synset('whole.n.02')" -> "Synset('object.n.01')";
         }
-
-
+        <BLANKLINE>
         """
         from nltk.util import edge_closure, edges2dot
 
@@ -2280,7 +2279,7 @@ class WordNetCorpusReader(CorpusReader):
 
         for ss in synsets:
             edges = edges.union(edge_closure(ss, rel, maxdepth, verbose))
-        dot_string = edges2dot(edges, shapes=shapes, attr=attr)
+        dot_string = edges2dot(sorted(list(edges)), shapes=shapes, attr=attr)
         return dot_string
 
 

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -276,6 +276,7 @@ def edges2dot(edges, shapes=None, attr=None):
     "B" -> "C";
     "C" -> "B";
     }
+    <BLANKLINE>
     """
     if not shapes:
         shapes = dict()
@@ -324,7 +325,7 @@ def unweighted_minimum_spanning_digraph(tree, children=iter, shapes=None, attr=N
     "Synset('unfree.a.02')" -> "Synset('restricted.a.01')";
     "Synset('restricted.a.01')" -> "Synset('classified.a.02')";
     }
-
+    <BLANKLINE>
     """
     return edges2dot(
         edge_closure(


### PR DESCRIPTION
Solve all the cosmetic Wordnet-related test failures mentioned in #2989. This leaves only two real test failures in wordnet.py, namely the ones solved in #2988.