### PR TITLE
Resolve the last failing doctests, add doctests to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,7 @@ jobs:
         id: restore-cache
         with:
           path: ~/third
-          key: third_${{ secrets.CACHE_VERSION }}
+          key: third_${{ hashFiles('tools/github_actions/third-party.sh') }}_${{ secrets.CACHE_VERSION }}
 
       - name: Download third party data
         run: |
@@ -119,7 +119,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/third
-          key: third_${{ secrets.CACHE_VERSION }}
+          key: third_${{ hashFiles('tools/github_actions/third-party.sh') }}_${{ secrets.CACHE_VERSION }}
         if: runner.os == 'Linux'
 
       - name: Run pytest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,4 +125,4 @@ jobs:
       - name: Run pytest
         shell: bash
         run: |
-          pytest --numprocesses auto -rsx --doctest-modules nltk/test
+          pytest --numprocesses auto -rsx --doctest-modules nltk

--- a/nltk/classify/senna.py
+++ b/nltk/classify/senna.py
@@ -30,9 +30,9 @@ The input is:
 Note: Unit tests for this module can be found in test/unit/test_senna.py
 
 >>> from nltk.classify import Senna
->>> pipeline = Senna('/usr/share/senna-v3.0', ['pos', 'chk', 'ner'])
+>>> pipeline = Senna('/usr/share/senna-v3.0', ['pos', 'chk', 'ner'])  # doctest: +SKIP
 >>> sent = 'Dusseldorf is an international business center'.split()
->>> [(token['word'], token['chk'], token['ner'], token['pos']) for token in pipeline.tag(sent)] # doctest: +SKIP
+>>> [(token['word'], token['chk'], token['ner'], token['pos']) for token in pipeline.tag(sent)]  # doctest: +SKIP
 [('Dusseldorf', 'B-NP', 'B-LOC', 'NNP'), ('is', 'B-VP', 'O', 'VBZ'), ('an', 'B-NP', 'O', 'DT'),
 ('international', 'I-NP', 'O', 'JJ'), ('business', 'I-NP', 'O', 'NN'), ('center', 'I-NP', 'O', 'NN')]
 """

--- a/nltk/classify/senna.py
+++ b/nltk/classify/senna.py
@@ -62,7 +62,7 @@ class Senna(TaggerI):
                 self._path = path.normpath(environ["SENNA"]) + sep
                 exe_file_2 = self.executable(self._path)
                 if not path.isfile(exe_file_2):
-                    raise OSError(
+                    raise LookupError(
                         "Senna executable expected at %s or %s but not found"
                         % (exe_file_1, exe_file_2)
                     )
@@ -115,7 +115,7 @@ class Senna(TaggerI):
         encoding = self._encoding
 
         if not path.isfile(self.executable(self._path)):
-            raise OSError(
+            raise LookupError(
                 "Senna executable expected at %s but not found"
                 % self.executable(self._path)
             )

--- a/nltk/corpus/reader/markdown.py
+++ b/nltk/corpus/reader/markdown.py
@@ -1,8 +1,6 @@
 from collections import namedtuple
 from functools import partial, wraps
 
-from yaml import safe_load
-
 from nltk.corpus.reader.api import CategorizedCorpusReader
 from nltk.corpus.reader.plaintext import PlaintextCorpusReader
 from nltk.corpus.reader.util import concat, read_blankline_block
@@ -206,6 +204,8 @@ class CategorizedMarkdownCorpusReader(CategorizedCorpusReader, MarkdownCorpusRea
         )
 
     def metadata_reader(self, stream):
+        from yaml import safe_load
+
         return [
             safe_load(t.content)
             for t in self.parser.parse(stream.read())

--- a/nltk/draw/table.py
+++ b/nltk/draw/table.py
@@ -76,8 +76,8 @@ class MultiListbox(Frame):
         :param cnf, kw: Configuration parameters for this widget.
             Use ``label_*`` to configure all labels; and ``listbox_*``
             to configure all listboxes.  E.g.:
-                >>> root = Tk()
-                >>> MultiListbox(root, ["Subject", "Sender", "Date"], label_foreground='red').pack()
+                >>> root = Tk()  # doctest: +SKIP
+                >>> MultiListbox(root, ["Subject", "Sender", "Date"], label_foreground='red').pack()  # doctest: +SKIP
         """
         # If columns was specified as an int, convert it to a list.
         if isinstance(columns, int):
@@ -300,10 +300,10 @@ class MultiListbox(Frame):
         Configure this widget.  Use ``label_*`` to configure all
         labels; and ``listbox_*`` to configure all listboxes.  E.g.:
 
