### PR TITLE
Fix race condition for directory creation

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -297,6 +297,7 @@
 - Steven Thomas Smith <https://github.com/essandess>
 - Jan Lennartz <https://github.com/Madnex>
 - Tim Sockel <https://github.com/TiMauzi>
+- Akihiro Yamazaki <https://github.com/zakkie>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -695,10 +695,8 @@ class Downloader:
             os.remove(filepath)
 
         # Ensure the download_dir exists
-        if not os.path.exists(download_dir):
-            os.makedirs(download_dir)
-        if not os.path.exists(os.path.join(download_dir, info.subdir)):
-            os.makedirs(os.path.join(download_dir, info.subdir))
+        os.makedirs(download_dir, exist_ok=True)
+        os.makedirs(os.path.join(download_dir, info.subdir), exist_ok=True)
 
         # Download the file.  This will raise an IOError if the url
         # is not found.


### PR DESCRIPTION
In our environment we sometime encounter the following errors:

```python
  File "/home/ubuntu/venv/lib/python3.9/site-packages/g2p_en/g2p.py", line 28, in <module>
    nltk.download('cmudict')
  File "/home/ubuntu/venv/lib/python3.9/site-packages/nltk/downloader.py", line 777, in download
    for msg in self.incr_download(info_or_id, download_dir, force):
  File "/home/ubuntu/venv/lib/python3.9/site-packages/nltk/downloader.py", line 642, in incr_download
    yield from self._download_package(info, download_dir, force)
  File "/home/ubuntu/venv/lib/python3.9/site-packages/nltk/downloader.py", line 701, in _download_package
    os.makedirs(os.path.join(download_dir, info.subdir))
  File "/usr/lib/python3.9/os.py", line 225, in makedirs
    mkdir(name, mode)
FileExistsError: [Errno 17] File exists: '/home/ubuntu/nltk_data/corpora'
```

Since multiple processes are started and all of them execute `nltk.download()`, they could be executed at the same time.
So I fixed it so that there is no error even if the directory exists.