### PR TITLE
Mention major Morphy change in ChangeLog

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,7 +4,8 @@ Version 3.9.1 2024-08-19
 Version 3.9 2024-08-18
 * Fix security vulnerability CVE-2024-39705 (breaking change)
 * Replace pickled models (punkt, chunker, taggers) by new pickle-free "_tab" packages
-* No longer sort WordNet synsets and relations (sort in calling function when required)
+* No longer sort Wordnet synsets and relations (sort in calling function when required)
+* Only strip the last suffix in Wordnet Morphy, thus restricting synsets() results
 * Add Python 3.12 support
 * Many other minor fixes
 


### PR DESCRIPTION
Issue #3321 reports a major change in the output of the synsets() method in Wordnet after #3225.

This PR proposes to mention the change in ChangeLog.