### PR TITLE
Fix CVE-2025-14009

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: requirements-txt-fixer
       - id: check-yaml
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.21.0
+    rev: v3.21.1
     hooks:
     - id: pyupgrade
       args: ["--py38-plus"]

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -2285,6 +2285,39 @@ def unzip(filename, root, verbose=True):
             raise Exception(message)
 
 
+def _validate_member(member, root_abs, abs_prefix, real_prefix):
+    """
+    Check a single ZIP member name for path-traversal and escape vectors.
+
+    Returns ``None`` if the member is safe, or a human-readable error
+    string if the member must be rejected.
+
+    Parameters
+    ----------
+    member : str
+        The archive entry name (forward-slash separated, as stored in the ZIP).
+    root_abs : str
+        Absolute path of the extraction root (used to build candidate paths).
+    abs_prefix : str
+        ``os.path.normcase(root_abs)`` with a trailing ``os.sep``.
+    real_prefix : str
+        ``os.path.normcase(os.path.realpath(root_abs))`` with a trailing
+        ``os.sep``.
+    """
+    if "\x00" in member:
+        return f"Null byte in entry name blocked: {member!r}"
+
+    target_abs = os.path.normcase(os.path.abspath(os.path.join(root_abs, member)))
+    if not target_abs.startswith(abs_prefix):
+        return f"Zip Slip blocked: {member}"
+
+    target_real = os.path.normcase(os.path.realpath(os.path.join(root_abs, member)))
+    if not target_real.startswith(real_prefix):
+        return f"Symlink escape blocked: {member}"
+
+    return None
+
+
 def _unzip_iter(filename, root, verbose=True):
     """
     Secure ZIP extraction using validate-then-extract.
@@ -2304,6 +2337,10 @@ def _unzip_iter(filename, root, verbose=True):
     Members are validated again immediately before each extraction.  This
     narrows (but does not eliminate) TOCTOU windows caused by filesystem
     changes between validation and write.
+
+    Extraction aborts on the first error (including I/O errors) rather
+    than skipping individual members.  Partial extraction of a potentially
+    malicious archive is worse than no extraction.
     """
 
     if verbose:
@@ -2327,28 +2364,10 @@ def _unzip_iter(filename, root, verbose=True):
 
         members = zf.namelist()
 
-        def _validate_member(member):
-            if "\x00" in member:
-                return f"Null byte in entry name blocked: {member!r}"
-
-            target_abs = os.path.normcase(
-                os.path.abspath(os.path.join(root_abs, member))
-            )
-            if not target_abs.startswith(abs_prefix):
-                return f"Zip Slip blocked: {member}"
-
-            target_real = os.path.normcase(
-                os.path.realpath(os.path.join(root_abs, member))
-            )
-            if not target_real.startswith(real_prefix):
-                return f"Symlink escape blocked: {member}"
-
-            return None
-
         # Phase 1 -- validate every member before touching the filesystem.
         has_violations = False
         for member in members:
-            error = _validate_member(member)
+            error = _validate_member(member, root_abs, abs_prefix, real_prefix)
             if error is not None:
                 yield ErrorMessage(filename, error)
                 has_violations = True
@@ -2365,7 +2384,7 @@ def _unzip_iter(filename, root, verbose=True):
             return
 
         for member in members:
-            error = _validate_member(member)
+            error = _validate_member(member, root_abs, abs_prefix, real_prefix)
             if error is not None:
                 yield ErrorMessage(filename, f"{error} (during extraction)")
                 return

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -66,6 +66,7 @@ or::
 
     python -m nltk.downloader [-d DATADIR] [-q] [-f] [-k] PACKAGE_IDS
 """
+
 # ----------------------------------------------------------------------
 
 """
@@ -1641,7 +1642,7 @@ class DownloaderGUI:
 
     def _info_edit(self, info_key):
         self._info_save()  # just in case.
-        (entry, callback) = self._info[info_key]
+        entry, callback = self._info[info_key]
         entry["state"] = "normal"
         entry["relief"] = "sunken"
         entry.focus()
@@ -2324,7 +2325,9 @@ def _unzip_iter(filename, root, verbose=True):
         has_violations = False
         for member in members:
             if "\x00" in member:
-                yield ErrorMessage(filename, f"Null byte in entry name blocked: {member!r}")
+                yield ErrorMessage(
+                    filename, f"Null byte in entry name blocked: {member!r}"
+                )
                 has_violations = True
                 continue
 
@@ -2480,7 +2483,7 @@ def _svn_revision(filename):
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
-    (stdout, stderr) = p.communicate()
+    stdout, stderr = p.communicate()
     if p.returncode != 0 or stderr or not stdout:
         raise ValueError(
             "Error determining svn_revision for %s: %s"
@@ -2635,7 +2638,7 @@ if __name__ == "__main__":
         help="download server index url",
     )
 
-    (options, args) = parser.parse_args()
+    options, args = parser.parse_args()
 
     downloader = Downloader(server_index_url=options.server_index_url)
 

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -2342,14 +2342,23 @@ def _unzip_iter(filename, root, verbose=True):
             if not target_real.startswith(real_prefix):
                 yield ErrorMessage(filename, f"Symlink escape blocked: {member}")
                 has_violations = True
+                continue
 
         if has_violations:
             return
 
         # Phase 2 -- all members passed; extract.
-        os.makedirs(root_abs, exist_ok=True)
-        for member in members:
-            zf.extract(member, root_abs)
+        try:
+            os.makedirs(root_abs, exist_ok=True)
+            for member in members:
+                zf.extract(member, root_abs)
+        except Exception as e:
+            try:
+                shutil.rmtree(root_abs)
+            except Exception:
+                pass
+            yield ErrorMessage(filename, f"Extraction error: {e}")
+            return
     except Exception as e:
         yield ErrorMessage(filename, f"Extraction error: {e}")
     finally:

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -2312,33 +2312,35 @@ def _unzip_iter(filename, root, verbose=True):
     try:
         root_abs = os.path.abspath(root)
         root_real = os.path.realpath(root_abs)
-        root_prefix = root_real.rstrip(os.sep) + os.sep
+        abs_prefix = root_abs.rstrip(os.sep) + os.sep
+        real_prefix = root_real.rstrip(os.sep) + os.sep
 
         members = zf.namelist()
 
         # Phase 1 -- validate every member before touching the filesystem.
-        # Note: validating up-front widens the TOCTOU window for symlink
-        # attacks compared to per-member check-then-extract, but guarantees
+        # Validating up-front widens the TOCTOU window for symlink attacks
+        # compared to per-member check-then-extract, but guarantees
         # all-or-nothing extraction semantics.
-        violations = []
+        has_violations = False
         for member in members:
             if "\x00" in member:
-                violations.append(f"Null byte in entry name blocked: {member!r}")
+                yield ErrorMessage(filename, f"Null byte in entry name blocked: {member!r}")
+                has_violations = True
                 continue
 
             target_abs = os.path.abspath(os.path.join(root_abs, member))
 