-                >>> master = Tk()
-                >>> mlb = MultiListbox(master, 5)
-                >>> mlb.configure(label_foreground='red')
-                >>> mlb.configure(listbox_foreground='red')
+                >>> master = Tk()  # doctest: +SKIP
+                >>> mlb = MultiListbox(master, 5)  # doctest: +SKIP
+                >>> mlb.configure(label_foreground='red')  # doctest: +SKIP
+                >>> mlb.configure(listbox_foreground='red')  # doctest: +SKIP
         """
         cnf = dict(list(cnf.items()) + list(kw.items()))
         for (key, val) in list(cnf.items()):

--- a/nltk/draw/table.py
+++ b/nltk/draw/table.py
@@ -76,13 +76,8 @@ class MultiListbox(Frame):
         :param cnf, kw: Configuration parameters for this widget.
             Use ``label_*`` to configure all labels; and ``listbox_*``
             to configure all listboxes.  E.g.:
-                >>> from nltk.draw.util import TextWidget, CanvasFrame, SpaceWidget
-                >>> from nltk.draw.table import MultiListbox
-                >>> cf = CanvasFrame(closeenough=10, width=300, height=300)
-                >>> c = cf.canvas()
-                >>> master = TextWidget(c, "hiya there", draggable=1)
-                >>> master = SpaceWidget(c, 0, 30)
-                >>> mlb = MultiListbox(master, 5, label_foreground='red')
+                >>> root = Tk()
+                >>> MultiListbox(root, ["Subject", "Sender", "Date"], label_foreground='red').pack()
         """
         # If columns was specified as an int, convert it to a list.
         if isinstance(columns, int):
@@ -139,7 +134,7 @@ class MultiListbox(Frame):
             # the default listbox behavior, which scrolls):
             lb.bind("<B1-Leave>", lambda e: "break")
             # Columns can be resized by dragging them:
-            l.bind("<Button-1>", self._resize_column)
+            lb.bind("<Button-1>", self._resize_column)
 
         # Columns can be resized by dragging them.  (This binding is
         # used if they click on the grid between columns:)
@@ -305,6 +300,7 @@ class MultiListbox(Frame):
         Configure this widget.  Use ``label_*`` to configure all
         labels; and ``listbox_*`` to configure all listboxes.  E.g.:
 
+                >>> master = Tk()
                 >>> mlb = MultiListbox(master, 5)
                 >>> mlb.configure(label_foreground='red')
                 >>> mlb.configure(listbox_foreground='red')
@@ -592,13 +588,13 @@ class Table:
     refers to the j-th column of the i-th row.  This can be used to
     both read and write values from the table.  E.g.:
 
-        >>> table[i,j] = 'hello'
+        >>> table[i,j] = 'hello'  # doctest: +SKIP
 
     The column (j) can be given either as an index number, or as a
     column name.  E.g., the following prints the value in the 3rd row
     for the 'First Name' column:
 
-        >>> print(table[3, 'First Name'])
+        >>> print(table[3, 'First Name'])  # doctest: +SKIP
         John
 
     You can configure the colors for individual rows, columns, or

--- a/nltk/draw/util.py
+++ b/nltk/draw/util.py
@@ -80,17 +80,17 @@ class CanvasWidget(metaclass=ABCMeta):
     arguments of the form ``attribute=value``:
 
         >>> from nltk.draw.util import TextWidget
-        >>> cn = TextWidget(Canvas(), 'test', color='red')
+        >>> cn = TextWidget(Canvas(), 'test', color='red')  # doctest: +SKIP
 
     Attribute values can also be changed after a canvas widget has
     been constructed, using the ``__setitem__`` operator:
 
-        >>> cn['font'] = 'times'
+        >>> cn['font'] = 'times'  # doctest: +SKIP
 
     The current value of an attribute value can be queried using the
     ``__getitem__`` operator:
 
-        >>> cn['color']
+        >>> cn['color']  # doctest: +SKIP
         'red'
 
     For a list of the attributes supported by a type of canvas widget,

--- a/nltk/parse/corenlp.py
+++ b/nltk/parse/corenlp.py
@@ -311,7 +311,8 @@ class GenericCoreNLPParser(ParserI, TokenizerI, TaggerI):
         """Tokenize a string of text.
 
         Skip these tests if CoreNLP is likely not ready.
-        >>> if "CLASSPATH" not in os.environ: import pytest; pytest.skip("CoreNLP jars unavailable")
+        >>> from nltk.test.setup_fixt import check_jar
+        >>> check_jar(CoreNLPServer._JAR, env_vars=("CORENLP",), is_regex=True)
 
         The CoreNLP server can be started using the following notation, although
         we recommend the `with CoreNLPServer() as server:` context manager notation
@@ -367,7 +368,8 @@ class GenericCoreNLPParser(ParserI, TokenizerI, TaggerI):
         :rtype: list(tuple(str, str))
 
         Skip these tests if CoreNLP is likely not ready.
-        >>> if "CLASSPATH" not in os.environ: import pytest; pytest.skip("CoreNLP jars unavailable")
+        >>> from nltk.test.setup_fixt import check_jar
+        >>> check_jar(CoreNLPServer._JAR, env_vars=("CORENLP",), is_regex=True)
 
         The CoreNLP server can be started using the following notation, although
         we recommend the `with CoreNLPServer() as server:` context manager notation
@@ -422,7 +424,8 @@ class GenericCoreNLPParser(ParserI, TokenizerI, TaggerI):
 class CoreNLPParser(GenericCoreNLPParser):
     """
     Skip these tests if CoreNLP is likely not ready.
-    >>> if "CLASSPATH" not in os.environ: import pytest; pytest.skip("CoreNLP jars unavailable")
+    >>> from nltk.test.setup_fixt import check_jar
+    >>> check_jar(CoreNLPServer._JAR, env_vars=("CORENLP",), is_regex=True)
 
     The recommended usage of `CoreNLPParser` is using the context manager notation:
     >>> with CoreNLPServer() as server:
