### PR TITLE
fix: comparison of a _WordNetObject to objects without _name (fixes #…

### DIFF
--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -211,10 +211,16 @@ class _WordNetObject:
         return hash(self._name)
 
     def __eq__(self, other):
-        return self._name == other._name
+        try:
+            return self._name == other._name
+        except AttributeError:
+            return False
 
     def __ne__(self, other):
-        return self._name != other._name
+        try:
+            return self._name != other._name
+        except AttributeError:
+            return True
 
     def __lt__(self, other):
         return self._name < other._name


### PR DESCRIPTION
Fixes #1944

When comparing a `_WordNetObject` (like a `Lemma` or `Synset`) to an object that lacks a `_name` attribute (like a simple string `"INVALID"`), Python threw an `AttributeError`. 

This PR updates the `__eq__` and `__ne__` dunder methods in `_WordNetObject` (`nltk/corpus/reader/wordnet.py`) to catch the `AttributeError` and return `False` or `True` respectively, mirroring the standard Python comparison behavior.
