### PR TITLE
Update skolemize.py

### DIFF
--- a/nltk/sem/nd.py
+++ b/nltk/sem/nd.py
@@ -102,12 +102,12 @@ def get_basic_assumptions(expression):
                     var_all = var
                 else:
                     expr_ = ExistsExpression(var_, expr_)
-            basic_assumptions.add(- AllExpression(var_all, expr_))
+            basic_assumptions.add(-AllExpression(var_all, expr_))
         basic_assumptions.add(ExistsExpression(var_all, expr_))
 
     cond = conjunctive_form(basic_assumptions)
     for x in basic_assumptions:
-        assert(not prove(ImpExpression(cond, -x)))
+        assert not prove(ImpExpression(cond, -x))
 
     return cond
 

--- a/nltk/sem/nd.py
+++ b/nltk/sem/nd.py
@@ -110,5 +110,3 @@ def get_basic_assumptions(expression):
         assert not prove(ImpExpression(cond, -x))
 
     return cond
-
-

--- a/nltk/sem/nd.py
+++ b/nltk/sem/nd.py
@@ -1,0 +1,114 @@
+from nltk.sem.logic import (
+    AllExpression,
+    AndExpression,
+    ApplicationExpression,
+    EqualityExpression,
+    ExistsExpression,
+    IffExpression,
+    ImpExpression,
+    NegatedExpression,
+    OrExpression,
+    VariableExpression,
+)
+
+
+def conjunctive_form(expressions):
+    if len(expressions) == 1:
+        return expressions.pop()
+    else:
+        return expressions.pop() & conjunctive_form(expressions)
+
+
+def disjunctive_form(expressions):
+    if len(expressions) == 1:
+        return expressions.pop()
+    else:
+        return expressions.pop() | disjunctive_form(expressions)
+
+
+def commuted_items(expression):
+    if isinstance(expression, AndExpression) or isinstance(expression, OrExpression):
+        expression.second = to_sorted(expression.second)
+        if isinstance(expression.first, expression.__class__):
+            items = commuted_items(expression.first)
+            items.append(expression.second)
+        else:
+            items = [to_sorted(expression.first), expression.second]
+
+    return sorted(set(items), key=lambda x: x.__str__())
+
+
+def to_sorted(expression):
+    if isinstance(expression, AndExpression):
+        return conjunctive_form(commuted_items(expression))
+    elif isinstance(expression, OrExpression):
+        return disjunctive_form(commuted_items(expression))
+    elif isinstance(expression, ApplicationExpression) or isinstance(
+        expression, EqualityExpression
+    ):
+        return expression
+    else:
+        expression.term = to_sorted(expression.term)
+        return expression
+
+
+import itertools
+
+
+def conj_elim(expression):
+    _, form, tree = expression.__reduce__()
+    tree = tree.copy()
+    if "term" in tree:
+        for term in conj_elim(tree["term"]):
+            tree["term"] = term
+            yield form[0](**tree)
+    elif "first" in tree:
+        firsts = conj_elim(tree["first"])
+        seconds = conj_elim(tree["second"])
+        firsts, firsts_ = itertools.tee(firsts)
+        for first in firsts_:
+            seconds, seconds_ = itertools.tee(seconds)
+            for second in seconds_:
+                tree["first"] = first
+                tree["second"] = second
+                yield form[0](**tree)
+        if isinstance(expression, AndExpression):
+            yield from firsts
+            yield from seconds
+    else:
+        yield expression
+
+
+def atomics(expression):
+    if hasattr(expression, "term"):
+        yield from atomics(expression.term)
+    elif hasattr(expression, "first"):
+        yield from atomics(expression.first)
+        yield from atomics(expression.second)
+    else:
+        yield expression
+
+
+def get_basic_assumptions(expression):
+    basic_assumptions = set()
+    atoms = set(atomics(expression))
+
+    for expr in atoms:
+        vars = expr.variables()
+        for var in vars:
+            expr_ = expr
+            for var_ in vars:
+                if var_ == var:
+                    var_all = var
+                else:
+                    expr_ = ExistsExpression(var_, expr_)
+            basic_assumptions.add(- AllExpression(var_all, expr_))
+        basic_assumptions.add(ExistsExpression(var_all, expr_))
+
+    cond = conjunctive_form(basic_assumptions)
+    for x in basic_assumptions:
+        assert(not prove(ImpExpression(cond, -x)))
+
+    return cond
+
+