@@ -586,7 +589,8 @@ class CoreNLPDependencyParser(GenericCoreNLPParser):
     """Dependency parser.
 
     Skip these tests if CoreNLP is likely not ready.
-    >>> if "CLASSPATH" not in os.environ: import pytest; pytest.skip("CoreNLP jars unavailable")
+    >>> from nltk.test.setup_fixt import check_jar
+    >>> check_jar(CoreNLPServer._JAR, env_vars=("CORENLP",), is_regex=True)
 
     The recommended usage of `CoreNLPParser` is using the context manager notation:
     >>> with CoreNLPServer() as server:

--- a/nltk/parse/corenlp.py
+++ b/nltk/parse/corenlp.py
@@ -7,9 +7,11 @@
 # For license information, see LICENSE.TXT
 
 import json
+import os  # required for doctests
 import re
 import socket
 import time
+from typing import List, Tuple
 
 from nltk.internals import _java_options, config_java, find_jar_iter, java
 from nltk.parse.api import ParserI
@@ -308,7 +310,15 @@ class GenericCoreNLPParser(ParserI, TokenizerI, TaggerI):
     def tokenize(self, text, properties=None):
         """Tokenize a string of text.
 
-        >>> parser = CoreNLPParser(url='http://localhost:9000')
+        Skip these tests if CoreNLP is likely not ready.
+        >>> if "CLASSPATH" not in os.environ: import pytest; pytest.skip("CoreNLP jars unavailable")
+
+        The CoreNLP server can be started using the following notation, although
+        we recommend the `with CoreNLPServer() as server:` context manager notation
+        to ensure that the server is always stopped.
+        >>> server = CoreNLPServer()
+        >>> server.start()
+        >>> parser = CoreNLPParser(url=server.url)
 
         >>> text = 'Good muffins cost $3.88\\nin New York.  Please buy me\\ntwo of them.\\nThanks.'
         >>> list(parser.tokenize(text))
@@ -321,7 +331,8 @@ class GenericCoreNLPParser(ParserI, TokenizerI, TaggerI):
         ...             properties={'tokenize.options': 'americanize=true'},
         ...     )
         ... )
-        ['The', 'color', 'of', 'the', 'wall', 'is', 'blue', '.']
+        ['The', 'colour', 'of', 'the', 'wall', 'is', 'blue', '.']
+        >>> server.stop()
 
         """
         default_properties = {"annotators": "tokenize,ssplit"}
@@ -349,24 +360,33 @@ class GenericCoreNLPParser(ParserI, TokenizerI, TaggerI):
         sentences = (" ".join(words) for words in sentences)
         return [sentences[0] for sentences in self.raw_tag_sents(sentences)]
 
-    def tag(self, sentence):
+    def tag(self, sentence: str) -> List[Tuple[str, str]]:
         """
         Tag a list of tokens.
 
         :rtype: list(tuple(str, str))
 
-        >>> parser = CoreNLPParser(url='http://localhost:9000', tagtype='ner')
-        >>> tokens = 'Rami Eid is studying at Stony Brook University in NY'.split()
-        >>> parser.tag(tokens)
-        [('Rami', 'PERSON'), ('Eid', 'PERSON'), ('is', 'O'), ('studying', 'O'), ('at', 'O'), ('Stony', 'ORGANIZATION'),
-        ('Brook', 'ORGANIZATION'), ('University', 'ORGANIZATION'), ('in', 'O'), ('NY', 'O')]
+        Skip these tests if CoreNLP is likely not ready.
+        >>> if "CLASSPATH" not in os.environ: import pytest; pytest.skip("CoreNLP jars unavailable")
 
-        >>> parser = CoreNLPParser(url='http://localhost:9000', tagtype='pos')
+        The CoreNLP server can be started using the following notation, although
+        we recommend the `with CoreNLPServer() as server:` context manager notation
+        to ensure that the server is always stopped.
+        >>> server = CoreNLPServer()
+        >>> server.start()
+        >>> parser = CoreNLPParser(url=server.url, tagtype='ner')
+        >>> tokens = 'Rami Eid is studying at Stony Brook University in NY'.split()
+        >>> parser.tag(tokens)  # doctest: +NORMALIZE_WHITESPACE
+        [('Rami', 'PERSON'), ('Eid', 'PERSON'), ('is', 'O'), ('studying', 'O'), ('at', 'O'), ('Stony', 'ORGANIZATION'),
+        ('Brook', 'ORGANIZATION'), ('University', 'ORGANIZATION'), ('in', 'O'), ('NY', 'STATE_OR_PROVINCE')]
+
+        >>> parser = CoreNLPParser(url=server.url, tagtype='pos')
         >>> tokens = "What is the airspeed of an unladen swallow ?".split()
-        >>> parser.tag(tokens)
+        >>> parser.tag(tokens)  # doctest: +NORMALIZE_WHITESPACE
         [('What', 'WP'), ('is', 'VBZ'), ('the', 'DT'),
         ('airspeed', 'NN'), ('of', 'IN'), ('an', 'DT'),
         ('unladen', 'JJ'), ('swallow', 'VB'), ('?', '.')]
