### PR TITLE
fix for word_tokenize() Failing to Split English Contractions When Followed by [\t\n\f\r]

### DIFF
--- a/nltk/tokenize/destructive.py
+++ b/nltk/tokenize/destructive.py
@@ -62,7 +62,7 @@ class NLTKWordTokenizer(TokenizerI):
         (re.compile("([»”’])", re.U), r" \1 "),
         (re.compile(r"''"), " '' "),
         (re.compile(r'"'), " '' "),
-        (re.compile(r"\s+"), " "), 
+        (re.compile(r"\s+"), " "),
         (re.compile(r"([^' ])('[sS]|'[mM]|'[dD]|') "), r"\1 \2 "),
         (re.compile(r"([^' ])('ll|'LL|'re|'RE|'ve|'VE|n't|N'T) "), r"\1 \2 "),
     ]

--- a/nltk/tokenize/destructive.py
+++ b/nltk/tokenize/destructive.py
@@ -62,7 +62,7 @@ class NLTKWordTokenizer(TokenizerI):
         (re.compile("([»”’])", re.U), r" \1 "),
         (re.compile(r"''"), " '' "),
         (re.compile(r'"'), " '' "),
-        (re.compile(r"\s+"), " "),
+        (re.compile(r"\s+"), " "), 
         (re.compile(r"([^' ])('[sS]|'[mM]|'[dD]|') "), r"\1 \2 "),
         (re.compile(r"([^' ])('ll|'LL|'re|'RE|'ve|'VE|n't|N'T) "), r"\1 \2 "),
     ]

--- a/nltk/tokenize/destructive.py
+++ b/nltk/tokenize/destructive.py
@@ -53,7 +53,6 @@ class NLTKWordTokenizer(TokenizerI):
         (re.compile("([«“‘„]|[`]+)", re.U), r" \1 "),
         (re.compile(r"^\""), r"``"),
         (re.compile(r"(``)"), r" \1 "),
-        (re.compile(r"[\t\n\f\r]"), " "),
         (re.compile(r"([ \(\[{<])(\"|\'{2})"), r"\1 `` "),
         (re.compile(r"(?i)(\')(?!re|ve|ll|m|t|s|d|n)(\w)\b", re.U), r"\1 \2"),
     ]

--- a/nltk/tokenize/destructive.py
+++ b/nltk/tokenize/destructive.py
@@ -53,6 +53,7 @@ class NLTKWordTokenizer(TokenizerI):
         (re.compile("([«“‘„]|[`]+)", re.U), r" \1 "),
         (re.compile(r"^\""), r"``"),
         (re.compile(r"(``)"), r" \1 "),
+        (re.compile(r"[\t\n\f\r]"), ""),
         (re.compile(r"([ \(\[{<])(\"|\'{2})"), r"\1 `` "),
         (re.compile(r"(?i)(\')(?!re|ve|ll|m|t|s|d|n)(\w)\b", re.U), r"\1 \2"),
     ]
@@ -62,6 +63,7 @@ class NLTKWordTokenizer(TokenizerI):
         (re.compile("([»”’])", re.U), r" \1 "),
         (re.compile(r"''"), " '' "),
         (re.compile(r'"'), " '' "),
+        (re.compile(r"[\t\n\f\r]"), ""),
         (re.compile(r"([^' ])('[sS]|'[mM]|'[dD]|') "), r"\1 \2 "),
         (re.compile(r"([^' ])('ll|'LL|'re|'RE|'ve|'VE|n't|N'T) "), r"\1 \2 "),
     ]

--- a/nltk/tokenize/destructive.py
+++ b/nltk/tokenize/destructive.py
@@ -62,7 +62,7 @@ class NLTKWordTokenizer(TokenizerI):
         (re.compile("([»”’])", re.U), r" \1 "),
         (re.compile(r"''"), " '' "),
         (re.compile(r'"'), " '' "),
-        (re.compile(r"[\t\n\f\r]"), " "),
+        (re.compile(r"\s+"), " "),
         (re.compile(r"([^' ])('[sS]|'[mM]|'[dD]|') "), r"\1 \2 "),
         (re.compile(r"([^' ])('ll|'LL|'re|'RE|'ve|'VE|n't|N'T) "), r"\1 \2 "),
     ]

--- a/nltk/tokenize/destructive.py
+++ b/nltk/tokenize/destructive.py
@@ -53,7 +53,7 @@ class NLTKWordTokenizer(TokenizerI):
         (re.compile("([«“‘„]|[`]+)", re.U), r" \1 "),
         (re.compile(r"^\""), r"``"),
         (re.compile(r"(``)"), r" \1 "),
-        (re.compile(r"[\t\n\f\r]"), ""),
+        (re.compile(r"[\t\n\f\r]"), " "),
         (re.compile(r"([ \(\[{<])(\"|\'{2})"), r"\1 `` "),
         (re.compile(r"(?i)(\')(?!re|ve|ll|m|t|s|d|n)(\w)\b", re.U), r"\1 \2"),
     ]
@@ -63,7 +63,7 @@ class NLTKWordTokenizer(TokenizerI):
         (re.compile("([»”’])", re.U), r" \1 "),
         (re.compile(r"''"), " '' "),
         (re.compile(r'"'), " '' "),
-        (re.compile(r"[\t\n\f\r]"), ""),
+        (re.compile(r"[\t\n\f\r]"), " "),
         (re.compile(r"([^' ])('[sS]|'[mM]|'[dD]|') "), r"\1 \2 "),
         (re.compile(r"([^' ])('ll|'LL|'re|'RE|'ve|'VE|n't|N'T) "), r"\1 \2 "),
     ]


### PR DESCRIPTION
With this pull request, I hope to fix the issue of #3189, or the word_tokenize() Failed to Split English Contractions When Followed by [\t\n\f\r]. 

Obviously this is the first draft, but I would like some initial review and comments. Thank you