### PR TITLE
Debug NLTK data location in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install pre-commit
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,14 +48,14 @@ jobs:
       - name: Install NLTK and dependencies
         run: pip install --upgrade pip && pip install --upgrade nltk
 
-      - name: Print NLTK_DATA in shell
-        shell: bash
-        run: |
-          echo "NLTK_DATA in shell: $NLTK_DATA"
-
       - name: Set NLTK_DATA environment variable
         shell: bash
         run: echo "NLTK_DATA=${{ github.workspace }}/nltk_data" >> $GITHUB_ENV
+
+      - name: Show NLTK_DATA in shell
+        shell: bash
+        run: |
+          echo "NLTK_DATA in shell: $NLTK_DATA"
 
       - name: Ensure minimal NLTK data for cache
         shell: bash
@@ -101,6 +101,7 @@ jobs:
           python -c "import os; print('Python sees GITHUB_WORKSPACE:', os.environ.get('GITHUB_WORKSPACE')); print('Python sees NLTK_DATA:', os.environ.get('NLTK_DATA'))"
 
       - name: List contents of NLTK data dir
+        shell: bash
         run: ls -lR "${{ github.workspace }}/nltk_data" || echo "nltk_data not found"
 
       - name: Cache nltk data
@@ -128,20 +129,25 @@ jobs:
           key: third_${{ runner.os }}_${{ hashFiles('tools/github_actions/third-party.sh') }}_v1
 
       - name: List contents of third-party dir before download
+        shell: bash
         run: ls -lR "${{ env.THIRD_PARTY_DIR }}" || echo "third-party dir not found"
 
       - name: Download third party data on cache miss
         if: steps.third-party-cache.outputs.cache-hit != 'true'
+        shell: bash
         run: |
           chmod +x ./tools/github_actions/third-party.sh
           ./tools/github_actions/third-party.sh
 
       - name: List contents of third-party dir after download/cache
+        shell: bash
         run: ls -lR "${{ env.THIRD_PARTY_DIR }}" || echo "third-party dir not found"
 
       - name: Print NLTK data search paths
+        shell: bash
         run: python -c "import nltk; print('NLTK data search paths:', nltk.data.path)"
 
       - name: Run pytest
+        shell: bash
         run: |
           pytest --numprocesses auto -rsx --doctest-modules nltk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install regex
+        run: pip install regex
+
       - name: Set NLTK_DATA environment variable
         shell: bash
         run: echo "NLTK_DATA=${{ github.workspace }}/nltk_data" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,6 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install NLTK and dependencies
-        run: pip install --upgrade pip && pip install --upgrade nltk
-
       - name: Set NLTK_DATA environment variable
         shell: bash
         run: echo "NLTK_DATA=${{ github.workspace }}/nltk_data" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install NLTK and dependencies
         run: pip install --upgrade pip && pip install --upgrade nltk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,99 +1,70 @@
 name: ci-workflow
-# run workflow for these events
+
 on: [push, pull_request, workflow_dispatch]
 
 env:
-  CORENLP: /home/runner/third/stanford-corenlp
-  CORENLP_MODELS: /home/runner/third/stanford-corenlp
-  STANFORD_PARSER: /home/runner/third/stanford-parser
-  STANFORD_MODELS: /home/runner/third/stanford-postagger
-  STANFORD_POSTAGGER: /home/runner/third/stanford-postagger
-  SENNA: /home/runner/third/senna
-  PROVER9: /home/runner/third/prover9/bin
-  MEGAM: /home/runner/third/megam
-  # TADM requires `libtaopetsc.so` from PETSc v2.3.3, and likely has more
-  # tricky to install requirements, so we don't run tests for it.
-  # TADM: /home/runner/third/tadm/bin
-  MALT_PARSER: /home/runner/third/maltparser
+  THIRD_PARTY_DIR: ${{ github.workspace }}/third
+  CORENLP: ${{ github.workspace }}/third/stanford-corenlp
+  CORENLP_MODELS: ${{ github.workspace }}/third/stanford-corenlp
+  STANFORD_PARSER: ${{ github.workspace }}/third/stanford-parser
+  STANFORD_MODELS: ${{ github.workspace }}/third/stanford-postagger
+  STANFORD_POSTAGGER: ${{ github.workspace }}/third/stanford-postagger
+  SENNA: ${{ github.workspace }}/third/senna
+  PROVER9: ${{ github.workspace }}/third/prover9/bin
+  MEGAM: ${{ github.workspace }}/third/megam
+  MALT_PARSER: ${{ github.workspace }}/third/maltparser
 
 jobs:
   pre-commit:
-    name: Run pre-commit
+    name: pre-commit
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
-      - run: |
+          python-version: "3.11"
+
+      - name: Install pre-commit
+        run: |
           pip install pre-commit
           pre-commit run --all-files
 
-  cache_nltk_data:
-    name: Cache nltk_data
-    needs: pre-commit
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-
-      - name: Cache nltk data
-        uses: actions/cache@v4
-        id: restore-cache
-        with:
-          path: ~/nltk_data
-          key: nltk_data_${{ secrets.CACHE_VERSION }}
-
-      - name: Download nltk data packages on cache miss
-        run: |
-          pip install regex # dependencies needed to download nltk data
-          python -c "import nltk; from pathlib import Path; path = Path('~/nltk_data').expanduser(); path.mkdir(exist_ok=True); nltk.download('all', download_dir=path)"
-        shell: bash
-        if: steps.restore-cache.outputs.cache-hit != 'true'
-
-  cache_third_party:
-    name: Cache third party tools
-    needs: pre-commit
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-
-      - name: Cache third party tools
-        uses: actions/cache@v4
-        id: restore-cache
-        with:
-          path: ~/third
-          key: third_${{ hashFiles('tools/github_actions/third-party.sh') }}_${{ secrets.CACHE_VERSION }}
-
-      - name: Download third party data
-        run: |
-          chmod +x ./tools/github_actions/third-party.sh
-          ./tools/github_actions/third-party.sh
-        if: steps.restore-cache.outputs.cache-hit != 'true'
-
   minimal_download_test:
     name: Minimal NLTK Download Test
-    runs-on: ubuntu-latest
-    env:
-      NLTK_DATA: /tmp/nltk_data
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
-      - run: |
-          pip install --upgrade pip
-          pip install --upgrade nltk
-          python -c "import nltk; nltk.download('wordnet')"
-          python -c "from nltk.corpus import wordnet; assert wordnet.synsets('dog'), 'Wordnet download failed or unusable'"
+          python-version: "3.11"
+
+      - name: Install NLTK and dependencies
+        run: pip install --upgrade pip && pip install --upgrade nltk
+
+      - name: Print NLTK_DATA in shell
+        shell: bash
+        run: |
+          echo "NLTK_DATA in shell: $NLTK_DATA"
+
+      - name: Set NLTK_DATA environment variable
+        shell: bash
+        run: echo "NLTK_DATA=${{ github.workspace }}/nltk_data" >> $GITHUB_ENV
+
+      - name: Ensure minimal NLTK data for cache
+        shell: bash
+        run: |
+          python -c "import os, nltk; d = os.environ['NLTK_DATA']; import pathlib; pathlib.Path(d).mkdir(parents=True, exist_ok=True); nltk.download('wordnet', download_dir=d)"
 
   test:
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
-    needs: [minimal_download_test, cache_nltk_data, cache_third_party]
+    needs: [pre-commit, minimal_download_test]
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
@@ -101,48 +72,76 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
+      - uses: actions/checkout@v5
 
-      - name: Setup python
+      - name: Set up Python
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Restore cached dependencies
-        uses: actions/cache@v4
-        id: restore-cache
-        with:
-          path: ${{ env.pythonLocation }}
-          key: python-dependencies-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements-ci.txt') }}-${{ env.pythonLocation }}
+      - name: Set NLTK_DATA environment variable
+        shell: bash
+        run: echo "NLTK_DATA=${{ github.workspace }}/nltk_data" >> $GITHUB_ENV
 
       - name: Install dependencies
         run: |
           pip install --upgrade pip
           pip install --upgrade --requirement requirements-ci.txt
-        #if: steps.restore-cache.outputs.cache-hit != 'true' # disabled due to a persistent issue with restoring cache on macos runner
 
