### PR TITLE
Test free-threaded Python with pytest-run-parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,11 +67,8 @@ jobs:
     needs: [pre-commit, minimal_download_test]
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         os: [ubuntu-latest, macos-latest, windows-latest]
-        exclude:
-          - os: windows-latest
-            python-version: '3.14t'  # scikit-learn issue on Py3.14t on Windows
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -154,3 +151,10 @@ jobs:
         shell: bash
         run: |
           pytest --numprocesses auto -rsx --doctest-modules nltk
+
+      - name: Run pytest-run-parallel
+        if: matrix.python-version == '3.13' || matrix.python-version == '3.14'
+        shell: bash
+        run: |
+          python -m pip install pytest-run-parallel[psutil]
+          pytest --iterations=8 --parallel-threads=auto --doctest-modules nltk

--- a/nltk/test/unit/lm/test_counter.py
+++ b/nltk/test/unit/lm/test_counter.py
@@ -30,6 +30,8 @@ class TestNgramCounter:
         assert self.bigram_counter.N() == 16
         assert self.trigram_counter.N() == 21
 
+    @pytest.mark.iterations(1)
+    @pytest.mark.parallel_threads(1)
     def test_counter_len_changes_with_lookup(self):
         assert len(self.bigram_counter) == 2
         self.bigram_counter[50]

--- a/nltk/test/unit/test_concordance.py
+++ b/nltk/test/unit/test_concordance.py
@@ -3,6 +3,8 @@ import sys
 import unittest
 from io import StringIO
 
+import pytest
+
 from nltk.corpus import gutenberg
 from nltk.text import Text
 
@@ -74,6 +76,7 @@ class TestConcordance(unittest.TestCase):
         concordance_out = self.text.concordance_list(self.query, lines=3)
         self.assertEqual(self.list_out[:3], [c.line for c in concordance_out])
 