-            if not target_abs.startswith(root_prefix):
-                violations.append(f"Zip Slip blocked: {member}")
+            if not target_abs.startswith(abs_prefix):
+                yield ErrorMessage(filename, f"Zip Slip blocked: {member}")
+                has_violations = True
                 continue
 
             target_real = os.path.realpath(target_abs)
-            if not target_real.startswith(root_prefix):
-                violations.append(f"Symlink escape blocked: {member}")
+            if not target_real.startswith(real_prefix):
+                yield ErrorMessage(filename, f"Symlink escape blocked: {member}")
+                has_violations = True
 
-        if violations:
-            for v in violations:
-                yield ErrorMessage(filename, v)
+        if has_violations:
             return
 
         # Phase 2 -- all members passed; extract.

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -162,7 +162,6 @@ default: unzip or not?
 import functools
 import itertools
 import os
-import shutil
 import subprocess
 import sys
 import textwrap
@@ -2308,6 +2307,8 @@ def _unzip_iter(filename, root, verbose=True):
         zf = zipfile.ZipFile(filename)
     except Exception as e:
         yield ErrorMessage(filename, e)
+        if verbose:
+            print()
         return
 
     try:
@@ -2353,19 +2354,14 @@ def _unzip_iter(filename, root, verbose=True):
             for member in members:
                 zf.extract(member, root_abs)
         except Exception as e:
-            try:
-                shutil.rmtree(root_abs)
-            except Exception:
-                pass
             yield ErrorMessage(filename, f"Extraction error: {e}")
             return
     except Exception as e:
         yield ErrorMessage(filename, f"Extraction error: {e}")
     finally:
         zf.close()
-
-    if verbose:
-        print()
+        if verbose:
+            print()
 
 
 ######################################################################

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -2297,6 +2297,10 @@ def _unzip_iter(filename, root, verbose=True):
     - Null-byte rejection (platform path-truncation vector)
     - Zip-Slip (.., absolute paths, drive letters)
     - Symlink-escape (writes through pre-existing symlinks)
+
+    Members are validated again immediately before each extraction.  This
+    narrows (but does not eliminate) TOCTOU windows caused by filesystem
+    changes between validation and write.
     """
 
     if verbose:
@@ -2319,29 +2323,26 @@ def _unzip_iter(filename, root, verbose=True):
 
         members = zf.namelist()
 
-        # Phase 1 -- validate every member before touching the filesystem.
-        # Validating up-front widens the TOCTOU window for symlink attacks
-        # compared to per-member check-then-extract, but guarantees
-        # all-or-nothing extraction semantics.
-        has_violations = False
-        for member in members:
+        def _validate_member(member):
             if "\x00" in member:
-                yield ErrorMessage(
-                    filename, f"Null byte in entry name blocked: {member!r}"
-                )
-                has_violations = True
-                continue
+                return None, f"Null byte in entry name blocked: {member!r}"
 
             target_abs = os.path.abspath(os.path.join(root_abs, member))
-
             if not target_abs.startswith(abs_prefix):
-                yield ErrorMessage(filename, f"Zip Slip blocked: {member}")
-                has_violations = True
-                continue
+                return None, f"Zip Slip blocked: {member}"
 
             target_real = os.path.realpath(target_abs)
             if not target_real.startswith(real_prefix):
-                yield ErrorMessage(filename, f"Symlink escape blocked: {member}")
+                return None, f"Symlink escape blocked: {member}"
+
+            return target_abs, None
+
+        # Phase 1 -- validate every member before touching the filesystem.
+        has_violations = False
+        for member in members:
+            _target_abs, validation_error = _validate_member(member)
+            if validation_error is not None:
+                yield ErrorMessage(filename, validation_error)
                 has_violations = True
                 continue
 
@@ -2352,6 +2353,12 @@ def _unzip_iter(filename, root, verbose=True):
         try:
             os.makedirs(root_abs, exist_ok=True)
             for member in members:
+                _target_abs, validation_error = _validate_member(member)
+                if validation_error is not None:
+                    yield ErrorMessage(
+                        filename, f"{validation_error} (during extraction)"
+                    )
+                    return
                 zf.extract(member, root_abs)
         except Exception as e:
             yield ErrorMessage(filename, f"Extraction error: {e}")

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -2298,6 +2298,9 @@ def _unzip_iter(filename, root, verbose=True):
     - Zip-Slip (.., absolute paths, drive letters)
     - Symlink-escape (writes through pre-existing symlinks)
 
+    All path comparisons use ``os.path.normcase`` so that the checks
+    are case-insensitive on Windows (no-op on POSIX).
+
     Members are validated again immediately before each extraction.  This
     narrows (but does not eliminate) TOCTOU windows caused by filesystem
     changes between validation and write.
@@ -2316,8 +2319,8 @@ def _unzip_iter(filename, root, verbose=True):
         return
 
     try:
-        root_abs = os.path.abspath(root)
-        root_real = os.path.realpath(root_abs)
+        root_abs = os.path.normcase(os.path.abspath(root))
+        root_real = os.path.normcase(os.path.realpath(root_abs))
         abs_prefix = root_abs.rstrip(os.sep) + os.sep
         real_prefix = root_real.rstrip(os.sep) + os.sep
 
@@ -2327,11 +2330,13 @@ def _unzip_iter(filename, root, verbose=True):
             if "\x00" in member:
                 return f"Null byte in entry name blocked: {member!r}"
 
-            target_abs = os.path.abspath(os.path.join(root_abs, member))
+            target_abs = os.path.normcase(
+                os.path.abspath(os.path.join(root_abs, member))
+            )
             if not target_abs.startswith(abs_prefix):
                 return f"Zip Slip blocked: {member}"
 
-            target_real = os.path.realpath(target_abs)
+            target_real = os.path.normcase(os.path.realpath(target_abs))
             if not target_real.startswith(real_prefix):
                 return f"Symlink escape blocked: {member}"
 

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -2319,10 +2319,11 @@ def _unzip_iter(filename, root, verbose=True):
         return
 
     try:
-        root_abs = os.path.normcase(os.path.abspath(root))
-        root_real = os.path.normcase(os.path.realpath(root_abs))
-        abs_prefix = root_abs.rstrip(os.sep) + os.sep
-        real_prefix = root_real.rstrip(os.sep) + os.sep
+        root_abs = os.path.abspath(root)
+        root_real = os.path.realpath(root_abs)
+
+        abs_prefix = os.path.normcase(root_abs).rstrip(os.sep) + os.sep
+        real_prefix = os.path.normcase(root_real).rstrip(os.sep) + os.sep
 
         members = zf.namelist()
 
@@ -2336,7 +2337,9 @@ def _unzip_iter(filename, root, verbose=True):
             if not target_abs.startswith(abs_prefix):
                 return f"Zip Slip blocked: {member}"
 
-            target_real = os.path.normcase(os.path.realpath(target_abs))
+            target_real = os.path.normcase(
+                os.path.realpath(os.path.join(root_abs, member))
+            )
             if not target_real.startswith(real_prefix):
                 return f"Symlink escape blocked: {member}"
 

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -2352,15 +2352,20 @@ def _unzip_iter(filename, root, verbose=True):
         # Phase 2 -- all members passed; extract.
         try:
             os.makedirs(root_abs, exist_ok=True)
-            for member in members:
-                error = _validate_member(member)
-                if error is not None:
-                    yield ErrorMessage(filename, f"{error} (during extraction)")
-                    return
-                zf.extract(member, root_abs)
         except Exception as e:
             yield ErrorMessage(filename, f"Extraction error: {e}")
             return
+
+        for member in members:
+            error = _validate_member(member)
+            if error is not None:
+                yield ErrorMessage(filename, f"{error} (during extraction)")
+                return
+            try:
+                zf.extract(member, root_abs)
+            except Exception as e:
+                yield ErrorMessage(filename, f"Extraction error for {member}: {e}")
+                return
     except Exception as e:
         yield ErrorMessage(filename, f"Validation error: {e}")
     finally:

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -2287,11 +2287,16 @@ def unzip(filename, root, verbose=True):
 
 def _unzip_iter(filename, root, verbose=True):
     """
