### PR TITLE
Fix k-alpha for expected disagreement equals 0

### DIFF
--- a/nltk/metrics/agreement.py
+++ b/nltk/metrics/agreement.py
@@ -304,7 +304,6 @@ class AnnotationTask:
         total_disagreement = 0.0
         total_ratings = 0
         all_valid_labels_freq = FreqDist([])
-
         total_do = 0.0  # Total observed disagreement for all items.
         for i, itemdata in self._grouped_data("item"):
             label_freqs = FreqDist(x["labels"] for x in itemdata)
@@ -313,8 +312,12 @@ class AnnotationTask:
                 # Ignore the item.
                 continue
             all_valid_labels_freq += label_freqs
-            total_do += self.Disagreement(label_freqs) * labels_count
-
+            total_do += self.Disagreement(label_freqs) * labels_count  
+        
+        if len(all_valid_labels_freq.keys()) == 1:
+            log.debug("Only one valid annotation value, alpha returning 1.")
+            return 1
+        
         do = total_do / sum(all_valid_labels_freq.values())
 
         de = self.Disagreement(all_valid_labels_freq)  # Expected disagreement.

--- a/nltk/test/unit/test_disagreement.py
+++ b/nltk/test/unit/test_disagreement.py
@@ -40,6 +40,25 @@ class TestDisagreement(unittest.TestCase):
         ]
         annotation_task = AnnotationTask(data)
         self.assertAlmostEqual(annotation_task.alpha(), -0.3333333)
+        
+    def test_easy3(self):
+        """
+        If expected disagreement is 0, K-Apha should be 1.
+        """
+        data=[
+            ('coder1', '1', 1),
+            ('coder2', '1', 1), 
+            ('coder1', '2', 2),
+            ('coder2', '2', 2)]
+        annotation_task = AnnotationTask(data)
+        self.assertAlmostEqual(annotation_task.alpha(), 1.0)
+        
+        data=[
+            ('coder1', '1', 1),
+            ('coder2', '1', 1), 
+            ('coder1', '2', 2)]
+        annotation_task = AnnotationTask(data)
+        self.assertAlmostEqual(annotation_task.alpha(), 1.0)
 
     def test_advanced(self):
         """


### PR DESCRIPTION
Fixes issue #3264 and adds 2 test cases.

**Issue description**:
The number of labels is considered before the number of valid items is determined. There is cases (s. below) where removing items with less than two annotation also reduced the number of labels considered. Hence, we have to check again after checking for valid labels if there's only one label present which means the annotators totally agree. Otherwise, we can run in a division by zero problem.

**Test case description:**
Per definition the expected disagreement only takes into consideration items where at least 2 coders have annotated. In case of a following dataset:
```python
        data=[
            ('coder1', '1', 1),
            ('coder2', '1', 1), 
            ('coder1', '2', 2)]
```
what is actually taken into consideration is 
```python
        data=[
            ('coder1', '1', 1),
            ('coder2', '1', 1), 
```
Hence, this should return k_alpha = 1.0.