### PR TITLE
Duplicate only real adjective satellites

### DIFF
--- a/nltk/corpus/reader/sentiwordnet.py
+++ b/nltk/corpus/reader/sentiwordnet.py
@@ -23,7 +23,7 @@ http://sentiwordnet.isti.cnr.it/
  SentiSynset('slow.v.03'), SentiSynset('slow.a.01'),\
  SentiSynset('slow.a.02'), SentiSynset('dense.s.04'),\
  SentiSynset('slow.a.04'), SentiSynset('boring.s.01'),\
- SentiSynset('dull.s.08'), SentiSynset('slowly.r.01'),\
+ SentiSynset('dull.s.05'), SentiSynset('slowly.r.01'),\
  SentiSynset('behind.r.03')]
     >>> happy = swn.senti_synsets('happy', 'a')
     >>> happy0 = list(happy)[0]

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -1327,7 +1327,7 @@ class WordNetCorpusReader(CorpusReader):
             self.add_omw()
 
         if lang not in self.langs():
-            raise WordNetError("Language is not supported.")
+            raise WordNetError(f"Language {lang} is not supported.")
 
         if self._exomw_reader and lang not in self.omw_langs:
             reader = self._exomw_reader
@@ -1452,11 +1452,14 @@ class WordNetCorpusReader(CorpusReader):
                     # map lemmas and parts of speech to synsets
                     self._lemma_pos_offset_map[lemma][pos] = synset_offsets
                     if pos == ADJ:
-                        # Filter adjective satellites:
+                        # index.adj uses only the ADJ pos, so identify ADJ_SAT using satellites set
                         satellite_offsets = [
-                            of for of in synset_offsets if of in self.satellite_offsets
+                            # Keep the ordering from index.adj
+                            offset
+                            for offset in synset_offsets
+                            if offset in self.satellite_offsets
                         ]
-                        # Duplicate only real satellites
+                        # Duplicate only a (possibly empty) list of real satellites
                         self._lemma_pos_offset_map[lemma][ADJ_SAT] = satellite_offsets
 
     def _load_exception_map(self):

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -1383,6 +1383,13 @@ class WordNetCorpusReader(CorpusReader):
         return list(self.provenances.keys())
 
     def _scan_satellites(self):
+        """
+        Scans the adjective data file and populates self.satellite_offsets with all adjective satellite synset offsets.
+
+        This method reads the adjective data file associated with the corpus reader,
+        identifies synsets of type 's' (adjective satellites), and adds their offsets
+        to the self.satellite_offsets set. The method does not return a value.
+        """
         adj_data_file = self._data_file(ADJ)
         satellite_offsets = set()
         adj_data_file.seek(0)
@@ -1449,11 +1456,8 @@ class WordNetCorpusReader(CorpusReader):
                         satellite_offsets = [
                             of for of in synset_offsets if of in self.satellite_offsets
                         ]
-                        if satellite_offsets:
-                            # Duplicate only real satellites
-                            self._lemma_pos_offset_map[lemma][
-                                ADJ_SAT
-                            ] = satellite_offsets
+                        # Duplicate only real satellites
+                        self._lemma_pos_offset_map[lemma][ADJ_SAT] = satellite_offsets
 
     def _load_exception_map(self):
         # load the exception file data into memory

--- a/nltk/test/wordnet.doctest
+++ b/nltk/test/wordnet.doctest
@@ -397,7 +397,7 @@ Walk through the noun synsets looking at their hypernyms:
     Synset('object.n.01') [Synset('physical_entity.n.01')]
 
 
-# Test for PR #3400: When specifying pos="a", both head adjectives and adjective satellites are returned.
+Issue 3399: When specifying pos="a", both head adjectives and adjective satellites are returned.
 
     >>> from nltk.corpus import wordnet as wn
     >>> # All adjective synsets (heads and satellites) for "good"

