### PR TITLE
Fixing issue #3360

### DIFF
--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -1745,9 +1745,12 @@ class PunktTokenizer(PunktSentenceTokenizer):
 
     def load_lang(self, lang="english"):
         from nltk.data import find
+        import pickle
 
-        lang_dir = find(f"tokenizers/punkt_tab/{lang}/")
-        self._params = load_punkt_params(lang_dir)
+        lang_file = find(f"tokenizers/punkt/{lang}.pickle")
+        with open(lang_file, "rb") as f:
+            self._params = pickle.load(f)
+
         self._lang = lang
 
     def save_params(self):


### PR DESCRIPTION
Hi, 
I solved issue #3360 by testing on Google Colab and Jupyter. 
On Google Colab it actually had the sent_tokenize() error not only from the first use. So I tried to search deeply in the source code, using the getsource function this is the block used;


```
import inspect
print(inspect.getsource(nltk.tokenize._get_punkt_tokenizer))
print(inspect.getsource(nltk.tokenize.punkt.PunktTokenizer))
```

the problem was in the punkt.py file, in the **PunktTokenizer class**, the PunktTokenizer class was trying to load a model from a non-existent folder. 
To fix the problem, I changed the load_lang function in PunktTokenizer to correctly load the tokenization model, using the .pickle file instead of looking for a non-existent folder, **removed the incorrect reference to punkt_tab/english/** and **pointed instead to the correct file punkt/english.pickle**. **Tested it on Google Colab**, and it **didn't report the error anymore**. 
If you want to check the Google Colab file this is the link https://colab.research.google.com/drive/1x4hyNd3fxUHRK5LC7qoO9mxOvYtSYHDt?usp=sharing. 

I hope I can get some feedback on this, and I hope I fixed the problem. 
I kindly ask, if there were any problems regarding the PR, to let me know, so I can improve them. 

Thanks for reviewing.