### PR TITLE
ci: update actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,9 +21,13 @@ jobs:
     name: Run pre-commit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
-      - uses: pre-commit/action@v2.0.3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x' # run with latest python version
+      - run: |
+          pip install pre-commit
+          pre-commit run --all-files
 
   cache_nltk_data:
     name: Cache nltk_data
@@ -34,7 +38,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache nltk data
         uses: actions/cache@v3
@@ -56,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache third party tools
         uses: actions/cache@v3
@@ -82,15 +86,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Set up JDK 16
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '16'


### PR DESCRIPTION
This PR updates the CI to use the latest versions of [actions/setup-python](https://github.com/actions/setup-python) and [actions/checkout](https://github.com/actions/checkout).
[pre-commit/action@v2.0.3](https://github.com/pre-commit/action) is replaced with a direct execution of the pre-commit command because the action is no longer actively developed.