### PR TITLE
Remove unnecessary sqlite code

### DIFF
--- a/nltk/sem/relextract.py
+++ b/nltk/sem/relextract.py
@@ -319,7 +319,6 @@ def in_demo(trace=0, sql=True):
             import sqlite3
 
             connection = sqlite3.connect(":memory:")
-            connection.text_factory = sqlite3.OptimizedUnicode
             cur = connection.cursor()
             cur.execute(
                 """create table Locations


### PR DESCRIPTION
`OptimizedUnicode` has been an alias for `str` since Python 3.2 and is scheduled for removal in Python 3.12. The default factory is already `str`, so the line wasn't doing anything.

See python/cpython#92547.