### PR TITLE
Throw warning when `LanguageModel` is initialized with incorrect vocabulary

### DIFF
--- a/nltk/lm/api.py
+++ b/nltk/lm/api.py
@@ -83,7 +83,7 @@ class LanguageModel(metaclass=ABCMeta):
             of creating a new one when training.
         :type vocabulary: `nltk.lm.Vocabulary` or None
         :param counter: If provided, use this object to count ngrams.
-        :type vocabulary: `nltk.lm.NgramCounter` or None
+        :type counter: `nltk.lm.NgramCounter` or None
         :param ngrams_fn: If given, defines how sentences in training text are turned to ngram
             sequences.
         :type ngrams_fn: function or None

--- a/nltk/lm/api.py
+++ b/nltk/lm/api.py
@@ -7,6 +7,7 @@
 """Language Model Interface."""
 
 import random
+import warnings
 from abc import ABCMeta, abstractmethod
 from bisect import bisect
 from itertools import accumulate
@@ -91,6 +92,12 @@ class LanguageModel(metaclass=ABCMeta):
         :type pad_fn: function or None
         """
         self.order = order
+        if vocabulary and not isinstance(vocabulary, Vocabulary):
+            warnings.warn(
+                f"The `vocabulary` argument passed to {self.__class__.__name__!r} "
+                "must be an instance of `nltk.lm.Vocabulary`.",
+                stacklevel=3,
+            )
         self.vocab = Vocabulary() if vocabulary is None else vocabulary
         self.counts = NgramCounter() if counter is None else counter
 


### PR DESCRIPTION
Resolves #3074

Hello!

## Pull request overview
* When a `LanguageModel` is initialized with a value other than a `Vocabulary` instance or `None`, throw a warning.
* Update incorrect docstring variable name

## Details
The NLTK documentation [here](https://www.nltk.org/api/nltk.lm.html#preparing-data) mentions the following structure commonly:
```python
from nltk.lm.preprocessing import padded_everygram_pipeline
train, vocab = padded_everygram_pipeline(2, text)
```
After which both `train` and `vocab` are used, commonly like:
```python
lm.fit(train, vocab)
```
However, a very reasonable idea would be to initialize the `LanguageModel` directly with the vocab, as the `LanguageModel.__init__` [accepts a `vocabulary` argument](https://www.nltk.org/api/nltk.lm.api.html#nltk.lm.api.LanguageModel.__init__). However, this does not work: the `LanguageModel` must be passed a `Vocabulary` instance, e.g. `Vocabulary(vocab)` with `vocab` from the previous example. With other words, if someone just uses `vocab`, a weird error will throw up, as shown in #3074.

See also https://github.com/nltk/nltk/issues/3074#issuecomment-1337629849 for some additional details and motivation for this PR.

## Results
After this PR, if the script in https://github.com/nltk/nltk/issues/3074#issue-1468420882 is ran, the following warning will occur:
```
[sic] UserWarning: The `vocabulary` argument passed to 'Lidstone' must be an instance of `nltk.lm.Vocabulary`.
  lm = Lidstone(gamma=0.2, vocabulary=vocab, order=N)
```

The other scripts in the PR, e.g. from https://github.com/nltk/nltk/issues/3074#issuecomment-1337629849, would not cause such warnings.

- Tom Aarsen