### PR TITLE
Add Python 3.11 to CI & documentation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,7 +76,7 @@ jobs:
     needs: [cache_nltk_data, cache_third_party]
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         os: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 NLTK -- the Natural Language Toolkit -- is a suite of open source Python
 modules, data sets, and tutorials supporting research and development in Natural
-Language Processing. NLTK requires Python version 3.7, 3.8, 3.9 or 3.10.
+Language Processing. NLTK requires Python version 3.7, 3.8, 3.9, 3.10 or 3.11.
 
 For documentation, please visit [nltk.org](https://www.nltk.org/).
 

--- a/nltk/__init__.py
+++ b/nltk/__init__.py
@@ -52,7 +52,7 @@ __license__ = "Apache License, Version 2.0"
 # Description of the toolkit, keywords, and the project's primary URL.
 __longdescr__ = """\
 The Natural Language Toolkit (NLTK) is a Python package for
-natural language processing.  NLTK requires Python 3.7, 3.8, 3.9 or 3.10."""
+natural language processing.  NLTK requires Python 3.7, 3.8, 3.9, 3.10 or 3.11."""
 __keywords__ = [
     "NLP",
     "CL",
@@ -88,6 +88,7 @@ __classifiers__ = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Scientific/Engineering :: Human Machine Interfaces",

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     },
     long_description="""\
 The Natural Language Toolkit (NLTK) is a Python package for
-natural language processing.  NLTK requires Python 3.7, 3.8, 3.9 or 3.10.""",
+natural language processing.  NLTK requires Python 3.7, 3.8, 3.9, 3.10 or 3.11.""",
     license="Apache License, Version 2.0",
     keywords=[
         "NLP",
@@ -99,6 +99,7 @@ natural language processing.  NLTK requires Python 3.7, 3.8, 3.9 or 3.10.""",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
         "Topic :: Scientific/Engineering :: Human Machine Interfaces",

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    py{37,38,39,310}
+    py{37,38,39,310,311}
     pypy
-    py{37,38,39,310}-nodeps
-    py{37,38,39,310}-jenkins
+    py{37,38,39,310,311}-nodeps
+    py{37,38,39,310,311}-jenkins
     py-travis
 
 [testenv]
@@ -74,6 +74,13 @@ commands = pytest
 
 [testenv:py310-nodeps]
 basepython = python3.10
+deps =
+    pytest
+    pytest-mock
+commands = pytest
+
+[testenv:py311-nodeps]
+basepython = python3.11
 deps =
     pytest
     pytest-mock

--- a/web/install.rst
+++ b/web/install.rst
@@ -1,7 +1,7 @@
 Installing NLTK
 ===============
 
-NLTK requires Python versions 3.7, 3.8, 3.9 or 3.10
+NLTK requires Python versions 3.7, 3.8, 3.9, 3.10 or 3.11.
 
 For Windows users, it is strongly recommended that you go through this guide to install Python 3 successfully https://docs.python-guide.org/starting/install3/win/#install3-windows
 


### PR DESCRIPTION
Resolves #3089

Hello!

## Pull Request overview
* Add Python 3.11 to CI.
* State support for Python 3.11 in documentation.

## Details
As of 2022-10-24, Python 3.11 has been fully released. As such, it is high time to officially add support for it in NLTK. This involves updating documentation and the CI test suite to ensure correct behaviour in Python 3.11. In this PR, I have done so. I believe to have updated all of the places where all valid Python versions are mentioned.

- Tom Aarsen