### PR TITLE
Resolve `TreebankWordDetokenizer` inconsistency with end-of-string contractions

### DIFF
--- a/nltk/test/tokenize.doctest
+++ b/nltk/test/tokenize.doctest
@@ -132,6 +132,15 @@ Testing treebank's detokenizer
     >>> s = "(Sentence) starting with parentheses."
     >>> detokenizer.detokenize(word_tokenize(s))
     '(Sentence) starting with parentheses.'
+    >>> s = "I've"
+    >>> detokenizer.detokenize(word_tokenize(s))
+    "I've"
+    >>> s = "Don't"
+    >>> detokenizer.detokenize(word_tokenize(s))
+    "Don't"
+    >>> s = "I'd"
+    >>> detokenizer.detokenize(word_tokenize(s))
+    "I'd"
 
 
 Sentence tokenization in word_tokenize:

--- a/nltk/tokenize/treebank.py
+++ b/nltk/tokenize/treebank.py
@@ -356,7 +356,11 @@ class TreebankWordDetokenizer(TokenizerI):
         :type convert_parentheses: bool, optional
         :return: str
         """
-        text = " " + " ".join(tokens) + " "
+        text = " ".join(tokens)
+
+        # Add extra space to make things easier
+        text = " " + text + " "
+
         # Reverse the contractions regexes.
         # Note: CONTRACTIONS4 are not used in tokenization.
         for regexp in self.CONTRACTIONS3:

--- a/nltk/tokenize/treebank.py
+++ b/nltk/tokenize/treebank.py
@@ -356,7 +356,7 @@ class TreebankWordDetokenizer(TokenizerI):
         :type convert_parentheses: bool, optional
         :return: str
         """
-        text = " ".join(tokens)
+        text = " " + " ".join(tokens) + " "
         # Reverse the contractions regexes.
         # Note: CONTRACTIONS4 are not used in tokenization.
         for regexp in self.CONTRACTIONS3:


### PR DESCRIPTION
Fixes #3069

Hello!

## Pull request overview
* Allow some `TreebankWordDetokenizer` rules to work like intended at the end of the string too.
* Add previously-failing tests for contractions from #3069.

## Details
See the two detokenization rules here.
https://github.com/nltk/nltk/blob/5575c28c86e2e24813bf0e026e84b2235a06f6a0/nltk/tokenize/treebank.py#L288-L290

These will never apply if the string tested for this regex has the contraction at the very end of the string, as the rules each require whitespace after the contracted part. For example, the top rule will find a match in `"it 'll "`, but not in `"it 'll"`.
Now, the requirement for whitespace is important: we don't want to match `I 'read that book`, so there are two fixes that spring to mind:

1. Replace the whitespace at the end of the rules with `( |$)`, allowing the end of text to match too.
2. Pad the input to `detokenize` to always have a space at the start and end of the string.

Because this second approach is used to solve similar issues in the `TreebankWordTokenizer` class (see below), I've opted to go for that approach.
https://github.com/nltk/nltk/blob/5575c28c86e2e24813bf0e026e84b2235a06f6a0/nltk/tokenize/treebank.py#L154-L155

Seems to work like a charm.

### Tests
I've adopted the failing test cases from #3069 into our test suite to cover this fix.

---


- Tom Aarsen