--- a/nltk/sem/nd.py
+++ b/nltk/sem/nd.py
@@ -86,7 +86,8 @@ def atomics(expression):
         yield from atomics(expression.first)
         yield from atomics(expression.second)
     else:
-        yield expression
+        if isinstance(expression, ApplicationExpression):
+            yield expression
 
 
 def get_basic_assumptions(expression):

--- a/nltk/sem/skolemize.py
+++ b/nltk/sem/skolemize.py
@@ -276,7 +276,7 @@ def commuted_items(expression):
         else:
             items = [to_sorted(expression.first), expression.second]
 
-    return sorted(set(items), key = lambda x: x.__str__())
+    return sorted(set(items), key=lambda x: x.__str__())
 
 
 def to_sorted(expression):

--- a/nltk/sem/skolemize.py
+++ b/nltk/sem/skolemize.py
@@ -307,16 +307,15 @@ def conj_elim(expression):
     elif "first" in tree:
         firsts = conj_elim(tree["first"])
         seconds = conj_elim(tree["second"])
-        for first in firsts:
+        firsts, firsts_ = itertools.tee(firsts)
+        for first in firsts_:
             seconds, seconds_ = itertools.tee(seconds)
             for second in seconds_:
                 tree["first"] = first
                 tree["second"] = second
                 yield form[0](**tree)
         if isinstance(expression, AndExpression):
-            firsts, firsts_ = itertools.tee(firsts)
-            yield from firsts_
-            seconds, seconds_ = itertools.tee(seconds)
-            yield from seconds_
+            yield from firsts
+            yield from seconds
     else:
         yield expression

--- a/nltk/sem/skolemize.py
+++ b/nltk/sem/skolemize.py
@@ -270,6 +270,7 @@ def disjunctive_form(expressions):
 
 def commuted_items(expression):
     if isinstance(expression, AndExpression) or isinstance(expression, OrExpression):
+        expression.second = to_sorted(expression.second)
         if isinstance(expression.first, expression.__class__):
             items = commuted_items(expression.first)
             items.append(expression.second)

--- a/nltk/sem/skolemize.py
+++ b/nltk/sem/skolemize.py
@@ -132,6 +132,119 @@ def skolemize(expression, univ_scope=None, used_variables=None):
         raise Exception("'%s' cannot be skolemized" % expression)
 
 
