### PR TITLE
Fix percentage escape in new-style string formatting

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -309,6 +309,7 @@
 - Peter de Blanc <https://github.com/pdeblanc>
 - Jose Cols <https://github.com/josecols>
 - Christopher Smith <https://github.com/smithct2>
+- Ryan Mannion <https://github.com/ryanamannion>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 

--- a/nltk/chunk/util.py
+++ b/nltk/chunk/util.py
@@ -294,10 +294,10 @@ class ChunkScore:
         """
         return (
             "ChunkParse score:\n"
-            + (f"    IOB Accuracy: {self.accuracy() * 100:5.1f}%%\n")
-            + (f"    Precision:    {self.precision() * 100:5.1f}%%\n")
-            + (f"    Recall:       {self.recall() * 100:5.1f}%%\n")
-            + (f"    F-Measure:    {self.f_measure() * 100:5.1f}%%")
+            + f"    IOB Accuracy: {self.accuracy() * 100:5.1f}%\n"
+            + f"    Precision:    {self.precision() * 100:5.1f}%\n"
+            + f"    Recall:       {self.recall() * 100:5.1f}%\n"
+            + f"    F-Measure:    {self.f_measure() * 100:5.1f}%"
         )
 
 


### PR DESCRIPTION
Commit https://github.com/nltk/nltk/commit/307dc7b36242004c56906b98a2d9597444df7af9 changed this message to new-style string formatting from printf-style, but did not remove the escape character for the percentage. This lead to the issue in https://github.com/nltk/nltk/issues/3414

This PR removes the now-unnecessary escape characters, as well as redundant parens in the multi-line string.

The example from [Chapter 7 of the NLTK book](https://www.nltk.org/book/ch07.html) Section 3.2 now prints as expected:

```pyi
>>> import nltk
>>> from nltk.corpus import conll2000
>>> cp = nltk.RegexpParser("")
>>> test_sents = conll2000.chunked_sents('test.txt', chunk_types=['NP'])
>>> print(cp.evaluate(test_sents))
<python-input-4>:1: DeprecationWarning: 
  Function evaluate() has been deprecated.  Use accuracy(gold)
  instead.
ChunkParse score:
    IOB Accuracy:  43.4%
    Precision:      0.0%
    Recall:         0.0%
    F-Measure:      0.0%
```