### PR TITLE
Prevent data.load from unpickling classes or functions

### DIFF
--- a/nltk/data.py
+++ b/nltk/data.py
@@ -658,6 +658,15 @@ AUTO_FORMATS = {
 }
 
 
+def restricted_pickle_load(string):
+    """
+    Prevents any class or function from loading.
+    """
+    from nltk.app.wordnet_app import RestrictedUnpickler
+
+    return RestrictedUnpickler(BytesIO(string)).load()
+
+
 def load(
     resource_url,
     format="auto",
@@ -751,7 +760,7 @@ def load(
     if format == "raw":
         resource_val = opened_resource.read()
     elif format == "pickle":
-        resource_val = pickle.load(opened_resource)
+        resource_val = restricted_pickle_load(opened_resource.read())
     elif format == "json":
         import json
 


### PR DESCRIPTION
Fix #3266 and [CVE-39705,](https://github.com/advisories/GHSA-cgvx-9447-vcch) by using the _RestrictedUnpickler_ class from _nltk.app.wordnet_app_, to prevent from loading pickled classes or functions.

For example:

```
from nltk.data import load
from nltk.corpus import treebank

pos = load("taggers/maxent_treebank_pos_tagger/PY3/english.pickle")
print(pos.tag(treebank.sents()[0]))
```
Without this PR, the pickle loads and works:

> [('Pierre', 'NNP'), ('Vinken', 'NNP'), (',', ','), ('61', 'CD'), ('years', 'NNS'), ('old', 'JJ'), (',', ','), ('will', 'MD'), ('join', 'VB'), ('the', 'DT'), ('board', 'NN'), ('as', 'IN'), ('a', 'DT'), ('nonexecutive', 'JJ'), ('director', 'NN'), ('Nov.', 'NNP'), ('29', 'CD'), ('.', '.')]

With this PR, loading classes or functions raise an error:
> _pickle.UnpicklingError: global 'nltk.tag.sequential.ClassifierBasedPOSTagger' is forbidden
