### PR TITLE
Lesk: handling ties

### DIFF
--- a/nltk/wsd.py
+++ b/nltk/wsd.py
@@ -44,7 +44,7 @@ def lesk(context_sentence, ambiguous_word, pos=None, synsets=None, lang="eng"):
 
     if not synsets:
         return None
-    
+
     sense = max(synsets, key=lambda ss: len(context.intersection(ss.definition().split())))
 
     return sense

--- a/nltk/wsd.py
+++ b/nltk/wsd.py
@@ -26,7 +26,7 @@ def lesk(context_sentence, ambiguous_word, pos=None, synsets=None, lang="eng"):
     Usage example::
 
         >>> lesk(['I', 'went', 'to', 'the', 'bank', 'to', 'deposit', 'money', '.'], 'bank', 'n')
-        Synset('savings_bank.n.02')
+        Synset('depository_financial_institution.n.01')
 
     [1] Lesk, Michael. "Automatic sense disambiguation using machine
     readable dictionaries: how to tell a pine cone from an ice cream
@@ -44,9 +44,7 @@ def lesk(context_sentence, ambiguous_word, pos=None, synsets=None, lang="eng"):
 
     if not synsets:
         return None
-
-    _, sense = max(
-        (len(context.intersection(ss.definition().split())), ss) for ss in synsets
-    )
+    
+    sense = max(synsets, key=lambda ss: len(context.intersection(ss.definition().split())))
 
     return sense


### PR DESCRIPTION
In case of ties for overlap scores, the current implementation of Lesk defaults to the higher index sense (e.g. max(synset) returns the last sense in the synset).

To improve performance, this PR defaults to the lower index sense (which tends to be more frequent, since synsets are generally ordered by frequency) in case of ties.

In the case of the "bank" example given in the function's documentation, the new assigned sense would be Synset('depository_financial_institution.n.01'), which I believe is the correct sense of the word.