### PR TITLE
ci: automate ci github action updates with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  # Enable version updates for GitHub Actions
+  # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+    groups:
+      # Group all GitHub Actions updates into a single PR
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: ci
+      include: scope


### PR DESCRIPTION
This PR automates commits to bump GitHub Actions. It's a replacement for PRs like: https://github.com/nltk/nltk/pull/3420
Thank you @cclauss for the suggestion