### PR TITLE
Warn on unpickling user-provided pickles

### DIFF
--- a/nltk/app/chartparser_app.py
+++ b/nltk/app/chartparser_app.py
@@ -77,6 +77,7 @@ from nltk.parse.chart import (
     TopDownPredictRule,
     TreeEdge,
 )
+from nltk.picklesec import load_with_warning
 from nltk.tree import Tree
 from nltk.util import in_idle
 
@@ -812,7 +813,7 @@ class ChartComparer:
 
     def load_chart(self, filename):
         with open(filename, "rb") as infile:
-            chart = pickle.load(infile)
+            chart = load_with_warning(infile)
         name = os.path.basename(filename)
         if name.endswith(".pickle"):
             name = name[:-7]
@@ -2269,7 +2270,7 @@ class ChartParserApp:
             return
         try:
             with open(filename, "rb") as infile:
-                chart = pickle.load(infile)
+                chart = load_with_warning(infile)
             self._chart = chart
             self._cv.update(chart)
             if self._matrix:
@@ -2307,7 +2308,7 @@ class ChartParserApp:
         try:
             if filename.endswith(".pickle"):
                 with open(filename, "rb") as infile:
-                    grammar = pickle.load(infile)
+                    grammar = load_with_warning(infile)
             else:
                 with open(filename) as infile:
                     grammar = CFG.fromstring(infile.read())

--- a/nltk/app/chartparser_app.py
+++ b/nltk/app/chartparser_app.py
@@ -77,7 +77,7 @@ from nltk.parse.chart import (
     TopDownPredictRule,
     TreeEdge,
 )
-from nltk.picklesec import load_with_warning
+from nltk.picklesec import pickle_load
 from nltk.tree import Tree
 from nltk.util import in_idle
 
@@ -813,7 +813,7 @@ class ChartComparer:
 
     def load_chart(self, filename):
         with open(filename, "rb") as infile:
-            chart = load_with_warning(infile)
+            chart = pickle_load(infile)
         name = os.path.basename(filename)
         if name.endswith(".pickle"):
             name = name[:-7]
@@ -2270,7 +2270,7 @@ class ChartParserApp:
             return
         try:
             with open(filename, "rb") as infile:
-                chart = load_with_warning(infile)
+                chart = pickle_load(infile)
             self._chart = chart
             self._cv.update(chart)
             if self._matrix:
@@ -2308,7 +2308,7 @@ class ChartParserApp:
         try:
             if filename.endswith(".pickle"):
                 with open(filename, "rb") as infile:
-                    grammar = load_with_warning(infile)
+                    grammar = pickle_load(infile)
             else:
                 with open(filename) as infile:
                     grammar = CFG.fromstring(infile.read())

--- a/nltk/app/wordnet_app.py
+++ b/nltk/app/wordnet_app.py
@@ -64,6 +64,7 @@ from urllib.parse import unquote_plus
 
 from nltk.corpus import wordnet as wn
 from nltk.corpus.reader.wordnet import Lemma, Synset
+from nltk.picklesec import RestrictedUnpickler
 
 firstClient = True
 
@@ -652,16 +653,6 @@ def _synset_relations(word, synset, synset_relations):
     )
 
     return html
-
-
-class RestrictedUnpickler(pickle.Unpickler):
-    """
-    Unpickler that prevents any class or function from being used during loading.
-    """
-
-    def find_class(self, module, name):
-        # Forbid every function
-        raise pickle.UnpicklingError(f"global '{module}.{name}' is forbidden")
 
 
 class Reference:

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -689,7 +689,7 @@ def restricted_pickle_load(string):
     """
     Prevents any class or function from loading.
     """
-    from nltk.app.wordnet_app import RestrictedUnpickler
+    from nltk.picklesec import RestrictedUnpickler
 
     return RestrictedUnpickler(BytesIO(string)).load()
 

