### PR TITLE
Remove redundant function call (demo())

### DIFF
--- a/nltk/chat/eliza.py
+++ b/nltk/chat/eliza.py
@@ -328,10 +328,8 @@ def eliza_chat():
 
     eliza_chatbot.converse()
 
-
 def demo():
     eliza_chat()
 
-
 if __name__ == "__main__":
-    demo()
+    eliza_chat()


### PR DESCRIPTION
keeping demo() for backwards-compatibility reasons