### PR TITLE
Require a minimal download test before running cached-data tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,8 @@ jobs:
       - run: |
           pip install --upgrade pip
           pip install --upgrade nltk
-          python -c "import nltk; nltk.download('wordnet'); from nltk.corpus import wordnet; assert wordnet.synsets('dog'), 'Wordnet download failed or unusable'"
+          python -c "import nltk; nltk.download('wordnet')"
+          python -c "from nltk.corpus import wordnet; assert wordnet.synsets('dog'), 'Wordnet download failed or unusable'"
 
   test:
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,8 @@ jobs:
   minimal_download_test:
     name: Minimal NLTK Download Test
     runs-on: ubuntu-latest
+    env:
+      NLTK_DATA: /tmp/nltk_data
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
@@ -86,7 +88,7 @@ jobs:
       - run: |
           pip install --upgrade pip
           pip install --upgrade nltk
-          python -c "import nltk; nltk.download('wordnet', download_dir='/tmp/nltk_data'); from nltk.corpus import wordnet; assert wordnet.synsets('dog'), 'Wordnet download failed or unusable'"
+          python -c "import nltk; nltk.download('wordnet'); from nltk.corpus import wordnet; assert wordnet.synsets('dog'), 'Wordnet download failed or unusable'"
 
   test:
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,9 +75,22 @@ jobs:
           ./tools/github_actions/third-party.sh
         if: steps.restore-cache.outputs.cache-hit != 'true'
 
+  minimal_download_test:
+    name: Minimal NLTK Download Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - run: |
+          pip install --upgrade pip
+          pip install --upgrade nltk
+          python -c "import nltk; nltk.download('wordnet', download_dir='/tmp/nltk_data'); from nltk.corpus import wordnet; assert wordnet.synsets('dog'), 'Wordnet download failed or unusable'"
+
   test:
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
-    needs: [cache_nltk_data, cache_third_party]
+    needs: [minimal_download_test, cache_nltk_data, cache_third_party]
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']


### PR DESCRIPTION
Prevents issues like #3308.

This PR updates the CI workflow to address issues where NLTK fails to run if required resources (such as `wordnet`) are not downloaded, as reported in #3308. The changes ensure that the main test suite, which relies on cached data, only runs if a minimal download test for a core NLTK resource (`wordnet`) succeeds on a fresh install.

Key changes:
- Added a `minimal_download_test` job that installs NLTK, downloads the `wordnet` corpus to a temporary directory, and verifies its usability.
- The main `test` job now depends on this minimal download test, as well as the cache jobs.
- If the minimal download test fails (e.g., due to a download or resource usage error), the cached-data tests will be skipped.
- This helps catch issues early when NLTK cannot download or load essential corpora on first use, preventing false positives from running only on pre-populated cached data.
