### PR TITLE
Set reachable depth for generate

### DIFF
--- a/nltk/grammar.py
+++ b/nltk/grammar.py
@@ -6,6 +6,7 @@
 #         Jason Narad <jason.narad@gmail.com>
 #         Peter Ljunglöf <peter.ljunglof@heatherleaf.se>
 #         Tom Aarsen <>
+#         Eric Kafe <kafe.eric@gmail.com>
 # URL: <https://www.nltk.org/>
 # For license information, see LICENSE.TXT
 #
@@ -303,6 +304,9 @@ class Production:
         :rtype: sequence(Nonterminal and terminal)
         """
         return self._rhs
+
+    def is_recursive(self):
+        return self.lhs() in self.rhs()
 
     def __len__(self):
         """
@@ -604,6 +608,12 @@ class CFG:
                 for prod in self._lhs_index.get(lhs, [])
                 if prod in self._rhs_index.get(rhs, [])
             ]
+
+    def is_recursive(self):
+        for prod in self.productions():
+            if prod.is_recursive():
+                return True
+        return False
 
     def leftcorners(self, cat):
         """

--- a/nltk/grammar.py
+++ b/nltk/grammar.py
@@ -6,7 +6,6 @@
 #         Jason Narad <jason.narad@gmail.com>
 #         Peter Ljunglöf <peter.ljunglof@heatherleaf.se>
 #         Tom Aarsen <>
-#         Eric Kafe <kafe.eric@gmail.com>
 # URL: <https://www.nltk.org/>
 # For license information, see LICENSE.TXT
 #
@@ -304,9 +303,6 @@ class Production:
         :rtype: sequence(Nonterminal and terminal)
         """
         return self._rhs
-
-    def is_recursive(self):
-        return self.lhs() in self.rhs()
 
     def __len__(self):
         """
@@ -608,12 +604,6 @@ class CFG:
                 for prod in self._lhs_index.get(lhs, [])
                 if prod in self._rhs_index.get(rhs, [])
             ]
-
-    def is_recursive(self):
-        for prod in self.productions():
-            if prod.is_recursive():
-                return True
-        return False
 
     def leftcorners(self, cat):
         """

--- a/nltk/parse/generate.py
+++ b/nltk/parse/generate.py
@@ -27,11 +27,8 @@ def generate(grammar, start=None, depth=None, n=None):
     if not start:
         start = grammar.start()
     if depth is None:
-        if grammar.is_recursive():
-            # This seems to be an almost maximal safe default with Python 3:
-            depth = (sys.getrecursionlimit() // 3) - 3
-        else:
-            depth = sys.maxsize
+        # Safe default, assuming the grammar may be recursive:
+        depth = (sys.getrecursionlimit() // 3) - 3
 
     iter = _generate_all(grammar, [start], depth)
 

--- a/nltk/parse/generate.py
+++ b/nltk/parse/generate.py
@@ -14,13 +14,6 @@ import sys
 from nltk.grammar import Nonterminal
 
 
-def is_recursive(grammar):
-    for prod in grammar.productions():
-        if prod.lhs() in prod.rhs():
-            return True
-    return False
-
-
 def generate(grammar, start=None, depth=None, n=None):
     """
     Generates an iterator of all sentences from a CFG.
@@ -34,7 +27,7 @@ def generate(grammar, start=None, depth=None, n=None):
     if not start:
         start = grammar.start()
     if depth is None:
-        if is_recursive(grammar):
+        if grammar.is_recursive():
             # This seems to be an almost maximal safe default with Python 3:
             depth = (sys.getrecursionlimit() // 3) - 3
         else:


### PR DESCRIPTION
Fix #3072: when a grammar is recursive, the default generation depth (_sys.maxsize_) is wildly out of reach.

```
import sys
print(sys.maxsize)
```

9223372036854775807

`print(sys.getrecursionlimit())`
1000

So this PR adds a test to check if the grammar is recursive, in which case the default "depth" is lowered to a safe value.
Because of indirect recursion between generate_all() and generate_one(), the depth cannot exceed one third of the recursion limit. Additionally, Python 3 has the undocumented peculiarity that the actually reachable recursion limit is 3 less than sys.getrecursionlimit().

With this PR, generating from the grammar in #3072 no longer raises any error:

```
from nltk.grammar import CFG
from nltk.parse.generate import generate

G = CFG.fromstring("""
S -> 'a' S | 
""")

gen = generate(G)
out = next(gen)
print(len(out))
```
329 

```print(''.join(out))```

aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