+        >>> server.stop()
         """
         return self.tag_sents([sentence])[0]
 
@@ -401,24 +421,35 @@ class GenericCoreNLPParser(ParserI, TokenizerI, TaggerI):
 
 class CoreNLPParser(GenericCoreNLPParser):
     """
-    >>> parser = CoreNLPParser(url='http://localhost:9000')
+    Skip these tests if CoreNLP is likely not ready.
+    >>> if "CLASSPATH" not in os.environ: import pytest; pytest.skip("CoreNLP jars unavailable")
 
-    >>> next(
-    ...     parser.raw_parse('The quick brown fox jumps over the lazy dog.')
-    ... ).pretty_print()  # doctest: +NORMALIZE_WHITESPACE
-                         ROOT
-                          |
-                          S
-           _______________|__________________________
-          |                         VP               |
-          |                _________|___             |
-          |               |             PP           |
-          |               |     ________|___         |
-          NP              |    |            NP       |
-      ____|__________     |    |     _______|____    |
-     DT   JJ    JJ   NN  VBZ   IN   DT      JJ   NN  .
-     |    |     |    |    |    |    |       |    |   |
-    The quick brown fox jumps over the     lazy dog  .
+    The recommended usage of `CoreNLPParser` is using the context manager notation:
+    >>> with CoreNLPServer() as server:
+    ...     parser = CoreNLPParser(url=server.url)
+    ...     next(
+    ...         parser.raw_parse('The quick brown fox jumps over the lazy dog.')
+    ...     ).pretty_print()  # doctest: +NORMALIZE_WHITESPACE
+                            ROOT
+                            |
+                            S
+            _______________|__________________________
+            |                         VP               |
+            |                _________|___             |
+            |               |             PP           |
+            |               |     ________|___         |
+            NP              |    |            NP       |
+        ____|__________     |    |     _______|____    |
+        DT   JJ    JJ   NN  VBZ   IN   DT      JJ   NN  .
+        |    |     |    |    |    |    |       |    |   |
+        The quick brown fox jumps over the     lazy dog  .
+
+    Alternatively, the server can be started using the following notation.
+    Note that `CoreNLPServer` does not need to be used if the CoreNLP server is started
+    outside of Python.
+    >>> server = CoreNLPServer()
+    >>> server.start()
+    >>> parser = CoreNLPParser(url=server.url)
 
     >>> (parse_fox, ), (parse_wolf, ) = parser.raw_parse_sents(
     ...     [
@@ -485,9 +516,9 @@ class CoreNLPParser(GenericCoreNLPParser):
      |                VP
      |     ___________|_____________
      |    |                         NP
-     |    |                  _______|_________
-     |    |                 NP               PRN
-     |    |            _____|_______      ____|______________
+     |    |                  _______|________________________
+     |    |                 NP           |        |          |
+     |    |            _____|_______     |        |          |
      NP   |           NP            |    |        NP         |
      |    |     ______|_________    |    |     ___|____      |
      DT  VBZ  PRP$   NNS       POS  NN -LRB-  DT       NN  -RRB-
@@ -531,7 +562,7 @@ class CoreNLPParser(GenericCoreNLPParser):
     ...         'that she was raped by her Iraqi captors.'
     ...     )
     ... ).height()
-    20
+    14
 
     >>> next(
     ...     parser.raw_parse(
@@ -539,7 +570,9 @@ class CoreNLPParser(GenericCoreNLPParser):
     ...         '0.05 percent, at 997.02.'
     ...     )
     ... ).height()
-    9
+    11
+
+    >>> server.stop()
     """
 
     _OUTPUT_FORMAT = "penn"
@@ -552,37 +585,48 @@ class CoreNLPParser(GenericCoreNLPParser):
 class CoreNLPDependencyParser(GenericCoreNLPParser):
     """Dependency parser.
 
-    >>> dep_parser = CoreNLPDependencyParser(url='http://localhost:9000')
+    Skip these tests if CoreNLP is likely not ready.
+    >>> if "CLASSPATH" not in os.environ: import pytest; pytest.skip("CoreNLP jars unavailable")
 
-    >>> parse, = dep_parser.raw_parse(
-    ...     'The quick brown fox jumps over the lazy dog.'
-    ... )
-    >>> print(parse.to_conll(4))  # doctest: +NORMALIZE_WHITESPACE
-    The     DT      4       det
-    quick   JJ      4       amod
-    brown   JJ      4       amod
-    fox     NN      5       nsubj
-    jumps   VBZ     0       ROOT
-    over    IN      9       case
-    the     DT      9       det
-    lazy    JJ      9       amod
-    dog     NN      5       nmod
-    .       .       5       punct
+    The recommended usage of `CoreNLPParser` is using the context manager notation:
+    >>> with CoreNLPServer() as server:
+    ...     dep_parser = CoreNLPDependencyParser(url=server.url)
+    ...     parse, = dep_parser.raw_parse(
+    ...         'The quick brown fox jumps over the lazy dog.'
+    ...     )
+    ...     print(parse.to_conll(4))  # doctest: +NORMALIZE_WHITESPACE
+    The        DT      4       det
+    quick      JJ      4       amod
+    brown      JJ      4       amod
+    fox        NN      5       nsubj
+    jumps      VBZ     0       ROOT
+    over       IN      9       case
+    the        DT      9       det
+    lazy       JJ      9       amod
+    dog        NN      5       obl
+    .  .       5       punct
 
