### PR TITLE
Support some zipped models

### DIFF
--- a/nltk/classify/maxent.py
+++ b/nltk/classify/maxent.py
@@ -1564,20 +1564,21 @@ class TadmMaxentClassifier(MaxentClassifier):
 def load_maxent_params(tab_dir):
     import numpy
 
+    from nltk.data import open_datafile
     from nltk.tabdata import MaxentDecoder
 
     mdec = MaxentDecoder()
     # Use .join() to reach the files regardless of zip/real FS.
-    with tab_dir.join("weights.txt").open(encoding="utf-8") as f:
+    with open_datafile(tab_dir, "weights.txt") as f:
         wgt = numpy.array(list(map(numpy.float64, mdec.txt2list(f))))
 
-    with tab_dir.join("mapping.tab").open(encoding="utf-8") as f:
+    with open_datafile(tab_dir, "mapping.tab") as f:
         mpg = mdec.tupkey2dict(f)
 
-    with tab_dir.join("labels.txt").open(encoding="utf-8") as f:
+    with open_datafile(tab_dir, "labels.txt") as f:
         lab = mdec.txt2list(f)
 
-    with tab_dir.join("alwayson.tab").open(encoding="utf-8") as f:
+    with open_datafile(tab_dir, "alwayson.tab") as f:
         aon = mdec.tab2ivdict(f)
 
     return wgt, mpg, lab, aon

--- a/nltk/classify/maxent.py
+++ b/nltk/classify/maxent.py
@@ -1567,17 +1567,17 @@ def load_maxent_params(tab_dir):
     from nltk.tabdata import MaxentDecoder
 
     mdec = MaxentDecoder()
-
-    with open(f"{tab_dir}/weights.txt") as f:
+    # Use .join() to reach the files regardless of zip/real FS.
+    with tab_dir.join("weights.txt").open(encoding="utf-8") as f:
         wgt = numpy.array(list(map(numpy.float64, mdec.txt2list(f))))
 
-    with open(f"{tab_dir}/mapping.tab") as f:
+    with tab_dir.join("mapping.tab").open(encoding="utf-8") as f:
         mpg = mdec.tupkey2dict(f)
 
-    with open(f"{tab_dir}/labels.txt") as f:
+    with tab_dir.join("labels.txt").open(encoding="utf-8") as f:
         lab = mdec.txt2list(f)
 
-    with open(f"{tab_dir}/alwayson.tab") as f:
+    with tab_dir.join("alwayson.tab").open(encoding="utf-8") as f:
         aon = mdec.tab2ivdict(f)
 
     return wgt, mpg, lab, aon
@@ -1610,7 +1610,7 @@ def maxent_pos_tagger():
     from nltk.data import find
     from nltk.tag.sequential import ClassifierBasedPOSTagger
 
