### PR TITLE
Add reference to entropy implementation used

### DIFF
--- a/nltk/lm/api.py
+++ b/nltk/lm/api.py
@@ -163,6 +163,10 @@ class LanguageModel(metaclass=ABCMeta):
 
     def contains_UNKs(self, ngram):
         """Helper method to indicate whether an ngram contains an UNK token or not.
+
+        :param tuple(str) ngram: ngram tuples
+        :rtype: bool
+        
         """
         return any([self.counts.unigrams[ng] for ng in ngram])
 
@@ -198,8 +202,10 @@ class LanguageModel(metaclass=ABCMeta):
         In case of <UNK> tokens, weight with the minimum relative frequency in the dataset.
 
         :param Iterable(tuple(str)) text_ngrams: A sequence of ngram tuples.
-        :param bool length_normalisation:
-        :param bool rel_freq_weighting:
+        :param bool length_normalisation: A boolean to indicate whether you want to
+            normalise by sequence length.
+        :param bool rel_freq_weighting: A boolean to indicate whether you want to
+            weight probabilities by ngram relative frequency.
         :rtype: float
 
         """
@@ -234,13 +240,13 @@ class LanguageModel(metaclass=ABCMeta):
             
         return entropy_extended
 
-    def perplexity_extended(self, text_ngrams, text_fdist, normalised=True, rel_freq_weighted=False):
+    def perplexity_extended(self, text_ngrams, length_normalisation=True, rel_freq_weighting=False):
         """Calculates the perplexity of the given text based on the extended version of the entropy method.
 
         This is simply 2 ** cross-entropy for the text, so the arguments are the same.
 
         """
-        return pow(2.0, self.entropy_extended(text_ngrams, text_fdist, normalised, rel_freq_weighted))
+        return pow(2.0, self.entropy_extended(text_ngrams, length_normalisation, rel_freq_weighting))
         
     def generate(self, num_words=1, text_seed=None, random_seed=None):
         """Generate words from the model.

--- a/nltk/lm/api.py
+++ b/nltk/lm/api.py
@@ -162,6 +162,8 @@ class LanguageModel(metaclass=ABCMeta):
 
     def entropy(self, text_ngrams):
         """Calculate cross-entropy of model for given evaluation text.
+        This implementation is based on the Shannon-McMillan-Breiman theorem,
+        as used and referenced by Jurafsky and Jordan Boyd-Graber.
 
         :param Iterable(tuple(str)) text_ngrams: A sequence of ngram tuples.
         :rtype: float

--- a/nltk/lm/api.py
+++ b/nltk/lm/api.py
@@ -12,6 +12,7 @@ from abc import ABCMeta, abstractmethod
 from bisect import bisect
 from itertools import accumulate
 
+from nltk import FreqDist
 from nltk.lm.counter import NgramCounter
 from nltk.lm.util import log_base2
 from nltk.lm.vocabulary import Vocabulary
@@ -182,6 +183,41 @@ class LanguageModel(metaclass=ABCMeta):
         """
         return pow(2.0, self.entropy(text_ngrams))
 
+    def entropy_extended(self, text_ngrams, text_fdist, length_normalisation=True, rel_freq_weighting=False):
+        """Calculate cross-entropy of model for given evaluation text.
+
+        This implementation is based on the standard Shannon entropy,
+        extended with the possibility to normalise the entropy by sentence length,
+        and/or weight the output by the relative frequency of the ngram.
+        In case of <UNK> tokens, weight with the minimum relative frequency in the dataset.
+
+        :param Iterable(tuple(str)) text_ngrams: A sequence of ngram tuples.
+        :param FreqDist text_fdist:
+        :param bool length_normalisation:
+        :param bool rel_freq_weighting:
+        :rtype: float
+
+        """
+        probabilities = [self.score(ngram[-1], ngram[:-1]) for ngram in text_ngrams]
+        # TODO add function to check for UNKs
+        if rel_freq_weighting:
+        # TODO add weighting according to frequency distribution
+        
+        entropy = -1 * sum([prob * log_base2(prob) for prob in probabilities])
+        
+        if length_normalisation:
+            entropy /= len(probabilities)
+            
+        return entropy_extended
+
+    def perplexity_extended(self, text_ngrams, text_fdist, normalised=True, rel_freq_weighted=False):
+        """Calculates the perplexity of the given text based on the extended version of the entropy method.
+
+        This is simply 2 ** cross-entropy for the text, so the arguments are the same.
+
+        """
+        return pow(2.0, self.entropy_extended(text_ngrams, text_fdist, normalised, rel_freq_weighted))
+        
     def generate(self, num_words=1, text_seed=None, random_seed=None):
         """Generate words from the model.
 

--- a/nltk/lm/api.py
+++ b/nltk/lm/api.py
@@ -159,8 +159,7 @@ class LanguageModel(metaclass=ABCMeta):
         return (
             self.counts[len(context) + 1][context] if context else self.counts.unigrams
         )
-
-    
+ 
     def entropy(self, text_ngrams):
         """Calculate cross-entropy of model for given evaluation text.
 

--- a/nltk/lm/api.py
+++ b/nltk/lm/api.py
@@ -162,6 +162,7 @@ class LanguageModel(metaclass=ABCMeta):
 
     def entropy(self, text_ngrams):
         """Calculate cross-entropy of model for given evaluation text.
+
         This implementation is based on the Shannon-McMillan-Breiman theorem,
         as used and referenced by Dan Jurafsky and Jordan Boyd-Graber.
 

--- a/nltk/lm/api.py
+++ b/nltk/lm/api.py
@@ -159,7 +159,7 @@ class LanguageModel(metaclass=ABCMeta):
         return (
             self.counts[len(context) + 1][context] if context else self.counts.unigrams
         )
- 
+
     def entropy(self, text_ngrams):
         """Calculate cross-entropy of model for given evaluation text.
 

--- a/nltk/lm/api.py
+++ b/nltk/lm/api.py
@@ -163,7 +163,7 @@ class LanguageModel(metaclass=ABCMeta):
     def entropy(self, text_ngrams):
         """Calculate cross-entropy of model for given evaluation text.
         This implementation is based on the Shannon-McMillan-Breiman theorem,
-        as used and referenced by Jurafsky and Jordan Boyd-Graber.
+        as used and referenced by Dan Jurafsky and Jordan Boyd-Graber.
 
         :param Iterable(tuple(str)) text_ngrams: A sequence of ngram tuples.
         :rtype: float


### PR DESCRIPTION
This is in reference to issue #2961.

This is just a simple addition to the [docs](https://www.nltk.org/api/nltk.lm.api.html#nltk.lm.api.LanguageModel.entropy), making it more clear that the entropy implementation in NLTK is the one based on the Shannon-McMillan-Breiman theorem, as used and referenced by Jurafsky ([Chapter 3 page 23 - 3.49](https://web.stanford.edu/~jurafsky/slp3/3.pdf)) and Jordan Boyd-Graber (`lm.txt` file in [this comment](https://github.com/nltk/nltk/issues/1342#issuecomment-203060085)).

This PR does not include the alternative implementation of the entropy function that was proposed in the issue.

