### PR TITLE
Fix #3394: Ensure punkt_tab is downloaded when punkt is requested

### DIFF
--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -749,13 +749,16 @@ class Downloader:
             return True
 
         else:
-            # Define a helper function for displaying output:
-            # Handle both string and list inputs to ensure punkt_tab is always included
+            # Fix for Issue #3394: Redirect or append 'punkt_tab' when 'punkt' is requested.
             if isinstance(info_or_id, str) and info_or_id == "punkt":
                 info_or_id = ["punkt", "punkt_tab"]
-            elif isinstance(info_or_id, list) and "punkt" in info_or_id and "punkt_tab" not in info_or_id:
+            elif (
+                isinstance(info_or_id, list)
+                and "punkt" in info_or_id
+                and "punkt_tab" not in info_or_id
+            ):
                 info_or_id.append("punkt_tab")
-
+            # Define a helper function for displaying output:
             def show(s, prefix2=""):
                 print_to(
                     textwrap.fill(

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -750,6 +750,12 @@ class Downloader:
 
         else:
             # Define a helper function for displaying output:
+            # Handle both string and list inputs to ensure punkt_tab is always included
+            if isinstance(info_or_id, str) and info_or_id == "punkt":
+                info_or_id = ["punkt", "punkt_tab"]
+            elif isinstance(info_or_id, list) and "punkt" in info_or_id and "punkt_tab" not in info_or_id:
+                info_or_id.append("punkt_tab")
+
             def show(s, prefix2=""):
                 print_to(
                     textwrap.fill(


### PR DESCRIPTION
### Description
This PR addresses the `LookupError` reported in #3394. Since the transition from the pickle-based `punkt` to the tabular `punkt_tab` in NLTK 3.9.1, users following tutorials that call `nltk.download('punkt')` are left with an environment that fails when calling `word_tokenize()`.

### Changes
Modified `nltk/downloader.py` to:
1. Intercept string requests for `'punkt'` and expand them to `['punkt', 'punkt_tab']`.
2. Check list-based requests and append `'punkt_tab'` if `'punkt'` is present but `'punkt_tab'` is missing.

This ensures a seamless experience for users while maintaining backward compatibility.

### Verification
- Reproduced the `LookupError` in a clean environment.
- Verified that `nltk.download('punkt')` now correctly installs the data required for `word_tokenize()`.
- Ran existing unit tests: `pytest nltk/test/unit/test_downloader.py` passed with 4/4 successes.

Closes #3394