### PR TITLE
Make Wordnet interoperable with various taggers and tagged corpora

### DIFF
--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -2108,6 +2108,23 @@ class WordNetCorpusReader(CorpusReader):
         # 2. Return all that are in the database (and check the original too)
         return filter_forms([form] + forms)
 
+    def tag2pos(self, tag, tagset="en-ptb") -> str:
+        """
+        Convert a tag from one of the tagsets in nltk_data/taggers/universal_tagset, to a
+        WordNet Part-of-Speech, using Universal Tags (Petrov et al., 2012) as intermediary.
+        Return None when WordNet does not cover that Pos.
+
+        >>> import nltk
+        >>> tagged = nltk.tag.pos_tag(nltk.tokenize.word_tokenize("Banks check books."))
+        >>> print([(word, tag, nltk.corpus.wordnet.tag2pos(tag)) for word,tag in tagged])
+        [('Banks', 'NNS', 'n'), ('check', 'VBP', 'v'), ('books', 'NNS', 'n'), ('.', '.', None)]
+        """
+
+        from nltk.tag import map_tag
+
+        utag2wnpos = {self._FILEMAP[pos].upper(): pos for pos in self._FILEMAP}
+        return utag2wnpos.get(map_tag(tagset, "universal", tag), None)
+
     #############################################################
     # Create information content from corpus
     #############################################################

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -2122,8 +2122,7 @@ class WordNetCorpusReader(CorpusReader):
 
         from nltk.tag import map_tag
 
-        utag2wnpos = {'NOUN': 'n', 'VERB': 'v', 'ADJ': 'a', 'ADV': 'r'}
-        return utag2wnpos.get(map_tag(tagset, "universal", tag), None)
+        return UTAG2WN_POS.get(map_tag(tagset, "universal", tag), None)
 
     #############################################################
     # Create information content from corpus

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -42,6 +42,7 @@ from operator import itemgetter
 from nltk.corpus.reader import CorpusReader
 from nltk.internals import deprecated
 from nltk.probability import FreqDist
+from nltk.tag import map_tag
 from nltk.util import binary_search_file as _binary_search_file
 
 ######################################################################
@@ -2123,7 +2124,7 @@ class WordNetCorpusReader(CorpusReader):
                 Supported tagsets are those recognized by the `map_tag` function
                 from `nltk.tag`. Common examples include:
                     - "en-ptb" (Penn Treebank tagset for English)
-                    - "universal" (Universal POS tagset)
+                    - "en-brown" (Brown tagset)
                 For a complete list of supported tagsets, refer to the `map_tag`
                 documentation or its source code in the NLTK library.
 