-    Secure ZIP extraction with minimal behavioural changes.
+    Secure ZIP extraction using validate-then-extract.
 
-    - Prevents classic Zip-Slip (.., absolute paths, drive letters)
-    - Prevents writes through pre-existing symlinks
-    - Preserves original extraction behaviour for valid archives
+    All members are validated before any extraction occurs.  If any member
+    fails validation the entire archive is rejected and nothing is written
+    to disk.
+
+    Checks performed on every member name:
+    - Null-byte rejection (platform path-truncation vector)
+    - Zip-Slip (.., absolute paths, drive letters)
+    - Symlink-escape (writes through pre-existing symlinks)
     """
 
     if verbose:
@@ -2304,38 +2309,44 @@ def _unzip_iter(filename, root, verbose=True):
         yield ErrorMessage(filename, e)
         return
 
-    # Canonical root
-    root_abs = os.path.abspath(root)
-    root_real = os.path.realpath(root_abs)
-    root_prefix = root_real.rstrip(os.sep) + os.sep
-
-    # Ensure the extraction root directory exists
-    os.makedirs(root, exist_ok=True)
-
     try:
-        for member in zf.namelist():
+        root_abs = os.path.abspath(root)
+        root_real = os.path.realpath(root_abs)
+        root_prefix = root_real.rstrip(os.sep) + os.sep
 
-            # Construct target path
-            raw_target = os.path.join(root_abs, member)
-            target_abs = os.path.abspath(raw_target)
+        members = zf.namelist()
 
-            # Zip-Slip check (absolute/traversal/drive-letter cases)
-            if not target_abs.startswith(root_prefix):
-                yield ErrorMessage(filename, f"Zip Slip blocked: {member}")
+        # Phase 1 -- validate every member before touching the filesystem.
+        # Note: validating up-front widens the TOCTOU window for symlink
+        # attacks compared to per-member check-then-extract, but guarantees
+        # all-or-nothing extraction semantics.
+        violations = []
+        for member in members:
+            if "\x00" in member:
+                violations.append(f"Null byte in entry name blocked: {member!r}")
                 continue
 
-            # Symlink-escape check
+            target_abs = os.path.abspath(os.path.join(root_abs, member))
+
+            if not target_abs.startswith(root_prefix):
+                violations.append(f"Zip Slip blocked: {member}")
+                continue
+
             target_real = os.path.realpath(target_abs)
             if not target_real.startswith(root_prefix):
-                yield ErrorMessage(filename, f"Symlink escape blocked: {member}")
-                continue
+                violations.append(f"Symlink escape blocked: {member}")
 
-            # Safe extraction
-            try:
-                zf.extract(member, root)
-            except Exception as e:
-                yield ErrorMessage(filename, f"Extraction error for {member}: {e}")
-                continue
+        if violations:
+            for v in violations:
+                yield ErrorMessage(filename, v)
+            return
+
+        # Phase 2 -- all members passed; extract.
+        os.makedirs(root_abs, exist_ok=True)
+        for member in members:
+            zf.extract(member, root_abs)
+    except Exception as e:
+        yield ErrorMessage(filename, f"Extraction error: {e}")
     finally:
         zf.close()
 

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -2325,24 +2325,24 @@ def _unzip_iter(filename, root, verbose=True):
 
         def _validate_member(member):
             if "\x00" in member:
-                return None, f"Null byte in entry name blocked: {member!r}"
+                return f"Null byte in entry name blocked: {member!r}"
 
             target_abs = os.path.abspath(os.path.join(root_abs, member))
             if not target_abs.startswith(abs_prefix):
-                return None, f"Zip Slip blocked: {member}"
+                return f"Zip Slip blocked: {member}"
 
             target_real = os.path.realpath(target_abs)
             if not target_real.startswith(real_prefix):
-                return None, f"Symlink escape blocked: {member}"
+                return f"Symlink escape blocked: {member}"
 
-            return target_abs, None
+            return None
 
         # Phase 1 -- validate every member before touching the filesystem.
         has_violations = False
         for member in members:
-            _target_abs, validation_error = _validate_member(member)
-            if validation_error is not None:
-                yield ErrorMessage(filename, validation_error)
+            error = _validate_member(member)
+            if error is not None:
+                yield ErrorMessage(filename, error)
                 has_violations = True
                 continue
 
@@ -2353,18 +2353,16 @@ def _unzip_iter(filename, root, verbose=True):
         try:
             os.makedirs(root_abs, exist_ok=True)
             for member in members:
-                _target_abs, validation_error = _validate_member(member)
-                if validation_error is not None:
-                    yield ErrorMessage(
-                        filename, f"{validation_error} (during extraction)"
-                    )
+                error = _validate_member(member)
+                if error is not None:
+                    yield ErrorMessage(filename, f"{error} (during extraction)")
                     return
                 zf.extract(member, root_abs)
         except Exception as e:
             yield ErrorMessage(filename, f"Extraction error: {e}")
             return
     except Exception as e:
-        yield ErrorMessage(filename, f"Extraction error: {e}")
+        yield ErrorMessage(filename, f"Validation error: {e}")
     finally:
         zf.close()
         if verbose:

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -2285,32 +2285,32 @@ def unzip(filename, root, verbose=True):
             raise Exception(message)
 
 
-def _validate_member(member, root_abs, abs_prefix, real_prefix):
+def _validate_member(member, root_abs):
     """
     Check a single ZIP member name for path-traversal and escape vectors.
 
     Returns ``None`` if the member is safe, or a human-readable error
-    string if the member must be rejected.
+    string if the member must be rejected.  Comparison prefixes are
+    derived from *root_abs* internally via ``os.path.normcase`` so that
+    callers cannot supply inconsistent values.
 
     Parameters
     ----------
     member : str
         The archive entry name (forward-slash separated, as stored in the ZIP).
     root_abs : str
