### PR TITLE
When a test connection to a CoreNLP server cannot be established, give a user the choice to keep the server process running

### DIFF
--- a/nltk/parse/corenlp.py
+++ b/nltk/parse/corenlp.py
@@ -101,9 +101,17 @@ class CoreNLPServer:
         self.java_options = java_options or ["-mx2g"]
 
     def start(self, stdout="devnull", stderr="devnull"):
-        """Starts the CoreNLP server
+        """Start the CoreNLP server
+
+        This method checks the status of the started server, but does **not** stop
+        the server process if those checks fail. If you want the server process
+        to be stopped in that case, either use this class as a context manager
+        (see :meth:`.__enter__()`) or catch :exc:`~corenlp.CoreNLPServerError`
+        exception and stop the server manually.
 
         :param stdout, stderr: Specifies where CoreNLP output is redirected. Valid values are 'devnull', 'stdout', 'pipe'
+        :raises CoreNLPServerError: If the server fails to start or a status check fails
+            (in which case the server process remains running).
         """
         import requests
 
@@ -165,8 +173,19 @@ class CoreNLPServer:
         self.popen.wait()
 
     def __enter__(self):
-        self.start()
+        """Start the CoreNLP server
 
+        This method checks the status of the started server and stops the server process
+        if those checks fail. If you want the server process to **not** be stopped in that case,
+        use the :meth:`.start`/ :meth:`.stop` methods.
+
+        :raises CoreNLPServerError: If the server fails to start.
+        """
+        try:
+            self.start()
+        except CoreNLPServerError:
+            self.stop()
+            raise
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/nltk/parse/corenlp.py
+++ b/nltk/parse/corenlp.py
@@ -138,33 +138,27 @@ class CoreNLPServer:
                 "The error was: {}".format(stderrdata.decode("ascii")),
             )
 
-        try:
-
-            for i in range(30):
-                try:
-                    response = requests.get(requests.compat.urljoin(self.url, "live"))
-                except requests.exceptions.ConnectionError:
-                    time.sleep(1)
-                else:
-                    if response.ok:
-                        break
+        for i in range(30):
+            try:
+                response = requests.get(requests.compat.urljoin(self.url, "live"))
+            except requests.exceptions.ConnectionError:
+                time.sleep(1)
             else:
-                raise CoreNLPServerError("Could not connect to the server.")
+                if response.ok:
+                    break
+        else:
+            raise CoreNLPServerError("Could not connect to the server.")
 
-            for i in range(60):
-                try:
-                    response = requests.get(requests.compat.urljoin(self.url, "ready"))
-                except requests.exceptions.ConnectionError:
-                    time.sleep(1)
-                else:
-                    if response.ok:
-                        break
+        for i in range(60):
+            try:
+                response = requests.get(requests.compat.urljoin(self.url, "ready"))
+            except requests.exceptions.ConnectionError:
+                time.sleep(1)
             else:
-                raise CoreNLPServerError("The server is not ready.")
-
-        except Exception:
-            self.popen.terminate()
-            raise
+                if response.ok:
+                    break
+        else:
+            raise CoreNLPServerError("The server is not ready.")
 
     def stop(self):
         self.popen.terminate()


### PR DESCRIPTION
I apologize it took me way longer to figure out a potentially better solution to the problem posed in #3430 (tldr: `CoreNLPServer` starts a separate server process but does not shut it down if the process fails a status check, resulting in a resource leak).

The class `CoreNLPServer` has two interfaces: explicit `start`/`stop` methods and the context manager interface. Currently the `__enter__`/`__exit__` methods just run the `start`/`stop` methods. With this PR:

1. `start` will **not** stop the server process in case of status check failure (pre-#3430 behavior);
2. `__enter__` *will* stop the server process in case the status checks in `start` fail.

This way a user can choose between automatic cleanup (with the context manager interface) and manual cleanup. To me, it kind of makes sense to leave the latter option, since the started server *is* running, NLTK just cannot connect to it via HTTP or the server doesn't report it's ready. Also, this variant of the fix also affects less users - only those who use the context manager interface. The PR includes updated docstrings.

I still believe the optimal solution to the resources leak is ***uncertain***, given that there is currently no way for a user to get logs from a failed CoreNLP server process &mdash; all they can get from NLTK in this scenario is a generic exception, so I don't *insist* on this solution. Note also that this variant of the fix runs the `stop` method to stop a failed server process which does wait on it to exit.