### PR TITLE
Temporarily remove `python-crfsuite` from CI dependencies & skip tests

### DIFF
--- a/nltk/tag/crf.py
+++ b/nltk/tag/crf.py
@@ -25,23 +25,23 @@ class CRFTagger(TaggerI):
     A module for POS tagging using CRFSuite https://pypi.python.org/pypi/python-crfsuite
 
     >>> from nltk.tag import CRFTagger
-    >>> ct = CRFTagger()
+    >>> ct = CRFTagger()  # doctest: +SKIP
 
     >>> train_data = [[('University','Noun'), ('is','Verb'), ('a','Det'), ('good','Adj'), ('place','Noun')],
     ... [('dog','Noun'),('eat','Verb'),('meat','Noun')]]
 
-    >>> ct.train(train_data,'model.crf.tagger')
-    >>> ct.tag_sents([['dog','is','good'], ['Cat','eat','meat']])
+    >>> ct.train(train_data,'model.crf.tagger')  # doctest: +SKIP
+    >>> ct.tag_sents([['dog','is','good'], ['Cat','eat','meat']])  # doctest: +SKIP
     [[('dog', 'Noun'), ('is', 'Verb'), ('good', 'Adj')], [('Cat', 'Noun'), ('eat', 'Verb'), ('meat', 'Noun')]]
 
     >>> gold_sentences = [[('dog','Noun'),('is','Verb'),('good','Adj')] , [('Cat','Noun'),('eat','Verb'), ('meat','Noun')]]
-    >>> ct.accuracy(gold_sentences)
+    >>> ct.accuracy(gold_sentences)  # doctest: +SKIP
     1.0
 
     Setting learned model file
-    >>> ct = CRFTagger()
-    >>> ct.set_model_file('model.crf.tagger')
-    >>> ct.accuracy(gold_sentences)
+    >>> ct = CRFTagger()  # doctest: +SKIP
+    >>> ct.set_model_file('model.crf.tagger')  # doctest: +SKIP
+    >>> ct.accuracy(gold_sentences)  # doctest: +SKIP
     1.0
     """
 

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -4,7 +4,6 @@ matplotlib
 pytest
 pytest-mock
 pytest-xdist[psutil]
-python-crfsuite
 regex
 scikit-learn
 tqdm


### PR DESCRIPTION
Hello!

## Pull Request overview
* Remove `python-crfsuite` from CI dependencies.
* Skip all CRFTagger doctests.

## Details
In response to https://github.com/nltk/nltk/pull/3090#issuecomment-1363327483. The hopes is to get the tests green again, despite `python-crfsuite` not being available for Python 3.11.

- Tom Aarsen