### PR TITLE
Avoid recursive suffix stripping in wordnet morphy

### DIFF
--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -2082,7 +2082,7 @@ class WordNetCorpusReader(CorpusReader):
         # Given an original string x
         # 1. Apply rules once to the input to get y1, y2, y3, etc.
         # 2. Return all that are in the database
-        # 3. If there are no matches: (edited by ekaf) don't recurse, return an empty list.
+        #    (edited by ekaf) If there are no matches return an empty list.
 
         exceptions = self._exception_map[pos]
         substitutions = self.MORPHOLOGICAL_SUBSTITUTIONS[pos]
@@ -2096,7 +2096,7 @@ class WordNetCorpusReader(CorpusReader):
             ]
 
         def filter_forms(forms):
-            result = []
+            result = []  # Return an empty list if we can't find anything
             seen = set()
             for form in forms:
                 if form in self._lemma_pos_offset_map:
@@ -2106,21 +2106,15 @@ class WordNetCorpusReader(CorpusReader):
                             seen.add(form)
             return result
 
-        # 0. Check the exception lists
-        if check_exceptions:
-            if form in exceptions:
-                return filter_forms([form] + exceptions[form])
-
-        # 1. Apply rules once to the input to get y1, y2, y3, etc.
-        forms = apply_rules([form])
+        if check_exceptions and form in exceptions:
+            # 0. Check the exception lists
+            forms = exceptions[form]
+        else:
+            # 1. Apply rules once to the input to get y1, y2, y3, etc.
+            forms = apply_rules([form])
 
         # 2. Return all that are in the database (and check the original too)
-        results = filter_forms([form] + forms)
-        if results:
-            return results
-
-        # Return an empty list if we can't find anything
-        return []
+        return filter_forms([form] + forms)
 
     #############################################################
     # Create information content from corpus

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -1423,6 +1423,7 @@ class WordNetCorpusReader(CorpusReader):
                     # map lemmas and parts of speech to synsets
                     self._lemma_pos_offset_map[lemma][pos] = synset_offsets
                     if pos == ADJ:
+                        # Duplicate all adjectives indiscriminately?:
                         self._lemma_pos_offset_map[lemma][ADJ_SAT] = synset_offsets
 
     def _load_exception_map(self):
@@ -2018,7 +2019,8 @@ class WordNetCorpusReader(CorpusReader):
         """
         Find a possible base form for the given form, with the given
         part of speech, by checking WordNet's list of exceptional
-        forms, or by substituting affixes for this part of speech.
+        forms, or by substituting suffixes for this part of speech.
+        If pos=None, try every part of speech until finding lemmas.
         Return the first form found in WordNet, or eventually None.
 
         >>> from nltk.corpus import wordnet as wn
@@ -2035,19 +2037,11 @@ class WordNetCorpusReader(CorpusReader):
         book
         >>> wn.morphy('book', wn.ADJ)
         """
-
-        if pos is None:
-            posl = POS_LIST
-        else:
-            posl = [pos]
-        analyses = []
-        for pos in posl:
+        for pos in [pos] if pos else POS_LIST:
             analyses = self._morphy(form, pos, check_exceptions)
             if analyses:
+                # Stop (don't try more parts of speech):
                 return analyses[0]
