### PR TITLE
Use "localhost" instead of "" as a host to check a port before starting CoreNLP server

### DIFF
--- a/nltk/parse/corenlp.py
+++ b/nltk/parse/corenlp.py
@@ -29,7 +29,7 @@ class CoreNLPServerError(EnvironmentError):
 
 def try_port(port=0):
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.bind(("", port))
+    sock.bind(("localhost", port))
 
     p = sock.getsockname()[1]
     sock.close()


### PR DESCRIPTION
Would fix #3428 . CoreNLP is only ever ran by NLTK on `localhost`, and I don't see a way to run a CoreNLP on anything other than `localhost` anyway.

Script used to occupy a port for testing: https://gist.github.com/asrelo/069f6dc7e49f7b974a5f6dc469213895 . For both cases below, the port 9000 on localhost is occupied (`python occupy_port.py 127.0.0.1:9000`).

The testing code:

```python
#import os
#os.environ['JAVA_HOME'] = 'C:\\Program Files\\Java\\jdk-23\\bin\\'
import nltk.parse.corenlp
server = nltk.parse.corenlp.CoreNLPServer(
    CORENLP_PATH,
    CORENLP_MODELS_PATH,
    port=9000,
)
with server:
    print('Success')
```

Before the fix, `server.__enter__()` fails after a long delay (~30 s) with a non-informative error (the server process failed to take the port and exited):

```
Traceback (most recent call last):
  File "<pyshell#7>", line 1, in <module>
    with server:
  File "<repo-root>\nltk\parse\corenlp.py", line 185, in __enter__
    self.start()
  File "<repo-root>\nltk\parse\corenlp.py", line 158, in start
    raise CoreNLPServerError("Could not connect to the server.")
nltk.parse.corenlp.CoreNLPServerError: Could not connect to the server.
```

After the fix, `CoreNLPServer.__init__()`, which currenly calls `try_port`, fails immediately with a better error:

```
Traceback (most recent call last):
  File "<pyshell#3>", line 1, in <module>
    server = nltk.parse.corenlp.CoreNLPServer(
  File "<repo-root>\nltk\parse\corenlp.py", line 78, in __init__
    try_port(port)
  File "<repo-root>\nltk\parse\corenlp.py", line 32, in try_port
    sock.bind(("localhost", port))
OSError: [WinError 10048] Only one usage of each socket address (protocol/network address/port) is normally permitted
```