### PR TITLE
cleanup mentions of python versions in documentation and metadata

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ Summary of our git branching model:
 - Do many small commits on that branch locally (`git add files-changed`,
   `git commit -m "Add some change"`);
 - Run the tests to make sure nothing breaks
-  (`tox -e py312` if you are on Python 3.12);
+  (`tox -e py313` if you are on Python 3.13);
 - Add your name to the `AUTHORS.md` file as a contributor;
 - Push to your fork on GitHub (with the name as your local branch:
   `git push origin branch-name`);
@@ -174,7 +174,7 @@ The [`.github/workflows/ci.yaml`](https://github.com/nltk/nltk/blob/develop/.git
        - Otherwise, download all the data packages through `nltk.download('all')`.
 
   - The `test` job
-    - tests against supported Python versions (`3.10`, `3.11`, `3.12`).
+    - tests against supported Python versions (`3.10`, `3.11`, `3.12`, `3.13`, `3.14`).
     - tests on `ubuntu-latest` and `macos-latest`.
     - relies on the `cache_nltk_data` job to ensure that `nltk_data` is available.
     - performs these steps:
@@ -194,7 +194,7 @@ The [`.github/workflows/ci.yaml`](https://github.com/nltk/nltk/blob/develop/.git
 #### To test with `tox` locally
 
 First setup a new virtual environment, see https://docs.python-guide.org/dev/virtualenvs/
-Then run `tox -e py312`.
+Then run `tox -e py313`.
 
 For example, using `pipenv`:
 
@@ -203,7 +203,7 @@ git clone https://github.com/nltk/nltk.git
 cd nltk
 pipenv install -r pip-req.txt
 pipenv install tox
-tox -e py312
+tox -e py313
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 NLTK -- the Natural Language Toolkit -- is a suite of open source Python
 modules, data sets, and tutorials supporting research and development in Natural
-Language Processing. NLTK requires Python version 3.10, 3.11, 3.12 or 3.13.
+Language Processing. NLTK requires Python version 3.10, 3.11, 3.12, 3.13, or 3.14.
 
 For documentation, please visit [nltk.org](https://www.nltk.org/).
 

--- a/nltk/test/unit/test_tgrep.py
+++ b/nltk/test/unit/test_tgrep.py
@@ -14,6 +14,11 @@ Unit tests for nltk.tgrep.
 
 import unittest
 
+import pytest
+
+# nltk.tgrep requires pyparsing package to work
+pytest.importorskip("pyparsing")
+
 from nltk import tgrep
 from nltk.tree import ParentedTree
 

--- a/nltk/test/unit/translate/test_bleu.py
+++ b/nltk/test/unit/translate/test_bleu.py
@@ -4,7 +4,7 @@ Tests for BLEU translation evaluation metric
 
 import unittest
 
-import numpy as np
+import pytest
 
 from nltk.data import find
 from nltk.translate.bleu_score import (
@@ -219,6 +219,8 @@ class TestBLEUFringeCases(unittest.TestCase):
             pass  # unittest.TestCase.assertWarns is only supported in Python >= 3.2.
 
     def test_numpy_weights(self):
+        # numpy is required for the test execution
+        np = pytest.importorskip("numpy")
         # Test case where there's 0 matches
         references = ["The candidate has no alignment to any of the references".split()]
         hypothesis = "John loves Mary".split()

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     },
     long_description="""\
 The Natural Language Toolkit (NLTK) is a Python package for
-natural language processing.  NLTK requires Python 3.10, 3.11, 3.12, or 3.13.""",
+natural language processing.  NLTK requires Python 3.10, 3.11, 3.12, 3.13, or 3.14.""",
     license="Apache License, Version 2.0",
     keywords=[
         "NLP",

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    py{310,311,312,313}
+    py{310,311,312,313,314}
     pypy
-    py{310,311,312,313}-nodeps
-    py{310,311,312,313}-jenkins
+    py{310,311,312,313,314}-nodeps
+    py{310,311,312,313,314}-jenkins
     py-travis
 
 [testenv]
@@ -79,6 +79,13 @@ commands = pytest
 
 [testenv:py313-nodeps]
 basepython = python3.13
+deps =
+    pytest
+    pytest-mock
+commands = pytest
+
+[testenv:py314-nodeps]
+basepython = python3.14
 deps =
     pytest
     pytest-mock

--- a/web/install.rst
+++ b/web/install.rst
@@ -1,7 +1,7 @@
 Installing NLTK
 ===============
 
-NLTK requires Python versions 3.10, 3.11, 3.12 or 3.13.
+NLTK requires Python versions 3.10, 3.11, 3.12, 3.13, or 3.14.
 
 For Windows users, it is strongly recommended that you go through this guide to install Python 3 successfully https://docs.python-guide.org/starting/install3/win/#install3-windows
 


### PR DESCRIPTION
This PR proposes including py3.14 in places where python versions are mentioned.
It also adds a few skips for scenarios where only core nltk tests are run without third party dependencies.