--- a/nltk/parse/transitionparser.py
+++ b/nltk/parse/transitionparser.py
@@ -553,7 +553,8 @@ class TransitionParser(ParserI):
         """
         result = []
         # First load the model
-        model = pickle_load(open(modelFile, "rb"))
+        with open(modelFile, "rb") as f:
+            model = pickle_load(f)
         operation = Transition(self._algorithm)
 
         for depgraph in depgraphs:

--- a/nltk/parse/transitionparser.py
+++ b/nltk/parse/transitionparser.py
@@ -21,6 +21,7 @@ except ImportError:
     pass
 
 from nltk.parse import DependencyEvaluator, DependencyGraph, ParserI
+from nltk.picklesec import load_with_warning
 
 
 class Configuration:
@@ -552,7 +553,7 @@ class TransitionParser(ParserI):
         """
         result = []
         # First load the model
-        model = pickle.load(open(modelFile, "rb"))
+        model = load_with_warning(open(modelFile, "rb"))
         operation = Transition(self._algorithm)
 
         for depgraph in depgraphs:

--- a/nltk/parse/transitionparser.py
+++ b/nltk/parse/transitionparser.py
@@ -21,7 +21,7 @@ except ImportError:
     pass
 
 from nltk.parse import DependencyEvaluator, DependencyGraph, ParserI
-from nltk.picklesec import load_with_warning
+from nltk.picklesec import pickle_load
 
 
 class Configuration:
@@ -553,7 +553,7 @@ class TransitionParser(ParserI):
         """
         result = []
         # First load the model
-        model = load_with_warning(open(modelFile, "rb"))
+        model = pickle_load(open(modelFile, "rb"))
         operation = Transition(self._algorithm)
 
         for depgraph in depgraphs:

--- a/nltk/picklesec.py
+++ b/nltk/picklesec.py
@@ -1,0 +1,57 @@
+# Natural Language Toolkit: Improve the security when loading pickled data.
+#
+# Copyright (C) 2001-2025 NLTK Project
+# Author: Eric Kafe <kafe.eric@gmail.com>
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+#
+
+from __future__ import annotations
+
+import pickle
+import warnings
+from typing import Any, BinaryIO
+
+
+class RestrictedUnpickler(pickle.Unpickler):
+    """
+    Unpickler that prevents any class or function from being used during loading.
+    """
+
+    def find_class(self, module, name):
+        # Forbid every function
+        raise pickle.UnpicklingError(f"global '{module}.{name}' is forbidden")
+
+
+_WARNING = (
+    "Security warning: loading pickles can execute arbitrary code. "
+    "Only load pickle files from trusted sources and never from untrusted "
+    "or unauthenticated locations."
+)
+
+
+class WarningUnpickler(pickle.Unpickler):
+    """
+    Unpickler that emits a warning before loading data.
+
+    This does NOT make unpickling safe; it only makes the risk explicit.
+    """
+
+    def __init__(self, file: BinaryIO, *, context: str | None = None, **kwargs: Any):
+        super().__init__(file, **kwargs)
+        self._context = context
+        self._warned = False
+
+    def load(self) -> Any:
+        if not self._warned:
+            msg = _WARNING if self._context is None else f"{_WARNING} ({self._context})"
+            warnings.warn(msg, RuntimeWarning, stacklevel=2)
+            self._warned = True
+        return super().load()
+
+
+def load_with_warning(file: BinaryIO, *, context: str | None = None) -> Any:
+    """
+    Convenience wrapper mirroring pickle.load(file), but with a warning.
+    """
+    return WarningUnpickler(file, context=context).load()

--- a/nltk/picklesec.py
+++ b/nltk/picklesec.py
@@ -1,4 +1,4 @@
-# Natural Language Toolkit: Improve the security when loading pickled data.
+# Natural Language Toolkit: Safer pickle loading.
 #
 # Copyright (C) 2001-2025 NLTK Project
 # Author: Eric Kafe <kafe.eric@gmail.com>
@@ -6,11 +6,26 @@
 # For license information, see LICENSE.TXT
 #
 
+"""
+Helpers for safer and/or more explicit pickle usage in NLTK.
+
+- RestrictedUnpickler: blocks unpickling of *any* globals (classes/functions).
+  Intended for loading NLTK data packages where we control the serialization.
+- WarningUnpickler: emits a security warning before unpickling (does not make
+  unpickling safe).
+"""
+
 from __future__ import annotations
 
 import pickle
 import warnings
 from typing import Any, BinaryIO
+
+PICKLE_WARNING = (
+    "Security warning: loading pickles can execute arbitrary code. "
+    "Only load pickle files from trusted sources and never from untrusted "
+    "or unauthenticated locations."
+)
 
 
 class RestrictedUnpickler(pickle.Unpickler):
@@ -18,24 +33,13 @@ class RestrictedUnpickler(pickle.Unpickler):
     Unpickler that prevents any class or function from being used during loading.
     """
 
