### PR TITLE
Towards pickle-free Punkt

### DIFF
--- a/nltk/data.py
+++ b/nltk/data.py
@@ -759,8 +759,8 @@ def load(
 
         resource_val = json.load(opened_resource)
         tag = None
-        if len(resource_val) != 1:
-            tag = next(resource_val.keys())
+        if len(resource_val) == 1:
+            tag = next(iter(resource_val.keys()))
         if tag not in json_tags:
             raise ValueError("Unknown json tag.")
     elif format == "yaml":

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -111,6 +111,7 @@ import string
 from collections import defaultdict
 from typing import Any, Dict, Iterator, List, Match, Optional, Tuple, Union
 
+from nltk import jsontags
 from nltk.probability import FreqDist
 from nltk.tokenize.api import TokenizerI
 
@@ -182,6 +183,7 @@ REASON_INITIAL_WITH_SPECIAL_ORTHOGRAPHIC_HEURISTIC = (
 ######################################################################
 
 
+@jsontags.register_tag
 class PunktLanguageVars:
     """
     Stores variables, mostly regular expressions, which may be
@@ -193,6 +195,8 @@ class PunktLanguageVars:
     """
 
     __slots__ = ("_re_period_context", "_re_word_tokenizer")
+
+    json_tag = "nltk.tokenize.punkt.PunktLanguageVars"
 
     def __getstate__(self):
         # All modifications to the class are performed by inheritance.
@@ -332,8 +336,18 @@ def _pair_iter(iterator):
 ######################################################################
 
 
+@jsontags.register_tag
 class PunktParameters:
     """Stores data used to perform sentence boundary detection with Punkt."""
+
+    json_tag = "nltk.tokenize.punkt.PunktParameters"
+
+    def encode_json_obj(self):
+        return (
+            list(self.collocations),
+            list(self.sent_starters),
+            list(self.ortho_context.items()),
+        )
 
     def __init__(self):
         self.abbrev_types = set()
@@ -391,9 +405,12 @@ class PunktParameters:
 ######################################################################
 
 
+@jsontags.register_tag
 class PunktToken:
     """Stores a token of text with annotations produced during
     sentence boundary detection."""
+
+    json_tag = "nltk.tokenize.punkt.PunktToken"
 
     _properties = ["parastart", "linestart", "sentbreak", "abbr", "ellipsis"]
     __slots__ = ["tok", "type", "period_final"] + _properties
@@ -531,10 +548,13 @@ class PunktToken:
 ######################################################################
 
 
+@jsontags.register_tag
 class PunktBaseClass:
     """
     Includes common components of PunktTrainer and PunktSentenceTokenizer.
     """
+
+    json_tag = "nltk.tokenize.punkt.PunktBaseClass"
 
     def __init__(self, lang_vars=None, token_cls=PunktToken, params=None):
         if lang_vars is None:
@@ -632,8 +652,11 @@ class PunktBaseClass:
 ######################################################################
 
 
+@jsontags.register_tag
 class PunktTrainer(PunktBaseClass):
     """Learns parameters used in Punkt sentence boundary detection."""
+
+    json_tag = "nltk.tokenize.punkt.PunktTrainer"
 
     def __init__(
         self, train_text=None, verbose=False, lang_vars=None, token_cls=PunktToken
@@ -1236,6 +1259,7 @@ class PunktTrainer(PunktBaseClass):
 ######################################################################
 
 
+@jsontags.register_tag
 class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
     """
     A sentence tokenizer which uses an unsupervised algorithm to build
@@ -1244,6 +1268,8 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
     This approach has been shown to work well for many European
     languages.
     """
+
+    json_tag = "nltk.tokenize.punkt.PunktSentenceTokenizer"
 
     def __init__(
         self, train_text=None, verbose=False, lang_vars=None, token_cls=PunktToken

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -183,7 +183,6 @@ REASON_INITIAL_WITH_SPECIAL_ORTHOGRAPHIC_HEURISTIC = (
 ######################################################################
 
 
-@jsontags.register_tag
 class PunktLanguageVars:
     """
     Stores variables, mostly regular expressions, which may be
@@ -195,8 +194,6 @@ class PunktLanguageVars:
     """
 
     __slots__ = ("_re_period_context", "_re_word_tokenizer")
-
-    json_tag = "nltk.tokenize.punkt.PunktLanguageVars"
 
     def __getstate__(self):
         # All modifications to the class are performed by inheritance.
@@ -346,28 +343,57 @@ class PunktParameters:
         return (
             list(self.collocations),
             list(self.sent_starters),
-            list(self.ortho_context.items()),
+            list(self.abbrev_types),
+            dict(self.ortho_context),
         )
 
-    def __init__(self):
-        self.abbrev_types = set()
-        """A set of word types for known abbreviations."""
+    @classmethod
+    def decode_json_obj(cls, obj):
+        collocations, sent_starters, abbrev_types, ortho_context = obj
+        return cls(
+            {tuple(x) for x in collocations},
+            set(sent_starters),
+            set(abbrev_types),
+            defaultdict(int, ortho_context),
+        )
 
-        self.collocations = set()
+    def __init__(
+        self,
+        collocations=None,
+        sent_starters=None,
+        abbrev_types=None,
+        ortho_context=None,
+    ):
+        """A set of word types for known abbreviations."""
+        if abbrev_types == None:
+            self.abbrev_types = set()
+        else:
+            self.abbrev_types = abbrev_types
+
         """A set of word type tuples for known common collocations
         where the first word ends in a period.  E.g., ('S.', 'Bach')
         is a common collocation in a text that discusses 'Johann
         S. Bach'.  These count as negative evidence for sentence
         boundaries."""
+        if collocations == None:
+            self.collocations = set()
+        else:
+            self.collocations = collocations
 
-        self.sent_starters = set()
         """A set of word types for words that often appear at the
         beginning of sentences."""
+        if sent_starters == None:
+            self.sent_starters = set()
+        else:
+            self.sent_starters = sent_starters
 
-        self.ortho_context = defaultdict(int)
         """A dictionary mapping word types to the set of orthographic
         contexts that word type appears in.  Contexts are represented
         by adding orthographic context flags: ..."""
+        if ortho_context == None:
+            self.ortho_context = defaultdict(int)
+        else:
+            self.ortho_context = ortho_context
 
     def clear_abbrevs(self):
         self.abbrev_types = set()
@@ -405,12 +431,9 @@ class PunktParameters:
 ######################################################################
 
 
-@jsontags.register_tag
 class PunktToken:
     """Stores a token of text with annotations produced during
     sentence boundary detection."""
-
-    json_tag = "nltk.tokenize.punkt.PunktToken"
 
     _properties = ["parastart", "linestart", "sentbreak", "abbr", "ellipsis"]
     __slots__ = ["tok", "type", "period_final"] + _properties
@@ -548,13 +571,10 @@ class PunktToken:
 ######################################################################
 
 
-@jsontags.register_tag
 class PunktBaseClass:
     """
     Includes common components of PunktTrainer and PunktSentenceTokenizer.
     """
-
-    json_tag = "nltk.tokenize.punkt.PunktBaseClass"
 
     def __init__(self, lang_vars=None, token_cls=PunktToken, params=None):
         if lang_vars is None:
@@ -652,11 +672,8 @@ class PunktBaseClass:
 ######################################################################
 
 
-@jsontags.register_tag
 class PunktTrainer(PunktBaseClass):
     """Learns parameters used in Punkt sentence boundary detection."""
-
-    json_tag = "nltk.tokenize.punkt.PunktTrainer"
 
     def __init__(
         self, train_text=None, verbose=False, lang_vars=None, token_cls=PunktToken
@@ -1259,7 +1276,6 @@ class PunktTrainer(PunktBaseClass):
 ######################################################################
 
 
-@jsontags.register_tag
 class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
     """
     A sentence tokenizer which uses an unsupervised algorithm to build
@@ -1268,8 +1284,6 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
     This approach has been shown to work well for many European
     languages.
     """
-
-    json_tag = "nltk.tokenize.punkt.PunktSentenceTokenizer"
 
     def __init__(
         self, train_text=None, verbose=False, lang_vars=None, token_cls=PunktToken


### PR DESCRIPTION
Add Json encoding/decoding to the _PunktParameters_ class, using the scheme from  _nltk.jsontags_.
With this PR, a pickled PunktParameters class can be encoded to a Json file, for ex. _tokenizers/punkt/PY3/english.pickle_:

```
from nltk.data import load
import json
from os.path import basename, splitext
from nltk.jsontags import JSONTaggedDecoder, JSONTaggedEncoder
decoder = JSONTaggedDecoder()
encoder = JSONTaggedEncoder()

file = 'tokenizers/punkt/PY3/english.pickle'
tokenizer = load(file)
pa = tokenizer._params
encoded = encoder.encode(pa)
fjson = splitext(basename(file))[0] + ".json"
with open(fjson, 'w') as f:
    f.write(encoded)
```

Load the resulting Json file using nltk.load:

```
encoded = load(fjson) 
pa2 = decoder.decode_obj(encoded)
```

Compare the decoded Json object with the original pickle:

`print(type(pa2))`
<class 'nltk.tokenize.punkt.PunktParameters'>
`print(pa.collocations == pa2.collocations)`
True
`print(pa.sent_starters == pa2.sent_starters)`
True
`print(pa.abbrev_types == pa2.abbrev_types)`
True
`print(pa.ortho_context == pa2.ortho_context)`
True

To make this work, I had to slightly modify two lines (762 and 763) in  _nltk/data.py_, so please review those lines in particular.