### PR TITLE
Prevent crash on BLEU if weights are np array

### DIFF
--- a/nltk/test/unit/translate/test_bleu.py
+++ b/nltk/test/unit/translate/test_bleu.py
@@ -5,6 +5,8 @@ Tests for BLEU translation evaluation metric
 import io
 import unittest
 
+import numpy as np
+
 from nltk.data import find
 from nltk.translate.bleu_score import (
     SmoothingFunction,
@@ -216,6 +218,14 @@ class TestBLEUFringeCases(unittest.TestCase):
             self.assertWarns(UserWarning, sentence_bleu, references, hypothesis)
         except AttributeError:
             pass  # unittest.TestCase.assertWarns is only supported in Python >= 3.2.
+
+    def test_numpy_weights(self):
+        # Test case where there's 0 matches
+        references = ["The candidate has no alignment to any of the references".split()]
+        hypothesis = "John loves Mary".split()
+
+        weights = np.array([0.25] * 4)
+        assert sentence_bleu(references, hypothesis, weights) == 0
 
 
 class TestBLEUvsMteval13a(unittest.TestCase):

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -198,7 +198,7 @@ def corpus_bleu(
 
     try:
         weights[0][0]
-    except TypeError:
+    except:
         weights = [weights]
     max_weight_length = max(len(weight) for weight in weights)
 


### PR DESCRIPTION
Resolves #3204

Hello!

## Pull Request overview
* Prevent crash on BLEU if the weights are an np.array rather than a tuple or a list of tuples.

## Details
As seen in #3204, this can result in a confusing error message. This PR should fix it by extending the caught error from just TypeError to others (like IndexError) as well.

I've also added a test case, which should have failed previously.

- Tom Aarsen