### PR TITLE
Added RTL language syntactic tree visualization support

### DIFF
--- a/nltk/tree/prettyprinter.py
+++ b/nltk/tree/prettyprinter.py
@@ -30,6 +30,8 @@ from operator import itemgetter
 from nltk.tree.tree import Tree
 from nltk.util import OrderedDict
 
+
+
 ANSICOLOR = {
     "black": 30,
     "red": 31,
@@ -362,7 +364,7 @@ class TreePrettyPrinter:
             leftcorner = "\u250c"
             rightcorner = "\u2510"
             vertline = " \u2502 "
-            tee = horzline + "\u252c" + horzline
+            tee = horzline + "\u252C" + horzline
             bottom = horzline + "\u2534" + horzline
             cross = horzline + "\u253c" + horzline
             ellipsis = "\u2026"

--- a/nltk/tree/tree.py
+++ b/nltk/tree/tree.py
@@ -760,15 +760,69 @@ class Tree(list):
 
         draw_trees(self)
 
-    def pretty_print(self, sentence=None, highlight=(), stream=None, **kwargs):
+    def pretty_print(self, sentence=None, highlight=(), stream=None, rtl=False, **kwargs):
         """
         Pretty-print this tree as ASCII or Unicode art.
         For explanation of the arguments, see the documentation for
         `nltk.tree.prettyprinter.TreePrettyPrinter`.
+
+        :param rtl: If True, display tree right-to-left for RTL languages (Arabic, Hebrew, etc.)
+        :type rtl: bool
         """
         from nltk.tree.prettyprinter import TreePrettyPrinter
 
-        print(TreePrettyPrinter(self, sentence, highlight).text(**kwargs), file=stream)
+        # Mirror the tree if RTL is requested
+        if rtl:
+            # First, collect the original leaf order
+            original_leaves = self.leaves()
+            # Mirror the tree structure
+            tree_to_print = self._mirror_structure_for_rtl()
+            # Restore the original leaf order
+            tree_to_print = self._restore_leaf_order(tree_to_print, original_leaves)
+        else:
+            tree_to_print = self
+
+        print(TreePrettyPrinter(tree_to_print, sentence, highlight).text(**kwargs), file=stream)
+
+    def _mirror_structure_for_rtl(self):
+        """
+        Mirror only the tree structure (non-terminals), keeping leaves in place.
+
+        :return: A new tree with reversed structure but original leaf order
+        :rtype: Tree
+        """
+        # Recursively mirror all children
+        mirrored_children = [
+            child._mirror_structure_for_rtl() if isinstance(child, Tree) else child
+            for child in reversed(self)
+        ]
+
+        # Create new tree with same label but reversed children
+        return type(self)(self._label, mirrored_children)
+
+    @staticmethod
+    def _restore_leaf_order(tree, original_leaves):
+        """
+        Replace leaves in the mirrored tree with original leaf order.
+
+        :param tree: The mirrored tree
+        :param original_leaves: List of leaves in original order
+        :return: Tree with structure mirrored but leaves in original order
+        :rtype: Tree
+        """
+        leaf_iter = iter(original_leaves)
+
+        def replace_leaves(subtree):
+            if isinstance(subtree, Tree):
+                new_children = []
+                for child in subtree:
+                    new_children.append(replace_leaves(child))
+                return type(subtree)(subtree.label(), new_children)
+            else:
+                # This is a leaf - replace with next original leaf
+                return next(leaf_iter)
+
+        return replace_leaves(tree)
 
     def __repr__(self):
         childstr = ", ".join(repr(c) for c in self)


### PR DESCRIPTION

# Summary
This pull request is aimed mainly at resolving issue #2886 in NTLK repository by enabling correct visualization of syntactic trees for right-to-left languages. With Arabic script languages being the main focus in this case,  however this implementation should work with any RTL language as well as the implementation is pretty basic in nature. Users can now pass an `rtl = True` parameter to enable `Tree.pretty.print()` to render trees that mirror the tree structure while maintaining the natural word order. 

# Description
The main issue is that because of the right-to-left nature of some langauges; a sentence input to TreePrettyPrinter will appear alligned in reverse to what should be their corresponding tree node label. In other words, the word in the right most of the sentence will appear at the opposite side of its corresponding node label, and so on. It is a purely visual inconsistency. Therefore, the way this implementation works on a technical level is that by simply passing `rtl = True` to `Tree.pretty.print()` the new methods: `_mirror_structure_for_rtl()` reverses or mirrors the entire tree, then `_restore_leaf_order()` replaces the sentence with the correct original order.

## Before

### Input

```
from nltk.tree import Tree

t = Tree.fromstring("(S (VP (V ذهب) (NP (DET ال) (N طفل)) (PP (PREP إلى) (NP (DET ال) (N حديقة)))))")

t.pretty_print()
```

### Output

<img width="854" height="842" alt="Screenshot 2025-11-25 185352" src="https://github.com/user-attachments/assets/768047e2-1312-49f7-a945-cb126ca166d9" />

## After

### Input

```
from nltk.tree import Tree

t = Tree.fromstring("(S (VP (V ذهب) (NP (DET ال) (N طفل)) (PP (PREP إلى) (NP (DET ال) (N حديقة)))))")

t.pretty_print(rtl=True)
```

### Output

<img width="978" height="846" alt="Screenshot 2025-11-25 185402" src="https://github.com/user-attachments/assets/5d915361-a6e4-4b21-a5a6-9f4d7725cf92" />
