### PR TITLE
fix edit_distance_align() in distance.py

### DIFF
--- a/nltk/metrics/distance.py
+++ b/nltk/metrics/distance.py
@@ -159,10 +159,10 @@ def edit_distance_align(s1, s2, substitution_cost=1):
     In case of multiple valid minimum-distance alignments, the
     backtrace has the following operation precedence:
 
-    1. Substitute s1 and s2 characters    
+    1. Substitute s1 and s2 characters
     2. Skip s1 character
     3. Skip s2 character
-    
+
     The backtrace is carried out in reverse string order.
 
     This function does not support transposition.

--- a/nltk/metrics/distance.py
+++ b/nltk/metrics/distance.py
@@ -129,9 +129,9 @@ def _edit_dist_backtrace(lev):
 
     while (i, j) != (0, 0):
         directions = [
+            (i - 1, j - 1),  # substitution
             (i - 1, j),  # skip s1
             (i, j - 1),  # skip s2
-            (i - 1, j - 1),  # substitution
         ]
 
         direction_costs = (
@@ -159,10 +159,10 @@ def edit_distance_align(s1, s2, substitution_cost=1):
     In case of multiple valid minimum-distance alignments, the
     backtrace has the following operation precedence:
 
-    1. Skip s1 character
-    2. Skip s2 character
-    3. Substitute s1 and s2 characters
-
+    1. Substitute s1 and s2 characters    
+    2. Skip s1 character
+    3. Skip s2 character
+    
     The backtrace is carried out in reverse string order.
 
     This function does not support transposition.

--- a/nltk/test/metrics.doctest
+++ b/nltk/test/metrics.doctest
@@ -62,7 +62,7 @@ String edit distance (Levenshtein):
     >>> edit_distance_align("shine", "shine")
     [(0, 0), (1, 1), (2, 2), (3, 3), (4, 4), (5, 5)]
     >>> edit_distance_align("rain", "brainy")
-    [(0, 0), (1, 1), (1, 2), (2, 3), (3, 4), (4, 5), (4, 6)]
+    [(0, 0), (0, 1), (1, 2), (2, 3), (3, 4), (4, 5), (4, 6)]
     >>> edit_distance_align("", "brainy")
     [(0, 0), (0, 1), (0, 2), (0, 3), (0, 4), (0, 5), (0, 6)]
     >>> edit_distance_align("", "")


### PR DESCRIPTION
This pull request provides a quick fix to issue #2954, in which the alignment mapping of two strings based on the minimum edit distance is wrong. 

The Levenshtein edit distance table, named `lev` inside [`edit_distance_align()`](https://github.com/nltk/nltk/blob/b0e85694107992e00a2f9fb48e6410c50fe1f1f6/nltk/metrics/distance.py#L147) was correct. The problem lied in the [`_edit_dist_backtrace()`](https://github.com/nltk/nltk/blob/b0e85694107992e00a2f9fb48e6410c50fe1f1f6/nltk/metrics/distance.py#L126) function. During back tracing, in previous version of [`_edit_dist_backtrace()`](https://github.com/nltk/nltk/blob/b0e85694107992e00a2f9fb48e6410c50fe1f1f6/nltk/metrics/distance.py#L126), the first cell in `(i - 1, j),  (i, j - 1), (i - 1, j - 1)` (in this order) that has the minimum cost value was selected to be the next cell in the path. However, it did not consider that going through either cell in `(i - 1, j),  (i, j - 1)` should always incur an additional cost because they correspond to insertion or deletion. Going though `(i - 1, j - 1)`, however, corresponds to a substitution, which can incur an additional cost of either *0* or a user defined substitution cost (default to *1* in [`edit_distance_align()`](https://github.com/nltk/nltk/blob/b0e85694107992e00a2f9fb48e6410c50fe1f1f6/nltk/metrics/distance.py#L147)). For example (see issue [#2954](https://github.com/nltk/nltk/issues/2954#issuecomment-1179968525) for an illustration of a similar example), suppose we are at cell `(i, j)` whose cost is *n*. Now, if the cost values for `(i - 1, j),  (i, j - 1), (i - 1, j - 1)` are all *n*, same as the cost value in cell `(i, j)`, then `(i - 1, j)` would be added to the path, which is an illegal move because you can't go through an insertion or deletion without an additional cost. In this case, the only viable path is through cell `(i - 1, j - 1)`, which is a substitution move of *0* cost. The easiest way to fix that is to change the order to `(i - 1, j - 1), (i - 1, j),  (i, j - 1)`. The corresponding docstring inside [`edit_distance_align()`](https://github.com/nltk/nltk/blob/b0e85694107992e00a2f9fb48e6410c50fe1f1f6/nltk/metrics/distance.py#L147) has also been updated to reflect this change.