-    def find_class(self, module, name):
-        # Forbid every function
+    def find_class(self, module: str, name: str) -> Any:
+        # Forbid every function/class global.
         raise pickle.UnpicklingError(f"global '{module}.{name}' is forbidden")
 
 
-_WARNING = (
-    "Security warning: loading pickles can execute arbitrary code. "
-    "Only load pickle files from trusted sources and never from untrusted "
-    "or unauthenticated locations."
-)
-
-
 class WarningUnpickler(pickle.Unpickler):
-    """
-    Unpickler that emits a warning before loading data.
-
-    This does NOT make unpickling safe; it only makes the risk explicit.
-    """
+    """Unpickler that emits PICKLE_WARNING once per instance."""
 
     def __init__(self, file: BinaryIO, *, context: str | None = None, **kwargs: Any):
         super().__init__(file, **kwargs)
@@ -44,14 +48,25 @@ class WarningUnpickler(pickle.Unpickler):
 
     def load(self) -> Any:
         if not self._warned:
-            msg = _WARNING if self._context is None else f"{_WARNING} ({self._context})"
+            msg = (
+                PICKLE_WARNING
+                if self._context is None
+                else f"{PICKLE_WARNING} ({self._context})"
+            )
             warnings.warn(msg, RuntimeWarning, stacklevel=2)
             self._warned = True
         return super().load()
 
 
-def load_with_warning(file: BinaryIO, *, context: str | None = None) -> Any:
+def pickle_load(
+    file: BinaryIO, *, context: str | None = None, restricted: bool = False
+) -> Any:
     """
-    Convenience wrapper mirroring pickle.load(file), but with a warning.
+    Convenience wrapper similar to pickle.load(file).
+
+    - If restricted=True, uses RestrictedUnpickler (no warning by default).
+    - If restricted=False, uses WarningUnpickler and emits a warning.
     """
+    if restricted:
+        return RestrictedUnpickler(file).load()
     return WarningUnpickler(file, context=context).load()

--- a/nltk/picklesec.py
+++ b/nltk/picklesec.py
@@ -53,7 +53,7 @@ class WarningUnpickler(pickle.Unpickler):
                 if self._context is None
                 else f"{PICKLE_WARNING} ({self._context})"
             )
-            warnings.warn(msg, RuntimeWarning, stacklevel=2)
+            warnings.warn(msg, RuntimeWarning, stacklevel=3)
             self._warned = True
         return super().load()
 

