### PR TITLE
Refactor dispersion plot

### DIFF
--- a/nltk/draw/dispersion.py
+++ b/nltk/draw/dispersion.py
@@ -23,7 +23,7 @@ def dispersion_plot(text, words, ignore_case=False, title="Lexical Dispersion Pl
     """
 
     try:
-        from matplotlib import pylab
+        import matplotlib.pyplot as plt
     except ImportError as e:
         raise ValueError(
             "The plot function requires matplotlib to be installed."
@@ -50,16 +50,20 @@ def dispersion_plot(text, words, ignore_case=False, title="Lexical Dispersion Pl
         x, y = list(zip(*points))
     else:
         x = y = ()
-    pylab.plot(x, y, "b|", scalex=0.1)
-    pylab.yticks(list(range(len(words))), words, color="b")
-    pylab.ylim(-1, len(words))
-    pylab.title(title)
-    pylab.xlabel("Word Offset")
-    pylab.show()
+    _, ax = plt.subplots()
+    ax.plot(x, y, "b|")
+    ax.set_yticks(list(range(len(words))), words, color="b")
+    ax.set_ylim(-1, len(words))
+    ax.set_title(title)
+    ax.set_xlabel("Word Offset")
+    return ax
 
 
 if __name__ == "__main__":
+    import matplotlib.pyplot as plt
+
     from nltk.corpus import gutenberg
 
     words = ["Elinor", "Marianne", "Edward", "Willoughby"]
     dispersion_plot(gutenberg.words("austen-sense.txt"), words)
+    plt.show()

--- a/nltk/draw/dispersion.py
+++ b/nltk/draw/dispersion.py
@@ -20,6 +20,8 @@ def dispersion_plot(text, words, ignore_case=False, title="Lexical Dispersion Pl
     :type words: list of str
     :param ignore_case: flag to set if case should be ignored when searching text
     :type ignore_case: bool
+    :return: a matplotlib Axes object that may still be modified before plotting
+    :rtype: Axes
     """
 
     try:

--- a/nltk/draw/dispersion.py
+++ b/nltk/draw/dispersion.py
@@ -31,12 +31,12 @@ def dispersion_plot(text, words, ignore_case=False, title="Lexical Dispersion Pl
         ) from e
 
     word2y = {
-        word.lower() if ignore_case else word: y
+        word.casefold() if ignore_case else word: y
         for y, word in enumerate(reversed(words))
     }
     xs, ys = [], []
     for x, token in enumerate(text):
-        token = token.lower() if ignore_case else token
+        token = token.casefold() if ignore_case else token
         y = word2y.get(token)
         if y is not None:
             xs.append(x)

--- a/nltk/draw/dispersion.py
+++ b/nltk/draw/dispersion.py
@@ -15,7 +15,7 @@ def dispersion_plot(text, words, ignore_case=False, title="Lexical Dispersion Pl
     Generate a lexical dispersion plot.
 
     :param text: The source text
-    :type text: list(str) or enum(str)
+    :type text: list(str) or iter(str)
     :param words: The target words
     :type words: list of str
     :param ignore_case: flag to set if case should be ignored when searching text

--- a/nltk/draw/dispersion.py
+++ b/nltk/draw/dispersion.py
@@ -25,8 +25,8 @@ def dispersion_plot(text, words, ignore_case=False, title="Lexical Dispersion Pl
     try:
         import matplotlib.pyplot as plt
     except ImportError as e:
-        raise ValueError(
-            "The plot function requires matplotlib to be installed."
+        raise ImportError(
+            "The plot function requires matplotlib to be installed. "
             "See https://matplotlib.org/"
         ) from e
 

--- a/nltk/draw/dispersion.py
+++ b/nltk/draw/dispersion.py
@@ -30,28 +30,20 @@ def dispersion_plot(text, words, ignore_case=False, title="Lexical Dispersion Pl
             "See https://matplotlib.org/"
         ) from e
 
-    text = list(text)
-    words.reverse()
+    word2y = {
+        word.lower() if ignore_case else word: y
+        for y, word in enumerate(reversed(words))
+    }
+    xs, ys = [], []
+    for x, token in enumerate(text):
+        token = token.lower() if ignore_case else token
+        y = word2y.get(token)
+        if y is not None:
+            xs.append(x)
+            ys.append(y)
 
-    if ignore_case:
-        words_to_comp = list(map(str.lower, words))
-        text_to_comp = list(map(str.lower, text))
-    else:
-        words_to_comp = words
-        text_to_comp = text
-
-    points = [
-        (x, y)
-        for x in range(len(text_to_comp))
-        for y in range(len(words_to_comp))
-        if text_to_comp[x] == words_to_comp[y]
-    ]
-    if points:
-        x, y = list(zip(*points))
-    else:
-        x = y = ()
     _, ax = plt.subplots()
-    ax.plot(x, y, "|")
+    ax.plot(xs, ys, "|")
     ax.set_yticks(list(range(len(words))), words, color="C0")
     ax.set_ylim(-1, len(words))
     ax.set_title(title)

--- a/nltk/draw/dispersion.py
+++ b/nltk/draw/dispersion.py
@@ -51,8 +51,8 @@ def dispersion_plot(text, words, ignore_case=False, title="Lexical Dispersion Pl
     else:
         x = y = ()
     _, ax = plt.subplots()
-    ax.plot(x, y, "b|")
-    ax.set_yticks(list(range(len(words))), words, color="b")
+    ax.plot(x, y, "|")
+    ax.set_yticks(list(range(len(words))), words, color="C0")
     ax.set_ylim(-1, len(words))
     ax.set_title(title)
     ax.set_xlabel("Word Offset")


### PR DESCRIPTION
This is a follow-up to a suggestion I made a while ago in #2247. I use dispersion plots a lot when teaching beginners. Students are often impressed and ask if tweaks can be made to the result. So I introduce them to the `??` IPython magic, which shows them the source code, but we typically stop short of actually playing around with a few tweaks, because:

- The data preparation part is written in a functional style which is a bit inscrutable, it emphasizes Python features which aren't typically the bread and butter of beginner introductions to Python.
- The plotting part uses Matplotlib's state-machine API, instead of the object-oriented one which is currently favored.

With the changes I'm proposing here, my hope is to make dispersion plot more hackable for beginners. I tried breaking up the changes into individual commits to facilitate discussion around different aspects of the issue. I'm aware that people's experience with teaching beginners may vary, so I'm very much open to discussion.

One part I'd definitely like to keep though is that `dispersion_plot` should return the `Axes` object it creates, so that the first tweaking attempts can be made without even looking at the source code. In light of #2239, I hope this is relatively uncontroversial.