### PR TITLE
remove support for python 3.9 which is end of life on Oct 31 2025

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
     needs: [pre-commit, minimal_download_test]
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
         os: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, 3.10, 3.11, 3.12]
+        python-version: ['3.10', '3.11', '3.12']
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,7 +174,7 @@ The [`.github/workflows/ci.yaml`](https://github.com/nltk/nltk/blob/develop/.git
        - Otherwise, download all the data packages through `nltk.download('all')`.
 
   - The `test` job
-    - tests against supported Python versions (`3.9`, `3.10`, `3.11`, `3.12`).
+    - tests against supported Python versions (`3.10`, `3.11`, `3.12`).
     - tests on `ubuntu-latest` and `macos-latest`.
     - relies on the `cache_nltk_data` job to ensure that `nltk_data` is available.
     - performs these steps:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 NLTK -- the Natural Language Toolkit -- is a suite of open source Python
 modules, data sets, and tutorials supporting research and development in Natural
-Language Processing. NLTK requires Python version 3.9, 3.10, 3.11 or 3.12.
+Language Processing. NLTK requires Python version 3.10, 3.11, 3.12 or 3.13.
 
 For documentation, please visit [nltk.org](https://www.nltk.org/).
 

--- a/nltk/__init__.py
+++ b/nltk/__init__.py
@@ -53,7 +53,7 @@ __license__ = "Apache License, Version 2.0"
 # Description of the toolkit, keywords, and the project's primary URL.
 __longdescr__ = """\
 The Natural Language Toolkit (NLTK) is a Python package for
-natural language processing.  NLTK requires Python 3.9, 3.10, 3.11, 3.12 or 3.13."""
+natural language processing.  NLTK requires Python 3.10, 3.11, 3.12 or 3.13."""
 __keywords__ = [
     "NLP",
     "CL",
@@ -85,7 +85,6 @@ __classifiers__ = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     },
     long_description="""\
 The Natural Language Toolkit (NLTK) is a Python package for
-natural language processing.  NLTK requires Python 3.9, 3.10, 3.11, 3.12, or 3.13.""",
+natural language processing.  NLTK requires Python 3.10, 3.11, 3.12, or 3.13.""",
     license="Apache License, Version 2.0",
     keywords=[
         "NLP",
@@ -95,7 +95,6 @@ natural language processing.  NLTK requires Python 3.9, 3.10, 3.11, 3.12, or 3.1
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
@@ -111,7 +110,7 @@ natural language processing.  NLTK requires Python 3.9, 3.10, 3.11, 3.12, or 3.1
         "Topic :: Text Processing :: Linguistic",
     ],
     package_data={"nltk": ["test/*.doctest", "VERSION"]},
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     install_requires=[
         "click",
         "joblib",

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    py{39,310,311,312,313}
+    py{310,311,312,313}
     pypy
-    py{39,310,311,312,313}-nodeps
-    py{39,310,311,312,313}-jenkins
+    py{310,311,312,313}-nodeps
+    py{310,311,312,313}-jenkins
     py-travis
 
 [testenv]
@@ -55,13 +55,6 @@ deps =
 commands =
     pytest
 
-
-[testenv:py39-nodeps]
-basepython = python3.9
-deps =
-    pytest
-    pytest-mock
-commands = pytest
 
 [testenv:py310-nodeps]
 basepython = python3.10

--- a/web/install.rst
+++ b/web/install.rst
@@ -1,7 +1,7 @@
 Installing NLTK
 ===============
 
-NLTK requires Python versions 3.9, 3.10, 3.11, 3.12 or 3.13.
+NLTK requires Python versions 3.10, 3.11, 3.12 or 3.13.
 
 For Windows users, it is strongly recommended that you go through this guide to install Python 3 successfully https://docs.python-guide.org/starting/install3/win/#install3-windows
 


### PR DESCRIPTION
Python 3.9 reached end of life on October 31, 2025.
This PR removes support for Python 3.9 and sets the minimum required version to Python 3.10.

CI will now run tests for Python 3.10+ and all mentions of Python 3.9 have been removed from package metadata, workflows, test configuration, and documentation.

This PR is cleanup intended to help with changes necessary for Python 3.14+
