### PR TITLE
Prevent multiple parallel downloads of the same package

### DIFF
--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -455,6 +455,35 @@ class LockFile:
     used to ensure unique package downloads.
 
     Refreshes eventual stale lockfiles left over from a previous crash.
+
+    Example usage:
+    >>> import os
+    >>> from tempfile import gettempdir
+    >>> from time import sleep
+    >>> class Info:
+    ...     def __init__(self, id, size):
+    ...         self.id = id
+    ...         self.size = size
+    >>> info = Info('test_package', 1000)
+    >>> lockfile = LockFile(info)
+
+    # Test lockfile creation
+    >>> lockfile.exists()
+    False
+    >>> sum('acquired ' in  msg.info for msg in list(lockfile.acquire()))
+    1
+    >>> lockfile.exists()
+    True
+
+    # Test lockfile age
+    >>> lockfile.age() < 1  # Should be very recent
+    True
+
+    # Test lockfile release
+    >>> sum('released ' in  msg.info for msg in list(lockfile.release()))
+    1
+    >>> lockfile.exists()
+    False
     """
 
     def __init__(self, info):

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -445,6 +445,87 @@ class SelectDownloadDirMessage(DownloaderMessage):
 
 
 ######################################################################
+# Lock File
+######################################################################
+
+
+class LockFile:
+    """
+    A temporary file named {info.id}.Lock in tempfile.gettempdir(),
+    used to ensure unique package downloads.
+
+    Refreshes eventual stale lockfiles left over from a previous crash.
+    """
+
+    def __init__(self, info):
+        from tempfile import gettempdir
+
+        self.info = info
+        self.path = os.path.join(gettempdir(), f"{self.info.id}.Lock")
+        # Expect at least 10 kb/s download speed:
+        self.time_out = round(self.info.size / 10000) + 2
+
+    def exists(self):
+        return os.path.exists(self.path)
+
+    def age(self):
+        return time.time() - os.path.getmtime(self.path)
+
+    def acquire(self):
+        self.is_mine = False
+        if self.exists():
+            age = self.age()
+            yield DownloadInfoMessage(
+                self.info, f"found locked, age:{round(age,2)} sec."
+            )
+
+            # Prevent deadlock (f. ex. a stale lock from a previous crash)
+            if age > self.time_out:  # if lock is too old it must be stale
+                yield DownloadInfoMessage(
+                    self.info,
+                    f"refreshing stale lock (older than {self.time_out} sec.)",
+                )
+            else:
+                # Another process is already downloading this package
+                yield from self.wait()
+                return
+        try:
+            with open(self.path, "w") as f:  # Open the lockfile
+                pass
+            self.is_mine = True
+            yield DownloadInfoMessage(self.info, f"acquired {self.path}")
+        except:
+            yield DownloadInfoMessage(
+                self.info, f"Error with lock {self.path}, consider deleting it."
+            )
+
+    def wait(self):
+        """Wait until lock is released. Time out otherwise"""
+        yield DownloadInfoMessage(self.info, f"waiting after {self.path} ...")
+        count_down = self.time_out
+        sleep_secs = 0.5
+        # Wait time_out seconds or until package is downloaded and unzipped
+        while count_down > 0 and self.exists():
+            time.sleep(sleep_secs)
+            count_down -= sleep_secs
+        if self.exists():
+            yield DownloadInfoMessage(self.info, f"timed out after {self.time_out}")
+
+    def release(self):
+        if self.exists():
+            try:
+                age = self.age()
+                os.remove(self.path)  # release the lock
+                yield DownloadInfoMessage(
+                    self.info, f"released lock, age:{round(age,2)} sec."
+                )
+            except:
+                yield ErrorMessage(self.info, f"Could not remove lock {self.path}.")
+        else:
+            yield DownloadInfoMessage(self.info, f"absent lock {self.path}")
+
+
+######################################################################
 # NLTK Data Server
 ######################################################################
 
@@ -683,50 +764,14 @@ class Downloader:
 
     def _download_package(self, info, download_dir, force):
         """
