### PR TITLE
Bug on edit distance align

### DIFF
--- a/nltk/metrics/distance.py
+++ b/nltk/metrics/distance.py
@@ -123,24 +123,35 @@ def edit_distance(s1, s2, substitution_cost=1, transpositions=False):
     return lev[len1][len2]
 
 
-def _edit_dist_backtrace(lev):
+def _edit_dist_backtrace(lev, s1, s2, substitution_cost=1):
     i, j = len(lev) - 1, len(lev[0]) - 1
     alignment = [(i, j)]
 
     while (i, j) != (0, 0):
         directions = [
-            (i - 1, j - 1),  # substitution
+            (i - 1, j - 1),  # substitution / match
             (i - 1, j),  # skip s1
             (i, j - 1),  # skip s2
         ]
 
-        direction_costs = (
-            (lev[i][j] if (i >= 0 and j >= 0) else float("inf"), (i, j))
-            for i, j in directions
-        )
+        direction_costs = []
+        for pi, pj in directions:
+            if pi < 0 or pj < 0:
+                cost = float("inf")
+            elif pi == i - 1 and pj == j - 1:  # diagonal
+                # Use actual transition cost: 0 for match, substitution_cost
+                # for mismatch. This ensures the backtrace prefers delete+insert
+                # (cost 2) over substitution when substitution_cost > 2.
+                sub_cost = 0 if s1[pi] == s2[pj] else substitution_cost
+                cost = lev[pi][pj] + sub_cost
+            else:  # skip s1 or skip s2
+                cost = lev[pi][pj] + 1
+            direction_costs.append((cost, (pi, pj)))
+
         _, (i, j) = min(direction_costs, key=operator.itemgetter(0))
 
         alignment.append((i, j))
+
     return list(reversed(alignment))
 
 
@@ -194,7 +205,7 @@ def edit_distance_align(s1, s2, substitution_cost=1):
             )
 
     # backtrace to find alignment
-    alignment = _edit_dist_backtrace(lev)
+    alignment = _edit_dist_backtrace(lev, s1, s2, substitution_cost)
     return alignment
 
 

--- a/nltk/test/unit/test_distance.py
+++ b/nltk/test/unit/test_distance.py
@@ -4,6 +4,7 @@ import pytest
 
 from nltk.metrics.distance import (
     edit_distance,
+    edit_distance_align,
     jaro_similarity,
     jaro_winkler_similarity,
 )
@@ -226,3 +227,167 @@ class TestJaroWinklerSimilarity:
         """Winkler similarity >= Jaro similarity for common prefixes."""
         s1, s2 = "MARTHA", "MARHTA"
         assert jaro_winkler_similarity(s1, s2) >= jaro_similarity(s1, s2)