+    Alternatively, the server can be started using the following notation.
+    Note that `CoreNLPServer` does not need to be used if the CoreNLP server is started
+    outside of Python.
+    >>> server = CoreNLPServer()
+    >>> server.start()
+    >>> dep_parser = CoreNLPDependencyParser(url=server.url)
+    >>> parse, = dep_parser.raw_parse('The quick brown fox jumps over the lazy dog.')
     >>> print(parse.tree())  # doctest: +NORMALIZE_WHITESPACE
     (jumps (fox The quick brown) (dog over the lazy) .)
 
     >>> for governor, dep, dependent in parse.triples():
     ...     print(governor, dep, dependent)  # doctest: +NORMALIZE_WHITESPACE
-        ('jumps', 'VBZ') nsubj ('fox', 'NN')
-        ('fox', 'NN') det ('The', 'DT')
-        ('fox', 'NN') amod ('quick', 'JJ')
-        ('fox', 'NN') amod ('brown', 'JJ')
-        ('jumps', 'VBZ') nmod ('dog', 'NN')
-        ('dog', 'NN') case ('over', 'IN')
-        ('dog', 'NN') det ('the', 'DT')
-        ('dog', 'NN') amod ('lazy', 'JJ')
-        ('jumps', 'VBZ') punct ('.', '.')
+    ('jumps', 'VBZ') nsubj ('fox', 'NN')
+    ('fox', 'NN') det ('The', 'DT')
+    ('fox', 'NN') amod ('quick', 'JJ')
+    ('fox', 'NN') amod ('brown', 'JJ')
+    ('jumps', 'VBZ') obl ('dog', 'NN')
+    ('dog', 'NN') case ('over', 'IN')
+    ('dog', 'NN') det ('the', 'DT')
+    ('dog', 'NN') amod ('lazy', 'JJ')
+    ('jumps', 'VBZ') punct ('.', '.')
 
     >>> (parse_fox, ), (parse_dog, ) = dep_parser.raw_parse_sents(
     ...     [
@@ -591,28 +635,28 @@ class CoreNLPDependencyParser(GenericCoreNLPParser):
     ...     ]
     ... )
     >>> print(parse_fox.to_conll(4))  # doctest: +NORMALIZE_WHITESPACE
-    The DT      4       det
-    quick       JJ      4       amod
-    brown       JJ      4       amod
-    fox NN      5       nsubj
-    jumps       VBZ     0       ROOT
-    over        IN      9       case
-    the DT      9       det
-    lazy        JJ      9       amod
-    dog NN      5       nmod
-    .   .       5       punct
+    The        DT      4       det
+    quick      JJ      4       amod
+    brown      JJ      4       amod
+    fox        NN      5       nsubj
+    jumps      VBZ     0       ROOT
+    over       IN      9       case
+    the        DT      9       det
+    lazy       JJ      9       amod
+    dog        NN      5       obl
+    .  .       5       punct
 
     >>> print(parse_dog.to_conll(4))  # doctest: +NORMALIZE_WHITESPACE
-    The DT      4       det
-    quick       JJ      4       amod
-    grey        JJ      4       amod
-    wolf        NN      5       nsubj
-    jumps       VBZ     0       ROOT
-    over        IN      9       case
-    the DT      9       det
-    lazy        JJ      9       amod
-    fox NN      5       nmod
-    .   .       5       punct
+    The        DT      4       det
+    quick      JJ      4       amod
+    grey       JJ      4       amod
+    wolf       NN      5       nsubj
+    jumps      VBZ     0       ROOT
+    over       IN      9       case
+    the        DT      9       det
+    lazy       JJ      9       amod
+    fox        NN      5       obl
+    .  .       5       punct
 
     >>> (parse_dog, ), (parse_friends, ) = dep_parser.parse_sents(
     ...     [
@@ -627,26 +671,26 @@ class CoreNLPDependencyParser(GenericCoreNLPParser):
     dog NN      0       ROOT
 
     >>> print(parse_friends.to_conll(4))  # doctest: +NORMALIZE_WHITESPACE
-    This        DT      6       nsubj
-    is  VBZ     6       cop
-    my  PRP$    4       nmod:poss
-    friends     NNS     6       nmod:poss
-    '   POS     4       case
-    cat NN      0       ROOT
-    -LRB-       -LRB-   9       punct
-    the DT      9       det
-    tabby       NN      6       appos
-    -RRB-       -RRB-   9       punct
+    This       DT      6       nsubj
+    is VBZ     6       cop
+    my PRP$    4       nmod:poss
+    friends    NNS     6       nmod:poss
+    '  POS     4       case
+    cat        NN      0       ROOT
+    (  -LRB-   9       punct
+    the        DT      9       det
+    tabby      NN      6       dep
+    )  -RRB-   9       punct
 
     >>> parse_john, parse_mary, = dep_parser.parse_text(
     ...     'John loves Mary. Mary walks.'
     ... )
 
     >>> print(parse_john.to_conll(4))  # doctest: +NORMALIZE_WHITESPACE
-    John        NNP     2       nsubj
-    loves       VBZ     0       ROOT
-    Mary        NNP     2       dobj
-    .   .       2       punct
+    John       NNP     2       nsubj
+    loves      VBZ     0       ROOT
+    Mary       NNP     2       obj
+    .  .       2       punct
 
     >>> print(parse_mary.to_conll(4))  # doctest: +NORMALIZE_WHITESPACE
     Mary        NNP     2       nsubj
@@ -665,7 +709,7 @@ class CoreNLPDependencyParser(GenericCoreNLPParser):
     ...         )
     ...     ).nodes
     ... )
