### PR TITLE
Pickle-free maxent chunkers

### DIFF
--- a/nltk/chunk/__init__.py
+++ b/nltk/chunk/__init__.py
@@ -153,6 +153,7 @@ zero-length assertions).
 """
 
 from nltk.chunk.api import ChunkParserI
+from nltk.chunk.named_entity import Maxent_NE_Chunker
 from nltk.chunk.regexp import RegexpChunkParser, RegexpParser
 from nltk.chunk.util import (
     ChunkScore,
@@ -164,34 +165,25 @@ from nltk.chunk.util import (
     tree2conllstr,
     tree2conlltags,
 )
-from nltk.data import load
-
-# Standard treebank POS tagger
-_BINARY_NE_CHUNKER = "chunkers/maxent_ne_chunker/english_ace_binary.pickle"
-_MULTICLASS_NE_CHUNKER = "chunkers/maxent_ne_chunker/english_ace_multiclass.pickle"
 
 
-def ne_chunk(tagged_tokens, binary=False):
+def ne_chunker(fmt="multiclass"):
     """
-    Use NLTK's currently recommended named entity chunker to
-    chunk the given list of tagged tokens.
+    Load NLTK's currently recommended named entity chunker.
     """
-    if binary:
-        chunker_pickle = _BINARY_NE_CHUNKER
-    else:
-        chunker_pickle = _MULTICLASS_NE_CHUNKER
-    chunker = load(chunker_pickle)
+    return Maxent_NE_Chunker(fmt)
+
+
+def ne_chunk(chunker, tagged_tokens):
+    """
+    Use chunker to chunk the given list of tagged tokens.
+    """
     return chunker.parse(tagged_tokens)
 
 
-def ne_chunk_sents(tagged_sentences, binary=False):
+def ne_chunk_sents(chunker, tagged_sentences):
     """
