### PR TITLE
Enhance example extraction in WordNetCorpusReader to include origins

### DIFF
--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -116,6 +116,7 @@ VERB_FRAME_STRINGS = (
 )
 
 SENSENUM_RE = re.compile(r"\.[\d]+\.")
+EXAMPLE_RE = re.compile(r'"([^"]*)"(?:-\s*([^;]*))?')
 
 
 ######################################################################
@@ -1598,10 +1599,13 @@ class WordNetCorpusReader(CorpusReader):
         try:
             # parse out the definitions and examples from the gloss
             columns_str, gloss = data_file_line.strip().split("|")
-            definition = re.sub(r"[\"].*?[\"]", "", gloss).strip()
-            examples = re.findall(r'"([^"]*)"', gloss)
-            for example in examples:
-                synset._examples.append(example)
+            definition = re.sub(EXAMPLE_RE, "", gloss).strip()
+            examples = re.findall(EXAMPLE_RE, gloss)
+            for example, origin in examples:
+                item = example.strip()
+                if origin:
+                    item += " -- " + origin.strip()
+                synset._examples.append(item)
 
             synset._definition = definition.strip("; ")
 


### PR DESCRIPTION
This pull request includes changes to the `nltk/corpus/reader/wordnet.py` file to improve the handling of examples in synset definitions. The most important changes include adding a new regular expression to match examples with optional origins and updating the `_synset_from_pos_and_line` method to use this new regular expression.

The current parser does not support extract examples with an origin in data lines.

```python
In [1]: from nltk.corpus import wordnet

In [2]: s = wordnet.synsets("predaceous")

In [3]: s[1].definition()
Out[3]: 'living by or given to victimizing others for personal gain; ; - Peter S. Prescott; - W.E.Swinton'

In [4]: s[1].examples()
Out[4]:
['predatory capitalists',
 'a predatory, insensate society in which innocence and decency can prove fatal',
 'a predacious kind of animal--the early geological gangster']
```

updated:

```python
In [1]: from nltk.corpus import wordnet

In [2]: s = wordnet.synsets("predaceous")

In [3]: s[1].definition()
Out[3]: 'living by or given to victimizing others for personal gain'

In [4]: s[1].examples()
Out[4]:
['predatory capitalists',
 'a predatory, insensate society in which innocence and decency can prove fatal -- Peter S. Prescott',
 'a predacious kind of animal--the early geological gangster -- W.E.Swinton']
```