### PR TITLE
fix broken link to the Coding Horror blog post in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,7 @@ Summary of our git branching model:
 - Use [PEP8](https://www.python.org/dev/peps/pep-0008/);
 - Write tests for your new features (please see "Tests" topic below);
 - Always remember that [commented code is dead
-  code](https://www.codinghorror.com/blog/2008/07/coding-without-comments.html);
+  code](https://blog.codinghorror.com/coding-without-comments/);
 - Name identifiers (variables, classes, functions, module names) with readable
   names (`x` is always wrong);
 - When manipulating strings, we prefer either [f-string


### PR DESCRIPTION
There's currently a busted link in CONTRIBUTING.md, but this PR fixes it.