### PR TITLE
Fix ru-rnc-new universal tag mapping lookup

### DIFF
--- a/nltk/tag/mapping.py
+++ b/nltk/tag/mapping.py
@@ -91,9 +91,16 @@ def tagset_mapping(source, target):
 
     if source not in _MAPPINGS or target not in _MAPPINGS[source]:
         if target == "universal":
-            _load_universal_map(source)
+            # Minimal fix: ru-rnc-new is embedded below, but _load_universal_map()
+            # will try to load taggers/universal_tagset/ru-rnc-new.map and can
+            # raise LookupError on installations where that file is absent.
+            if source != "ru-rnc-new":
+                _load_universal_map(source)
+
             # Added the new Russian National Corpus mappings because the
             # Russian model for nltk.pos_tag() uses it.
+            if "ru-rnc-new" not in _MAPPINGS:
+                _MAPPINGS["ru-rnc-new"] = {}
             _MAPPINGS["ru-rnc-new"]["universal"] = {
                 "A": "ADJ",
                 "A-PRO": "PRON",

--- a/nltk/tag/mapping.py
+++ b/nltk/tag/mapping.py
@@ -91,35 +91,34 @@ def tagset_mapping(source, target):
 
     if source not in _MAPPINGS or target not in _MAPPINGS[source]:
         if target == "universal":
-            # Minimal fix: ru-rnc-new is embedded below, but _load_universal_map()
-            # will try to load taggers/universal_tagset/ru-rnc-new.map and can
-            # raise LookupError on installations where that file is absent.
-            if source != "ru-rnc-new":
+            if source == "ru-rnc-new":
+                # ru-rnc-new.map is not shipped in the universal_tagset data package,
+                # so avoid _load_universal_map("ru-rnc-new") and use the embedded mapping.
+                # Ensure unknown tags map to 'X' (same behavior as _load_universal_map()).
+                _MAPPINGS[source][target].default_factory = lambda: "X"
+                _MAPPINGS[source][target].update(
+                    {
+                        "A": "ADJ",
+                        "A-PRO": "PRON",
+                        "ADV": "ADV",
+                        "ADV-PRO": "PRON",
+                        "ANUM": "ADJ",
+                        "CONJ": "CONJ",
+                        "INTJ": "X",
+                        "NONLEX": ".",
+                        "NUM": "NUM",
+                        "PARENTH": "PRT",
+                        "PART": "PRT",
+                        "PR": "ADP",
+                        "PRAEDIC": "PRT",
+                        "PRAEDIC-PRO": "PRON",
+                        "S": "NOUN",
+                        "S-PRO": "PRON",
+                        "V": "VERB",
+                    }
+                )
+            else:
                 _load_universal_map(source)
-
-            # Added the new Russian National Corpus mappings because the
-            # Russian model for nltk.pos_tag() uses it.
-            if "ru-rnc-new" not in _MAPPINGS:
-                _MAPPINGS["ru-rnc-new"] = {}
-            _MAPPINGS["ru-rnc-new"]["universal"] = {
-                "A": "ADJ",
-                "A-PRO": "PRON",
-                "ADV": "ADV",
-                "ADV-PRO": "PRON",
-                "ANUM": "ADJ",
-                "CONJ": "CONJ",
-                "INTJ": "X",
-                "NONLEX": ".",
-                "NUM": "NUM",
-                "PARENTH": "PRT",
-                "PART": "PRT",
-                "PR": "ADP",
-                "PRAEDIC": "PRT",
-                "PRAEDIC-PRO": "PRON",
-                "S": "NOUN",
-                "S-PRO": "PRON",
-                "V": "VERB",
-            }
 
     return _MAPPINGS[source][target]
 

--- a/nltk/test/unit/test_pos_tag.py
+++ b/nltk/test/unit/test_pos_tag.py
@@ -104,6 +104,56 @@ class TestPosTag(unittest.TestCase):
             == expected_tagged
         )
 
