### PR TITLE
fix(security): block XML entity expansion (XXE) in downloader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,8 @@ jobs:
         with:
           python-version: "3.14"
 
-      - name: Install regex
-        run: pip install regex
+      - name: Install core dependencies
+        run: pip install regex defusedxml
 
       - name: Set NLTK_DATA environment variable
         shell: bash

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -310,6 +310,7 @@
 - Peter de Blanc <https://github.com/pdeblanc>
 - Jose Cols <https://github.com/josecols>
 - Christopher Smith <https://github.com/smithct2>
+- scruge1 <https://github.com/scruge1>
 - Ryan Mannion <https://github.com/ryanamannion>
 - Peter Pollak <https://github.com/Syzygy2048/>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -13,7 +13,7 @@ Version 3.9.4 2026-03-24
 
 Thanks to the following contributors to 3.9.4:
 Min-Yen Kan, Eric Kafe, Emily Voss, bowiechen, Hrudhai01,
-jancallewaert, Mr-Neutr0n, pollak.peter89, ylwango613, 
+jancallewaert, Mr-Neutr0n, pollak.peter89, ylwango613,
 
 Version 3.9.3 2026-02-21
 

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -173,6 +173,8 @@ from hashlib import md5, sha256
 from urllib.error import HTTPError, URLError
 from xml.etree import ElementTree
 
+from defusedxml.ElementTree import parse as safe_parse
+
 import nltk
 from nltk.pathsec import ZipFile, urlopen
 
@@ -977,7 +979,7 @@ class Downloader:
 
         # Download the index file.
         self._index = nltk.internals.ElementWrapper(
-            ElementTree.parse(urlopen(self._url)).getroot()
+            safe_parse(urlopen(self._url)).getroot()
         )
         self._index_timestamp = time.time()
 

--- a/nltk/test/unit/test_downloader_xxe.py
+++ b/nltk/test/unit/test_downloader_xxe.py
@@ -1,0 +1,72 @@
+"""
+Tests for XML Entity Expansion (XXE) protection in nltk.downloader.
+
+Verifies that defusedxml blocks Billion Laughs (XML bomb) payloads
+when parsing the package index from a remote URL.
+"""
+
+import io
+import unittest
+from unittest.mock import patch
+
+from defusedxml import EntitiesForbidden
+
+from nltk.downloader import Downloader
+
+# Billion Laughs payload: ~1KB input expands to ~3GB in memory
+BILLION_LAUGHS_XML = """\
+<?xml version="1.0"?>
+<!DOCTYPE lolz [
+  <!ENTITY lol "lol">
+  <!ENTITY lol2 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
+  <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">
+  <!ENTITY lol4 "&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;">
+  <!ENTITY lol5 "&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;">
+  <!ENTITY lol6 "&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;">
+  <!ENTITY lol7 "&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;">
+  <!ENTITY lol8 "&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;">
+  <!ENTITY lol9 "&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;">
+]>
+<root>&lol9;</root>
+"""
+
+
+class TestDownloaderXXE(unittest.TestCase):
+    """Verify that the downloader rejects XML bomb payloads."""
+
+    def test_billion_laughs_blocked(self):
+        """defusedxml must reject entity expansion in index XML."""
+        downloader = Downloader()
+        xml_bytes = BILLION_LAUGHS_XML.encode("utf-8")
+
+        with patch("nltk.downloader.urlopen", return_value=io.BytesIO(xml_bytes)):
+            with self.assertRaises(EntitiesForbidden):
+                downloader._update_index(url="http://example.com/malicious.xml")
+
+    def test_valid_xml_parses(self):
+        """Normal XML index should parse without error."""
+        valid_xml = """\
+<?xml version="1.0"?>
+<nltk_data>
+  <packages>
+    <package id="test_pkg" name="Test" subdir="corpora"
+             url="http://example.com/test.zip" size="1024"
+             unzipped_size="2048" checksum="abc123"/>
+  </packages>
+  <collections>
+    <collection id="test_col" name="Test Collection">
+      <item ref="test_pkg"/>
+    </collection>
+  </collections>
+</nltk_data>
+"""
+        downloader = Downloader()
+        xml_bytes = valid_xml.encode("utf-8")
+
+        with patch("nltk.downloader.urlopen", return_value=io.BytesIO(xml_bytes)):
+            downloader._update_index(url="http://example.com/valid.xml")
+            self.assertIn("test_pkg", downloader._packages)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,4 +1,5 @@
 click
+defusedxml
 gensim>=4.0.0 ; python_version < '3.14'
 markdown-it-py
 matplotlib

--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,7 @@ natural language processing.  NLTK requires Python 3.10, 3.11, 3.12, 3.13, or 3.
     package_data={"nltk": ["test/*.doctest", "VERSION"]},
     python_requires=">=3.10",
     install_requires=[
+        "defusedxml",
         "click",
         "joblib",
         "regex>=2021.8.3",


### PR DESCRIPTION
## Summary

Replace `xml.etree.ElementTree.parse` with `defusedxml.ElementTree.parse` in `_update_index()` to prevent Billion Laughs (XML Entity Expansion) attacks via crafted `server_index_url` payloads.

## Problem

`nltk/downloader.py:980` fetches an XML index from a configurable URL and parses it with the stdlib XML parser, which does not limit entity expansion. A Billion Laughs payload (~1KB) causes exponential memory allocation (~3GB), crashing the process (CWE-776).

## Changes

- `nltk/downloader.py`: Import `defusedxml.ElementTree.parse` and use it for remote XML index parsing
- `setup.py`: Add `defusedxml` to `install_requires`
- `nltk/test/unit/test_downloader_xxe.py`: New test verifying Billion Laughs is rejected + normal XML still parses
- `AUTHORS.md`: Added contributor entry

## Testing

- `test_billion_laughs_blocked`: Confirms `EntitiesForbidden` is raised on XML bomb payload
- `test_valid_xml_parses`: Confirms normal NLTK index XML still parses correctly
- All pre-commit hooks pass (black, isort, ruff, pyupgrade)
- Tested on Python 3.10.11

This is a resubmission of #3541 with CONTRIBUTING.md compliance (develop branch target, pre-commit hooks, AUTHORS.md entry, tests).

Related Huntr report submitted.