### PR TITLE
Load PunktParameters from tab files

### DIFF
--- a/nltk/chunk/__init__.py
+++ b/nltk/chunk/__init__.py
@@ -174,16 +174,32 @@ def ne_chunker(fmt="multiclass"):
     return Maxent_NE_Chunker(fmt)
 
 
-def ne_chunk(chunker, tagged_tokens):
+def ne_chunk(tagged_tokens, binary=False):
     """
-    Use chunker to chunk the given list of tagged tokens.
+    Use NLTK's currently recommended named entity chunker to
+    chunk the given list of tagged tokens.
+
+    >>> from nltk.chunk import ne_chunk
+    >>> from nltk.corpus import treebank
+    >>> from pprint import pprint
+    >>> pprint(ne_chunk(treebank.tagged_sents()[2][8:14])) # doctest: +NORMALIZE_WHITESPACE
+    Tree('S', [('chairman', 'NN'), ('of', 'IN'), Tree('ORGANIZATION', [('Consolidated', 'NNP'), ('Gold', 'NNP'), ('Fields', 'NNP')]), ('PLC', 'NNP')])
+
     """
+    if binary:
+        chunker = ne_chunker(fmt="binary")
+    else:
+        chunker = ne_chunker()
     return chunker.parse(tagged_tokens)
 
 
-def ne_chunk_sents(chunker, tagged_sentences):
+def ne_chunk_sents(tagged_sentences, binary=False):
     """
-    Use chunker to chunk the given list of tagged sentences,
-    each consisting of a list of tagged tokens.
+    Use NLTK's currently recommended named entity chunker to chunk the
+    given list of tagged sentences, each consisting of a list of tagged tokens.
     """
+    if binary:
+        chunker = ne_chunker(fmt="binary")
+    else:
+        chunker = ne_chunker()
     return chunker.parse_sents(tagged_sentences)

--- a/nltk/compat.py
+++ b/nltk/compat.py
@@ -15,7 +15,6 @@ from functools import wraps
 DATA_UPDATES = [
     ("chunkers", "maxent_ne_chunker"),
     ("taggers", "maxent_treebank_pos_tagger"),
-    ("tokenizers", "punkt"),
 ]
 
 _PY3_DATA_UPDATES = [os.path.join(*path_list) for path_list in DATA_UPDATES]

--- a/nltk/compat.py
+++ b/nltk/compat.py
@@ -12,9 +12,7 @@ from functools import wraps
 
 # The following datasets have a /PY3 subdirectory containing
 # a full copy of the data which has been re-encoded or repickled.
-DATA_UPDATES = [
-    ("tokenizers", "punkt"),
-]
+DATA_UPDATES = []
 
 _PY3_DATA_UPDATES = [os.path.join(*path_list) for path_list in DATA_UPDATES]
 

--- a/nltk/compat.py
+++ b/nltk/compat.py
@@ -12,10 +12,7 @@ from functools import wraps
 
 # The following datasets have a /PY3 subdirectory containing
 # a full copy of the data which has been re-encoded or repickled.
-DATA_UPDATES = [
-    ("chunkers", "maxent_ne_chunker"),
-    ("taggers", "maxent_treebank_pos_tagger"),
-]
+DATA_UPDATES = []
 
 _PY3_DATA_UPDATES = [os.path.join(*path_list) for path_list in DATA_UPDATES]
 

--- a/nltk/corpus/reader/plaintext.py
+++ b/nltk/corpus/reader/plaintext.py
@@ -39,7 +39,7 @@ class PlaintextCorpusReader(CorpusReader):
         root,
         fileids,
         word_tokenizer=WordPunctTokenizer(),
-        sent_tokenizer=nltk.data.LazyLoader("tokenizers/punkt/english.pickle"),
+        sent_tokenizer=PunktTokenizer(),
         para_block_reader=read_blankline_block,
         encoding="utf8",
     ):
@@ -163,10 +163,7 @@ class CategorizedPlaintextCorpusReader(CategorizedCorpusReader, PlaintextCorpusR
 class PortugueseCategorizedPlaintextCorpusReader(CategorizedPlaintextCorpusReader):
     def __init__(self, *args, **kwargs):
         CategorizedCorpusReader.__init__(self, kwargs)
-        kwargs["sent_tokenizer"] = nltk.data.LazyLoader(
-            "tokenizers/punkt/portuguese.pickle"
-        )
-        PlaintextCorpusReader.__init__(self, *args, **kwargs)
+        kwargs["sent_tokenizer"] = PunktTokenizer("portuguese")
 
 
 class EuroparlCorpusReader(PlaintextCorpusReader):

--- a/nltk/corpus/reader/plaintext.py
+++ b/nltk/corpus/reader/plaintext.py
@@ -39,7 +39,7 @@ class PlaintextCorpusReader(CorpusReader):
         root,
         fileids,
         word_tokenizer=WordPunctTokenizer(),
-        sent_tokenizer=PunktTokenizer(),
+        sent_tokenizer=None,
         para_block_reader=read_blankline_block,
         encoding="utf8",
     ):