@@ -2137,8 +2138,6 @@ class WordNetCorpusReader(CorpusReader):
             >>> print([(word, tag, nltk.corpus.wordnet.tag2pos(tag)) for word, tag in tagged])
             [('Banks', 'NNS', 'n'), ('check', 'VBP', 'v'), ('books', 'NNS', 'n'), ('.', '.', None)]
         """
-
-        from nltk.tag import map_tag
 
         return UTAG2WN_POS.get(map_tag(tagset, "universal", tag), None)
 

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -2122,7 +2122,7 @@ class WordNetCorpusReader(CorpusReader):
 
         from nltk.tag import map_tag
 
-        utag2wnpos = {self._FILEMAP[pos].upper(): pos for pos in self._FILEMAP}
+        utag2wnpos = {'NOUN': 'n', 'VERB': 'v', 'ADJ': 'a', 'ADV': 'r'}
         return utag2wnpos.get(map_tag(tagset, "universal", tag), None)
 
     #############################################################

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -2108,7 +2108,7 @@ class WordNetCorpusReader(CorpusReader):
         # 2. Return all that are in the database (and check the original too)
         return filter_forms([form] + forms)
 
-    def tag2pos(self, tag, tagset="en-ptb") -> str:
+    def tag2pos(self, tag, tagset="en-ptb") -> Optional[str]:
         """
         Convert a tag from one of the tagsets in nltk_data/taggers/universal_tagset, to a
         WordNet Part-of-Speech, using Universal Tags (Petrov et al., 2012) as intermediary.

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -2139,8 +2139,10 @@ class WordNetCorpusReader(CorpusReader):
             >>> print([(word, tag, nltk.corpus.wordnet.tag2pos(tag)) for word, tag in tagged])
             [('Banks', 'NNS', 'n'), ('check', 'VBP', 'v'), ('books', 'NNS', 'n'), ('.', '.', None)]
         """
+        if tagset != "universal":
+            tag = map_tag(tagset, "universal", tag)
 
-        return UNIVERSAL_TAG_TO_WN_POS.get(map_tag(tagset, "universal", tag), None)
+        return UNIVERSAL_TAG_TO_WN_POS.get(tag, None)
 
     #############################################################
     # Create information content from corpus

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -2118,19 +2118,20 @@ class WordNetCorpusReader(CorpusReader):
         WordNet Part-of-Speech, using Universal Tags (Petrov et al., 2012) as intermediary.
         Return None when WordNet does not cover that POS.
 
-        Args:
-            tag (str): The part-of-speech tag to convert.
-            tagset (str): The tagset of the input tag. Defaults to "en-ptb".
-                Supported tagsets are those recognized by the `map_tag` function
-                from `nltk.tag`. Common examples include:
-                    - "en-ptb" (Penn Treebank tagset for English)
-                    - "en-brown" (Brown tagset)
-                For a complete list of supported tagsets, refer to the `map_tag`
-                documentation or its source code in the NLTK library.
+        :param tag: The part-of-speech tag to convert.
+        :type tag: str
+        :param tagset: The tagset of the input tag. Defaults to "en-ptb".
+            Supported tagsets are those recognized by the `map_tag` function
+            from `nltk.tag`. Common examples include:
+                - "en-ptb" (Penn Treebank tagset for English)
+                - "en-brown" (Brown tagset)
+            For a complete list of supported tagsets, refer to the `map_tag`
+            documentation or its source code in the NLTK library.
+        :type tagset: str
 
-        Returns:
-            The corresponding WordNet POS tag ('n', 'v', 'a', 'r') or None
+        :returns: The corresponding WordNet POS tag ('n', 'v', 'a', 'r') or None
             if the tag cannot be mapped to a WordNet POS.
+        :rtype: str or None
 
         Example:
             >>> import nltk

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -2120,6 +2120,12 @@ class WordNetCorpusReader(CorpusReader):
         Args:
             tag (str): The part-of-speech tag to convert.
             tagset (str): The tagset of the input tag. Defaults to "en-ptb".
+                Supported tagsets are those recognized by the `map_tag` function
+                from `nltk.tag`. Common examples include:
+                    - "en-ptb" (Penn Treebank tagset for English)
+                    - "universal" (Universal POS tagset)
+                For a complete list of supported tagsets, refer to the `map_tag`
+                documentation or its source code in the NLTK library.
 
         Returns:
             The corresponding WordNet POS tag ('n', 'v', 'a', 'r') or None

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -2110,14 +2110,23 @@ class WordNetCorpusReader(CorpusReader):
 
     def tag2pos(self, tag, tagset="en-ptb") -> Optional[str]:
         """
-        Convert a tag from one of the tagsets in nltk_data/taggers/universal_tagset, to a
+        Convert a tag from one of the tagsets in nltk_data/taggers/universal_tagset to a
         WordNet Part-of-Speech, using Universal Tags (Petrov et al., 2012) as intermediary.
-        Return None when WordNet does not cover that Pos.
+        Return None when WordNet does not cover that POS.
 
-        >>> import nltk
-        >>> tagged = nltk.tag.pos_tag(nltk.tokenize.word_tokenize("Banks check books."))
-        >>> print([(word, tag, nltk.corpus.wordnet.tag2pos(tag)) for word,tag in tagged])
-        [('Banks', 'NNS', 'n'), ('check', 'VBP', 'v'), ('books', 'NNS', 'n'), ('.', '.', None)]
+        Args:
+            tag (str): The part-of-speech tag to convert.
+            tagset (str): The tagset of the input tag. Defaults to "en-ptb".
+
+        Returns:
+            Optional[str]: The corresponding WordNet POS tag ('n', 'v', 'a', 'r') or None
+            if the tag cannot be mapped to a WordNet POS.
+
+        Example:
+            >>> import nltk
+            >>> tagged = nltk.tag.pos_tag(nltk.tokenize.word_tokenize("Banks check books."))
+            >>> print([(word, tag, nltk.corpus.wordnet.tag2pos(tag)) for word, tag in tagged])
+            [('Banks', 'NNS', 'n'), ('check', 'VBP', 'v'), ('books', 'NNS', 'n'), ('.', '.', None)]
         """
 
         from nltk.tag import map_tag

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -70,6 +70,9 @@ ADJ, ADJ_SAT, ADV, NOUN, VERB = "a", "s", "r", "n", "v"
 
 POS_LIST = [NOUN, VERB, ADJ, ADV]
 
+# Convert from Universal Tags (Petrov et al., 2012) to Wordnet Pos
+UTAG2WN_POS = {"NOUN": "n", "VERB": "v", "ADJ": "a", "ADV": "r"}
+
 # A table of strings that are used to express verb frames.
 VERB_FRAME_STRINGS = (
     None,
@@ -2108,7 +2111,7 @@ class WordNetCorpusReader(CorpusReader):
         # 2. Return all that are in the database (and check the original too)
         return filter_forms([form] + forms)
 
-    def tag2pos(self, tag, tagset="en-ptb") -> Optional[str]:
+    def tag2pos(self, tag, tagset="en-ptb"):
         """
         Convert a tag from one of the tagsets in nltk_data/taggers/universal_tagset to a
         WordNet Part-of-Speech, using Universal Tags (Petrov et al., 2012) as intermediary.