+    def test_pos_tag_rus_universal_mapping_does_not_require_ru_rnc_new_map_file(self):
+        """
+        Regression test for #2434: some environments crash when requesting universal
+        tags for Russian due to an attempted lookup of ru-rnc-new.map, which is not
+        shipped in the universal_tagset data package. Ensure the code works even
+        when that mapping file cannot be loaded, and ensure the mapping cache is
+        not pre-initialized by previous tests.
+        """
+        from collections import defaultdict
+
+        import nltk.tag.mapping as mapping
+
+        text = "Илья оторопел и дважды перечитал бумажку."
+        expected_tagged = [
+            ("Илья", "NOUN"),
+            ("оторопел", "VERB"),
+            ("и", "CONJ"),
+            ("дважды", "ADV"),
+            ("перечитал", "VERB"),
+            ("бумажку", "NOUN"),
+            (".", "."),
+        ]
+
+        # Save & replace the global mapping cache so earlier tests cannot mask this.
+        saved_mappings = mapping._MAPPINGS
+        try:
+            mapping._MAPPINGS = defaultdict(
+                lambda: defaultdict(lambda: defaultdict(lambda: "UNK"))
+            )
+
+            real_load = mapping.load
+
+            def load_side_effect(resource, *args, **kwargs):
+                # Simulate the real missing-file scenario for ru-rnc-new.map only.
+                if str(resource).endswith("/ru-rnc-new.map"):
+                    raise LookupError(
+                        "ru-rnc-new.map not available in universal_tagset"
+                    )
+                return real_load(resource, *args, **kwargs)
+
+            with unittest.mock.patch.object(
+                mapping, "load", side_effect=load_side_effect
+            ):
+                assert (
+                    pos_tag(word_tokenize(text), tagset="universal", lang="rus")
+                    == expected_tagged
+                )
+        finally:
+            mapping._MAPPINGS = saved_mappings
+
     def test_pos_tag_unknown_lang(self):
         text = "모르겠 습니 다"
         self.assertRaises(NotImplementedError, pos_tag, word_tokenize(text), lang="kor")

--- a/nltk/test/unit/test_pos_tag.py
+++ b/nltk/test/unit/test_pos_tag.py
@@ -109,12 +109,13 @@ class TestPosTag(unittest.TestCase):
         Regression test for #2434: some environments crash when requesting universal
         tags for Russian due to an attempted lookup of ru-rnc-new.map, which is not
         shipped in the universal_tagset data package. Ensure the code works even
-        when that mapping file cannot be loaded, and ensure the mapping cache is
+        when that mapping file is missing, and ensure the mapping cache is
         not pre-initialized by previous tests.
         """
         from collections import defaultdict
 
         import nltk.tag.mapping as mapping
+        from nltk.data import normalize_resource_url
 
         text = "Илья оторопел и дважды перечитал бумажку."
         expected_tagged = [
@@ -134,23 +135,20 @@ class TestPosTag(unittest.TestCase):
                 lambda: defaultdict(lambda: defaultdict(lambda: "UNK"))
             )
 
-            real_load = mapping.load
-
-            def load_side_effect(resource, *args, **kwargs):
-                # Simulate the real missing-file scenario for ru-rnc-new.map only.
-                if str(resource).endswith("/ru-rnc-new.map"):
-                    raise LookupError(
-                        "ru-rnc-new.map not available in universal_tagset"
-                    )
-                return real_load(resource, *args, **kwargs)
-
-            with unittest.mock.patch.object(
-                mapping, "load", side_effect=load_side_effect
-            ):
-                assert (
-                    pos_tag(word_tokenize(text), tagset="universal", lang="rus")
-                    == expected_tagged
+            # In current published nltk_data, ru-rnc-new.map is not shipped.
+            # (We intentionally don't assert on the error message text here.)
+            with self.assertRaises(LookupError):
+                mapping.load(
+                    normalize_resource_url(
+                        "nltk:taggers/universal_tagset/ru-rnc-new.map"
+                    ),
+                    format="text",
                 )
+
+            assert (
+                pos_tag(word_tokenize(text), tagset="universal", lang="rus")
+                == expected_tagged
+            )
         finally:
             mapping._MAPPINGS = saved_mappings
 


### PR DESCRIPTION
Fix #2434 (and avoid reopening #2151).

Some users see pos_tag(..., lang="rus", tagset="universal") crash with a LookupError on a clean install. This happens because the ru-rnc-new.map file is not present in the published taggers/universal_tagset.zip NLTK data package, so NLTK tries to load a mapping file that doesn’t exist.

The problem is most visible in fresh environments (new venvs, containers, or CI) that download nltk_data from scratch, and it can appear “mysteriously” depending on import/test order (if the mapping cache was already populated, the missing file may not be looked up).

This PR makes Russian universal tagging reliable by using the built-in ru-rnc-new → universal mapping in code instead of attempting to load a non-existent file from universal_tagset.zip.