### PR TITLE
ci: add labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,3 +2,48 @@
 CI:
   - .github/workflows/*
   - .github/labeler.yml
+
+classifier:
+  - nltk/classify/**/*
+
+cli:
+  - nltk/cli.py
+
+cluster:
+  - nltk/cluster/**/*
+
+corpus:
+  - nltk/corpus/**/*
+
+GUI:
+  - nltk/app/**/*
+
+internals:
+  - nltk/internals.py
+
+language-model:
+  - nltk/lm/**/*
+
+metrics:
+  - nltk/metrics/**/*
+
+parsing:
+  - nltk/parse/**/*
+
+sentiment:
+  - nltk/sentiment/**/*
+
+stem/lemma:
+  - nltk/stem/**/*
+
+tagger:
+  - nltk/tag/**/*
+
+tokenizer:
+  - nltk/tokenize/**/*
+
+twitter:
+  - nltk/twitter/**/*
+
+wordnet:
+  - nltk/corpus/reader/wordnet.py

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,4 @@
+# https://github.com/actions/labeler
+CI:
+  - .github/workflows/*
+  - .github/labeler.yml

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,15 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v4
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        sync-labels: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: requirements-txt-fixer
+      - id: check-yaml
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.1.0
     hooks:


### PR DESCRIPTION
This PR introduces automatic [labelling](https://github.com/actions/labeler) of new pull requests based on the paths of files being changed.

For example, CI label will be applied when `.github/workflows/*` or `.github/labeler.yml` files change. We can define more labels and paths.