### PR TITLE
Fix CoreNLPServer non-default port issue (#2244)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -291,6 +291,7 @@
 - Alexandre Perez-Lebel <https://github.com/aperezlebel>
 - Fernando Carranza <https://github.com/fernandocar86>
 - Martin Kondratzky <https://github.com/martinkondra>
+- Heungson Lee <https://github.com/heungson>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 

--- a/nltk/parse/corenlp.py
+++ b/nltk/parse/corenlp.py
@@ -74,9 +74,10 @@ class CoreNLPServer:
                 port = try_port(9000)
             except OSError:
                 port = try_port()
-                corenlp_options.append(str(port))
+                corenlp_options.extend(["-port", str(port)])
         else:
             try_port(port)
+            corenlp_options.extend(["-port", str(port)])
 
         self.url = f"http://localhost:{port}"
 


### PR DESCRIPTION
Issue #2244 fixed.
In case where a port other than the default port (9000) is used, '-port' option is also added to the command line options.