-    tab_dir = find("taggers/maxent_treebank_pos_tagger_tab/english")
+    tab_dir = find("taggers/maxent_treebank_pos_tagger_tab/english/")
     wgt, mpg, lab, aon = load_maxent_params(tab_dir)
     mc = MaxentClassifier(
         BinaryMaxentFeatureEncoding(lab, mpg, alwayson_features=aon), wgt

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -464,6 +464,11 @@ _resource_cache = {}
    need to be loaded more than once."""
 
 
+def open_datafile(path, file_name):
+    # Use .join() to reach the file regardless of zip/real FS.
+    return path.join(file_name).open(encoding="utf-8")
+
+
 def find(resource_name, paths=None):
     """
     Find the given resource by searching through the directories and

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -465,10 +465,25 @@ _resource_cache = {}
 
 
 def open_datafile(path, file_name):
+    """
+    Open a file using a PathPointer, supporting both filesystem and zip file paths.
+
+    :param path: A PathPointer (FileSystemPathPointer or ZipFilePathPointer)
+        representing the directory containing the file.
+    :type path: PathPointer
+    :param file_name: The name of the file to open within the directory.
+    :type file_name: str
+    :return: A file-like object opened with UTF-8 encoding.
+    :rtype: file
+
+    Example usage:
+        >>> from nltk.data import find, open_datafile
+        >>> path = find('corpora/abc')
+        >>> with open_datafile(path, 'rural.txt') as f:
+        ...     text = f.read()
+    """
     # Use .join() to reach the file regardless of zip/real FS.
     return path.join(file_name).open(encoding="utf-8")
-
-
 def find(resource_name, paths=None):
     """
     Find the given resource by searching through the directories and

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -484,6 +484,8 @@ def open_datafile(path, file_name):
     """
     # Use .join() to reach the file regardless of zip/real FS.
     return path.join(file_name).open(encoding="utf-8")
+
+
 def find(resource_name, paths=None):
     """
     Find the given resource by searching through the directories and

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -466,21 +466,27 @@ _resource_cache = {}
 
 def open_datafile(path, file_name="", encoding="utf-8"):
     """
-    Open a file using a PathPointer, supporting both filesystem and zip file paths.
+    Open a data file using a PathPointer, supporting both filesystem and zip file paths.
 
-    :param path: A PathPointer (FileSystemPathPointer or ZipFilePathPointer) representing
-        the file (when file_name is empty), or the directory containing the file.
+    The function can be used in two ways:
+
+    1. `path` is a PathPointer to a directory, and `file_name` is the name of a file
+       within that directory.
+    2. `path` is a PathPointer to a file, and `file_name` is left empty.
+
+    :param path: A PathPointer (e.g. FileSystemPathPointer or ZipFilePathPointer)
+        representing either the file to open (when file_name is empty), or the
+        directory containing the file.
     :type path: PathPointer
-    :param file_name: The name of the file to open within the directory.
+    :param file_name: The name of the file to open within the directory. Leave empty
+        if `path` already points to the file.
     :type file_name: str
-    :return: A file-like object opened with specified encoding.
-    :rtype: file
-
-    Example usage:
-        >>> from nltk.data import find, open_datafile
-        >>> path = find('corpora/abc')
-        >>> with open_datafile(path, 'rural.txt') as f:
-        ...     text = f.read()
+    :param encoding: The character encoding to use when opening the file. If None,
+        a binary stream is returned.
+    :type encoding: str or None
+    :return: A file-like object (binary stream if encoding is None, otherwise a text
+        stream with the specified encoding).
+    :rtype: file-like
     """
     if file_name:
         # Use .join() to reach the file regardless of zip/real FS.

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -464,16 +464,16 @@ _resource_cache = {}
    need to be loaded more than once."""
 
 
-def open_datafile(path, file_name):
+def open_datafile(path, file_name="", encoding="utf-8"):
     """
     Open a file using a PathPointer, supporting both filesystem and zip file paths.
 
-    :param path: A PathPointer (FileSystemPathPointer or ZipFilePathPointer)
-        representing the directory containing the file.
+    :param path: A PathPointer (FileSystemPathPointer or ZipFilePathPointer) representing
+        the file (when file_name is empty), or the directory containing the file.
     :type path: PathPointer
     :param file_name: The name of the file to open within the directory.
     :type file_name: str
-    :return: A file-like object opened with UTF-8 encoding.
+    :return: A file-like object opened with specified encoding.
     :rtype: file
 
     Example usage:
@@ -482,8 +482,10 @@ def open_datafile(path, file_name):
         >>> with open_datafile(path, 'rural.txt') as f:
         ...     text = f.read()
     """
-    # Use .join() to reach the file regardless of zip/real FS.
-    return path.join(file_name).open(encoding="utf-8")
+    if file_name:
+        # Use .join() to reach the file regardless of zip/real FS.
+        path = path.join(file_name)
+    return path.open(encoding=encoding)
 
 
 def find(resource_name, paths=None):

--- a/nltk/help.py
+++ b/nltk/help.py
@@ -13,7 +13,7 @@ import json
 import re
 from textwrap import wrap
 
-from nltk.data import find
+from nltk.data import find, open_datafile
 
 
 def brown_tagset(tagpattern=None):
@@ -45,8 +45,7 @@ def _print_entries(tags, tagdict):
 
 def _format_tagset(tagset, tagpattern=None):
     # Load tagset from json file.
-    tag_json_file = find(f"help/tagsets_json/PY3_json/{tagset}.json")
-    with open(tag_json_file) as fin:
+    with open_datafile(find("help/tagsets_json/PY3_json/"), f"{tagset}.json") as fin:
         tagdict = json.load(fin)
 
     if not tagpattern:

--- a/nltk/tag/mapping.py
+++ b/nltk/tag/mapping.py
@@ -32,7 +32,7 @@ X - other: foreign words, typos, abbreviations
 from collections import defaultdict
 from os.path import join
 
-from nltk.data import find, open_datafile
+from nltk.data import load
 
 _UNIVERSAL_DATA = "taggers/universal_tagset/"
 _UNIVERSAL_TAGS = (
@@ -56,9 +56,7 @@ _MAPPINGS = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: "UNK")))
 
 
 def _load_universal_map(fileid):
