### PR TITLE
Change in Polish encodings of udhr corpus reader

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -291,6 +291,7 @@
 - Alexandre Perez-Lebel <https://github.com/aperezlebel>
 - Fernando Carranza <https://github.com/fernandocar86>
 - Martin Kondratzky <https://github.com/martinkondra>
+- M.K. Pawelkiewicz <https://github.com/hamiltonianflow>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 

--- a/nltk/corpus/reader/udhr.py
+++ b/nltk/corpus/reader/udhr.py
@@ -13,6 +13,8 @@ class UdhrCorpusReader(PlaintextCorpusReader):
         (".*-Hebrew$", "hebrew"),
         (".*-Arabic$", "cp1256"),
         ("Czech_Cesky-UTF8", "cp1250"),  # yeah
+        ("Polish-Latin2", "cp1250"),
+        ("Polish_Polski-Latin2", "cp1250"),
         (".*-Cyrillic$", "cyrillic"),
         (".*-SJIS$", "SJIS"),
         (".*-GB2312$", "GB2312"),

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -1497,7 +1497,7 @@ class DownloaderGUI:
         for (i, (key, label, callback)) in enumerate(info):
             Label(infoframe, text=label).grid(column=0, row=i, sticky="e")
             entry = Entry(
-                infoframe, font="courier", relief="groove", disabledforeground="black"
+                infoframe, font="courier", relief="groove", disabledforeground="#007aff"
             )
             self._info[key] = (entry, callback)
             entry.bind("<Return>", self._info_save)

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -1497,7 +1497,11 @@ class DownloaderGUI:
         for (i, (key, label, callback)) in enumerate(info):
             Label(infoframe, text=label).grid(column=0, row=i, sticky="e")
             entry = Entry(
-                infoframe, font="courier", relief="groove", disabledforeground="#007aff"
+                infoframe,
+                font="courier",
+                relief="groove",
+                disabledforeground="#007aff",
+                foreground="#007aff",
             )
             self._info[key] = (entry, callback)
             entry.bind("<Return>", self._info_save)

--- a/nltk/test/unit/test_corpora.py
+++ b/nltk/test/unit/test_corpora.py
@@ -26,6 +26,16 @@ class TestUdhr(unittest.TestCase):
             txt = udhr.raw(name)
             assert not isinstance(txt, bytes), name
 
+    def test_polish_encoding(self):
+        text_pl = udhr.raw("Polish-Latin2")[:164]
+        text_ppl = udhr.raw("Polish_Polski-Latin2")[:164]
+        expected = """POWSZECHNA DEKLARACJA PRAW CZŁOWIEKA
+[Preamble]
+Trzecia Sesja Ogólnego Zgromadzenia ONZ, obradująca w Paryżu, \
+uchwaliła 10 grudnia 1948 roku jednomyślnie Powszechną"""
+        assert text_pl == expected, "Polish-Latin2"
+        assert text_ppl == expected, "Polish_Polski-Latin2"
+
 
 class TestIndian(unittest.TestCase):
     def test_words(self):


### PR DESCRIPTION
Modification in `UdhrCorpusReader` corpus reader class, which changes the encoding used for Polish language files `Polish-Latin2` and `Polish_Polski-Latin2` from `ISO-8859-2` to `cp1250`, so that they are properly read.

Fixes #3037

