### PR TITLE
For FreqDist plotting, no longer show plot by default

### DIFF
--- a/nltk/probability.py
+++ b/nltk/probability.py
@@ -245,7 +245,7 @@ class FreqDist(Counter):
         return self.most_common(1)[0][0]
 
     def plot(
-        self, *args, title="", cumulative=False, percents=False, show=True, **kwargs
+        self, *args, title="", cumulative=False, percents=False, show=False, **kwargs
     ):
         """
         Plot samples from the frequency distribution
@@ -1927,7 +1927,7 @@ class ConditionalFreqDist(defaultdict):
         cumulative=False,
         percents=False,
         conditions=None,
-        show=True,
+        show=False,
         **kwargs,
     ):
         """


### PR DESCRIPTION
Resolves #2788

Hello!

### Pull Request overview
* For `FreqDist` and `ConditionalFreqDist`, only return the ax rather than also showing the plot by default.

### Details
See #2788 for details. Note that the third case mentioned in that issue has already been solved in 8c759729d3a1d03fd724c96c6d82c38382ef2e82.

- Tom Aarsen