@@ -2119,7 +2122,7 @@ class WordNetCorpusReader(CorpusReader):
             tagset (str): The tagset of the input tag. Defaults to "en-ptb".
 
         Returns:
-            Optional[str]: The corresponding WordNet POS tag ('n', 'v', 'a', 'r') or None
+            The corresponding WordNet POS tag ('n', 'v', 'a', 'r') or None
             if the tag cannot be mapped to a WordNet POS.
 
         Example:

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -72,7 +72,7 @@ ADJ, ADJ_SAT, ADV, NOUN, VERB = "a", "s", "r", "n", "v"
 POS_LIST = [NOUN, VERB, ADJ, ADV]
 
 # Convert from Universal Tags (Petrov et al., 2012) to Wordnet Pos
-UTAG2WN_POS = {"NOUN": "n", "VERB": "v", "ADJ": "a", "ADV": "r"}
+UNIVERSAL_TAG_TO_WN_POS = {"NOUN": "n", "VERB": "v", "ADJ": "a", "ADV": "r"}
 
 # A table of strings that are used to express verb frames.
 VERB_FRAME_STRINGS = (
@@ -2140,7 +2140,7 @@ class WordNetCorpusReader(CorpusReader):
             [('Banks', 'NNS', 'n'), ('check', 'VBP', 'v'), ('books', 'NNS', 'n'), ('.', '.', None)]
         """
 
-        return UTAG2WN_POS.get(map_tag(tagset, "universal", tag), None)
+        return UNIVERSAL_TAG_TO_WN_POS.get(map_tag(tagset, "universal", tag), None)
 
     #############################################################
     # Create information content from corpus

--- a/nltk/test/unit/test_wordnet.py
+++ b/nltk/test/unit/test_wordnet.py
@@ -244,3 +244,21 @@ class WordnNetDemo(unittest.TestCase):
         self.assertTrue(hasattr(cat_lemmas, "__iter__"))
         self.assertTrue(hasattr(cat_lemmas, "__next__") or hasattr(eng_lemmas, "next"))
         self.assertTrue(cat_lemmas.__iter__() is cat_lemmas)
+
+    def test_en_ptb_tags(self):
+        # Penn Treebank tags
+        self.assertEqual(wn.tag2pos("NN"), "n")  # noun
+        self.assertEqual(wn.tag2pos("NNS"), "n")
+        self.assertEqual(wn.tag2pos("VB"), "v")  # verb
+        self.assertEqual(wn.tag2pos("VBD"), "v")
+        self.assertEqual(wn.tag2pos("JJ"), "a")  # adjective
+        self.assertEqual(wn.tag2pos("RB"), "r")  # adverb
+        self.assertIsNone(wn.tag2pos("."))  # punctuation
+
+    def test_en_brown_tags(self):
+        # Brown tagset
+        self.assertEqual(wn.tag2pos("NN", tagset="en-brown"), "n")
+        self.assertEqual(wn.tag2pos("VB", tagset="en-brown"), "v")
+        self.assertEqual(wn.tag2pos("JJ", tagset="en-brown"), "a")
+        self.assertEqual(wn.tag2pos("RB", tagset="en-brown"), "r")
+        self.assertIsNone(wn.tag2pos("(", tagset="en-brown"))

--- a/nltk/test/unit/test_wordnet.py
+++ b/nltk/test/unit/test_wordnet.py
@@ -246,19 +246,54 @@ class WordnNetDemo(unittest.TestCase):
         self.assertTrue(cat_lemmas.__iter__() is cat_lemmas)
 
     def test_en_ptb_tags(self):
-        # Penn Treebank tags
+        # Common PTB tags (mapped in both PTB and Brown)
         self.assertEqual(wn.tag2pos("NN"), "n")  # noun
-        self.assertEqual(wn.tag2pos("NNS"), "n")
         self.assertEqual(wn.tag2pos("VB"), "v")  # verb
-        self.assertEqual(wn.tag2pos("VBD"), "v")
         self.assertEqual(wn.tag2pos("JJ"), "a")  # adjective
         self.assertEqual(wn.tag2pos("RB"), "r")  # adverb
-        self.assertIsNone(wn.tag2pos("."))  # punctuation
+
+    def test_en_ptb_tags(self):
+        # Common PTB tags (mapped in both PTB and Brown)
+        self.assertEqual(wn.tag2pos("NN"), "n")  # noun
+        self.assertEqual(wn.tag2pos("VB"), "v")  # verb
+        self.assertEqual(wn.tag2pos("JJ"), "a")  # adjective
+        self.assertEqual(wn.tag2pos("RB"), "r")  # adverb
+
+        # PTB-specific tags (mapped in PTB, not in Brown)
+        self.assertEqual(wn.tag2pos("NNS"), "n")  # plural noun (PTB only)
+        self.assertEqual(wn.tag2pos("VBD"), "v")  # verb, past tense (PTB only)
+        self.assertEqual(
+            wn.tag2pos("VBG"), "v"
+        )  # verb, gerund/present participle (PTB only)
+        self.assertEqual(wn.tag2pos("JJR"), "a")  # adjective, comparative (PTB only)
+        self.assertEqual(wn.tag2pos("RBR"), "r")  # adverb, comparative (PTB only)
+
+        # Tags that should yield None (not mapped in WordNet)
+        self.assertIsNone(wn.tag2pos("PRP"))
+        self.assertIsNone(wn.tag2pos("WP"))
+        self.assertIsNone(wn.tag2pos("TO"))
+        self.assertIsNone(wn.tag2pos("PRT"))
+        self.assertIsNone(wn.tag2pos("POS"))
+        self.assertIsNone(wn.tag2pos("."))
 
     def test_en_brown_tags(self):
-        # Brown tagset
-        self.assertEqual(wn.tag2pos("NN", tagset="en-brown"), "n")
-        self.assertEqual(wn.tag2pos("VB", tagset="en-brown"), "v")
-        self.assertEqual(wn.tag2pos("JJ", tagset="en-brown"), "a")
-        self.assertEqual(wn.tag2pos("RB", tagset="en-brown"), "r")
+        # Common Brown tags (mapped in both PTB and Brown)
+        self.assertEqual(wn.tag2pos("NN", tagset="en-brown"), "n")  # noun
+        self.assertEqual(wn.tag2pos("VB", tagset="en-brown"), "v")  # verb
+        self.assertEqual(wn.tag2pos("JJ", tagset="en-brown"), "a")  # adjective
+        self.assertEqual(wn.tag2pos("RB", tagset="en-brown"), "r")  # adverb
+
+        # Brown-specific tags (mapped in Brown, not in PTB)
+        self.assertEqual(
+            wn.tag2pos("HV", tagset="en-brown"), "v"
+        )  # 'have' auxiliary (Brown only)
+        self.assertEqual(
+            wn.tag2pos("BEZ", tagset="en-brown"), "v"
+        )  # 'be' auxiliary, 3rd person singular present (Brown only)
+        self.assertEqual(
+            wn.tag2pos("DOZ", tagset="en-brown"), "v"
+        )  # 'do' auxiliary, 3rd person singular present (Brown only)
+
+        # Tags that should yield None (not mapped in WordNet)
+        self.assertIsNone(wn.tag2pos("PPL", tagset="en-brown"))
         self.assertIsNone(wn.tag2pos("(", tagset="en-brown"))

--- a/nltk/test/unit/test_wordnet.py
+++ b/nltk/test/unit/test_wordnet.py
@@ -252,13 +252,6 @@ class WordnNetDemo(unittest.TestCase):
         self.assertEqual(wn.tag2pos("JJ"), "a")  # adjective
         self.assertEqual(wn.tag2pos("RB"), "r")  # adverb
 
-    def test_en_ptb_tags(self):
-        # Common PTB tags (mapped in both PTB and Brown)
-        self.assertEqual(wn.tag2pos("NN"), "n")  # noun
-        self.assertEqual(wn.tag2pos("VB"), "v")  # verb
-        self.assertEqual(wn.tag2pos("JJ"), "a")  # adjective
-        self.assertEqual(wn.tag2pos("RB"), "r")  # adverb
-
         # PTB-specific tags (mapped in PTB, not in Brown)
         self.assertEqual(wn.tag2pos("NNS"), "n")  # plural noun (PTB only)
         self.assertEqual(wn.tag2pos("VBD"), "v")  # verb, past tense (PTB only)


### PR DESCRIPTION
Fix #3392 by adding a function that uses Universal Tags (Petrov et al., 2012), to convert the tags available in _nltk_data/taggers/universal_tagset_ to Wordnet Part-of-Speech. This allows to restrict Wordnet searches to the relevant grammatical category.

```
from nltk.corpus import wordnet as wn
from nltk.corpus import brown
form,tag = brown.tagged_sents()[0][17]
print((form, tag))
```
('evidence', 'NN')

Restricting the Wordnet search to _n_ discards the verbal senses:

`
print(wn.synsets(form, wn.tag2pos(tag, brown._tagset)))
`

[Synset('evidence.n.01'), Synset('evidence.n.02'), Synset('evidence.n.03')]
