### PR TITLE
Resolve CoreNLP Regression

### DIFF
--- a/nltk/parse/corenlp.py
+++ b/nltk/parse/corenlp.py
@@ -48,7 +48,6 @@ class CoreNLPServer:
         java_options=None,
         corenlp_options=None,
         port=None,
-        strict_json=True,
     ):
 
         if corenlp_options is None:
@@ -100,7 +99,6 @@ class CoreNLPServer:
 
         self.corenlp_options = corenlp_options
         self.java_options = java_options or ["-mx2g"]
-        self.strict_json = strict_json
 
     def start(self, stdout="devnull", stderr="devnull"):
         """Starts the CoreNLP server
@@ -179,7 +177,13 @@ class CoreNLPServer:
 class GenericCoreNLPParser(ParserI, TokenizerI, TaggerI):
     """Interface to the CoreNLP Parser."""
 
-    def __init__(self, url="http://localhost:9000", encoding="utf8", tagtype=None):
+    def __init__(
+        self,
+        url="http://localhost:9000",
+        encoding="utf8",
+        tagtype=None,
+        strict_json=True,
+    ):
         import requests
 
         self.url = url
@@ -189,6 +193,7 @@ class GenericCoreNLPParser(ParserI, TokenizerI, TaggerI):
             raise ValueError("tagtype must be either 'pos', 'ner' or None")
 
         self.tagtype = tagtype
+        self.strict_json = strict_json
 
         self.session = requests.Session()
 


### PR DESCRIPTION
Hello!

### Pull request overview
* #2993 introduced `strict_json` in `CoreNLPServer`, but tries to use it in `GenericCoreNLPParser`.

### How to reproduce
```python
from nltk.parse.corenlp import CoreNLPServer, CoreNLPParser

with CoreNLPServer() as server:
    sentence = "This is my sentence, which I'd like to get parsed."
    parser = CoreNLPParser(server.url)
    next(parser.parse_text(sentence)).pretty_print()
```

### Before this PR
```
Traceback (most recent call last):
  File "c:\GitHub\nltk\nltk_0002.py", line 6, in <module>
    next(parser.parse_text(sentence)).pretty_print()
  File "c:\GitHub\nltk\nltk\parse\corenlp.py", line 298, in parse_text
    parsed_data = self.api_call(text, *args, **kwargs)
  File "c:\GitHub\nltk\nltk\parse\corenlp.py", line 252, in api_call
    return response.json(strict=self.strict_json)
AttributeError: 'CoreNLPParser' object has no attribute 'strict_json'
```

### After this PR
```
                                     ROOT                                     
                                      |
                                      S                                       
  ____________________________________|____________________________________   
 |        VP                                                               |  
 |     ___|_________________                                               |  
 |    |                     NP                                             |  
 |    |         ____________|_________                                     |  
 |    |        |            |        SBAR                                  |  
 |    |        |            |     ____|________                            |  
 |    |        |            |    |             S                           |  
 |    |        |            |    |     ________|____                       |  
 |    |        |            |    |    |             VP                     |  
 |    |        |            |    |    |     ________|___                   |
 |    |        |            |    |    |    |            VP                 |
 |    |        |            |    |    |    |    ________|___               |
 |    |        |            |    |    |    |   |            S              |
 |    |        |            |    |    |    |   |            |              |
 |    |        |            |    |    |    |   |            VP             |
 |    |        |            |    |    |    |   |     _______|___           |
 |    |        |            |    |    |    |   |    |           VP         |
 |    |        |            |    |    |    |   |    |        ___|____      |
 NP   |        NP           |   WHNP  NP   |   |    |       |        VP    |
 |    |    ____|_____       |    |    |    |   |    |       |        |     |
 DT  VBZ PRP$        NN     ,   WDT  PRP  VBD  VB   TO      VB      VBN    .
 |    |   |          |      |    |    |    |   |    |       |        |     |
This  is  my      sentence  ,  which  I    'd like  to     get     parsed  .
```

I've simply moved `strict_json` fully to `GenericCoreNLPParser`.

- Tom Aarsen