### PR TITLE
Fix order of words in y-axis of dispersion_plot

### DIFF
--- a/nltk/draw/dispersion.py
+++ b/nltk/draw/dispersion.py
@@ -44,6 +44,8 @@ def dispersion_plot(text, words, ignore_case=False, title="Lexical Dispersion Pl
             xs.append(x)
             ys.append(y)
 
+    words = list(word2y.keys())
+    
     _, ax = plt.subplots()
     ax.plot(xs, ys, "|")
     ax.set_yticks(list(range(len(words))), words, color="C0")

--- a/nltk/draw/dispersion.py
+++ b/nltk/draw/dispersion.py
@@ -44,8 +44,8 @@ def dispersion_plot(text, words, ignore_case=False, title="Lexical Dispersion Pl
             xs.append(x)
             ys.append(y)
 
-    words = list(word2y.keys())
-    
+    words = words[::-1]
+
     _, ax = plt.subplots()
     ax.plot(xs, ys, "|")
     ax.set_yticks(list(range(len(words))), words, color="C0")


### PR DESCRIPTION
Input words are reversed to create 'y' ticks but the internal 'words' list is not updated accordingly.
This has been fixed by getting 'words' back from 'word2y', which is sensitive to 'ignore_case'.
If 'words' should not be sensitive to 'ignore_case', then the following should be used instead:
```
# do not modify input 'words' list (as used to be the case with .reverse())
words = words[::-1]
```