-    21
+    23
 
     Phone  numbers.
 
@@ -681,35 +725,38 @@ class CoreNLPDependencyParser(GenericCoreNLPParser):
     ...         dep_parser.raw_parse('The underscore _ should not simply disappear.')
     ...     ).to_conll(4)
     ... )  # doctest: +NORMALIZE_WHITESPACE
-    The         DT  3   det
-    underscore  VBP 3   amod
-    _           NN  7   nsubj
-    should      MD  7   aux
-    not         RB  7   neg
-    simply      RB  7   advmod
-    disappear   VB  0   ROOT
-    .           .   7   punct
+    The        DT      2       det
+    underscore NN      7       nsubj
+    _  NFP     7       punct
+    should     MD      7       aux
+    not        RB      7       advmod
+    simply     RB      7       advmod
+    disappear  VB      0       ROOT
+    .  .       7       punct
 
     >>> print(
-    ...     '\\n'.join(
-    ...         next(
-    ...             dep_parser.raw_parse(
-    ...                 'for all of its insights into the dream world of teen life , and its electronic expression through '
-    ...                 'cyber culture , the film gives no quarter to anyone seeking to pull a cohesive story out of its 2 '
-    ...                 '1/2-hour running time .'
-    ...             )
-    ...         ).to_conll(4).split('\\n')[-8:]
-    ...     )
-    ... )
-    its	PRP$	40	nmod:poss
-    2 1/2	CD	40	nummod
-    -	:	40	punct
-    hour	NN	31	nmod
-    running	VBG	42	amod
-    time	NN	40	dep
-    .	.	24	punct
-    <BLANKLINE>
+    ...     next(
+    ...         dep_parser.raw_parse(
+    ...             'for all of its insights into the dream world of teen life , and its electronic expression through '
+    ...             'cyber culture , the film gives no quarter to anyone seeking to pull a cohesive story out of its 2 '
+    ...             '1/2-hour running time .'
+    ...         )
+    ...     ).to_conll(4)
+    ... )  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    for        IN      2       case
+    all        DT      24      obl
+    of IN      5       case
+    its        PRP$    5       nmod:poss
+    insights   NNS     2       nmod
+    into       IN      9       case
+    the        DT      9       det
+    dream      NN      9       compound
+    world      NN      5       nmod
+    of IN      12      case
+    teen       NN      12      compound
+    ...
 
