### PR TITLE
Write downloaded model files atomically

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -302,6 +302,7 @@
 - Akihiro Yamazaki <https://github.com/zakkie>
 - Ron Urbach <https://github.com/sharpblade4>
 - Vivek Kalyan <https://github.com/vivekkalyan>
+- Rimvydas Naktinis <https://github.com/naktinis>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 


### PR DESCRIPTION
Avoiding scenarios where one processes may be reading a file that is being written by another one by only moving the file to the final location after it has been fully written.