### PR TITLE
Add /retest and [ci: retest] comment trigger for CI

### DIFF
--- a/.github/workflows/retest.yml
+++ b/.github/workflows/retest.yml
@@ -11,6 +11,7 @@ jobs:
       github.event.issue.pull_request &&
       (
         contains(github.event.comment.body, '/retest') ||
+        contains(github.event.comment.body, '[CI: retest]') ||
         contains(github.event.comment.body, '[ci: retest]')
       )
     runs-on: ubuntu-latest

--- a/.github/workflows/retest.yml
+++ b/.github/workflows/retest.yml
@@ -1,0 +1,56 @@
+name: Retest CI
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  retest:
+    # Only run on PR comments (not issue comments) containing /retest or [ci: retest]
+    if: >
+      github.event.issue.pull_request &&
+      (
+        contains(github.event.comment.body, '/retest') ||
+        contains(github.event.comment.body, '[ci: retest]')
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      pull-requests: read
+    steps:
+      - name: Get PR head ref
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            core.setOutput('ref', pr.head.ref);
+            core.setOutput('sha', pr.head.sha);
+            core.info(`PR #${context.issue.number} head: ${pr.head.ref} @ ${pr.head.sha}`);
+
+      - name: Trigger CI workflow
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'ci.yml',
+              ref: '${{ steps.pr.outputs.ref }}',
+            });
+            core.info('CI workflow dispatched successfully.');
+
+      - name: React to comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket',
+            });


### PR DESCRIPTION
This PR patches https://github.com/nltk/nltk/issues/3281 and makes `[CI: retest]` work again. Also included some other common alias for the trigger comments, (i) `/retest` and `[ci: retest]`.


We can only test whether it works after it's merged to the develop branch. 