### PR TITLE
Replace deprecated error with BadZipFile

### DIFF
--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -2244,7 +2244,7 @@ def _unzip_iter(filename, root, verbose=True):
 
     try:
         zf = zipfile.ZipFile(filename)
-    except zipfile.error as e:
+    except zipfile.BadZipFile:
         yield ErrorMessage(filename, "Error with downloaded zip file")
         return
     except Exception as e:


### PR DESCRIPTION
`zipfile`'s `error` have been deprecated since Python 3.2, use `BadZipFile` instead, added in 3.2.

* https://docs.python.org/3/library/zipfile.html#zipfile.BadZipfile
* https://github.com/python/cpython/blob/6829b1256a596301f82e3573214230186a4babfd/Lib/zipfile.py#L53
* https://github.com/python/cpython/issues/86437