### PR TITLE
update CI badge after workflow filename changed ci.yaml -> ci.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Natural Language Toolkit (NLTK)
 [![PyPI](https://img.shields.io/pypi/v/nltk.svg)](https://pypi.python.org/pypi/nltk)
-![CI](https://github.com/nltk/nltk/actions/workflows/ci.yaml/badge.svg?branch=develop)
+![CI](https://github.com/nltk/nltk/actions/workflows/ci.yml/badge.svg?branch=develop)
 
 NLTK -- the Natural Language Toolkit -- is a suite of open source Python
 modules, data sets, and tutorials supporting research and development in Natural


### PR DESCRIPTION
This PR updates the link to CI badge in README. This is needed due to filename update as part of improvements in https://github.com/nltk/nltk/commit/4473fde9e.

----------------------------------------
Before:
<img width="352" height="232" alt="image" src="https://github.com/user-attachments/assets/59ee6ee1-6fd8-4426-8acb-3b57e744832f" />
----------------------------------------
After:
<img width="352" height="232" alt="image" src="https://github.com/user-attachments/assets/b28ff457-5a60-4cc5-9307-1ae013fbe497" />
----------------------------------------

