### PR TITLE
Use a lru cache when instantiating PunktTokenizer

### DIFF
--- a/nltk/tokenize/__init__.py
+++ b/nltk/tokenize/__init__.py
@@ -59,6 +59,7 @@ tokenization, see the other methods provided in this package.
 For further information, please see Chapter 3 of the NLTK book.
 """
 
+import functools
 import re
 
 from nltk.data import load
@@ -92,6 +93,18 @@ from nltk.tokenize.treebank import TreebankWordDetokenizer, TreebankWordTokenize
 from nltk.tokenize.util import regexp_span_tokenize, string_span_tokenize
 
 
+@functools.lru_cache
+def _get_punkt_tokenizer(language="english"):
+    """
+    A constructor for the PunktTokenizer that utilizes
+    a lru cache for performance.
+
+    :param language: the model name in the Punkt corpus
+    :type language: str
+    """
+    return PunktTokenizer(language)
+
+
 # Standard sentence tokenizer.
 def sent_tokenize(text, language="english"):
     """
@@ -103,7 +116,7 @@ def sent_tokenize(text, language="english"):
     :param text: text to split into sentences
     :param language: the model name in the Punkt corpus
     """
-    tokenizer = PunktTokenizer(language)
+    tokenizer = _get_punkt_tokenizer(language)
     return tokenizer.tokenize(text)
 
 


### PR DESCRIPTION
This fixes #3299 

Now, there's an internal function decorated by an LRU cache when instantiating the `PunktTokenizer`. This still allows us to provide different languages when tokenizing, but still benefiting from a cache mechanism. By default, the LRU cache has a size of 128 tokenizers.

3.8.1 benchmark from [here](https://github.com/nltk/nltk/issues/3299#issue-2465821088):

```text
A length of 300     takes 0.01 s
A length of 3000    takes 0.03 s
A length of 30000   takes 0.34 s
A length of 300000  takes 3.38 s
A length of 3000000 takes 33.88 s
```

3.8.2 benchmark:

```text
A length of 300     takes 2.55 s
A length of 3000    takes 24.08 s
A length of 30000   takes 238.63 s
...DNF
```

Benchmark from this change: 

```text
A length of 300     takes 0.01 s
A length of 3000    takes 0.01 s
A length of 30000   takes 0.09 s
A length of 300000  takes 0.92 s
A length of 3000000 takes 9.21 s
```

Please let me know if you have any additional comments.