### PR TITLE
Expand some userpaths in internals.py #2825

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -296,6 +296,7 @@
 - M.K. Pawelkiewicz <https://github.com/hamiltonianflow>
 - Steven Thomas Smith <https://github.com/essandess>
 - Jan Lennartz <https://github.com/Madnex>
+- Ethan Knights <https://github.com/ethanknights>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -540,6 +540,7 @@ def find_file_iter(
 
     # Check environment variables
     for env_var in env_vars:
+        env_var = os.path.expanduser(env_var)
         if env_var in os.environ:
             if finding_dir:  # This is to file a directory instead of file
                 yielded = True
@@ -1086,12 +1087,12 @@ def slice_bounds(sequence, slice_obj, allow_step=False):
 
 def is_writable(path):
     # Ensure that it exists.
-    if not os.path.exists(path):
+    if not os.path.exists(os.path.expanduser(path)):
         return False
 
     # If we're on a posix system, check its permissions.
     if hasattr(os, "getuid"):
-        statdata = os.stat(path)
+        statdata = os.stat(os.path.expanduser(path))
         perm = stat.S_IMODE(statdata.st_mode)
         # is it world-writable?
         if perm & 0o002:

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -540,7 +540,6 @@ def find_file_iter(
 
     # Check environment variables
     for env_var in env_vars:
-        env_var = os.path.expanduser(env_var)
         if env_var in os.environ:
             if finding_dir:  # This is to file a directory instead of file
                 yielded = True


### PR DESCRIPTION
Hi - I added some of the path expansions to internals.py as described in #2825.

The tox command seems ok (output below).

```
================= 488 passed, 34 skipped, 9 xfailed, 1 warning in 249.04s (0:04:09) ==================
.pkg: _exit nltk/test> python /Users/ethanknights/PycharmProjects/nltk/venv/lib/python3.9/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
  python3.7: OK (273.95=setup[17.25]+cmd[1.94,254.76] seconds)
  congratulations :) (274.45 seconds)
```

Note - I tried expanding the remaining paths with a few different approaches. e.g., Adding a utility function that converted tuples to lists and expanded each of their items, like this:

```
file_names = expand_list_of_userpaths(file_names)
searchpath = expand_list_of_userpaths(searchpath)
``` 

But this wasn't a robust solution (particularly for the `filename` variable), so these paths remain unchanged for now.  
In any-case, hopefully this PR is a start!