### PR TITLE
minor fix for wordnet lemmatization pos param documentation

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -297,6 +297,7 @@
 - Steven Thomas Smith <https://github.com/essandess>
 - Jan Lennartz <https://github.com/Madnex>
 - Tim Sockel <https://github.com/TiMauzi>
+- Ron Urbach <https://github.com/sharpblade4>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 

--- a/nltk/stem/wordnet.py
+++ b/nltk/stem/wordnet.py
@@ -39,7 +39,7 @@ class WordNetLemmatizer:
         :param pos: The Part Of Speech tag. Valid options are `"n"` for nouns,
             `"v"` for verbs, `"a"` for adjectives, `"r"` for adverbs and `"s"`
             for satellite adjectives.
-        :param pos: str
+        :type pos: str
         :return: The lemma of `word`, for the given `pos`.
         """
         lemmas = wn._morphy(word, pos)


### PR DESCRIPTION
Encountered extra parameter in the [documentation of wordnet lemmatization](https://www.nltk.org/api/nltk.stem.wordnet.html).  

The minor issue is that `pos` declared twice as `param` instead of declaring its `type`. 

Followed [contribution instructions](https://github.com/nltk/nltk/blob/develop/CONTRIBUTING.md) to apply a minor fix to solve that. 