### PR TITLE
fix: use defusedxml to prevent XML entity expansion DoS in downloader

### DIFF
--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -171,7 +171,6 @@ import warnings
 import zipfile
 from hashlib import md5, sha256
 from urllib.error import HTTPError, URLError
-from defusedxml.ElementTree import parse as safe_parse
 from xml.etree import ElementTree
 
 import nltk
@@ -977,6 +976,17 @@ class Downloader:
         self._url = url or self._url
 
         # Download the index file.
+        # Use defusedxml to prevent XML entity expansion (Billion Laughs) attacks.
+        try:
+            from defusedxml.ElementTree import parse as safe_parse
+        except ImportError:
+            warnings.warn(
+                "defusedxml is not installed. XML parsing will use the standard "
+                "library, which is vulnerable to entity expansion attacks. "
+                "Install defusedxml: pip install defusedxml",
+                stacklevel=2,
+            )
+            safe_parse = ElementTree.parse
         self._index = nltk.internals.ElementWrapper(
             safe_parse(urlopen(self._url)).getroot()
         )

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -171,10 +171,7 @@ import warnings
 import zipfile
 from hashlib import md5, sha256
 from urllib.error import HTTPError, URLError
-try:
-    from defusedxml.ElementTree import parse as safe_parse
-except ImportError:
-    from xml.etree.ElementTree import parse as safe_parse
+from defusedxml.ElementTree import parse as safe_parse
 from xml.etree import ElementTree
 
 import nltk

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -171,6 +171,10 @@ import warnings
 import zipfile
 from hashlib import md5, sha256
 from urllib.error import HTTPError, URLError
+try:
+    from defusedxml.ElementTree import parse as safe_parse
+except ImportError:
+    from xml.etree.ElementTree import parse as safe_parse
 from xml.etree import ElementTree
 
 import nltk
@@ -977,7 +981,7 @@ class Downloader:
 
         # Download the index file.
         self._index = nltk.internals.ElementWrapper(
-            ElementTree.parse(urlopen(self._url)).getroot()
+            safe_parse(urlopen(self._url)).getroot()
         )
         self._index_timestamp = time.time()
 

--- a/nltk/test/unit/test_downloader_xxe.py
+++ b/nltk/test/unit/test_downloader_xxe.py
@@ -1,0 +1,37 @@
+"""Test that the NLTK downloader is protected against XML entity expansion attacks.
+
+This test verifies that parsing a malicious XML index file with recursive entity
+definitions (Billion Laughs / XML bomb) does not cause excessive memory consumption
+or denial of service.
+"""
+
+import io
+import unittest.mock
+
+import pytest
+from defusedxml.common import EntitiesForbidden
+
+from nltk.downloader import Downloader
+
+
+# Billion Laughs payload - exponential entity expansion
+BILLION_LAUGHS_XML = b"""\
+<?xml version="1.0"?>
+<!DOCTYPE lolz [
+  <!ENTITY lol "lol">
+  <!ENTITY lol2 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
+  <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">
+  <!ENTITY lol4 "&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;">
+]>
+<nltk_data>&lol4;</nltk_data>
+"""
+
+
+def test_downloader_rejects_xml_entity_expansion():
+    """Verify that the downloader rejects XML with entity expansion (Billion Laughs)."""
+    d = Downloader()
+
+    with unittest.mock.patch("nltk.downloader.urlopen") as mock_urlopen:
+        mock_urlopen.return_value = io.BytesIO(BILLION_LAUGHS_XML)
+        with pytest.raises(EntitiesForbidden):
+            d._update_index()

--- a/setup.py
+++ b/setup.py
@@ -114,6 +114,7 @@ natural language processing.  NLTK requires Python 3.10, 3.11, 3.12, 3.13, or 3.
     python_requires=">=3.10",
     install_requires=[
         "click",
+        "defusedxml",
         "joblib",
         "regex>=2021.8.3",
         "tqdm",


### PR DESCRIPTION
## Summary
Replace `ElementTree.parse()` with `defusedxml.ElementTree.parse()` in `_update_index()` to prevent Billion Laughs (XML bomb) attacks via crafted `server_index_url` payloads.

## Problem
`nltk/downloader.py:980` fetches an XML index from a configurable URL and parses it with `xml.etree.ElementTree.parse()` without entity expansion limits. A Billion Laughs payload causes exponential memory allocation (~3GB from 1KB), crashing the process.

## Fix
- Uses `defusedxml.ElementTree.parse` which blocks entity expansion
- Falls back to stdlib `ElementTree` if `defusedxml` is not installed
- One-line change at the vulnerable call site

## Testing
Verified on Python 3.10.11 — entity expansion confirmed without fix, blocked with fix.

Related Huntr report submitted.