### PR TITLE
fix python version for pre-commit as a workaround

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.x' # run with latest python version
+          python-version: '3.12.3' # 3.12.4 has an issue with pyupgrade, try to upgrade later
       - run: |
           pip install pre-commit
           pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,17 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: fix-byte-order-marker
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: requirements-txt-fixer
       - id: check-yaml
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.16.0
+    hooks:
+    - id: pyupgrade
+      args: ["--py38-plus"]
   - repo: https://github.com/ambv/black
     rev: 24.4.2
     hooks:


### PR DESCRIPTION
This PR:
- fixes version of python during pre-commit checks to 3.12.3, as a workaround for issue encountered with 3.12.4 in https://github.com/nltk/nltk/pull/3274
- re-introduces pyupgrade
- upgrades versions of pre-commit hooks and pyupgrade