### PR TITLE
nltk.tokenize.casual.TweetTokenizer: Add support to tokenize emoji flag sequences

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -291,6 +291,7 @@
 - Alexandre Perez-Lebel <https://github.com/aperezlebel>
 - Fernando Carranza <https://github.com/fernandocar86>
 - Martin Kondratzky <https://github.com/martinkondra>
+- Steven Thomas Smith <https://github.com/essandess>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 

--- a/nltk/test/unit/test_tokenize.py
+++ b/nltk/test/unit/test_tokenize.py
@@ -384,11 +384,20 @@ class TestTokenize:
         assert result == expected
 
         # emoji flag sequences, including enclosed letter pairs
-	# Expected behavior from:
-        # https://github.com/nltk/nltk/pull/3034#issuecomment-1223956957
+        # Expected behavior from #3034
         test4 = "🇦🇵🇵🇱🇪"
         expected = ["🇦🇵", "🇵🇱", "🇪"]
         result = tokenizer.tokenize(test4)
+        assert result == expected
+
+        test5 = "Hi 🇨🇦, 😍!!"
+        expected = ["Hi", "🇨🇦", ",", "😍", "!", "!"]
+        result = tokenizer.tokenize(test5)
+        assert result == expected
+
+        test6 = "<3 🇨🇦 🤝 🇵🇱 <3"
+        expected = ["<3", "🇨🇦", "🤝", "🇵🇱", "<3"]
+        result = tokenizer.tokenize(test6)
         assert result == expected
 
     def test_pad_asterisk(self):

--- a/nltk/test/unit/test_tokenize.py
+++ b/nltk/test/unit/test_tokenize.py
@@ -383,6 +383,14 @@ class TestTokenize:
         result = tokenizer.tokenize(test3)
         assert result == expected
 
+        # emoji flag sequences, including enclosed letter pairs
+	# Expected behavior from:
+        # https://github.com/nltk/nltk/pull/3034#issuecomment-1223956957
+        test4 = "🇦🇵🇵🇱🇪"
+        expected = ["🇦🇵", "🇵🇱", "🇪"]
+        result = tokenizer.tokenize(test4)
+        assert result == expected
+
     def test_pad_asterisk(self):
         """
         Test padding of asterisk for word tokenization.

--- a/nltk/tokenize/casual.py
+++ b/nltk/tokenize/casual.py
@@ -127,6 +127,29 @@ URLS = r"""			# Capture 1: entire matched URL
   )
 """
 
+# emoji flag sequence
+# https://en.wikipedia.org/wiki/Regional_indicator_symbol
+# For regex simplicity, include all possible enclosed letter pairs,
+# not the ISO subset of two-letter regional indicator symbols.
+# See https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Current_codes
+# Future regional flag support may be handled with the regex for
+# U+1F3F4 🏴 followed by emoji tag sequences:
+# r'\U0001F3F4[\U000E0000-\U000E007E]{5}\U000E007F'
+FLAGS = r"""
+  (?:
+    [\U0001F1E6-\U0001F1FF]{2}  # all enclosed letter pairs
+    |
+    # English flag
+    \U0001F3F4\U000E0067\U000E0062\U000E0065\U000E006e\U000E0067\U000E007F
+    |
+    # Scottish flag
+    \U0001F3F4\U000E0067\U000E0062\U000E0073\U000E0063\U000E0074\U000E007F
+    |
+    # For Wales? Why Richard, it profit a man nothing to give his soul for the whole world … but for Wales!
+    \U0001F3F4\U000E0067\U000E0062\U000E0077\U000E006C\U000E0073\U000E007F
+  )
+"""
+
 # Regex for recognizing phone numbers:
 PHONE_REGEX = r"""
     (?:
@@ -165,6 +188,8 @@ REGEXPS = (
         |
         [\U0001F3FB-\U0001F3FF]
     )""",
+    # flags
+    FLAGS,
     # Remaining word types:
     r"""
     (?:[^\W\d_](?:[^\W\d_]|['\-_])+[^\W\d_]) # Words with apostrophes or dashes.


### PR DESCRIPTION
nltk.tokenize.casual.TweetTokenizer: Add support to tokenize emoji flag sequences
* TweetTokenizer currently splits emoji flags into individual tokens of enclosed letters, e.g. 🇨🇦 -> '🇨 ', '🇦 '
* This patch keeps emoji flag sequences intact
* Without this PR:
> ```python
> nltk.tokenize.casual.TweetTokenizer().tokenize(text='Hi 🇨🇦, 😍!!')
> ['Hi', '🇨', '🇦', ',', '😍', '!', '!']
> ```
* With this PR:
> ```python
> nltk.tokenize.casual.TweetTokenizer().tokenize(text='Hi 🇨🇦, 😍!!')
> ['Hi', '🇨🇦', ',', '😍', '!', '!']
> ```