### PR TITLE
Update weblinks for the Open Multilingual Wordnet

### DIFF
--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -2179,7 +2179,7 @@ class WordNetCorpusReader(CorpusReader):
         language to Princeton WordNet 3.0 synset offsets, allowing NLTK's
         WordNet functions to then be used with that language.
 
-        See the "Tab files" section at https://omwn.org/omw1.html
+        See the "Tab files" section at https://omwn.org/omw1.html for
         documentation on the Multilingual WordNet tab file format.
 
         :param tab_file: Tab file as a file or file-like object

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -26,7 +26,7 @@ https://wordnet.princeton.edu/
 
 This module also allows you to find lemmas in languages
 other than English from the Open Multilingual Wordnet
-http://compling.hss.ntu.edu.sg/omw/
+https://omwn.org/
 
 """
 
@@ -2179,7 +2179,7 @@ class WordNetCorpusReader(CorpusReader):
         language to Princeton WordNet 3.0 synset offsets, allowing NLTK's
         WordNet functions to then be used with that language.
 
-        See the "Tab files" section at http://compling.hss.ntu.edu.sg/omw/ for
+        See the "Tab files" section at https://omwn.org/omw1.html
         documentation on the Multilingual WordNet tab file format.
 
         :param tab_file: Tab file as a file or file-like object


### PR DESCRIPTION
Hi,

This updates the links to the Open Multilingual Wordnet in the wordnet corpus reader to the new web page: https://omwn.org.

It closes #3095.



