### PR TITLE
minimal changes to run CI for python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install pre-commit
         run: |
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install regex
         run: pip install regex
@@ -67,7 +67,7 @@ jobs:
     needs: [pre-commit, minimal_download_test]
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/nltk/corpus/util.py
+++ b/nltk/corpus/util.py
@@ -11,6 +11,7 @@
 
 import gc
 import re
+import types
 
 import nltk
 
@@ -139,15 +140,4 @@ def _make_bound_method(func, self):
     """
     Magic for creating bound methods (used for _unload).
     """
-
-    class Foo:
-        def meth(self):
-            pass
-
-    f = Foo()
-    bound_method = type(f.meth)
-
-    try:
-        return bound_method(func, self, self.__class__)
-    except TypeError:  # python3
-        return bound_method(func, self)
+    return types.MethodType(func, self)

--- a/nltk/test/conftest.py
+++ b/nltk/test/conftest.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from nltk.corpus.reader import CorpusReader
@@ -30,4 +32,7 @@ def teardown_loaded_corpora():
     for name in dir(nltk.corpus):
         obj = getattr(nltk.corpus, name, None)
         if isinstance(obj, CorpusReader) and hasattr(obj, "_unload"):
+            # skip unload on Python 3.13+ to avoid segfaults
+            if sys.version_info >= (3, 13):
+                continue
             obj._unload()

--- a/nltk/test/conftest.py
+++ b/nltk/test/conftest.py
@@ -27,12 +27,13 @@ def teardown_loaded_corpora():
 
     yield  # first, wait for the test to end
 
+    # skip unload on Python 3.13+ to avoid segfaults
+    if sys.version_info >= (3, 13):
+        return
+
     import nltk.corpus
 
     for name in dir(nltk.corpus):
         obj = getattr(nltk.corpus, name, None)
         if isinstance(obj, CorpusReader) and hasattr(obj, "_unload"):
-            # skip unload on Python 3.13+ to avoid segfaults
-            if sys.version_info >= (3, 13):
-                continue
             obj._unload()


### PR DESCRIPTION
This PR is a followup from https://github.com/nltk/nltk/pull/3451 and an incremental step towards https://github.com/nltk/nltk/issues/3442

We now run tests for py3.13 in CI. The "_unload" function of LazyCorpusLoader is effectively disabled for py3.13 during test execution because it leads to segfaults when the test suite is run in it's entirety as a whole. We will rely on native Python garbage collection instead.

The implementation of "_make_bound_method" is replaced with a more modern alternative as a followup from https://github.com/nltk/nltk/pull/3451, direct and indirect use of this method in tests / CI continues to work.