+    @pytest.mark.parallel_threads(1)
     def test_concordance_print(self):
         print_out = """Displaying 11 of 11 matches:
         ong the former , one was of a most monstrous size . ... This came towards us ,

--- a/nltk/test/unit/test_corpora.py
+++ b/nltk/test/unit/test_corpora.py
@@ -72,6 +72,7 @@ class TestFloresta(unittest.TestCase):
 
 
 class TestSinicaTreebank(unittest.TestCase):
+    @pytest.mark.parallel_threads(1)
     def test_sents(self):
         first_3_sents = sinica_treebank.sents()[:3]
         self.assertEqual(
@@ -79,6 +80,7 @@ class TestSinicaTreebank(unittest.TestCase):
             [["一"], ["友情"], ["嘉珍", "和", "我", "住在", "同一條", "巷子"]],
         )
 
+    @pytest.mark.parallel_threads(1)
     def test_parsed_sents(self):
         parsed_sents = sinica_treebank.parsed_sents()[25]
         self.assertEqual(
@@ -97,12 +99,14 @@ class TestSinicaTreebank(unittest.TestCase):
 class TestCoNLL2007(unittest.TestCase):
     # Reading the CoNLL 2007 Dependency Treebanks
 
+    @pytest.mark.parallel_threads(1)
     def test_sents(self):
         sents = conll2007.sents("esp.train")[0]
         self.assertEqual(
             sents[:6], ["El", "aumento", "del", "índice", "de", "desempleo"]
         )
 
+    @pytest.mark.parallel_threads(1)
     def test_parsed_sents(self):
         parsed_sents = conll2007.parsed_sents("esp.train")[0]
 

--- a/nltk/test/unit/test_downloader.py
+++ b/nltk/test/unit/test_downloader.py
@@ -2,6 +2,8 @@ import os
 import shutil
 import unittest.mock
 
+import pytest
+
 from nltk import download
 from nltk.downloader import build_index
 
@@ -24,6 +26,7 @@ def test_downloader_using_non_existing_parent_download_dir(tmp_path):
     assert download_status is True
 
 
+@pytest.mark.iterations(1)
 def test_downloader_redownload(tmp_path):
     """Test that a second download correctly triggers the 'already up-to-date' message"""
 

--- a/nltk/test/unit/test_nombank.py
+++ b/nltk/test/unit/test_nombank.py
@@ -4,6 +4,8 @@ Unit tests for nltk.corpus.nombank
 
 import unittest
 
+import pytest
+
 from nltk.corpus import nombank
 
 # Load the nombank once.
@@ -11,6 +13,7 @@ nombank.nouns()
 
 
 class NombankDemo(unittest.TestCase):
+    @pytest.mark.parallel_threads(1)
     def test_numbers(self):
         # No. of instances.
         self.assertEqual(len(nombank.instances()), 114574)
@@ -19,6 +22,7 @@ class NombankDemo(unittest.TestCase):
         # No. of nouns.
         self.assertEqual(len(nombank.nouns()), 4704)
 
+    @pytest.mark.parallel_threads(1)
     def test_instance(self):
         self.assertEqual(nombank.instances()[0].roleset, "perc-sign.01")
 

--- a/nltk/test/unit/test_pos_tag.py
+++ b/nltk/test/unit/test_pos_tag.py
@@ -6,6 +6,8 @@ import io
 import unittest
 import unittest.mock
 
+import pytest
+
 from nltk import pos_tag, word_tokenize
 from nltk.help import brown_tagset, claws5_tagset, upenn_tagset
 
@@ -66,12 +68,15 @@ class TestPosTag(unittest.TestCase):
         tagset(query_regex)
         self.assertEqual(mock_stdout.getvalue(), expected_output)
 
+    @pytest.mark.parallel_threads(1)
     def test_tagsets_upenn(self):
         self.check_stdout(upenn_tagset, r".*\$", UPENN_TAGSET_DOLLAR_TEST)
 
+    @pytest.mark.parallel_threads(1)
     def test_tagsets_brown(self):
         self.check_stdout(brown_tagset, r"NNS", BROWN_TAGSET_NNS_TEST)
 
+    @pytest.mark.parallel_threads(1)
     def test_tagsets_claw5(self):
         self.check_stdout(claws5_tagset, r"VHD", CLAW5_TAGSET_VHD_TEST)
 

--- a/nltk/test/unit/test_util.py
+++ b/nltk/test/unit/test_util.py
@@ -9,6 +9,8 @@ def everygram_input():
     return iter(["a", "b", "c"])
 
 
+@pytest.mark.iterations(1)
+@pytest.mark.parallel_threads(1)
 def test_everygrams_without_padding(everygram_input):
     expected_output = [
         ("a",),
@@ -22,6 +24,8 @@ def test_everygrams_without_padding(everygram_input):
     assert output == expected_output
 
 
+@pytest.mark.iterations(1)
+@pytest.mark.parallel_threads(1)
 def test_everygrams_max_len(everygram_input):
     expected_output = [
         ("a",),
@@ -34,6 +38,8 @@ def test_everygrams_max_len(everygram_input):
     assert output == expected_output
 
 
+@pytest.mark.iterations(1)
+@pytest.mark.parallel_threads(1)
 def test_everygrams_min_len(everygram_input):
     expected_output = [
         ("a", "b"),
@@ -44,6 +50,8 @@ def test_everygrams_min_len(everygram_input):
     assert output == expected_output
 
 
+@pytest.mark.iterations(1)
+@pytest.mark.parallel_threads(1)
 def test_everygrams_pad_right(everygram_input):
     expected_output = [
         ("a",),
@@ -63,6 +71,8 @@ def test_everygrams_pad_right(everygram_input):
     assert output == expected_output
 
 
+@pytest.mark.iterations(1)
+@pytest.mark.parallel_threads(1)
 def test_everygrams_pad_left(everygram_input):
     expected_output = [
         (None,),

--- a/nltk/test/unit/test_wordnet.py
+++ b/nltk/test/unit/test_wordnet.py
@@ -5,6 +5,8 @@ See also nltk/test/wordnet.doctest
 
 import unittest
 
+import pytest
+
 from nltk.corpus import wordnet as wn
 from nltk.corpus import wordnet_ic as wnic
 
@@ -14,6 +16,7 @@ L = wn.lemma
 
 
 class WordnNetDemo(unittest.TestCase):
+    @pytest.mark.parallel_threads(1)
     def test_retrieve_synset(self):
         move_synset = S("go.v.21")
         self.assertEqual(move_synset.name(), "move.v.15")
@@ -23,6 +26,7 @@ class WordnNetDemo(unittest.TestCase):
         )
         self.assertEqual(move_synset.examples(), ["Can I go now?"])
 
+    @pytest.mark.parallel_threads(1)
     def test_retrieve_synsets(self):
         self.assertEqual(sorted(wn.synsets("zap", pos="n")), [S("zap.n.01")])
         self.assertEqual(
@@ -30,6 +34,7 @@ class WordnNetDemo(unittest.TestCase):
             [S("microwave.v.01"), S("nuke.v.01"), S("zap.v.01"), S("zap.v.02")],
         )
 
+    @pytest.mark.parallel_threads(1)
     def test_hyperhyponyms(self):
         # Not every synset as hypernyms()
         self.assertEqual(S("travel.v.01").hypernyms(), [])
@@ -65,6 +70,7 @@ class WordnNetDemo(unittest.TestCase):
             sorted(S("fall.v.12").root_hypernyms()), [S("act.v.01"), S("fall.v.17")]
         )
 
+    @pytest.mark.parallel_threads(1)
     def test_derivationally_related_forms(self):
         # Test `derivationally_related_forms()`
         self.assertEqual(
@@ -81,6 +87,7 @@ class WordnNetDemo(unittest.TestCase):
         )
         self.assertEqual(L("zap.v.03.zap").derivationally_related_forms(), [])
 
+    @pytest.mark.parallel_threads(1)
     def test_meronyms_holonyms(self):
         # Test meronyms, holonyms.
         self.assertEqual(
@@ -111,6 +118,7 @@ class WordnNetDemo(unittest.TestCase):
             ],
         )
 
+    @pytest.mark.parallel_threads(1)
     def test_antonyms(self):
         # Test antonyms.
         self.assertEqual(
@@ -120,6 +128,7 @@ class WordnNetDemo(unittest.TestCase):
             L("increase.v.1.increase").antonyms(), [L("decrease.v.01.decrease")]
         )
 
+    @pytest.mark.parallel_threads(1)
     def test_misc_relations(self):
         # Test misc relations.
         self.assertEqual(S("snore.v.1").entailments(), [S("sleep.v.01")])
@@ -143,6 +152,7 @@ class WordnNetDemo(unittest.TestCase):
             L("English.a.1.English").pertainyms(), [L("england.n.01.England")]
         )
 
+    @pytest.mark.parallel_threads(1)
     def test_lch(self):
         # Test LCH.
         self.assertEqual(
@@ -154,12 +164,14 @@ class WordnNetDemo(unittest.TestCase):
             [S("woman.n.01")],
         )
 
+    @pytest.mark.parallel_threads(1)
     def test_domains(self):
         # Test domains.
         self.assertEqual(S("code.n.03").topic_domains(), [S("computer_science.n.01")])
         self.assertEqual(S("pukka.a.01").region_domains(), [S("india.n.01")])
         self.assertEqual(S("freaky.a.01").usage_domains(), [S("slang.n.02")])
 
+    @pytest.mark.parallel_threads(1)
     def test_in_topic_domains(self):
         # Test in domains.
         self.assertEqual(
@@ -172,6 +184,7 @@ class WordnNetDemo(unittest.TestCase):
             sorted(S("slang.n.02").in_usage_domains())[1], S("airhead.n.01")
         )
 
+    @pytest.mark.parallel_threads(1)
     def test_wordnet_similarities(self):
         # Path based similarities.
         self.assertAlmostEqual(S("cat.n.01").path_similarity(S("cat.n.01")), 1.0)
@@ -220,6 +233,7 @@ class WordnNetDemo(unittest.TestCase):
             S("dog.n.01").lin_similarity(S("cat.n.01"), semcor_ic), 0.8863, places=3
         )
 
+    @pytest.mark.parallel_threads(1)
     def test_omw_lemma_no_trailing_underscore(self):
         expected = sorted(
             [
@@ -231,6 +245,7 @@ class WordnNetDemo(unittest.TestCase):
         )
         self.assertEqual(sorted(S("about-face.n.02").lemma_names(lang="slv")), expected)
 
+    @pytest.mark.parallel_threads(1)
     def test_iterable_type_for_all_lemma_names(self):
         # Duck-test for iterables.
         # See https://stackoverflow.com/a/36230057/610569
@@ -269,6 +284,7 @@ class WordnNetDemo(unittest.TestCase):
         self.assertIsNone(wn.tag2pos("POS"))
         self.assertIsNone(wn.tag2pos("."))
 
+    @pytest.mark.parallel_threads(1)
     def test_en_brown_tags(self):
         # Common Brown tags (mapped in both PTB and Brown)
         self.assertEqual(wn.tag2pos("NN", tagset="en-brown"), "n")  # noun

--- a/nltk/test/unit/translate/test_bleu.py
+++ b/nltk/test/unit/translate/test_bleu.py
@@ -134,6 +134,7 @@ class TestBLEU(unittest.TestCase):
             weights = (1.0 / n,) * n  # Uniform weights.
             assert sentence_bleu(references, hypothesis, weights) == 1.0
 
+    @pytest.mark.parallel_threads(1)
     def test_partial_matches_hypothesis_longer_than_reference(self):
         references = ["John loves Mary".split()]
         hypothesis = "John loves Mary who loves Mike".split()
@@ -149,6 +150,7 @@ class TestBLEU(unittest.TestCase):
 
 # @unittest.skip("Skipping fringe cases for BLEU.")
 class TestBLEUFringeCases(unittest.TestCase):
+    @pytest.mark.parallel_threads(1)
     def test_case_where_n_is_bigger_than_hypothesis_length(self):
         # Test BLEU to nth order of n-grams, where n > len(hypothesis).
         references = ["John loves Mary ?".split()]
@@ -204,6 +206,7 @@ class TestBLEUFringeCases(unittest.TestCase):
         hypothesis = []
         assert sentence_bleu(references, hypothesis) == 0
 
+    @pytest.mark.parallel_threads(1)
     def test_reference_or_hypothesis_shorter_than_fourgrams(self):
         # Test case where the length of reference or hypothesis
         # is shorter than 4.
@@ -273,6 +276,7 @@ class TestBLEUvsMteval13a(unittest.TestCase):
 
 
 class TestBLEUWithBadSentence(unittest.TestCase):
+    @pytest.mark.parallel_threads(1)
     def test_corpus_bleu_with_bad_sentence(self):
         hyp = "Teo S yb , oe uNb , R , T t , , t Tue Ar saln S , , 5istsi l , 5oe R ulO sae oR R"
         ref = str(

--- a/nltk/test/unit/translate/test_ibm5.py
+++ b/nltk/test/unit/translate/test_ibm5.py
@@ -5,6 +5,8 @@ Tests for IBM Model 5 training methods
 import unittest
 from collections import defaultdict
 
+import pytest
+
 from nltk.translate import AlignedSent, IBMModel, IBMModel4, IBMModel5
 from nltk.translate.ibm_model import AlignmentInfo
 
@@ -124,6 +126,7 @@ class TestIBMModel5(unittest.TestCase):
         )
         self.assertEqual(round(probability, 4), round(expected_probability, 4))
 
+    @pytest.mark.parallel_threads(1)
     def test_prune(self):
         # arrange
         alignment_infos = [

--- a/nltk/test/unit/translate/test_meteor.py
+++ b/nltk/test/unit/translate/test_meteor.py
@@ -1,5 +1,7 @@
 import unittest
 
+import pytest
+
 from nltk.translate.meteor_score import meteor_score
 
 
@@ -7,6 +9,7 @@ class TestMETEOR(unittest.TestCase):
     reference = [["this", "is", "a", "test"], ["this", "is" "test"]]
     candidate = ["THIS", "Is", "a", "tEST"]
 
+    @pytest.mark.parallel_threads(1)
     def test_meteor(self):
         score = meteor_score(self.reference, self.candidate, preprocess=str.lower)
         assert score == 0.9921875


### PR DESCRIPTION
To be confident about free-threaded compatibility, it is recommended to test with [`pytest-run-parallel`](https://github.com/Quansight-Labs/pytest-run-parallel).
* https://py-free-threading.github.io/testing

Something like:
% `uvx --with=pytest-run-parallel pytest --iterations=8 --parallel-threads=auto`

@purificant @MrMarvel @ekaf

---
Update 2025_11_09:
* [x] `import sklearn` currently re-enables the GIL but a fix is in progress...
    * https://github.com/scikit-learn/scikit-learn/pull/32528#issuecomment-3506086127
* [ ] 37 test functions are currently marked as thread-unsafe.
> @pytest.mark.iterations(1)
@pytest.mark.parallel_threads(1)

