### PR TITLE
Resolve XSS vulnerability in local Wordnet browser search path

### DIFF
--- a/nltk/app/wordnet_app.py
+++ b/nltk/app/wordnet_app.py
@@ -48,6 +48,7 @@ Options::
 import base64
 import copy
 import getopt
+import html
 import io
 import os
 import pickle
@@ -132,11 +133,13 @@ class MyServerHandler(BaseHTTPRequestHandler):
             # This doesn't seem to work with MWEs.
             type = "text/html"
             parts = (sp.split("?")[1]).split("&")
-            word = [
-                p.split("=")[1].replace("+", " ")
-                for p in parts
-                if p.startswith("nextWord")
-            ][0]
+            word = html.escape(
+                [
+                    p.split("=")[1].replace("+", " ")
+                    for p in parts
+                    if p.startswith("nextWord")
+                ][0]
+            )
             page, word = page_from_word(word)
         elif sp.startswith("lookup_"):
             # TODO add a variation of this that takes a non ecoded word or MWE.


### PR DESCRIPTION
The ?nextWord= parameter in the search path was reflected into the HTML response (both <title> and <body>) without escaping, allowing script injection. The 2022 fix (c8cedf10d) addressed the static page path only; this patch covers the remaining search path.

Escape the word at parse time with html.escape() before it enters the page-rendering pipeline.

The `html` module is part of Python’s standard library, so importing `html` should not cause any issues.
