### PR TITLE
dispersion plot not working properly

### DIFF
--- a/nltk/draw/dispersion.py
+++ b/nltk/draw/dispersion.py
@@ -4,6 +4,7 @@
 # Author: Steven Bird <stevenbird1@gmail.com>
 # URL: <https://www.nltk.org/>
 # For license information, see LICENSE.TXT
+# See issue #3133
 
 """
 A utility for displaying lexical dispersion.

--- a/nltk/draw/dispersion.py
+++ b/nltk/draw/dispersion.py
@@ -46,7 +46,7 @@ def dispersion_plot(text, words, ignore_case=False, title="Lexical Dispersion Pl
 
     _, ax = plt.subplots()
     ax.plot(xs, ys, "|")
-    ax.set_yticks(list(range(len(words))), words, color="C0")
+    ax.set_yticks(list(reversed(range(len(words)))), words, color="C0")
     ax.set_ylim(-1, len(words))
     ax.set_title(title)
     ax.set_xlabel("Word Offset")

--- a/nltk/draw/dispersion.py
+++ b/nltk/draw/dispersion.py
@@ -4,7 +4,6 @@
 # Author: Steven Bird <stevenbird1@gmail.com>
 # URL: <https://www.nltk.org/>
 # For license information, see LICENSE.TXT
-# See issue #3133
 
 """
 A utility for displaying lexical dispersion.


### PR DESCRIPTION
This is a fix to issue #3133.

Dispersion plot makes obvious mistakes.
To replicate this error do as follows:

```
import nltk
from nltk.books import *
text7.dispersion_plot(["chairman", "director", "money", "stocks", "old"])
text7.dispersion_plot(["chairman", "director", "money", "stocks", "old", "he"])
plt.show()
```

Looking at these plots, it should be clear, that the plots are not correct. All yticks change simply because "he" is introduced, although all distributions should stay the same, and "he" should have new distribution.
This error is persistent throughout other texts and other words.

The y-ticks are added in the opposite way of the matching distributions.

The same plots can be created after this change to see that the distributions now match the correct ytick.
Let me know I need to provide any other information.