-    Use NLTK's currently recommended named entity chunker to chunk the
-    given list of tagged sentences, each consisting of a list of tagged tokens.
+    Use chunker to chunk the given list of tagged sentences,
+    each consisting of a list of tagged tokens.
     """
-    if binary:
-        chunker_pickle = _BINARY_NE_CHUNKER
-    else:
-        chunker_pickle = _MULTICLASS_NE_CHUNKER
-    chunker = load(chunker_pickle)
     return chunker.parse_sents(tagged_sentences)

--- a/nltk/classify/maxent.py
+++ b/nltk/classify/maxent.py
@@ -1557,6 +1557,68 @@ class TadmMaxentClassifier(MaxentClassifier):
 
 
 ######################################################################
+# Load/Save Classifier Parameters as Tab-files
+######################################################################
+
+
+def load_maxent_params(tab_dir):
+    import numpy
+
+    from nltk.tabdata import MaxentDecoder
+
+    mdec = MaxentDecoder()
+
+    with open(f"{tab_dir}/weights.txt") as f:
+        wgt = numpy.array(list(map(numpy.float64, mdec.txt2list(f))))
+
+    with open(f"{tab_dir}/mapping.tab") as f:
+        mpg = mdec.tupkey2dict(f)
+
+    with open(f"{tab_dir}/labels.txt") as f:
+        lab = mdec.txt2list(f)
+
+    with open(f"{tab_dir}/alwayson.tab") as f:
+        aon = mdec.tab2ivdict(f)
+
+    return wgt, mpg, lab, aon
+
+
+def save_maxent_params(wgt, mpg, lab, aon, tab_dir="/tmp"):
+
+    from os import mkdir
+    from os.path import isdir
+
+    from nltk.tabdata import MaxentEncoder
+
+    menc = MaxentEncoder()
+    if not isdir(tab_dir):
+        mkdir(tab_dir)
+
+    print(f"Saving Maxent parameters in {tab_dir}")
+
+    with open(f"{tab_dir}/weights.txt", "w") as f:
+        f.write(f"{menc.list2txt(map(repr, wgt.tolist()))}")
+    with open(f"{tab_dir}/mapping.tab", "w") as f:
+        f.write(f"{menc.tupdict2tab(mpg)}")
+    with open(f"{tab_dir}/labels.txt", "w") as f:
+        f.write(f"{menc.list2txt(lab)}")
+    with open(f"{tab_dir}/alwayson.tab", "w") as f:
+        f.write(f"{menc.ivdict2tab(aon)}")
+
+
+def maxent_pos_tagger():
+    from nltk.data import find
+    from nltk.tag.sequential import ClassifierBasedPOSTagger
+
+    tab_dir = find("taggers/maxent_treebank_pos_tagger_tab/english")
+    wgt, mpg, lab, aon = load_maxent_params(tab_dir)
+    mc = MaxentClassifier(
+        BinaryMaxentFeatureEncoding(lab, mpg, alwayson_features=aon), wgt
+    )
+    return ClassifierBasedPOSTagger(classifier=mc)
+
+
+######################################################################
 # { Demo
 ######################################################################
 def demo():

--- a/nltk/compat.py
+++ b/nltk/compat.py
@@ -13,8 +13,6 @@ from functools import wraps
 # The following datasets have a /PY3 subdirectory containing
 # a full copy of the data which has been re-encoded or repickled.
 DATA_UPDATES = [
-    #    ("chunkers", "maxent_ne_chunker"),
-    ("taggers", "maxent_treebank_pos_tagger"),
     ("tokenizers", "punkt"),
 ]
 

--- a/nltk/compat.py
+++ b/nltk/compat.py
@@ -13,7 +13,7 @@ from functools import wraps
 # The following datasets have a /PY3 subdirectory containing
 # a full copy of the data which has been re-encoded or repickled.
 DATA_UPDATES = [
-    ("chunkers", "maxent_ne_chunker"),
+    #    ("chunkers", "maxent_ne_chunker"),
     ("taggers", "maxent_treebank_pos_tagger"),
     ("tokenizers", "punkt"),
 ]

--- a/nltk/tabdata.py
+++ b/nltk/tabdata.py
@@ -1,0 +1,70 @@
+class TabEncoder:
+
+    def list2txt(self, s):
+        return "\n".join(s)
+
+    def set2txt(self, s):
+        return self.list2txt(list(s))
+
+    def tup2tab(self, tup):
+        return "\t".join(tup)
+
+    def tups2tab(self, x):
+        return "\n".join([self.tup2tab(tup) for tup in x])
+
+
+class MaxentEncoder(TabEncoder):
+
+    def dict2tab(self, d):
+        return self.tups2tab([(a, str(b)) for a, b in d.items()])
+
+    def tupdict2tab(self, d):
+        def rep(a, b):
+            if a == "wordlen":
+                return repr(b)
+            if b in [True, False, None]:
+                return f"repr-{b}"
+            return b
+
+        return self.tups2tab(
+            [(a, rep(a, b), c, repr(d)) for ((a, b, c), d) in d.items()]
+        )
+
+
+class TabDecoder:
+
+    def txt2list(self, f):
+        return [x.removesuffix("\n") for x in f]
+
+    def txt2set(self, f):
+        return {x.removesuffix("\n") for x in f}
+
+    def tab2tup(self, s):
+        return tuple(s.split("\t"))
+
+    def tab2tups(self, f):
+        return [self.tab2tup(x.removesuffix("\n")) for x in f]
+
+
+class MaxentDecoder(TabDecoder):
+
+    def tab2dict(self, f):
+        return {a: int(b) for a, b in self.tab2tups(f)}
+
+    def tupkey2dict(self, f):
+
+        def rep(a, b):
+            if a == "wordlen":
+                return int(b)
+            if b == "repr-None":
+                return None
+            if b == "repr-True":
+                return True
+            if b == "repr-False":
+                return False
+            return b
+
+        return {(a, rep(a, b), c): int(d) for (a, b, c, d) in self.tab2tups(f)}
+
+    def tab2intdict(self, f):
+        return defaultdict(int, self.tab2dict(f))

--- a/nltk/tabdata.py
+++ b/nltk/tabdata.py
@@ -1,3 +1,12 @@
+# Natural Language Toolkit: Encode/Decocode Data as Tab-files
+#
+# Copyright (C) 2024 NLTK Project
+# Author: Eric Kafe <kafe.eric@gmail.com>
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+#
+
+
 class TabEncoder:
 
     def list2txt(self, s):
@@ -16,6 +25,7 @@ class TabEncoder:
         return self.tups2tab(d.items())
 
     def ivdict2tab(self, d):
+        # From integer-value dictionary
         return self.tups2tab([(a, str(b)) for a, b in d.items()])
 
 
@@ -37,6 +47,7 @@ class TabDecoder:
         return {a: b for a, b in self.tab2tups(f)}
 
     def tab2ivdict(self, f):
+        # To integer-value dictionary
         return {a: int(b) for a, b in self.tab2tups(f)}
 
 

--- a/nltk/tabdata.py
+++ b/nltk/tabdata.py
@@ -12,23 +12,11 @@ class TabEncoder:
     def tups2tab(self, x):
         return "\n".join([self.tup2tab(tup) for tup in x])
 
-
-class MaxentEncoder(TabEncoder):
-
     def dict2tab(self, d):
+        return self.tups2tab(d.items())
+
+    def ivdict2tab(self, d):
         return self.tups2tab([(a, str(b)) for a, b in d.items()])
-
-    def tupdict2tab(self, d):
-        def rep(a, b):
-            if a == "wordlen":
-                return repr(b)
-            if b in [True, False, None]:
-                return f"repr-{b}"
-            return b
-
-        return self.tups2tab(
-            [(a, rep(a, b), c, repr(d)) for ((a, b, c), d) in d.items()]
-        )
 
 
 class TabDecoder:
@@ -45,11 +33,34 @@ class TabDecoder:
     def tab2tups(self, f):
         return [self.tab2tup(x.removesuffix("\n")) for x in f]
 
+    def tab2dict(self, f):
+        return {a: b for a, b in self.tab2tups(f)}
+
+    def tab2ivdict(self, f):
+        return {a: int(b) for a, b in self.tab2tups(f)}
+
+
+# ---------------------------------------------------------------------------
+# Maxent data
+# ---------------------------------------------------------------------------
+
+
+class MaxentEncoder(TabEncoder):
+
+    def tupdict2tab(self, d):
+        def rep(a, b):
+            if a == "wordlen":
+                return repr(b)
+            if b in [True, False, None]:
+                return f"repr-{b}"
+            return b
+
+        return self.tups2tab(
+            [(a, rep(a, b), c, repr(d)) for ((a, b, c), d) in d.items()]
+        )
+
 
 class MaxentDecoder(TabDecoder):
-
-    def tab2dict(self, f):
-        return {a: int(b) for a, b in self.tab2tups(f)}
 
     def tupkey2dict(self, f):
 
@@ -66,5 +77,15 @@ class MaxentDecoder(TabDecoder):
 
         return {(a, rep(a, b), c): int(d) for (a, b, c, d) in self.tab2tups(f)}
 
+
+# ---------------------------------------------------------------------------
+# Punkt data
+# ---------------------------------------------------------------------------
+
+
+class PunktDecoder(TabDecoder):
+
     def tab2intdict(self, f):
-        return defaultdict(int, self.tab2dict(f))
+        from collections import defaultdict
+
+        return defaultdict(int, {a: int(b) for a, b in self.tab2tups(f)})


### PR DESCRIPTION
Tab files are not exposed to the "sleepy" vulnerabilities reported with Python pickles.

This PR adds a loader for the [corresponding data package](https://github.com/nltk/nltk_data/pull/217).

```
from nltk.chunk import ne_chunker
from nltk.corpus import treebank
from pprint import pprint

sent = treebank.tagged_sents()[2]
```
The chunker is initialized with parameters saved as tab-files. 
Load the "binary" model:

```
chunker = ne_chunker("binary")
pprint(chunker.parse(sent))
```
> Tree('S', [Tree('NE', [('Rudolph', 'NNP'), ('Agnew', 'NNP')]), (',', ','), ('55', 'CD'), ('years', 'NNS'), ('old', 'JJ'), ('and', 'CC'), ('former', 'JJ'), ('chairman', 'NN'), ('of', 'IN'), Tree('NE', [('Consolidated', 'NNP'), ('Gold', 'NNP'), ('Fields', 'NNP'), ('PLC', 'NNP')]), (',', ','), ('was', 'VBD'), ('named', 'VBN'), ('*-1', '-NONE-'), ('a', 'DT'), ('nonexecutive', 'JJ'), ('director', 'NN'), ('of', 'IN'), ('this', 'DT'), Tree('NE', [('British', 'JJ')]), ('industrial', 'JJ'), ('conglomerate', 'NN'), ('.', '.')])

Load the recommended "multiclass" model:
```
chunker = ne_chunker()
pprint(chunker.parse(sent))
```

> Tree('S', [Tree('PERSON', [('Rudolph', 'NNP')]), Tree('GPE', [('Agnew', 'NNP')]), (',', ','), ('55', 'CD'), ('years', 'NNS'), ('old', 'JJ'), ('and', 'CC'), ('former', 'JJ'), ('chairman', 'NN'), ('of', 'IN'), Tree('ORGANIZATION', [('Consolidated', 'NNP'), ('Gold', 'NNP'), ('Fields', 'NNP')]), ('PLC', 'NNP'), (',', ','), ('was', 'VBD'), ('named', 'VBN'), ('*-1', '-NONE-'), ('a', 'DT'), ('nonexecutive', 'JJ'), ('director', 'NN'), ('of', 'IN'), ('this', 'DT'), Tree('GPE', [('British', 'JJ')]), ('industrial', 'JJ'), ('conglomerate', 'NN'), ('.', '.')])
