### PR TITLE
Fix retest workflow for fork-based PRs

### DIFF
--- a/.github/workflows/retest.yml
+++ b/.github/workflows/retest.yml
@@ -19,7 +19,7 @@ jobs:
       actions: write
       pull-requests: read
     steps:
-      - name: Get PR head ref
+      - name: Get PR head info
         id: pr
         uses: actions/github-script@v7
         with:
@@ -29,11 +29,38 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.issue.number,
             });
+            const isFork = pr.head.repo.full_name !== `${context.repo.owner}/${context.repo.repo}`;
             core.setOutput('ref', pr.head.ref);
             core.setOutput('sha', pr.head.sha);
-            core.info(`PR #${context.issue.number} head: ${pr.head.ref} @ ${pr.head.sha}`);
+            core.setOutput('is_fork', isFork.toString());
+            core.info(`PR #${context.issue.number} head: ${pr.head.ref} @ ${pr.head.sha} (fork: ${isFork})`);
 
-      - name: Trigger CI workflow
+      - name: Re-run CI for fork PRs
+        if: steps.pr.outputs.is_fork == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runs = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'ci.yml',
+              head_sha: '${{ steps.pr.outputs.sha }}',
+              per_page: 1,
+            });
+            if (runs.data.workflow_runs.length === 0) {
+              core.setFailed('No CI run found for this PR head SHA.');
+              return;
+            }
+            const runId = runs.data.workflow_runs[0].id;
+            core.info(`Re-running CI workflow run ${runId}`);
+            await github.rest.actions.reRunWorkflow({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: runId,
+            });
+
+      - name: Dispatch CI for same-repo PRs
+        if: steps.pr.outputs.is_fork == 'false'
         uses: actions/github-script@v7
         with:
           script: |
@@ -43,7 +70,6 @@ jobs:
               workflow_id: 'ci.yml',
               ref: '${{ steps.pr.outputs.ref }}',
             });
-            core.info('CI workflow dispatched successfully.');
 
       - name: React to comment
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary

- `[CI: retest]` and `/retest` comments on fork-based PRs silently failed because `createWorkflowDispatch` only works for branches in the same repository
- For fork PRs, use `reRunWorkflow` on the existing CI run (matched by head SHA) instead
- Keep `createWorkflowDispatch` for same-repo branches (unchanged behavior)

## Test plan

- [ ] Comment `[CI: retest]` on a fork-based PR (e.g. #3282) and verify CI re-runs
- [ ] Comment `[CI: retest]` on a same-repo PR and verify it still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)