### PR TITLE
Make sure dispersion plot spans full text length

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -110,6 +110,7 @@
 - Tom Lippincott
 - Peter Ljunglöf
 - Alex Louden
+- David Lukeš
 - Joseph Lynch
 - Nitin Madnani
 - Felipe Madrigal

--- a/nltk/draw/dispersion.py
+++ b/nltk/draw/dispersion.py
@@ -48,6 +48,8 @@ def dispersion_plot(text, words, ignore_case=False, title="Lexical Dispersion Pl
 
     _, ax = plt.subplots()
     ax.plot(xs, ys, "|")
+    ax.dataLim.x0, ax.dataLim.x1 = 0, len(text) - 1
+    ax.autoscale(axis="x")
     ax.set_yticks(list(range(len(words))), words, color="C0")
     ax.set_ylim(-1, len(words))
     ax.set_title(title)


### PR DESCRIPTION
By default, Matplotlib autoscales the x-axis based on where hits are found. This may result in an unintuitive visualization of the dispersion which "zooms in" on the portion of the text with hits, failing to represent the preceding and/or following stretches with no hits:

```python
from nltk.draw import dispersion_plot
text = ["foo"] * 10_000 + (["bar"] + ["foo"] * 100) * 5 + ["foo"] * 10_000
ax = dispersion_plot(text, ["bar"])
```

![image](https://github.com/nltk/nltk/assets/2734517/baf9bd19-9939-49d5-a9c9-b4f98550ef05)

A more intuitive visualization is one where the x-axis always spans the full length of the text. The most straightforward way to achieve this is via `ax.set_xlim(0, len(text) - 1)`, but since this disables autoscaling, it unfortunately also gets rid of the margins added during autoscaling, which add aesthetically pleasing breathing room to the plot:

```python
ax.set_xlim(0, len(text) - 1)
```

![image](https://github.com/nltk/nltk/assets/2734517/1baff3c1-aa89-4b50-b66a-8dfd33989855)

So instead, we can explicitly set the data limits via `ax.dataLim`, and re-apply autoscaling:

```python
ax.dataLim.x0, ax.dataLim.x1 = 0, len(text) - 1
ax.autoscale(axis="x")
```

![image](https://github.com/nltk/nltk/assets/2734517/08020be6-cab9-454d-a9f3-7b7c4e7c77ab)

This is the solution suggested by this PR.