-            else:
-                continue
-        return None
 
     MORPHOLOGICAL_SUBSTITUTIONS = {
         NOUN: [

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -2018,8 +2018,8 @@ class WordNetCorpusReader(CorpusReader):
         """
         Find a possible base form for the given form, with the given
         part of speech, by checking WordNet's list of exceptional
-        forms, and by recursively stripping affixes for this part of
-        speech until a form in WordNet is found.
+        forms, or by substituting affixes for this part of speech.
+        Return the first form found in WordNet, or eventually None.
 
         >>> from nltk.corpus import wordnet as wn
         >>> print(wn.morphy('dogs'))
@@ -2037,17 +2037,17 @@ class WordNetCorpusReader(CorpusReader):
         """
 
         if pos is None:
-            morphy = self._morphy
-            analyses = chain(a for p in POS_LIST for a in morphy(form, p))
+            posl = POS_LIST
         else:
+            posl = [pos]
+        analyses = []
+        for pos in posl:
             analyses = self._morphy(form, pos, check_exceptions)
-
-        # get the first one we find
-        first = list(islice(analyses, 1))
-        if len(first) == 1:
-            return first[0]
-        else:
-            return None
+            if analyses:
+                return analyses[0]
+            else:
+                continue
+        return None
 
     MORPHOLOGICAL_SUBSTITUTIONS = {
         NOUN: [
@@ -2096,7 +2096,7 @@ class WordNetCorpusReader(CorpusReader):
             ]
 
         def filter_forms(forms):
-            result = []  # Return an empty list if we can't find anything
+            result = []
             seen = set()
             for form in forms:
                 if form in self._lemma_pos_offset_map:

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -2082,8 +2082,7 @@ class WordNetCorpusReader(CorpusReader):
         # Given an original string x
         # 1. Apply rules once to the input to get y1, y2, y3, etc.
         # 2. Return all that are in the database
-        # 3. If there are no matches, keep applying rules until you either
-        #    find a match or you can't go any further
+        # 3. If there are no matches: (edited by ekaf) don't recurse, return an empty list.
 
         exceptions = self._exception_map[pos]
         substitutions = self.MORPHOLOGICAL_SUBSTITUTIONS[pos]
@@ -2119,13 +2118,6 @@ class WordNetCorpusReader(CorpusReader):
         results = filter_forms([form] + forms)
         if results:
             return results
-
-        # 3. If there are no matches, keep applying rules until we find a match
-        while forms:
-            forms = apply_rules(forms)
-            results = filter_forms(forms)
-            if results:
-                return results
 
         # Return an empty list if we can't find anything
         return []

--- a/nltk/stem/wordnet.py
+++ b/nltk/stem/wordnet.py
@@ -13,7 +13,8 @@ class WordNetLemmatizer:
     """
     WordNet Lemmatizer
 
-    Lemmatize using WordNet's built-in morphy function.
+    Lemmatize by picking the shortest of the possible lemmas,
+    using the wordnet corpus reader's built-in _morphy function.
     Returns the input word unchanged if it cannot be found in WordNet.
 
         >>> from nltk.stem import WordNetLemmatizer

--- a/nltk/stem/wordnet.py
+++ b/nltk/stem/wordnet.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2001-2023 NLTK Project
 # Author: Steven Bird <stevenbird1@gmail.com>
 #         Edward Loper <edloper@gmail.com>
+#         Eric Kafe <kafe.eric@gmail.com>
 # URL: <https://www.nltk.org/>
 # For license information, see LICENSE.TXT
 
@@ -13,9 +14,45 @@ class WordNetLemmatizer:
     """
     WordNet Lemmatizer
 
-    Lemmatize by picking the shortest of the possible lemmas,
-    using the wordnet corpus reader's built-in _morphy function.
-    Returns the input word unchanged if it cannot be found in WordNet.
+    Provides 3 lemmatizer modes:
+
+    1. _morphy() is an alias to WordNet's _morphy lemmatizer.
+    It returns a list of all lemmas found in WordNet.
+
+    >>> wnl = WordNetLemmatizer()
+    >>> print(wnl._morphy('us', 'n'))
+    ['us', 'u']
+
+    2. morphy() is a restrictive wrapper around _morphy().
+    It returns the first lemma found in WordNet,
+    or None if no lemma is found.
+
+    >>> print(wnl.morphy('us', 'n'))
+    us
+
+    >>> print(wnl.morphy('catss'))
+    None
+
+    3. lemmatize() is a permissive wrapper around _morphy().
+    It returns the shortest lemma found in WordNet,
+    or the input string unchanged if nothing is found.
+
+    >>> print(wnl.lemmatize('us', 'n'))
+    u
+
+    >>> print(wnl.lemmatize('Anythinggoeszxcv'))
+    Anythinggoeszxcv
+
+    """
+
+    morphy = wn.morphy
+
+    _morphy = wn._morphy
+
+    def lemmatize(self, word: str, pos: str = "n") -> str:
+        """Lemmatize `word` by picking the shortest of the possible lemmas,
+        using the wordnet corpus reader's built-in _morphy function.
+        Returns the input word unchanged if it cannot be found in WordNet.
 
         >>> from nltk.stem import WordNetLemmatizer
         >>> wnl = WordNetLemmatizer()
@@ -29,12 +66,6 @@ class WordNetLemmatizer:
         abacus
         >>> print(wnl.lemmatize('hardrock'))
         hardrock
-    """
-
-    def lemmatize(self, word: str, pos: str = "n") -> str:
-        """Lemmatize `word` by picking the shortest of the possible lemmas,
-        using the wordnet corpus reader's built-in _morphy function.
-        Returns the input word unchanged if it cannot be found in WordNet.
 
         :param word: The input word to lemmatize.
         :type word: str
@@ -44,7 +75,7 @@ class WordNetLemmatizer:
         :type pos: str
         :return: The shortest lemma of `word`, for the given `pos`.
         """
-        lemmas = wn._morphy(word, pos)
+        lemmas = self._morphy(word, pos)
         return min(lemmas, key=len) if lemmas else word
 
     def __repr__(self):

--- a/nltk/stem/wordnet.py
+++ b/nltk/stem/wordnet.py
@@ -31,7 +31,8 @@ class WordNetLemmatizer:
     """
 
     def lemmatize(self, word: str, pos: str = "n") -> str:
-        """Lemmatize `word` using WordNet's built-in morphy function.
+        """Lemmatize `word` by picking the shortest of the possible lemmas,
+        using the wordnet corpus reader's built-in _morphy function.
         Returns the input word unchanged if it cannot be found in WordNet.
 
         :param word: The input word to lemmatize.
@@ -40,7 +41,7 @@ class WordNetLemmatizer:
             `"v"` for verbs, `"a"` for adjectives, `"r"` for adverbs and `"s"`
             for satellite adjectives.
         :type pos: str
-        :return: The lemma of `word`, for the given `pos`.
+        :return: The shortest lemma of `word`, for the given `pos`.
         """
         lemmas = wn._morphy(word, pos)
         return min(lemmas, key=len) if lemmas else word


### PR DESCRIPTION
Fix #2567: the implementation of Wordnet's __\_morphy_ lemmatizer in NLTK is buggy, because it adds a recursive step, which is not a part of the _morphy_ program,  as implemented in the "morph.c" source file that was  included with the original Princeton WordNet, and described in the [morphy manual](https://wordnet.princeton.edu/documentation/morphy7wn). 

So currently, when one pass over the possible morphological substitutions does not yield any known lemma, additional passes may be applied on the results. For ex.:

```
from nltk.corpus import wordnet as wn

for w in ['cats', 'catss']:
    print(f"{w} -> {wn._morphy(w, pos='n')}")

```

> cats -> ['cat']
> catss -> ['cat']

After this PR, the "s" suffix is only stripped once, leading to the rejection of the bad "catss" form:

> cats -> ['cat']
> catss -> []

This last result agrees with the official [Princeton output](http://wordnetweb.princeton.edu/perl/webwn?s=catss), as well as with the [implementation in Wn](https://github.com/goodmami/wn/blob/main/wn/morphy.py) by @goodmami.

Similarly, the following errors do not occur after this PR:

| Call | Before | After |
| ---- | ------ | ----- |
| _morphy('possesses', 'n') | ['posse'] | [] |
| _morphy('ramesses', 'v') | ['ram'] | [] |
| _morphy('iss', 'n') | ['i'] | [] |
| _morphy('anchoresses', 'v') | ['anchor'] | [] |
| _morphy('askeses', 'v') | ['ask'] | [] |
| _morphy('bibless', 'n') | ['bible'] | [] |
| _morphy('bowses', 'n') | ['bow'] | [] |
| _morphy('carses', 'n') | ['car'] | [] |
| _morphy('cateresses', 'v') | ['cater'] | [] |
| _morphy('chowses', 'n') | ['chow'] | [] |
| _morphy('hydrases', 'n') | ['hydra'] | [] |
| _morphy('idlesses', 'n') | ['idle'] | [] |
| _morphy('idlesses', 'v') | ['idle'] | [] |
| _morphy('marses', 'v') | ['mar'] | [] |
| _morphy('pareses', 'v') | ['pare'', ' 'par'] | [] |
| _morphy('replicases', 'n') | ['replica'] | [] |
| _morphy('semises', 'n') | ['semi'] | [] |
| _morphy('tootses', 'n') | ['toot'] | [] |
| _morphy('tootses', 'v') | ['toot'] | [] |
| _morphy('torqueses', 'n') | ['torque'] | [] |

On the other hand. this PR does not change the results of [@tomaarsen's plurals test](https://github.com/nltk/nltk/issues/2567#issuecomment-715439448): WordNetLemmatizer still performs better 470 times, morphy 32 times, and there are 62 ties.

However, this PR proposes to add a few comments in WordNetLemmatizer, to make it more clear that its lemmatize() function picks the shortest lemma among the candidates returned by _\_morphy_, and that this behaviour is not a bug but a feature.