### PR TITLE
sunset python 3.7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,7 +80,7 @@ jobs:
     needs: [cache_nltk_data, cache_third_party]
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ Summary of our git branching model:
 - Do many small commits on that branch locally (`git add files-changed`,
   `git commit -m "Add some change"`);
 - Run the tests to make sure nothing breaks
-  (`tox -e py37` if you are on Python 3.7);
+  (`tox -e py312` if you are on Python 3.12);
 - Add your name to the `AUTHORS.md` file as a contributor;
 - Push to your fork on GitHub (with the name as your local branch:
   `git push origin branch-name`);
@@ -169,7 +169,7 @@ The [`.github/workflows/ci.yaml`](https://github.com/nltk/nltk/blob/develop/.git
        - Otherwise, download all the data packages through `nltk.download('all')`.
 
   - The `test` job
-    - tests against supported Python versions (`3.7`, `3.8`, `3.9`).
+    - tests against supported Python versions (`3.8`, `3.9`, `3.10`, `3.11`, `3.12`).
     - tests on `ubuntu-latest` and `macos-latest`.
     - relies on the `cache_nltk_data` job to ensure that `nltk_data` is available.
     - performs these steps:
@@ -189,7 +189,7 @@ The [`.github/workflows/ci.yaml`](https://github.com/nltk/nltk/blob/develop/.git
 #### To test with `tox` locally
 
 First setup a new virtual environment, see https://docs.python-guide.org/dev/virtualenvs/
-Then run `tox -e py37`.
+Then run `tox -e py312`.
 
 For example, using `pipenv`:
 
@@ -198,7 +198,7 @@ git clone https://github.com/nltk/nltk.git
 cd nltk
 pipenv install -r pip-req.txt
 pipenv install tox
-tox -e py37
+tox -e py312
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 NLTK -- the Natural Language Toolkit -- is a suite of open source Python
 modules, data sets, and tutorials supporting research and development in Natural
-Language Processing. NLTK requires Python version 3.7, 3.8, 3.9, 3.10, 3.11 or 3.12.
+Language Processing. NLTK requires Python version 3.8, 3.9, 3.10, 3.11 or 3.12.
 
 For documentation, please visit [nltk.org](https://www.nltk.org/).
 

--- a/nltk/__init__.py
+++ b/nltk/__init__.py
@@ -52,7 +52,7 @@ __license__ = "Apache License, Version 2.0"
 # Description of the toolkit, keywords, and the project's primary URL.
 __longdescr__ = """\
 The Natural Language Toolkit (NLTK) is a Python package for
-natural language processing.  NLTK requires Python 3.7, 3.8, 3.9, 3.10 or 3.11."""
+natural language processing.  NLTK requires Python 3.8, 3.9, 3.10, 3.11 or 3.12."""
 __keywords__ = [
     "NLP",
     "CL",
@@ -84,11 +84,11 @@ __classifiers__ = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Scientific/Engineering :: Human Machine Interfaces",

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     },
     long_description="""\
 The Natural Language Toolkit (NLTK) is a Python package for
-natural language processing.  NLTK requires Python 3.7, 3.8, 3.9, 3.10, 3.11 or 3.12.""",
+natural language processing.  NLTK requires Python 3.8, 3.9, 3.10, 3.11 or 3.12.""",
     license="Apache License, Version 2.0",
     keywords=[
         "NLP",
@@ -95,7 +95,6 @@ natural language processing.  NLTK requires Python 3.7, 3.8, 3.9, 3.10, 3.11 or 
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -112,7 +111,7 @@ natural language processing.  NLTK requires Python 3.7, 3.8, 3.9, 3.10, 3.11 or 
         "Topic :: Text Processing :: Linguistic",
     ],
     package_data={"nltk": ["test/*.doctest", "VERSION"]},
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
         "click",
         "joblib",

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    py{37,38,39,310,311}
+    py{38,39,310,311,312}
     pypy
-    py{37,38,39,310,311}-nodeps
-    py{37,38,39,310,311}-jenkins
+    py{38,39,310,311,312}-nodeps
+    py{38,39,310,311,312}-jenkins
     py-travis
 
 [testenv]
@@ -55,13 +55,6 @@ deps =
 commands =
     pytest
 
-[testenv:py37-nodeps]
-basepython = python3.7
-deps =
-    pytest
-    pytest-mock
-commands = pytest
-
 [testenv:py38-nodeps]
 basepython = python3.8
 deps =
@@ -85,6 +78,13 @@ commands = pytest
 
 [testenv:py311-nodeps]
 basepython = python3.11
+deps =
+    pytest
+    pytest-mock
+commands = pytest
+
+[testenv:py312-nodeps]
+basepython = python3.12
 deps =
     pytest
     pytest-mock

--- a/web/dev/local_testing.rst
+++ b/web/dev/local_testing.rst
@@ -25,24 +25,24 @@ Please consult https://tox.wiki for more info about the tox tool.
 Examples
 --------
 
-Run tests for python 3.7 in verbose mode; executing only tests
+Run tests for python 3.12 in verbose mode; executing only tests
 that failed in the last test run::
 
-    tox -e py37 -- -v --failed
+    tox -e py312 -- -v --failed
 
 Run tree doctests for all available interpreters::
 
     tox -- tree.doctest
 
-Run a selected unit test for Python 3.7::
+Run a selected unit test for Python 3.12::
 
-    tox -e py37 -- -v nltk.test.unit.test_seekable_unicode_stream_reader
+    tox -e py312 -- -v nltk.test.unit.test_seekable_unicode_stream_reader
 
 By default, numpy, scipy and scikit-learn are installed in tox virtualenvs.
 This is slow, requires working build toolchain and is not always feasible.
 In order to skip numpy & friends, use ``..-nodeps`` environments::
 
-    tox -e py37-nodeps,py37,pypy
+    tox -e py312-nodeps,py312,pypy
 
 It is also possible to run tests without tox. This way NLTK would be tested
 only under single interpreter, but it may be easier to have numpy and other

--- a/web/install.rst
+++ b/web/install.rst
@@ -1,7 +1,7 @@
 Installing NLTK
 ===============
 
-NLTK requires Python versions 3.7, 3.8, 3.9, 3.10 or 3.11.
+NLTK requires Python versions 3.8, 3.9, 3.10, 3.11 or 3.12.
 
 For Windows users, it is strongly recommended that you go through this guide to install Python 3 successfully https://docs.python-guide.org/starting/install3/win/#install3-windows
 


### PR DESCRIPTION
Python 3.7 is end of life since 2023-06-27: https://devguide.python.org/versions/
Proposing to remove references from docs and discontinue testing in CI.