### PR TITLE
Develop text lemmatize function

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -302,6 +302,7 @@
 - Akihiro Yamazaki <https://github.com/zakkie>
 - Ron Urbach <https://github.com/sharpblade4>
 - Vivek Kalyan <https://github.com/vivekkalyan>
+- Siwon Seo <https://github.com/Sion1225>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -2131,6 +2131,30 @@ class WordNetCorpusReader(CorpusReader):
         return []
 
     #############################################################
+    #  Convert Pos tags from other tagsets
+    #############################################################
+
+    def tag2pos(self, tag, tagset="en-ptb") -> str:
+        """Convert Tag, from one of the tagsets in nltk_data/taggers/universal_tagset,
+        to WordNet Part-of-speech, using Universal Tags as intermediary.
+        Return None when WordNet does not cover the Pos.
+
+        >>> from nltk.corpus import wordnet as wn
+        >>> from nltk.tag import pos_tag
+        >>> from nltk.tokenize import word_tokenize
+        >>> text="Taggers are fun"
+        >>> print([(word, tag, wn.tag2pos(tag)) for word,tag in pos_tag(word_tokenize(text))])
+        [('Taggers', 'NNS', 'n'), ('are', 'VBP', 'v'), ('fun', 'JJ', 'a')]
+        >>> print([(word, tag, wn.tag2pos(tag, 'universal')) for word,tag in pos_tag(word_tokenize(text), 'universal')])
+        [('Taggers', 'NOUN', 'n'), ('are', 'VERB', 'v'), ('fun', 'ADJ', 'a')]
+        """
+        from nltk.tag import map_tag
+
+        if tagset != "universal":
+            tag = map_tag(tagset, "universal", tag)
+        return {"NOUN": "n", "VERB": "v", "ADJ": "a", "ADV": "r"}.get(tag, None)
+
+    #############################################################
     # Create information content from corpus
     #############################################################
     def ic(self, corpus, weight_senses_equally=False, smoothing=1.0):

--- a/nltk/stem/__init__.py
+++ b/nltk/stem/__init__.py
@@ -31,4 +31,4 @@ from nltk.stem.porter import PorterStemmer
 from nltk.stem.regexp import RegexpStemmer
 from nltk.stem.rslp import RSLPStemmer
 from nltk.stem.snowball import SnowballStemmer
-from nltk.stem.wordnet import WordNetLemmatizer
+from nltk.stem.wordnet import AutoLemmatizer, WordNetLemmatizer

--- a/nltk/stem/__init__.py
+++ b/nltk/stem/__init__.py
@@ -31,4 +31,4 @@ from nltk.stem.porter import PorterStemmer
 from nltk.stem.regexp import RegexpStemmer
 from nltk.stem.rslp import RSLPStemmer
 from nltk.stem.snowball import SnowballStemmer
-from nltk.stem.wordnet import TextLemmatizer, WordNetLemmatizer
+from nltk.stem.wordnet import WordNetLemmatizer

--- a/nltk/stem/wordnet.py
+++ b/nltk/stem/wordnet.py
@@ -48,9 +48,6 @@ class WordNetLemmatizer:
         lemmas = wn._morphy(word, pos)
         return min(lemmas, key=len) if lemmas else word
 
