### PR TITLE
fix the Jaro similarity score for single-character strings and empty strings

### DIFF
--- a/nltk/metrics/distance.py
+++ b/nltk/metrics/distance.py
@@ -311,6 +311,13 @@ def jaro_similarity(s1, s2):
         - `m` is the no. of matching characters
         - `t` is the half no. of possible transpositions.
     """
+    # By definition, the similarity of a string with itself is 1.0.
+    # This also handles edge cases where both strings are empty or
+    # single-character identical strings, where the matching window
+    # formula (floor(max(|s1|,|s2|) / 2) - 1) yields -1.
+    if s1 == s2:
+        return 1.0
+
     # First, store the length of the strings
     # because they will be re-used several times.
     len_s1, len_s2 = len(s1), len(s2)
@@ -340,7 +347,7 @@ def jaro_similarity(s1, s2):
             transpositions += 1
 
     if matches == 0:
-        return 0
+        return 0.0
     else:
         return (
             1
@@ -439,6 +446,21 @@ def jaro_winkler_similarity(s1, s2, p=0.1, max_l=4):
 
     >>> round(jaro_winkler_similarity('TANYA', 'TONYA', p=0.1, max_l=100), 3)
     0.88
+
+    Test edge cases for very short or empty strings.
+
+    >>> jaro_similarity("", "") == 1.0
+    True
+    >>> jaro_similarity("", "nonempty") == 0.0
+    True
+    >>> jaro_similarity("a", "a") == 1.0
+    True
+    >>> jaro_similarity("a", "b") == 0.0
+    True
+    >>> jaro_winkler_similarity("", "") == 1.0
+    True
+    >>> jaro_winkler_similarity("a", "a") == 1.0
+    True
     """
     # To ensure that the output of the Jaro-Winkler's similarity
     # falls between [0,1], the product of l * p needs to be

--- a/nltk/test/unit/test_distance.py
+++ b/nltk/test/unit/test_distance.py
@@ -2,7 +2,11 @@ from typing import Tuple
 
 import pytest
 
-from nltk.metrics.distance import edit_distance
+from nltk.metrics.distance import (
+    edit_distance,
+    jaro_similarity,
+    jaro_winkler_similarity,
+)
 
 
 class TestEditDistance:
@@ -127,3 +131,98 @@ class TestEditDistance:
                     transpositions=transpositions,
                 )
                 assert predicted == expected
+
+
+class TestJaroSimilarity:
+    """Tests for jaro_similarity against the algorithm pseudocode."""
+
+    # ---------------------------------------------------------
+    # Edge cases: empty and single-character strings
+    # ---------------------------------------------------------
+
+    def test_both_empty(self):
+        """Identical empty strings have similarity 1.0."""
+        assert jaro_similarity("", "") == 1.0
+
+    def test_empty_vs_nonempty(self):
+        """Empty vs non-empty string has similarity 0.0."""
+        assert jaro_similarity("", "abc") == 0.0
+        assert jaro_similarity("abc", "") == 0.0
+
+    def test_single_char_identical(self):
+        """Single-char identical strings have similarity 1.0.
+
+        Regression: match_bound = max(1,1)//2 - 1 = -1 caused 0
+        matches, returning 0.0 instead of 1.0.
+        """
+        assert jaro_similarity("a", "a") == 1.0
+
+    def test_single_char_different(self):
+        assert jaro_similarity("a", "b") == 0.0
+
+    # ---------------------------------------------------------
+    # Known values from Wikipedia / census papers
+    # ---------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "s1,s2,expected",
+        [
+            ("MARTHA", "MARHTA", 0.944),
+            ("DWAYNE", "DUANE", 0.822),
+            ("DIXON", "DICKSON", 0.790),
+            ("CRATE", "TRACE", 0.733),
+            ("billy", "billy", 1.000),
+            ("billy", "bill", 0.933),
+            ("billy", "susan", 0.000),
+        ],
+    )
+    def test_known_values(self, s1, s2, expected):
+        assert round(jaro_similarity(s1, s2), 3) == expected
+
+    # ---------------------------------------------------------
+    # Symmetry: jaro(s1, s2) == jaro(s2, s1)
+    # ---------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "s1,s2",
+        [
+            ("MARTHA", "MARHTA"),
+            ("abc", ""),
+            ("a", "b"),
+            ("DIXON", "DICKSON"),
+        ],
+    )
+    def test_symmetry(self, s1, s2):
+        assert jaro_similarity(s1, s2) == jaro_similarity(s2, s1)
+
+    # ---------------------------------------------------------
+    # Return type consistency
+    # ---------------------------------------------------------
+
+    def test_return_type_is_float(self):
+        """All return paths should produce a float."""
+        assert isinstance(jaro_similarity("a", "a"), float)
+        assert isinstance(jaro_similarity("a", "b"), float)
+        assert isinstance(jaro_similarity("", ""), float)
+        assert isinstance(jaro_similarity("MARTHA", "MARHTA"), float)
+
+
+class TestJaroWinklerSimilarity:
+    """Tests for jaro_winkler_similarity edge cases."""
+
+    def test_both_empty(self):
+        assert jaro_winkler_similarity("", "") == 1.0
+
+    def test_single_char_identical(self):
+        assert jaro_winkler_similarity("a", "a") == 1.0
+
+    def test_single_char_different(self):
+        assert jaro_winkler_similarity("a", "b") == 0.0
+
+    def test_known_value(self):
+        assert round(jaro_winkler_similarity("MARTHA", "MARHTA"), 3) == 0.961
+
+    def test_winkler_ge_jaro(self):
+        """Winkler similarity >= Jaro similarity for common prefixes."""
+        s1, s2 = "MARTHA", "MARHTA"
+        assert jaro_winkler_similarity(s1, s2) >= jaro_similarity(s1, s2)


### PR DESCRIPTION
The similarity calculated for single character strings and empty strings was wrong. The similarity between z and z was returned as 0. The similarity between two empty strings was returned as 0 as well. This brings the implementation in line with the implementation of Apache Commons Text. See https://github.com/apache/commons-text/blob/master/src/main/java/org/apache/commons/text/similarity/JaroWinklerSimilarity.java#L76 and https://commons.apache.org/proper/commons-text/apidocs/org/apache/commons/text/similarity/JaroWinklerSimilarity.html#apply(java.lang.CharSequence,java.lang.CharSequence)