### PR TITLE
Make WordNet's synset relations available from the lemmas

### DIFF
--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -326,7 +326,7 @@ class Lemma(_WordNetObject):
     def _related(self, relation_symbol):
         get_synset = self._wordnet_corpus_reader.synset_from_pos_and_offset
         if (self._name, relation_symbol) not in self._synset._lemma_pointers:
-            return []
+            return self._synset._related(relation_symbol)
         return [
             get_synset(pos, offset)._lemmas[lemma_index]
             for pos, offset, lemma_index in self._synset._lemma_pointers[

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -324,15 +324,28 @@ class Lemma(_WordNetObject):
         return "%s('%s.%s')" % tup
 
     def _related(self, relation_symbol):
+        """Returns the lemma's relations, plus its' synset's relations.
+        Note that with the in_topic_domain() relation (-c), a few lemmas have
+        both lemma and synset targets. For ex:
+
+        >>> from nltk.corpus import wordnet as wn
+        >>> insect = wn.lemmas("insect")[0]
+        >>> print(insect)
+        Lemma('insect.n.01.insect')
+
+        >>> print(f"In topic domains: {insect.in_topic_domains()}")
+        In topic domains: [Lemma('chirpy.a.01.chirpy'), Synset('holometabolism.n.01')]
+        """
         get_synset = self._wordnet_corpus_reader.synset_from_pos_and_offset
+        ssrels = self._synset._related(relation_symbol)
         if (self._name, relation_symbol) not in self._synset._lemma_pointers:
-            return self._synset._related(relation_symbol)
+            return ssrels
         return [
             get_synset(pos, offset)._lemmas[lemma_index]
             for pos, offset, lemma_index in self._synset._lemma_pointers[
                 self._name, relation_symbol
             ]
-        ]
+        ] + ssrels  # a few domain relations concern both lemmas and synsets
 
     def count(self):
         """Return the frequency count for this Lemma"""

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -324,17 +324,15 @@ class Lemma(_WordNetObject):
         return "%s('%s.%s')" % tup
 
     def _related(self, relation_symbol):
-        """Returns the lemma's relations, plus its' synset's relations.
-        Note that with the in_topic_domain() relation (-c), a few lemmas have
+        """Returns the lemma's relation targets for the given relation_symbol.
+        Includes both the lemma ("lexical") relations and the synset ("semantic") relations.
+
+        The in_topic_domain() relation (-c) is hybrid, becuse a few lemmas have
         both lemma and synset targets. For ex:
 
         >>> from nltk.corpus import wordnet as wn
-        >>> insect = wn.lemmas("insect")[0]
-        >>> print(insect)
-        Lemma('insect.n.01.insect')
-
-        >>> print(f"In topic domains: {insect.in_topic_domains()}")
-        In topic domains: [Lemma('chirpy.a.01.chirpy'), Synset('holometabolism.n.01')]
+        >>> print(wn.lemmas("insect")[0].in_topic_domains())
+        [Lemma('chirpy.a.01.chirpy'), Synset('holometabolism.n.01')]
         """
         get_synset = self._wordnet_corpus_reader.synset_from_pos_and_offset
         ssrels = self._synset._related(relation_symbol)

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -327,12 +327,16 @@ class Lemma(_WordNetObject):
         """Returns the lemma's relation targets for the given relation_symbol.
         Includes both the lemma ("lexical") relations and the synset ("semantic") relations.
 
-        The in_topic_domain() relation (-c) is hybrid, becuse a few lemmas have
+        The in_topic_domain() relation (-c) is hybrid, because a few lemmas have
         both lemma and synset targets. For ex:
 
         >>> from nltk.corpus import wordnet as wn
         >>> print(wn.lemmas("insect")[0].in_topic_domains())
         [Lemma('chirpy.a.01.chirpy'), Synset('holometabolism.n.01')]
+
+        :param relation_symbol: pointer symbol denoting a WordNet relation
+        :type relation_symbol: string
+        :return: list of target lemmas and/or synsets
         """
         get_synset = self._wordnet_corpus_reader.synset_from_pos_and_offset
         ssrels = self._synset._related(relation_symbol)


### PR DESCRIPTION
Fix #1970: make WordNet's synset relations available from the lemmas.

```
from nltk.corpus import wordnet as wn
insect = wn.lemmas("insect")[0]
print(insect.hypernyms())
```

> [Synset('arthropod.n.01')]

The _in_topic_domain()_ relation ("-c") is hybrid, because a few lemmas have both lemma and synset targets. For ex:

`print(insect.in_topic_domains())`

> [Lemma('chirpy.a.01.chirpy'), Synset('holometabolism.n.01')]