-    def __repr__(self) -> str:
-        return "<WordNetLemmatizer>"
-
     def lemmatize_text(self, text: str) -> Iterator[Tuple[str, str]]:
         """Tokenize input text, estimate the Universal Tag of each word,
         lemmatize the result and return an iterator over the (lemma, tag) tuples.
@@ -61,12 +58,11 @@ class WordNetLemmatizer:
         :return: an iterator over the estimated (lemma, tag) tuple of each word
 
         >>> from nltk.stem import WordNetLemmatizer
-        >>> from nltk.tag import tuple2str
         >>> wntl = WordNetLemmatizer().lemmatize_text
-        >>> print(' '.join([tuple2str(tup) for tup in wntl('Proverbs are short sentences drawn from long experience.')]))
-        Proverbs/NOUN be/VERB short/ADJ sentence/NOUN draw/VERB from/ADP long/ADJ experience/NOUN ./.
-        >>> print(' '.join([tuple2str(tup) for tup in wntl('proverbs are short sentences drawn from long experience.')]))
-        proverb/NOUN be/VERB short/ADJ sentence/NOUN draw/VERB from/ADP long/ADJ experience/NOUN ./.
+        >>> print([tup for tup in wntl('Proverbs are short sentences drawn from long experience.')])
+        [('Proverbs', 'NOUN'), ('be', 'VERB'), ('short', 'ADJ'), ('sentence', 'NOUN'), ('draw', 'VERB'), ('from', 'ADP'), ('long', 'ADJ'), ('experience', 'NOUN'), ('.', '.')]
+        >>> print([tup for tup in wntl('proverbs are short sentences drawn from long experience.')])
+        [('proverb', 'NOUN'), ('be', 'VERB'), ('short', 'ADJ'), ('sentence', 'NOUN'), ('draw', 'VERB'), ('from', 'ADP'), ('long', 'ADJ'), ('experience', 'NOUN'), ('.', '.')]
         """
         from nltk.tag import pos_tag
         from nltk.tokenize import word_tokenize
@@ -78,6 +74,9 @@ class WordNetLemmatizer:
             # Tokenize the input text and POS-tag each word, using Universal Tags:
             for word, tag in pos_tag(word_tokenize(text), tagset="universal")
         )
+
+    def __repr__(self) -> str:
+        return "<WordNetLemmatizer>"
 
 
 def universal_tag_to_wn_pos(tag) -> str:

--- a/nltk/stem/wordnet.py
+++ b/nltk/stem/wordnet.py
@@ -62,9 +62,9 @@ class AutoLemmatizer:
 
         >>> from nltk.stem import AutoLemmatizer
         >>> auto_wnl = AutoLemmatizer()
-        >>> print(auto_wnl.lemmatize('Proverbs are short sentences drawn from long experience.'))
+        >>> print(auto_wnl.auto_lemmatize('Proverbs are short sentences drawn from long experience.'))
         ['Proverbs', 'be', 'short', 'sentence', 'draw', 'from', 'long', 'experience', '.']
-        >>> print(auto_wnl.lemmatize('proverbs are short sentences drawn from long experience.'))
+        >>> print(auto_wnl.auto_lemmatize('proverbs are short sentences drawn from long experience.'))
         ['proverb', 'be', 'short', 'sentence', 'draw', 'from', 'long', 'experience', '.']
     """
 

--- a/nltk/stem/wordnet.py
+++ b/nltk/stem/wordnet.py
@@ -1,6 +1,6 @@
 # Natural Language Toolkit: WordNet stemmer interface
 #
-# Copyright (C) 2001-2023 NLTK Project
+# Copyright (C) 2001-2024 NLTK Project
 # Author: Steven Bird <stevenbird1@gmail.com>
 #         Edward Loper <edloper@gmail.com>
 # URL: <https://www.nltk.org/>
@@ -9,8 +9,6 @@
 from typing import List
 
 from nltk.corpus import wordnet as wn
-from nltk.tag import pos_tag
-from nltk.tokenize import word_tokenize
 
 
 class WordNetLemmatizer:
@@ -19,19 +17,6 @@ class WordNetLemmatizer:
 
     Lemmatize using WordNet's built-in morphy function.
     Returns the input word unchanged if it cannot be found in WordNet.
-
-        >>> from nltk.stem import WordNetLemmatizer
-        >>> wnl = WordNetLemmatizer()
-        >>> print(wnl.lemmatize('dogs'))
-        dog
-        >>> print(wnl.lemmatize('churches'))
-        church
-        >>> print(wnl.lemmatize('aardwolves'))
-        aardwolf
-        >>> print(wnl.lemmatize('abaci'))
-        abacus
-        >>> print(wnl.lemmatize('hardrock'))
-        hardrock
     """
 
     def lemmatize(self, word: str, pos: str = "n") -> str:
@@ -45,69 +30,54 @@ class WordNetLemmatizer:
             for satellite adjectives.
         :type pos: str
         :return: The lemma of `word`, for the given `pos`.
