### PR TITLE
Fix saving PerceptronTagger

### DIFF
--- a/nltk/tag/perceptron.py
+++ b/nltk/tag/perceptron.py
@@ -276,13 +276,13 @@ class PerceptronTagger(TaggerI):
     def load_from_json(self, lang="eng", loc=None):
         # Automatically find path to the tagger if location is not specified.
         if not loc:
-            loc = find(f"taggers/averaged_perceptron_tagger_{lang}/")
+            loc = find(f"taggers/averaged_perceptron_tagger_{lang}")
         jsons = lang_jsons(lang)
-        with open(loc + jsons["weights"]) as fin:
+        with open(path_join(loc, jsons["weights"])) as fin:
             self.model.weights = json.load(fin)
-        with open(loc + jsons["tagdict"]) as fin:
+        with open(path_join(loc, jsons["tagdict"])) as fin:
             self.tagdict = json.load(fin)
-        with open(loc + jsons["classes"]) as fin:
+        with open(path_join(loc, jsons["classes"])) as fin:
             self.classes = set(json.load(fin))
             self.model.classes = self.classes
 

--- a/nltk/tag/perceptron.py
+++ b/nltk/tag/perceptron.py
@@ -142,15 +142,23 @@ class PerceptronTagger(TaggerI):
     https://explosion.ai/blog/part-of-speech-pos-tagger-in-python
 
     >>> from nltk.tag.perceptron import PerceptronTagger
-
-    Train the model
-
     >>> tagger = PerceptronTagger(load=False)
+
+    Train and save the model:
 
     >>> tagger.train([[('today','NN'),('is','VBZ'),('good','JJ'),('day','NN')],
     ... [('yes','NNS'),('it','PRP'),('beautiful','JJ')]], save_loc=tagger.save_dir)
 
-    >>> tagger.tag(['today','is','a','beautiful','day'])
+    Load the saved model:
+
+    >>> tagger2 = PerceptronTagger(loc=tagger.save_dir)
+    >>> print(sorted(list(tagger2.classes)))
+    ['JJ', 'NN', 'NNS', 'PRP', 'VBZ']
+
+    >>> print(tagger2.classes == tagger.classes)
+    True
+
+    >>> tagger2.tag(['today','is','a','beautiful','day'])
     [('today', 'NN'), ('is', 'PRP'), ('a', 'PRP'), ('beautiful', 'JJ'), ('day', 'NN')]
 
     Use the pretrain model (the default constructor)
@@ -169,7 +177,7 @@ class PerceptronTagger(TaggerI):
     START = ["-START-", "-START2-"]
     END = ["-END-", "-END2-"]
 
-    def __init__(self, load=True, lang="eng"):
+    def __init__(self, load=True, lang="eng", loc=None):
         """
         :param load: Load the json model upon instantiation.
         """
@@ -179,7 +187,7 @@ class PerceptronTagger(TaggerI):
         self.lang = lang
         self.save_dir = path_join(TRAINED_TAGGER_PATH, f"{TAGGER_NAME}_{self.lang}")
         if load:
-            self.load_from_json(lang)
+            self.load_from_json(lang, loc)
 
     def tag(self, tokens, return_conf=False, use_tagdict=True):
         """


### PR DESCRIPTION
Fix #3379 and #3380. This is a more comprehensive alternative to #3381, with additional code cleanup. 
This PR also tests the _save_to_json_ functionality , by specifying a _save_loc_ in the call to _train_ from the doctest in the PerceptronTagger class, and saves the trained tagger in the _tempfile.gettempdir()_ directory. 
Also, the _jsontags_ encode/decode mechanism is now used when loading and saving.
A little more code cleanup could be considered, since there is no obvious need to define both _self.classes_ and _self.model.classes_ to denote the same thing in the PerceptronTagger class. I nevertheless chose not to change that, since it goes way back and would  break old code. 
