### PR TITLE
Pickless-less tagsets helper

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-repos:
+repos:   
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-repos:   
+repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:

--- a/nltk/compat.py
+++ b/nltk/compat.py
@@ -14,7 +14,7 @@ from functools import wraps
 # a full copy of the data which has been re-encoded or repickled.
 DATA_UPDATES = [
     ("chunkers", "maxent_ne_chunker"),
-    ("help", "tagsets"),
+    ("help"),
     ("taggers", "maxent_treebank_pos_tagger"),
     ("tokenizers", "punkt"),
 ]

--- a/nltk/compat.py
+++ b/nltk/compat.py
@@ -14,7 +14,6 @@ from functools import wraps
 # a full copy of the data which has been re-encoded or repickled.
 DATA_UPDATES = [
     ("chunkers", "maxent_ne_chunker"),
-    ("help"),
     ("taggers", "maxent_treebank_pos_tagger"),
     ("tokenizers", "punkt"),
 ]

--- a/nltk/help.py
+++ b/nltk/help.py
@@ -9,11 +9,11 @@
 Provide structured access to documentation.
 """
 
+import json
 import re
 from textwrap import wrap
 
-from nltk.data import load
-
+from nltk.data import find
 
 def brown_tagset(tagpattern=None):
     _format_tagset("brown_tagset", tagpattern)
@@ -43,7 +43,11 @@ def _print_entries(tags, tagdict):
 
 
 def _format_tagset(tagset, tagpattern=None):
-    tagdict = load("help/tagsets/" + tagset + ".pickle")
+    # Load tagset from json file.
+    tag_json_file = find(f"help/tagsets_json/PY3_json/{tagset}.json")
+    with open(tag_json_file) as fin:
+        tagdict = json.load(fin)
+
     if not tagpattern:
         _print_entries(sorted(tagdict), tagdict)
     elif tagpattern in tagdict:

--- a/nltk/help.py
+++ b/nltk/help.py
@@ -15,6 +15,7 @@ from textwrap import wrap
 
 from nltk.data import find
 
+
 def brown_tagset(tagpattern=None):
     _format_tagset("brown_tagset", tagpattern)
 

--- a/nltk/test/unit/test_pos_tag.py
+++ b/nltk/test/unit/test_pos_tag.py
@@ -2,11 +2,31 @@
 Tests for nltk.pos_tag
 """
 
-
+import io
 import unittest
+import unittest.mock
 
 from nltk import pos_tag, word_tokenize
+from nltk.help import brown_tagset, claws5_tagset, upenn_tagset
 
+
+UPENN_TAGSET_DOLLAR_TEST = """$: dollar
+    $ -$ --$ A$ C$ HK$ M$ NZ$ S$ U.S.$ US$
+PRP$: pronoun, possessive
+    her his mine my our ours their thy your
+WP$: WH-pronoun, possessive
+    whose
+"""
+
+BROWN_TAGSET_NNS_TEST = """NNS: noun, plural, common
+    irregularities presentments thanks reports voters laws legislators
+    years areas adjustments chambers $100 bonds courts sales details raises
+    sessions members congressmen votes polls calls ...
+"""
+
+CLAW5_TAGSET_VHD_TEST ="""VHD: past tense form of the verb "HAVE"
+    had, 'd
+"""
 
 class TestPosTag(unittest.TestCase):
     def test_pos_tag_eng(self):
@@ -40,6 +60,22 @@ class TestPosTag(unittest.TestCase):
             (".", "."),
         ]
         assert pos_tag(word_tokenize(text), tagset="universal") == expected_tagged
+
+
+    @unittest.mock.patch('sys.stdout', new_callable=io.StringIO)
+    def check_stdout(self, tagset, query_regex, expected_output, mock_stdout):
+        tagset(query_regex)
+        self.assertEqual(mock_stdout.getvalue(), expected_output)
+
+    def test_tagsets_upenn(self):
+        self.check_stdout(upenn_tagset, r".*\$", UPENN_TAGSET_DOLLAR_TEST)
+
+    def test_tagsets_brown(self):
+        self.check_stdout(brown_tagset, r"NNS", BROWN_TAGSET_NNS_TEST)
+
+    def test_tagsets_claw5(self):
+        self.check_stdout(claws5_tagset, r"VHD", CLAW5_TAGSET_VHD_TEST)
+
 
     def test_pos_tag_rus(self):
         text = "Илья оторопел и дважды перечитал бумажку."

--- a/nltk/test/unit/test_pos_tag.py
+++ b/nltk/test/unit/test_pos_tag.py
@@ -9,7 +9,6 @@ import unittest.mock
 from nltk import pos_tag, word_tokenize
 from nltk.help import brown_tagset, claws5_tagset, upenn_tagset
 
-
 UPENN_TAGSET_DOLLAR_TEST = """$: dollar
     $ -$ --$ A$ C$ HK$ M$ NZ$ S$ U.S.$ US$
 PRP$: pronoun, possessive
@@ -24,9 +23,10 @@ BROWN_TAGSET_NNS_TEST = """NNS: noun, plural, common
     sessions members congressmen votes polls calls ...
 """
 
-CLAW5_TAGSET_VHD_TEST ="""VHD: past tense form of the verb "HAVE"
+CLAW5_TAGSET_VHD_TEST = """VHD: past tense form of the verb "HAVE"
     had, 'd
 """
+
 
 class TestPosTag(unittest.TestCase):
     def test_pos_tag_eng(self):
@@ -61,8 +61,7 @@ class TestPosTag(unittest.TestCase):
         ]
         assert pos_tag(word_tokenize(text), tagset="universal") == expected_tagged
 
-
-    @unittest.mock.patch('sys.stdout', new_callable=io.StringIO)
+    @unittest.mock.patch("sys.stdout", new_callable=io.StringIO)
     def check_stdout(self, tagset, query_regex, expected_output, mock_stdout):
         tagset(query_regex)
         self.assertEqual(mock_stdout.getvalue(), expected_output)
@@ -75,7 +74,6 @@ class TestPosTag(unittest.TestCase):
 
     def test_tagsets_claw5(self):
         self.check_stdout(claws5_tagset, r"VHD", CLAW5_TAGSET_VHD_TEST)
-
 
     def test_pos_tag_rus(self):
         text = "Илья оторопел и дважды перечитал бумажку."


### PR DESCRIPTION
Instead of loading of tagsets pickle, this PR loads the tagsets_json dataset.

Related: https://github.com/nltk/nltk/issues/3266


### Testing

```
% python3 -m unittest nltk/test/unit/test_pos_tag.py -vvv
test_pos_tag_eng (nltk.test.unit.test_pos_tag.TestPosTag) ... ok
test_pos_tag_eng_universal (nltk.test.unit.test_pos_tag.TestPosTag) ... ok
test_pos_tag_rus (nltk.test.unit.test_pos_tag.TestPosTag) ... ok
test_pos_tag_rus_universal (nltk.test.unit.test_pos_tag.TestPosTag) ... ok
test_pos_tag_unknown_lang (nltk.test.unit.test_pos_tag.TestPosTag) ... ok
test_tagsets_brown (nltk.test.unit.test_pos_tag.TestPosTag) ... ok
test_tagsets_claw5 (nltk.test.unit.test_pos_tag.TestPosTag) ... ok
test_tagsets_upenn (nltk.test.unit.test_pos_tag.TestPosTag) ... ok
test_unspecified_lang (nltk.test.unit.test_pos_tag.TestPosTag) ... ok

----------------------------------------------------------------------
Ran 9 tests in 0.421s

OK
```