-        Absolute path of the extraction root (used to build candidate paths).
-    abs_prefix : str
-        ``os.path.normcase(root_abs)`` with a trailing ``os.sep``.
-    real_prefix : str
-        ``os.path.normcase(os.path.realpath(root_abs))`` with a trailing
-        ``os.sep``.
+        Absolute path of the extraction root (used to build candidate paths
+        and derive comparison prefixes via ``os.path.normcase``).
     """
     if "\x00" in member:
         return f"Null byte in entry name blocked: {member!r}"
 
+    abs_prefix = os.path.normcase(root_abs).rstrip(os.sep) + os.sep
     target_abs = os.path.normcase(os.path.abspath(os.path.join(root_abs, member)))
     if not target_abs.startswith(abs_prefix):
         return f"Zip Slip blocked: {member}"
 
+    real_prefix = os.path.normcase(os.path.realpath(root_abs)).rstrip(os.sep) + os.sep
     target_real = os.path.normcase(os.path.realpath(os.path.join(root_abs, member)))
     if not target_real.startswith(real_prefix):
         return f"Symlink escape blocked: {member}"
@@ -2334,9 +2334,10 @@ def _unzip_iter(filename, root, verbose=True):
     All path comparisons use ``os.path.normcase`` so that the checks
     are case-insensitive on Windows (no-op on POSIX).
 
-    Members are validated again immediately before each extraction.  This
-    narrows (but does not eliminate) TOCTOU windows caused by filesystem
-    changes between validation and write.
+    Members are validated again immediately before each extraction as a
+    best-effort check against filesystem changes between Phase 1 and the
+    actual write, but this cannot eliminate TOCTOU races inherent in
+    non-atomic extraction.
 
     Extraction aborts on the first error (including I/O errors) rather
     than skipping individual members.  Partial extraction of a potentially
@@ -2351,23 +2352,20 @@ def _unzip_iter(filename, root, verbose=True):
         zf = zipfile.ZipFile(filename)
     except Exception as e:
         yield ErrorMessage(filename, e)
+        # Flush the "Unzipping ..." line here because the try/finally that
+        # normally handles this is never entered (zf was never assigned).
         if verbose:
             print()
         return
 
     try:
         root_abs = os.path.abspath(root)
-        root_real = os.path.realpath(root_abs)
-
-        abs_prefix = os.path.normcase(root_abs).rstrip(os.sep) + os.sep
-        real_prefix = os.path.normcase(root_real).rstrip(os.sep) + os.sep
-
         members = zf.namelist()
 
         # Phase 1 -- validate every member before touching the filesystem.
         has_violations = False
         for member in members:
-            error = _validate_member(member, root_abs, abs_prefix, real_prefix)
+            error = _validate_member(member, root_abs)
             if error is not None:
                 yield ErrorMessage(filename, error)
                 has_violations = True
@@ -2384,7 +2382,7 @@ def _unzip_iter(filename, root, verbose=True):
             return
 
         for member in members:
-            error = _validate_member(member, root_abs, abs_prefix, real_prefix)
+            error = _validate_member(member, root_abs)
             if error is not None:
                 yield ErrorMessage(filename, f"{error} (during extraction)")
                 return

--- a/nltk/test/unit/test_downloader_unzip.py
+++ b/nltk/test/unit/test_downloader_unzip.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
-from nltk.downloader import ErrorMessage, _unzip_iter
+from nltk.downloader import ErrorMessage, _unzip_iter, _validate_member
 
 
 def _make_zip(file_path: Path, members: dict[str, bytes]) -> None:
@@ -24,6 +24,17 @@ def _run_unzip_iter(zip_path: Path, extract_root: Path, verbose: bool = False):
     messages (if any).
     """
     return list(_unzip_iter(str(zip_path), str(extract_root), verbose=verbose))
+
+
+def _assert_blocked(messages, *expected_substrings):
+    """Assert that *messages* contain at least one ``ErrorMessage`` whose
+    text includes every string in *expected_substrings*."""
+    err_msgs = [m for m in messages if isinstance(m, ErrorMessage)]
+    assert err_msgs, f"Expected ErrorMessage(s) containing {expected_substrings!r}"
+    combined = " ".join(str(m.message) for m in err_msgs)
+    for s in expected_substrings:
+        assert s in combined, f"Expected {s!r} in error output: {combined}"
+    return err_msgs
 
 
 class TestSecureUnzip:
@@ -52,7 +63,6 @@ class TestSecureUnzip:
 
         messages = _run_unzip_iter(zip_path, extract_root, verbose=False)
 
-        # No ErrorMessage should be yielded for valid archives.
         assert not any(isinstance(m, ErrorMessage) for m in messages)
 
         assert (extract_root / "pkg" / "file.txt").read_bytes() == b"hello"
@@ -82,14 +92,7 @@ class TestSecureUnzip:
 
         messages = _run_unzip_iter(zip_path, extract_root, verbose=False)
 
-        err_msgs = [m for m in messages if isinstance(m, ErrorMessage)]
-        assert (
-            err_msgs
-        ), "Expected an ErrorMessage for a Zip-Slip parent-directory attempt"
-
-        combined_messages = " ".join(str(m.message) for m in err_msgs)
-        assert "Zip Slip" in combined_messages and "blocked" in combined_messages
-
+        _assert_blocked(messages, "Zip Slip", "blocked")
         assert not outside_target.exists()
 
         # Fail-fast: nothing should be extracted from a malicious archive.
@@ -121,13 +124,7 @@ class TestSecureUnzip:
 
             messages = _run_unzip_iter(zip_path, extract_root, verbose=False)
 
-            err_msgs = [m for m in messages if isinstance(m, ErrorMessage)]
-            assert (
-                err_msgs
-            ), "Expected an ErrorMessage for absolute-path Zip-Slip attempt"
-
-            combined_messages = " ".join(str(m.message) for m in err_msgs)
-            assert "Zip Slip" in combined_messages and "blocked" in combined_messages
+            _assert_blocked(messages, "Zip Slip", "blocked")
 
             assert not absolute_target.exists()
 
@@ -174,7 +171,7 @@ class TestSecureUnzip:
         messages = _run_unzip_iter(zip_path, extract_root, verbose=False)
 
         assert not outside_target.exists()
-        assert any(isinstance(m, ErrorMessage) for m in messages)
+        _assert_blocked(messages, "Symlink escape", "blocked")
 
         # Fail-fast: nothing should be extracted from a malicious archive.
         assert not (extract_root / "pkg" / "good.txt").exists()
@@ -192,8 +189,6 @@ class TestSecureUnzip:
 
         assert any(isinstance(m, ErrorMessage) for m in messages)
 
-        # If the implementation chooses to create the root directory at all,
-        # it should not leave partially extracted content.
         if extract_root.exists():
             assert not any(extract_root.iterdir())
 
@@ -219,16 +214,14 @@ class TestSecureUnzip:
         with patch(
             "nltk.downloader.zipfile.ZipFile.namelist",
             return_value=poisoned_names,
-        ):
+        ), patch(
+            "nltk.downloader.zipfile.ZipFile.extract",
+        ) as mock_extract:
             messages = _run_unzip_iter(zip_path, extract_root, verbose=False)
 
