### PR TITLE
fix floating point precision in language model probability sums

### DIFF
--- a/nltk/lm/api.py
+++ b/nltk/lm/api.py
@@ -6,6 +6,7 @@
 # For license information, see LICENSE.TXT
 """Language Model Interface."""
 
+import math
 import random
 import warnings
 from abc import ABCMeta, abstractmethod
@@ -46,7 +47,7 @@ class Smoothing(metaclass=ABCMeta):
 
 def _mean(items):
     """Return average (aka mean) for sequence of items."""
-    return sum(items) / len(items)
+    return math.fsum(items) / len(items)
 
 
 def _random_generator(seed_or_generator):
@@ -65,7 +66,7 @@ def _weighted_choice(population, weights, random_generator=None):
     if len(population) != len(weights):
         raise ValueError("The number of weights does not match the population")
     cum_weights = list(accumulate(weights))
-    total = cum_weights[-1]
+    total = math.fsum(weights)
     threshold = random_generator.random()
     return population[bisect(cum_weights, total * threshold)]
 

--- a/nltk/test/lm.doctest
+++ b/nltk/test/lm.doctest
@@ -62,10 +62,11 @@ https://github.com/nltk/nltk/issues/367#issuecomment-14646110
 
 For doctest to work we have to sort the vocabulary keys.
 
+    >>> import math
     >>> V_keys = sorted(V)
-    >>> round(sum(lm.score(w, ("b",)) for w in V_keys), 6)
+    >>> round(math.fsum(lm.score(w, ("b",)) for w in V_keys), 6)
     1.0
-    >>> round(sum(lm.score(w, ("a",)) for w in V_keys), 6)
+    >>> round(math.fsum(lm.score(w, ("a",)) for w in V_keys), 6)
     1.0
 
     >>> [lm.score(w, ("b",)) for w in V_keys]


### PR DESCRIPTION
Fixes #3275

The language model code uses `sum()` to add up probabilities and log-scores, but `sum()` accumulates rounding errors when you're adding many small floats together. On Python 3.9+ this can cause probability sums that should equal 1.0 to drift enough to break assertions (related to cpython#100425).

Switched to `math.fsum()` which uses the Shewchuk algorithm to track partial sums accurately. Changed it in `_mean()` (used by `entropy()`), in `_weighted_choice()` (used by `generate()`), and in the doctest that sums scores over the vocabulary.