### PR TITLE
ci: bump action version

### DIFF
--- a/.github/workflows/cffconvert.yml
+++ b/.github/workflows/cffconvert.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out a copy of the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Check whether the citation metadata from CITATION.cff is valid
         uses: citation-file-format/cffconvert-github-action@2.0.0


### PR DESCRIPTION
This PR is small CI change to update [actions/checkout](https://github.com/actions/checkout#checkout-v3) to v3 similar to how v3 is used in other CI workflows in this repo.