### PR TITLE
Ensure https download

### DIFF
--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -1270,7 +1270,7 @@ class DownloaderShell:
                     print("  Cancelled!")
                 else:
                     if not new_url.startswith(("http://", "https://")):
-                        new_url = "http://" + new_url
+                        new_url = "https://" + new_url
                     try:
                         self._ds.url = new_url
                     except Exception as e:


### PR DESCRIPTION
The _ntlk unsafe deserialization vulnerability_ consists in two weaknesses:
CWE-502 (_Deserialization of Untrusted Data_), which is solved in NLTK 3.8.2, and CWE-300 (_Channel Accessible by Non-Endpoint_), which this PR solves.