+def richardize(expression, univ_scope=None, used_variables=None):
+    """
+    richardize? the expression and convert to a simplest equivalent form FOL
+    """
+    if univ_scope is None:
+        univ_scope = set()
+    if used_variables is None:
+        used_variables = set()
+
+    if isinstance(expression, AllExpression):
+        term = richardize(
+            expression.term,
+            univ_scope | {expression.variable},
+            used_variables | {expression.variable},
+        )
+        return AllExpression(expression.variable, term)
+        # term.replace(
+        #     expression.variable,
+        #     VariableExpression(unique_variable(ignore=used_variables)),
+        # )
+    elif isinstance(expression, AndExpression):
+        return richardize(expression.first, univ_scope, used_variables) & richardize(
+            expression.second, univ_scope, used_variables
+        )
+    elif isinstance(expression, OrExpression):
+        return to_cnf(
+            richardize(expression.first, univ_scope, used_variables),
+            richardize(expression.second, univ_scope, used_variables),
+        )
+    elif isinstance(expression, ImpExpression):
+        return to_cnf(
+            richardize(-expression.first, univ_scope, used_variables),
+            richardize(expression.second, univ_scope, used_variables),
+        )
+    elif isinstance(expression, IffExpression):
+        return to_cnf(
+            richardize(-expression.first, univ_scope, used_variables),
+            richardize(expression.second, univ_scope, used_variables),
+        ) & to_cnf(
+            richardize(expression.first, univ_scope, used_variables),
+            richardize(-expression.second, univ_scope, used_variables),
+        )
+    elif isinstance(expression, EqualityExpression):
+        return expression
+    elif isinstance(expression, NegatedExpression):
+        negated = expression.term
+        if isinstance(negated, AllExpression):
+            term = richardize(
+                -negated.term, univ_scope, used_variables | {negated.variable}
+            )
+            if univ_scope:
+                return term.replace(negated.variable, skolem_function(univ_scope))
+            else:
+                # skolem_constant = VariableExpression(
+                #     unique_variable(ignore=used_variables)
+                # )
+                return ExistsExpression(negated.variable, term)#.replace(negated.variable, skolem_constant)
+        elif isinstance(negated, AndExpression):
+            return to_cnf(
+                richardize(-negated.first, univ_scope, used_variables),
+                richardize(-negated.second, univ_scope, used_variables),
+            )
+        elif isinstance(negated, OrExpression):
+            return richardize(-negated.first, univ_scope, used_variables) & richardize(
+                -negated.second, univ_scope, used_variables
+            )
+        elif isinstance(negated, ImpExpression):
+            return richardize(negated.first, univ_scope, used_variables) & richardize(
+                -negated.second, univ_scope, used_variables
+            )
+        elif isinstance(negated, IffExpression):
+            return to_cnf(
+                richardize(-negated.first, univ_scope, used_variables),
+                richardize(-negated.second, univ_scope, used_variables),
+            ) & to_cnf(
+                richardize(negated.first, univ_scope, used_variables),
+                richardize(negated.second, univ_scope, used_variables),
+            )
+        elif isinstance(negated, EqualityExpression):
+            return expression
+        elif isinstance(negated, NegatedExpression):
+            return richardize(negated.term, univ_scope, used_variables)
+        elif isinstance(negated, ExistsExpression):
+            term = richardize(
+                -negated.term,
+                univ_scope | {negated.variable},
+                used_variables | {negated.variable},
+            )
+            return AllExpression(negated.variable, term)
+            # term.replace(
+            #     negated.variable,
+            #     VariableExpression(unique_variable(ignore=used_variables)),
+            # )
+        elif isinstance(negated, ApplicationExpression):
+            return expression
+        else:
+            raise Exception("'%s' cannot be richardized" % expression)
+    elif isinstance(expression, ExistsExpression):
+        term = richardize(
+            expression.term, univ_scope, used_variables | {expression.variable}
+        )
+        if univ_scope:
+            return term.replace(expression.variable, skolem_function(univ_scope))
+        else:
+            return ExistsExpression(expression.variable, term)
+            # skolem_constant = VariableExpression(unique_variable(ignore=used_variables))
+            # return term.replace(expression.variable, skolem_constant)
+    elif isinstance(expression, ApplicationExpression):
+        return expression
+    else:
+        raise Exception("'%s' cannot be richardized" % expression)
+
+        
 def to_cnf(first, second):
     """
     Convert this split disjunction to conjunctive normal form (CNF)

--- a/nltk/sem/skolemize.py
+++ b/nltk/sem/skolemize.py
@@ -285,7 +285,7 @@ def to_sorted(expression):
         return conjunctive_form(commuted_items(expression))
     elif isinstance(expression, OrExpression):
         return disjunctive_form(commuted_items(expression))
-    elif isinstance(expression, ApplicationExpression):
+    elif isinstance(expression, ApplicationExpression) or isinstance(expression, EqualityExpression):
         return expression
     else:
         expression.term = to_sorted(expression.term)

--- a/nltk/sem/skolemize.py
+++ b/nltk/sem/skolemize.py
@@ -307,16 +307,16 @@ def conj_elim(expression):
     elif "first" in tree:
         firsts = conj_elim(tree["first"])
         seconds = conj_elim(tree["second"])
-        if isinstance(expression, AndExpression):
-            firsts, firsts_ = itertools.tee(firsts)
-            yield from firsts_
-            seconds, seconds_ = itertools.tee(seconds)
-            yield from seconds_
         for first in firsts:
             seconds, seconds_ = itertools.tee(seconds)
             for second in seconds_:
                 tree["first"] = first
                 tree["second"] = second
                 yield form[0](**tree)
+        if isinstance(expression, AndExpression):
+            firsts, firsts_ = itertools.tee(firsts)
+            yield from firsts_
+            seconds, seconds_ = itertools.tee(seconds)
+            yield from seconds_
     else:
         yield expression

--- a/nltk/sem/skolemize.py
+++ b/nltk/sem/skolemize.py
@@ -147,7 +147,10 @@ def richardize(expression, univ_scope=None, used_variables=None):
             univ_scope | {expression.variable},
             used_variables | {expression.variable},
         )
-        return AllExpression(expression.variable, term)
+        if expression.variable in term.variables():
+            return AllExpression(expression.variable, term)
+        else:
+            return term
     elif isinstance(expression, AndExpression):
         return richardize(expression.first, univ_scope, used_variables) & richardize(
             expression.second, univ_scope, used_variables
@@ -178,7 +181,10 @@ def richardize(expression, univ_scope=None, used_variables=None):
             term = richardize(
                 -negated.term, univ_scope, used_variables | {negated.variable}
             )
-            return ExistsExpression(negated.variable, term)
+            if negated.variable in term.variables():
+                return ExistsExpression(negated.variable, term)
+            else:
+                return term
         elif isinstance(negated, AndExpression):
             return to_cnf(
                 richardize(-negated.first, univ_scope, used_variables),
@@ -210,7 +216,10 @@ def richardize(expression, univ_scope=None, used_variables=None):
                 univ_scope | {negated.variable},
                 used_variables | {negated.variable},
             )
-            return AllExpression(negated.variable, term)
+            if negated.variable in term.variables():
+                return AllExpression(negated.variable, term)
+            else:
+                return term
         elif isinstance(negated, ApplicationExpression):
             return expression
         else:
@@ -219,7 +228,10 @@ def richardize(expression, univ_scope=None, used_variables=None):
         term = richardize(
             expression.term, univ_scope, used_variables | {expression.variable}
         )
-        return ExistsExpression(expression.variable, term)
+        if expression.variable in term.variables():
+            return ExistsExpression(expression.variable, term)
+        else:
+            return term
     elif isinstance(expression, ApplicationExpression):
         return expression
     else:

--- a/nltk/sem/skolemize.py
+++ b/nltk/sem/skolemize.py
@@ -253,21 +253,21 @@ def to_cnf(first, second):
     else:
         return first | second
 
-    
+
 def conjunctive_form(expressions):
     if len(expressions) == 1:
         return expressions.pop()
     else:
         return expressions.pop() & conjunctive_form(expressions)
 
-    
+
 def disjunctive_form(expressions):
     if len(expressions) == 1:
         return expressions.pop()
     else:
         return expressions.pop() | disjunctive_form(expressions)
 
-    
+
 def commuted_items(expression):
     if isinstance(expression, AndExpression) or isinstance(expression, OrExpression):
         if isinstance(expression.first, expression.__class__):

--- a/nltk/sem/skolemize.py
+++ b/nltk/sem/skolemize.py
@@ -285,24 +285,28 @@ def to_sorted(expression):
         return conjunctive_form(commuted_items(expression))
     elif isinstance(expression, OrExpression):
         return disjunctive_form(commuted_items(expression))
-    elif isinstance(expression, ApplicationExpression) or isinstance(expression, EqualityExpression):
+    elif isinstance(expression, ApplicationExpression) or isinstance(
+        expression, EqualityExpression
+    ):
         return expression
     else:
         expression.term = to_sorted(expression.term)
         return expression
 
+
 import itertools
+
 
 def conj_elim(expression):
     _, form, tree = expression.__reduce__()
     tree = tree.copy()
-    if 'term' in tree:
-        for term in conj_elim(tree['term']):
-            tree['term'] = term
+    if "term" in tree:
+        for term in conj_elim(tree["term"]):
+            tree["term"] = term
             yield form[0](**tree)
-    elif 'first' in tree:
-        firsts = conj_elim(tree['first'])
-        seconds = conj_elim(tree['second'])
+    elif "first" in tree:
+        firsts = conj_elim(tree["first"])
+        seconds = conj_elim(tree["second"])
         if isinstance(expression, AndExpression):
             firsts, firsts_ = itertools.tee(firsts)
             yield from firsts_
@@ -311,8 +315,8 @@ def conj_elim(expression):
         for first in firsts:
             seconds, seconds_ = itertools.tee(seconds)
             for second in seconds_:
-                tree['first'] = first
-                tree['second'] = second
+                tree["first"] = first
+                tree["second"] = second
                 yield form[0](**tree)
     else:
         yield expression

--- a/nltk/sem/skolemize.py
+++ b/nltk/sem/skolemize.py
@@ -148,10 +148,6 @@ def richardize(expression, univ_scope=None, used_variables=None):
             used_variables | {expression.variable},
         )
         return AllExpression(expression.variable, term)
-        # term.replace(
-        #     expression.variable,
-        #     VariableExpression(unique_variable(ignore=used_variables)),
-        # )
     elif isinstance(expression, AndExpression):
         return richardize(expression.first, univ_scope, used_variables) & richardize(
             expression.second, univ_scope, used_variables
@@ -185,10 +181,7 @@ def richardize(expression, univ_scope=None, used_variables=None):
             if univ_scope:
                 return term.replace(negated.variable, skolem_function(univ_scope))
             else:
-                # skolem_constant = VariableExpression(
-                #     unique_variable(ignore=used_variables)
-                # )
-                return ExistsExpression(negated.variable, term)#.replace(negated.variable, skolem_constant)
+                return ExistsExpression(negated.variable, term)
         elif isinstance(negated, AndExpression):
             return to_cnf(
                 richardize(-negated.first, univ_scope, used_variables),
@@ -221,10 +214,6 @@ def richardize(expression, univ_scope=None, used_variables=None):
                 used_variables | {negated.variable},
             )
             return AllExpression(negated.variable, term)
-            # term.replace(
-            #     negated.variable,
-            #     VariableExpression(unique_variable(ignore=used_variables)),
-            # )
         elif isinstance(negated, ApplicationExpression):
             return expression
         else:
@@ -237,8 +226,6 @@ def richardize(expression, univ_scope=None, used_variables=None):
             return term.replace(expression.variable, skolem_function(univ_scope))
         else:
             return ExistsExpression(expression.variable, term)
-            # skolem_constant = VariableExpression(unique_variable(ignore=used_variables))
-            # return term.replace(expression.variable, skolem_constant)
     elif isinstance(expression, ApplicationExpression):
         return expression
     else:

--- a/nltk/sem/skolemize.py
+++ b/nltk/sem/skolemize.py
@@ -178,10 +178,7 @@ def richardize(expression, univ_scope=None, used_variables=None):
             term = richardize(
                 -negated.term, univ_scope, used_variables | {negated.variable}
             )
-            if univ_scope:
-                return term.replace(negated.variable, skolem_function(univ_scope))
-            else:
-                return ExistsExpression(negated.variable, term)
+            return ExistsExpression(negated.variable, term)
         elif isinstance(negated, AndExpression):
             return to_cnf(
                 richardize(-negated.first, univ_scope, used_variables),
@@ -222,10 +219,7 @@ def richardize(expression, univ_scope=None, used_variables=None):
         term = richardize(
             expression.term, univ_scope, used_variables | {expression.variable}
         )
-        if univ_scope:
-            return term.replace(expression.variable, skolem_function(univ_scope))
-        else:
-            return ExistsExpression(expression.variable, term)
+        return ExistsExpression(expression.variable, term)
     elif isinstance(expression, ApplicationExpression):
         return expression
     else:

--- a/nltk/sem/skolemize.py
+++ b/nltk/sem/skolemize.py
@@ -252,3 +252,36 @@ def to_cnf(first, second):
         return r_first & r_second
     else:
         return first | second
+
+def conjunctive_form(expressions):
+    if len(expressions) == 1:
+        return expressions.pop()
+    else:
+        return expressions.pop() & conjunctive_form(expressions)
+
+def disjunctive_form(expressions):
+	if len(expressions) == 1:
+		return expressions.pop()
+	else:
+		return expressions.pop() | disjunctive_form(expressions)
+
+def commuted_items(expression):
+	if isinstance(expression, AndExpression) or isinstance(expression, OrExpression):
+		if isinstance(expression.first, expression.__class__):
+			items = commuted_items(expression.first)
+			items.append(expression.second)
+		else:
+			items = [to_sorted(expression.first), expression.second]
+
+	return sorted(set(items), key = lambda x: x.__str__())
+
+def to_sorted(expression):
+	if isinstance(expression, AndExpression):
+		return conjunctive_form(commuted_items(expression))
+	elif isinstance(expression, OrExpression):
+		return disjunctive_form(commuted_items(expression))
+	elif isinstance(expression, ApplicationExpression):
+		return expression
+	else:
+		expression.term = to_sorted(expression.term)
+		return expression

--- a/nltk/sem/skolemize.py
+++ b/nltk/sem/skolemize.py
@@ -231,7 +231,7 @@ def richardize(expression, univ_scope=None, used_variables=None):
     else:
         raise Exception("'%s' cannot be richardized" % expression)
 
-        
+
 def to_cnf(first, second):
     """
     Convert this split disjunction to conjunctive normal form (CNF)

