### PR TITLE
Support the plus-sign in OEWN 2025+ version name

### DIFF
--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -1491,7 +1491,7 @@ class WordNetCorpusReader(CorpusReader):
         fh = self._data_file(ADJ)
         fh.seek(0)
         for line in fh:
-            match = re.search(r"Word[nN]et (\d+|\d+\.\d+) Copyright", line)
+            match = re.search(r"Word[nN]et (\d+\+?|\d+\.\d+) Copyright", line)
             if match is not None:
                 version = match.group(1)
                 fh.seek(0)


### PR DESCRIPTION
The regular expression that extracts the wordnet version number needs a small edit, to be compatible with the new OEWN _2025+_.