### PR TITLE
ci: bump action versions

### DIFF
--- a/.github/workflows/cffconvert.yml
+++ b/.github/workflows/cffconvert.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out a copy of the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Check whether the citation metadata from CITATION.cff is valid
         uses: citation-file-format/cffconvert-github-action@2.0.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Cache nltk data
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: restore-cache
         with:
           path: ~/nltk_data
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Cache third party tools
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: restore-cache
         with:
           path: ~/third
@@ -94,7 +94,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Restore cached dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: restore-cache
         with:
           path: ${{ env.pythonLocation }}
@@ -107,13 +107,13 @@ jobs:
         #if: steps.restore-cache.outputs.cache-hit != 'true' # disabled due to a persistent issue with restoring cache on macos runner
 
       - name: Use cached nltk data
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/nltk_data
           key: nltk_data_${{ secrets.CACHE_VERSION }}
 
       - name: Use cached third party tools
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/third
           key: third_${{ hashFiles('tools/github_actions/third-party.sh') }}_${{ secrets.CACHE_VERSION }}


### PR DESCRIPTION
This PR addresses warning when executing CI workflow. For example: https://github.com/nltk/nltk/actions/runs/8178559704
![image](https://github.com/nltk/nltk/assets/4669013/b56afcbe-c1c0-4127-ae57-ec339c80d8ac)

actions/cache is updated to [v4](https://github.com/actions/cache/releases/tag/v4.0.0)
actions/checkout is updated to [v4](https://github.com/actions/checkout?tab=readme-ov-file#checkout-v4)