### PR TITLE
Use Python 3.13 for pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,6 @@ jobs:
       - name: Install pre-commit
         run: pip install pre-commit
 
-      - name: Clear pre-commit cache
-        run: pre-commit clean
-
       - name: Run pre-commit hooks
         run: pre-commit run --all-files
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,16 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.14"
+          python-version: "3.13"  # or your chosen version
 
       - name: Install pre-commit
-        run: |
-          pip install pre-commit
-          pre-commit run --all-files
+        run: pip install pre-commit
+
+      - name: Clear pre-commit cache
+        run: pre-commit clean
+
+      - name: Run pre-commit hooks
+        run: pre-commit run --all-files
 
   minimal_download_test:
     name: Minimal NLTK Download Test


### PR DESCRIPTION
This fixes #3483, by temporarily using Python 3.13 for pre-commit, until more knowledge is available about the incompatibility with Python 3.14. 

This issue occurs only with Python 3.14. It does not occur with Python 3.13 or earlier. Python 3.14 introduces stricter handling of `str` and `bytes`, which might be the root cause. The failing hook is `pyupgrade`, but it is unclear whether this issue stems from `pyupgrade` or `pre-commit` itself.

Later, we will need to determine whether the problem originates in `pre-commit` or `pyupgrade`, and wait for updates to these tool(s), that ensure compatibility with Python 3.14.

Meanwhile, let's use the latest Python 3.13 for pre-commit, since it is the latest that works.