### PR TITLE
Load wordnet without OMW

### DIFF
--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -1179,9 +1179,6 @@ class WordNetCorpusReader(CorpusReader):
                 "The multilingual functions are not available with this Wordnet version"
             )
             self.omw_langs = set()
-        else:
-            self.add_provs(self._omw_reader)
-            self.omw_langs = set(self.provenances.keys())
 
         # A cache to store the wordnet data of multiple languages
         self._lang_data = defaultdict(list)
@@ -1280,6 +1277,10 @@ class WordNetCorpusReader(CorpusReader):
 
         if lang in self._lang_data.keys():
             return
+
+        if self.langs() == ["eng"]:
+            self.add_provs(self._omw_reader)
+            self.omw_langs = set(self.provenances.keys())
 
         if lang not in self.langs():
             raise WordNetError("Language is not supported.")

--- a/nltk/test/wordnet.doctest
+++ b/nltk/test/wordnet.doctest
@@ -45,13 +45,12 @@ A synset is identified with a 3-part name of the form: word.pos.nn:
     Synset('dog.n.01')
 
 The WordNet corpus reader gives access to the Open Multilingual
-WordNet, using ISO-639 language codes.
+WordNet, using ISO-639 language codes. These languages are not
+loaded by default, but only lazily, when needed.
 
-    >>> sorted(wn.langs())
-    ['als', 'arb', 'bul', 'cat', 'cmn', 'dan', 'ell', 'eng', 'eus',
-    'fin', 'fra', 'glg', 'heb', 'hrv', 'ind', 'isl', 'ita', 'ita_iwn',
-    'jpn', 'lit', 'nld', 'nno', 'nob', 'pol', 'por', 'ron', 'slk',
-    'slv', 'spa', 'swe', 'tha', 'zsm']
+    >>> wn.langs()
+    ['eng']
+
     >>> wn.synsets(b'\xe7\x8a\xac'.decode('utf-8'), lang='jpn')
     [Synset('dog.n.01'), Synset('spy.n.01')]
 
@@ -59,6 +58,12 @@ WordNet, using ISO-639 language codes.
     ['いぬ', 'まわし者', 'スパイ', '回し者', '回者', '密偵',
     '工作員', '廻し者', '廻者', '探', '探り', '犬', '秘密捜査員',
     '諜報員', '諜者', '間者', '間諜', '隠密']
+
+    >>> sorted(wn.langs())
+    ['als', 'arb', 'bul', 'cat', 'cmn', 'dan', 'ell', 'eng', 'eus',
+    'fin', 'fra', 'glg', 'heb', 'hrv', 'ind', 'isl', 'ita', 'ita_iwn',
+    'jpn', 'lit', 'nld', 'nno', 'nob', 'pol', 'por', 'ron', 'slk',
+    'slv', 'spa', 'swe', 'tha', 'zsm']
 
     >>> wn.synset('dog.n.01').lemma_names('ita')
     ['Canis_familiaris', 'cane']


### PR DESCRIPTION
Fix #3024: allow wordnet to load without requiring OMW.

> from nltk.corpus import wordnet as wn
> ss_list = wn.synsets('test')
> print(ss_list)

[Synset('trial.n.02'), Synset('test.n.02'), Synset('examination.n.02'), Synset('test.n.04'), Synset('test.n.05'), Synset('test.n.06'), Synset('test.v.01'), Synset('screen.v.01'), Synset('quiz.v.01'), Synset('test.v.04'), Synset('test.v.05'), Synset('test.v.06'), Synset('test.v.07')]

> print(wn.langs())

['eng']

> spanish = [ss.lemmas(lang='spa') for ss in ss_list]
> print(spanish)

[[Lemma('trial.n.02.prueba')], [Lemma('test.n.02.test')], [Lemma('examination.n.02.examen'), Lemma('examination.n.02.test')], [Lemma('test.n.04.examen'), Lemma('test.n.04.prueba'), Lemma('test.n.04.test')], [Lemma('test.n.05.ensayo'), Lemma('test.n.05.prueba')], [], [Lemma('test.v.01.ensayar'), Lemma('test.v.01.examinar'), Lemma('test.v.01.probar')], [], [], [], [], [], []]

> print(wn.langs())

['eng', 'als', 'arb', 'bul', 'cmn', 'dan', 'ell', 'fin', 'fra', 'heb', 'hrv', 'isl', 'ita', 'ita_iwn', 'jpn', 'cat', 'eus', 'glg', 'spa', 'ind', 'zsm', 'nld', 'nno', 'nob', 'pol', 'por', 'ron', 'lit', 'slk', 'slv', 'swe', 'tha']