+    >>> server.stop()
     """
 
     _OUTPUT_FORMAT = "conll2007"

--- a/nltk/parse/transitionparser.py
+++ b/nltk/parse/transitionparser.py
@@ -752,6 +752,7 @@ def demo():
     >>> parser_std.train([gold_sent],'temp.arcstd.model', verbose=False)
      Number of training examples : 1
      Number of valid (projective) examples : 1
+    >>> input_file.close()
     >>> remove(input_file.name)
 
     B. Check the ARC-EAGER training
@@ -767,6 +768,7 @@ def demo():
      Number of training examples : 1
      Number of valid (projective) examples : 1
 
+    >>> input_file.close()
     >>> remove(input_file.name)
 
     ###################### Check The Parsing Function ########################

--- a/nltk/tag/senna.py
+++ b/nltk/tag/senna.py
@@ -17,20 +17,20 @@ The input is:
 Note: Unit tests for this module can be found in test/unit/test_senna.py
 
 >>> from nltk.tag import SennaTagger
->>> tagger = SennaTagger('/usr/share/senna-v3.0')
+>>> tagger = SennaTagger('/usr/share/senna-v3.0')  # doctest: +SKIP
 >>> tagger.tag('What is the airspeed of an unladen swallow ?'.split()) # doctest: +SKIP
 [('What', 'WP'), ('is', 'VBZ'), ('the', 'DT'), ('airspeed', 'NN'),
 ('of', 'IN'), ('an', 'DT'), ('unladen', 'NN'), ('swallow', 'NN'), ('?', '.')]
 
 >>> from nltk.tag import SennaChunkTagger
->>> chktagger = SennaChunkTagger('/usr/share/senna-v3.0')
+>>> chktagger = SennaChunkTagger('/usr/share/senna-v3.0')  # doctest: +SKIP
 >>> chktagger.tag('What is the airspeed of an unladen swallow ?'.split()) # doctest: +SKIP
 [('What', 'B-NP'), ('is', 'B-VP'), ('the', 'B-NP'), ('airspeed', 'I-NP'),
 ('of', 'B-PP'), ('an', 'B-NP'), ('unladen', 'I-NP'), ('swallow', 'I-NP'),
 ('?', 'O')]
 
 >>> from nltk.tag import SennaNERTagger
->>> nertagger = SennaNERTagger('/usr/share/senna-v3.0')
+>>> nertagger = SennaNERTagger('/usr/share/senna-v3.0')  # doctest: +SKIP
 >>> nertagger.tag('Shakespeare theatre was in London .'.split()) # doctest: +SKIP
 [('Shakespeare', 'B-PER'), ('theatre', 'O'), ('was', 'O'), ('in', 'O'),
 ('London', 'B-LOC'), ('.', 'O')]
@@ -80,14 +80,14 @@ class SennaChunkTagger(Senna):
         Extracts the chunks in a BIO chunk-tagged sentence.
 
         >>> from nltk.tag import SennaChunkTagger
-        >>> chktagger = SennaChunkTagger('/usr/share/senna-v3.0')
+        >>> chktagger = SennaChunkTagger('/usr/share/senna-v3.0')  # doctest: +SKIP
         >>> sent = 'What is the airspeed of an unladen swallow ?'.split()
-        >>> tagged_sent = chktagger.tag(sent) # doctest: +SKIP
-        >>> tagged_sent # doctest: +SKIP
+        >>> tagged_sent = chktagger.tag(sent)  # doctest: +SKIP
+        >>> tagged_sent  # doctest: +SKIP
         [('What', 'B-NP'), ('is', 'B-VP'), ('the', 'B-NP'), ('airspeed', 'I-NP'),
         ('of', 'B-PP'), ('an', 'B-NP'), ('unladen', 'I-NP'), ('swallow', 'I-NP'),
         ('?', 'O')]
-        >>> list(chktagger.bio_to_chunks(tagged_sent, chunk_type='NP')) # doctest: +SKIP
+        >>> list(chktagger.bio_to_chunks(tagged_sent, chunk_type='NP'))  # doctest: +SKIP
         [('What', '0'), ('the airspeed', '2-3'), ('an unladen swallow', '5-6-7')]
 
         :param tagged_sent: A list of tuples of word and BIO chunk tag.

--- a/nltk/test/setup_fixt.py
+++ b/nltk/test/setup_fixt.py
@@ -1,11 +1,23 @@
-# Skip doctest when a required binary is not available
-from nltk.internals import find_binary
+from nltk.internals import find_binary, find_jar
 
 
-def check_binary(binary):
+def check_binary(binary: str, **args):
+    """Skip a test via `pytest.skip` if the `binary` executable is not found.
+    Keyword arguments are passed to `nltk.internals.find_binary`."""
     import pytest
 
     try:
-        find_binary(binary)
+        find_binary(binary, **args)
     except LookupError:
         pytest.skip(f"Skipping test because the {binary} binary was not found")
+
+
+def check_jar(name_pattern: str, **args):
+    """Skip a test via `pytest.skip` if the `name_pattern` jar is not found.
+    Keyword arguments are passed to `nltk.internals.find_jar`."""
+    import pytest
+
+    try:
+        find_jar(name_pattern, **args)
+    except LookupError:
+        pytest.skip(f"Skipping test because the {name_pattern!r} jar was not found")

--- a/nltk/text.py
+++ b/nltk/text.py
@@ -270,8 +270,7 @@ class TokenSearcher:
         a single token must be surrounded by angle brackets.  E.g.
 
         >>> from nltk.text import TokenSearcher
-        >>> print('hack'); from nltk.book import text1, text5, text9
-        hack
+        >>> from nltk.book import text1, text5, text9
         >>> text5.findall("<.*><.*><bro>")
         you rule bro; telling you bro; u twizted bro
         >>> text1.findall("<a>(<.*>)<man>")
@@ -410,20 +409,7 @@ class Text:
         """
         Return collocations derived from the text, ignoring stopwords.
 
-            >>> from nltk.book import text4 # doctest: +NORMALIZE_WHITESPACE
-            *** Introductory Examples for the NLTK Book ***
-            Loading text1, ..., text9 and sent1, ..., sent9
-            Type the name of the text or sentence to view it.
-            Type: 'texts()' or 'sents()' to list the materials.
-            text1: Moby Dick by Herman Melville 1851
-            text2: Sense and Sensibility by Jane Austen 1811
-            text3: The Book of Genesis
-            text4: Inaugural Address Corpus
-            text5: Chat Corpus
-            text6: Monty Python and the Holy Grail
-            text7: Wall Street Journal
-            text8: Personals Corpus
-            text9: The Man Who Was Thursday by G . K . Chesterton 1908
+            >>> from nltk.book import text4
             >>> text4.collocation_list()[:2]
             [('United', 'States'), ('fellow', 'citizens')]
 
@@ -643,8 +629,7 @@ class Text:
         The text is a list of tokens, and a regexp pattern to match
         a single token must be surrounded by angle brackets.  E.g.
 
-        >>> print('hack'); from nltk.book import text1, text5, text9
-        hack
+        >>> from nltk.book import text1, text5, text9
         >>> text5.findall("<.*><.*><bro>")
         you rule bro; telling you bro; u twizted bro
         >>> text1.findall("<a>(<.*>)<man>")
@@ -714,8 +699,7 @@ class TextCollection(Text):
 
     >>> import nltk.corpus
     >>> from nltk.text import TextCollection
