### PR TITLE
Make Wordnet information_content() accept adjective satellites

### DIFF
--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -2420,8 +2420,8 @@ def _lcs_ic(synset1, synset2, ic, verbose=False):
 
 def information_content(synset, ic):
     pos = synset._pos
-    if pos == "s":
-        pos = "a"
+    if pos == ADJ_SAT:
+        pos = ADJ
     try:
         icpos = ic[pos]
     except KeyError as e:

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -2419,11 +2419,14 @@ def _lcs_ic(synset1, synset2, ic, verbose=False):
 
 
 def information_content(synset, ic):
+    pos = synset._pos
+    if pos == "s":
+        pos = "a"
     try:
-        icpos = ic[synset._pos]
+        icpos = ic[pos]
     except KeyError as e:
         msg = "Information content file has no entries for part-of-speech: %s"
-        raise WordNetError(msg % synset._pos) from e
+        raise WordNetError(msg % pos) from e
 
     counts = icpos[synset._offset]
     if counts == 0:


### PR DESCRIPTION
Fix https://github.com/nltk/nltk_data/issues/185, so that the Wordnet information_content() function can handle adjective satellites:

>import itertools
from nltk.corpus import wordnet as wn
from nltk.corpus import genesis
genesis_ic = wn.ic(genesis, False, 0.0)
synsets = wn.synsets("daily", pos=wn.ADJ)
print(synsets)

[Synset('daily.s.01'), Synset('casual.s.03')]

>print([(i,i[0].res_similarity(i[1],genesis_ic)) for i in itertools.product(synsets,synsets)])

[((Synset('daily.s.01'), Synset('daily.s.01')), 1e+300), ((Synset('daily.s.01'), Synset('casual.s.03')), 0), ((Synset('casual.s.03'), Synset('daily.s.01')), 0), ((Synset('casual.s.03'), Synset('casual.s.03')), 1e+300)]
