### PR TITLE
Update destructive.py

### DIFF
--- a/nltk/test/unit/test_tokenize.py
+++ b/nltk/test/unit/test_tokenize.py
@@ -440,6 +440,35 @@ class TestTokenize:
         ]
         assert word_tokenize(text) == expected
 
+    def test_dash_tokenization(self):
+        """
+        Test for em-dashes and en-dashes (Issue #3459)
+        """
+        tokenizer = NLTKWordTokenizer()
+
+        # Test case from Issue #3459 (Em-Dash: \u2014)
+        s_em = "The food—which was delicious—reminded me of home."
+        expected_em = [
+            'The', 'food', '—', 'which', 'was', 'delicious',
+            '—', 'reminded', 'me', 'of', 'home', '.'
+        ]
+        self.assertEqual(tokenizer.tokenize(s_em), expected_em)
+
+        # Test case for En-Dash (\u2013)
+        s_en = "The score was 3–1."
+        expected_en = ['The', 'score', 'was', '3', '–', '1', '.']
+        self.assertEqual(tokenizer.tokenize(s_en), expected_en)
+        
+        # Test case for Horizontal Bar (\u2015)
+        s_bar = "He said — wait for it — a new thing."
+        expected_bar = ['He', 'said', '—', 'wait', 'for', 'it', '—', 'a', 'new', 'thing', '.']
+        self.assertEqual(tokenizer.tokenize(s_bar), expected_bar)
+        
+        # Test case for Figure Dash (\u2012)
+        s_fig = "The number is 12‒34."
+        expected_fig = ['The', 'number', 'is', '12', '‒', '34', '.']
+        self.assertEqual(tokenizer.tokenize(s_fig), expected_fig)
+
     def test_pad_dotdot(self):
         """
         Test padding of dotdot* for word tokenization.

--- a/nltk/test/unit/test_tokenize.py
+++ b/nltk/test/unit/test_tokenize.py
@@ -444,7 +444,6 @@ class TestTokenize:
         """
         Test for em-dashes and en-dashes (Issue #3459)
         """
-        tokenizer = NLTKWordTokenizer()
 
         # Test case from Issue #3459 (Em-Dash: \u2014)
         s_em = "The food—which was delicious—reminded me of home."
@@ -462,12 +461,12 @@ class TestTokenize:
             "home",
             ".",
         ]
-        self.assertEqual(tokenizer.tokenize(s_em), expected_em)
+        assert word_tokenize(s_em) == expected_em
 
         # Test case for En-Dash (\u2013)
         s_en = "The score was 3–1."
         expected_en = ["The", "score", "was", "3", "–", "1", "."]
-        self.assertEqual(tokenizer.tokenize(s_en), expected_en)
+        assert word_tokenize(s_en) == expected_en
 
         # Test case for Horizontal Bar (\u2015)
         s_bar = "He said — wait for it — a new thing."
@@ -484,12 +483,12 @@ class TestTokenize:
             "thing",
             ".",
         ]
-        self.assertEqual(tokenizer.tokenize(s_bar), expected_bar)
+        assert word_tokenize(s_bar) == expected_bar
 
         # Test case for Figure Dash (\u2012)
         s_fig = "The number is 12‒34."
         expected_fig = ["The", "number", "is", "12", "‒", "34", "."]
-        self.assertEqual(tokenizer.tokenize(s_fig), expected_fig)
+        assert word_tokenize(s_fig) == expected_fig
 
     def test_pad_dotdot(self):
         """

--- a/nltk/test/unit/test_tokenize.py
+++ b/nltk/test/unit/test_tokenize.py
@@ -449,24 +449,46 @@ class TestTokenize:
         # Test case from Issue #3459 (Em-Dash: \u2014)
         s_em = "The food—which was delicious—reminded me of home."
         expected_em = [
-            'The', 'food', '—', 'which', 'was', 'delicious',
-            '—', 'reminded', 'me', 'of', 'home', '.'
+            "The",
+            "food",
+            "—",
+            "which",
+            "was",
+            "delicious",
+            "—",
+            "reminded",
+            "me",
+            "of",
+            "home",
+            ".",
         ]
         self.assertEqual(tokenizer.tokenize(s_em), expected_em)
 
         # Test case for En-Dash (\u2013)
         s_en = "The score was 3–1."
-        expected_en = ['The', 'score', 'was', '3', '–', '1', '.']
+        expected_en = ["The", "score", "was", "3", "–", "1", "."]
         self.assertEqual(tokenizer.tokenize(s_en), expected_en)
-        
+
         # Test case for Horizontal Bar (\u2015)
         s_bar = "He said — wait for it — a new thing."
-        expected_bar = ['He', 'said', '—', 'wait', 'for', 'it', '—', 'a', 'new', 'thing', '.']
+        expected_bar = [
+            "He",
+            "said",
+            "—",
+            "wait",
+            "for",
+            "it",
+            "—",
+            "a",
+            "new",
+            "thing",
+            ".",
+        ]
         self.assertEqual(tokenizer.tokenize(s_bar), expected_bar)
-        
+
         # Test case for Figure Dash (\u2012)
         s_fig = "The number is 12‒34."
-        expected_fig = ['The', 'number', 'is', '12', '‒', '34', '.']
+        expected_fig = ["The", "number", "is", "12", "‒", "34", "."]
         self.assertEqual(tokenizer.tokenize(s_fig), expected_fig)
 
     def test_pad_dotdot(self):

--- a/nltk/test/unit/test_tokenize.py
+++ b/nltk/test/unit/test_tokenize.py
@@ -469,15 +469,15 @@ class TestTokenize:
         assert word_tokenize(s_en) == expected_en
 
         # Test case for Horizontal Bar (\u2015)
-        s_bar = "He said — wait for it — a new thing."
+        s_bar = "He said ― wait for it ― a new thing."
         expected_bar = [
             "He",
             "said",
-            "—",
+            "―",
             "wait",
             "for",
             "it",
-            "—",
+            "―",
             "a",
             "new",
             "thing",
@@ -489,6 +489,9 @@ class TestTokenize:
         s_fig = "The number is 12‒34."
         expected_fig = ["The", "number", "is", "12", "‒", "34", "."]
         assert word_tokenize(s_fig) == expected_fig
+
+        # Regression guard for hyphen-minus
+        assert word_tokenize("state-of-the-art") == ["state-of-the-art"]
 
     def test_pad_dotdot(self):
         """

--- a/nltk/tokenize/destructive.py
+++ b/nltk/tokenize/destructive.py
@@ -85,7 +85,8 @@ class NLTKWordTokenizer(TokenizerI):
             re.compile(r"\.{2,}", re.U),
             r" \g<0> ",
         ),  # See https://github.com/nltk/nltk/pull/2322
-        (re.compile(r"[;@#$%&]"), r" \g<0> "),
+        (re.compile(r"[;@#$%&]"), r" \g<0> 
+        (re.compile(r"\u2014", re.U), r" \g<0> "), # \u2014 handles emdashes
         (
             re.compile(r'([^\.])(\.)([\]\)}>"\']*)\s*$'),
             r"\1 \2\3 ",

--- a/nltk/tokenize/destructive.py
+++ b/nltk/tokenize/destructive.py
@@ -86,7 +86,7 @@ class NLTKWordTokenizer(TokenizerI):
             r" \g<0> ",
         ),  # See https://github.com/nltk/nltk/pull/2322
         (re.compile(r"[;@#$%&]"), r" \g<0> 
-        (re.compile(r"\u2014", re.U), r" \g<0> "), # \u2014 handles emdashes
+        (re.compile(r"\u2014", re.UNICODE), r" \g<0> "),  # \u2014 handles emdashes
         (
             re.compile(r'([^\.])(\.)([\]\)}>"\']*)\s*$'),
             r"\1 \2\3 ",

--- a/nltk/tokenize/destructive.py
+++ b/nltk/tokenize/destructive.py
@@ -85,7 +85,7 @@ class NLTKWordTokenizer(TokenizerI):
             re.compile(r"\.{2,}", re.U),
             r" \g<0> ",
         ),  # See https://github.com/nltk/nltk/pull/2322
-        (re.compile(r"[;@#$%&]"), r" \g<0> 
+        (re.compile(r"[;@#$%&]"), r" \g<0> "),
         (re.compile(r"\u2014", re.UNICODE), r" \g<0> "),  # \u2014 handles emdashes
         (
             re.compile(r'([^\.])(\.)([\]\)}>"\']*)\s*$'),

--- a/nltk/tokenize/destructive.py
+++ b/nltk/tokenize/destructive.py
@@ -86,7 +86,7 @@ class NLTKWordTokenizer(TokenizerI):
             r" \g<0> ",
         ),  # See https://github.com/nltk/nltk/pull/2322
         (re.compile(r"[;@#$%&]"), r" \g<0> "),
-        (re.compile(r"\u2014", re.UNICODE), r" \g<0> "),  # \u2014 handles emdashes
+        (re.compile(r"[\u2012-\u2015]", re.UNICODE), r" \g<0> "),  # Handles figure dash, en dashes, em dashes and horizontal bars
         (
             re.compile(r'([^\.])(\.)([\]\)}>"\']*)\s*$'),
             r"\1 \2\3 ",

--- a/nltk/tokenize/destructive.py
+++ b/nltk/tokenize/destructive.py
@@ -86,7 +86,10 @@ class NLTKWordTokenizer(TokenizerI):
             r" \g<0> ",
         ),  # See https://github.com/nltk/nltk/pull/2322
         (re.compile(r"[;@#$%&]"), r" \g<0> "),
-        (re.compile(r"[\u2012-\u2015]", re.UNICODE), r" \g<0> "),  # Handles figure dash, en dashes, em dashes and horizontal bars
+        (
+            re.compile(r"[\u2012-\u2015]", re.UNICODE),
+            r" \g<0> ",
+        ),  # Handles figure dash, en dashes, em dashes and horizontal bars
         (
             re.compile(r'([^\.])(\.)([\]\)}>"\']*)\s*$'),
             r"\1 \2\3 ",


### PR DESCRIPTION
Fixes #3459 

I'd like to propose a fix for this issue. As @ryanavella pointed out, the NLTKWordTokenizer currently doesn't treat the em-dash (—) as a separate punctuation mark, which causes it to incorrectly merge adjacent words (e.g., food—which).

This is because the em-dash is missing from the PUNCTUATION regex list in nltk/tokenize/destructive.py.

The Fix
I've added a new rule to the PUNCTUATION list to specifically handle the em-dash by padding it with spaces.

Here is the diff for the change in nltk/tokenize/destructive.py:

```diff
--- a/nltk/tokenize/destructive.py
+++ b/nltk/tokenize/destructive.py
@@ -87,6 +87,7 @@
             re.compile(r"\.{2,}", re.U),
             r" \g<0> ",
         ),  # See https://github.com/nltk/nltk/pull/2322
         (re.compile(r"[;@#$%&]"), r" \g<0> "),
+        (re.compile(r"\u2014", re.U), r" \g<0> "), # Handle em-dashes
         (
             re.compile(r'([^\.])(\.)([\]\)}>"\']*)\s*$'),
             r"\1 \2\3 ",
```

Test Results
With this fix, the tokenizer now correctly handles the example provided in the issue:

Python

import nltk
s = "The food—which was delicious—reminded me of home."
Before:

Python

>>> nltk.word_tokenize(s)
['The', 'food—which', 'was', 'delicious—reminded', 'me', 'of', 'home', '.']
After:

Python

>>> nltk.word_tokenize(s)
['The', 'food', '—', 'which', 'was', 'delicious', '—', 'reminded', 'me', 'of', 'home', '.']
Regarding the pos_tag Issue
This tokenization fix also resolves the root cause of the incorrect pos_tag output. The tagger was previously receiving "garbage" tokens (food—which) and making incorrect guesses.

With the corrected tokens, the pos_tag output is now logical:

Python

>>> nltk.pos_tag(nltk.word_tokenize(s))
[('The', 'DT'), ('food', 'NN'), ('—', 'NNP'), ('which', 'WDT'), ('was', 'VBD'), 
 ('delicious', 'JJ'), ('—', 'NNP'), ('reminded', 'VBD'), ('me', 'PRP'), 
 ('of', 'IN'), ('home', 'NN'), ('.', '.')]


The tagger correctly identifies all the words (food, which, delicious, etc.). It appears to default to NNP (Proper Noun) for the lone — token, which is a reasonable guess from the statistical model given it's likely an unknown token in that context. The core tokenization problem is solved.

I have tested this locally and am happy to open a Pull Request.