@@ -85,7 +85,10 @@ class PlaintextCorpusReader(CorpusReader):
         :rtype: list(list(str))
         """
         if self._sent_tokenizer is None:
-            raise ValueError("No sentence tokenizer for this corpus")
+            try:
+                self._sent_tokenizer = PunktTokenizer()
+            except:
+                raise ValueError("No sentence tokenizer for this corpus")
 
         return concat(
             [
@@ -102,7 +105,10 @@ class PlaintextCorpusReader(CorpusReader):
         :rtype: list(list(list(str)))
         """
         if self._sent_tokenizer is None:
-            raise ValueError("No sentence tokenizer for this corpus")
+            try:
+                self._sent_tokenizer = PunktTokenizer()
+            except:
+                raise ValueError("No sentence tokenizer for this corpus")
 
         return concat(
             [

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -658,6 +658,15 @@ AUTO_FORMATS = {
 }
 
 
+def restricted_pickle_load(string):
+    """
+    Prevents any class or function from loading.
+    """
+    from nltk.app.wordnet_app import RestrictedUnpickler
+
+    return RestrictedUnpickler(BytesIO(string)).load()
+
+
 def load(
     resource_url,
     format="auto",
@@ -751,7 +760,7 @@ def load(
     if format == "raw":
         resource_val = opened_resource.read()
     elif format == "pickle":
-        resource_val = pickle.load(opened_resource)
+        resource_val = restricted_pickle_load(opened_resource.read())
     elif format == "json":
         import json
 

--- a/nltk/metrics/agreement.py
+++ b/nltk/metrics/agreement.py
@@ -312,12 +312,12 @@ class AnnotationTask:
                 # Ignore the item.
                 continue
             all_valid_labels_freq += label_freqs
-            total_do += self.Disagreement(label_freqs) * labels_count  
-        
+            total_do += self.Disagreement(label_freqs) * labels_count
+
         if len(all_valid_labels_freq.keys()) == 1:
             log.debug("Only one valid annotation value, alpha returning 1.")
             return 1
-        
+
         do = total_do / sum(all_valid_labels_freq.values())
 
         de = self.Disagreement(all_valid_labels_freq)  # Expected disagreement.

--- a/nltk/sentiment/util.py
+++ b/nltk/sentiment/util.py
@@ -13,7 +13,6 @@ Utility methods for Sentiment Analysis.
 import codecs
 import csv
 import json
-import pickle
 import random
 import re
 import sys
@@ -23,6 +22,7 @@ from copy import deepcopy
 import nltk
 from nltk.corpus import CategorizedPlaintextCorpusReader
 from nltk.data import load
+from nltk.tokenize import PunktTokenizer
 from nltk.tokenize.casual import EMOTICON_RE
 
 # ////////////////////////////////////////////////////////////
@@ -428,7 +428,7 @@ def parse_tweets_set(
     """
     tweets = []
     if not sent_tokenizer:
-        sent_tokenizer = load("tokenizers/punkt/english.pickle")
+        sent_tokenizer = PunktTokenizer()
 
     with codecs.open(filename, "rt") as csvfile:
         reader = csv.reader(csvfile)

--- a/nltk/tabdata.py
+++ b/nltk/tabdata.py
@@ -7,6 +7,12 @@
 #
 
 
+def rm_nl(s):
+    if s[-1] == "\n":
+        return s[:-1]
+    return s
+
+
 class TabEncoder:
 
     def list2txt(self, s):
@@ -32,16 +38,16 @@ class TabEncoder:
 class TabDecoder:
 
     def txt2list(self, f):
-        return [x.removesuffix("\n") for x in f]
+        return [rm_nl(x) for x in f]
 
     def txt2set(self, f):
-        return {x.removesuffix("\n") for x in f}
+        return {rm_nl(x) for x in f}
 
     def tab2tup(self, s):
         return tuple(s.split("\t"))
 
     def tab2tups(self, f):
-        return [self.tab2tup(x.removesuffix("\n")) for x in f]
+        return [self.tab2tup(rm_nl(x)) for x in f]
 
     def tab2dict(self, f):
         return {a: b for a, b in self.tab2tups(f)}

--- a/nltk/tabdata.py
+++ b/nltk/tabdata.py
@@ -47,9 +47,6 @@ class TabDecoder:
 
 class MaxentEncoder(TabEncoder):
 
-    def dict2tab(self, d):
-        return self.ivdict2tab(d)
-
     def tupdict2tab(self, d):
         def rep(a, b):
             if a == "wordlen":
@@ -64,9 +61,6 @@ class MaxentEncoder(TabEncoder):
 
 
 class MaxentDecoder(TabDecoder):
-
-    def tab2dict(self, f):
-        return self.tab2ivdict(f)
 
     def tupkey2dict(self, f):
 

--- a/nltk/tabdata.py
+++ b/nltk/tabdata.py
@@ -1,3 +1,12 @@
+# Natural Language Toolkit: Encode/Decocode Data as Tab-files
+#
+# Copyright (C) 2024 NLTK Project
+# Author: Eric Kafe <kafe.eric@gmail.com>
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+#
+
+
 class TabEncoder:
 
     def list2txt(self, s):
@@ -16,6 +25,7 @@ class TabEncoder:
         return self.tups2tab(d.items())
 
     def ivdict2tab(self, d):
+        # From integer-value dictionary
         return self.tups2tab([(a, str(b)) for a, b in d.items()])
 
 
@@ -37,6 +47,7 @@ class TabDecoder:
         return {a: b for a, b in self.tab2tups(f)}
 
     def tab2ivdict(self, f):
+        # To integer-value dictionary
         return {a: int(b) for a, b in self.tab2tups(f)}
 
 

--- a/nltk/tabdata.py
+++ b/nltk/tabdata.py
@@ -1,0 +1,97 @@
+class TabEncoder:
+
+    def list2txt(self, s):
+        return "\n".join(s)
+
+    def set2txt(self, s):
+        return self.list2txt(list(s))
+
+    def tup2tab(self, tup):
+        return "\t".join(tup)
+
+    def tups2tab(self, x):
+        return "\n".join([self.tup2tab(tup) for tup in x])
+
+    def dict2tab(self, d):
+        return self.tups2tab(d.items())
+
+    def ivdict2tab(self, d):
+        return self.tups2tab([(a, str(b)) for a, b in d.items()])
+
+
+class TabDecoder:
+
+    def txt2list(self, f):
+        return [x.removesuffix("\n") for x in f]
+
+    def txt2set(self, f):
+        return {x.removesuffix("\n") for x in f}
+
+    def tab2tup(self, s):
+        return tuple(s.split("\t"))
+
+    def tab2tups(self, f):
+        return [self.tab2tup(x.removesuffix("\n")) for x in f]
+
+    def tab2dict(self, f):
+        return {a: b for a, b in self.tab2tups(f)}
+
+    def tab2ivdict(self, f):
+        return {a: int(b) for a, b in self.tab2tups(f)}
+
+
+# ---------------------------------------------------------------------------
+# Maxent data
+# ---------------------------------------------------------------------------
+
+
+class MaxentEncoder(TabEncoder):
+
+    def dict2tab(self, d):
+        return self.ivdict2tab(d)
+
+    def tupdict2tab(self, d):
+        def rep(a, b):
+            if a == "wordlen":
+                return repr(b)
+            if b in [True, False, None]:
+                return f"repr-{b}"
+            return b
+
+        return self.tups2tab(
+            [(a, rep(a, b), c, repr(d)) for ((a, b, c), d) in d.items()]
+        )
+
+
+class MaxentDecoder(TabDecoder):
+
+    def tab2dict(self, f):
+        return self.tab2ivdict(f)
+
+    def tupkey2dict(self, f):
+
+        def rep(a, b):
+            if a == "wordlen":
+                return int(b)
+            if b == "repr-None":
+                return None
+            if b == "repr-True":
+                return True
+            if b == "repr-False":
+                return False
+            return b
+
+        return {(a, rep(a, b), c): int(d) for (a, b, c, d) in self.tab2tups(f)}
+
+
+# ---------------------------------------------------------------------------
+# Punkt data
+# ---------------------------------------------------------------------------
+
+
+class PunktDecoder(TabDecoder):
+
+    def tab2intdict(self, f):
+        from collections import defaultdict
+
+        return defaultdict(int, {a: int(b) for a, b in self.tab2tups(f)})

--- a/nltk/test/data.doctest
+++ b/nltk/test/data.doctest
@@ -18,9 +18,15 @@ Loading Data Files
 Resources are loaded using the function `nltk.data.load()`, which
 takes as its first argument a URL specifying what file should be
 loaded.  The ``nltk:`` protocol loads files from the NLTK data
-distribution:
+distribution.
 
-    >>> tokenizer = nltk.data.load('nltk:tokenizers/punkt/english.pickle')
+However, since July 2024, unpickling is restricted to simple types,
+and now fails with a pickle.Unpickling Error.
+Instead, all the unsafe pickle packages are now replaced by classes:
+
+    >>> from nltk.tokenize import PunktTokenizer
+    >>> tokenizer = PunktTokenizer()
+
     >>> tokenizer.tokenize('Hello.  This is a test.  It works!')
     ['Hello.', 'This is a test.', 'It works!']
 
@@ -28,10 +34,7 @@ It is important to note that there should be no space following the
 colon (':') in the URL; 'nltk: tokenizers/punkt/english.pickle' will
 not work!
 
-The ``nltk:`` protocol is used by default if no protocol is specified:
-
-    >>> nltk.data.load('tokenizers/punkt/english.pickle')
-    <nltk.tokenize.punkt.PunktSentenceTokenizer object at ...>
+The ``nltk:`` protocol is used by default if no protocol is specified.
 
 But it is also possible to load resources from ``http:``, ``ftp:``,
 and ``file:`` URLs:

--- a/nltk/test/data.doctest
+++ b/nltk/test/data.doctest
@@ -21,10 +21,7 @@ loaded.  The ``nltk:`` protocol loads files from the NLTK data
 distribution.
 
 However, since July 2024, unpickling is restricted to simple types,
-so the following now fails with a pickle.Unpickling Error:
-
-    >>> tokenizer = nltk.data.load('nltk:tokenizers/punkt/english.pickle')
-
+and now fails with a pickle.Unpickling Error.
 Instead, all the unsafe pickle packages are now replaced by classes:
 
     >>> from nltk.tokenize import PunktTokenizer

--- a/nltk/test/data.doctest
+++ b/nltk/test/data.doctest
@@ -18,9 +18,18 @@ Loading Data Files
 Resources are loaded using the function `nltk.data.load()`, which
 takes as its first argument a URL specifying what file should be
 loaded.  The ``nltk:`` protocol loads files from the NLTK data
-distribution:
+distribution.
+
+However, since July 2024, unpickling is restricted to simple types,
+so the following now fails with a pickle.Unpickling Error:
 
     >>> tokenizer = nltk.data.load('nltk:tokenizers/punkt/english.pickle')
+
+Instead, all the unsafe pickle packages are now replaced by classes:
+
+    >>> from nltk.tokenize import PunktTokenizer
+    >>> tokenizer = PunktTokenizer()
+
     >>> tokenizer.tokenize('Hello.  This is a test.  It works!')
     ['Hello.', 'This is a test.', 'It works!']
 
@@ -28,10 +37,7 @@ It is important to note that there should be no space following the
 colon (':') in the URL; 'nltk: tokenizers/punkt/english.pickle' will
 not work!
 
-The ``nltk:`` protocol is used by default if no protocol is specified:
-
-    >>> nltk.data.load('tokenizers/punkt/english.pickle')
-    <nltk.tokenize.punkt.PunktSentenceTokenizer object at ...>
+The ``nltk:`` protocol is used by default if no protocol is specified.
 
 But it is also possible to load resources from ``http:``, ``ftp:``,
 and ``file:`` URLs:

--- a/nltk/test/portuguese.doctest_latin1
+++ b/nltk/test/portuguese.doctest_latin1
@@ -227,7 +227,8 @@ As versões do NLTK a partir da 0.9b1 incluem um modelo treinado para a segmenta
 em português, o qual pode ser carregado pela maneira a seguir. É mais rápido carregar um modelo
 já treinado do que repetir o treinamento do mesmo.
 
-    >>> stok = nltk.data.load('tokenizers/punkt/portuguese.pickle')
+    >>> from nltk.tokenize import PunktTokenizer
+    >>> stok = PunktTokenizer("portuguese")
 
 Stemming
 --------

--- a/nltk/test/portuguese_en.doctest
+++ b/nltk/test/portuguese_en.doctest
@@ -447,7 +447,9 @@ Sentence Segmentation
 
 Punkt is a language-neutral sentence segmentation tool.  We
 
-    >>> sent_tokenizer=nltk.data.load('tokenizers/punkt/portuguese.pickle')
+    >>> from nltk.tokenize import PunktTokenizer
+    >>> sent_tokenizer = PunktTokenizer("portuguese")
+
     >>> raw_text = machado.raw('romance/marm05.txt')
     >>> sentences = sent_tokenizer.tokenize(raw_text)
     >>> for sent in sentences[1000:1005]:
@@ -483,6 +485,7 @@ material into training and testing data:
 
 Now we train the sentence segmenter (or sentence tokenizer) and use it on our test sentences:
 
+    >>> from nltk.tokenize import PunktSentenceTokenizer
     >>> stok = nltk.PunktSentenceTokenizer(train)
     >>> print(stok.tokenize(test))
     ['O 7 e Meio \xe9 um ex-libris da noite algarvia.',
@@ -517,7 +520,8 @@ NLTK's data collection includes a trained model for Portuguese sentence
 segmentation, which can be loaded as follows.  It is faster to load a trained model than
 to retrain it.
 
-    >>> stok = nltk.data.load('tokenizers/punkt/portuguese.pickle')
+    >>> from nltk.tokenize import PunktTokenizer
+    >>> stok = PunktTokenizer("portuguese")
 
 Stemming
 --------

--- a/nltk/test/portuguese_en.doctest
+++ b/nltk/test/portuguese_en.doctest
@@ -447,7 +447,9 @@ Sentence Segmentation
 
 Punkt is a language-neutral sentence segmentation tool.  We
 
-    >>> sent_tokenizer=nltk.data.load('tokenizers/punkt/portuguese.pickle')
+    >>> from nltk.tokenize import PunktTokenizer
+    >>> sent_tokenizer = PunktTokenizer("portuguese")
+
     >>> raw_text = machado.raw('romance/marm05.txt')
     >>> sentences = sent_tokenizer.tokenize(raw_text)
     >>> for sent in sentences[1000:1005]:

--- a/nltk/test/portuguese_en.doctest
+++ b/nltk/test/portuguese_en.doctest
@@ -485,6 +485,7 @@ material into training and testing data:
 
 Now we train the sentence segmenter (or sentence tokenizer) and use it on our test sentences:
 
+    >>> from nltk.tokenize import PunktSentenceTokenizer
     >>> stok = nltk.PunktSentenceTokenizer(train)
     >>> print(stok.tokenize(test))
     ['O 7 e Meio \xe9 um ex-libris da noite algarvia.',
@@ -519,7 +520,8 @@ NLTK's data collection includes a trained model for Portuguese sentence
 segmentation, which can be loaded as follows.  It is faster to load a trained model than
 to retrain it.
 
-    >>> stok = nltk.data.load('tokenizers/punkt/portuguese.pickle')
+    >>> from nltk.tokenize import PunktTokenizer
+    >>> stok = PunktTokenizer("portuguese")
 
 Stemming
 --------

--- a/nltk/test/unit/test_disagreement.py
+++ b/nltk/test/unit/test_disagreement.py
@@ -39,23 +39,21 @@ class TestDisagreement(unittest.TestCase):
         ]
         annotation_task = AnnotationTask(data)
         self.assertAlmostEqual(annotation_task.alpha(), -0.3333333)
-        
+
     def test_easy3(self):
         """
         If expected disagreement is 0, K-Apha should be 1.
         """
-        data=[
-            ('coder1', '1', 1),
-            ('coder2', '1', 1), 
-            ('coder1', '2', 2),
-            ('coder2', '2', 2)]
+        data = [
+            ("coder1", "1", 1),
+            ("coder2", "1", 1),
+            ("coder1", "2", 2),
+            ("coder2", "2", 2),
+        ]
         annotation_task = AnnotationTask(data)
         self.assertAlmostEqual(annotation_task.alpha(), 1.0)
-        
-        data=[
-            ('coder1', '1', 1),
-            ('coder2', '1', 1), 
-            ('coder1', '2', 2)]
+
+        data = [("coder1", "1", 1), ("coder2", "1", 1), ("coder1", "2", 2)]
         annotation_task = AnnotationTask(data)
         self.assertAlmostEqual(annotation_task.alpha(), 1.0)
 

--- a/nltk/tokenize/__init__.py
+++ b/nltk/tokenize/__init__.py
@@ -66,7 +66,7 @@ from nltk.tokenize.casual import TweetTokenizer, casual_tokenize
 from nltk.tokenize.destructive import NLTKWordTokenizer
 from nltk.tokenize.legality_principle import LegalitySyllableTokenizer
 from nltk.tokenize.mwe import MWETokenizer
-from nltk.tokenize.punkt import PunktSentenceTokenizer
+from nltk.tokenize.punkt import PunktSentenceTokenizer, PunktTokenizer
 from nltk.tokenize.regexp import (
     BlanklineTokenizer,
     RegexpTokenizer,
@@ -103,7 +103,7 @@ def sent_tokenize(text, language="english"):
     :param text: text to split into sentences
     :param language: the model name in the Punkt corpus
     """
-    tokenizer = load(f"tokenizers/punkt/{language}.pickle")
+    tokenizer = PunktTokenizer(language)
     return tokenizer.tokenize(text)
 
 

--- a/nltk/tokenize/__init__.py
+++ b/nltk/tokenize/__init__.py
@@ -66,7 +66,7 @@ from nltk.tokenize.casual import TweetTokenizer, casual_tokenize
 from nltk.tokenize.destructive import NLTKWordTokenizer
 from nltk.tokenize.legality_principle import LegalitySyllableTokenizer
 from nltk.tokenize.mwe import MWETokenizer
-from nltk.tokenize.punkt import PunktTokenizer
+from nltk.tokenize.punkt import PunktSentenceTokenizer, PunktTokenizer
 from nltk.tokenize.regexp import (
     BlanklineTokenizer,
     RegexpTokenizer,

--- a/nltk/tokenize/__init__.py
+++ b/nltk/tokenize/__init__.py
@@ -66,7 +66,9 @@ from nltk.tokenize.casual import TweetTokenizer, casual_tokenize
 from nltk.tokenize.destructive import NLTKWordTokenizer
 from nltk.tokenize.legality_principle import LegalitySyllableTokenizer
 from nltk.tokenize.mwe import MWETokenizer
-from nltk.tokenize.punkt import PunktSentenceTokenizer
+
+# from nltk.tokenize.punkt import PunktSentenceTokenizer
+from nltk.tokenize.punkt import PunktTokenizer
 from nltk.tokenize.regexp import (
     BlanklineTokenizer,
     RegexpTokenizer,
@@ -103,7 +105,8 @@ def sent_tokenize(text, language="english"):
     :param text: text to split into sentences
     :param language: the model name in the Punkt corpus
     """
-    tokenizer = load(f"tokenizers/punkt/{language}.pickle")
+    #    tokenizer = load(f"tokenizers/punkt/{language}.pickle")
+    tokenizer = PunktTokenizer(language)
     return tokenizer.tokenize(text)
 
 

--- a/nltk/tokenize/__init__.py
+++ b/nltk/tokenize/__init__.py
@@ -66,8 +66,6 @@ from nltk.tokenize.casual import TweetTokenizer, casual_tokenize
 from nltk.tokenize.destructive import NLTKWordTokenizer
 from nltk.tokenize.legality_principle import LegalitySyllableTokenizer
 from nltk.tokenize.mwe import MWETokenizer
-
-# from nltk.tokenize.punkt import PunktSentenceTokenizer
 from nltk.tokenize.punkt import PunktTokenizer
 from nltk.tokenize.regexp import (
     BlanklineTokenizer,
@@ -105,7 +103,6 @@ def sent_tokenize(text, language="english"):
     :param text: text to split into sentences
     :param language: the model name in the Punkt corpus
     """
-    #    tokenizer = load(f"tokenizers/punkt/{language}.pickle")
     tokenizer = PunktTokenizer(language)
     return tokenizer.tokenize(text)
 

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -30,7 +30,8 @@ English.
     ... can start with non-capitalized words.  i is a good variable
     ... name.
     ... '''
-    >>> sent_detector = nltk.data.load('tokenizers/punkt/english.pickle')
+#    >>> sent_detector = nltk.data.load('tokenizers/punkt/english.pickle')
+    >>> sent_detector = PunktTokenizer()
     >>> print('\n-----\n'.join(sent_detector.tokenize(text.strip())))
     Punkt knows that the periods in Mr. Smith and Johann S. Bach
     do not mark sentence boundaries.
@@ -1736,8 +1737,9 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
 
 class PunktTokenizer(PunktSentenceTokenizer):
 
-    #    def __init__(self, lang="english"):
-    #        self.load_lang(lang)
+    def __init__(self, lang="english"):
+        PunktSentenceTokenizer.__init__(self)
+        self.load_lang(lang)
 
     def load_lang(self, lang="english"):
         from nltk.data import find

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -1734,6 +1734,34 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
         return "unknown"
 
 
+def load_punkt_params(lang="english"):
+    from nltk.data import find
+
+    def tab2tups(f):
+        return {tuple(x.removesuffix("\n").split("\t")) for x in f}
+
+    lang_dir = find(f"tokenizers/punkt_tab/{lang}/")
+
+    # Make a new Parameters object:
+    params = PunktParameters()
+    with open(f"{lang_dir}/collocations.tab") as f:
+        params.collocations = tab2tups(f)
+    with open(f"{lang_dir}/sent_starters.txt") as f:
+        params.sent_starters = {x.removesuffix("\n") for x in f}
+    with open(f"{lang_dir}/abbrev_types.txt") as f:
+        params.abbrev_types = {x.removesuffix("\n") for x in f}
+    with open(f"{lang_dir}/ortho_context.tab") as f:
+        params.ortho_context = defaultdict(int, {a: int(b) for a, b in tab2tups(f)})
+    return params
+
+
+def punkt_tokenizer(lang="english"):
+    # Make a new Tokenizer
+    tokenizer = PunktSentenceTokenizer()
+    tokenizer._params = load_punkt_params(lang)
+    return tokenizer
+
+
 DEBUG_DECISION_FMT = """Text: {text!r} (at offset {period_index})
 Sentence break? {break_decision} ({reason})
 Collocation? {collocation}

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -23,14 +23,13 @@ before it can be used.
 The NLTK data package includes a pre-trained Punkt tokenizer for
 English.
 
-    >>> import nltk.data
+    >>> from nltk.tokenize import PunktTokenizer
     >>> text = '''
     ... Punkt knows that the periods in Mr. Smith and Johann S. Bach
     ... do not mark sentence boundaries.  And sometimes sentences
     ... can start with non-capitalized words.  i is a good variable
     ... name.
     ... '''
-#    >>> sent_detector = nltk.data.load('tokenizers/punkt/english.pickle')
     >>> sent_detector = PunktTokenizer()
     >>> print('\n-----\n'.join(sent_detector.tokenize(text.strip())))
     Punkt knows that the periods in Mr. Smith and Johann S. Bach
@@ -1736,6 +1735,9 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
 
 
 class PunktTokenizer(PunktSentenceTokenizer):
+    """
+    Punkt Sentence Tokenizer that loads/saves its parameters from/to data files
+    """
 
     def __init__(self, lang="english"):
         PunktSentenceTokenizer.__init__(self)

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -23,14 +23,14 @@ before it can be used.
 The NLTK data package includes a pre-trained Punkt tokenizer for
 English.
 
-    >>> import nltk.data
+    >>> from nltk.tokenize import PunktTokenizer
     >>> text = '''
     ... Punkt knows that the periods in Mr. Smith and Johann S. Bach
     ... do not mark sentence boundaries.  And sometimes sentences
     ... can start with non-capitalized words.  i is a good variable
     ... name.
     ... '''
-    >>> sent_detector = nltk.data.load('tokenizers/punkt/english.pickle')
+    >>> sent_detector = PunktTokenizer()
     >>> print('\n-----\n'.join(sent_detector.tokenize(text.strip())))
     Punkt knows that the periods in Mr. Smith and Johann S. Bach
     do not mark sentence boundaries.
@@ -196,7 +196,7 @@ class PunktLanguageVars:
 
     def __getstate__(self):
         # All modifications to the class are performed by inheritance.
-        # Non-default parameters to be pickled must be defined in the inherited
+        # Non-default parameters to be saved must be defined in the inherited
         # class.
         return 1
 
@@ -1734,32 +1734,66 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
         return "unknown"
 
 
-def load_punkt_params(lang="english"):
-    from nltk.data import find
+class PunktTokenizer(PunktSentenceTokenizer):
+    """
+    Punkt Sentence Tokenizer that loads/saves its parameters from/to data files
+    """
 
-    def tab2tups(f):
-        return {tuple(x.removesuffix("\n").split("\t")) for x in f}
+    def __init__(self, lang="english"):
+        PunktSentenceTokenizer.__init__(self)
+        self.load_lang(lang)
 
-    lang_dir = find(f"tokenizers/punkt_tab/{lang}/")
+    def load_lang(self, lang="english"):
+        from nltk.data import find
 
+        lang_dir = find(f"tokenizers/punkt_tab/{lang}/")
+        self._params = load_punkt_params(lang_dir)
+        self._lang = lang
+
+    def save_params(self):
+        save_punkt_params(self._params, dir=f"/tmp/{self._lang}")
+
+
+def load_punkt_params(lang_dir):
+    from nltk.tabdata import PunktDecoder
+
+    pdec = PunktDecoder()
     # Make a new Parameters object:
     params = PunktParameters()
     with open(f"{lang_dir}/collocations.tab") as f:
-        params.collocations = tab2tups(f)
+        params.collocations = pdec.tab2tups(f)
     with open(f"{lang_dir}/sent_starters.txt") as f:
-        params.sent_starters = {x.removesuffix("\n") for x in f}
+        params.sent_starters = pdec.txt2set(f)
     with open(f"{lang_dir}/abbrev_types.txt") as f:
-        params.abbrev_types = {x.removesuffix("\n") for x in f}
+        params.abbrev_types = pdec.txt2set(f)
     with open(f"{lang_dir}/ortho_context.tab") as f:
-        params.ortho_context = defaultdict(int, {a: int(b) for a, b in tab2tups(f)})
+        params.ortho_context = pdec.tab2intdict(f)
     return params
 
 
-def punkt_tokenizer(lang="english"):
-    # Make a new Tokenizer
-    tokenizer = PunktSentenceTokenizer()
-    tokenizer._params = load_punkt_params(lang)
-    return tokenizer
+def save_punkt_params(params, dir="/tmp/punkt_tab"):
+    from os import mkdir
+    from os.path import isdir
+
+    from nltk.tabdata import TabEncoder
+
+    if not isdir(dir):
+        mkdir(dir)
+    tenc = TabEncoder()
+    with open(f"{dir}/collocations.tab", "w") as f:
+        f.write(f"{tenc.tups2tab(params.collocations)}")
+    with open(f"{dir}/sent_starters.txt", "w") as f:
+        f.write(f"{tenc.set2txt(params.sent_starters)}")
+    with open(f"{dir}/abbrev_types.txt", "w") as f:
+        f.write(f"{tenc.set2txt(params.abbrev_types)}")
+    with open(f"{dir}/ortho_context.tab", "w") as f:
+        f.write(f"{tenc.ivdict2tab(params.ortho_context)}")
+
+
+# def punkt_tokenizer(lang="english"):
+# Make a new Tokenizer
+#    tokenizer = PunktTokenizer(lang)
+#    return tokenizer
 
 
 DEBUG_DECISION_FMT = """Text: {text!r} (at offset {period_index})

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -196,7 +196,7 @@ class PunktLanguageVars:
 
     def __getstate__(self):
         # All modifications to the class are performed by inheritance.
-        # Non-default parameters to be pickled must be defined in the inherited
+        # Non-default parameters to be saved must be defined in the inherited
         # class.
         return 1
 
@@ -1734,32 +1734,62 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
         return "unknown"
 
 
-def load_punkt_params(lang="english"):
-    from nltk.data import find
+class PunktTokenizer(PunktSentenceTokenizer):
 
-    def tab2tups(f):
-        return {tuple(x.removesuffix("\n").split("\t")) for x in f}
+    #    def __init__(self, lang="english"):
+    #        self.load_lang(lang)
 
-    lang_dir = find(f"tokenizers/punkt_tab/{lang}/")
+    def load_lang(self, lang="english"):
+        from nltk.data import find
 
+        lang_dir = find(f"tokenizers/punkt_tab/{lang}/")
+        self._params = load_punkt_params(lang_dir)
+        self._lang = lang
+
+    def save_params(self):
+        save_punkt_params(self._params, dir=f"/tmp/{self._lang}")
+
+
+def load_punkt_params(lang_dir):
+    from nltk.tabdata import PunktDecoder
+
+    pdec = PunktDecoder()
     # Make a new Parameters object:
     params = PunktParameters()
     with open(f"{lang_dir}/collocations.tab") as f:
-        params.collocations = tab2tups(f)
+        params.collocations = pdec.tab2tups(f)
     with open(f"{lang_dir}/sent_starters.txt") as f:
-        params.sent_starters = {x.removesuffix("\n") for x in f}
+        params.sent_starters = pdec.txt2set(f)
     with open(f"{lang_dir}/abbrev_types.txt") as f:
-        params.abbrev_types = {x.removesuffix("\n") for x in f}
+        params.abbrev_types = pdec.txt2set(f)
     with open(f"{lang_dir}/ortho_context.tab") as f:
-        params.ortho_context = defaultdict(int, {a: int(b) for a, b in tab2tups(f)})
+        params.ortho_context = pdec.tab2intdict(f)
     return params
 
 
-def punkt_tokenizer(lang="english"):
-    # Make a new Tokenizer
-    tokenizer = PunktSentenceTokenizer()
-    tokenizer._params = load_punkt_params(lang)
-    return tokenizer
+def save_punkt_params(params, dir="/tmp/punkt_tab"):
+    from os import mkdir
+    from os.path import isdir
+
+    from nltk.tabdata import TabEncoder
+
+    if not isdir(dir):
+        mkdir(dir)
+    tenc = TabEncoder()
+    with open(f"{dir}/collocations.tab", "w") as f:
+        f.write(f"{tenc.tups2tab(params.collocations)}")
+    with open(f"{dir}/sent_starters.txt", "w") as f:
+        f.write(f"{tenc.set2txt(params.sent_starters)}")
+    with open(f"{dir}/abbrev_types.txt", "w") as f:
+        f.write(f"{tenc.set2txt(params.abbrev_types)}")
+    with open(f"{dir}/ortho_context.tab", "w") as f:
+        f.write(f"{tenc.ivdict2tab(params.ortho_context)}")
+
+
+# def punkt_tokenizer(lang="english"):
+# Make a new Tokenizer
+#    tokenizer = PunktTokenizer(lang)
+#    return tokenizer
 
 
 DEBUG_DECISION_FMT = """Text: {text!r} (at offset {period_index})


### PR DESCRIPTION
Tab files are not exposed to the "sleepy" vulnerabilities reported with Python pickles.

This PR adds a loader for the [corresponding data package](https://github.com/nltk/nltk_data/pull/215).

```
from nltk.tokenize.punkt import PunktTokenizer
tokenizer = PunktTokenizer()

text = 'tél. abst. dec. 15'

tokenizer.load_lang('english')
print(tokenizer.tokenize(text))
```
['tél.', 'abst.', 'dec. 15']

Using the new _load_lang_ function, this tokenizer can change language on the fly:

```
tokenizer.load_lang('french')
print(tokenizer.tokenize(text))
```
['tél. abst. dec.', '15']
