### PR TITLE
Properly initialize Portuguese corpus

### DIFF
--- a/nltk/corpus/reader/plaintext.py
+++ b/nltk/corpus/reader/plaintext.py
@@ -168,7 +168,7 @@ class CategorizedPlaintextCorpusReader(CategorizedCorpusReader, PlaintextCorpusR
 #       override the `sent_tokenizer`.
 class PortugueseCategorizedPlaintextCorpusReader(CategorizedPlaintextCorpusReader):
     def __init__(self, *args, **kwargs):
-        CategorizedCorpusReader.__init__(self, kwargs)
+        CategorizedPlaintextCorpusReader.__init__(self, *args, **kwargs)
         kwargs["sent_tokenizer"] = PunktTokenizer("portuguese")
 
 

--- a/nltk/corpus/reader/plaintext.py
+++ b/nltk/corpus/reader/plaintext.py
@@ -163,13 +163,11 @@ class CategorizedPlaintextCorpusReader(CategorizedCorpusReader, PlaintextCorpusR
         PlaintextCorpusReader.__init__(self, *args, **kwargs)
 
 
-# FIXME: Is there a better way? How to not hardcode this?
-#       Possibly, add a language kwargs to CategorizedPlaintextCorpusReader to
-#       override the `sent_tokenizer`.
 class PortugueseCategorizedPlaintextCorpusReader(CategorizedPlaintextCorpusReader):
     def __init__(self, *args, **kwargs):
         CategorizedPlaintextCorpusReader.__init__(self, *args, **kwargs)
-        kwargs["sent_tokenizer"] = PunktTokenizer("portuguese")
+        # Fixed (@ekaf 2025), new way to invoke Punkt:
+        self._sent_tokenizer = PunktTokenizer("portuguese")
 
 
 class EuroparlCorpusReader(PlaintextCorpusReader):

--- a/nltk/corpus/reader/plaintext.py
+++ b/nltk/corpus/reader/plaintext.py
@@ -164,6 +164,16 @@ class CategorizedPlaintextCorpusReader(CategorizedCorpusReader, PlaintextCorpusR
 
 
 class PortugueseCategorizedPlaintextCorpusReader(CategorizedPlaintextCorpusReader):
+    """
+    This class is identical with CategorizedPlaintextCorpusReader,
+    except that it initializes a Portuguese PunktTokenizer:
+
+    >>> from nltk.corpus import machado
+    >>> print(machado._sent_tokenizer._lang)
+    portuguese
+
+    """
+
     def __init__(self, *args, **kwargs):
         CategorizedPlaintextCorpusReader.__init__(self, *args, **kwargs)
         # Fixed (@ekaf 2025), new way to invoke Punkt:


### PR DESCRIPTION
Fix https://github.com/nltk/nltk/issues/3373: before this PR, the PortugueseCategorizedPlaintextCorpusReader was not properly initialized, due to a mismatch between the class that it inherits from, and the class that it initialized.