### PR TITLE
Tackle performance and accuracy regression of sentence tokenizer since NLTK 3.6.6

### DIFF
--- a/nltk/test/unit/test_tokenize.py
+++ b/nltk/test/unit/test_tokenize.py
@@ -13,6 +13,7 @@ from nltk.tokenize import (
     TreebankWordTokenizer,
     TweetTokenizer,
     punkt,
+    sent_tokenize,
     word_tokenize,
 )
 
@@ -809,3 +810,21 @@ class TestTokenize:
         )
         # The sentence should be split into two sections,
         # with one split and hence one decision.
+
+    @pytest.mark.parametrize(
+        "sentences, expected",
+        [
+            (
+                "this is a test. . new sentence.",
+                ["this is a test.", ".", "new sentence."],
+            ),
+            ("This... That", ["This... That"]),
+            ("This. . . That", ["This.", ".", ".", "That"]),
+            (
+                "1. This is R .\n2. This is A .\n3. That's all",
+                ["1.", "This is R .", "2.", "This is A .", "3.", "That's all"],
+            ),
+        ],
+    )
+    def test_sent_tokenize(self, sentences: str, expected: List[str]):
+        assert sent_tokenize(sentences) == expected

--- a/nltk/test/unit/test_tokenize.py
+++ b/nltk/test/unit/test_tokenize.py
@@ -818,12 +818,23 @@ class TestTokenize:
                 "this is a test. . new sentence.",
                 ["this is a test.", ".", "new sentence."],
             ),
-            ("This... That", ["This... That"]),
             ("This. . . That", ["This.", ".", ".", "That"]),
+            ("This..... That", ["This..... That"]),
+            ("This... That", ["This... That"]),
+            ("This.. . That", ["This.. .", "That"]),
+            ("This. .. That", ["This.", ".. That"]),
+            ("This. ,. That", ["This.", ",.", "That"]),
+            ("This!!! That", ["This!!!", "That"]),
+            ("This! That", ["This!", "That"]),
             (
                 "1. This is R .\n2. This is A .\n3. That's all",
                 ["1.", "This is R .", "2.", "This is A .", "3.", "That's all"],
             ),
+            (
+                "1. This is R .\t2. This is A .\t3. That's all",
+                ["1.", "This is R .", "2.", "This is A .", "3.", "That's all"],
+            ),
+            ("Hello.\tThere", ["Hello.", "There"]),
         ],
     )
     def test_sent_tokenize(self, sentences: str, expected: List[str]):

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -7,6 +7,7 @@
 #         Edward Loper <edloper@gmail.com> (rewrite)
 #         Joel Nothman <jnothman@student.usyd.edu.au> (almost rewrite)
 #         Arthur Darcet <arthur@darcet.fr> (fixes)
+#         Tom Aarsen <> (tackle ReDoS & performance issues)
 # URL: <https://www.nltk.org/>
 # For license information, see LICENSE.TXT
 
@@ -106,7 +107,9 @@ The algorithm for this tokenizer is described in::
 
 import math
 import re
+import string
 from collections import defaultdict
+from typing import Any, Dict, Iterator, List, Match, Optional, Tuple, Union
 
 from nltk.probability import FreqDist
 from nltk.tokenize.api import TokenizerI
@@ -578,7 +581,9 @@ class PunktBaseClass:
     # { Annotation Procedures
     # ////////////////////////////////////////////////////////////
 
-    def _annotate_first_pass(self, tokens):
+    def _annotate_first_pass(
+        self, tokens: Iterator[PunktToken]
+    ) -> Iterator[PunktToken]:
         """
         Perform the first pass of annotation, which makes decisions
         based purely based on the word type of each word:
@@ -599,7 +604,7 @@ class PunktBaseClass:
             self._first_pass_annotation(aug_tok)
             yield aug_tok
 
-    def _first_pass_annotation(self, aug_tok):
+    def _first_pass_annotation(self, aug_tok: PunktToken) -> None:
         """
         Performs type-based annotation on a single token.
         """
@@ -1269,13 +1274,13 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
     # { Tokenization
     # ////////////////////////////////////////////////////////////
 
-    def tokenize(self, text, realign_boundaries=True):
+    def tokenize(self, text: str, realign_boundaries: bool = True) -> List[str]:
         """
         Given a text, returns a list of the sentences in that text.
         """
         return list(self.sentences_from_text(text, realign_boundaries))
 
-    def debug_decisions(self, text):
+    def debug_decisions(self, text: str) -> Iterator[Dict[str, Any]]:
         """
         Classifies candidate periods as sentence breaks, yielding a dict for
         each that may be used to understand why the decision was made.
