### PR TITLE
Fix FunctionalCategory.substitute() ignoring substituted direction

### DIFF
--- a/nltk/ccg/api.py
+++ b/nltk/ccg/api.py
@@ -328,7 +328,7 @@ class FunctionalCategory(AbstractCCGCategory):
         sub_res = self._res.substitute(subs)
         sub_dir = self._dir.substitute(subs)
         sub_arg = self._arg.substitute(subs)
-        return FunctionalCategory(sub_res, sub_arg, self._dir)
+        return FunctionalCategory(sub_res, sub_arg, sub_dir)
 
     # A function can unify with another function, so long as its
     # constituents can unify, or with an unrestricted variable.

--- a/nltk/test/unit/test_ccg.py
+++ b/nltk/test/unit/test_ccg.py
@@ -1,0 +1,46 @@
+"""
+Tests for the CCG (Combinatory Categorial Grammar) module.
+"""
+
+import unittest
+
+from nltk.ccg.api import Direction, FunctionalCategory, PrimitiveCategory
+
+
+class TestFunctionalCategorySubstitute(unittest.TestCase):
+    """Test that FunctionalCategory.substitute() applies substitutions
+    to all three components: result, argument, and direction."""
+
+    def test_substitute_applies_to_direction(self):
+        """Direction substitutions must propagate through substitute().
+
+        Regression test: previously, substitute() computed the substituted
+        direction but returned the original direction instead.
+        """
+        res = PrimitiveCategory("S")
+        arg = PrimitiveCategory("NP")
+        # A variable direction (restrictions="_") that should be substituted
+        variable_dir = Direction("/", "_")
+
+        category = FunctionalCategory(res, arg, variable_dir)
+
+        # Substitute the variable direction with concrete restrictions
+        new_restrictions = ["."]
+        subs = [("_", new_restrictions)]
+        result = category.substitute(subs)
+
+        # The direction's restrictions should now be ["."], not "_"
+        self.assertFalse(result.dir().is_variable())
+        self.assertEqual(result.dir().restrs(), new_restrictions)
+
+    def test_substitute_no_op_on_concrete_direction(self):
+        """Substitution on a non-variable direction should be a no-op."""
+        res = PrimitiveCategory("S")
+        arg = PrimitiveCategory("NP")
+        concrete_dir = Direction("\\", ["."])
+
+        category = FunctionalCategory(res, arg, concrete_dir)
+
+        result = category.substitute([("_", ",")])
+
+        self.assertEqual(result.dir().restrs(), ["."])


### PR DESCRIPTION
Fixes #3550

## What's going on

`FunctionalCategory.substitute()` computes substituted versions of all three components (result, direction, argument), but when building the return value it accidentally passes the original `self._dir` instead of the substituted `sub_dir`. This means substitutions targeting the direction are silently dropped. The bug has been there since the CCG module was first added in 2009.

## The fix

One-line change on line 331: `self._dir` → `sub_dir`.

## Before and after

```python
from nltk.ccg.api import Direction, FunctionalCategory, PrimitiveCategory

res = PrimitiveCategory("S")
arg = PrimitiveCategory("NP")
variable_dir = Direction("/", "_")

category = FunctionalCategory(res, arg, variable_dir)
result = category.substitute([("_", ["."])])

# Before: result.dir().is_variable() == True,  result.dir().restrs() == '_'
# After:  result.dir().is_variable() == False, result.dir().restrs() == ['.']
```

## Tests

Added `test_ccg.py` with a regression test that fails on the old code and passes with this fix. Verified by temporarily reverting the change and confirming the test catches it.