### PR TITLE
Use reRunWorkflow for both fork and branch PRs

### DIFF
--- a/.github/workflows/retest-pr.yml
+++ b/.github/workflows/retest-pr.yml
@@ -13,10 +13,15 @@ jobs:
       issues: write
       pull-requests: read
     steps:
-      - name: Check trigger phrase
+      - name: Check authorization and trigger phrase
         uses: actions/github-script@v7
         with:
           script: |
+            const assoc = context.payload.comment.author_association;
+            if (!['OWNER', 'MEMBER', 'COLLABORATOR'].includes(assoc)) {
+              core.setFailed('Not authorized (association: ' + assoc + ')');
+              return;
+            }
             const body = context.payload.comment.body;
             if (!body.includes('/retest') &&
                 !body.includes('[CI: retest]') &&
@@ -24,7 +29,7 @@ jobs:
               core.setFailed('No recognized retest trigger found.');
             }
 
-      - name: Get PR head info
+      - name: Get PR head SHA
         id: pr
         uses: actions/github-script@v7
         with:
@@ -34,40 +39,30 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.issue.number,
             })).data;
-            const baseRepo = context.repo.owner + '/' + context.repo.repo;
-            const isFork = pr.head.repo.full_name !== baseRepo;
-            core.setOutput('ref', pr.head.ref);
             core.setOutput('sha', pr.head.sha);
-            core.setOutput('is_fork', String(isFork));
 
-      - name: Rerun or dispatch CI
+      - name: Re-run CI
         uses: actions/github-script@v7
         with:
           script: |
-            const isFork = '${{ steps.pr.outputs.is_fork }}' === 'true';
-            if (isFork) {
-              const runs = await github.rest.actions.listWorkflowRuns({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                workflow_id: 'ci.yml',
-                head_sha: '${{ steps.pr.outputs.sha }}',
-                per_page: 1,
-              });
-              if (runs.data.workflow_runs.length === 0) {
-                core.setFailed('No CI run found for this PR head SHA.');
-                return;
-              }
-              const runId = runs.data.workflow_runs[0].id;
+            const runs = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'ci.yml',
+              head_sha: '${{ steps.pr.outputs.sha }}',
+              per_page: 1,
+            });
+            if (runs.data.workflow_runs.length === 0) {
+              core.setFailed('No CI run found for this PR head SHA.');
+              return;
+            }
+            const run = runs.data.workflow_runs[0];
+            if (run.status === 'completed') {
               await github.rest.actions.reRunWorkflow({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                run_id: runId,
+                run_id: run.id,
               });
             } else {
-              await github.rest.actions.createWorkflowDispatch({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                workflow_id: 'ci.yml',
-                ref: '${{ steps.pr.outputs.ref }}',
-              });
+              core.info('CI is already running (status: ' + run.status + '). Nothing to re-run.');
             }


### PR DESCRIPTION
Results now attach to the PR check suite for all PR types. Skip gracefully if CI is already running.

Now `[CI: retest]` it should work for both fork and branch