+
+            >>> from nltk.stem import WordNetLemmatizer
+            >>> wnl = WordNetLemmatizer()
+            >>> print(wnl.lemmatize('dogs'))
+            dog
+            >>> print(wnl.lemmatize('churches'))
+            church
+            >>> print(wnl.lemmatize('aardwolves'))
+            aardwolf
+            >>> print(wnl.lemmatize('abaci'))
+            abacus
+            >>> print(wnl.lemmatize('hardrock'))
+            hardrock
         """
         lemmas = wn._morphy(word, pos)
         return min(lemmas, key=len) if lemmas else word
 
+    def lemmatize_text(self, text: str) -> List[str]:
+        """
+        Tokenize input text, estimate the part-of-speech tag of each word,
+        and return a list of lemmas and pos tag.
+
+        Returns each input word unchanged when it cannot be found in WordNet.
+
+        :param text: The input text to lemmatize.
+        :type text: str
+        :return: A list with the estimated lemma and pos tag of each `word` in the input text.
+
+            >>> from nltk.stem import WordNetLemmatizer
+            >>> wntl = WordNetLemmatizer().lemmatize_text
+            >>> print(wntl('Proverbs are short sentences drawn from long experience.'))
+            ['Proverbs', 'be', 'short', 'sentence', 'draw', 'from', 'long', 'experience', '.']
+            >>> print(wntl('proverbs are short sentences drawn from long experience.'))
+            ['proverb', 'be', 'short', 'sentence', 'draw', 'from', 'long', 'experience', '.']
+        """
+        from nltk.tag import pos_tag
+        from nltk.tokenize import word_tokenize
+
+        return [
+            # Lemmatize each POS-tagged word:
+            (self.lemmatize(word, self.tag2pos(tag)), tag)
+            # Tokenize the input text and POS tag each word:
+            for word, tag in pos_tag(word_tokenize(text))
+        ]
+
+    @staticmethod
+    def tag2pos(tag):
+        return {"N": "n", "V": "v", "J": "a", "R": "r"}.get(tag[0], "n")
+
     def __repr__(self):
         return "<WordNetLemmatizer>"
-
-
-class TextLemmatizer:
-    """
-    WordNet Text Lemmatizer
-
-    Lemmatize from corpus using word_tokenize, WordNet's built-in morphy function and pos_tag.
-    Returns the input word unchanged if it cannot be found in WordNet.
-
-        >>> from nltk.stem import TextLemmatizer
-        >>> text_wnl = TextLemmatizer()
-        >>> print(text_wnl.lemmatize('Proverbs are short sentences drawn from long experience.'))
-        ['Proverbs', 'be', 'short', 'sentence', 'draw', 'from', 'long', 'experience', '.']
-        >>> print(text_wnl.auto_lemmatize('proverbs are short sentences drawn from long experience.'))
-        ['proverb', 'be', 'short', 'sentence', 'draw', 'from', 'long', 'experience', '.']
-    """
-
-    # POS tag dict for matching with WordNet's lemmatize
-    pos_word_dict = {
-        "VBP": "v",
-        "VB": "v",
-        "VBG": "v",
-        "VBD": "v",
-        "VBN": "v",
-        "VBZ": "v",
-        "JJ": "a",
-        "JJR": "a",
-        "JJS": "a",
-        "RB": "r",
-        "RBR": "r",
-        "RBS": "r",
-        "NN": "n",
-        "NNS": "n",
-        "NNP": "n",
-        "NNPS": "n",
-    }
-
-    def lemmatize(self, sentence: str) -> List:
-        """Automatically lemmatize `word` with out pos using pos_tag and WordNet's built-in morphy function.
-        Returns the input word unchanged if it cannot be found in WordNet.
-
-        :param word: The input word to lemmatize.
-        :type word: str
-        :return: The list for lemma of `word`, for automatically estimates `pos`.
-        """
-        # Tokenize the sentence
-        words = word_tokenize(sentence)
-
-        # POS tagging
-        pos_tags = pos_tag(words)
-
-        # Lemmatize the words
-        lemma_list = []
-        for i, word in enumerate(words):
-            lemma = WordNetLemmatizer().lemmatize(
-                word, self.pos_word_dict.get(pos_tags[i][1], "n")
-            )  # word.lower() can be used but it is trade-off problem
-            lemma_list.append(lemma)
-
-        return lemma_list

--- a/nltk/stem/wordnet.py
+++ b/nltk/stem/wordnet.py
@@ -53,15 +53,15 @@ class WordNetLemmatizer:
         return "<WordNetLemmatizer>"
 
 
-class AutoLemmatizer:
+class TextLemmatizer:
     """