--- a/nltk/sem/skolemize.py
+++ b/nltk/sem/skolemize.py
@@ -253,35 +253,39 @@ def to_cnf(first, second):
     else:
         return first | second
 
+    
 def conjunctive_form(expressions):
     if len(expressions) == 1:
         return expressions.pop()
     else:
         return expressions.pop() & conjunctive_form(expressions)
 
+    
 def disjunctive_form(expressions):
-	if len(expressions) == 1:
-		return expressions.pop()
-	else:
-		return expressions.pop() | disjunctive_form(expressions)
+    if len(expressions) == 1:
+        return expressions.pop()
+    else:
+        return expressions.pop() | disjunctive_form(expressions)
 
+    
 def commuted_items(expression):
-	if isinstance(expression, AndExpression) or isinstance(expression, OrExpression):
-		if isinstance(expression.first, expression.__class__):
-			items = commuted_items(expression.first)
-			items.append(expression.second)
-		else:
-			items = [to_sorted(expression.first), expression.second]
+    if isinstance(expression, AndExpression) or isinstance(expression, OrExpression):
+        if isinstance(expression.first, expression.__class__):
+            items = commuted_items(expression.first)
+            items.append(expression.second)
+        else:
+            items = [to_sorted(expression.first), expression.second]
 
-	return sorted(set(items), key = lambda x: x.__str__())
+    return sorted(set(items), key = lambda x: x.__str__())
+
 
 def to_sorted(expression):
