### PR TITLE
lm: bound recursion depth to prevent DoS

### DIFF
--- a/nltk/lm/models.py
+++ b/nltk/lm/models.py
@@ -74,9 +74,10 @@ class StupidBackoff(LanguageModel):
         self.alpha = alpha
 
     def unmasked_score(self, word, context=None):
-        # Defensive bound to prevent unbounded recursion on long contexts
-        if context and len(context) > 50:
-            context = context[-50:]
+        if context:
+            max_ctx = self.order - 1
+            if len(context) > max_ctx:
+                context = context[-max_ctx:]
 
         if not context:
             # Base recursion
@@ -105,12 +106,15 @@ class InterpolatedLanguageModel(LanguageModel):
         self.estimator = smoothing_cls(self.vocab, self.counts, **params)
 
     def unmasked_score(self, word, context=None):
-        if context and len(context) > 50:
-            context = context[-50:]
+        if context:
+            max_ctx = self.order - 1
+            if len(context) > max_ctx:
+                context = context[-max_ctx:]
 
         if not context:
             # The base recursion case: no context, we only have a unigram.
             return self.estimator.unigram_score(word)
+
         if not self.counts[context]:
             # It can also happen that we have no data for this context.
             # In that case we defer to the lower-order ngram.
@@ -118,6 +122,7 @@ class InterpolatedLanguageModel(LanguageModel):
             alpha, gamma = 0, 1
         else:
             alpha, gamma = self.estimator.alpha_gamma(word, context)
+
         return alpha + gamma * self.unmasked_score(word, context[1:])
 
 

--- a/nltk/lm/models.py
+++ b/nltk/lm/models.py
@@ -74,12 +74,18 @@ class StupidBackoff(LanguageModel):
         self.alpha = alpha
 
     def unmasked_score(self, word, context=None):
+        # Defensive bound to prevent unbounded recursion on long contexts
+        if context and len(context) > 50:
+            context = context[-50:]
+
         if not context:
             # Base recursion
             return self.counts.unigrams.freq(word)
+
         counts = self.context_counts(context)
         word_count = counts[word]
         norm_count = counts.N()
+
         if word_count > 0:
             return word_count / norm_count
         else:
@@ -99,6 +105,9 @@ class InterpolatedLanguageModel(LanguageModel):
         self.estimator = smoothing_cls(self.vocab, self.counts, **params)
 
     def unmasked_score(self, word, context=None):
+        if context and len(context) > 50:
+            context = context[-50:]
+
         if not context:
             # The base recursion case: no context, we only have a unigram.
             return self.estimator.unigram_score(word)


### PR DESCRIPTION
**This patch mitigates a denial-of-service issue caused by unbounded recursion in NLTK language models.**

_A defensive limit is applied to the context length in recursive scoring paths (StupidBackoff and interpolated models), preventing stack exhaustion while preserving existing behavior for normal usage._

The fix does not change public APIs or model semantics and only affects pathological inputs with excessively long contexts.