-        err_msgs = [m for m in messages if isinstance(m, ErrorMessage)]
-        assert err_msgs, "Expected an ErrorMessage for null-byte entry name"
+        _assert_blocked(messages, "Null byte", "blocked")
+        mock_extract.assert_not_called()
 
-        combined_messages = " ".join(str(m.message) for m in err_msgs)
-        assert "Null byte" in combined_messages and "blocked" in combined_messages
-
-        # Nothing should be extracted.
         assert not (extract_root / "pkg" / "good.txt").exists()
 
     @pytest.mark.skipif(
@@ -260,13 +253,8 @@ class TestSecureUnzip:
 
             messages = _run_unzip_iter(zip_path, extract_root, verbose=False)
 
-            err_msgs = [m for m in messages if isinstance(m, ErrorMessage)]
-            assert (
-                len(err_msgs) >= 2
-            ), "Expected at least two ErrorMessages for multiple violations"
-
-            combined = " ".join(str(m.message) for m in err_msgs)
-            assert "Zip Slip" in combined
+            err_msgs = _assert_blocked(messages, "Zip Slip")
+            assert len(err_msgs) >= 2, "Expected at least two ErrorMessages"
 
             assert not absolute_target.exists()
 
@@ -300,11 +288,8 @@ class TestSecureUnzip:
         ):
             messages = _run_unzip_iter(zip_path, extract_root, verbose=False)
 
-        err_msgs = [m for m in messages if isinstance(m, ErrorMessage)]
-        assert err_msgs, "Expected extraction failure to yield an ErrorMessage"
-        assert any("Extraction error" in str(m.message) for m in err_msgs)
+        _assert_blocked(messages, "Extraction error")
 
-        # Existing filesystem content should not be removed.
         assert existing_file.read_bytes() == b"keep-me"
 
     def test_namelist_raises_yields_errormessage(self, tmp_path: Path) -> None:
@@ -323,9 +308,7 @@ class TestSecureUnzip:
         ):
             messages = _run_unzip_iter(zip_path, extract_root, verbose=False)
 
-        err_msgs = [m for m in messages if isinstance(m, ErrorMessage)]
-        assert err_msgs, "Expected an ErrorMessage when namelist() raises"
-        assert any("corrupted central directory" in str(m.message) for m in err_msgs)
+        _assert_blocked(messages, "corrupted central directory")
 
         if extract_root.exists():
             assert not any(extract_root.iterdir())
@@ -359,3 +342,77 @@ class TestSecureUnzip:
         captured = capsys.readouterr()
         assert "Unzipping" in captured.out
         assert captured.out.endswith("\n")
+
+
+class TestValidateMember:
+    """Direct unit tests for ``_validate_member`` path validation logic."""
+
+    @staticmethod
+    def _prefixes(root_abs):
+        """Compute abs_prefix and real_prefix for a given root."""
+        abs_prefix = os.path.normcase(root_abs).rstrip(os.sep) + os.sep
+        real_prefix = (
+            os.path.normcase(os.path.realpath(root_abs)).rstrip(os.sep) + os.sep
+        )
+        return abs_prefix, real_prefix
+
+    def test_safe_relative_path_passes(self, tmp_path):
+        root = str(tmp_path / "root")
+        abs_p, real_p = self._prefixes(root)
+        assert _validate_member("pkg/file.txt", root, abs_p, real_p) is None
+
+    def test_parent_traversal_blocked(self, tmp_path):
+        root = str(tmp_path / "root")
+        abs_p, real_p = self._prefixes(root)
+        result = _validate_member("../evil.txt", root, abs_p, real_p)
+        assert result is not None and "Zip Slip" in result
+
+    def test_deeply_nested_traversal_blocked(self, tmp_path):
+        root = str(tmp_path / "root")
+        abs_p, real_p = self._prefixes(root)
+        result = _validate_member("a/b/c/../../../../evil.txt", root, abs_p, real_p)
+        assert result is not None and "Zip Slip" in result
+
+    def test_null_byte_blocked(self, tmp_path):
+        root = str(tmp_path / "root")
+        abs_p, real_p = self._prefixes(root)
+        result = _validate_member("pkg/evil\x00.txt", root, abs_p, real_p)
+        assert result is not None and "Null byte" in result
+
+    @pytest.mark.skipif(
+        sys.platform.startswith("win"),
+        reason="Absolute POSIX paths are not meaningful on Windows",
+    )
+    def test_absolute_posix_path_blocked(self, tmp_path):
+        root = str(tmp_path / "root")
+        abs_p, real_p = self._prefixes(root)
+        result = _validate_member("/etc/passwd", root, abs_p, real_p)
+        assert result is not None and "Zip Slip" in result
+
+    @pytest.mark.skipif(
+        not sys.platform.startswith("win"),
+        reason="Drive-letter paths are only meaningful on Windows",
+    )
+    def test_windows_drive_letter_blocked(self, tmp_path):
+        root = str(tmp_path / "root")
+        abs_p, real_p = self._prefixes(root)
+        result = _validate_member("C:\\Windows\\evil.txt", root, abs_p, real_p)
+        assert result is not None and "Zip Slip" in result
+
+    def test_normcase_is_applied_to_path_comparisons(self, tmp_path):
+        """Simulate case-folding normcase (as on Windows) to verify that
+        _validate_member applies it to both target and prefix paths."""
+        root = str(tmp_path / "Root")
+        original_normcase = os.path.normcase
+
+        def case_folding_normcase(p):
+            return original_normcase(p).lower()
+
+        abs_p = case_folding_normcase(root).rstrip(os.sep) + os.sep
+        real_p = case_folding_normcase(os.path.realpath(root)).rstrip(os.sep) + os.sep
+
+        with patch("os.path.normcase", side_effect=case_folding_normcase):
+            assert _validate_member("pkg/file.txt", root, abs_p, real_p) is None
+
+            result = _validate_member("../evil.txt", root, abs_p, real_p)
+            assert result is not None and "Zip Slip" in result

--- a/nltk/test/unit/test_downloader_unzip.py
+++ b/nltk/test/unit/test_downloader_unzip.py
@@ -225,6 +225,10 @@ class TestSecureUnzip:
         # Nothing should be extracted.
         assert not (extract_root / "pkg" / "good.txt").exists()
 
+    @pytest.mark.skipif(
+        sys.platform.startswith("win"),
+        reason="Absolute POSIX paths are not meaningful on Windows",
+    )
     def test_multiple_violation_types_all_reported_and_nothing_extracted(
         self, tmp_path: Path
     ) -> None:

--- a/nltk/test/unit/test_downloader_unzip.py
+++ b/nltk/test/unit/test_downloader_unzip.py
@@ -166,7 +166,10 @@ class TestSecureUnzip:
         _make_zip(zip_path, members)
 
         extract_root.mkdir()
-        os.symlink(outside_dir, extract_root / "dir_link")
+        try:
+            os.symlink(outside_dir, extract_root / "dir_link")
+        except OSError:
+            pytest.skip("Symlink creation not permitted on this platform")
 
         messages = _run_unzip_iter(zip_path, extract_root, verbose=False)
 