@@ -1311,7 +1316,9 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
                 "break_decision": tokens[0].sentbreak,
             }
 
-    def span_tokenize(self, text, realign_boundaries=True):
+    def span_tokenize(
+        self, text: str, realign_boundaries: bool = True
+    ) -> Iterator[Tuple[int, int]]:
         """
         Given a text, generates (start, end) spans of sentences
         in the text.
@@ -1322,7 +1329,9 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
         for sentence in slices:
             yield (sentence.start, sentence.stop)
 
-    def sentences_from_text(self, text, realign_boundaries=True):
+    def sentences_from_text(
+        self, text: str, realign_boundaries: bool = True
+    ) -> List[str]:
         """
         Given a text, generates the sentences in that text by only
         testing candidate sentence breaks. If realign_boundaries is
@@ -1331,7 +1340,18 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
         """
         return [text[s:e] for s, e in self.span_tokenize(text, realign_boundaries)]
 
-    def _match_potential_end_contexts(self, text):
+    def _get_last_whitespace_index(self, text: str) -> int:
+        """
+        Given a text, find the index of the *last* occurrence of *any*
+        whitespace character, i.e. " ", "\n", "\t", "\r", etc.
+        If none is found, return 0.
+        """
+        for i in range(len(text) - 1, -1, -1):
+            if text[i] in string.whitespace:
+                return i
+        return 0
+
+    def _match_potential_end_contexts(self, text: str) -> Iterator[Tuple[Match, str]]:
         """
         Given a text, find the matches of potential sentence breaks,
         alongside the contexts surrounding these sentence breaks.
@@ -1362,37 +1382,51 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
 
             >>> pst = PunktSentenceTokenizer()
             >>> text = "Very bad acting!!! I promise."
-            >>> pst._match_potential_end_contexts(text)
-            [(<re.Match object; span=(17, 18), match='!'>, 'acting!!! I')]
+            >>> list(pst._match_potential_end_contexts(text))
+            [(<re.Match object; span=(17, 18), match='!'>, 'Very bad acting!!! I')]
 
         :param text: String of one or more sentences
         :type text: str
         :return: List of match-context tuples.
         :rtype: List[Tuple[re.Match, str]]
         """
-        before_words = {}
-        matches = []
-        for match in reversed(list(self._lang_vars.period_context_re().finditer(text))):
-            # Ignore matches that have already been captured by matches to the right of this match
-            if matches and match.end() > before_start:
-                continue
-            # Find the word before the current match
-            split = text[: match.start()].rsplit(maxsplit=1)
-            before_start = len(split[0]) if len(split) == 2 else 0
-            before_words[match] = split[-1] if split else ""
-            matches.append(match)
+        previous_slice = slice(0, 0)
+        previous_match = None
+        for match in self._lang_vars.period_context_re().finditer(text):
 
-        return [
-            (
-                match,
-                before_words[match] + match.group() + match.group("after_tok"),
+            # Get the slice of the previous word
+            before_text = text[previous_slice.stop : match.start()]
+            last_space_index = self._get_last_whitespace_index(before_text)
+            if last_space_index:
+                last_space_index += previous_slice.stop
+            else:
+                last_space_index = previous_slice.start
+            prev_word_slice = slice(last_space_index, match.start())
+
+            # If the previous slice does not overlap with this slice, then
+            # we can yield it
+            if previous_match and previous_slice.stop <= prev_word_slice.start:
+                yield (
+                    previous_match,
+                    text[previous_slice]
+                    + previous_match.group()
+                    + previous_match.group("after_tok"),
+                )
+            previous_match = match
+            previous_slice = prev_word_slice
+
+        if previous_match:
+            yield (
+                previous_match,
+                text[previous_slice]
+                + previous_match.group()
+                + previous_match.group("after_tok"),
             )
-            for match in matches[::-1]
-        ]
 
-    def _slices_from_text(self, text):
+    def _slices_from_text(self, text: str) -> Iterator[slice]:
         last_break = 0
         for match, context in self._match_potential_end_contexts(text):
+            print(context)
             if self.text_contains_sentbreak(context):
                 yield slice(last_break, match.end())
                 if match.group("next_tok"):
@@ -1404,7 +1438,9 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
         # The last sentence should not contain trailing whitespace.
         yield slice(last_break, len(text.rstrip()))
 
-    def _realign_boundaries(self, text, slices):
+    def _realign_boundaries(
+        self, text: str, slices: Iterator[slice]
+    ) -> Iterator[slice]:
         """
         Attempts to realign punctuation that falls after the period but
         should otherwise be included in the same sentence.