-      - name: Use cached nltk data
+      - name: Ensure minimal NLTK data for cache
+        shell: bash
+        run: |
+          python -c "import os, nltk; d = os.environ['NLTK_DATA']; import pathlib; pathlib.Path(d).mkdir(parents=True, exist_ok=True); nltk.download('wordnet', download_dir=d)"
+
+      - name: Show NLTK_DATA and workspace
+        shell: bash
+        run: |
+          echo "GITHUB_WORKSPACE is: $GITHUB_WORKSPACE"
+          echo "NLTK_DATA is: $NLTK_DATA"
+          python -c "import os; print('Python sees GITHUB_WORKSPACE:', os.environ.get('GITHUB_WORKSPACE')); print('Python sees NLTK_DATA:', os.environ.get('NLTK_DATA'))"
+
+      - name: List contents of NLTK data dir
+        run: ls -lR "${{ github.workspace }}/nltk_data" || echo "nltk_data not found"
+
+      - name: Cache nltk data
         uses: actions/cache@v4
+        id: nltk-data-cache
         with:
-          path: ~/nltk_data
-          key: nltk_data_${{ secrets.CACHE_VERSION }}
+          path: ${{ github.workspace }}/nltk_data
+          key: nltk_data_${{ runner.os }}_v1
 
-      - name: Use cached third party tools
+      - name: Download nltk data on cache miss
+        if: steps.nltk-data-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          python -c "import os; import nltk; from pathlib import Path; path = Path(os.environ['NLTK_DATA']); path.mkdir(parents=True, exist_ok=True); nltk.download('all', download_dir=path)"
+
+      # --- THIRD PARTY TOOLS CACHE SECTION ---
+      - name: Ensure third-party directory exists
+        run: mkdir -p "${{ env.THIRD_PARTY_DIR }}"
+
+      - name: Cache third party tools
         uses: actions/cache@v4
+        id: third-party-cache
         with:
-          path: ~/third
-          key: third_${{ hashFiles('tools/github_actions/third-party.sh') }}_${{ secrets.CACHE_VERSION }}
-        if: runner.os == 'Linux'
+          path: ${{ env.THIRD_PARTY_DIR }}
+          key: third_${{ runner.os }}_${{ hashFiles('tools/github_actions/third-party.sh') }}_v1
 
-      - name: Set up JDK 16
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'zulu'
-          java-version: '16'
-        if: runner.os == 'Linux'
+      - name: List contents of third-party dir before download
+        run: ls -lR "${{ env.THIRD_PARTY_DIR }}" || echo "third-party dir not found"
+
+      - name: Download third party data on cache miss
+        if: steps.third-party-cache.outputs.cache-hit != 'true'
+        run: |
+          chmod +x ./tools/github_actions/third-party.sh
+          ./tools/github_actions/third-party.sh
+
+      - name: List contents of third-party dir after download/cache
+        run: ls -lR "${{ env.THIRD_PARTY_DIR }}" || echo "third-party dir not found"
+
+      - name: Print NLTK data search paths
+        run: python -c "import nltk; print('NLTK data search paths:', nltk.data.path)"
 
       - name: Run pytest
-        shell: bash
         run: |
           pytest --numprocesses auto -rsx --doctest-modules nltk

--- a/tools/github_actions/third-party.sh
+++ b/tools/github_actions/third-party.sh
@@ -1,112 +1,129 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This install script is used in our GitHub Actions CI.
-# See .github/workflows/ci.yaml
+# See .github/workflows/ci.yml
+
+set -e
+
+# Use the THIRD_PARTY_DIR environment variable set by the workflow.
+if [ -z "$THIRD_PARTY_DIR" ]; then
+    echo "Error: THIRD_PARTY_DIR environment variable is not set."
+    exit 1
+fi
 
 # Installing the third-party software and the appropriate env variables.
-pushd ${HOME}
-[[ ! -d 'third' ]] && mkdir 'third'
-pushd 'third'
+pushd "$THIRD_PARTY_DIR" 2>/dev/null || { mkdir -p "$THIRD_PARTY_DIR"; pushd "$THIRD_PARTY_DIR"; }
 
 # Download nltk stanford dependencies
-# Downloaded to ~/third/stanford-corenlp
+# Downloaded to $THIRD_PARTY_DIR/stanford-corenlp
 # stanford_corenlp_package_zip_name=$(curl -s 'https://stanfordnlp.github.io/CoreNLP/' | grep -o 'stanford-corenlp-full-.*\.zip' | head -n1)
 stanford_corenlp_package_zip_name="stanford-corenlp-4.5.1.zip"
 [[ ${stanford_corenlp_package_zip_name} =~ (.+)\.zip ]]
 stanford_corenlp_package_name=${BASH_REMATCH[1]}
