### PR TITLE
Stop the CoreNLP server if a test connection to it cannot be established

### DIFF
--- a/nltk/parse/corenlp.py
+++ b/nltk/parse/corenlp.py
@@ -138,27 +138,33 @@ class CoreNLPServer:
                 "The error was: {}".format(stderrdata.decode("ascii")),
             )
 
-        for i in range(30):
-            try:
-                response = requests.get(requests.compat.urljoin(self.url, "live"))
-            except requests.exceptions.ConnectionError:
-                time.sleep(1)
-            else:
-                if response.ok:
-                    break
-        else:
-            raise CoreNLPServerError("Could not connect to the server.")
+        try:
 
-        for i in range(60):
-            try:
-                response = requests.get(requests.compat.urljoin(self.url, "ready"))
-            except requests.exceptions.ConnectionError:
-                time.sleep(1)
+            for i in range(30):
+                try:
+                    response = requests.get(requests.compat.urljoin(self.url, "live"))
+                except requests.exceptions.ConnectionError:
+                    time.sleep(1)
+                else:
+                    if response.ok:
+                        break
             else:
-                if response.ok:
-                    break
-        else:
-            raise CoreNLPServerError("The server is not ready.")
+                raise CoreNLPServerError("Could not connect to the server.")
+
+            for i in range(60):
+                try:
+                    response = requests.get(requests.compat.urljoin(self.url, "ready"))
+                except requests.exceptions.ConnectionError:
+                    time.sleep(1)
+                else:
+                    if response.ok:
+                        break
+            else:
+                raise CoreNLPServerError("The server is not ready.")
+
+        except Exception:
+            self.popen.terminate()
+            raise
 
     def stop(self):
         self.popen.terminate()


### PR DESCRIPTION
The method `start` of class `CoreNLPServer` from module `nltk.parse.corenlp` launches a CoreNLP server as a separate process and then [checks](https://github.com/nltk/nltk/blob/3.9.2/nltk/parse/corenlp.py#L141) its status: 1. by a test for premature exit, 2. by poking some of its endpoints repeatedly.

If any of the endpoints test fails, an exception is raised. However, the server process is not shut down; and as the `popen` attribute of the class does not appear to be the part of intended public interface, the track of the started server process is lost. This causes a resources leak, primarily from potential bound to the given network port.

This PR makes it so the server process is terminated if a test connection to it cannot be established to avoid the resources leak. It does not even wait on the process to terminate, just sends the signal.

***This is an opinionated change***; some would consider leaving the process up for investigation by user instead (i.e. leaving the code as is), or leaving an option to do it, or even exposing the process as part of interface.