### PR TITLE
fix: enable py 3.12 in ci and fix error in bleu calculation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,7 +76,7 @@ jobs:
     needs: [cache_nltk_data, cache_third_party]
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 NLTK -- the Natural Language Toolkit -- is a suite of open source Python
 modules, data sets, and tutorials supporting research and development in Natural
-Language Processing. NLTK requires Python version 3.7, 3.8, 3.9, 3.10 or 3.11.
+Language Processing. NLTK requires Python version 3.7, 3.8, 3.9, 3.10, 3.11 or 3.12.
 
 For documentation, please visit [nltk.org](https://www.nltk.org/).
 

--- a/nltk/test/unit/translate/test_bleu.py
+++ b/nltk/test/unit/translate/test_bleu.py
@@ -2,7 +2,6 @@
 Tests for BLEU translation evaluation metric
 """
 
-import io
 import unittest
 
 import numpy as np

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -42,6 +42,14 @@ class Fraction:
     def __gt__(self, other):
         return float(self) > float(other)
 
+    def __add__(self, other):
+        if isinstance(other, int):
+            other = Fraction(other, 1)
+        return Fraction(
+            self.numerator * other.denominator + other.numerator * self.denominator,
+            self.denominator * other.denominator,
+        )
+
 
 def sentence_bleu(
     references,

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -31,15 +31,15 @@ class Fraction(_Fraction):
 
     @property
     def numerator(self):
-        if self._normalize:
-            return self._numerator
-        return self._original_numerator
+        if not self._normalize:
+            return self._original_numerator
+        return super().numerator
 
     @property
     def denominator(self):
-        if self._normalize:
-            return self._denominator
-        return self._original_denominator
+        if not self._normalize:
+            return self._original_denominator
+        return super().denominator
 
 
 def sentence_bleu(
@@ -603,7 +603,8 @@ class SmoothingFunction:
         """
         return [
             Fraction(p_n[i].numerator + 1, p_n[i].denominator + 1, _normalize=False)
-            if i != 0 else p_n[0]
+            if i != 0
+            else p_n[0]
             for i in range(len(p_n))
         ]
 

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -603,7 +603,8 @@ class SmoothingFunction:
         In COLING 2004.
         """
         return [
-            Fraction(p_n[i].numerator + 1, p_n[i].denominator + 1) if i != 0 else p_n[0] for i in range(len(p_n))
+            Fraction(p_n[i].numerator + 1, p_n[i].denominator + 1) if i != 0 else p_n[0]
+            for i in range(len(p_n))
         ]
 
     def method3(self, p_n, *args, **kwargs):

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -35,7 +35,9 @@ class Fraction:
         return float(self) < float(other)
 
     def __eq__(self, other):
-        return self.numerator == other.numerator and self.denominator == other.denominator
+        return (
+            self.numerator == other.numerator and self.denominator == other.denominator
+        )
 
     def __gt__(self, other):
         return float(self) > float(other)
@@ -601,10 +603,7 @@ class SmoothingFunction:
         In COLING 2004.
         """
         return [
-            Fraction(p_n[i].numerator + 1, p_n[i].denominator + 1)
-            if i != 0
-            else p_n[0]
-            for i in range(len(p_n))
+            Fraction(p_n[i].numerator + 1, p_n[i].denominator + 1) if i != 0 else p_n[0] for i in range(len(p_n))
         ]
 
     def method3(self, p_n, *args, **kwargs):

--- a/nltk/translate/bleu_score.py
+++ b/nltk/translate/bleu_score.py
@@ -7,14 +7,38 @@
 # For license information, see LICENSE.TXT
 
 """BLEU score implementation."""
+from __future__ import annotations
 
 import math
 import sys
 import warnings
 from collections import Counter
-from fractions import Fraction
+from dataclasses import dataclass
 
 from nltk.util import ngrams
+
+
+@dataclass
+class Fraction:
+    """
+    This class is used to represent a fraction with both the numerator and denominator saved for later retrieval.
+    Python 3.12 removed _normalize=False from the standard lib Fraction constructor.
+    """
+
+    numerator: int | float
+    denominator: int = 1
+
+    def __float__(self):
+        return self.numerator / self.denominator
+
+    def __lt__(self, other):
+        return float(self) < float(other)
+
+    def __eq__(self, other):
+        return self.numerator == other.numerator and self.denominator == other.denominator
+
+    def __gt__(self, other):
+        return float(self) > float(other)
 
 
 def sentence_bleu(
@@ -222,7 +246,7 @@ def corpus_bleu(
 
     # Collects the various precision values for the different ngram orders.
     p_n = [
-        Fraction(p_numerators[i], p_denominators[i], _normalize=False)
+        Fraction(p_numerators[i], p_denominators[i])
         for i in range(1, max_weight_length + 1)
     ]
 
@@ -365,7 +389,7 @@ def modified_precision(references, hypothesis, n):
     # Usually this happens when the ngram order is > len(reference).
     denominator = max(1, sum(counts.values()))
 
-    return Fraction(numerator, denominator, _normalize=False)
+    return Fraction(numerator, denominator)
 
 
 def closest_ref_length(references, hyp_len):
@@ -577,7 +601,7 @@ class SmoothingFunction:
         In COLING 2004.
         """
         return [
-            Fraction(p_n[i].numerator + 1, p_n[i].denominator + 1, _normalize=False)
+            Fraction(p_n[i].numerator + 1, p_n[i].denominator + 1)
             if i != 0
             else p_n[0]
             for i in range(len(p_n))

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     },
     long_description="""\
 The Natural Language Toolkit (NLTK) is a Python package for
-natural language processing.  NLTK requires Python 3.7, 3.8, 3.9, 3.10 or 3.11.""",
+natural language processing.  NLTK requires Python 3.7, 3.8, 3.9, 3.10, 3.11 or 3.12.""",
     license="Apache License, Version 2.0",
     keywords=[
         "NLP",
@@ -100,6 +100,7 @@ natural language processing.  NLTK requires Python 3.7, 3.8, 3.9, 3.10 or 3.11."
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
         "Topic :: Scientific/Engineering :: Human Machine Interfaces",


### PR DESCRIPTION
## The problem

`Fraction(..., _normalize=False)` [was removed in python 3.12](https://docs.python.org/3/library/fractions.html#fractions.Fraction) so it causes error in NLTK functions trying to call it this way.

## Changes

* **Enable CI testing for python 3.12**

* **Indicate 3.12 in docs and metadata**

* **Fix BLEU calculation**  
  I have add Child class for Fraction to support `_normalize=False`. Please let me know is better to have functions return `(numerator, denominator)` instead of complex class.
  