### PR TITLE
drop python 3.8 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,7 +80,7 @@ jobs:
     needs: [cache_nltk_data, cache_third_party]
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,7 +174,7 @@ The [`.github/workflows/ci.yaml`](https://github.com/nltk/nltk/blob/develop/.git
        - Otherwise, download all the data packages through `nltk.download('all')`.
 
   - The `test` job
-    - tests against supported Python versions (`3.8`, `3.9`, `3.10`, `3.11`, `3.12`).
+    - tests against supported Python versions (`3.9`, `3.10`, `3.11`, `3.12`).
     - tests on `ubuntu-latest` and `macos-latest`.
     - relies on the `cache_nltk_data` job to ensure that `nltk_data` is available.
     - performs these steps:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 NLTK -- the Natural Language Toolkit -- is a suite of open source Python
 modules, data sets, and tutorials supporting research and development in Natural
-Language Processing. NLTK requires Python version 3.8, 3.9, 3.10, 3.11 or 3.12.
+Language Processing. NLTK requires Python version 3.9, 3.10, 3.11 or 3.12.
 
 For documentation, please visit [nltk.org](https://www.nltk.org/).
 

--- a/RELEASE-HOWTO.txt
+++ b/RELEASE-HOWTO.txt
@@ -13,7 +13,7 @@ Building an NLTK distribution
    - Optionally test demonstration code locally
      make demotest
    - Optionally test individual modules:
-     tox-3.8 -e py38 nltk.package.module
+     tox -e py312 nltk.package.module
    - Check the data index is up-to-date:
      cd ../nltk_data; make; push
 

--- a/nltk/__init__.py
+++ b/nltk/__init__.py
@@ -53,7 +53,7 @@ __license__ = "Apache License, Version 2.0"
 # Description of the toolkit, keywords, and the project's primary URL.
 __longdescr__ = """\
 The Natural Language Toolkit (NLTK) is a Python package for
-natural language processing.  NLTK requires Python 3.8, 3.9, 3.10, 3.11, 3.12 or 3.13."""
+natural language processing.  NLTK requires Python 3.9, 3.10, 3.11, 3.12 or 3.13."""
 __keywords__ = [
     "NLP",
     "CL",
@@ -85,7 +85,6 @@ __classifiers__ = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     },
     long_description="""\
 The Natural Language Toolkit (NLTK) is a Python package for
-natural language processing.  NLTK requires Python 3.8, 3.9, 3.10, 3.11, 3.12, or 3.13.""",
+natural language processing.  NLTK requires Python 3.9, 3.10, 3.11, 3.12, or 3.13.""",
     license="Apache License, Version 2.0",
     keywords=[
         "NLP",
@@ -95,7 +95,6 @@ natural language processing.  NLTK requires Python 3.8, 3.9, 3.10, 3.11, 3.12, o
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
@@ -112,7 +111,7 @@ natural language processing.  NLTK requires Python 3.8, 3.9, 3.10, 3.11, 3.12, o
         "Topic :: Text Processing :: Linguistic",
     ],
     package_data={"nltk": ["test/*.doctest", "VERSION"]},
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=[
         "click",
         "joblib",

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    py{38,39,310,311,312,313}
+    py{39,310,311,312,313}
     pypy
-    py{38,39,310,311,312,313}-nodeps
-    py{38,39,310,311,312,313}-jenkins
+    py{39,310,311,312,313}-nodeps
+    py{39,310,311,312,313}-jenkins
     py-travis
 
 [testenv]
@@ -55,12 +55,6 @@ deps =
 commands =
     pytest
 
-[testenv:py38-nodeps]
-basepython = python3.8
-deps =
-    pytest
-    pytest-mock
-commands = pytest
 
 [testenv:py39-nodeps]
 basepython = python3.9

--- a/web/install.rst
+++ b/web/install.rst
@@ -1,7 +1,7 @@
 Installing NLTK
 ===============
 
-NLTK requires Python versions 3.8, 3.9, 3.10, 3.11, 3.12 or 3.13.
+NLTK requires Python versions 3.9, 3.10, 3.11, 3.12 or 3.13.
 
 For Windows users, it is strongly recommended that you go through this guide to install Python 3 successfully https://docs.python-guide.org/starting/install3/win/#install3-windows
 
@@ -29,10 +29,10 @@ These instructions assume that you do not already have Python installed on your 
 32-bit binary installation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-#. Install Python 3.8: https://www.python.org/downloads/ (avoid the 64-bit versions)
+#. Install Python 3.12: https://www.python.org/downloads/ (avoid the 64-bit versions)
 #. Install Numpy (optional): https://numpy.org/install/
 #. Install NLTK: https://pypi.python.org/pypi/nltk
-#. Test installation: ``Start>Python38``, then type ``import nltk``
+#. Test installation: ``Start>Python312``, then type ``import nltk``
 
 Installing Third-Party Software
 -------------------------------


### PR DESCRIPTION
This PR removes support for Python 3.8 across the entire NLTK codebase, updating the minimum supported Python version to 3.9.

- CI will no longer run tests for Python 3.8
- Any mention of Python 3.8 in the documentation or configuration is updated to the minimum supported Python 3.9

Python 3.8 is end of life on `2024-10-07` (https://devguide.python.org/versions/)

For comparison, Python 3.14 is planned for release in 2025-10, Python 3.9 will be end of life 2025-10.
Cleaning up any references to 3.8 is a first step towards testing with 3.14 in CI and dropping support for 3.9 soon.
