### PR TITLE
Corrected ResolutionProver.find_answers

### DIFF
--- a/nltk/inference/resolution.py
+++ b/nltk/inference/resolution.py
@@ -141,13 +141,13 @@ class ResolutionProverCommand(BaseProverCommand):
         answers = set()
         answer_ex = VariableExpression(Variable(ResolutionProver.ANSWER_KEY))
         for clause in self._clauses:
-            for term in clause:
-                if (
-                    isinstance(term, ApplicationExpression)
-                    and term.function == answer_ex
-                    and not isinstance(term.argument, IndividualVariableExpression)
-                ):
-                    answers.add(term.argument)
+            if (
+                len(clause) == 1
+                and isinstance(clause[0], ApplicationExpression)
+                and clause[0].function == answer_ex
+                and not isinstance(clause[0].argument, IndividualVariableExpression)
+            ):
+                answers.add(clause[0].argument)
         return answers
 
     @staticmethod


### PR DESCRIPTION
Fixes #3046: corrected ResolutionProver.find_answers such that incorrect clauses no longer are added as answers.