@@ -1434,7 +1470,7 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
                 if text[sentence1]:
                     yield sentence1
 
-    def text_contains_sentbreak(self, text):
+    def text_contains_sentbreak(self, text: str) -> bool:
         """
         Returns True if the given text includes a sentence break.
         """
@@ -1446,7 +1482,7 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
                 found = True
         return False
 
-    def sentences_from_text_legacy(self, text):
+    def sentences_from_text_legacy(self, text: str) -> Iterator[str]:
         """
         Given a text, generates the sentences in that text. Annotates all
         tokens, rather than just those with possible sentence breaks. Should
@@ -1455,7 +1491,9 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
         tokens = self._annotate_tokens(self._tokenize_words(text))
         return self._build_sentence_list(text, tokens)
 
-    def sentences_from_tokens(self, tokens):
+    def sentences_from_tokens(
+        self, tokens: Iterator[PunktToken]
+    ) -> Iterator[PunktToken]:
         """
         Given a sequence of tokens, generates lists of tokens, each list
         corresponding to a sentence.
@@ -1470,7 +1508,7 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
         if sentence:
             yield sentence
 
-    def _annotate_tokens(self, tokens):
+    def _annotate_tokens(self, tokens: Iterator[PunktToken]) -> Iterator[PunktToken]:
         """
         Given a set of tokens augmented with markers for line-start and
         paragraph-start, returns an iterator through those tokens with full
@@ -1491,7 +1529,9 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
 
         return tokens
 
-    def _build_sentence_list(self, text, tokens):
+    def _build_sentence_list(
+        self, text: str, tokens: Iterator[PunktToken]
+    ) -> Iterator[str]:
         """
         Given the original text and the list of augmented word tokens,
         construct and return a tokenized list of sentence strings.
@@ -1546,7 +1586,7 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
             yield sentence
 
     # [XX] TESTING
-    def dump(self, tokens):
+    def dump(self, tokens: Iterator[PunktToken]) -> None:
         print("writing to /tmp/punkt.new...")
         with open("/tmp/punkt.new", "w") as outfile:
             for aug_tok in tokens:
@@ -1569,7 +1609,9 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
     # { Annotation Procedures
     # ////////////////////////////////////////////////////////////
 
-    def _annotate_second_pass(self, tokens):
+    def _annotate_second_pass(
+        self, tokens: Iterator[PunktToken]
+    ) -> Iterator[PunktToken]:
         """
         Performs a token-based classification (section 4) over the given
         tokens, making use of the orthographic heuristic (4.1.1), collocation
@@ -1579,7 +1621,9 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
             self._second_pass_annotation(token1, token2)
             yield token1
 
-    def _second_pass_annotation(self, aug_tok1, aug_tok2):
+    def _second_pass_annotation(
+        self, aug_tok1: PunktToken, aug_tok2: Optional[PunktToken]
+    ) -> Optional[str]:
         """
         Performs token-based classification over a pair of contiguous tokens
         updating the first.
@@ -1658,7 +1702,7 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
 
         return
 
-    def _ortho_heuristic(self, aug_tok):
+    def _ortho_heuristic(self, aug_tok: PunktToken) -> Union[bool, str]:
         """
         Decide whether the given token is the first token in a sentence.
         """

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -1426,7 +1426,6 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
     def _slices_from_text(self, text: str) -> Iterator[slice]:
         last_break = 0
         for match, context in self._match_potential_end_contexts(text):
-            print(context)
             if self.text_contains_sentbreak(context):
                 yield slice(last_break, match.end())
                 if match.group("next_tok"):

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -1383,12 +1383,12 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
             >>> pst = PunktSentenceTokenizer()
             >>> text = "Very bad acting!!! I promise."
             >>> list(pst._match_potential_end_contexts(text))
-            [(<re.Match object; span=(17, 18), match='!'>, 'Very bad acting!!! I')]
+            [(<re.Match object; span=(17, 18), match='!'>, 'acting!!! I')]
 
         :param text: String of one or more sentences
         :type text: str
