### PR TITLE
remove ci workaround for issue in python 3.12.4 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12.3' # 3.12.4 has an issue with pyupgrade, try to upgrade later
+          python-version: '3.12'
       - run: |
           pip install pre-commit
           pre-commit run --all-files


### PR DESCRIPTION
This PR restores using latest python 3.12 in CI now that 3.12.5 has been rolled out with a fix for the original issue. This means the workaround in https://github.com/nltk/nltk/pull/3280 is not longer needed.

cc @alvations 