-if [[ ! -d ${stanford_corenlp_package_name} ]]; then
-	curl -L "https://nlp.stanford.edu/software/$stanford_corenlp_package_zip_name" -o ${stanford_corenlp_package_zip_name}
-	# wget -nv "https://nlp.stanford.edu/software/$stanford_corenlp_package_zip_name"
-	unzip -q ${stanford_corenlp_package_zip_name}
-	rm ${stanford_corenlp_package_zip_name}
-	mv ${stanford_corenlp_package_name} 'stanford-corenlp'
+if [[ ! -d "${stanford_corenlp_package_name}" ]]; then
+    curl -L "https://nlp.stanford.edu/software/$stanford_corenlp_package_zip_name" -o "${stanford_corenlp_package_zip_name}"
+    # wget -nv "https://nlp.stanford.edu/software/$stanford_corenlp_package_zip_name"
+    unzip -q "${stanford_corenlp_package_zip_name}"
+    rm "${stanford_corenlp_package_zip_name}"
+    mv "${stanford_corenlp_package_name}" 'stanford-corenlp'
 fi
 
-
-# Downloaded to ~/third/stanford-parser
-#stanford_parser_package_zip_name=$(curl -s 'https://nlp.stanford.edu/software/lex-parser.shtml' | grep -o 'stanford-parser-full-.*\.zip' | head -n1)
+# Downloaded to $THIRD_PARTY_DIR/stanford-parser
+# stanford_parser_package_zip_name=$(curl -s 'https://nlp.stanford.edu/software/lex-parser.shtml' | grep -o 'stanford-parser-full-.*\.zip' | head -n1)
 stanford_parser_package_zip_name="stanford-parser-full-2018-10-17.zip"
 [[ ${stanford_parser_package_zip_name} =~ (.+)\.zip ]]
 stanford_parser_package_name=${BASH_REMATCH[1]}
-if [[ ! -d ${stanford_parser_package_name} ]]; then
-	curl -L "https://nlp.stanford.edu/software/$stanford_parser_package_zip_name" -o ${stanford_parser_package_zip_name}
-	# wget -nv "https://nlp.stanford.edu/software/$stanford_parser_package_zip_name"
-	unzip -q ${stanford_parser_package_zip_name}
-	rm ${stanford_parser_package_zip_name}
-	mv ${stanford_parser_package_name} 'stanford-parser'
+if [[ ! -d "${stanford_parser_package_name}" ]]; then
+    curl -L "https://nlp.stanford.edu/software/$stanford_parser_package_zip_name" -o "${stanford_parser_package_zip_name}"
+    # wget -nv "https://nlp.stanford.edu/software/$stanford_parser_package_zip_name"
+    unzip -q "${stanford_parser_package_zip_name}"
+    rm "${stanford_parser_package_zip_name}"
+    mv "${stanford_parser_package_name}" 'stanford-parser'
 fi
 
-# Downloaded to ~/third/stanford-postagger
-#stanford_tagger_package_zip_name=$(curl -s 'https://nlp.stanford.edu/software/tagger.shtml' | grep -o 'stanford-postagger-full-.*\.zip' | head -n1)
+# Downloaded to $THIRD_PARTY_DIR/stanford-postagger
+# stanford_tagger_package_zip_name=$(curl -s 'https://nlp.stanford.edu/software/tagger.shtml' | grep -o 'stanford-postagger-full-.*\.zip' | head -n1)
 stanford_tagger_package_zip_name="stanford-postagger-full-2018-10-16.zip"
 [[ ${stanford_tagger_package_zip_name} =~ (.+)\.zip ]]
 stanford_tagger_package_name=${BASH_REMATCH[1]}
-if [[ ! -d ${stanford_tagger_package_name} ]]; then
-	curl -L "https://nlp.stanford.edu/software/$stanford_tagger_package_zip_name" -o ${stanford_tagger_package_zip_name}
-	# wget -nv "https://nlp.stanford.edu/software/$stanford_tagger_package_zip_name"
-	unzip -q ${stanford_tagger_package_zip_name}
-	rm ${stanford_tagger_package_zip_name}
-	mv ${stanford_tagger_package_name} 'stanford-postagger'
+if [[ ! -d "${stanford_tagger_package_name}" ]]; then
+    curl -L "https://nlp.stanford.edu/software/$stanford_tagger_package_zip_name" -o "${stanford_tagger_package_zip_name}"
+    # wget -nv "https://nlp.stanford.edu/software/$stanford_tagger_package_zip_name"
+    unzip -q "${stanford_tagger_package_zip_name}"
+    rm "${stanford_tagger_package_zip_name}"
+    mv "${stanford_tagger_package_name}" 'stanford-postagger'
 fi
 
