### PR TITLE
Only import tkinter if a GUI is needed

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -303,6 +303,7 @@
 - Ron Urbach <https://github.com/sharpblade4>
 - Vivek Kalyan <https://github.com/vivekkalyan>
 - Tom Strange https://github.com/strangetom
+- Samer Masterson <https://github.com/samertm>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 

--- a/nltk/__init__.py
+++ b/nltk/__init__.py
@@ -19,6 +19,7 @@ isort:skip_file
 """
 
 import os
+import importlib
 
 # //////////////////////////////////////////////////////
 # Metadata
@@ -169,7 +170,6 @@ draw = lazyimport.LazyModule("draw", locals(), globals())
 toolbox = lazyimport.LazyModule("toolbox", locals(), globals())
 
 # Optional loading
-
 try:
     import numpy
 except ImportError:
@@ -179,11 +179,10 @@ else:
 
 from nltk.downloader import download, download_shell
 
-try:
-    import tkinter
-except ImportError:
-    pass
-else:
+# Check if tkinter exists without importing it to avoid crashes after
+# forks on macOS. Only nltk.app, nltk.draw, and demo modules should
+# have top-level tkinter imports. See #2949 for more details.
+if importlib.util.find_spec('tkinter'):
     try:
         from nltk.downloader import download_gui
     except RuntimeError as e:

--- a/nltk/sem/drt.py
+++ b/nltk/sem/drt.py
@@ -37,17 +37,7 @@ from nltk.sem.logic import (
     is_indvar,
     unique_variable,
 )
-
-# Import Tkinter-based modules if they are available
-try:
-    from tkinter import Canvas, Tk
-    from tkinter.font import Font
-
-    from nltk.util import in_idle
-
-except ImportError:
-    # No need to print a warning here, nltk.draw has already printed one.
-    pass
+from nltk.util import in_idle
 
 
 class DrtTokens(Tokens):
@@ -1105,6 +1095,12 @@ class DrsDrawer:
         """
         master = None
         if not canvas:
+
+            # Only import tkinter if the user has indicated that they
+            # want to draw a UI. See issue #2949 for more info.
+            from tkinter import Canvas, Tk
+            from tkinter.font import Font
+
             master = Tk()
             master.title("DRT")
 


### PR DESCRIPTION
Only import tkinter if the user is calling a function that explicitly uses a GUI instead of at the top-level.

This avoids the issue on macOS where calling fork after importing nltk without using any gui-related features causes the program to segfault.

Also adds the env var NLTK_DOWNLOADER_FORCE_INTERACTIVE_SHELL which forces the use of the interactive shell when using interactive downloader if set to 'true'.

Fixes #2949.

Tested that the reproducing program no longer crashes:

```
import torch
from torch.utils.data import DataLoader, TensorDataset
import os
import torch.multiprocessing as mp

import nltk

if __name__ == "__main__":
    if mp.get_start_method(allow_none=True) is None and os.name != 'nt':
        mp.set_start_method('fork')

    train = TensorDataset(torch.ones((50, 5)))

    pipe = DataLoader(dataset=train, batch_size=5, num_workers=1)
    itr = iter(pipe)
    data = next(itr)
    print(data)
```

Tested that the nltk downloader GUI still works when explicitly requested.

Tested that the nltk.sem.drt draw demos still work.