### PR TITLE
Fix retest workflow for fork-based PRs

### DIFF
--- a/.github/workflows/retest.yml
+++ b/.github/workflows/retest.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: write
+      issues: write
       pull-requests: read
     steps:
       - name: Get PR head info

--- a/.github/workflows/retest.yml
+++ b/.github/workflows/retest.yml
@@ -19,7 +19,7 @@ jobs:
       actions: write
       pull-requests: read
     steps:
-      - name: Get PR head ref
+      - name: Get PR head info
         id: pr
         uses: actions/github-script@v7
         with:
@@ -29,11 +29,38 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.issue.number,
             });
+            const isFork = pr.head.repo.full_name !== `${context.repo.owner}/${context.repo.repo}`;
             core.setOutput('ref', pr.head.ref);
             core.setOutput('sha', pr.head.sha);
-            core.info(`PR #${context.issue.number} head: ${pr.head.ref} @ ${pr.head.sha}`);
+            core.setOutput('is_fork', isFork.toString());
+            core.info(`PR #${context.issue.number} head: ${pr.head.ref} @ ${pr.head.sha} (fork: ${isFork})`);
 
-      - name: Trigger CI workflow
+      - name: Re-run CI for fork PRs
+        if: steps.pr.outputs.is_fork == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runs = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'ci.yml',
+              head_sha: '${{ steps.pr.outputs.sha }}',
+              per_page: 1,
+            });
+            if (runs.data.workflow_runs.length === 0) {
+              core.setFailed('No CI run found for this PR head SHA.');
+              return;
+            }
+            const runId = runs.data.workflow_runs[0].id;
+            core.info(`Re-running CI workflow run ${runId}`);
+            await github.rest.actions.reRunWorkflow({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: runId,
+            });
+
+      - name: Dispatch CI for same-repo PRs
+        if: steps.pr.outputs.is_fork == 'false'
         uses: actions/github-script@v7
         with:
           script: |
@@ -43,7 +70,6 @@ jobs:
               workflow_id: 'ci.yml',
               ref: '${{ steps.pr.outputs.ref }}',
             });
-            core.info('CI workflow dispatched successfully.');
 
       - name: React to comment
         uses: actions/github-script@v7

--- a/.github/workflows/retest.yml
+++ b/.github/workflows/retest.yml
@@ -20,6 +20,7 @@ jobs:
       actions: write
       issues: write
       pull-requests: read
+      reactions: write
     steps:
       - name: Get PR head info
         id: pr
@@ -72,6 +73,7 @@ jobs:
               workflow_id: 'ci.yml',
               ref: '${{ steps.pr.outputs.ref }}',
             });
+            core.info('CI workflow dispatched successfully.');
 
       - name: React to comment
         uses: actions/github-script@v7

--- a/.github/workflows/retest.yml
+++ b/.github/workflows/retest.yml
@@ -6,9 +6,10 @@ on:
 
 jobs:
   retest:
-    # Only run on PR comments (not issue comments) containing /retest or [ci: retest]
+    # Only org members/collaborators can trigger retest on PR comments
     if: >
       github.event.issue.pull_request &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
       (
         contains(github.event.comment.body, '/retest') ||
         contains(github.event.comment.body, '[CI: retest]') ||


### PR DESCRIPTION
The createWorkflowDispatch only works for branches in the same repo, so [CI: retest] on fork PRs silently failed. For fork PRs, use reRunWorkflow on the existing CI run (matched by head SHA) instead. Keep createWorkflowDispatch for same-repo branches.

Evidence: https://github.com/alvations/nltk/pull/84

With this change in alvations/nltk develop branch, we simulated a bad pull-request from yet another fork to the alvations/nltk fork and then checked that the `[CI: retest]` works across forks. 

Then true test here would be that the next comments will auto re-trigger the CI/CD after this PR is merged.