### PR TITLE
Use `input()` in `nltk.chat.chatbot()` for Jupyter support

### DIFF
--- a/nltk/chat/__init__.py
+++ b/nltk/chat/__init__.py
@@ -33,15 +33,12 @@ bots = [
 
 
 def chatbots():
-    import sys
-
     print("Which chatbot would you like to talk to?")
     botcount = len(bots)
     for i in range(botcount):
         print("  %d: %s" % (i + 1, bots[i][1]))
     while True:
-        print("\nEnter a number in the range 1-%d: " % botcount, end=" ")
-        choice = sys.stdin.readline().strip()
+        choice = input(f"\nEnter a number in the range 1-{botcount}: ").strip()
         if choice.isdigit() and (int(choice) - 1) in range(botcount):
             break
         else:


### PR DESCRIPTION
Fixes #3021 

Hello!

### Pull request overview
* Replace `sys.stdin.readline()` with `input()` in `nltk.chat.chatbot()`

### Details
The following snippet is used to let users pick which of the 5 NLTK chatbots should be instantiated:
https://github.com/nltk/nltk/blob/1f28903066fe3ee3a4ab75085bfd5254184d135c/nltk/chat/__init__.py#L43-L44

However, the `sys.stdin.readline()` constantly triggers in such a way that `choice` is an empty string. This causes an endless loop, exactly as described in #3021:
![image](https://user-images.githubusercontent.com/37621491/179717693-6158f0e6-a459-4cf4-838d-a29c6dc539dd.png)
Note that this is the output directly after running the cell. Be warned when testing this, this ended up crashing my computer due to the endless loop.

---

### Changes
This PR simply updates this somewhat outdated form of getting user input by using the better supported `input()`. Running the cell now results in:
![image](https://user-images.githubusercontent.com/37621491/179719289-499acf3d-c898-47ce-8374-9d901c2b46b2.png)
After which the chatbot works like intended & expected.

Thank you @jmcelroy01 for raising this issue.

- Tom Aarsen