-
-    with open_datafile(find(_UNIVERSAL_DATA), fileid + ".map") as f:
-        contents = f.read()
+    contents = load(join(_UNIVERSAL_DATA, fileid + ".map"), format="text")
 
     # When mapping to the Universal Tagset,
     # map unknown inputs to 'X' not 'UNK'

--- a/nltk/tag/mapping.py
+++ b/nltk/tag/mapping.py
@@ -32,9 +32,9 @@ X - other: foreign words, typos, abbreviations
 from collections import defaultdict
 from os.path import join
 
-from nltk.data import load
+from nltk.data import find, open_datafile
 
-_UNIVERSAL_DATA = "taggers/universal_tagset"
+_UNIVERSAL_DATA = "taggers/universal_tagset/"
 _UNIVERSAL_TAGS = (
     "VERB",
     "NOUN",
@@ -56,7 +56,9 @@ _MAPPINGS = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: "UNK")))
 
 
 def _load_universal_map(fileid):
-    contents = load(join(_UNIVERSAL_DATA, fileid + ".map"), format="text")
+
+    with open_datafile(find(_UNIVERSAL_DATA), fileid + ".map") as f:
+        contents = f.read()
 
     # When mapping to the Universal Tagset,
     # map unknown inputs to 'X' not 'UNK'

--- a/nltk/tag/perceptron.py
+++ b/nltk/tag/perceptron.py
@@ -16,7 +16,7 @@ from os.path import join as path_join
 from tempfile import gettempdir
 
 from nltk import jsontags
-from nltk.data import find, load, open_datafile
+from nltk.data import find, open_datafile
 from nltk.tag.api import TaggerI
 
 try:

--- a/nltk/tag/perceptron.py
+++ b/nltk/tag/perceptron.py
@@ -136,7 +136,7 @@ class PerceptronTagger(TaggerI):
 
     Load the saved model:
 
-    >>> from nltk.data import find, open_datafile
+    >>> from nltk.data import find
     >>> tagger2 = PerceptronTagger(loc=find(tagger.save_dir))
     >>> print(sorted(list(tagger2.classes)))
     ['JJ', 'NN', 'NNS', 'PRP', 'VBZ']

--- a/nltk/tag/perceptron.py
+++ b/nltk/tag/perceptron.py
@@ -16,7 +16,7 @@ from os.path import join as path_join
 from tempfile import gettempdir
 
 from nltk import jsontags
-from nltk.data import find, load
+from nltk.data import find, load, open_datafile
 from nltk.tag.api import TaggerI
 
 try:
@@ -136,7 +136,7 @@ class PerceptronTagger(TaggerI):
 
     Load the saved model:
 
-    >>> from nltk.data import find
+    >>> from nltk.data import find, open_datafile
     >>> tagger2 = PerceptronTagger(loc=find(tagger.save_dir))
     >>> print(sorted(list(tagger2.classes)))
     ['JJ', 'NN', 'NNS', 'PRP', 'VBZ']
@@ -274,12 +274,12 @@ class PerceptronTagger(TaggerI):
 
     def load_from_json(self, lang="eng", loc=None):
         # Automatically find path to the tagger if location is not specified.
+        # loc can refer to zip or real FS
         if not loc:
             loc = find(f"taggers/averaged_perceptron_tagger_{lang}/")
 
         def load_param(json_file):