-    Auto WordNet Lemmatizer
+    WordNet Text Lemmatizer
 
     Lemmatize from corpus using word_tokenize, WordNet's built-in morphy function and pos_tag.
     Returns the input word unchanged if it cannot be found in WordNet.
 
-        >>> from nltk.stem import AutoLemmatizer
-        >>> auto_wnl = AutoLemmatizer()
+        >>> from nltk.stem import TextLemmatizer
+        >>> auto_wnl = TextLemmatizer()
         >>> print(auto_wnl.lemmatize('Proverbs are short sentences drawn from long experience.'))
         ['Proverbs', 'be', 'short', 'sentence', 'draw', 'from', 'long', 'experience', '.']
         >>> print(auto_wnl.lemmatize('proverbs are short sentences drawn from long experience.'))
@@ -88,7 +88,7 @@ class AutoLemmatizer:
         "NNPS": "n",
     }
 
-    def auto_lemmatize(self, sentence: str) -> List:
+    def lemmatize(self, sentence: str) -> List:
         """Automatically lemmatize `word` with out pos using pos_tag and WordNet's built-in morphy function.
         Returns the input word unchanged if it cannot be found in WordNet.
 
@@ -105,9 +105,9 @@ class AutoLemmatizer:
         # Lemmatize the words
         lemma_list = []
         for i, word in enumerate(words):
-            lemmas = wn._morphy(
+            lemma = WordNetLemmatizer().lemmatize(
                 word, self.pos_word_dict.get(pos_tags[i][1], "n")
             )  # word.lower() can be used but it is trade-off problem
-            lemma_list.append(min(lemmas, key=len) if lemmas else word)
+            lemma_list.append(lemma)
 
         return lemma_list

--- a/nltk/stem/wordnet.py
+++ b/nltk/stem/wordnet.py
@@ -59,9 +59,9 @@ class WordNetLemmatizer:
 
         >>> from nltk.stem import WordNetLemmatizer
         >>> wntl = WordNetLemmatizer().lemmatize_text
-        >>> print([tup for tup in wntl('Proverbs are short sentences drawn from long experience.')])
+        >>> print(list(wntl("Proverbs are short sentences drawn from long experience.")))
         [('Proverbs', 'NOUN'), ('be', 'VERB'), ('short', 'ADJ'), ('sentence', 'NOUN'), ('draw', 'VERB'), ('from', 'ADP'), ('long', 'ADJ'), ('experience', 'NOUN'), ('.', '.')]
-        >>> print([tup for tup in wntl('proverbs are short sentences drawn from long experience.')])
+        >>> print(list(wntl("proverbs are short sentences drawn from long experience.")))
         [('proverb', 'NOUN'), ('be', 'VERB'), ('short', 'ADJ'), ('sentence', 'NOUN'), ('draw', 'VERB'), ('from', 'ADP'), ('long', 'ADJ'), ('experience', 'NOUN'), ('.', '.')]
         """
         from nltk.tag import pos_tag
@@ -70,16 +70,10 @@ class WordNetLemmatizer:
         yield from (
             # Lemmatixe each word using the WordNet Pos corresponding to its
             # Universal tag (or 'n' when WordNet does not cover that Pos):
-            (self.lemmatize(word, universal_tag_to_wn_pos(tag) or "n"), tag)
+            (self.lemmatize(word, wn.tag2pos(tag, "universal") or "n"), tag)
             # Tokenize the input text and POS-tag each word, using Universal Tags:
-            for word, tag in pos_tag(word_tokenize(text), tagset="universal")
+            for word, tag in pos_tag(word_tokenize(text), "universal")
         )
 
     def __repr__(self) -> str:
         return "<WordNetLemmatizer>"
-
-
-def universal_tag_to_wn_pos(tag) -> str:
-    """Convert Universal Tag to WordNet Part-of-speech.
-    Return None when WordNet does not cover the Pos"""
-    return {"NOUN": "n", "VERB": "v", "ADJ": "a", "ADV": "r"}.get(tag, None)