--- a/nltk/tbl/demo.py
+++ b/nltk/tbl/demo.py
@@ -246,14 +246,14 @@ def postag(
             baseline_tagger = UnigramTagger(
                 baseline_data, backoff=baseline_backoff_tagger
             )
-            with open(cache_baseline_tagger, "w") as print_rules:
+            with open(cache_baseline_tagger, "wb") as print_rules:
                 pickle.dump(baseline_tagger, print_rules)
             print(
                 "Trained baseline tagger, pickled it to {}".format(
                     cache_baseline_tagger
                 )
             )
-        with open(cache_baseline_tagger) as print_rules:
+        with open(cache_baseline_tagger, "rb") as print_rules:
             baseline_tagger = pickle_load(print_rules)
             print(f"Reloaded pickled tagger from {cache_baseline_tagger}")
     else:
@@ -322,10 +322,10 @@ def postag(
     # serializing the tagger to a pickle file and reloading (just to see it works)
     if serialize_output is not None:
         taggedtest = brill_tagger.tag_sents(testing_data)
-        with open(serialize_output, "w") as print_rules:
+        with open(serialize_output, "wb") as print_rules:
             pickle.dump(brill_tagger, print_rules)
         print(f"Wrote pickled tagger to {serialize_output}")
-        with open(serialize_output) as print_rules:
+        with open(serialize_output, "rb") as print_rules:
             brill_tagger_reloaded = pickle_load(print_rules)
         print(f"Reloaded pickled tagger from {serialize_output}")
         taggedtest_reloaded = brill_tagger.tag_sents(testing_data)

--- a/nltk/tbl/demo.py
+++ b/nltk/tbl/demo.py
@@ -13,6 +13,7 @@ import random
 import time
 
 from nltk.corpus import treebank
+from nltk.picklesec import load_with_warning
 from nltk.tag import BrillTaggerTrainer, RegexpTagger, UnigramTagger
 from nltk.tag.brill import Pos, Word
 from nltk.tbl import Template, error_list
@@ -253,7 +254,7 @@ def postag(
                 )
             )
         with open(cache_baseline_tagger) as print_rules:
-            baseline_tagger = pickle.load(print_rules)
+            baseline_tagger = load_with_warning(print_rules)
             print(f"Reloaded pickled tagger from {cache_baseline_tagger}")
     else:
         baseline_tagger = UnigramTagger(baseline_data, backoff=baseline_backoff_tagger)
@@ -325,7 +326,7 @@ def postag(
             pickle.dump(brill_tagger, print_rules)
         print(f"Wrote pickled tagger to {serialize_output}")
         with open(serialize_output) as print_rules:
-            brill_tagger_reloaded = pickle.load(print_rules)
+            brill_tagger_reloaded = load_with_warning(print_rules)
         print(f"Reloaded pickled tagger from {serialize_output}")
         taggedtest_reloaded = brill_tagger.tag_sents(testing_data)
         if taggedtest == taggedtest_reloaded:

--- a/nltk/tbl/demo.py
+++ b/nltk/tbl/demo.py
@@ -13,7 +13,7 @@ import random
 import time
 
 from nltk.corpus import treebank
-from nltk.picklesec import load_with_warning
+from nltk.picklesec import pickle_load
 from nltk.tag import BrillTaggerTrainer, RegexpTagger, UnigramTagger
 from nltk.tag.brill import Pos, Word
 from nltk.tbl import Template, error_list
@@ -254,7 +254,7 @@ def postag(
                 )
             )
         with open(cache_baseline_tagger) as print_rules:
-            baseline_tagger = load_with_warning(print_rules)
+            baseline_tagger = pickle_load(print_rules)
             print(f"Reloaded pickled tagger from {cache_baseline_tagger}")
     else:
         baseline_tagger = UnigramTagger(baseline_data, backoff=baseline_backoff_tagger)
@@ -326,7 +326,7 @@ def postag(
             pickle.dump(brill_tagger, print_rules)
         print(f"Wrote pickled tagger to {serialize_output}")
         with open(serialize_output) as print_rules:
-            brill_tagger_reloaded = load_with_warning(print_rules)
+            brill_tagger_reloaded = pickle_load(print_rules)
         print(f"Reloaded pickled tagger from {serialize_output}")
         taggedtest_reloaded = brill_tagger.tag_sents(testing_data)
         if taggedtest == taggedtest_reloaded:

--- a/nltk/tbl/demo.py
+++ b/nltk/tbl/demo.py
@@ -328,7 +328,7 @@ def postag(
         with open(serialize_output, "rb") as print_rules:
             brill_tagger_reloaded = pickle_load(print_rules)
         print(f"Reloaded pickled tagger from {serialize_output}")
-        taggedtest_reloaded = brill_tagger.tag_sents(testing_data)
+        taggedtest_reloaded = brill_tagger_reloaded.tag_sents(testing_data)
         if taggedtest == taggedtest_reloaded:
             print("Reloaded tagger tried on test set, results identical")
         else:

--- a/nltk/test/unit/test_pickle_load_warnings.py
+++ b/nltk/test/unit/test_pickle_load_warnings.py
@@ -1,0 +1,60 @@
+import pickle
+from pathlib import Path
+
+import pytest
+
+from nltk.parse.chart import Chart
+
+WARN_RE = r"Security warning: loading pickles can execute arbitrary code"
+
+
+def test_chartparser_app_warns_on_unpickle(tmp_path: Path):
+    # Arrange: create a pickled Chart object (ChartComparer.load_chart expects this)
+    pkl = tmp_path / "chart.pickle"
+    chart = Chart(["a", "b"])
+    with pkl.open("wb") as f:
+        pickle.dump(chart, f)
+
+    from nltk.app.chartparser_app import ChartComparer
+
+    # Act + Assert: warning emitted when unpickling
+    with pytest.warns(RuntimeWarning, match=WARN_RE):
+        comparer = ChartComparer()
+        comparer.load_chart(str(pkl))
+
+
+def test_transitionparser_warns_on_model_unpickle(tmp_path: Path):
+    # transitionparser optionally depends on numpy/scipy/sklearn; skip if missing
+    pytest.importorskip("numpy")
+    pytest.importorskip("scipy")
+    pytest.importorskip("sklearn")
+
+    from nltk.parse import DependencyGraph
+    from nltk.parse.transitionparser import TransitionParser
+
+    model_path = tmp_path / "tp.model"
+
+    # Minimal projective example (adapted from transitionparser.py doctest)
+    gold_sent = DependencyGraph(
+        """
+Economic  JJ     2      ATT
+news  NN     3       SBJ
+has       VBD       0       ROOT
+little      JJ      5       ATT
+effect   NN     3       OBJ
+on     IN      5       ATT
+financial       JJ       8       ATT
+markets    NNS      6       PC
+.    .      3       PU
+"""
+    )
+
+    # Train quickly to produce a real pickled sklearn model file
+    parser = TransitionParser(TransitionParser.ARC_STANDARD)
+    parser.train([gold_sent], str(model_path), verbose=False)
+
+    # Act + Assert: warning emitted when unpickling model in parse()
+    with pytest.warns(RuntimeWarning, match=WARN_RE):
+        result = parser.parse([gold_sent], str(model_path))
+
+    assert len(result) == 1

--- a/nltk/test/unit/test_pickle_load_warnings.py
+++ b/nltk/test/unit/test_pickle_load_warnings.py
@@ -1,3 +1,5 @@
+# Test pickle_load warnings
+
 import pickle
 from pathlib import Path
 

--- a/nltk/test/unit/test_pickle_load_warnings.py
+++ b/nltk/test/unit/test_pickle_load_warnings.py
@@ -1,32 +1,28 @@
-# Test pickle_load warnings
-
+import ast
+import inspect
 import pickle
 from pathlib import Path
 
 import pytest
 
 from nltk.parse.chart import Chart
+from nltk.picklesec import pickle_load
 
 WARN_RE = r"Security warning: loading pickles can execute arbitrary code"
 
 
-def test_chartparser_app_warns_on_unpickle(tmp_path: Path):
-    # Arrange: create a pickled Chart object (ChartComparer.load_chart expects this)
-    pkl = tmp_path / "chart.pickle"
-    chart = Chart(["a", "b"])
+def test_pickle_load_emits_warning(tmp_path: Path):
+    pkl = tmp_path / "obj.pickle"
     with pkl.open("wb") as f:
-        pickle.dump(chart, f)
+        pickle.dump(Chart(["a", "b"]), f)
 
-    from nltk.app.chartparser_app import ChartComparer
+    with pkl.open("rb") as f, pytest.warns(RuntimeWarning, match=WARN_RE):
+        obj = pickle_load(f, context="test")
 
-    # Act + Assert: warning emitted when unpickling
-    with pytest.warns(RuntimeWarning, match=WARN_RE):
-        comparer = ChartComparer()
-        comparer.load_chart(str(pkl))
+    assert isinstance(obj, Chart)
 
 
 def test_transitionparser_warns_on_model_unpickle(tmp_path: Path):
-    # transitionparser optionally depends on numpy/scipy/sklearn; skip if missing
     pytest.importorskip("numpy")
     pytest.importorskip("scipy")
     pytest.importorskip("sklearn")
@@ -36,7 +32,6 @@ def test_transitionparser_warns_on_model_unpickle(tmp_path: Path):
 
     model_path = tmp_path / "tp.model"
 
-    # Minimal projective example (adapted from transitionparser.py doctest)
     gold_sent = DependencyGraph(
         """
 Economic  JJ     2      ATT
@@ -51,12 +46,33 @@ markets    NNS      6       PC
 """
     )
 
-    # Train quickly to produce a real pickled sklearn model file
     parser = TransitionParser(TransitionParser.ARC_STANDARD)
     parser.train([gold_sent], str(model_path), verbose=False)
 
-    # Act + Assert: warning emitted when unpickling model in parse()
     with pytest.warns(RuntimeWarning, match=WARN_RE):
         result = parser.parse([gold_sent], str(model_path))
 
     assert len(result) == 1
+
+
+def test_chartparser_app_uses_pickle_load_not_pickle_load():
+    # Headless CI can't instantiate Tk-based UI classes, so do a static check:
+    # - no calls to pickle.load(...)
+    # - references pickle_load(...)
+    import nltk.app.chartparser_app as chartparser_app
+
+    src = inspect.getsource(chartparser_app)
+    tree = ast.parse(src)
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            if isinstance(node.func.value, ast.Name) and node.func.value.id == "pickle":
+                if node.func.attr == "load":
+                    raise AssertionError(
+                        "Found a call to pickle.load(...) in nltk.app.chartparser_app; expected pickle_load(...)"
+                    )
+
+    names = {n.id for n in ast.walk(tree) if isinstance(n, ast.Name)}
+    assert (
+        "pickle_load" in names
+    ), "Expected nltk.app.chartparser_app to reference pickle_load"

--- a/nltk/test/unit/test_pickle_load_warnings.py
+++ b/nltk/test/unit/test_pickle_load_warnings.py
@@ -55,7 +55,7 @@ markets    NNS      6       PC
     assert len(result) == 1
 
 
-def test_chartparser_app_uses_pickle_load_not_pickle_load():
+def test_chartparser_app_uses_pickle_load_not_pickle_load_standard():
     # Headless CI can't instantiate Tk-based UI classes, so do a static check:
     # - no calls to pickle.load(...)
     # - references pickle_load(...)


### PR DESCRIPTION
Fix #3486.

## Summary
Some NLTK modules still load local pickle files directly (charts/grammars and transition parser models). Because unpickling can execute arbitrary code, this PR makes the risk explicit by routing these call sites through `nltk.picklesec.pickle_load(...)`, which emits a short, consistent security warning (optionally with context).

This PR also fixes `nltk/tbl/demo.py` on Python 3 by opening pickle files in binary mode (`rb`/`wb`).

## Why move `RestrictedUnpickler`
`RestrictedUnpickler` is a general security primitive (used to prevent unpickling of classes/functions) and is not specific to the WordNet UI. Keeping it in `nltk.app.wordnet_app` makes it harder to discover and encourages duplication.

This PR moves `RestrictedUnpickler` to a more natural and reusable location, `nltk.picklesec`, alongside related pickle-security helpers. `nltk.app.wordnet_app` continues to work by importing the class from the new module.

## Changes
- Add `nltk/picklesec.py`:
  - `RestrictedUnpickler` (moved; behavior unchanged)
  - `WarningUnpickler` + `pickle_load(...)` wrapper (warning-only)
- Replace `pickle.load(...)` with `pickle_load(...)` in:
  - `nltk/app/chartparser_app.py`
  - `nltk/parse/transitionparser.py`
  - `nltk/tbl/demo.py`
- Fix Python 3 pickle I/O in `nltk/tbl/demo.py` by using `rb`/`wb`.

## Rationale
Replacing pickle entirely in these modules is not currently practical: the serialized objects can be complex and may involve third-party types (e.g., scikit-learn models). This PR therefore focuses on a pragmatic improvement: clearly warn when unpickling is triggered from a user-supplied file path, and centralize pickle security utilities in one place.

## Testing
- Unit tests verify the warning is emitted when unpickling via:
  - `ChartComparer.load_chart(...)` (chartparser app)
  - `TransitionParser.parse(..., modelFile)` (skips if numpy/scipy/sklearn are missing)
- Manually verified `nltk.tbl.demo.demo_serialize_tagger()` works on Python 3 after the `rb`/`wb` fix.