-            # Use .join() to reach the files regardless of zip/real FS.
-            with loc.join(json_file).open(encoding="utf-8") as fin:
+            with open_datafile(loc, json_file) as fin:
                 return json.load(fin)
 
         self.decode_json_params(

--- a/nltk/tag/perceptron.py
+++ b/nltk/tag/perceptron.py
@@ -136,7 +136,8 @@ class PerceptronTagger(TaggerI):
 
     Load the saved model:
 
-    >>> tagger2 = PerceptronTagger(loc=tagger.save_dir)
+    >>> from nltk.data import find
+    >>> tagger2 = PerceptronTagger(loc=find(tagger.save_dir))
     >>> print(sorted(list(tagger2.classes)))
     ['JJ', 'NN', 'NNS', 'PRP', 'VBZ']
 

--- a/nltk/tag/perceptron.py
+++ b/nltk/tag/perceptron.py
@@ -274,10 +274,11 @@ class PerceptronTagger(TaggerI):
     def load_from_json(self, lang="eng", loc=None):
         # Automatically find path to the tagger if location is not specified.
         if not loc:
-            loc = find(f"taggers/averaged_perceptron_tagger_{lang}")
+            loc = find(f"taggers/averaged_perceptron_tagger_{lang}/")
 
         def load_param(json_file):
-            with open(path_join(loc, json_file)) as fin:
+            # Use .join() to reach the files regardless of zip/real FS.
+            with loc.join(json_file).open(encoding="utf-8") as fin:
                 return json.load(fin)
 
         self.decode_json_params(

--- a/nltk/test/unit/test_json2csv_corpus.py
+++ b/nltk/test/unit/test_json2csv_corpus.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import pytest
 
 from nltk.corpus import twitter_samples
+from nltk.data import open_datafile
 from nltk.twitter.common import json2csv, json2csv_entities
 
 
@@ -32,7 +33,9 @@ subdir = Path(__file__).parent / "files"
 
 @pytest.fixture
 def infile():
-    with open(twitter_samples.abspath("tweets.20150430-223406.json")) as infile:
+    with open_datafile(
+        twitter_samples.abspath("tweets.20150430-223406.json")
+    ) as infile:
         return [next(infile) for x in range(100)]
 
 

--- a/nltk/test/unit/test_open_datafile.py
+++ b/nltk/test/unit/test_open_datafile.py
@@ -1,0 +1,82 @@
+import os
+import zipfile
+from tempfile import TemporaryDirectory
+
+from nltk.data import ZipFilePathPointer, open_datafile
+
+
+def _create_test_zip(root_dir, rel_dir, file_name, contents: bytes):
+    """
+    Create a zip file under root_dir with a single file at rel_dir/file_name
+    containing 'contents'. Return the full path to the zip file and the
+    relative path inside the zip.
+    """
+    zip_path = os.path.join(root_dir, "testdata.zip")
+    arcname = os.path.join(rel_dir, file_name).replace(os.path.sep, "/")
+
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr(arcname, contents)
+
+    return zip_path, arcname
+
+
+def test_open_datafile_directory_and_filename_from_zip():
+    """open_datafile should open a file inside a zip when given dir + file_name."""
+    with TemporaryDirectory() as tmpdir:
+        rel_dir = os.path.join("corpora", "testpkg")
+        file_name = "sample.txt"
+        text = "Hello from zipped data\n"
+        data = text.encode("utf-8")
+
+        zip_path, arcname = _create_test_zip(tmpdir, rel_dir, file_name, data)
+
+        # Directory entry inside the zip (must end with '/').
+        dir_entry = rel_dir.replace(os.path.sep, "/") + "/"
+
+        # PathPointer representing the *directory* inside the zip.
+        path = ZipFilePathPointer(zip_path, dir_entry)
+
+        with open_datafile(path, file_name=file_name, encoding="utf-8") as f:
+            result = f.read()
+
+        assert result == text
+
+
+def test_open_datafile_file_pointer_from_zip():
+    """open_datafile should open a file pointer directly when file_name is empty."""
+    with TemporaryDirectory() as tmpdir:
+        rel_dir = os.path.join("corpora", "testpkg")
+        file_name = "sample.txt"
+        text = "Direct file pointer from zipped data\n"
+        data = text.encode("utf-8")
+
+        zip_path, arcname = _create_test_zip(tmpdir, rel_dir, file_name, data)
+
+        # Directory pointer first, then join to the file to simulate having a file pointer.
+        dir_entry = rel_dir.replace(os.path.sep, "/") + "/"
+        dir_pointer = ZipFilePathPointer(zip_path, dir_entry)
+        file_pointer = dir_pointer.join(file_name)
+
+        with open_datafile(file_pointer, encoding="utf-8") as f:
+            result = f.read()
+
+        assert result == text
+
+
+def test_open_datafile_binary_mode_from_zip():
+    """open_datafile should return a binary stream when encoding=None."""
+    with TemporaryDirectory() as tmpdir:
+        rel_dir = os.path.join("corpora", "testpkg")
+        file_name = "binary.bin"
+        binary_data = b"\x00\x01\x02\xff"
+
+        zip_path, arcname = _create_test_zip(tmpdir, rel_dir, file_name, binary_data)
+
+        dir_entry = rel_dir.replace(os.path.sep, "/") + "/"
+        dir_pointer = ZipFilePathPointer(zip_path, dir_entry)
+
+        with open_datafile(dir_pointer, file_name=file_name, encoding=None) as f:
+            result = f.read()
+
+        assert isinstance(result, (bytes, bytearray))
+        assert result == binary_data

--- a/nltk/test/unit/test_pl196x.py
+++ b/nltk/test/unit/test_pl196x.py
@@ -6,7 +6,7 @@ from nltk.corpus.reader import pl196x
 
 class TestCorpusViews(unittest.TestCase):
     def test_corpus_reader(self):
-        pl196x_dir = nltk.data.find("corpora/pl196x")
+        pl196x_dir = nltk.data.find("corpora/pl196x/")
         pl = pl196x.Pl196xCorpusReader(
             pl196x_dir, r".*\.xml", textids="textids.txt", cat_file="cats.txt"
         )

--- a/nltk/test/unit/translate/test_bleu.py
+++ b/nltk/test/unit/translate/test_bleu.py
@@ -6,7 +6,7 @@ import unittest
 
 import pytest
 
-from nltk.data import find
+from nltk.data import find, open_datafile
 from nltk.translate.bleu_score import (
     SmoothingFunction,
     brevity_penalty,
@@ -237,13 +237,13 @@ class TestBLEUvsMteval13a(unittest.TestCase):
 
         # Reads the BLEU scores from the `mteval-13a.output` file.
         # The order of the list corresponds to the order of the ngrams.
-        with open(mteval_output_file) as mteval_fin:
+        with open_datafile(mteval_output_file) as mteval_fin:
             # The numbers are located in the last 2nd line of the file.
             # The first and 2nd item in the list are the score and system names.
             mteval_bleu_scores = map(float, mteval_fin.readlines()[-2].split()[1:-1])
 
-        with open(ref_file, encoding="utf8") as ref_fin:
-            with open(hyp_file, encoding="utf8") as hyp_fin:
+        with open_datafile(ref_file, encoding="utf8") as ref_fin:
+            with open_datafile(hyp_file, encoding="utf8") as hyp_fin:
                 # Whitespace tokenize the file.
                 # Note: split() automatically strip().
                 hypothesis = list(map(lambda x: x.split(), hyp_fin))

--- a/nltk/test/unit/translate/test_nist.py
+++ b/nltk/test/unit/translate/test_nist.py
@@ -5,7 +5,7 @@ Tests for NIST translation evaluation metric
 import io
 import unittest
 
-from nltk.data import find
+from nltk.data import find, open_datafile
 from nltk.translate.nist_score import corpus_nist
 
 
@@ -17,13 +17,13 @@ class TestNIST(unittest.TestCase):
 
         # Reads the NIST scores from the `mteval-13a.output` file.
         # The order of the list corresponds to the order of the ngrams.
-        with open(mteval_output_file) as mteval_fin:
+        with open_datafile(mteval_output_file) as mteval_fin:
             # The numbers are located in the last 4th line of the file.
             # The first and 2nd item in the list are the score and system names.
             mteval_nist_scores = map(float, mteval_fin.readlines()[-4].split()[1:-1])
 
-        with open(ref_file, encoding="utf8") as ref_fin:
-            with open(hyp_file, encoding="utf8") as hyp_fin:
+        with open_datafile(ref_file, encoding="utf8") as ref_fin:
+            with open_datafile(hyp_file, encoding="utf8") as hyp_fin:
                 # Whitespace tokenize the file.
                 # Note: split() automatically strip().
                 hypotheses = list(map(lambda x: x.split(), hyp_fin))

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -1757,16 +1757,18 @@ class PunktTokenizer(PunktSentenceTokenizer):
 def load_punkt_params(lang_dir):
     from nltk.tabdata import PunktDecoder
 
-    pdec = PunktDecoder()
     # Make a new Parameters object:
     params = PunktParameters()
-    with open(f"{lang_dir}/collocations.tab", encoding="utf-8") as f:
+
+    pdec = PunktDecoder()
+    # Use .join() to reach the files regardless of zip/real FS.
+    with lang_dir.join("collocations.tab").open(encoding="utf-8") as f:
         params.collocations = set(pdec.tab2tups(f))
-    with open(f"{lang_dir}/sent_starters.txt", encoding="utf-8") as f:
+    with lang_dir.join("sent_starters.txt").open(encoding="utf-8") as f:
         params.sent_starters = pdec.txt2set(f)
-    with open(f"{lang_dir}/abbrev_types.txt", encoding="utf-8") as f:
+    with lang_dir.join("abbrev_types.txt").open(encoding="utf-8") as f:
         params.abbrev_types = pdec.txt2set(f)
-    with open(f"{lang_dir}/ortho_context.tab", encoding="utf-8") as f:
+    with lang_dir.join("ortho_context.tab").open(encoding="utf-8") as f:
         params.ortho_context = pdec.tab2intdict(f)
     return params
 

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -1755,6 +1755,7 @@ class PunktTokenizer(PunktSentenceTokenizer):
 
 
 def load_punkt_params(lang_dir):
+    from nltk.data import open_datafile
     from nltk.tabdata import PunktDecoder
 
     # Make a new Parameters object:
@@ -1762,13 +1763,13 @@ def load_punkt_params(lang_dir):
 
     pdec = PunktDecoder()
     # Use .join() to reach the files regardless of zip/real FS.
-    with lang_dir.join("collocations.tab").open(encoding="utf-8") as f:
+    with open_datafile(lang_dir, "collocations.tab") as f:
         params.collocations = set(pdec.tab2tups(f))
-    with lang_dir.join("sent_starters.txt").open(encoding="utf-8") as f:
+    with open_datafile(lang_dir, "sent_starters.txt") as f:
         params.sent_starters = pdec.txt2set(f)
-    with lang_dir.join("abbrev_types.txt").open(encoding="utf-8") as f:
+    with open_datafile(lang_dir, "abbrev_types.txt") as f:
         params.abbrev_types = pdec.txt2set(f)
-    with lang_dir.join("ortho_context.tab").open(encoding="utf-8") as f:
+    with open_datafile(lang_dir, "ortho_context.tab") as f:
         params.ortho_context = pdec.tab2intdict(f)
     return params
 


### PR DESCRIPTION
The latest version of this PR fixes issue #3473 for all the unit tests under _nltk/test/unit_, which can then load their datafiles from zipped packages..

The first commits solved the problem for the models concerned by nltk.data's switch-* mechanism. For ex., the doctests that can't otherwise run when those packages are zipped, succeed after the modifications proposed here.

```
import nltk
tokenizer = nltk.data.load('tokenizers/punkt/english.pickle')
print(tokenizer.tokenize("Hello! How are you?"))
```
['Hello!', 'How are you?']

```
import nltk
from nltk.corpus import treebank
from pprint import pprint
chunker = nltk.data.load('chunkers/maxent_ne_chunker/PY3/english_ace_multiclass.pickle')
pprint(chunker.parse(treebank.tagged_sents()[2][8:14]))  # doctest: +NORMALIZE_WHITESPACE
```
Tree('S', [('chairman', 'NN'), ('of', 'IN'), Tree('ORGANIZATION', [('Consolidated', 'NNP'), ('Gold', 'NNP'), ('Fields', 'NNP')]), ('PLC', 'NNP')])

```
import nltk
from nltk.tokenize import word_tokenize
tagger = nltk.data.load('taggers/maxent_treebank_pos_tagger/PY3/english.pickle')
print(tagger.tag(word_tokenize("Hello, how are you?")))
```
[('Hello', 'NNP'), (',', ','), ('how', 'WRB'), ('are', 'VBP'), ('you', 'PRP'), ('?', '.')]

```
import nltk
from nltk.tokenize import word_tokenize
tagger = nltk.data.load('taggers/averaged_perceptron_tagger/averaged_perceptron_tagger.pickle')
print(tagger.tag(word_tokenize("Hello, how are you?")))
```
[('Hello', 'NNP'), (',', ','), ('how', 'WRB'), ('are', 'VBP'), ('you', 'PRP'), ('?', '.')]