-# Download SENNA to ~/third/senna
-senna_file_name=$(curl -s 'https://ronan.collobert.com/senna/download.html' | grep -o 'senna-v.*.tgz' | head -n1)
-senna_folder_name='senna'
-if [[ ! -d $senna_folder_name ]]; then
-	curl -L "https://ronan.collobert.com/senna/$senna_file_name" -o ${senna_file_name}
-	# wget -nv "https://ronan.collobert.com/senna/$senna_file_name"
-	tar -xzf ${senna_file_name}
-	rm ${senna_file_name}
+# Download SENNA to $THIRD_PARTY_DIR/senna
+# senna_file_name=$(curl -s 'https://ronan.collobert.com/senna/download.html' | grep -o 'senna-v.*.tgz' | head -n1)
+if [[ "$(uname -s)" == "Linux" ]]; then
+    senna_file_name=$(curl -s 'https://ronan.collobert.com/senna/download.html' | grep -o 'senna-v.*.tgz' | head -n1)
+    senna_folder_name='senna'
+    if [[ ! -d "${senna_folder_name}" ]]; then
+        curl -L "https://ronan.collobert.com/senna/$senna_file_name" -o "${senna_file_name}"
+        # wget -nv "https://ronan.collobert.com/senna/$senna_file_name"
+        tar -xzf "${senna_file_name}"
+        rm "${senna_file_name}"
+    fi
+else
+    echo "Skipping SENNA download on $(uname -s)"
 fi
 
-# Download PROVER9 to ~/third/prover9
-prover9_file_name="p9m4-v05.tar.gz"
-[[ ${prover9_file_name} =~ (.+)\.tar\.gz ]]
-prover9_folder_name=${BASH_REMATCH[1]}
-if [[ ! -d ${prover9_folder_name} ]]; then
-	curl -L "https://www.cs.unm.edu/~mccune/prover9/gui/$prover9_file_name" -o ${prover9_file_name}
-	tar -xzf ${prover9_file_name}
-	mv ${prover9_folder_name} 'prover9'
-	rm ${prover9_file_name}
+# Download PROVER9 to $THIRD_PARTY_DIR/prover9
+if [[ "$(uname -s)" == "Linux" ]]; then
+    prover9_file_name="p9m4-v05.tar.gz"
+    [[ ${prover9_file_name} =~ (.+)\.tar\.gz ]]
+    prover9_folder_name=${BASH_REMATCH[1]}
+    if [[ ! -d "${prover9_folder_name}" ]]; then
+        curl -L "https://www.cs.unm.edu/~mccune/prover9/gui/$prover9_file_name" -o "${prover9_file_name}"
+        tar -xzf "${prover9_file_name}"
+        mv "${prover9_folder_name}" 'prover9'
+        rm "${prover9_file_name}"
+    fi
+else
+    echo "Skipping PROVER9 download on $(uname -s)"
 fi
 
-# Download MEGAM to ~/third/megam
-megam_file_name="megam_i686.opt.gz"
-[[ ${megam_file_name} =~ (.+)\.gz ]]
-megam_folder_name=${BASH_REMATCH[1]}
-if [[ ! -d ${megam_folder_name} ]]; then
-	curl -L "http://hal3.name/megam/$megam_file_name" -o ${megam_file_name}
-	gunzip -vf ${megam_file_name}
-	mkdir -p "megam"
-	mv ${megam_folder_name} "megam/${megam_folder_name}"
-	chmod -R 711 "megam/$megam_folder_name"
+# Download MEGAM to $THIRD_PARTY_DIR/megam
+if [[ "$(uname -s)" == "Linux" ]]; then
+    megam_file_name="megam_i686.opt.gz"
+    [[ ${megam_file_name} =~ (.+)\.gz ]]
+    megam_folder_name=${BASH_REMATCH[1]}
+    if [[ ! -d "${megam_folder_name}" ]]; then
+        curl -L "http://hal3.name/megam/$megam_file_name" -o "${megam_file_name}"
+        gunzip -vf "${megam_file_name}"
+        mkdir -p "megam"
+        mv "${megam_folder_name}" "megam/${megam_folder_name}"
+        chmod -R 711 "megam/${megam_folder_name}"
+    fi
+else
+    echo "Skipping MEGAM download on $(uname -s)"
 fi
 
 # TADM requires `libtaopetsc.so` from PETSc v2.3.3, and likely has more
 # tricky to install requirements, so we don't run tests for it.