--- a/nltk/stem/wordnet.py
+++ b/nltk/stem/wordnet.py
@@ -6,7 +6,11 @@
 # URL: <https://www.nltk.org/>
 # For license information, see LICENSE.TXT
 
+from typing import List
+
 from nltk.corpus import wordnet as wn
+from nltk.tag import pos_tag
+from nltk.tokenize import word_tokenize
 
 
 class WordNetLemmatizer:
@@ -47,3 +51,63 @@ class WordNetLemmatizer:
 
     def __repr__(self):
         return "<WordNetLemmatizer>"
+
+
+class AutoLemmatizer:
+    """
+    Auto WordNet Lemmatizer
+
+    Lemmatize from corpus using word_tokenize, WordNet's built-in morphy function and pos_tag.
+    Returns the input word unchanged if it cannot be found in WordNet.
+
+        >>> from nltk.stem import AutoLemmatizer
+        >>> auto_wnl = AutoLemmatizer()
+        >>> print(auto_wnl.lemmatize('Proverbs are short sentences drawn from long experience.'))
+        ['Proverbs', 'be', 'short', 'sentence', 'draw', 'from', 'long', 'experience', '.']
+        >>> print(auto_wnl.lemmatize('proverbs are short sentences drawn from long experience.'))
+        ['proverb', 'be', 'short', 'sentence', 'draw', 'from', 'long', 'experience', '.']
+    """
+
+    # POS tag dict for matching with WordNet's lemmatize
+    pos_word_dict = {
+        "VBP": "v",
+        "VB": "v",
+        "VBG": "v",
+        "VBD": "v",
+        "VBN": "v",
+        "VBZ": "v",
+        "JJ": "a",
+        "JJR": "a",
+        "JJS": "a",
+        "RB": "r",
+        "RBR": "r",
+        "RBS": "r",
+        "NN": "n",
+        "NNS": "n",
+        "NNP": "n",
+        "NNPS": "n",
+    }
+
+    def auto_lemmatize(self, sentence: str) -> List:
+        """Automatically lemmatize `word` with out pos using pos_tag and WordNet's built-in morphy function.
+        Returns the input word unchanged if it cannot be found in WordNet.
+
+        :param word: The input word to lemmatize.
+        :type word: str
+        :return: The list for lemma of `word`, for automatically estimates `pos`.
+        """
+        # Tokenize the sentence
+        words = word_tokenize(sentence)
+
+        # POS tagging
+        pos_tags = pos_tag(words)
+
+        # Lemmatize the words
+        lemma_list = []
+        for i, word in enumerate(words):
+            lemmas = wn._morphy(
+                word, self.pos_word_dict.get(pos_tags[i][1], "n")
+            )  # word.lower() can be used but it is trade-off problem
+            lemma_list.append(min(lemmas, key=len) if lemmas else word)
+
+        return lemma_list


### PR DESCRIPTION
I have been working with natural language processing and often needed to know which words were used in certain corpora. Many dictionaries are comprised of word stems, requiring the extraction of stems from sentences. For example, specific words can be key clues or carry important information, necessitating the extraction of sentences using these words, or processing sentence information with them.

In this context, I have developed a class called AutoLemmatizer in stem/wordnet.py that automatically performs tokenization and part-of-speech-based lemmatization, returning the lemmas of all words used in a sentence.

- I also considered converting 'n't' to 'not,' but have not implemented it yet.

- For big data, this process takes long time, and this task can be processed by multi-processing pipeline. if you interest, please let me know. I'm developing this.

I would be pleased if this contribution is considered useful and adopted.

```python
>>> from nltk.stem import AutoLemmatizer
>>> auto_wnl = AutoLemmatizer()
>>> print(auto_wnl.auto_lemmatize('Proverbs are short sentences drawn from long experience.'))
['Proverbs', 'be', 'short', 'sentence', 'draw', 'from', 'long', 'experience', '.']
>>> print(auto_wnl.auto_lemmatize('proverbs are short sentences drawn from long experience.'))
['proverb', 'be', 'short', 'sentence', 'draw', 'from', 'long', 'experience', '.']
```

issue: #3256