-    >>> print('hack'); from nltk.book import text1, text2, text3
-    hack
+    >>> from nltk.book import text1, text2, text3
     >>> gutenberg = TextCollection(nltk.corpus.gutenberg)
     >>> mytexts = TextCollection([text1, text2, text3])
 

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -1396,12 +1396,13 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
 
             # Get the slice of the previous word
             before_text = text[previous_slice.stop : match.start()]
-            last_space_index = self._get_last_whitespace_index(before_text)
-            if last_space_index:
-                last_space_index += previous_slice.stop
+            index_after_last_space = self._get_last_whitespace_index(before_text)
+            if index_after_last_space:
+                # + 1 to exclude the space itself
+                index_after_last_space += previous_slice.stop + 1
             else:
-                last_space_index = previous_slice.start
-            prev_word_slice = slice(last_space_index, match.start())
+                index_after_last_space = previous_slice.start
+            prev_word_slice = slice(index_after_last_space, match.start())
 
             # If the previous slice does not overlap with this slice, then
             # we can yield the previous match and slice. If there is an overlap,

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,10 +1,10 @@
 click
 gensim>=4.0.0
 matplotlib
-pycrfsuite
 pytest
 pytest-mock
 pytest-xdist[psutil]
+python-crfsuite
 regex
 scikit-learn
 twython

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,8 +1,11 @@
+click
 gensim>=4.0.0
 matplotlib
+pycrfsuite
 pytest
 pytest-mock
 pytest-xdist[psutil]
 regex
 scikit-learn
 twython
+yaml

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -7,4 +7,5 @@ pytest-xdist[psutil]
 python-crfsuite
 regex
 scikit-learn
+tqdm
 twython

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -8,4 +8,3 @@ python-crfsuite
 regex
 scikit-learn
 twython
-yaml

--- a/tools/github_actions/third-party.sh
+++ b/tools/github_actions/third-party.sh
@@ -10,7 +10,7 @@ pushd 'third'
 # Download nltk stanford dependencies
 # Downloaded to ~/third/stanford-corenlp
 # stanford_corenlp_package_zip_name=$(curl -s 'https://stanfordnlp.github.io/CoreNLP/' | grep -o 'stanford-corenlp-full-.*\.zip' | head -n1)
-stanford_corenlp_package_zip_name="stanford-corenlp-full-2018-10-05.zip"
+stanford_corenlp_package_zip_name="stanford-corenlp-4.5.1.zip"
 [[ ${stanford_corenlp_package_zip_name} =~ (.+)\.zip ]]
 stanford_corenlp_package_name=${BASH_REMATCH[1]}
 if [[ ! -d ${stanford_corenlp_package_name} ]]; then


### PR DESCRIPTION
Resolves #2989

Hello!

## Pull request overview
* Fix all tests from this list:
    ```
    ====================================================================================== short test summary info ====================================================================================== 
    FAILED nltk/text.py::nltk.text.Text.collocation_list
    FAILED nltk/draw/table.py::nltk.draw.table.MultiListbox.__init__
    FAILED nltk/draw/table.py::nltk.draw.table.MultiListbox.configure
    FAILED nltk/draw/table.py::nltk.draw.table.Table
    FAILED nltk/parse/corenlp.py::nltk.parse.corenlp.CoreNLPDependencyParser
    FAILED nltk/parse/corenlp.py::nltk.parse.corenlp.CoreNLPParser
    FAILED nltk/parse/corenlp.py::nltk.parse.corenlp.GenericCoreNLPParser.tag
    FAILED nltk/parse/corenlp.py::nltk.parse.corenlp.GenericCoreNLPParser.tokenize
    FAILED nltk/parse/transitionparser.py::nltk.parse.transitionparser.demo
    FAILED nltk/tokenize/punkt.py::nltk.tokenize.punkt.PunktSentenceTokenizer._match_potential_end_contexts
    ========================================================== 10 failed, 689 passed, 29 skipped, 9 xfailed, 22 warnings in 143.19s (0:02:23) ===========================================================
    ```
* Add automatic doctests to the CI, making us go from 489 to 686 automatically passing tests 🎉
* Update `requirements-ci.txt` with `click`, `python-crfsuite` and `tqdm` as they are required for doctests.
* Skip additional doctests for `tkinter`, as `tkinter.Tk()` requires a display to exist.
* Replace `OSError` with `LookupError` when SENNA can't be found.
* Resolve breaking issue in `MultiListBox` that prevents it from being instantiated.
* Update the Stanford CoreNLP version used in the CI from `full 2018-10-05` to the most recent `4.5.1`.
* Void the third party CI cache every time `tools/github_actions/third-party.sh` is updated.
* Add a `check_jar` function which calls `pytest.skip` if a jar is unavailable, and otherwise does nothing.

### Details
The changes are primarily very small and few and far between, so I'm going to add comments to the changed code rather than describing the changes in this PR text itself. That way, it's easier to see which comment refers to what piece of code. The only exception is to CoreNLP, which is a somewhat big change:

#### CoreNLP
I've reworked the doctests in that file to include `server = CoreNLPServer(...)`, `server.start()`, `server.stop()` or `with CoreNLPServer() as server:`. That way, the tests actually do pass now if the CoreNLP jars are on `CLASSPATH`.

Thanks to @ekaf and @Madnex for working on the other doctests & compiling the broken ones.

- Tom Aarsen