### PR TITLE
Fix dunning log likelihood ValueError

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -298,6 +298,7 @@
 - Jan Lennartz <https://github.com/Madnex>
 - Tim Sockel <https://github.com/TiMauzi>
 - Ron Urbach <https://github.com/sharpblade4>
+- Vivek Kalyan <https://github.com/vivekkalyan>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 

--- a/nltk/test/unit/test_tokenize.py
+++ b/nltk/test/unit/test_tokenize.py
@@ -884,3 +884,17 @@ class TestTokenize:
             (9, 10),
             (10, 11),
         ]
+
+
+class TestPunktTrainer:
+    def test_punkt_train(self) -> None:
+        trainer = punkt.PunktTrainer()
+        trainer.train("This is a test.")
+
+    def test_punkt_train_single_word(self) -> None:
+        trainer = punkt.PunktTrainer()
+        trainer.train("This.")
+
+    def test_punkt_train_no_punc(self) -> None:
+        trainer = punkt.PunktTrainer()
+        trainer.train("This is a test")

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -1073,7 +1073,9 @@ class PunktTrainer(PunktBaseClass):
         p1 = count_b / N
         p2 = 0.99
 
-        null_hypo = count_ab * math.log(p1) + (count_a - count_ab) * math.log(1.0 - p1)
+        null_hypo = count_ab * math.log(p1 + 1e-8) + (count_a - count_ab) * math.log(
+            1.0 - p1 + 1e-8
+        )
         alt_hypo = count_ab * math.log(p2) + (count_a - count_ab) * math.log(1.0 - p2)
 
         likelihood = null_hypo - alt_hypo


### PR DESCRIPTION
This pull request addresses a `ValueError` that occurs in the `_dunning_log_likelihood` function during the execution of `PunktTrainer.train()`. The error is triggered when `count_b` is equal to `N`, resulting in `p1` being equal to 1, and subsequently causing `math.log(1.0 - p1)` to be `math.log(0)`, which is undefined.

To fix this issue, a small epsilon value of `1e-8` is added to the arguments of the logarithm functions to ensure they are always within a valid range, preventing the `ValueError`.

Additionally, this pull request includes new tests for the `PunktTrainer` class to prevent regression.