### PR TITLE
Allow resizing the nltk.download() GUI columns

### DIFF
--- a/nltk/draw/table.py
+++ b/nltk/draw/table.py
@@ -193,7 +193,7 @@ class MultiListbox(Frame):
         x1 = event.x + event.widget.winfo_x()
         x2 = lb.winfo_x() + lb.winfo_width()
 
-        lb["width"] = max(3, lb["width"] + (x1 - x2) // charwidth)
+        lb["width"] = max(3, int(lb["width"] + (x1 - x2) // charwidth))
 
     def _resize_column_buttonrelease_cb(self, event):
         event.widget.unbind("<ButtonRelease-%d>" % event.num)


### PR DESCRIPTION
Closes #3149

Hello!

## Pull Request overview
* Allow resizing of a `MultiListbox` tkinter element, i.e. allows `nltk.download()` to have its columns resized.

## Details
See #3149 for details. This PR only implements the changes suggested by @E-Paine. Resizing works as intended now.

Thank you @E-Paine for opening the issue.

- Tom Aarsen