### PR TITLE
Use deque.popleft() instead of list.pop(0)

### DIFF
--- a/nltk/grammar.py
+++ b/nltk/grammar.py
@@ -69,6 +69,7 @@ with the right hand side (*rhs*) in a tree (*tree*) is known as
 "expanding" *lhs* to *rhs* in *tree*.
 """
 import re
+from collections import deque
 from functools import total_ordering
 
 from nltk.featstruct import SLASH, TYPE, FeatDict, FeatStruct, FeatStructReader
@@ -771,7 +772,7 @@ class CFG:
         lexical
         """
         result = []
-        unitary = []
+        unitary = deque([])
         for rule in grammar.productions():
             if len(rule) == 1 and rule.is_nonlexical():
                 unitary.append(rule)
@@ -779,7 +780,7 @@ class CFG:
                 result.append(rule)
 
         while unitary:
-            rule = unitary.pop(0)
+            rule = unitary.popleft()
             for item in grammar.productions(lhs=rule.rhs()[0]):
                 new_rule = Production(rule.lhs(), item.rhs())
                 if len(new_rule) != 1 or new_rule.is_lexical():


### PR DESCRIPTION
Replaced a list with a deque so that deque.popleft() can be used instead of list.pop(0).

This improves performance, since popping from the beginning of a deque is O(1), but list's pop(0) incurs O(n) memory movement[^1].

There's a few more instances of pop(0) floating around that could be updated, but I figured I'd just start here for now. :)

[^1]: https://docs.python.org/3.10/library/collections.html#collections.deque