--- a/nltk/test/unit/test_downloader_unzip.py
+++ b/nltk/test/unit/test_downloader_unzip.py
@@ -2,6 +2,7 @@ import os
 import sys
 import zipfile
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -27,17 +28,12 @@ def _run_unzip_iter(zip_path: Path, extract_root: Path, verbose: bool = False):
 
 class TestSecureUnzip:
     """
-    Tests for secure ZIP extraction behaviour in nltk.downloader._unzip_iter.
+    Tests for the validate-then-extract strategy in ``_unzip_iter``.
 
-    These tests are specifically designed so that:
-
-    * On the old implementation (using zf.extractall(root) without checks),
-      the "Zip-Slip" tests will fail because they rely on the new behaviour
-      (yielding ErrorMessage for escaping entries, and NOT writing outside
-      the extraction root).
-
-    * On the new implementation, the tests pass, because the new path
-      validation prevents escapes and emits the expected ErrorMessage.
+    The implementation scans every member for security violations (path
+    traversal, absolute paths, symlink escapes, null bytes) *before*
+    extracting anything.  If any member fails validation the entire archive
+    is rejected and nothing is written to disk.
     """
 
     def test_normal_relative_paths_are_extracted(self, tmp_path: Path) -> None:
@@ -70,43 +66,34 @@ class TestSecureUnzip:
         must not be written outside the extraction root, and must cause
         _unzip_iter to yield an ErrorMessage.
 
-        On the old implementation (extractall(root)), this test will fail
-        because the file outside the root is actually created and no
-        ErrorMessage is yielded.
+        The entire archive is rejected: even safe entries must NOT be
+        extracted when any member fails validation.
         """
         zip_path = tmp_path / "zip_slip_parent.zip"
         extract_root = tmp_path / "extract"
 
-        # This is the path that would be written if "../outside.txt" is
-        # extracted with extractall(root).
         outside_target = (extract_root / ".." / "outside.txt").resolve()
 
         members = {
             "pkg/good.txt": b"ok",
-            # This would escape extract_root if not validated.
             "../outside.txt": b"evil",
         }
         _make_zip(zip_path, members)
 
         messages = _run_unzip_iter(zip_path, extract_root, verbose=False)
 
-        # With the secure implementation, the escaping entry must be blocked
-        # and reported as an ErrorMessage.
         err_msgs = [m for m in messages if isinstance(m, ErrorMessage)]
         assert (
             err_msgs
         ), "Expected an ErrorMessage for a Zip-Slip parent-directory attempt"
 
-        # Check that the message text indicates it was blocked. Adjust to the
-        # exact wording if needed.
         combined_messages = " ".join(str(m.message) for m in err_msgs)
         assert "Zip Slip" in combined_messages and "blocked" in combined_messages
 
-        # The escaping path must not have been written.
         assert not outside_target.exists()
 
-        # The safe entry should still be extracted under the root.
-        assert (extract_root / "pkg" / "good.txt").read_bytes() == b"ok"
+        # Fail-fast: nothing should be extracted from a malicious archive.
+        assert not (extract_root / "pkg" / "good.txt").exists()
 
     @pytest.mark.skipif(
         sys.platform.startswith("win"),
@@ -118,20 +105,16 @@ class TestSecureUnzip:
         extracted as-is; it should not overwrite arbitrary filesystem paths,
         and should result in an ErrorMessage.
 
-        On the old implementation (extractall(root)), this test will fail
-        because the absolute path gets created without any ErrorMessage.
+        The entire archive is rejected when any member fails validation.
         """
         zip_path = tmp_path / "zip_slip_abs_posix.zip"
         extract_root = tmp_path / "extract"
 
-        # Choose a unique location in /tmp to avoid interfering with real files.
         absolute_target = Path("/tmp") / f"nltk_zip_slip_test_{os.getpid()}"
 
         try:
             members = {
                 "pkg/good.txt": b"ok",
-                # This absolute path should never be created by the secure
-                # implementation.
                 str(absolute_target): b"evil",
             }
             _make_zip(zip_path, members)
@@ -146,19 +129,15 @@ class TestSecureUnzip:
             combined_messages = " ".join(str(m.message) for m in err_msgs)
             assert "Zip Slip" in combined_messages and "blocked" in combined_messages
 
-            # Absolute path must not be created by the secure implementation.
             assert not absolute_target.exists()
 
-            # Safe entry must still be extracted under extract_root.
-            assert (extract_root / "pkg" / "good.txt").read_bytes() == b"ok"
+            # Fail-fast: nothing should be extracted from a malicious archive.
+            assert not (extract_root / "pkg" / "good.txt").exists()
         finally:
-            # Best-effort cleanup if the implementation under test behaves
-            # incorrectly and creates the file.
             if absolute_target.exists():
                 try:
                     absolute_target.unlink()
                 except OSError:
-                    # Ignore cleanup errors: file may not exist or be locked.
                     pass
 
     def test_entries_resolved_outside_root_are_blocked_via_symlink(
@@ -169,8 +148,7 @@ class TestSecureUnzip:
         points outside the root, writing through that symlink should not
         be allowed to escape the root.
 
-        This test documents the desired hardening to defend against this
-        class of attacks.
+        The entire archive is rejected when any member fails validation.
         """
         if not hasattr(os, "symlink"):
             pytest.skip("Symlinks not supported on this platform")
@@ -188,16 +166,15 @@ class TestSecureUnzip:
         _make_zip(zip_path, members)
 
         extract_root.mkdir()
-        # Pre-existing symlink inside extract_root pointing *outside* it.
         os.symlink(outside_dir, extract_root / "dir_link")
 
         messages = _run_unzip_iter(zip_path, extract_root, verbose=False)
 
-        # Desired property:
         assert not outside_target.exists()
-        assert (extract_root / "pkg" / "good.txt").read_bytes() == b"ok"
-        # Should yield an ErrorMessage for the blocked symlink escape
         assert any(isinstance(m, ErrorMessage) for m in messages)
+
+        # Fail-fast: nothing should be extracted from a malicious archive.
+        assert not (extract_root / "pkg" / "good.txt").exists()
 
     def test_bad_zipfile_yields_errormessage(self, tmp_path: Path) -> None:
         """
@@ -216,6 +193,81 @@ class TestSecureUnzip:
         # it should not leave partially extracted content.
         if extract_root.exists():
             assert not any(extract_root.iterdir())
+
+    def test_null_byte_in_member_name_is_blocked(self, tmp_path: Path) -> None:
+        """
+        A member name containing a null byte must be rejected.  Null bytes
+        can cause path truncation on some platforms, so they are never
+        legitimate in archive entry names.
+
+        The entire archive is rejected when any member fails validation.
+
+        Note: CPython's zipfile module truncates names at null bytes on
+        read, so we patch ``namelist()`` to simulate a library that
+        preserves them.
+        """
+        zip_path = tmp_path / "null_byte.zip"
+        extract_root = tmp_path / "extract"
+
+        _make_zip(zip_path, {"pkg/good.txt": b"ok", "pkg/evil.txt": b"evil"})
+
+        poisoned_names = ["pkg/good.txt", "pkg/evil\x00.txt"]
+
+        with patch("zipfile.ZipFile.namelist", return_value=poisoned_names):
+            messages = _run_unzip_iter(zip_path, extract_root, verbose=False)
+
+        err_msgs = [m for m in messages if isinstance(m, ErrorMessage)]
+        assert err_msgs, "Expected an ErrorMessage for null-byte entry name"
+
+        combined_messages = " ".join(str(m.message) for m in err_msgs)
+        assert "Null byte" in combined_messages and "blocked" in combined_messages
+
+        # Nothing should be extracted.
+        assert not (extract_root / "pkg" / "good.txt").exists()
+
+    def test_multiple_violation_types_all_reported_and_nothing_extracted(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        An archive that combines several different violation types (path
+        traversal and absolute path) must report every violation and
+        extract nothing.  This verifies that the validation scan does not
+        short-circuit after the first bad entry.
+        """
+        zip_path = tmp_path / "multi_violation.zip"
+        extract_root = tmp_path / "extract"
+
+        absolute_target = Path("/tmp") / f"nltk_multi_viol_test_{os.getpid()}"
+
+        try:
+            members = {
+                "data/a.txt": b"aaa",
+                "../traversal.txt": b"evil1",
+                str(absolute_target): b"evil2",
+                "data/b.txt": b"bbb",
+            }
+            _make_zip(zip_path, members)
+
+            messages = _run_unzip_iter(zip_path, extract_root, verbose=False)
+
+            err_msgs = [m for m in messages if isinstance(m, ErrorMessage)]
+            assert len(err_msgs) >= 2, (
+                "Expected at least two ErrorMessages for multiple violations"
+            )
+
+            combined = " ".join(str(m.message) for m in err_msgs)
+            assert "Zip Slip" in combined
+
+            assert not absolute_target.exists()
+
+            if extract_root.exists():
+                assert not any(extract_root.iterdir())
+        finally:
+            if absolute_target.exists():
+                try:
+                    absolute_target.unlink()
+                except OSError:
+                    pass
 
     def test_unzip_iter_verbose_writes_to_stdout(self, capsys, tmp_path: Path) -> None:
         """

--- a/nltk/test/unit/test_downloader_unzip.py
+++ b/nltk/test/unit/test_downloader_unzip.py
@@ -213,7 +213,10 @@ class TestSecureUnzip:
 
         poisoned_names = ["pkg/good.txt", "pkg/evil\x00.txt"]
 
-        with patch("zipfile.ZipFile.namelist", return_value=poisoned_names):
+        with patch(
+            "nltk.downloader.zipfile.ZipFile.namelist",
+            return_value=poisoned_names,
+        ):
             messages = _run_unzip_iter(zip_path, extract_root, verbose=False)
 
         err_msgs = [m for m in messages if isinstance(m, ErrorMessage)]
@@ -272,6 +275,34 @@ class TestSecureUnzip:
                     absolute_target.unlink()
                 except OSError:
                     pass
+
+    def test_extraction_error_does_not_delete_preexisting_root_content(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        If extraction fails mid-stream, pre-existing content under the
+        extraction root must be preserved.
+        """
+        zip_path = tmp_path / "extract_error.zip"
+        extract_root = tmp_path / "extract"
+        existing_file = extract_root / "already_there.txt"
+
+        _make_zip(zip_path, {"pkg/file.txt": b"data"})
+        extract_root.mkdir()
+        existing_file.write_bytes(b"keep-me")
+
+        with patch(
+            "nltk.downloader.zipfile.ZipFile.extract",
+            side_effect=OSError("simulated extraction failure"),
+        ):
+            messages = _run_unzip_iter(zip_path, extract_root, verbose=False)
+
+        err_msgs = [m for m in messages if isinstance(m, ErrorMessage)]
+        assert err_msgs, "Expected extraction failure to yield an ErrorMessage"
+        assert any("Extraction error" in str(m.message) for m in err_msgs)
+
+        # Existing filesystem content should not be removed.
+        assert existing_file.read_bytes() == b"keep-me"
 
     def test_unzip_iter_verbose_writes_to_stdout(self, capsys, tmp_path: Path) -> None:
         """

--- a/nltk/test/unit/test_downloader_unzip.py
+++ b/nltk/test/unit/test_downloader_unzip.py
@@ -251,9 +251,9 @@ class TestSecureUnzip:
             messages = _run_unzip_iter(zip_path, extract_root, verbose=False)
 
             err_msgs = [m for m in messages if isinstance(m, ErrorMessage)]
-            assert len(err_msgs) >= 2, (
-                "Expected at least two ErrorMessages for multiple violations"
-            )
+            assert (
+                len(err_msgs) >= 2
+            ), "Expected at least two ErrorMessages for multiple violations"
 
             combined = " ".join(str(m.message) for m in err_msgs)
             assert "Zip Slip" in combined

--- a/nltk/test/unit/test_downloader_unzip.py
+++ b/nltk/test/unit/test_downloader_unzip.py
@@ -304,6 +304,29 @@ class TestSecureUnzip:
         # Existing filesystem content should not be removed.
         assert existing_file.read_bytes() == b"keep-me"
 
+    def test_namelist_raises_yields_errormessage(self, tmp_path: Path) -> None:
+        """
+        If ``zf.namelist()`` itself raises (e.g. corrupted central directory),
+        an ErrorMessage must be yielded and the zip file must be closed.
+        """
+        zip_path = tmp_path / "namelist_bomb.zip"
+        extract_root = tmp_path / "extract"
+
+        _make_zip(zip_path, {"pkg/file.txt": b"data"})
+
+        with patch(
+            "nltk.downloader.zipfile.ZipFile.namelist",
+            side_effect=RuntimeError("corrupted central directory"),
+        ):
+            messages = _run_unzip_iter(zip_path, extract_root, verbose=False)
+
+        err_msgs = [m for m in messages if isinstance(m, ErrorMessage)]
+        assert err_msgs, "Expected an ErrorMessage when namelist() raises"
+        assert any("corrupted central directory" in str(m.message) for m in err_msgs)
+
+        if extract_root.exists():
+            assert not any(extract_root.iterdir())
+
     def test_unzip_iter_verbose_writes_to_stdout(self, capsys, tmp_path: Path) -> None:
         """
         When verbose=True, _unzip_iter should write a status line to stdout.
@@ -318,3 +341,18 @@ class TestSecureUnzip:
         _run_unzip_iter(zip_path, extract_root, verbose=True)
         captured = capsys.readouterr()
         assert "Unzipping" in captured.out
+
+    def test_verbose_output_on_corrupt_zip(self, capsys, tmp_path: Path) -> None:
+        """
+        When verbose=True and the file is not a valid zip, the output line
+        must still be terminated with a newline so the terminal is left in
+        a clean state.
+        """
+        zip_path = tmp_path / "corrupt.txt"
+        zip_path.write_bytes(b"not a zip")
+        extract_root = tmp_path / "extract"
+
+        _run_unzip_iter(zip_path, extract_root, verbose=True)
+        captured = capsys.readouterr()
+        assert "Unzipping" in captured.out
+        assert captured.out.endswith("\n")

--- a/nltk/test/unit/test_downloader_unzip.py
+++ b/nltk/test/unit/test_downloader_unzip.py
@@ -347,36 +347,23 @@ class TestSecureUnzip:
 class TestValidateMember:
     """Direct unit tests for ``_validate_member`` path validation logic."""
 
-    @staticmethod
-    def _prefixes(root_abs):
-        """Compute abs_prefix and real_prefix for a given root."""
-        abs_prefix = os.path.normcase(root_abs).rstrip(os.sep) + os.sep
-        real_prefix = (
-            os.path.normcase(os.path.realpath(root_abs)).rstrip(os.sep) + os.sep
-        )
-        return abs_prefix, real_prefix
-
     def test_safe_relative_path_passes(self, tmp_path):
         root = str(tmp_path / "root")
-        abs_p, real_p = self._prefixes(root)
-        assert _validate_member("pkg/file.txt", root, abs_p, real_p) is None
+        assert _validate_member("pkg/file.txt", root) is None
 
     def test_parent_traversal_blocked(self, tmp_path):
         root = str(tmp_path / "root")
-        abs_p, real_p = self._prefixes(root)
-        result = _validate_member("../evil.txt", root, abs_p, real_p)
+        result = _validate_member("../evil.txt", root)
         assert result is not None and "Zip Slip" in result
 
     def test_deeply_nested_traversal_blocked(self, tmp_path):
         root = str(tmp_path / "root")
-        abs_p, real_p = self._prefixes(root)
-        result = _validate_member("a/b/c/../../../../evil.txt", root, abs_p, real_p)
+        result = _validate_member("a/b/c/../../../../evil.txt", root)
         assert result is not None and "Zip Slip" in result
 
     def test_null_byte_blocked(self, tmp_path):
         root = str(tmp_path / "root")
-        abs_p, real_p = self._prefixes(root)
-        result = _validate_member("pkg/evil\x00.txt", root, abs_p, real_p)
+        result = _validate_member("pkg/evil\x00.txt", root)
         assert result is not None and "Null byte" in result
 
     @pytest.mark.skipif(
@@ -385,8 +372,7 @@ class TestValidateMember:
     )
     def test_absolute_posix_path_blocked(self, tmp_path):
         root = str(tmp_path / "root")
-        abs_p, real_p = self._prefixes(root)
-        result = _validate_member("/etc/passwd", root, abs_p, real_p)
+        result = _validate_member("/etc/passwd", root)
         assert result is not None and "Zip Slip" in result
 
     @pytest.mark.skipif(
@@ -395,9 +381,19 @@ class TestValidateMember:
     )
     def test_windows_drive_letter_blocked(self, tmp_path):
         root = str(tmp_path / "root")
-        abs_p, real_p = self._prefixes(root)
-        result = _validate_member("C:\\Windows\\evil.txt", root, abs_p, real_p)
+        result = _validate_member("C:\\Windows\\evil.txt", root)
         assert result is not None and "Zip Slip" in result
+
+    def test_backslash_traversal(self, tmp_path):
+        """On Windows, backslash is a path separator so ``..\\evil.txt``
+        is a traversal attack.  On POSIX, backslash is a literal filename
+        character and the member name is harmless."""
+        root = str(tmp_path / "root")
+        result = _validate_member("..\\evil.txt", root)
+        if sys.platform.startswith("win"):
+            assert result is not None and "Zip Slip" in result
+        else:
+            assert result is None
 
     def test_normcase_is_applied_to_path_comparisons(self, tmp_path):
         """Simulate case-folding normcase (as on Windows) to verify that
@@ -408,11 +404,11 @@ class TestValidateMember:
         def case_folding_normcase(p):
             return original_normcase(p).lower()
 
-        abs_p = case_folding_normcase(root).rstrip(os.sep) + os.sep
-        real_p = case_folding_normcase(os.path.realpath(root)).rstrip(os.sep) + os.sep
+        with patch(
+            "nltk.downloader.os.path.normcase",
+            side_effect=case_folding_normcase,
+        ):
+            assert _validate_member("pkg/file.txt", root) is None
 
-        with patch("os.path.normcase", side_effect=case_folding_normcase):
-            assert _validate_member("pkg/file.txt", root, abs_p, real_p) is None
-
-            result = _validate_member("../evil.txt", root, abs_p, real_p)
+            result = _validate_member("../evil.txt", root)
             assert result is not None and "Zip Slip" in result


### PR DESCRIPTION
## Summary

Hardens the `_unzip_iter` function in `nltk/downloader.py` against
CVE-2025-14009 by switching from a per-member check-and-extract strategy
to a **validate-then-extract** approach.

The previous implementation validated each ZIP member individually and
skipped bad entries while continuing to extract the rest. This meant a
malicious archive could still leave files on disk. The new implementation
scans *every* member before writing anything -- if any member fails
validation, the entire archive is rejected with zero filesystem side
effects.

### Changes

**`nltk/downloader.py`**

- **Validate-then-extract**: Phase 1 scans all members for violations;
  Phase 2 only runs if every member passes.
- **Null-byte rejection**: Member names containing `\x00` are rejected
  (defense-in-depth against path truncation on some platforms).
- **Resource leak fix**: The entire function body is wrapped in
  `try/finally` to guarantee `ZipFile.close()`, even when the caller
  abandons the generator after the first `ErrorMessage`.
- **Consistent path handling**: Extraction uses `root_abs` (the
  canonicalized path) instead of the raw `root` parameter.
- **Single `namelist()` call**: The member list is read once and reused
  in both phases.

**`nltk/test/unit/test_downloader_unzip.py`**

- Updated existing Zip-Slip tests to assert fail-fast semantics: safe
  entries must *not* be extracted from a malicious archive.
- Added `test_null_byte_in_member_name_is_blocked` (uses a mock since
  CPython's `zipfile` truncates names at null bytes on read).
- Added `test_multiple_violation_types_all_reported_and_nothing_extracted`
  to verify that all violations are reported and nothing is extracted
  when an archive contains multiple different violation types.
- Updated class docstring to reflect the validate-then-extract design.

### Security checks performed on every member

| Check | Blocks |
|---|---|
| Null-byte rejection | Path truncation on platforms where `\x00` terminates C strings |
| Zip-Slip | `../` traversal, absolute paths, Windows drive letters |
| Symlink-escape | Writes through pre-existing symlinks that point outside the extraction root |

### Trade-off

Validating all members up-front widens the TOCTOU window for symlink
attacks compared to the per-member approach. An attacker who can create a
symlink inside the extraction root between Phase 1 and Phase 2 could
theoretically bypass the symlink check. This requires write access to the
extraction directory during a narrow window. The benefit -- all-or-nothing
extraction -- outweighs this risk in practice.

## References

- [CVE-2025-14009](https://access.redhat.com/security/cve/cve-2025-14009)
- [Bugzilla 2440724](https://bugzilla.redhat.com/show_bug.cgi?id=2440724)
- CWE-94: Improper Control of Generation of Code ('Code Injection')
```