### PR TITLE
Auto update the year in copyright notice.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -303,6 +303,7 @@
 - Ron Urbach <https://github.com/sharpblade4>
 - Vivek Kalyan <https://github.com/vivekkalyan>
 - Tom Strange https://github.com/strangetom
+- Nana Adjei Manu <https://github.com/claeusdev>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 

--- a/web/conf.py
+++ b/web/conf.py
@@ -12,6 +12,7 @@
 
 import os
 import sys
+from datetime import datetime
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -119,7 +120,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "NLTK"
-copyright = "2024, NLTK Project"
+copyright = f"{datetime.now().year} NLTK Project"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
There are many other places that still have the year 2024, is there a timeline to update those or should i update those as well?