### PR TITLE
replace eval() with getattr() in collocations CLI

### DIFF
--- a/nltk/collocations.py
+++ b/nltk/collocations.py
@@ -389,17 +389,27 @@ def demo(scorer=None, compare_scorer=None):
 # bigram_measures = BigramAssocMeasures()
 # trigram_measures = TrigramAssocMeasures()
 
+# Command-line interface for demonstrating bigram collocations.
+#
+# Usage: python -m nltk.collocations [scorer] [compare_scorer]
+#
+# Demonstrates bigram collocations on the WebText corpus.
+# Defaults to likelihood_ratio and raw_freq if not specified.
+#
+# Available scorers:
+#   chi_sq, dice, fisher, jaccard, likelihood_ratio, mi_like,
+#   phi_sq, pmi, poisson_stirling, raw_freq, student_t
 if __name__ == "__main__":
     import sys
 
     from nltk.metrics import BigramAssocMeasures
 
     try:
-        scorer = eval("BigramAssocMeasures." + sys.argv[1])
+        scorer = getattr(BigramAssocMeasures, sys.argv[1], None)
     except IndexError:
         scorer = None
     try:
-        compare_scorer = eval("BigramAssocMeasures." + sys.argv[2])
+        compare_scorer = getattr(BigramAssocMeasures, sys.argv[2], None)
     except IndexError:
         compare_scorer = None
 


### PR DESCRIPTION
This PR replaces [eval()](https://docs.python.org/3/library/functions.html#eval) with [getattr()](https://docs.python.org/3/library/functions.html#getattr) when parsing command-line arguments.

The `__main__` block previously used `eval()` to dynamically access `BigramAssocMeasures` methods based on command-line arguments. Since we only need attribute access (not expression evaluation), `getattr()` is more appropriate. Using `eval()` on user provided input also unnecessarily allows arbitrary code execution, which `getattr()` prevents.