### PR TITLE
10x Faster Levenshtein Distances

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -302,6 +302,7 @@
 - Akihiro Yamazaki <https://github.com/zakkie>
 - Ron Urbach <https://github.com/sharpblade4>
 - Vivek Kalyan <https://github.com/vivekkalyan>
+- Ash Vardanian <https://github.com/ashvardanian>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,7 +141,8 @@ the desired feature.
 
 You can use `pytest` to run your tests, no matter which type of test it is:
 
-```
+```bash
+pip install -r requirements-test.txt
 cd nltk/test
 pytest util.doctest  # doctest
 pytest unit/translate/test_nist.py  # unittest
@@ -193,7 +194,7 @@ Then run `tox -e py312`.
 
 For example, using `pipenv`:
 
-```
+```bash
 git clone https://github.com/nltk/nltk.git
 cd nltk
 pipenv install -r pip-req.txt

--- a/nltk/metrics/distance.py
+++ b/nltk/metrics/distance.py
@@ -22,8 +22,6 @@ As metrics, they must satisfy the following three requirements:
 import operator
 import warnings
 
-import stringzilla as sz
-
 
 def _edit_dist_init(len1, len2):
     lev = []
@@ -91,7 +89,9 @@ def edit_distance(s1, s2, substitution_cost=1, transpositions=False):
     # StringZilla currently doesn't support transpositions and cost-parameterized substitutions.
     # It's C implementation is 10x faster than a pure Python implementation.
     if not transpositions and substitution_cost == 1:
-        return sz.edit_distance_unicode(s1, s2)
+        from stringzilla import edit_distance_unicode as sz_edit_dist
+
+        return sz_edit_dist(s1, s2)
 
     # set up a 2-D array
     len1 = len(s1)

--- a/nltk/metrics/distance.py
+++ b/nltk/metrics/distance.py
@@ -22,6 +22,8 @@ As metrics, they must satisfy the following three requirements:
 import operator
 import warnings
 
+import stringzilla as sz
+
 
 def _edit_dist_init(len1, len2):
     lev = []
@@ -85,6 +87,12 @@ def edit_distance(s1, s2, substitution_cost=1, transpositions=False):
     :type transpositions: bool
     :rtype: int
     """
+
+    # StringZilla currently doesn't support transpositions and cost-parameterized substitutions.
+    # It's C implementation is 10x faster than a pure Python implementation.
+    if not transpositions and substitution_cost == 1:
+        return sz.edit_distance_unicode(s1, s2)
+
     # set up a 2-D array
     len1 = len(s1)
     len2 = len(s2)

--- a/pip-req.txt
+++ b/pip-req.txt
@@ -13,3 +13,4 @@ click>=7.1.2
 joblib>=1.0.1
 tqdm>=4.59.0
 pre-commit>=2.13.0
+stringzilla>=3.1.2

--- a/setup.py
+++ b/setup.py
@@ -117,6 +117,7 @@ natural language processing.  NLTK requires Python 3.8, 3.9, 3.10, 3.11 or 3.12.
         "joblib",
         "regex>=2021.8.3",
         "tqdm",
+        "stringzilla>=3.1.2",
     ],
     extras_require=extras_require,
     packages=find_packages(),


### PR DESCRIPTION
This PR replaces the native Python implementation of the Levenshtein distance with a SIMD-accelerated version from the StringZilla library.

On ~5 letter words from a typical English corpus - StringZilla is over 10x faster than current Python implementation in NLTK (1.24 s ± 57.4 ms vs 13.5 s ± 287 ms per loop across 7 runs). On a multilingual corpus with longer words - same result. 

1. StringZilla uses less `if` branches than most native implementations, so it's faster than many implementations in the serial mode. When AVX-512 is available it can use specialized assembly instructions to accelerate evaluation.
2. StringZilla currently [provides wheels](https://pypi.org/project/stringzilla/#files) for {manylinux, musllinux, macos, windows} × { 32-bit, 64-bit } × { x86, Arm, PowerPC } × [ Python 3.6, Python 3.12 ] making it practically the most portable hardware-accelerated library in the Python ecosystem.