### PR TITLE
Prevent symlink-based path traversal in CorpusReader.open()

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -311,6 +311,7 @@
 - Jose Cols <https://github.com/josecols>
 - Christopher Smith <https://github.com/smithct2>
 - Ryan Mannion <https://github.com/ryanamannion>
+- CHOOCS <https://github.com/CHOOCS/>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 

--- a/nltk/corpus/reader/api.py
+++ b/nltk/corpus/reader/api.py
@@ -222,9 +222,9 @@ class CorpusReader:
     def open(self, file):
         """
         Return an open stream that can be used to read the given file.
-        Security patched: prevents path traversal & absolute path access.
+        Securely prevents path traversal, absolute path access, and symlink escapes.
         """
-        # -------- SECURITY PATCH START --------
+
         file = str(file)
 
         if os.path.isabs(file):
@@ -232,11 +232,19 @@ class CorpusReader:
 
         if ".." in file.replace("\\", "/").split("/"):
             raise ValueError("Path traversal attempt blocked")
-        # -------- SECURITY PATCH END --------
 
         encoding = self.encoding(file)
-        stream = self._root.join(file).open(encoding)
-        return stream
+        candidate = self._root.join(file)
+
+        # Enforce containment for filesystem-backed corpora
+        if isinstance(self._root, FileSystemPathPointer):
+            root_real = os.path.realpath(self._root.path)
+            candidate_real = os.path.realpath(candidate.path)
+
+            if os.path.commonpath([root_real, candidate_real]) != root_real:
+                raise ValueError("Resolved path escapes corpus root")
+
+        return candidate.open(encoding)
 
     def encoding(self, file):
         """


### PR DESCRIPTION
## Summary

This PR fixes a security issue in CorpusReader.open() where path validation relied solely on lexical checks (os.path.isabs and .. filtering), which could be bypassed using symbolic links within the corpus root. An attacker could exploit this to read arbitrary files outside the intended directory.

## Root Cause
The previous implementation:
- Blocked absolute paths
- Rejected paths containing `..`

However, it did not validate the resolved filesystem path, allowing symlink-based escapes such as:

```
corpus_root/outside_corpus -> /
outside_corpus/etc/passwd
```

## Changes
- Added canonical path resolution using os.path.realpath
- Enforced strict containment check:
    - Ensure resolved file path remains within resolved corpus root
- Applied check only for filesystem-backed corpora (FileSystemPathPointer)
- Preserved existing validation for:
    - Absolute paths
    - `..` traversal attempts

## Testing
- Existing test suite passes without modification
- Manually verified with PoC:
    - Symlink escape is now correctly blocked
    - Legitimate corpus file access remains unaffected

## Patched Version
```
reader.open("outside_corpus/etc/passwd")
# Raises ValueError: Resolved path escapes corpus root
```