### PR TITLE
Added return Notimplemented instead of raising the NotImplementedErro…

### DIFF
--- a/nltk/featstruct.py
+++ b/nltk/featstruct.py
@@ -2127,13 +2127,13 @@ class CustomFeatureValue:
         raise NotImplementedError("abstract base class")
 
     def __eq__(self, other):
-        raise NotImplementedError("abstract base class")
+        return NotImplemented
 
     def __ne__(self, other):
         return not self == other
 
     def __lt__(self, other):
-        raise NotImplementedError("abstract base class")
+        return NotImplemented
 
     def __hash__(self):
         raise TypeError("%s objects or unhashable" % self.__class__.__name__)

--- a/nltk/sem/drt.py
+++ b/nltk/sem/drt.py
@@ -214,7 +214,7 @@ class DrtExpression:
         return DrtNegatedExpression(self)
 
     def __and__(self, other):
-        raise NotImplementedError()
+        return NotImplemented
 
     def __or__(self, other):
         assert isinstance(other, DrtExpression)

--- a/nltk/sem/logic.py
+++ b/nltk/sem/logic.py
@@ -995,7 +995,7 @@ class Expression(SubstituteBindingsI):
         return IffExpression(self, other)
 
     def __eq__(self, other):
-        raise NotImplementedError()
+        return NotImplemented
 
     def __ne__(self, other):
         return not self == other


### PR DESCRIPTION
We have detected this issue in the `develop` branch of `nltk` project on the version with commit hash `3b72fa`. This issue is an instance of a improper method call. 

**Fixes for improper method call:**
In file: `nltk/sem/drt.py`,`nltk/sem/logic.py`,`nltk/featstruct.py` class: `DrtExpression`,`Expression`,`CustomFeatureValue`,  there are some special method `__and__`,`__eq__`,`__lt__` and `__eq__` that raises a NotImplementedError. If a special method supporting a [binary operation is not implemented it should return ](https://docs.python.org/3/library/constants.html#NotImplemented)NotImplemented. On the other hand, NotImplementedError should be raised from abstract methods inside user defined base classes to indicate that [derived classes should override those methods. ](https://docs.python.org/3/library/exceptions.html#NotImplementedError)iCR suggested that the special method `__and__`,`__eq__`,`__lt__` and `__eq__` should return NotImplemented instead of raising an exception. An example of how NotImplemented helps the interpreter support a binary operation is [interpreter support a binary operation is here.](https://docs.python.org/3/library/numbers.html#implementing-the-arithmetic-operations)

This issue was detected by our **OpenRefactory's Intelligent Code Repair (iCR)**. We are running **iCR** on libraries in the `PyPI` repository to identify issues and fix them. You will get more info at: [pypi.openrefactory.com](https://pypi.openrefactory.com/)