### PR TITLE
Fix: bug ccg logic side effect on lexicon

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -303,6 +303,7 @@
 - Ron Urbach <https://github.com/sharpblade4>
 - Vivek Kalyan <https://github.com/vivekkalyan>
 - Tom Strange https://github.com/strangetom
+- Vincent Peth <https://github.com/ShadokDuBas>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 

--- a/nltk/ccg/logic.py
+++ b/nltk/ccg/logic.py
@@ -8,11 +8,14 @@
 Helper functions for CCG semantics computation
 """
 
+import copy
+
 from nltk.sem.logic import *
 
 
 def compute_type_raised_semantics(semantics):
-    core = semantics
+    semantics_copy = copy.deepcopy(semantics)
+    core = semantics_copy
     parent = None
     while isinstance(core, LambdaExpression):
         parent = core
@@ -26,9 +29,9 @@ def compute_type_raised_semantics(semantics):
     if parent is not None:
         parent.term = core
     else:
-        semantics = core
+        semantics_copy = core
 
-    return LambdaExpression(var, semantics)
+    return LambdaExpression(var, semantics_copy)
 
 
 def compute_function_semantics(function, argument):


### PR DESCRIPTION
See [issue 3345](https://github.com/nltk/nltk/issues/3345) for an in-detail explanation of the bug

Bug : In CCG, using a type-raising rule modifies the semantics of the words in the lexicon.
Fix : The function computing the semantics of a type-raising rules now makes a copy of its arguments, so as to not modify them.