### PR TITLE
Prefix regexes with r to avoid 'invalid escape sequence' Deprecation warnings

### DIFF
--- a/nltk/tokenize/regexp.py
+++ b/nltk/tokenize/regexp.py
@@ -16,14 +16,14 @@ money expressions, and any other non-whitespace sequences:
 
     >>> from nltk.tokenize import RegexpTokenizer
     >>> s = "Good muffins cost $3.88\nin New York.  Please buy me\ntwo of them.\n\nThanks."
-    >>> tokenizer = RegexpTokenizer('\w+|\$[\d\.]+|\S+')
+    >>> tokenizer = RegexpTokenizer(r'\w+|\$[\d\.]+|\S+')
     >>> tokenizer.tokenize(s) # doctest: +NORMALIZE_WHITESPACE
     ['Good', 'muffins', 'cost', '$3.88', 'in', 'New', 'York', '.',
     'Please', 'buy', 'me', 'two', 'of', 'them', '.', 'Thanks', '.']
 
 A ``RegexpTokenizer`` can use its regexp to match delimiters instead:
 
-    >>> tokenizer = RegexpTokenizer('\s+', gaps=True)
+    >>> tokenizer = RegexpTokenizer(r'\s+', gaps=True)
     >>> tokenizer.tokenize(s) # doctest: +NORMALIZE_WHITESPACE
     ['Good', 'muffins', 'cost', '$3.88', 'in', 'New', 'York.',
     'Please', 'buy', 'me', 'two', 'of', 'them.', 'Thanks.']
@@ -34,7 +34,7 @@ the start or end of the string.
 The material between the tokens is discarded.  For example,
 the following tokenizer selects just the capitalized words:
 
-    >>> capword_tokenizer = RegexpTokenizer('[A-Z]\w+')
+    >>> capword_tokenizer = RegexpTokenizer(r'[A-Z]\w+')
     >>> capword_tokenizer.tokenize(s)
     ['Good', 'New', 'York', 'Please', 'Thanks']
 
@@ -50,7 +50,7 @@ that use pre-defined regular expressions.
 All of the regular expression tokenizers are also available as functions:
 
     >>> from nltk.tokenize import regexp_tokenize, wordpunct_tokenize, blankline_tokenize
-    >>> regexp_tokenize(s, pattern='\w+|\$[\d\.]+|\S+') # doctest: +NORMALIZE_WHITESPACE
+    >>> regexp_tokenize(s, pattern=r'\w+|\$[\d\.]+|\S+') # doctest: +NORMALIZE_WHITESPACE
     ['Good', 'muffins', 'cost', '$3.88', 'in', 'New', 'York', '.',
     'Please', 'buy', 'me', 'two', 'of', 'them', '.', 'Thanks', '.']
     >>> wordpunct_tokenize(s) # doctest: +NORMALIZE_WHITESPACE
@@ -77,7 +77,7 @@ class RegexpTokenizer(TokenizerI):
     A tokenizer that splits a string using a regular expression, which
     matches either the tokens or the separators between tokens.
 
-        >>> tokenizer = RegexpTokenizer('\w+|\$[\d\.]+|\S+')
+        >>> tokenizer = RegexpTokenizer(r'\w+|\$[\d\.]+|\S+')
 
     :type pattern: str
     :param pattern: The pattern used to build this tokenizer.


### PR DESCRIPTION
Hello!

### Pull request overview
* Prefix some regexes in docstrings with `r`.

### Details
See [this](https://github.com/nltk/nltk/actions/runs/3135601325/jobs/5092758588) GitHub Action for the source of these warnings:
```python
nltk/tokenize/regexp.py::nltk.tokenize.regexp
  <doctest nltk.tokenize.regexp[2]>:1: DeprecationWarning: invalid escape sequence '\w'

nltk/tokenize/regexp.py::nltk.tokenize.regexp
  <doctest nltk.tokenize.regexp[4]>:1: DeprecationWarning: invalid escape sequence '\s'

nltk/tokenize/regexp.py::nltk.tokenize.regexp
  <doctest nltk.tokenize.regexp[6]>:1: DeprecationWarning: invalid escape sequence '\w'

nltk/tokenize/regexp.py::nltk.tokenize.regexp
  <doctest nltk.tokenize.regexp[11]>:1: DeprecationWarning: invalid escape sequence '\w'

nltk/tokenize/regexp.py::nltk.tokenize.regexp.RegexpTokenizer
  <doctest nltk.tokenize.regexp.RegexpTokenizer[0]>:1: DeprecationWarning: invalid escape sequence '\w'
```

This PR fixes these by prefixing `r` to these strings, turning them into "raw" strings, which is preferred for strings that represent regexes.

- Tom Aarsen