-
-# Download TADM to ~/third/tadm
+# Download TADM to $THIRD_PARTY_DIR/tadm
 # tadm_file_name="tadm-0.9.8.tgz"
 # [[ ${tadm_file_name} =~ (.+)\.tgz ]]
 # tadm_folder_name=${BASH_REMATCH[1]}
-# if [[ ! -d ${tadm_folder_name} ]]; then
-# 	curl -L "https://master.dl.sourceforge.net/project/tadm/tadm/tadm%200.9.8/$tadm_file_name?viasf=1" -o ${tadm_file_name}
-# 	tar -xvzf ${tadm_file_name}
-# 	rm ${tadm_file_name}
-#	chmod -R 711 "./tadm/bin/tadm"
+# if [[ ! -d "${tadm_folder_name}" ]]; then
+#     curl -L "https://master.dl.sourceforge.net/project/tadm/tadm/tadm%200.9.8/$tadm_file_name?viasf=1" -o "${tadm_file_name}"
+#     tar -xvzf "${tadm_file_name}"
+#     rm "${tadm_file_name}"
+#     chmod -R 711 "./tadm/bin/tadm"
 # fi
 
-# Download MaltParser to ~/third/maltparser
+# Download MaltParser to $THIRD_PARTY_DIR/maltparser
+# malt_file_name=$(curl -s 'http://maltparser.org/download.html' | grep -o 'maltparser-.*\.tar.gz' | head -n1)
 malt_file_name="maltparser-1.9.2.tar.gz"
 [[ ${malt_file_name} =~ (.+)\.tar\.gz ]]
 malt_folder_name=${BASH_REMATCH[1]}
-if [[ ! -d ${malt_folder_name} ]]; then
-	curl -L "http://maltparser.org/dist/$malt_file_name" -o ${malt_file_name}
-	tar -xzf ${malt_file_name}
-	mv ${malt_folder_name} 'maltparser'
-	rm ${malt_file_name}
+if [[ ! -d "${malt_folder_name}" ]]; then
+    curl -L "http://maltparser.org/dist/$malt_file_name" -o "${malt_file_name}"
+    tar -xzf "${malt_file_name}"
+    mv "${malt_folder_name}" 'maltparser'
+    rm "${malt_file_name}"
 fi
 
-ls ~/third
+ls -l "$THIRD_PARTY_DIR"
 
-popd
 popd


### PR DESCRIPTION
This PR sets the `NLTK_DATA` environment variable in the CI workflow to ${{ github.workspace }}/nltk_data` on all platforms. This change may help improve portability and could potentially resolve a number of mysterious issues, if the problem was related to environment variable differences between runners.

Additionally this PR adds steps to the CI workflow to:

- List contents of ``${{ github.workspace }}/nltk_data`
- Print NLTK data search paths

## Motivation

Recent CI failures (see [GitHub Actions run #17965789421, job #51098247790](https://github.com/nltk/nltk/actions/runs/17965789421/job/51098247790)) show errors related to missing NLTK corpora or data files.  This CI failure occurs after merging #3425, although the CI on the PR itself succeeded, which appears mysterious.
The test job fails because required resources do not appear to be present or accessible, despite running with debug logging enabled.

## Changes

- Added two diagnostic steps before running pytest:
    - `ls -lR `${{ github.workspace }}/nltk_data || echo "nltk_data not found"`
    - `python -c "import nltk; print('NLTK data search paths:', nltk.data.path)"`

## Purpose

These steps will make it easier to diagnose exactly what data is available and where NLTK is searching for it, by outputting the relevant information in the CI logs.  
This should help resolve failures caused by data download, cache, or environment issues.

Once the problem is identified and fixed, the debug steps could be removed, but I suggest to keep them, since they will certainly prove handy sometime .

Thank you for reviewing!
