### PR TITLE
Use LRU cache when getting POS tagger 

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -302,6 +302,7 @@
 - Akihiro Yamazaki <https://github.com/zakkie>
 - Ron Urbach <https://github.com/sharpblade4>
 - Vivek Kalyan <https://github.com/vivekkalyan>
+- Tom Strange https://github.com/strangetom
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 

--- a/nltk/tag/__init__.py
+++ b/nltk/tag/__init__.py
@@ -65,6 +65,8 @@ For more information, please consult chapter 5 of the NLTK Book.
 isort:skip_file
 """
 
+import functools
+
 from nltk.tag.api import TaggerI
 from nltk.tag.util import str2tuple, tuple2str, untag
 from nltk.tag.sequential import (
@@ -100,6 +102,7 @@ PRETRAINED_TAGGERS = {
 }
 
 
+@functools.lru_cache
 def _get_tagger(lang=None):
     if lang == "rus":
         tagger = PerceptronTagger(lang=lang)


### PR DESCRIPTION
This PR fixes a similar performance regression to #3299 but with the part of speech tagger. 
The approach here is the same as in #3300.

Using this code to benchmark:
```py
import nltk, time
sentence = nltk.word_tokenize("This is a sentence to tag")
for length in [10**i for i in range(2, 6)]:
    start_t = time.time()
    _ = [nltk.pos_tag(sent) for sent in [sentence]*length]
    print(f"A length of {length*3:<{6}} takes {time.time() - start_t:.2f} s")
```

**Output with NLTK 3.8.2**
```
A length of 300    takes 6.69 s
A length of 3000   takes 65.70 s
A length of 30000  takes 681.80 s
... DNF
```

**Output from this PR**
```
A length of 300    takes 0.02 s
A length of 3000   takes 0.06 s
A length of 30000  takes 0.67 s
A length of 300000 takes 6.42 s
```