### PR TITLE
Add a note stating that a hashtag is unsupported in VADER

### DIFF
--- a/nltk/sentiment/vader.py
+++ b/nltk/sentiment/vader.py
@@ -356,6 +356,11 @@ class SentimentIntensityAnalyzer:
         Return a float for sentiment strength based on the input text.
         Positive values are positive valence, negative value are negative
         valence.
+
+        :note: Hashtags are not taken into consideration (e.g. #BAD is neutral). If you
+            are interested in processing the text in the hashtags too, then we recommend
+            preprocessing your data to remove the #, after which the hashtag text may be
+            matched as if it was a normal word in the sentence.
         """
         # text, words_and_emoticons, is_cap_diff = self.preprocess(text)
         sentitext = SentiText(


### PR DESCRIPTION
Resolves #2637

Hello!

## Pull Request overview
* Add a note stating that a hashtag, e.g. `#BAD`, is unsupported (neutral) in VADER

## Details
See https://github.com/nltk/nltk/pull/2840#issuecomment-933884265 for a discussion on needing such a note.

- Tom Aarsen