+
+
+def _alignment_has_no_substitutions(alignment):
+    """Check that no step in the alignment is a diagonal move between mismatched positions."""
+    for k in range(len(alignment) - 1):
+        i1, j1 = alignment[k]
+        i2, j2 = alignment[k + 1]
+        if i2 == i1 + 1 and j2 == j1 + 1:
+            return False  # diagonal move = substitution or match; caller must verify
+    return True
+
+
+def _alignment_cost(alignment, s1, s2, substitution_cost):
+    """Compute the total cost of an alignment."""
+    cost = 0
+    for k in range(len(alignment) - 1):
+        i1, j1 = alignment[k]
+        i2, j2 = alignment[k + 1]
+        if i2 == i1 + 1 and j2 == j1 + 1:
+            # diagonal: match or substitution
+            if s1[i1] != s2[j1]:
+                cost += substitution_cost
+            # else: match, cost 0
+        elif i2 == i1 + 1 and j2 == j1:
+            cost += 1  # deletion
+        elif i2 == i1 and j2 == j1 + 1:
+            cost += 1  # insertion
+    return cost
+
+
+class TestEditDistanceAlign:
+    def test_default_rain_to_shine(self):
+        """Docstring example: rain -> shine with default substitution_cost=1."""
+        result = edit_distance_align("rain", "shine")
+        assert result == [(0, 0), (1, 1), (2, 2), (3, 3), (4, 4), (4, 5)]
+
+    def test_identical_strings(self):
+        """Identical strings should produce a pure diagonal alignment."""
+        result = edit_distance_align("abc", "abc")
+        assert result == [(0, 0), (1, 1), (2, 2), (3, 3)]
+
+    def test_empty_to_nonempty(self):
+        """Empty s1 -> all insertions."""
+        result = edit_distance_align("", "abc")
+        assert result == [(0, 0), (0, 1), (0, 2), (0, 3)]
+
+    def test_nonempty_to_empty(self):
+        """Non-empty s1 to empty s2 -> all deletions."""
+        result = edit_distance_align("abc", "")
+        assert result == [(0, 0), (1, 0), (2, 0), (3, 0)]
+
+    def test_both_empty(self):
+        result = edit_distance_align("", "")
+        assert result == [(0, 0)]
+
+    def test_single_char_substitution(self):
+        """Single character substitution with default cost."""
+        result = edit_distance_align("a", "b")
+        assert result == [(0, 0), (1, 1)]
+
+    # --- The core bug fix: substitution_cost > 2 ---
+
+    def test_inf_sub_cost_different_chars(self):
+        """Bug from issue #3017: sub_cost=inf should avoid substitution."""
+        result = edit_distance_align("a", "b", float("inf"))
+        # Must use delete + insert, NOT substitution
+        assert result in [
+            [(0, 0), (0, 1), (1, 1)],  # insert then delete
+            [(0, 0), (1, 0), (1, 1)],  # delete then insert
+        ]
+
+    def test_inf_sub_cost_identical_strings(self):
+        """With sub_cost=inf, identical strings must still use diagonal (match, cost 0)."""
+        result = edit_distance_align("abc", "abc", float("inf"))
+        assert result == [(0, 0), (1, 1), (2, 2), (3, 3)]
+
+    def test_inf_sub_cost_partial_match(self):
+        """With sub_cost=inf, matching chars use diagonal, mismatched use del+ins."""
+        result = edit_distance_align("ab", "cb", float("inf"))
+        # a->del, ins->c, b=b(match)
+        assert result == [(0, 0), (0, 1), (1, 1), (2, 2)]
+        cost = _alignment_cost(result, "ab", "cb", float("inf"))
+        assert cost == 2  # one delete + one insert
+
+    def test_inf_sub_cost_longer_partial_match(self):
+        """Longer string with inf sub_cost: matches use diagonal, mismatches use del+ins."""
+        result = edit_distance_align("abcd", "axcy", float("inf"))
+        cost = _alignment_cost(result, "abcd", "axcy", float("inf"))
+        assert cost == 4  # two mismatched pairs, each costs 2 (del+ins)
+
+    def test_sub_cost_2_prefers_substitution(self):
+        """When sub_cost=2 (equal to del+ins), substitution is preferred per precedence."""
+        result = edit_distance_align("a", "b", 2)
+        # Diagonal is listed first in candidates, so tied cost -> diagonal wins
+        assert result == [(0, 0), (1, 1)]
+
+    def test_sub_cost_3_avoids_substitution(self):
+        """When sub_cost=3 (more than del+ins=2), should avoid substitution."""
+        result = edit_distance_align("a", "b", 3)
+        assert result in [
+            [(0, 0), (0, 1), (1, 1)],
+            [(0, 0), (1, 0), (1, 1)],
+        ]
+
+    # --- Alignment cost consistency ---
+
+    @pytest.mark.parametrize(
+        "s1,s2,sub_cost",
+        [
+            ("rain", "shine", 1),
+            ("kitten", "sitting", 1),
+            ("abc", "def", 1),
+            ("abc", "def", 2),
+            ("abc", "def", float("inf")),
+            ("abc", "abc", float("inf")),
+            ("", "abc", 1),
+            ("abc", "", 1),
+            ("saturday", "sunday", 1),
+        ],
+    )
+    def test_alignment_cost_equals_edit_distance(self, s1, s2, sub_cost):
+        """The cost of the alignment path must equal the edit distance."""
+        alignment = edit_distance_align(s1, s2, sub_cost)
+        cost = _alignment_cost(alignment, s1, s2, sub_cost)
+        expected = edit_distance(s1, s2, substitution_cost=sub_cost)
+        assert cost == expected
+
+    # --- Alignment structural validity ---
+
+    @pytest.mark.parametrize(
+        "s1,s2,sub_cost",
+        [
+            ("abc", "xyz", 1),
+            ("abc", "xyz", float("inf")),
+            ("hello", "world", 1),
+            ("hello", "world", float("inf")),
+        ],
+    )
+    def test_alignment_starts_and_ends_correctly(self, s1, s2, sub_cost):
+        """Alignment must start at (0,0) and end at (len(s1), len(s2))."""
+        alignment = edit_distance_align(s1, s2, sub_cost)
+        assert alignment[0] == (0, 0)
+        assert alignment[-1] == (len(s1), len(s2))
+
+    @pytest.mark.parametrize(
+        "s1,s2,sub_cost",
+        [
+            ("abc", "xyz", 1),
+            ("abc", "xyz", float("inf")),
+            ("rain", "shine", 1),
+        ],
+    )
+    def test_alignment_steps_are_valid(self, s1, s2, sub_cost):
+        """Each step must advance by exactly (1,1), (1,0), or (0,1)."""
+        alignment = edit_distance_align(s1, s2, sub_cost)
+        for k in range(len(alignment) - 1):
+            i1, j1 = alignment[k]
+            i2, j2 = alignment[k + 1]
+            di, dj = i2 - i1, j2 - j1
+            assert (di, dj) in [
+                (1, 1),
+                (1, 0),
+                (0, 1),
+            ], f"Invalid step from {(i1,j1)} to {(i2,j2)}"


### PR DESCRIPTION
This pull request attempts to fix the issue raised by @yzhangcs's [comment](https://github.com/nltk/nltk/pull/3017#issuecomment-1557141556) as a follow-up to #3017. In short, when the substitution cost is greater than 2, the path generated by [`_edit_dist_backtrace()`](https://github.com/nltk/nltk/blob/develop/nltk/metrics/distance.py#L126) still includes substitution. This is incorrect because a deletion followed by an insertion incur a cost of 2, which is lower than substitution, and thus should be preferred over substitution.

In the following test case due to @yzhangcs, the current [`_edit_dist_backtrace()`](https://github.com/nltk/nltk/blob/develop/nltk/metrics/distance.py#L126) gives the following output
```python
from nltk.metrics.distance import edit_distance_align

>>> edit_distance_align('a', 'b', float('inf')) 
[(0, 0), (1, 1)]
```
After the fix it correctly outputs `[(0, 0), (0, 1), (1, 1)]`. I tried to add the test case provided by @yzhangcs, but didn't figure out how. Could the maintainers of NLTK look into this and add this test case?