-        :return: List of match-context tuples.
-        :rtype: List[Tuple[re.Match, str]]
+        :return: Generator of match-context tuples.
+        :rtype: Iterator[Tuple[Match, str]]
         """
         previous_slice = slice(0, 0)
         previous_match = None
@@ -1404,7 +1404,8 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
             prev_word_slice = slice(last_space_index, match.start())
 
             # If the previous slice does not overlap with this slice, then
-            # we can yield it
+            # we can yield the previous match and slice. If there is an overlap,
+            # then we do not yield the previous match and slice.
             if previous_match and previous_slice.stop <= prev_word_slice.start:
                 yield (
                     previous_match,
@@ -1415,6 +1416,7 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
             previous_match = match
             previous_slice = prev_word_slice
 
+        # Yield the last match and context, if it exists
         if previous_match:
             yield (
                 previous_match,


### PR DESCRIPTION
Resolves #3013, resolves #2981 and resolves #2934.

Hello!

## Pull request overview
* Improve accuracy of `sent_tokenize`, i.e. resolve issues from #2934.
* Improve time-efficiency of `sent_tokenize` (and the underlying PunktTokenizer), as reported by #3013.
* Consequently, improve efficiency of `word_tokenize` which relies on `sent_tokenize` whenever `preserve_line=False`. Issues with this performance were reported in #2981.
* Add test cases based on provided samples from #2934.
* Added type hinting to some `punkt.py` methods.

---

## Changes
The primary changes refer to a complete overhaul of the `_match_potential_end_contexts` method introduced in #2869. This method was introduced to combat a nasty ReDoS for long words, but it unknowingly introduced some other issues. For example, the `rsplit` in the following line removed the whitespace that it was splitting on, which caused `. .` to be parsed equivalently as `..` in some cases. 
https://github.com/nltk/nltk/blob/6de8254092a04b1d8f756ebade835393cbf44ffa/nltk/tokenize/punkt.py#L1380
Furthermore, the `text[: match.start()]` ends up being quite expensive with enormous strings. The new implementation also removes the need for fully computing this list in order to reverse it:
https://github.com/nltk/nltk/blob/6de8254092a04b1d8f756ebade835393cbf44ffa/nltk/tokenize/punkt.py#L1375
Now, we can simply iterate over the iterator like normal, which should also be more memory-efficient. 

## Experiments
### Accuracy
In the end, we're most interested in what effects these changes have. First of all, let's talk accuracy. The changes from NLTK 3.6.6 introduced some small issues, for which tests have been developed now:
```python
    @pytest.mark.parametrize(
        "sentences, expected",
        [
            (
                "this is a test. . new sentence.",
                ["this is a test.", ".", "new sentence."],
            ),
            ("This. . . That", ["This.", ".", ".", "That"]),
            ("This..... That", ["This..... That"]),
            ("This... That", ["This... That"]),
            ("This.. . That", ["This.. .", "That"]),
            ("This. .. That", ["This.", ".. That"]),
            ("This. ,. That", ["This.", ",.", "That"]),
            ("This!!! That", ["This!!!", "That"]),
            ("This! That", ["This!", "That"]),
            (
                "1. This is R .\n2. This is A .\n3. That's all",
                ["1.", "This is R .", "2.", "This is A .", "3.", "That's all"],
            ),
            (
                "1. This is R .\t2. This is A .\t3. That's all",
                ["1.", "This is R .", "2.", "This is A .", "3.", "That's all"],
            ),
            ("Hello.\tThere", ["Hello.", "There"]),
        ],
    )
    def test_sent_tokenize(self, sentences: str, expected: List[str]):
        assert sent_tokenize(sentences) == expected
```

Thank you @radcheb, @griverorz and @davidmezzetti for helping provide some of these previously broken test cases. As you can see via the CI, all of these tests pass now. These results correspond exactly with the results from NLTK 3.6.5 and before. Note that I'm open to receive more hand-crafted test cases!

I generated approximately 20k test cases combining different types of punctuation, out of which some of the new results still differ compared to NLTK 3.6.5 and before. However, these were all cases with two different types of sequential punctuation, like so:
```python
>>> nltk.__version__
'3.6.5'
>>> nltk.sent_tokenize(".!,?a")
['.', '!,?a']
>>> nltk.sent_tokenize(".!,? a")
['.!,?', 'a']
```
In 3.6.5, for some reason, adding a space before `a` causes the other punctuation marks to group together?
The new behaviour is:
```python
>>> nltk.sent_tokenize(".!,?a")
['.', '!,?a']
>>> nltk.sent_tokenize(".!,? a")
['.', '!,?', 'a']
```
This seems to be more consistent, but it's difficult to determine what the correct result should even be, in odd cases like these. In short, I have no issues with these tiny changes relative to NLTK 3.6.5 and before.

### Efficiency
As we recognize that NLTK is used for large text processing, efficiency is of high priority. I've ran some experiments to verify the new efficiencies. 
<details>
<summary><b>word_tokenize efficiency summary</b></summary>

To generate the results, we use the following simple script:
```python
from nltk import word_tokenize
import time

n = 8
for element in ["a", "a ", "abc ", "a.", "abc.", "a. ", "abc. "]:
    print(f"Running experiments with repeated occurrences of {element!r}.")
    for length in [10**i for i in range(2, n)]:
        text = element * length
        start_t = time.time()
        out = word_tokenize(text)
        print(f"A length of {length:<{n}} takes {time.time() - start_t:.4f}s (len={len(out)})")
    print()
```

Which creates an input string for `word_tokenize` by repeating `element` some number of times. This is ran for NLTK 3.6.5, NLTK 3.7, and after this PR. Note that some variations are normal, as I'm only running it once.

#### Baseline efficiency (NLTK 3.6.5)
```python
Running experiments with repeated occurrences of 'a'.
A length of 100      takes 0.0100s (len=1)
A length of 1000     takes 0.0050s (len=1)
A length of 10000    takes 0.6000s (len=1)
...
# Non-linear

Running experiments with repeated occurrences of 'a '.
A length of 100      takes 0.0050s (len=100)
A length of 1000     takes 0.0010s (len=1000)
A length of 10000    takes 0.0090s (len=10000)
A length of 100000   takes 0.0939s (len=100000)
A length of 1000000  takes 1.0470s (len=1000000)
A length of 10000000 takes 10.7118s (len=10000000)
# Linear

Running experiments with repeated occurrences of 'abc '.
A length of 100      takes 0.0220s (len=100)
A length of 1000     takes 0.0030s (len=1000)
A length of 10000    takes 0.0190s (len=10000)
A length of 100000   takes 0.2420s (len=100000)
A length of 1000000  takes 1.7701s (len=1000000)
A length of 10000000 takes 19.7902s (len=10000000)
# Linear

Running experiments with repeated occurrences of 'a.'.
A length of 100      takes 0.2211s (len=2)
A length of 1000     takes 0.0730s (len=2)
A length of 10000    takes 7.0727s (len=2)
...
# Non-linear

Running experiments with repeated occurrences of 'abc.'.
A length of 100      takes 0.0080s (len=2)
A length of 1000     takes 0.1940s (len=2)
A length of 10000    takes 14.9596s (len=2)
...
# Non-linear

Running experiments with repeated occurrences of 'a. '.
A length of 100      takes 0.0080s (len=101)
A length of 1000     takes 0.0250s (len=1001)
A length of 10000    takes 0.2290s (len=10001)
A length of 100000   takes 1.4147s (len=100001)
A length of 1000000  takes 13.8890s (len=1000001)
...
# Linear

Running experiments with repeated occurrences of 'abc. '.
A length of 100      takes 0.0160s (len=200)
A length of 1000     takes 0.0670s (len=2000)
A length of 10000    takes 0.5420s (len=20000)
A length of 100000   takes 5.0774s (len=200000)
...
# Linear
```
The comments were manually added, based on whether it seems like the performance is linear or not.
As described in #2869, a really long single word caused a serious ReDoS. So, the first experiment with just repeated `a` had to be terminated manually. Furthermore, `a.` and `abc.` also seem to cause worse-than-linear time complexities. Lastly, `a. ` and `abc. ` seem to be linear again, but just slow.

#### Baseline efficiency (NLTK 3.7)
```python
Running experiments with repeated occurrences of 'a'.
A length of 100      takes 0.0050s (len=1)
A length of 1000     takes 0.0010s (len=1)
A length of 10000    takes 0.0030s (len=1)
A length of 100000   takes 0.0320s (len=1)
A length of 1000000  takes 0.3201s (len=1)
A length of 10000000 takes 2.9845s (len=1)
# Linear

Running experiments with repeated occurrences of 'a '.
A length of 100      takes 0.0010s (len=100)
A length of 1000     takes 0.0010s (len=1000)
A length of 10000    takes 0.0080s (len=10000)        
A length of 100000   takes 0.0797s (len=100000)
A length of 1000000  takes 0.8070s (len=1000000)
A length of 10000000 takes 8.2493s (len=10000000)
# Linear

Running experiments with repeated occurrences of 'abc '.
A length of 100      takes 0.0240s (len=100)
A length of 1000     takes 0.0020s (len=1000)
A length of 10000    takes 0.0160s (len=10000)
A length of 100000   takes 0.1660s (len=100000)
A length of 1000000  takes 1.4884s (len=1000000)
A length of 10000000 takes 14.7242s (len=10000000)
# Linear

Running experiments with repeated occurrences of 'a.'.
A length of 100      takes 0.2760s (len=2)
A length of 1000     takes 0.0010s (len=2)
A length of 10000    takes 0.0090s (len=2)
A length of 100000   takes 0.1050s (len=2)
A length of 1000000  takes 0.9317s (len=2)
A length of 10000000 takes 8.8467s (len=2)
# Linear

Running experiments with repeated occurrences of 'abc.'.
A length of 100      takes 0.0010s (len=2)
A length of 1000     takes 0.0010s (len=2)
A length of 10000    takes 0.0160s (len=2)
A length of 100000   takes 0.1900s (len=2)
A length of 1000000  takes 1.4831s (len=2)
A length of 10000000 takes 14.7677s (len=2)
# Linear

Running experiments with repeated occurrences of 'a. '.
A length of 100      takes 0.0060s (len=101)
A length of 1000     takes 0.0170s (len=1001)
A length of 10000    takes 0.1841s (len=10001)
A length of 100000   takes 2.5929s (len=100001)
...
# Non-linear (I waited several minutes)

Running experiments with repeated occurrences of 'abc. '.
A length of 100      takes 0.0100s (len=200)
A length of 1000     takes 0.0509s (len=2000)
A length of 10000    takes 0.5420s (len=20000)
A length of 100000   takes 6.8013s (len=200000)
...
# Non-linear (I waited several minutes)
```
As can be seen here, `a.` and `abc.` seem to have been solved since NLTK 3.6.5. The tests for `a. ` and `abc. ` again show O(n), but it's slightly worse than 10x as slow for 10x as much data.

#### New efficiency
```python
Running experiments with repeated occurrences of 'a'.
A length of 100      takes 0.0060s (len=1)
A length of 1000     takes 0.0010s (len=1)
A length of 10000    takes 0.0030s (len=1)
A length of 100000   takes 0.0320s (len=1)
A length of 1000000  takes 0.3006s (len=1)
A length of 10000000 takes 3.3780s (len=1)
# Linear

Running experiments with repeated occurrences of 'a '.
A length of 100      takes 0.0010s (len=100)
A length of 1000     takes 0.0010s (len=1000)
A length of 10000    takes 0.0080s (len=10000)
A length of 100000   takes 0.1020s (len=100000)
A length of 1000000  takes 0.7950s (len=1000000)
A length of 10000000 takes 9.4390s (len=10000000)
# Linear

Running experiments with repeated occurrences of 'abc '.
A length of 100      takes 0.0210s (len=100)
A length of 1000     takes 0.0020s (len=1000)
A length of 10000    takes 0.0160s (len=10000)
A length of 100000   takes 0.1920s (len=100000)
A length of 1000000  takes 1.7082s (len=1000000)
A length of 10000000 takes 17.7505s (len=10000000)
# Linear

Running experiments with repeated occurrences of 'a.'.
A length of 100      takes 0.2178s (len=2)
A length of 1000     takes 0.0010s (len=2)
A length of 10000    takes 0.0100s (len=2)
A length of 100000   takes 0.1360s (len=2)
A length of 1000000  takes 0.9942s (len=2)
A length of 10000000 takes 10.4847s (len=2)
# Linear

Running experiments with repeated occurrences of 'abc.'.
A length of 100      takes 0.0020s (len=2)
A length of 1000     takes 0.0020s (len=2)
A length of 10000    takes 0.0170s (len=2)
A length of 100000   takes 0.2130s (len=2)
A length of 1000000  takes 1.7320s (len=2)
A length of 10000000 takes 18.1585s (len=2)
# Linear

Running experiments with repeated occurrences of 'a. '.
A length of 100      takes 0.0060s (len=101)
A length of 1000     takes 0.0180s (len=1001)
A length of 10000    takes 0.2560s (len=10001)
A length of 100000   takes 1.6629s (len=100001)
A length of 1000000  takes 16.1289s (len=1000001)
...
# Linear

Running experiments with repeated occurrences of 'abc. '.
A length of 100      takes 0.0170s (len=200)
A length of 1000     takes 0.1070s (len=2000)
A length of 10000    takes 0.6226s (len=20000)
A length of 100000   takes 5.0704s (len=200000)
A length of 1000000  takes 50.7210s (len=2000000)
...
# Linear
```
All of these computation times are linear to the size of the input, which is satisfactory. The first experiment works unlike for NLTK 3.6.5, thanks to #2869. Beyond that, there is perhaps a small speedup for some (e.g. 16s -> 14s for `abc`), and perhaps some slowdown for others (e.g. 14s -> 16s for `a. `), but I can't conclusively say that without some (overkill) significance testing.

To conclude, there is no longer any non-linear time complexity in these tests.

</details>

<details>
<summary><b>sent_tokenize efficiency summary</b></summary>

To generate the results, we use a very similar script as with word_tokenize:
```python
from nltk import sent_tokenize
import time

n = 8
for element in ["a", "a ", "abc ", "a.", "abc.", "a. ", "abc. "]:
    print(f"Running experiments with repeated occurrences of {element!r}.")
    for length in [10**i for i in range(2, n)]:
        text = element * length
        start_t = time.time()
        out = sent_tokenize(text)
        print(f"A length of {length:<{n}} takes {time.time() - start_t:.4f}s (len={len(out)})")
    print()
```

Which creates an input string for `sent_tokenize` by repeating `element` some number of times. This is ran for NLTK 3.6.5, NLTK 3.7, and after this PR. Note that some variations are normal, as I'm only running it once.

#### Baseline efficiency (NLTK 3.6.5)
```python
Running experiments with repeated occurrences of 'a'.
A length of 100      takes 0.0050s (len=1)
A length of 1000     takes 0.0060s (len=1)
A length of 10000    takes 0.6029s (len=1)
...
# Non-linear

Running experiments with repeated occurrences of 'a '.
A length of 100      takes 0.0050s (len=1)
A length of 1000     takes 0.0000s (len=1)
A length of 10000    takes 0.0000s (len=1)
A length of 100000   takes 0.0060s (len=1)
A length of 1000000  takes 0.0840s (len=1)
A length of 10000000 takes 0.6043s (len=1)
# Linear

Running experiments with repeated occurrences of 'abc '.
A length of 100      takes 0.0020s (len=1)
A length of 1000     takes 0.0000s (len=1)
A length of 10000    takes 0.0010s (len=1)
A length of 100000   takes 0.0180s (len=1)
A length of 1000000  takes 0.1700s (len=1)
A length of 10000000 takes 1.6243s (len=1)
# Linear

Running experiments with repeated occurrences of 'a.'.
A length of 100      takes 0.0030s (len=1)
A length of 1000     takes 0.0570s (len=1)
A length of 10000    takes 5.0565s (len=1)
...
# Non-linear

Running experiments with repeated occurrences of 'abc.'.
A length of 100      takes 0.0110s (len=1)
A length of 1000     takes 0.2360s (len=1)
A length of 10000    takes 14.6740s (len=1)
...
# Non-linear

Running experiments with repeated occurrences of 'a. '.
A length of 100      takes 0.0080s (len=1)
A length of 1000     takes 0.0190s (len=1)
A length of 10000    takes 0.2060s (len=1)
A length of 100000   takes 1.7631s (len=1)
A length of 1000000  takes 12.7064s (len=1)
...
# Linear

Running experiments with repeated occurrences of 'abc. '.
A length of 100      takes 0.0070s (len=100)
A length of 1000     takes 0.0160s (len=1000)
A length of 10000    takes 0.1630s (len=10000)
A length of 100000   takes 1.4806s (len=100000)
A length of 1000000  takes 13.8376s (len=1000000)
# Linear
```
All of `a.`, `abc.` and `a` had poor performance for this version.

#### Baseline efficiency (NLTK 3.7)
```python
Running experiments with repeated occurrences of 'a'.
A length of 100      takes 0.0060s (len=1)
A length of 1000     takes 0.0000s (len=1)
A length of 10000    takes 0.0010s (len=1)
A length of 100000   takes 0.0000s (len=1)
A length of 1000000  takes 0.0040s (len=1)
A length of 10000000 takes 0.0470s (len=1)
# Linear

Running experiments with repeated occurrences of 'a '.
A length of 100      takes 0.0010s (len=1)
A length of 1000     takes 0.0000s (len=1)
A length of 10000    takes 0.0010s (len=1)
A length of 100000   takes 0.0020s (len=1)
A length of 1000000  takes 0.0150s (len=1)
A length of 10000000 takes 0.1120s (len=1)
# Linear

Running experiments with repeated occurrences of 'abc '.
A length of 100      takes 0.0020s (len=1)
A length of 1000     takes 0.0000s (len=1)
A length of 10000    takes 0.0000s (len=1)
A length of 100000   takes 0.0020s (len=1)
A length of 1000000  takes 0.0260s (len=1)
A length of 10000000 takes 0.2830s (len=1)
# Linear

Running experiments with repeated occurrences of 'a.'.
A length of 100      takes 0.0030s (len=1)
A length of 1000     takes 0.0010s (len=1)
A length of 10000    takes 0.0000s (len=1)
A length of 100000   takes 0.0050s (len=1)
A length of 1000000  takes 0.0520s (len=1)
A length of 10000000 takes 0.4911s (len=1)
# Linear

Running experiments with repeated occurrences of 'abc.'.
A length of 100      takes 0.0020s (len=1)
A length of 1000     takes 0.0000s (len=1)
A length of 10000    takes 0.0010s (len=1)
A length of 100000   takes 0.0050s (len=1)
A length of 1000000  takes 0.0550s (len=1)
A length of 10000000 takes 0.5165s (len=1)
# Linear

Running experiments with repeated occurrences of 'a. '.
A length of 100      takes 0.0050s (len=1)
A length of 1000     takes 0.0120s (len=1)
A length of 10000    takes 0.1700s (len=1)
A length of 100000   takes 2.2183s (len=1)
...
# Non-linear (I waited for approximately 15 minutes here)

Running experiments with repeated occurrences of 'abc. '.
A length of 100      takes 0.0070s (len=100)
A length of 1000     takes 0.0170s (len=1000)
A length of 10000    takes 0.1736s (len=10000)
A length of 100000   takes 3.3012s (len=100000)
...
# Non-linear
```
Here, `a. ` and `abc. ` are non-linear, which is indicative of the performance issues people are having.

#### New efficiency
```python
Running experiments with repeated occurrences of 'a'.
A length of 100      takes 0.0070s (len=1)
A length of 1000     takes 0.0000s (len=1)
A length of 10000    takes 0.0000s (len=1)
A length of 100000   takes 0.0010s (len=1)
A length of 1000000  takes 0.0040s (len=1)
A length of 10000000 takes 0.0430s (len=1)
# Linear

Running experiments with repeated occurrences of 'a '.
A length of 100      takes 0.0020s (len=1)
A length of 1000     takes 0.0000s (len=1)
A length of 10000    takes 0.0010s (len=1)
A length of 100000   takes 0.0010s (len=1)
A length of 1000000  takes 0.0130s (len=1)
A length of 10000000 takes 0.1480s (len=1)
# Linear

Running experiments with repeated occurrences of 'abc '.
A length of 100      takes 0.0020s (len=1)
A length of 1000     takes 0.0000s (len=1)
A length of 10000    takes 0.0010s (len=1)
A length of 100000   takes 0.0040s (len=1)
A length of 1000000  takes 0.0230s (len=1)
A length of 10000000 takes 0.2340s (len=1)
# Linear

Running experiments with repeated occurrences of 'a.'.
A length of 100      takes 0.0030s (len=1)
A length of 1000     takes 0.0000s (len=1)
A length of 10000    takes 0.0000s (len=1)
A length of 100000   takes 0.0060s (len=1)
A length of 1000000  takes 0.0480s (len=1)
A length of 10000000 takes 0.4950s (len=1)
# Linear

Running experiments with repeated occurrences of 'abc.'.
A length of 100      takes 0.0010s (len=1)
A length of 1000     takes 0.0000s (len=1)
A length of 10000    takes 0.0010s (len=1)
A length of 100000   takes 0.0050s (len=1)
A length of 1000000  takes 0.0585s (len=1)
A length of 10000000 takes 0.5450s (len=1)
# Linear

Running experiments with repeated occurrences of 'a. '.
A length of 100      takes 0.0060s (len=1)
A length of 1000     takes 0.0170s (len=1)
A length of 10000    takes 0.1670s (len=1)
A length of 100000   takes 1.4250s (len=1)
A length of 1000000  takes 14.6518s (len=1)
...
# Linear

Running experiments with repeated occurrences of 'abc. '.
A length of 100      takes 0.0090s (len=100)
A length of 1000     takes 0.0180s (len=1000)
A length of 10000    takes 0.2020s (len=10000)
A length of 100000   takes 1.8661s (len=100000)
A length of 1000000  takes 18.4968s (len=1000000)
...
# Linear
```
Again, all the performances seem to be linear now. The performance seems to be as good as pre-NLTK 3.6.5, or even better (e.g. for `a`). 

To conclude, the performance in terms of time-efficiency is as good, or better, than it ever has been.

</details>

### In short
It seems like this PR should:
* correctly tackle the (accuracy) regressions reported in #2934, as shown via new test cases.
* correctly tackle the (efficiency) regressions reported in #3013 (sent_tokenize) and #2981 (word_tokenize), as shown with time-efficiency experiments.

I'm open to receive new test cases to help improve the robustness of both `word_tokenize` and `sent_tokenize`. The goal of this PR was to make both of these functions linear time complexity. Future PRs could then try to improve the efficiency of certain sections of code to decrease the "slope" of the linear increase.

Thanks to @12mohaned for pointing me to #2934, although I was too busy to work on it at the time. I also want to thank @radcheb, @juhoinkinen and @ViktorDrugge for raising their respective issues, and those who contributed in them.

- Tom Aarsen