### PR TITLE
Fix concurrent download race conditions with file-based locking

### DIFF
--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -676,19 +676,8 @@ class Downloader:
         yield StartPackageMessage(info)
         yield ProgressMessage(0)
 
-        # Do we already have the current version?
-        status = self.status(info, download_dir)
-        if not force and status == self.INSTALLED:
-            yield UpToDateMessage(info)
-            yield ProgressMessage(100)
-            yield FinishPackageMessage(info)
-            return
-
-        # Remove the package from our status cache
-        self._status_cache.pop(info.id, None)
-
-        # Check for (and remove) any old/stale version.
         filepath = os.path.join(download_dir, info.filename)
+        tmp_filepath = filepath + ".tmp"
 
         # Defense-in-depth: verify filepath stays within download_dir
         real_download = os.path.realpath(os.path.abspath(download_dir))
@@ -701,41 +690,106 @@ class Downloader:
             )
             return
 
+        MAX_ZOMBIE_TIME = 60
+        POLL_INTERVAL = 15
+
+        # 1. Cooperative Wait Loop
+        while True:
+            self._status_cache.pop(info.id, None)
+            status = self.status(info, download_dir)
+
+            if not force and status == self.INSTALLED:
+                yield UpToDateMessage(info)
+                yield ProgressMessage(100)
+                yield FinishPackageMessage(info)
+                return
+
+            try:
+                if os.path.exists(tmp_filepath):
+                    last_size = os.path.getsize(tmp_filepath)
+                    mtime = os.path.getmtime(tmp_filepath)
+
+                    import time
+
+                    time.sleep(POLL_INTERVAL)
+
+                    if os.path.exists(tmp_filepath):
+                        new_size = os.path.getsize(tmp_filepath)
+                        if new_size > last_size:
+                            continue
+                        if (time.time() - mtime) < MAX_ZOMBIE_TIME:
+                            continue
+            except (FileNotFoundError, OSError):
+                pass
+
+            # 2. Atomic Claim
+            try:
+                # Ensure the download_dir exists
+                os.makedirs(download_dir, exist_ok=True)
+                os.makedirs(os.path.join(download_dir, info.subdir), exist_ok=True)
+                fd = os.open(tmp_filepath, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+                os.close(fd)
+                break
+            except FileExistsError:
+                continue
+
+        # 3. Post-Lock Verification (Double-Check)
+        self._status_cache.pop(info.id, None)
+        status = self.status(info, download_dir)
+        if not force and status == self.INSTALLED:
+            if os.path.exists(tmp_filepath):
+                try:
+                    os.remove(tmp_filepath)
+                except FileNotFoundError:
+                    pass
+            yield UpToDateMessage(info)
+            yield ProgressMessage(100)
+            yield FinishPackageMessage(info)
+            return
+
+        # 4. Remove Stale / Old versions
         if os.path.exists(filepath):
             if status == self.STALE:
                 yield StaleMessage(info)
-            os.remove(filepath)
+            try:
+                os.remove(filepath)
+            except FileNotFoundError:
+                pass
 
-        # Ensure the download_dir exists
-        os.makedirs(download_dir, exist_ok=True)
-        os.makedirs(os.path.join(download_dir, info.subdir), exist_ok=True)
-
-        # Download the file.  This will raise an IOError if the url
-        # is not found.
+        # 5. Download Leader
         yield StartDownloadMessage(info)
         yield ProgressMessage(5)
         try:
             infile = urlopen(info.url)
-            with open(filepath, "wb") as outfile:
+            with open(tmp_filepath, "ab") as outfile:
                 num_blocks = max(1, info.size / (1024 * 16))
                 for block in itertools.count():
-                    s = infile.read(1024 * 16)  # 16k blocks.
-                    outfile.write(s)
+                    s = infile.read(1024 * 16)
                     if not s:
                         break
-                    if block % 2 == 0:  # how often?
+                    outfile.write(s)
+                    if block % 10 == 0:
+                        os.utime(tmp_filepath, None)
                         yield ProgressMessage(min(80, 5 + 75 * (block / num_blocks)))
             infile.close()
+
+            os.replace(tmp_filepath, filepath)
+
         except OSError as e:
+            if os.path.exists(tmp_filepath):
+                try:
+                    os.remove(tmp_filepath)
+                except FileNotFoundError:
+                    pass
             yield ErrorMessage(
                 info,
                 "Error downloading %r from <%s>:" "\n  %s" % (info.id, info.url, e),
             )
             return
+
         yield FinishDownloadMessage(info)
         yield ProgressMessage(80)
 
-        # If it's a zipfile, uncompress it.
         if info.filename.endswith(".zip"):
             zipdir = os.path.join(download_dir, info.subdir)
             # Unzip if we're unzipping by default; *or* if it's already

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -676,6 +676,18 @@ class Downloader:
         yield StartPackageMessage(info)
         yield ProgressMessage(0)
 
+        # Do we already have the current version?
+        status = self.status(info, download_dir)
+        if not force and status == self.INSTALLED:
+            yield UpToDateMessage(info)
+            yield ProgressMessage(100)
+            yield FinishPackageMessage(info)
+            return
+
+        # Remove the package from our status cache
+        self._status_cache.pop(info.id, None)
+
+        # Check for (and remove) any old/stale version.
         filepath = os.path.join(download_dir, info.filename)
         tmp_filepath = filepath + ".tmp"
 
@@ -691,7 +703,7 @@ class Downloader:
             return
 
         MAX_ZOMBIE_TIME = 60
-        POLL_INTERVAL = 2  # Reduced to 2 seconds so fast downloads don't block waiters
+        POLL_INTERVAL = 2
 
         # 1. Cooperative Wait Loop
         while True:
@@ -706,19 +718,20 @@ class Downloader:
 
             try:
                 if os.path.exists(tmp_filepath):
-                    last_size = os.path.getsize(tmp_filepath)
-                    mtime = os.path.getmtime(tmp_filepath)
-
-                    import time
+                    before_stat = os.stat(tmp_filepath)
+                    last_size = before_stat.st_size
 
                     time.sleep(POLL_INTERVAL)
 
                     if os.path.exists(tmp_filepath):
-                        new_size = os.path.getsize(tmp_filepath)
+                        after_stat = os.stat(tmp_filepath)
+                        new_size = after_stat.st_size
+                        new_mtime = after_stat.st_mtime
+
                         if new_size > last_size:
                             continue
 
-                        if (time.time() - mtime) < MAX_ZOMBIE_TIME:
+                        if (time.time() - new_mtime) < MAX_ZOMBIE_TIME:
                             continue
 
                         # ZOMBIE RECOVERY FIX: Remove the dead file so it can be claimed
@@ -731,8 +744,10 @@ class Downloader:
 
             # 2. Atomic Claim
             try:
+                # Ensure the download_dir exists
                 os.makedirs(download_dir, exist_ok=True)
                 os.makedirs(os.path.join(download_dir, info.subdir), exist_ok=True)
+
                 fd = os.open(tmp_filepath, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
                 os.close(fd)
                 break
@@ -753,7 +768,6 @@ class Downloader:
             yield FinishPackageMessage(info)
             return
 
-        # 4. Remove Stale / Old versions
         if os.path.exists(filepath):
             if status == self.STALE:
                 yield StaleMessage(info)
@@ -765,9 +779,9 @@ class Downloader:
         # 5. Download Leader
         yield StartDownloadMessage(info)
         yield ProgressMessage(5)
+
         try:
             infile = urlopen(info.url)
-            # FIX: Use 'wb' instead of 'ab'. O_EXCL ensures it is a fresh file.
             with open(tmp_filepath, "wb") as outfile:
                 num_blocks = max(1, info.size / (1024 * 16))
                 for block in itertools.count():
@@ -781,8 +795,6 @@ class Downloader:
             infile.close()
 
             os.replace(tmp_filepath, filepath)
-
-            # FIX: Clear cache immediately after successful download
             self._status_cache.pop(info.id, None)
 
         except OSError as e:
@@ -800,8 +812,10 @@ class Downloader:
         yield FinishDownloadMessage(info)
         yield ProgressMessage(80)
 
+        # Check if it needs to be unzipped.
         if info.filename.endswith(".zip"):
             zipdir = os.path.join(download_dir, info.subdir)
+
             # Unzip if we're unzipping by default; *or* if it's already
             # been unzipped (presumably a previous version).
             if info.unzip or os.path.exists(os.path.join(zipdir, info.id)):

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -691,7 +691,7 @@ class Downloader:
             return
 
         MAX_ZOMBIE_TIME = 60
-        POLL_INTERVAL = 15
+        POLL_INTERVAL = 2  # Reduced to 2 seconds so fast downloads don't block waiters
 
         # 1. Cooperative Wait Loop
         while True:
@@ -717,14 +717,20 @@ class Downloader:
                         new_size = os.path.getsize(tmp_filepath)
                         if new_size > last_size:
                             continue
+
                         if (time.time() - mtime) < MAX_ZOMBIE_TIME:
                             continue
+
+                        # ZOMBIE RECOVERY FIX: Remove the dead file so it can be claimed
+                        try:
+                            os.remove(tmp_filepath)
+                        except OSError:
+                            pass
             except (FileNotFoundError, OSError):
                 pass
 
             # 2. Atomic Claim
             try:
-                # Ensure the download_dir exists
                 os.makedirs(download_dir, exist_ok=True)
                 os.makedirs(os.path.join(download_dir, info.subdir), exist_ok=True)
                 fd = os.open(tmp_filepath, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
@@ -761,7 +767,8 @@ class Downloader:
         yield ProgressMessage(5)
         try:
             infile = urlopen(info.url)
-            with open(tmp_filepath, "ab") as outfile:
+            # FIX: Use 'wb' instead of 'ab'. O_EXCL ensures it is a fresh file.
+            with open(tmp_filepath, "wb") as outfile:
                 num_blocks = max(1, info.size / (1024 * 16))
                 for block in itertools.count():
                     s = infile.read(1024 * 16)
@@ -774,6 +781,9 @@ class Downloader:
             infile.close()
 
             os.replace(tmp_filepath, filepath)
+
+            # FIX: Clear cache immediately after successful download
+            self._status_cache.pop(info.id, None)
 
         except OSError as e:
             if os.path.exists(tmp_filepath):

--- a/nltk/test/unit/test_downloader_atomic.py
+++ b/nltk/test/unit/test_downloader_atomic.py
@@ -1,57 +1,107 @@
+import hashlib
+import io
 import os
 import shutil
 import tempfile
+import threading
 import time
 import unittest
-from concurrent.futures import ThreadPoolExecutor
-from unittest.mock import MagicMock, patch
+import zipfile
+from concurrent.futures import ProcessPoolExecutor
+from http.server import BaseHTTPRequestHandler, HTTPServer
 
 from nltk.downloader import Downloader, Package
 
+# 1. Dynamically generate a valid, minimal ZIP file in memory
+zip_buffer = io.BytesIO()
+with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_STORED) as zf:
+    # FIX: Place the text file inside an 'abc' folder within the zip
+    zf.writestr("abc/dummy.txt", b"real zip payload")
+ZIP_BYTES = zip_buffer.getvalue()
+ZIP_SIZE = len(ZIP_BYTES)
+ZIP_MD5 = hashlib.md5(ZIP_BYTES).hexdigest()
+
+
+# Create a custom server class to safely track requests
+class TrackingServer(HTTPServer):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.request_count = 0
+
+
+class TrackingHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.server.request_count += 1
+
+        # Artificial delay to guarantee multiple processes hit the lock logic
+        # while the file is actively downloading.
+        time.sleep(0.1)
+
+        self.send_response(200)
+        self.send_header("Content-type", "application/zip")
+        self.send_header("Content-Length", str(ZIP_SIZE))
+        self.end_headers()
+        self.wfile.write(ZIP_BYTES)
+
+    def log_message(self, format, *args):
+        pass  # Suppress console logging during the test run
+
 
 class TestDownloaderAtomic(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Start a local server on a random open port
+        cls.server = TrackingServer(("127.0.0.1", 0), TrackingHandler)
+        cls.port = cls.server.server_port
+        cls.server_thread = threading.Thread(target=cls.server.serve_forever)
+        cls.server_thread.daemon = True
+        cls.server_thread.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.shutdown()
+        cls.server.server_close()
+        cls.server_thread.join()
+
     def setUp(self):
         self.test_dir = tempfile.mkdtemp()
-        # Size and unzipped_size must exactly match the length of b"data" (4 bytes)
+        self.server.request_count = 0  # Reset count for each test
+
         self.pkg = Package(
             id="abc",
-            url="http://example.com/abc.zip",
-            size=4,
-            unzipped_size=4,
+            url=f"http://127.0.0.1:{self.port}/abc.zip",
+            size=ZIP_SIZE,
+            unzipped_size=16,  # Length of b"real zip payload"
             filename="abc.zip",
-            checksum="mock_md5",
-            unzip=False,
+            checksum=ZIP_MD5,
+            unzip=True,  # Set to True! Let's test the actual unzip logic
         )
 
     def tearDown(self):
         if os.path.exists(self.test_dir):
             shutil.rmtree(self.test_dir)
 
-    @patch("nltk.downloader.md5_hexdigest", return_value="mock_md5")
-    @patch("time.sleep", side_effect=time.sleep)
-    @patch("nltk.downloader.urlopen")
-    def test_concurrent_downloads_cooperate(self, mock_urlopen, mock_sleep, mock_md5):
-        """Verify multiple parallel calls result in exactly ONE network request."""
-
-        def side_effect(*args, **kwargs):
-            # A 100ms delay ensures all threads hit the loop while the file is downloading
-            time.sleep(0.1)
-            mock_resp = MagicMock()
-            mock_resp.read.side_effect = [b"data", b""]
-            return mock_resp
-
-        mock_urlopen.side_effect = side_effect
+    def test_concurrent_downloads_cooperate(self):
+        """Verify multiple parallel processes result in exactly ONE network request."""
         dl = Downloader(download_dir=self.test_dir)
         num_concurrent = 3
 
-        with ThreadPoolExecutor(max_workers=num_concurrent) as executor:
+        # ProcessPoolExecutor simulates the exact environment where BadZipFile occurs
+        with ProcessPoolExecutor(max_workers=num_concurrent) as executor:
             futures = [
                 executor.submit(dl.download, self.pkg, quiet=True)
                 for _ in range(num_concurrent)
             ]
             results = [f.result() for f in futures]
 
+        # All processes should report success
         self.assertTrue(all(results))
-        # PROOF: Our atomic lock prevents redundant downloads
-        self.assertEqual(mock_urlopen.call_count, 1)
+
+        # PROOF 1: The local server should have only received 1 request
+        self.assertEqual(self.server.request_count, 1)
+
+        # PROOF 2: The zip file exists and is valid
         self.assertTrue(os.path.exists(os.path.join(self.test_dir, "abc.zip")))
+
+        # PROOF 3: NLTK successfully unzipped the file without throwing BadZipFile
+        self.assertTrue(os.path.exists(os.path.join(self.test_dir, "abc", "dummy.txt")))

--- a/nltk/test/unit/test_downloader_atomic.py
+++ b/nltk/test/unit/test_downloader_atomic.py
@@ -1,0 +1,57 @@
+import os
+import shutil
+import tempfile
+import time
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import MagicMock, patch
+
+from nltk.downloader import Downloader, Package
+
+
+class TestDownloaderAtomic(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        # Size and unzipped_size must exactly match the length of b"data" (4 bytes)
+        self.pkg = Package(
+            id="abc",
+            url="http://example.com/abc.zip",
+            size=4,
+            unzipped_size=4,
+            filename="abc.zip",
+            checksum="mock_md5",
+            unzip=False,
+        )
+
+    def tearDown(self):
+        if os.path.exists(self.test_dir):
+            shutil.rmtree(self.test_dir)
+
+    @patch("nltk.downloader.md5_hexdigest", return_value="mock_md5")
+    @patch("time.sleep", side_effect=time.sleep)
+    @patch("nltk.downloader.urlopen")
+    def test_concurrent_downloads_cooperate(self, mock_urlopen, mock_sleep, mock_md5):
+        """Verify multiple parallel calls result in exactly ONE network request."""
+
+        def side_effect(*args, **kwargs):
+            # A 100ms delay ensures all threads hit the loop while the file is downloading
+            time.sleep(0.1)
+            mock_resp = MagicMock()
+            mock_resp.read.side_effect = [b"data", b""]
+            return mock_resp
+
+        mock_urlopen.side_effect = side_effect
+        dl = Downloader(download_dir=self.test_dir)
+        num_concurrent = 3
+
+        with ThreadPoolExecutor(max_workers=num_concurrent) as executor:
+            futures = [
+                executor.submit(dl.download, self.pkg, quiet=True)
+                for _ in range(num_concurrent)
+            ]
+            results = [f.result() for f in futures]
+
+        self.assertTrue(all(results))
+        # PROOF: Our atomic lock prevents redundant downloads
+        self.assertEqual(mock_urlopen.call_count, 1)
+        self.assertTrue(os.path.exists(os.path.join(self.test_dir, "abc.zip")))

--- a/nltk/test/unit/test_downloader_atomic.py
+++ b/nltk/test/unit/test_downloader_atomic.py
@@ -1,5 +1,6 @@
 import hashlib
 import io
+import multiprocessing
 import os
 import shutil
 import tempfile
@@ -15,7 +16,6 @@ from nltk.downloader import Downloader, Package
 # 1. Dynamically generate a valid, minimal ZIP file in memory
 zip_buffer = io.BytesIO()
 with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_STORED) as zf:
-    # FIX: Place the text file inside an 'abc' folder within the zip
     zf.writestr("abc/dummy.txt", b"real zip payload")
 ZIP_BYTES = zip_buffer.getvalue()
 ZIP_SIZE = len(ZIP_BYTES)
@@ -74,7 +74,7 @@ class TestDownloaderAtomic(unittest.TestCase):
             unzipped_size=16,  # Length of b"real zip payload"
             filename="abc.zip",
             checksum=ZIP_MD5,
-            unzip=True,  # Set to True! Let's test the actual unzip logic
+            unzip=True,
         )
 
     def tearDown(self):
@@ -86,8 +86,11 @@ class TestDownloaderAtomic(unittest.TestCase):
         dl = Downloader(download_dir=self.test_dir)
         num_concurrent = 3
 
-        # ProcessPoolExecutor simulates the exact environment where BadZipFile occurs
-        with ProcessPoolExecutor(max_workers=num_concurrent) as executor:
+        # Use 'spawn' to prevent deadlocks from forking a process that already has running threads
+        mp_ctx = multiprocessing.get_context("spawn")
+        with ProcessPoolExecutor(
+            max_workers=num_concurrent, mp_context=mp_ctx
+        ) as executor:
             futures = [
                 executor.submit(dl.download, self.pkg, quiet=True)
                 for _ in range(num_concurrent)


### PR DESCRIPTION
Fix #3248: this PR resolves the `BadZipFile` and redundant server load issues caused when multiple processes call `nltk.download()` concurrently. 

In a previous workaround (#PR #3247),  randomized temp files prevented local corruption, while allowing an unbounded number of simultaneous network requests. This PR implements a "cooperative" model to ensure safety while protecting NLTK's infrastructure.

### Key Changes
* **File-Based Locking (`O_EXCL`):** Uses atomic file creation to guarantee exactly one process initiates the download.
* **Cooperative Waiting:** Secondary processes monitor the active `.tmp` file's growth instead of starting duplicate downloads.
* **Zombie Recovery:** A 60-second timeout allows a sibling process to take over if the leader crashes.
* **Atomic Move:** Uses `os.replace` to guarantee the final `.zip` is only visible when 100% complete.

### Testing
Added `nltk/test/unit/test_downloader_atomic.py`. This test forces thread contention and strictly asserts that exactly one network request (`urlopen`) is made, proving the lock successfully prevents redundant server load.