-                Download package unless a parallel process is already downloading it.
-
-                Creates a file named {info.id}.Lock in tempfile.gettempdir(),
-                and removes it after the package is downloaded and unzipped.
-        2
-                Removes eventual stale lockfiles left over from a previous crash.
+        Download package unless a parallel process is already downloading it.
+        Uses a LockFile, and removes it after the package is downloaded and unzipped.
         """
 
-        lock = os.path.join(gettempdir(), f"{info.id}.Lock")
-
-        # Expect at least 10 kb/s download speed:
-        max_secs = round(info.size / 10000) + 2
-
-        if os.path.exists(lock):
-            age = time.time() - os.path.getmtime(lock)
-
-            yield DownloadInfoMessage(info, f"found locked, age:{round(age,2)} sec.")
-
-            # Prevent deadlock (f. ex. a stale lock from a previous crash)
-            if age > max_secs:  # if lock is too old it must be stale
-                os.remove(lock)
-                yield DownloadInfoMessage(
-                    info, f"removed stale lock (older than {max_secs} sec.)"
-                )
-
-            else:
-                # Another process is already downloading this package
-                yield DownloadInfoMessage(info, "preventing redundant download")
-                time_out = max_secs  # Time out if download doesn't finish in max_secs
-                # Wait time_out seconds or until package is downloaded and unzipped
-                while time_out > 0 and os.path.exists(lock):
-                    sleep_secs = 0.5
-                    time.sleep(sleep_secs)
-                    time_out -= sleep_secs
-                if os.path.exists(lock):
-                    yield DownloadInfoMessage(info, f"timed out after {max_secs}")
-                return
-
-        try:
-            with open(lock, "w") as f:  # Open the lockfile
-                pass
-            yield DownloadInfoMessage(info, f"acquired lock {lock}")
-        except:
-            yield ErrorMessage(info, f"Error with lock {lock}, please delete it.")
+        lock = LockFile(info)
+        yield from lock.acquire()
+        if not lock.is_mine:  # Another process is already downloading this package
+            return
 
         yield StartPackageMessage(info)
         yield ProgressMessage(0)
@@ -792,10 +837,7 @@ class Downloader:
                 yield FinishUnzipMessage(info)
 
         yield FinishPackageMessage(info)
-        if os.path.exists(lock):
-            age = time.time() - os.path.getmtime(lock)
-            os.remove(lock)  # release the lock
-            yield DownloadInfoMessage(info, f"released lock, age:{round(age,2)} sec.")
+        yield from lock.release()
 
     def download(
         self,

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -646,7 +646,7 @@ class Downloader:
         else:
             lock = self.download_locks.setdefault(info.id, self._lock)
             # Check that another process is not already downloading this package:
-            if not lock._semlock._get_value():
+            if lock._semlock._is_zero():
                 while self.status(info, download_dir) != self.INSTALLED:
                     time.sleep(1)
                 yield ErrorMessage(info, f"Another process already downloaded {info}")


### PR DESCRIPTION
Fix #3248 using file locks.

In #3248, @naktinis describes a situation where users launch multiple useless parallel downloads of the same file, and cause race conditions. Rather than encouraging this behaviour as #3247 does, this PR attacks the root cause of the problem by using locks to prevent the useless downloads.

So [this test](https://github.com/nltk/nltk/issues/3248#issue-2266412613) (updated to request the current _punkt_tab_ instead of the deprecated _punkt_ package) now succeeds:

```
import os
import nltk
import time
import random
import shutil
import multiprocessing

def download_and_run():
    time.sleep(random.random() * 2)
    nltk.download('punkt_tab', force=True, download_dir='models')
    nltk.data.path.insert(0, 'models')
    print(nltk.sent_tokenize("Some text to split. Another sentence."))

if __name__ == "__main__":
    shutil.rmtree('models', ignore_errors=True)

    processes = []
    for i in range(10):
        processes.append(multiprocessing.Process(target=download_and_run))

    for p in processes:
        p.start()

    for p in processes:
        p.join()
```

[nltk_data]   Package punkt_tab: creating lockfile
[nltk_data]   Package punkt_tab: acquired lock, age:0.0 sec.
[nltk_data] Downloading package punkt_tab to models...
[nltk_data]   Package punkt_tab: found locked, age:0.01 sec.
[nltk_data]   Package punkt_tab: preventing redundant download ...
[nltk_data]   Package punkt_tab: found locked, age:0.41 sec.
[nltk_data]   Package punkt_tab: preventing redundant download ...
[nltk_data]   Package punkt_tab: found locked, age:0.49 sec.
[nltk_data]   Package punkt_tab: preventing redundant download ...
[nltk_data]   Package punkt_tab: found locked, age:0.62 sec.
[nltk_data]   Package punkt_tab: preventing redundant download ...
[nltk_data]   Package punkt_tab: found locked, age:0.72 sec.
[nltk_data]   Package punkt_tab: preventing redundant download ...
[nltk_data]   Package punkt_tab: found locked, age:1.08 sec.
[nltk_data]   Package punkt_tab: preventing redundant download ...
[nltk_data]   Package punkt_tab: found locked, age:1.22 sec.
[nltk_data]   Package punkt_tab: preventing redundant download ...
[nltk_data]   Package punkt_tab: found locked, age:1.34 sec.
[nltk_data]   Package punkt_tab: preventing redundant download ...
[nltk_data]   Package punkt_tab: found locked, age:1.35 sec.
[nltk_data]   Package punkt_tab: preventing redundant download ...
[nltk_data]   Unzipping tokenizers/punkt_tab.zip.
[nltk_data]   Package punkt_tab: released lock, age:2.7 sec.
['Some text to split.', 'Another sentence.']
['Some text to split.', 'Another sentence.']
['Some text to split.', 'Another sentence.']
['Some text to split.', 'Another sentence.']
['Some text to split.', 'Another sentence.']
['Some text to split.', 'Another sentence.']
['Some text to split.', 'Another sentence.']
['Some text to split.', 'Another sentence.']
['Some text to split.', 'Another sentence.']
['Some text to split.', 'Another sentence.']
