### PR TITLE
add tests for _make_bound_method

### DIFF
--- a/nltk/test/unit/test_corpus_util.py
+++ b/nltk/test/unit/test_corpus_util.py
@@ -1,0 +1,65 @@
+"""
+Tests for nltk.corpus.util module
+"""
+
+import pytest
+
+from nltk.corpus.util import _make_bound_method
+
+
+class TestMakeBoundMethod:
+    """Tests for _make_bound_method function"""
+
+    def test_creates_bound_method(self):
+        """Test that _make_bound_method creates a proper bound method"""
+
+        class TestClass:
+            def __init__(self, value):
+                self.value = value
+
+        def test_func(self):
+            return self.value * 2
+
+        obj = TestClass(5)
+        bound_method = _make_bound_method(test_func, obj)
+
+        # verify it's callable
+        assert callable(bound_method)
+
+        # verify it returns the correct value
+        assert bound_method() == 10
+
+    def test_bound_method_has_correct_self(self):
+        """Test that the bound method has correct self binding"""
+
+        class Counter:
+            def __init__(self):
+                self.count = 0
+
+        def increment(self):
+            self.count += 1
+            return self.count
+
+        obj = Counter()
+        bound_increment = _make_bound_method(increment, obj)
+
+        # call multiple times and verify state changes
+        assert bound_increment() == 1
+        assert bound_increment() == 2
+        assert obj.count == 2
+
+    def test_bound_method_with_arguments(self):
+        """Test that bound method works with additional arguments"""
+
+        class Multiplier:
+            def __init__(self, base):
+                self.base = base
+
+        def multiply(self, factor):
+            return self.base * factor
+
+        obj = Multiplier(3)
+        bound_multiply = _make_bound_method(multiply, obj)
+
+        assert bound_multiply(4) == 12
+        assert bound_multiply(10) == 30


### PR DESCRIPTION
This PR is a stepping stone towards addressing https://github.com/nltk/nltk/issues/3442 and having green CI for py 3.13 / 3.14.

This PR adds explicit test coverage for `_make_bound_method`. This method is also tested indirectly and extensively in CI during corpus unload as a side effect of running other tests.

I suspect the current implementation of `_make_bound_method` is not compatible with py3.13 due to internal python api changes, therefore, the first step is to ensure it works for py3.10-3.12 in CI. The intention is to produce another PR as a followup with py3.13 specific changes.