### PR TITLE
Load Punkt collocations as a set

### DIFF
--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -1761,7 +1761,7 @@ def load_punkt_params(lang_dir):
     # Make a new Parameters object:
     params = PunktParameters()
     with open(f"{lang_dir}/collocations.tab", encoding="utf-8") as f:
-        params.collocations = pdec.tab2tups(f)
+        params.collocations = set(pdec.tab2tups(f))
     with open(f"{lang_dir}/sent_starters.txt", encoding="utf-8") as f:
         params.sent_starters = pdec.txt2set(f)
     with open(f"{lang_dir}/abbrev_types.txt", encoding="utf-8") as f:


### PR DESCRIPTION
Fix #3310, by loading PunktParameters.collocations as a set instead of a list.