### PR TITLE
fix miscellaneous minor misspelled words

### DIFF
--- a/nltk/tokenize/destructive.py
+++ b/nltk/tokenize/destructive.py
@@ -69,7 +69,7 @@ class NLTKWordTokenizer(TokenizerI):
     # For improvements for starting/closing quotes from TreebankWordTokenizer,
     # see discussion on https://github.com/nltk/nltk/pull/1437
     # Adding to TreebankWordTokenizer, nltk.word_tokenize now splits on
-    # - chervon quotes u'\xab' and u'\xbb' .
+    # - chevron quotes u'\xab' and u'\xbb' .
     # - unicode quotes u'\u2018', u'\u2019', u'\u201c' and u'\u201d'
     # See https://github.com/nltk/nltk/issues/1995#issuecomment-376741608
     # Also, behavior of splitting on clitics now follows Stanford CoreNLP

--- a/nltk/tokenize/destructive.py
+++ b/nltk/tokenize/destructive.py
@@ -69,7 +69,7 @@ class NLTKWordTokenizer(TokenizerI):
     # For improvements for starting/closing quotes from TreebankWordTokenizer,
     # see discussion on https://github.com/nltk/nltk/pull/1437
     # Adding to TreebankWordTokenizer, nltk.word_tokenize now splits on
-    # - chevron quotes u'\xab' and u'\xbb' .
+    # - chevron quotes u'\xab' and u'\xbb'
     # - unicode quotes u'\u2018', u'\u2019', u'\u201c' and u'\u201d'
     # See https://github.com/nltk/nltk/issues/1995#issuecomment-376741608
     # Also, behavior of splitting on clitics now follows Stanford CoreNLP

--- a/nltk/tokenize/nist.py
+++ b/nltk/tokenize/nist.py
@@ -46,7 +46,7 @@ class NISTTokenizer(TokenizerI):
     >>> nist = NISTTokenizer()
 
     # Input strings.
-    >>> albb = u'Alibaba Group Holding Limited (Chinese: 阿里巴巴集团控股 有限公司) us a Chinese e-commerce company...'
+    >>> albb = u'Alibaba Group Holding Limited (Chinese: 阿里巴巴集团控股 有限公司) is a Chinese e-commerce company...'
     >>> amz = u'Amazon.com, Inc. (/ˈæməzɒn/) is an American electronic commerce...'
     >>> rkt = u'Rakuten, Inc. (楽天株式会社 Rakuten Kabushiki-gaisha) is a Japanese electronic commerce and Internet company based in Tokyo.'
 

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -1185,7 +1185,7 @@ class PunktTrainer(PunktBaseClass):
         Returns True given a token and the token that precedes it if it
         seems clear that the token is beginning a sentence.
         """
-        # If a token (i) is preceded by a sentece break that is
+        # If a token (i) is preceded by a sentence break that is
         # not a potential ordinal number or initial, and (ii) is
         # alphabetic, then it is a a sentence-starter.
         return (


### PR DESCRIPTION
fixed minor misspellings:
- chervon -> chevron
- us a -> is a
- sentece -> sentence

fantastic project and I hope to learn more about the code in this repo as time goes on.