--- a/nltk/test/wordnet.doctest
+++ b/nltk/test/wordnet.doctest
@@ -156,7 +156,7 @@ Lemmas
     >>> wn.lemma_from_key(eat.key()).synset()
     Synset('feed.v.06')
     >>> wn.lemma_from_key('feebleminded%5:00:00:retarded:00')
-    Lemma('backward.s.03.feebleminded')
+    Lemma('backward.s.01.feebleminded')
     >>> for lemma in wn.synset('eat.v.03').lemmas():
     ...     print(lemma, lemma.count())
     ...
@@ -395,6 +395,29 @@ Walk through the noun synsets looking at their hypernyms:
     Synset('abstraction.n.06') [Synset('entity.n.01')]
     Synset('thing.n.12') [Synset('physical_entity.n.01')]
     Synset('object.n.01') [Synset('physical_entity.n.01')]
+
+
+# Test for PR #3400: When specifying pos="a", both head adjectives and adjective satellites are returned.
+
+    >>> from nltk.corpus import wordnet as wn
+    >>> # All adjective synsets (heads and satellites) for "good"
+    >>> syns_a = wn.synsets('good', pos='a')
+    >>> sorted(set(s.pos() for s in syns_a))
+    ['a', 's']
+    >>> # Only head adjectives
+    >>> syns_head = [s for s in syns_a if s.pos() == 'a']
+    >>> all(s.pos() == 'a' for s in syns_head)
+    True
+    >>> # Only satellites
+    >>> syns_sat = wn.synsets('good', pos='s')
+    >>> all(s.pos() == 's' for s in syns_sat)
+    True
+    >>> # The union when using pos='a' matches the combined sets
+    >>> set(syns_a) == set(syns_head) | set(syns_sat)
+    True
+    >>> # But pos='s' never returns head adjectives
+    >>> all(s.pos() != 'a' for s in wn.synsets('good', pos='s'))
+    True
 
 
 ------
@@ -648,7 +671,7 @@ Issue 3077: Incorrect part-of-speech filtering in all_synsets
     >>> next(wn.all_synsets(lang="hrv", pos="v"))
     Synset('breathe.v.01')
     >>> next(wn.all_synsets(lang="hrv", pos="s"))
-    Synset('ideological.s.02')
+    Synset('ideological.s.01')
     >>> next(wn.all_synsets(lang="hrv", pos="a"))
     Synset('able.a.01')
 


### PR DESCRIPTION
### Fix #3399 by duplicating only real adjective satellites in lemma_pos_offset map.

**Background:**  
In WordNet, adjectives are divided into head adjectives (pos `'a'`) and adjective satellites (pos `'s'`). Traditionally, when querying synsets with `pos='a'`, both head adjectives and satellites are returned, as satellites are a subtype of adjectives. This matches most users’ expectations and is the established behavior in NLTK.

**Change:**  
This PR ensures that only true adjective satellites are duplicated under the satellite key (`'s'`) in the `lemma_pos_offset_map`, rather than indiscriminately duplicating all adjectives. This makes the internal data structure more faithful to the actual distinction in WordNet.

**User-visible behavior and impact:**  
- When you call `wn.synsets('lemma', pos='a')`, you still get **both head adjectives and adjective satellites**, as before.
- When you call `wn.synsets('lemma', pos='s')`, you get **only adjective satellites**.
- However, since spurious (incorrect) adjective satellite senses are now removed, some previously available “satellite” senses will disappear when queried with `pos='s'`.
- **This is not a low-impact change:** If a satellite sense that was previously spurious had a low sense number, then all following satellite senses will shift to a lower index after its removal. Thus, a few doctest or user outputs involving sense numbers for adjective satellites may need to be updated to match the new, correct numbering.
- For most users and typical scripts relying on `pos='a'` or default queries, behavior remains as expected. Only code or tests that depend on the enumeration or existence of specific satellite senses with `pos='s'` will require correction.

**Summary:**  
This change increases accuracy and maintainability, but may require updating some tests and scripts where the output for adjective satellites (with `pos='s'`) changes due to the removal of spurious senses and renumbering of the remaining ones.