### PR TITLE
Solve breaking issue with CharTokenizer

### DIFF
--- a/nltk/test/unit/test_tokenize.py
+++ b/nltk/test/unit/test_tokenize.py
@@ -16,6 +16,7 @@ from nltk.tokenize import (
     sent_tokenize,
     word_tokenize,
 )
+from nltk.tokenize.simple import CharTokenizer
 
 
 def load_stanford_segmenter():
@@ -865,3 +866,21 @@ class TestTokenize:
     )
     def test_sent_tokenize(self, sentences: str, expected: List[str]):
         assert sent_tokenize(sentences) == expected
+
+    def test_string_tokenizer(self) -> None:
+        sentence = "Hello there"
+        tokenizer = CharTokenizer()
+        assert tokenizer.tokenize(sentence) == list(sentence)
+        assert list(tokenizer.span_tokenize(sentence)) == [
+            (0, 1),
+            (1, 2),
+            (2, 3),
+            (3, 4),
+            (4, 5),
+            (5, 6),
+            (6, 7),
+            (7, 8),
+            (8, 9),
+            (9, 10),
+            (10, 11),
+        ]

--- a/nltk/tokenize/simple.py
+++ b/nltk/tokenize/simple.py
@@ -70,6 +70,8 @@ class CharTokenizer(StringTokenizer):
     is ever required directly, use ``for char in string``.
     """
 
+    _string = None
+
     def tokenize(self, s):
         return list(s)
 


### PR DESCRIPTION
Closes #3155

Hello!

## Pull Request overview
* Add `_string = None` to prevent `TypeError` due to abstract class.
* Add tests to ensure that it can be initialized.

## Details
The `_string = None` will prevent the `TypeError`. Other than that, the value isn't used.

- Tom Aarsen