### PR TITLE
Add json "strict" parameter to CoreNLP

### DIFF
--- a/nltk/parse/corenlp.py
+++ b/nltk/parse/corenlp.py
@@ -48,6 +48,7 @@ class CoreNLPServer:
         java_options=None,
         corenlp_options=None,
         port=None,
+        strict_json=True,
     ):
 
         if corenlp_options is None:
@@ -98,6 +99,7 @@ class CoreNLPServer:
 
         self.corenlp_options = corenlp_options
         self.java_options = java_options or ["-mx2g"]
+        self.strict_json = strict_json
 
     def start(self, stdout="devnull", stderr="devnull"):
         """Starts the CoreNLP server
@@ -246,7 +248,7 @@ class GenericCoreNLPParser(ParserI, TokenizerI, TaggerI):
 
         response.raise_for_status()
 
-        return response.json()
+        return response.json(strict=self.strict_json)
 
     def raw_parse_sents(
         self, sentences, verbose=False, properties=None, *args, **kwargs


### PR DESCRIPTION
This allows the (optional) processing of text control characters without raising errors.


Attempting to process text with control characters like the vertical tab `\x0b`/`\v` causes the following error:

```
from nltk.parse.corenlp import CoreNLPParser
CORENLP_PARSER = CoreNLPParser(url='http://localhost:9000/')

CORENLP_PARSER.api_call(
    'Hello\x0bWorld!',
    properties={
        'annotators': 'ssplit',
        'tokenize.language': 'en',
    }
)

# JSONDecodeError
# Invalid control character at: line x column y (char z)
```

A simple fix to this is to allow processing of text that does not follow strict json specs. 
This is done by passing `strict=False`. 

CoreNLP deals in strings and doesn't really care about the json specs. 
The commit currently maintains backwards compatibility. 
Maybe there is even an argument made to make the default non-strict?

[1] https://docs.python-requests.org/en/latest/api/#requests.Response.json
[2] https://docs.python.org/3/library/json.html#json.loads
[3] https://docs.python.org/3/library/json.html#json.JSONDecoder

