### PR TITLE
Visualization of the nltk codebase

### DIFF
--- a/.codeboarding/Advanced_NLP_Models_Evaluation.md
+++ b/.codeboarding/Advanced_NLP_Models_Evaluation.md
@@ -1,0 +1,195 @@
+```mermaid
+
+graph LR
+
+    nltk_classify_api_ClassifierI["nltk.classify.api.ClassifierI"]
+
+    nltk_classify_maxent_MaxentClassifier["nltk.classify.maxent.MaxentClassifier"]
+
+    nltk_cluster_util_VectorSpaceClusterer["nltk.cluster.util.VectorSpaceClusterer"]
+
+    nltk_cluster_kmeans_KMeansClusterer["nltk.cluster.kmeans.KMeansClusterer"]
+
+    nltk_lm_api_LanguageModel["nltk.lm.api.LanguageModel"]
+
+    nltk_lm_models_MLE["nltk.lm.models.MLE"]
+
+    nltk_metrics_agreement_AnnotationTask["nltk.metrics.agreement.AnnotationTask"]
+
+    nltk_metrics_distance_edit_distance["nltk.metrics.distance.edit_distance"]
+
+    nltk_translate_ibm_model_IBMModel["nltk.translate.ibm_model.IBMModel"]
+
+    nltk_translate_bleu_score_corpus_bleu["nltk.translate.bleu_score.corpus_bleu"]
+
+    nltk_classify_maxent_MaxentClassifier -- "implements" --> nltk_classify_api_ClassifierI
+
+    nltk_cluster_kmeans_KMeansClusterer -- "inherits from" --> nltk_cluster_util_VectorSpaceClusterer
+
+    nltk_lm_models_MLE -- "implements" --> nltk_lm_api_LanguageModel
+
+    nltk_metrics_agreement_AnnotationTask -- "uses" --> nltk_metrics_distance_edit_distance
+
+    nltk_translate_bleu_score_corpus_bleu -- "evaluates output from" --> nltk_translate_ibm_model_IBMModel
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+Component Overview: Advanced NLP Models & Evaluation
+
+
+
+### nltk.classify.api.ClassifierI
+
+This is an abstract base class that defines the fundamental interface for all classifiers within NLTK. It mandates essential methods such as `labels()`, `classify()`, and `prob_classify()`, ensuring a consistent API across diverse classification algorithms.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/classify/api.py#L42-L47" target="_blank" rel="noopener noreferrer">`nltk.classify.api.ClassifierI:labels` (42:47)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/classify/api.py#L49-L57" target="_blank" rel="noopener noreferrer">`nltk.classify.api.ClassifierI:classify` (49:57)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/classify/api.py#L59-L68" target="_blank" rel="noopener noreferrer">`nltk.classify.api.ClassifierI:prob_classify` (59:68)</a>
+
+
+
+
+
+### nltk.classify.maxent.MaxentClassifier
+
+Implements the Maximum Entropy Classifier, a widely used probabilistic classifier in NLP. It learns a set of weights for features based on training data to make predictions.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### nltk.cluster.util.VectorSpaceClusterer
+
+An abstract base class for clustering algorithms that operate on data represented in vector spaces. It provides common functionalities like vector normalization and defines the interface for vector-based clustering and classification.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### nltk.cluster.kmeans.KMeansClusterer
+
+Implements the K-Means clustering algorithm, an iterative method that partitions data points into a specified number of clusters, aiming to minimize the variance within each cluster.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### nltk.lm.api.LanguageModel
+
+An abstract base class that defines the core interface for all language models in NLTK. It provides methods for common language modeling tasks such as fitting a model to data, scoring sequences, calculating entropy, and generating text.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/lm/api.py#L103-L115" target="_blank" rel="noopener noreferrer">`nltk.lm.api.LanguageModel:fit` (103:115)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/lm/api.py#L117-L125" target="_blank" rel="noopener noreferrer">`nltk.lm.api.LanguageModel:score` (117:125)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/lm/api.py#L162-L174" target="_blank" rel="noopener noreferrer">`nltk.lm.api.LanguageModel:entropy` (162:174)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/lm/api.py#L184-L237" target="_blank" rel="noopener noreferrer">`nltk.lm.api.LanguageModel:generate` (184:237)</a>
+
+
+
+
+
+### nltk.lm.models.MLE
+
+Implements a Maximum Likelihood Estimation (MLE) language model, which estimates the probabilities of word sequences directly from their observed frequencies in the training data without any smoothing.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### nltk.metrics.agreement.AnnotationTask
+
+A class designed for calculating various inter-annotator agreement metrics, such as observed agreement, Cohen's Kappa, and Krippendorff's Alpha, which are crucial for evaluating the reliability of human annotations in NLP tasks.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### nltk.metrics.distance.edit_distance
+
+A function that calculates the Levenshtein edit distance between two sequences. This fundamental metric quantifies the minimum number of single-character edits (insertions, deletions, or substitutions) required to transform one sequence into the other, widely used for string similarity.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### nltk.translate.ibm_model.IBMModel
+
+An abstract base class that serves as the foundation for the IBM statistical machine translation models (Model 1 through Model 5). It defines common functionalities and attributes shared across these foundational models for word alignment and translation probability estimation.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### nltk.translate.bleu_score.corpus_bleu
+
+A function to compute the Bilingual Evaluation Understudy (BLEU) score for a corpus of translated sentences. BLEU is a widely adopted metric for automatically evaluating the quality of machine translation output by comparing n-gram overlaps with reference translations.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Applications_Interfaces.md
+++ b/.codeboarding/Applications_Interfaces.md
@@ -1,0 +1,259 @@
+```mermaid
+
+graph LR
+
+    nltk_app_chartparser_app_ChartParserApp["nltk.app.chartparser_app.ChartParserApp"]
+
+    nltk_app_collocations_app_CollocationsView["nltk.app.collocations_app.CollocationsView"]
+
+    nltk_app_concordance_app_ConcordanceSearchView["nltk.app.concordance_app.ConcordanceSearchView"]
+
+    nltk_app_rdparser_app_RecursiveDescentApp["nltk.app.rdparser_app.RecursiveDescentApp"]
+
+    nltk_app_srparser_app_ShiftReduceApp["nltk.app.srparser_app.ShiftReduceApp"]
+
+    nltk_draw_util_CanvasFrame["nltk.draw.util.CanvasFrame"]
+
+    nltk_twitter_twitterclient_Twitter["nltk.twitter.twitterclient.Twitter"]
+
+    nltk_collocations_AbstractCollocationFinder["nltk.collocations.AbstractCollocationFinder"]
+
+    nltk_chat_util_Chat["nltk.chat.util.Chat"]
+
+    nltk_ccg_chart_CCGChartParser["nltk.ccg.chart.CCGChartParser"]
+
+    nltk_app_chartparser_app_ChartParserApp -- "Uses" --> nltk_parse_chart_SteppingChartParser
+
+    nltk_app_chartparser_app_ChartParserApp -- "Uses" --> nltk_draw_util_CanvasFrame
+
+    nltk_app_collocations_app_CollocationsView -- "Uses" --> nltk_collocations_AbstractCollocationFinder
+
+    nltk_app_collocations_app_CollocationsView -- "Uses" --> nltk_draw_util_CanvasFrame
+
+    nltk_app_concordance_app_ConcordanceSearchView -- "Uses" --> nltk_draw_util_CanvasFrame
+
+    nltk_app_rdparser_app_RecursiveDescentApp -- "Uses" --> nltk_parse_recursivedescent_SteppingRecursiveDescentParser
+
+    nltk_app_rdparser_app_RecursiveDescentApp -- "Uses" --> nltk_draw_util_CanvasFrame
+
+    nltk_app_srparser_app_ShiftReduceApp -- "Uses" --> nltk_parse_shiftreduce_SteppingShiftReduceParser
+
+    nltk_app_srparser_app_ShiftReduceApp -- "Uses" --> nltk_draw_util_CanvasFrame
+
+    nltk_twitter_twitterclient_Twitter -- "Uses" --> nltk_twitter_api_TweetHandlerI
+
+    nltk_twitter_twitterclient_Twitter -- "Uses" --> nltk_twitter_twitterclient_Query
+
+    nltk_twitter_twitterclient_Twitter -- "Uses" --> nltk_twitter_twitterclient_Streamer
+
+    nltk_ccg_chart_CCGChartParser -- "Uses" --> nltk_ccg_combinator
+
+    nltk_ccg_chart_CCGChartParser -- "Uses" --> nltk_ccg_lexicon
+
+    nltk_ccg_chart_CCGChartParser -- "Uses" --> nltk_ccg_logic
+
+    nltk_ccg_chart_CCGChartParser -- "Uses" --> nltk_parse_chart
+
+    nltk_ccg_chart_CCGChartParser -- "Uses" --> nltk_tree
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The `Applications & Interfaces` component of NLTK serves as the user-facing layer, providing interactive tools and integrations that demonstrate and utilize NLTK's core NLP functionalities. This component is crucial for making NLTK accessible and for showcasing its capabilities through practical applications.
+
+
+
+### nltk.app.chartparser_app.ChartParserApp
+
+A GUI application that visually demonstrates the chart parsing process. It allows users to load grammars and sentences, step through the parsing process, and view the chart, matrix, and results.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/parse/chart.py#L1528-L1687" target="_blank" rel="noopener noreferrer">`nltk.parse.chart.SteppingChartParser` (1528:1687)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/draw/util.py#L1765-L1998" target="_blank" rel="noopener noreferrer">`nltk.draw.util.CanvasFrame` (1765:1998)</a>
+
+
+
+
+
+### nltk.app.collocations_app.CollocationsView
+
+A GUI application for exploring collocations in a text corpus. It allows users to select a corpus, specify n-gram size, and view the most significant collocations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/collocations.py#L46-L146" target="_blank" rel="noopener noreferrer">`nltk.collocations.AbstractCollocationFinder` (46:146)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/draw/util.py#L1765-L1998" target="_blank" rel="noopener noreferrer">`nltk.draw.util.CanvasFrame` (1765:1998)</a>
+
+
+
+
+
+### nltk.app.concordance_app.ConcordanceSearchView
+
+A GUI application for performing and displaying concordances (keyword-in-context). Users can select a corpus and search for specific words or patterns.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/draw/util.py#L1765-L1998" target="_blank" rel="noopener noreferrer">`nltk.draw.util.CanvasFrame` (1765:1998)</a>
+
+
+
+
+
+### nltk.app.rdparser_app.RecursiveDescentApp
+
+A GUI application that visually demonstrates the recursive descent parsing algorithm, allowing users to step through the parsing process and observe the parse tree and frontier.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/parse/recursivedescent.py#L344-L644" target="_blank" rel="noopener noreferrer">`nltk.parse.recursivedescent.SteppingRecursiveDescentParser` (344:644)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/draw/util.py#L1765-L1998" target="_blank" rel="noopener noreferrer">`nltk.draw.util.CanvasFrame` (1765:1998)</a>
+
+
+
+
+
+### nltk.app.srparser_app.ShiftReduceApp
+
+A GUI application that visualizes the shift-reduce parsing algorithm, showing the stack, input, and reducible productions.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/parse/shiftreduce.py#L284-L440" target="_blank" rel="noopener noreferrer">`nltk.parse.shiftreduce.SteppingShiftReduceParser` (284:440)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/draw/util.py#L1765-L1998" target="_blank" rel="noopener noreferrer">`nltk.draw.util.CanvasFrame` (1765:1998)</a>
+
+
+
+
+
+### nltk.draw.util.CanvasFrame
+
+A Tkinter-based frame that contains a canvas widget, providing a drawing surface for other widgets and managing scrolling. It's a fundamental building block for many NLTK GUI applications.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### nltk.twitter.twitterclient.Twitter
+
+The primary class for interacting with the Twitter API, handling authentication, queries, and streaming of tweets.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/twitter/api.py#L78-L144" target="_blank" rel="noopener noreferrer">`nltk.twitter.api.TweetHandlerI` (78:144)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/twitter/twitterclient.py#L120-L306" target="_blank" rel="noopener noreferrer">`nltk.twitter.twitterclient.Query` (120:306)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/twitter/twitterclient.py#L39-L117" target="_blank" rel="noopener noreferrer">`nltk.twitter.twitterclient.Streamer` (39:117)</a>
+
+
+
+
+
+### nltk.collocations.AbstractCollocationFinder
+
+An abstract base class that defines the common interface and provides core functionalities for finding collocations (e.g., n-gram frequency distribution, filtering, scoring).
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### nltk.chat.util.Chat
+
+Provides the foundational utilities and a base class for creating simple rule-based chatbots. Specific chatbots (like Eliza) inherit from or utilize components within this module.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### nltk.ccg.chart.CCGChartParser
+
+Implements a chart parser specifically designed for Combinatory Categorial Grammar (CCG), enabling the parsing of sentences based on CCG rules.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/ccg/combinator.py#L0-L0" target="_blank" rel="noopener noreferrer">`nltk.ccg.combinator` (0:0)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/ccg/lexicon.py#L0-L0" target="_blank" rel="noopener noreferrer">`nltk.ccg.lexicon` (0:0)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/ccg/logic.py#L0-L0" target="_blank" rel="noopener noreferrer">`nltk.ccg.logic` (0:0)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/parse/chart.py#L0-L0" target="_blank" rel="noopener noreferrer">`nltk.parse.chart` (0:0)</a>
+
+- `nltk.tree` (0:0)
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Core_Utilities_Foundations.md
+++ b/.codeboarding/Core_Utilities_Foundations.md
@@ -1,0 +1,43 @@
+```mermaid
+
+graph LR
+
+    NLTK_Data["NLTK Data"]
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+Analysis of NLTK modules, focusing on the 'data' module and its interactions with other parts of NLTK for managing linguistic resources. The analysis aims to understand how data is loaded, accessed, and utilized across the library, identifying key functions and classes involved in data handling and their relationships with components responsible for tokenization, stemming, and tagging. This will help in understanding the overall architecture and data flow within NLTK, especially concerning its extensibility and performance with large linguistic datasets. The analysis will also cover error handling and efficiency in data operations, providing insights into potential optimizations and common pitfalls in NLTK data usage. The 'data' module is central to NLTK's functionality, enabling access to corpora, pre-trained models, and other linguistic resources essential for natural language processing tasks. Understanding its internal mechanisms and interactions is crucial for effective NLTK development and application. The analysis will also consider the module's role in supporting various data formats and its adaptability to new linguistic resources, highlighting its importance in the broader NLP ecosystem. The 'data' module's design principles, such as lazy loading and resource management, will be examined to understand their impact on performance and memory usage. Furthermore, the analysis will explore how the 'data' module integrates with other NLTK components, such as tokenizers, taggers, and parsers, to provide a seamless workflow for NLP tasks. This comprehensive analysis will contribute to a deeper understanding of NLTK's architecture and its capabilities in handling diverse linguistic data.
+
+
+
+### NLTK Data
+
+The NLTK data module.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/data.py#L0-L0" target="_blank" rel="noopener noreferrer">`nltk.data` (0:0)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Data_Corpus_Management.md
+++ b/.codeboarding/Data_Corpus_Management.md
@@ -1,0 +1,243 @@
+```mermaid
+
+graph LR
+
+    nltk_data["nltk.data"]
+
+    nltk_downloader["nltk.downloader"]
+
+    nltk_corpus["nltk.corpus"]
+
+    nltk_corpus_reader_api["nltk.corpus.reader.api"]
+
+    nltk_corpus_reader_util["nltk.corpus.reader.util"]
+
+    nltk_corpus_reader_plaintext["nltk.corpus.reader.plaintext"]
+
+    nltk_corpus_reader_wordnet["nltk.corpus.reader.wordnet"]
+
+    nltk_internals["nltk.internals"]
+
+    nltk_tokenize["nltk.tokenize"]
+
+    nltk_data -- "uses" --> nltk_internals
+
+    nltk_downloader -- "used by" --> nltk_data
+
+    nltk_data -- "used by" --> nltk_corpus_reader_api
+
+    nltk_data -- "used by" --> nltk_tokenize
+
+    nltk_downloader -- "uses" --> nltk_data
+
+    nltk_downloader -- "uses" --> nltk_internals
+
+    nltk_corpus -- "uses" --> nltk_corpus_reader_api
+
+    nltk_corpus -- "uses" --> nltk_tokenize
+
+    nltk_corpus_reader_api -- "uses" --> nltk_data
+
+    nltk_corpus_reader_api -- "uses" --> nltk_corpus_reader_util
+
+    nltk_corpus_reader_util -- "uses" --> nltk_data
+
+    nltk_corpus_reader_util -- "uses" --> nltk_tokenize
+
+    nltk_corpus_reader_plaintext -- "implements" --> nltk_corpus_reader_api
+
+    nltk_corpus_reader_plaintext -- "uses" --> nltk_tokenize
+
+    nltk_corpus_reader_wordnet -- "implements" --> nltk_corpus_reader_api
+
+    nltk_corpus_reader_wordnet -- "uses" --> nltk_internals
+
+    nltk_internals -- "used by" --> nltk_data
+
+    nltk_internals -- "used by" --> nltk_corpus_reader_util
+
+    nltk_tokenize -- "uses" --> nltk_data
+
+    nltk_tokenize -- "used by" --> nltk_corpus_reader_plaintext
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+This component is central to NLTK's ability to handle and provide access to its vast collection of linguistic data, including corpora, pre-trained models, and grammars. It ensures that users can easily locate, load, and process various data formats, abstracting away the underlying storage mechanisms.
+
+
+
+### nltk.data
+
+This module is the primary interface for locating and loading NLTK's linguistic data. It abstracts away the underlying file system details and provides functions to find data files and directories, supporting various URL protocols (e.g., `nltk:`, `file:`, `https:`). It also manages the NLTK data search path.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/data.py#L0-L0" target="_blank" rel="noopener noreferrer">`nltk.data` (0:0)</a>
+
+
+
+
+
+### nltk.downloader
+
+This module provides functionality for downloading and installing NLTK data packages from the official NLTK data server. It manages the process of fetching, verifying, and extracting data, making it easy for users to acquire necessary linguistic resources.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/downloader.py#L0-L0" target="_blank" rel="noopener noreferrer">`nltk.downloader` (0:0)</a>
+
+
+
+
+
+### nltk.corpus
+
+This package serves as the central access point for all NLTK corpora. It provides a unified API to load and interact with various linguistic datasets, abstracting the specific reader implementations for different data formats. It acts as a registry for available corpora.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `nltk.corpus` (0:0)
+
+
+
+
+
+### nltk.corpus.reader.api
+
+This module defines the abstract base classes and common interfaces (e.g., `CorpusReader`) for all NLTK corpus readers. It establishes a contract for how different types of linguistic data can be accessed and processed, promoting consistency and extensibility across various data formats.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/corpus/reader/api.py#L0-L0" target="_blank" rel="noopener noreferrer">`nltk.corpus.reader.api` (0:0)</a>
+
+
+
+
+
+### nltk.corpus.reader.util
+
+This module provides a collection of utility functions and helper classes (e.g., `StreamBackedCorpusView`) specifically designed to support the implementation of various corpus readers. This includes functionalities for handling file paths, character encodings, and efficient stream processing of large data files.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/corpus/reader/util.py#L0-L0" target="_blank" rel="noopener noreferrer">`nltk.corpus.reader.util` (0:0)</a>
+
+
+
+
+
+### nltk.corpus.reader.plaintext
+
+A concrete implementation of a corpus reader designed to process and provide access to plain text corpora. It handles the basic reading and tokenization of raw text files, making it a fundamental reader for many common datasets.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/corpus/reader/plaintext.py#L0-L0" target="_blank" rel="noopener noreferrer">`nltk.corpus.reader.plaintext` (0:0)</a>
+
+
+
+
+
+### nltk.corpus.reader.wordnet
+
+A specialized corpus reader for the WordNet lexical database. It provides methods to access WordNet's synsets, lemmas, definitions, and relationships, enabling semantic processing. This demonstrates the extensibility of the `corpus.reader.api`.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/corpus/reader/wordnet.py#L0-L0" target="_blank" rel="noopener noreferrer">`nltk.corpus.reader.wordnet` (0:0)</a>
+
+
+
+
+
+### nltk.internals
+
+This module provides internal utility functions and configurations for NLTK, including mechanisms for locating external programs (like Java for Stanford tools) and managing internal data paths. It's a foundational dependency for data loading and external tool integration.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/internals.py#L0-L0" target="_blank" rel="noopener noreferrer">`nltk.internals` (0:0)</a>
+
+
+
+
+
+### nltk.tokenize
+
+This package provides various tokenization algorithms, which are essential for breaking down raw text from corpora into meaningful units (words, sentences). Many corpus readers rely on tokenizers to provide structured data for further NLP tasks.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `nltk.tokenize` (0:0)
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Syntactic_Structural_Analysis.md
+++ b/.codeboarding/Syntactic_Structural_Analysis.md
@@ -1,0 +1,305 @@
+```mermaid
+
+graph LR
+
+    nltk_tree_tree_Tree["nltk.tree.tree.Tree"]
+
+    nltk_grammar_CFG["nltk.grammar.CFG"]
+
+    nltk_featstruct_FeatStruct["nltk.featstruct.FeatStruct"]
+
+    nltk_parse_api_ParserI["nltk.parse.api.ParserI"]
+
+    nltk_parse_chart_ChartParser["nltk.parse.chart.ChartParser"]
+
+    nltk_parse_dependencygraph_DependencyGraph["nltk.parse.dependencygraph.DependencyGraph"]
+
+    nltk_tag_api_TaggerI["nltk.tag.api.TaggerI"]
+
+    nltk_tag_sequential_SequentialBackoffTagger["nltk.tag.sequential.SequentialBackoffTagger"]
+
+    nltk_tag_hmm_HiddenMarkovModelTagger["nltk.tag.hmm.HiddenMarkovModelTagger"]
+
+    nltk_chunk_regexp_RegexpParser["nltk.chunk.regexp.RegexpParser"]
+
+    nltk_parse_api_ParserI -- "produces" --> nltk_tree_tree_Tree
+
+    nltk_chunk_regexp_RegexpParser -- "takes as input and transforms" --> nltk_tree_tree_Tree
+
+    nltk_parse_dependencygraph_DependencyGraph -- "can be converted to/from" --> nltk_tree_tree_Tree
+
+    nltk_parse_chart_ChartParser -- "consumes" --> nltk_grammar_CFG
+
+    nltk_tree_tree_Tree -- "defines grammar rules for, productions generated from" --> nltk_grammar_CFG
+
+    nltk_grammar_CFG -- "utilizes for feature-based grammars" --> nltk_featstruct_FeatStruct
+
+    nltk_parse_chart_ChartParser -- "implements" --> nltk_parse_api_ParserI
+
+    nltk_parse_api_ParserI -- "produces for dependency parsing" --> nltk_parse_dependencygraph_DependencyGraph
+
+    nltk_parse_chart_ChartParser -- "produces" --> nltk_tree_tree_Tree
+
+    nltk_tag_sequential_SequentialBackoffTagger -- "implements" --> nltk_tag_api_TaggerI
+
+    nltk_tag_hmm_HiddenMarkovModelTagger -- "implements" --> nltk_tag_api_TaggerI
+
+    nltk_tag_sequential_SequentialBackoffTagger -- "can use as backoff strategy" --> nltk_tag_hmm_HiddenMarkovModelTagger
+
+    nltk_chunk_regexp_RegexpParser -- "implicitly relies on output from" --> nltk_tag_api_TaggerI
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+This section provides a detailed overview of the core components within the `Syntactic & Structural Analysis` subsystem of NLTK. These components are fundamental because they represent the primary data structures, formalisms, and algorithmic approaches used for analyzing the grammatical and structural properties of text, from basic tagging to complex parsing.
+
+
+
+### nltk.tree.tree.Tree
+
+This class serves as the fundamental data structure for representing hierarchical linguistic structures, such as parse trees and chunk structures. It provides a robust framework for manipulating, traversing, and converting these tree representations, making it central to both constituent parsing and chunking.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/tree/tree.py#L444-L477" target="_blank" rel="noopener noreferrer">`nltk.tree.tree.Tree:chomsky_normal_form` (444:477)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/tree/tree.py#L479-L502" target="_blank" rel="noopener noreferrer">`nltk.tree.tree.Tree:un_chomsky_normal_form` (479:502)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/tree/tree.py#L504-L525" target="_blank" rel="noopener noreferrer">`nltk.tree.tree.Tree:collapse_unary` (504:525)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/tree/tree.py#L351-L374" target="_blank" rel="noopener noreferrer">`nltk.tree.tree.Tree:productions` (351:374)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/tree/tree.py#L376-L394" target="_blank" rel="noopener noreferrer">`nltk.tree.tree.Tree:pos` (376:394)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/tree/tree.py#L581-L699" target="_blank" rel="noopener noreferrer">`nltk.tree.tree.Tree:fromstring` (581:699)</a>
+
+
+
+
+
+### nltk.grammar.CFG
+
+Represents Context-Free Grammars, which define the formal rules for generating or parsing sentences. It manages a set of productions and a start symbol, and provides functionalities for checking grammar properties and transforming grammars (e.g., to Chomsky Normal Form). It is crucial for rule-based parsing.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/grammar.py#L738-L758" target="_blank" rel="noopener noreferrer">`nltk.grammar.CFG:chomsky_normal_form` (738:758)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/grammar.py#L787-L817" target="_blank" rel="noopener noreferrer">`nltk.grammar.CFG:binarize` (787:817)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/grammar.py#L0-L0" target="_blank" rel="noopener noreferrer">`nltk.grammar.CFG:eliminate_start_rules` (0:0)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/grammar.py#L841-L880" target="_blank" rel="noopener noreferrer">`nltk.grammar.CFG:remove_mixed_rules` (841:880)</a>
+
+
+
+
+
+### nltk.featstruct.FeatStruct
+
+This abstract base class represents feature structures, which are used in feature-based grammars to capture more complex linguistic information than simple atomic categories. It supports operations like unification, crucial for advanced grammatical analysis and constraint satisfaction.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/featstruct.py#L381-L390" target="_blank" rel="noopener noreferrer">`nltk.featstruct.FeatStruct:freeze` (381:390)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/featstruct.py#L448-L454" target="_blank" rel="noopener noreferrer">`nltk.featstruct.FeatStruct:walk` (448:454)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/featstruct.py#L0-L0" target="_blank" rel="noopener noreferrer">`nltk.featstruct.FeatStruct:substitute` (0:0)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/featstruct.py#L0-L0" target="_blank" rel="noopener noreferrer">`nltk.featstruct.FeatStruct:retract` (0:0)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/featstruct.py#L0-L0" target="_blank" rel="noopener noreferrer">`nltk.featstruct.FeatStruct:rename` (0:0)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/featstruct.py#L531-L532" target="_blank" rel="noopener noreferrer">`nltk.featstruct.FeatStruct:unify` (531:532)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/featstruct.py#L534-L540" target="_blank" rel="noopener noreferrer">`nltk.featstruct.FeatStruct:subsumes` (534:540)</a>
+
+
+
+
+
+### nltk.parse.api.ParserI
+
+An abstract interface that defines the contract for all parsers within NLTK. It specifies core methods like `parse` and `parse_sents`, ensuring a consistent API for various parsing implementations (e.g., chart parsers, dependency parsers).
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/parse/api.py#L36-L56" target="_blank" rel="noopener noreferrer">`nltk.parse.api.ParserI:parse` (36:56)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/parse/api.py#L58-L63" target="_blank" rel="noopener noreferrer">`nltk.parse.api.ParserI:parse_sents` (58:63)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/parse/api.py#L30-L34" target="_blank" rel="noopener noreferrer">`nltk.parse.api.ParserI:grammar` (30:34)</a>
+
+
+
+
+
+### nltk.parse.chart.ChartParser
+
+A concrete implementation of `ParserI` and a base class for chart-based parsers. These parsers employ a dynamic programming approach to efficiently parse sentences by building a chart of possible constituents. This is a common and efficient parsing strategy for context-free grammars.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/parse/chart.py#L1472-L1474" target="_blank" rel="noopener noreferrer">`nltk.parse.chart.ChartParser:parse` (1472:1474)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/parse/chart.py#L0-L0" target="_blank" rel="noopener noreferrer">`nltk.parse.chart.ChartParser:trace` (0:0)</a>
+
+
+
+
+
+### nltk.parse.dependencygraph.DependencyGraph
+
+Represents dependency parse trees, where words are linked by directed, labeled relations, focusing on grammatical relationships rather than constituent structure. It provides methods for graph manipulation, conversion to other formats, and structural analysis.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/parse/dependencygraph.py#L0-L0" target="_blank" rel="noopener noreferrer">`nltk.parse.dependencygraph.DependencyGraph:to_tree` (0:0)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/parse/dependencygraph.py#L412-L425" target="_blank" rel="noopener noreferrer">`nltk.parse.dependencygraph.DependencyGraph:triples` (412:425)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/parse/dependencygraph.py#L141-L184" target="_blank" rel="noopener noreferrer">`nltk.parse.dependencygraph.DependencyGraph:to_dot` (141:184)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/parse/dependencygraph.py#L501-L528" target="_blank" rel="noopener noreferrer">`nltk.parse.dependencygraph.DependencyGraph:to_conll` (501:528)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/parse/dependencygraph.py#L0-L0" target="_blank" rel="noopener noreferrer">`nltk.parse.dependencygraph.DependencyGraph:find_cycles` (0:0)</a>
+
+
+
+
+
+### nltk.tag.api.TaggerI
+
+An abstract interface for all taggers in NLTK, defining methods for tagging individual sentences or batches of sentences. This ensures interchangeability among different tagging algorithms (e.g., rule-based, statistical).
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/tag/api.py#L39-L48" target="_blank" rel="noopener noreferrer">`nltk.tag.api.TaggerI:tag` (39:48)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/tag/api.py#L50-L56" target="_blank" rel="noopener noreferrer">`nltk.tag.api.TaggerI:tag_sents` (50:56)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/tag/api.py#L62-L76" target="_blank" rel="noopener noreferrer">`nltk.tag.api.TaggerI:accuracy` (62:76)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/tag/api.py#L96-L154" target="_blank" rel="noopener noreferrer">`nltk.tag.api.TaggerI:confusion` (96:154)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/tag/api.py#L156-L171" target="_blank" rel="noopener noreferrer">`nltk.tag.api.TaggerI:recall` (156:171)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/tag/api.py#L173-L188" target="_blank" rel="noopener noreferrer">`nltk.tag.api.TaggerI:precision` (173:188)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/tag/api.py#L190-L218" target="_blank" rel="noopener noreferrer">`nltk.tag.api.TaggerI:f_measure` (190:218)</a>
+
+
+
+
+
+### nltk.tag.sequential.SequentialBackoffTagger
+
+A base class for sequential taggers that employ a backoff strategy. This means they try more specific tagging models first and fall back to simpler ones if a tag cannot be determined, improving robustness and coverage.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/tag/sequential.py#L86-L102" target="_blank" rel="noopener noreferrer">`nltk.tag.sequential.SequentialBackoffTagger:choose_tag` (86:102)</a>
+
+
+
+
+
+### nltk.tag.hmm.HiddenMarkovModelTagger
+
+Implements a Hidden Markov Model (HMM) for part-of-speech tagging. This is a statistical approach that models sequences of observations (words) and hidden states (POS tags) to predict the most likely tag sequence using algorithms like Viterbi.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/tag/hmm.py#L385-L411" target="_blank" rel="noopener noreferrer">`nltk.tag.hmm.HiddenMarkovModelTagger:_best_path` (385:411)</a>
+
+
+
+
+
+### nltk.chunk.regexp.RegexpParser
+
+A chunk parser that uses regular expressions to identify and group sequences of tagged words into "chunks" (e.g., noun phrases, verb phrases). This provides a rule-based approach to shallow parsing, often applied after POS tagging.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/chunk/regexp.py#L1256-L1278" target="_blank" rel="noopener noreferrer">`nltk.chunk.regexp.RegexpParser:parse` (1256:1278)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/chunk/regexp.py#L0-L0" target="_blank" rel="noopener noreferrer">`nltk.chunk.regexp.RegexpParser:grammar` (0:0)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Text_Preprocessing.md
+++ b/.codeboarding/Text_Preprocessing.md
@@ -1,0 +1,109 @@
+```mermaid
+
+graph LR
+
+    PunktSentenceTokenizer["PunktSentenceTokenizer"]
+
+    TreebankWordTokenizer["TreebankWordTokenizer"]
+
+    PorterStemmer["PorterStemmer"]
+
+    WordNetLemmatizer["WordNetLemmatizer"]
+
+    PunktSentenceTokenizer -- "produces input for" --> TreebankWordTokenizer
+
+    TreebankWordTokenizer -- "produces input for" --> PorterStemmer
+
+    TreebankWordTokenizer -- "produces input for" --> WordNetLemmatizer
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+The Text Preprocessing component is designed to transform raw textual data into a structured format suitable for various Natural Language Processing (NLP) tasks. It primarily handles the initial stages of text normalization, specifically tokenization and morphological normalization (stemming and lemmatization).
+
+
+
+### PunktSentenceTokenizer
+
+This component is responsible for segmenting raw text into individual sentences. It employs an unsupervised algorithm to learn patterns of abbreviations, collocations, and sentence-starting words, enabling it to accurately identify sentence boundaries.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/tokenize/punkt.py#L1238-L1733" target="_blank" rel="noopener noreferrer">`nltk.tokenize.punkt.PunktSentenceTokenizer` (1238:1733)</a>
+
+
+
+
+
+### TreebankWordTokenizer
+
+This component performs word tokenization, splitting sentences into individual words and punctuation marks. It adheres to the conventions of the Penn Treebank, handling common English contractions and various punctuation rules to produce a consistent stream of tokens.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/tokenize/treebank.py#L28-L212" target="_blank" rel="noopener noreferrer">`nltk.tokenize.treebank.TreebankWordTokenizer` (28:212)</a>
+
+
+
+
+
+### PorterStemmer
+
+This component implements the Porter stemming algorithm, a rule-based method for reducing words to their morphological root or stem. It removes common suffixes to conflate different inflected forms of a word into a single base form (e.g., "running," "runs," "ran" all become "run").
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/stem/porter.py#L1-L1" target="_blank" rel="noopener noreferrer">`nltk.stem.porter.PorterStemmer` (1:1)</a>
+
+
+
+
+
+### WordNetLemmatizer
+
+This component performs lemmatization, a more linguistically sophisticated process than stemming. It uses the WordNet lexical database to reduce words to their canonical base form (lemma), considering their part of speech (e.g., "better" becomes "good," "am" becomes "be").
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/stem/wordnet.py#L10-L88" target="_blank" rel="noopener noreferrer">`nltk.stem.wordnet.WordNetLemmatizer` (10:88)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,239 @@
+```mermaid
+
+graph LR
+
+    Core_Utilities_Foundations["Core Utilities & Foundations"]
+
+    Data_Corpus_Management["Data & Corpus Management"]
+
+    Text_Preprocessing["Text Preprocessing"]
+
+    Syntactic_Structural_Analysis["Syntactic & Structural Analysis"]
+
+    Advanced_NLP_Models_Evaluation["Advanced NLP Models & Evaluation"]
+
+    Applications_Interfaces["Applications & Interfaces"]
+
+    Core_Utilities_Foundations -- "provides foundational services to" --> Data_Corpus_Management
+
+    Core_Utilities_Foundations -- "provides foundational services to" --> Text_Preprocessing
+
+    Core_Utilities_Foundations -- "provides foundational services to" --> Syntactic_Structural_Analysis
+
+    Core_Utilities_Foundations -- "provides foundational services to" --> Advanced_NLP_Models_Evaluation
+
+    Core_Utilities_Foundations -- "provides foundational services to" --> Applications_Interfaces
+
+    Core_Utilities_Foundations -- "supports statistical computations for" --> Advanced_NLP_Models_Evaluation
+
+    Data_Corpus_Management -- "provides raw linguistic data to" --> Text_Preprocessing
+
+    Data_Corpus_Management -- "supplies pre-trained models and grammars to" --> Syntactic_Structural_Analysis
+
+    Text_Preprocessing -- "provides tokenized and normalized text to" --> Syntactic_Structural_Analysis
+
+    Text_Preprocessing -- "provides tokenized and normalized text to" --> Advanced_NLP_Models_Evaluation
+
+    Syntactic_Structural_Analysis -- "provides structured linguistic data to" --> Advanced_NLP_Models_Evaluation
+
+    Applications_Interfaces -- "utilizes functionalities from" --> Core_Utilities_Foundations
+
+    Applications_Interfaces -- "utilizes functionalities from" --> Data_Corpus_Management
+
+    Applications_Interfaces -- "utilizes functionalities from" --> Text_Preprocessing
+
+    Applications_Interfaces -- "utilizes functionalities from" --> Syntactic_Structural_Analysis
+
+    Applications_Interfaces -- "utilizes functionalities from" --> Advanced_NLP_Models_Evaluation
+
+    click Core_Utilities_Foundations href "https://github.com/nltk/nltk/blob/develop/.codeboarding//Core_Utilities_Foundations.md" "Details"
+
+    click Data_Corpus_Management href "https://github.com/nltk/nltk/blob/develop/.codeboarding//Data_Corpus_Management.md" "Details"
+
+    click Text_Preprocessing href "https://github.com/nltk/nltk/blob/develop/.codeboarding//Text_Preprocessing.md" "Details"
+
+    click Syntactic_Structural_Analysis href "https://github.com/nltk/nltk/blob/develop/.codeboarding//Syntactic_Structural_Analysis.md" "Details"
+
+    click Advanced_NLP_Models_Evaluation href "https://github.com/nltk/nltk/blob/develop/.codeboarding//Advanced_NLP_Models_Evaluation.md" "Details"
+
+    click Applications_Interfaces href "https://github.com/nltk/nltk/blob/develop/.codeboarding//Applications_Interfaces.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+Final architecture analysis for `nltk`, consolidating insights from both CFG and Source analysis into a high-level data flow overview. The `nltk` library is designed with a modular architecture, allowing for a clear separation of concerns across various Natural Language Processing (NLP) tasks. The core components are structured to facilitate a pipeline approach, where processed data flows from foundational layers to more complex analytical and application-oriented modules. The six components are chosen because they represent the fundamental, distinct, and logically grouped functionalities that constitute the core of the NLTK library. They illustrate a typical NLP pipeline, from raw data to advanced analysis and application: Core Utilities & Foundations (bedrock), Data & Corpus Management (fundamental for resources), Text Preprocessing (initial and crucial step), Syntactic & Structural Analysis (core linguistic intelligence), Advanced NLP Models & Evaluation (sophisticated algorithms and machine learning capabilities), and Applications & Interfaces (fundamental for user accessibility and practical utility). Together, these components form a comprehensive, modular, and highly interconnected architecture that enables NLTK to address a vast array of Natural Language Processing challenges, from basic text manipulation to complex semantic and statistical modeling.
+
+
+
+### Core Utilities & Foundations
+
+This component provides the fundamental building blocks for the entire NLTK library. It includes general-purpose data structures (e.g., `OrderedDict`, `Trie`), essential utility functions, internal helper functions, compatibility layers, and core statistical tools like frequency distributions and various probability models. It underpins almost all other NLTK functionalities.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/util.py#L1-L1" target="_blank" rel="noopener noreferrer">`nltk.util` (1:1)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/collections.py#L1-L1" target="_blank" rel="noopener noreferrer">`nltk.collections` (1:1)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/internals.py#L1-L1" target="_blank" rel="noopener noreferrer">`nltk.internals` (1:1)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/decorators.py#L1-L1" target="_blank" rel="noopener noreferrer">`nltk.decorators` (1:1)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/jsontags.py#L1-L1" target="_blank" rel="noopener noreferrer">`nltk.jsontags` (1:1)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/compat.py#L1-L1" target="_blank" rel="noopener noreferrer">`nltk.compat` (1:1)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/lazyimport.py#L1-L1" target="_blank" rel="noopener noreferrer">`nltk.lazyimport` (1:1)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/langnames.py#L1-L1" target="_blank" rel="noopener noreferrer">`nltk.langnames` (1:1)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/probability.py#L1-L1" target="_blank" rel="noopener noreferrer">`nltk.probability` (1:1)</a>
+
+
+
+
+
+### Data & Corpus Management
+
+This component is responsible for managing NLTK's extensive collection of linguistic data. It handles the loading, locating, and downloading of corpora, pre-trained models, and grammars. It also provides standardized interfaces and reader classes for accessing and processing various types of linguistic data, abstracting away underlying file formats.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/data.py#L1-L1" target="_blank" rel="noopener noreferrer">`nltk.data` (1:1)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/downloader.py#L1-L1" target="_blank" rel="noopener noreferrer">`nltk.downloader` (1:1)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/corpus/reader/api.py#L1-L1" target="_blank" rel="noopener noreferrer">`nltk.corpus.reader.api` (1:1)</a>
+
+- `nltk.corpus.reader` (1:1)
+
+
+
+
+
+### Text Preprocessing
+
+This component focuses on transforming raw text into structured linguistic units suitable for further analysis. Its primary functions include tokenization (breaking down text into words, sentences, or multi-word expressions) and morphological normalization (reducing words to their base or root forms through stemming and lemmatization).
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `nltk.tokenize` (1:1)
+
+- `nltk.stem` (1:1)
+
+
+
+
+
+### Syntactic & Structural Analysis
+
+This component analyzes the grammatical and structural properties of text. It includes functionalities for Part-of-Speech (POS) tagging (assigning grammatical categories to words), chunking (identifying multi-word phrases), Named Entity Recognition (categorizing entities like persons or locations), and parsing (generating syntactic parse trees or dependency graphs). It also defines formal grammars and handles feature structures and tree representations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `nltk.tag` (1:1)
+
+- `nltk.chunk` (1:1)
+
+- `nltk.parse` (1:1)
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/grammar.py#L1-L1" target="_blank" rel="noopener noreferrer">`nltk.grammar` (1:1)</a>
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/featstruct.py#L1-L1" target="_blank" rel="noopener noreferrer">`nltk.featstruct` (1:1)</a>
+
+- `nltk.tree` (1:1)
+
+
+
+
+
+### Advanced NLP Models & Evaluation
+
+This component encompasses higher-level NLP tasks that often involve statistical or machine learning models. It includes tools for building and evaluating statistical language models (e.g., N-gram models), machine translation (e.g., IBM models, BLEU scores), text classification, and clustering. Crucially, it also provides a comprehensive suite of metrics for evaluating the performance and quality of various NLP models and tasks.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `nltk.lm` (1:1)
+
+- `nltk.translate` (1:1)
+
+- `nltk.classify` (1:1)
+
+- `nltk.cluster` (1:1)
+
+- `nltk.metrics` (1:1)
+
+
+
+
+
+### Applications & Interfaces
+
+This component provides interactive applications, graphical user interfaces (GUIs), and specific integrations (e.g., Twitter API) to demonstrate NLTK's capabilities and allow users to interact with NLP concepts. It also includes utilities for tasks like collocation discovery and simple chat-bots, serving as a user-facing layer for the library's functionalities.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `nltk.app` (1:1)
+
+- `nltk.draw` (1:1)
+
+- `nltk.twitter` (1:1)
+
+- <a href="https://github.com/nltk/nltk/blob/master/nltk/collocations.py#L1-L1" target="_blank" rel="noopener noreferrer">`nltk.collocations` (1:1)</a>
+
+- `nltk.chat` (1:1)
+
+- `nltk.ccg` (1:1)
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
With this PR, I intorduce high-level diagrams of the nltk codebase to help new contributors orient themselves in the codebase.
You can see how the proposed changes render here:
https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/nltk/on_boarding.md

I can see that the nltk has almost 3K forks. This means that as well as the love we all have for nltk (14k :stars:), a lot of people play around with the codebase. The goal of the diagrams is to help those people navigate the codebase faster and identify the component they want to play around, and now start working on it with the big-picture context. Would love to hear what is your opinion on this!

I'd usually open a discussion first, but you don't have them enabled for this repo so I decided to go ahead and open a PR.

Any feedback is more than welcome!

Full transparency: we’re exploring this idea as a potential startup, but we’re still early and figuring out what’s actually useful to developers. (We also just introduced completely free github action to keep the docs up-to-date, lmk if you like the idea and I can integrate it for you :) )