-	if isinstance(expression, AndExpression):
-		return conjunctive_form(commuted_items(expression))
-	elif isinstance(expression, OrExpression):
-		return disjunctive_form(commuted_items(expression))
-	elif isinstance(expression, ApplicationExpression):
-		return expression
-	else:
-		expression.term = to_sorted(expression.term)
-		return expression
+    if isinstance(expression, AndExpression):
+        return conjunctive_form(commuted_items(expression))
+    elif isinstance(expression, OrExpression):
+        return disjunctive_form(commuted_items(expression))
+    elif isinstance(expression, ApplicationExpression):
+        return expression
+    else:
+        expression.term = to_sorted(expression.term)
+        return expression


### PR DESCRIPTION
add a function, `richardize `(just a name trying to make it not confused with `simplify` or `__reduce__` ), modified from `skolemize`.

The function name does not represent any logician Richard, and maybe the NLTK maintenance party can choose a better name.
The new function changes minimum from `skolemize`, and instead conversion to CNF (which is not equivalent but equisatisfiable to the input FOL expression), `richardize(your_expr).equiv(your_expr)` will be True.

The motivation of this function is that I did not find `simplify`  to work in the way I wished, and for a pretty messy expression, _e.g._,  those with a lot of consecutive negations, the new function can make it neater.