### PR TITLE
Resolve XSS vulnerability in local Wordnet browser

### DIFF
--- a/nltk/app/wordnet_app.py
+++ b/nltk/app/wordnet_app.py
@@ -127,7 +127,12 @@ class MyServerHandler(BaseHTTPRequestHandler):
             else:
                 # Handle files here.
                 word = sp
-                page = get_static_page_by_path(usp)
+                try:
+                    page = get_static_page_by_path(usp)
+                except FileNotFoundError:
+                    page = "Internal error: Path for static page '%s' is unknown" % usp
+                    # Set type to plain to prevent XSS by printing the path as HTML
+                    type = "text/plain"
         elif sp.startswith("search"):
             # This doesn't seem to work with MWEs.
             type = "text/html"
@@ -816,8 +821,7 @@ def get_static_page_by_path(path):
         return get_static_web_help_page()
     elif path == "wx_help.html":
         return get_static_wx_help_page()
-    else:
-        return "Internal error: Path for static page '%s' is unknown" % path
+    raise FileNotFoundError()
 
 
 def get_static_web_help_page():


### PR DESCRIPTION
Hello!

## Pull Request overview
* Resolve Cross Site Scripting vulnerability in `nltk.app.wordnet_app`. This ***only*** affected users of this browser interface to Wordnet, and ***not*** other users of Wordnet. If the following image is not familiar to you, then you are not affected:

![image](https://user-images.githubusercontent.com/37621491/209820009-db046398-df78-41cf-ac15-a014762c00b2.png)


## Details
Whenever an unknown path was supplied in the localhost, e.g. `http://localhost:8000/<script>alert(1)</script>.html`, then the wordnet app would try to find a file called `<script>alert(1)</script>.html`, be unable to do so, and then report back with an error on the website saying that `"Internal error: Path for static page '<script>alert(1)</script>' is unknown"`. However, this page was loaded as HTML, so the script would be executed.

I don't believe that there is a real attack vector here, as the pages that are normally seen are directly from Wordnet, so one of the Wordnet URLs would need to be modified into a malicious link. That said, there is no reason not to fix this.

## Reproducing
The wordnet browser app can be started like so:
```python
import nltk
nltk.app.wordnet()
```
Then, browsing to `http://localhost:8000/<script>alert(1)</script>.html` would cause the following popup to appear:
![image](https://user-images.githubusercontent.com/37621491/209820250-234c5fee-1e3e-4477-93d4-d6fea8eb23ed.png)


## The fix
By setting the `Content-type` to `text/plain` when an unknown path is used, we prevent any code from being executed. 

## After the fix
When running the reproduction code, we now see:
![image](https://user-images.githubusercontent.com/37621491/209820150-8bd0c58d-48ce-46a0-8ff4-feeda6b1c934.png)
And no popup.

This vulnerability was disclosed according to our [security policy](https://github.com/nltk/nltk/blob/develop/SECURITY.md), and we are thankful for that.

- Tom Aarsen