### PR TITLE
Fix proxy settings ignored by pathsec.urlopen

### DIFF
--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -246,7 +246,18 @@ def urlopen(url, *args, **kwargs):
     """Secure wrapper for urllib.request.urlopen with redirect validation."""
     url_str = url.full_url if hasattr(url, "full_url") else str(url)
     validate_network_url(url_str, context="pathsec.urlopen")
-    opener = urllib.request.build_opener(_ValidatingRedirectHandler())
+
+    # Start with our security-enforcing redirect handler
+    handlers = [_ValidatingRedirectHandler()]
+
+    # Inherit existing global handlers (e.g., proxies set by nltk.set_proxy)
+    if urllib.request._opener is not None:
+        for handler in urllib.request._opener.handlers:
+            # Exclude existing redirect handlers to ensure our validator is used
+            if not isinstance(handler, urllib.request.HTTPRedirectHandler):
+                handlers.append(handler)
+
+    opener = urllib.request.build_opener(*handlers)
     return opener.open(url, *args, **kwargs)
 
 

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -243,19 +243,27 @@ class _ValidatingRedirectHandler(urllib.request.HTTPRedirectHandler):
 
 
 def urlopen(url, *args, **kwargs):
-    """Secure wrapper for urllib.request.urlopen with redirect validation."""
+    """
+    Secure wrapper for urllib.request.urlopen with redirect validation.
+    Inherits NLTK proxy settings, but intentionally ignores other custom
+    global handlers to strictly enforce the security sandbox.
+    """
     url_str = url.full_url if hasattr(url, "full_url") else str(url)
     validate_network_url(url_str, context="pathsec.urlopen")
 
     # Start with our security-enforcing redirect handler
     handlers = [_ValidatingRedirectHandler()]
 
-    # Inherit existing global handlers (e.g., proxies set by nltk.set_proxy)
+    # Safely inherit proxy settings without reusing handler instances
+    # (Reusing instances overwrites their .parent, breaking the global opener)
     if urllib.request._opener is not None:
         for handler in urllib.request._opener.handlers:
-            # Exclude existing redirect handlers to ensure our validator is used
-            if not isinstance(handler, urllib.request.HTTPRedirectHandler):
-                handlers.append(handler)
+            if isinstance(handler, urllib.request.ProxyHandler):
+                handlers.append(urllib.request.ProxyHandler(handler.proxies))
+            elif isinstance(handler, urllib.request.ProxyBasicAuthHandler):
+                handlers.append(urllib.request.ProxyBasicAuthHandler(handler.passwd))
+            elif isinstance(handler, urllib.request.ProxyDigestAuthHandler):
+                handlers.append(urllib.request.ProxyDigestAuthHandler(handler.passwd))
 
     opener = urllib.request.build_opener(*handlers)
     return opener.open(url, *args, **kwargs)

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -259,7 +259,9 @@ def urlopen(url, *args, **kwargs):
     if urllib.request._opener is not None:
         for handler in urllib.request._opener.handlers:
             if isinstance(handler, urllib.request.ProxyHandler):
-                handlers.append(urllib.request.ProxyHandler(handler.proxies))
+                # Copy the dictionary to prevent shared mutable state
+                isolated_proxies = dict(handler.proxies) if handler.proxies else {}
+                handlers.append(urllib.request.ProxyHandler(isolated_proxies))
             elif isinstance(handler, urllib.request.ProxyBasicAuthHandler):
                 handlers.append(urllib.request.ProxyBasicAuthHandler(handler.passwd))
             elif isinstance(handler, urllib.request.ProxyDigestAuthHandler):

--- a/nltk/test/unit/test_pathsec.py
+++ b/nltk/test/unit/test_pathsec.py
@@ -143,6 +143,9 @@ def test_urlopen_honors_set_proxy_and_redirect_validation():
     """
     test_proxy = "http://proxy.example.com:8080"
 
+    # 1. Capture the pre-existing global state so we don't clobber it
+    original_opener = urllib.request._opener
+
     # Setup: Directly inject a ProxyHandler into the global opener
     # to strictly test pathsec's inheritance, bypassing environment-dependent nltk.set_proxy behavior.
     proxy_handler = urllib.request.ProxyHandler({"http": test_proxy})
@@ -183,4 +186,5 @@ def test_urlopen_honors_set_proxy_and_redirect_validation():
         ), "ProxyHandler instance was reused instead of copied! This breaks the global opener."
 
     finally:
-        urllib.request.install_opener(None)
+        # Teardown: Safely restore the original global opener, leaving no trace of this test
+        urllib.request.install_opener(original_opener)

--- a/nltk/test/unit/test_pathsec.py
+++ b/nltk/test/unit/test_pathsec.py
@@ -2,43 +2,39 @@ import builtins
 import io
 import os
 import socket
+import urllib.request
 import zipfile
+from unittest.mock import MagicMock, patch
 from urllib.error import HTTPError, URLError
 
 import pytest
 
+import nltk
 import nltk.downloader  # We will inspect this module directly
+from nltk import pathsec
 from nltk.downloader import Downloader
 
 
 @pytest.fixture(autouse=True)
 def enable_enforcement():
-    """
-    Dynamically toggle enforcement if pathsec exists.
-    If on a branch without pathsec.py, proceed normally.
-    """
-    try:
-        import nltk.pathsec
-
-        original_enforce = nltk.pathsec.ENFORCE
-        nltk.pathsec.ENFORCE = True
-        yield
-        nltk.pathsec.ENFORCE = original_enforce
-    except ImportError:
-        yield
+    """Dynamically toggle enforcement on for the duration of the tests."""
+    original_enforce = pathsec.ENFORCE
+    pathsec.ENFORCE = True
+    yield
+    pathsec.ENFORCE = original_enforce
 
 
 # --- SSRF NETWORK TESTS ---
 
 
 def test_valid_http_url():
-    dl = Downloader(
-        server_index_url="https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/index.xml"
-    )
+    """Ensure valid URLs pass the SSRF filter without raising security exceptions."""
     try:
-        dl.index()
-    except URLError:
-        pass
+        pathsec.validate_network_url(
+            "https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/index.xml"
+        )
+    except (ValueError, PermissionError) as e:
+        pytest.fail(f"Valid HTTP URL was incorrectly blocked by pathsec: {e}")
 
 
 def test_ssrf_invalid_scheme():
@@ -60,7 +56,7 @@ def test_ssrf_cloud_metadata_link_local():
 
 
 def test_ssrf_ip_obfuscation():
-    """Will FAIL on PR #3520 (on Unix) because string-matching misses the decimal IP."""
+    """Will FAIL on vulnerable branches (on Unix) because string-matching misses the decimal IP."""
     dl = Downloader(server_index_url="http://2852039166/latest/meta-data/")
     try:
         dl.index()
@@ -69,7 +65,7 @@ def test_ssrf_ip_obfuscation():
         # SUCCESS (Your Branch): Our sentinel proactively blocked the restricted IP.
         pass
     except HTTPError as e:
-        # FAILURE (PR #3520): The request bypassed local filters and hit the network layer!
+        # FAILURE: The request bypassed local filters and hit the network layer!
         pytest.fail(f"Vulnerability bypassed localized string filters: {e}")
     except URLError as e:
         # SUCCESS (Windows only): DNS resolution strictly fails on decimal IPs natively.
@@ -87,17 +83,12 @@ def test_path_traversal_absolute():
     Test if absolute paths bypass standard relative traversal checks.
     Will FAIL on vulnerable branches because standard builtins.open does not check path boundaries.
     """
-    try:
-        from nltk.pathsec import open as target_open
-    except ImportError:
-        target_open = builtins.open
-
     # Cross-platform absolute path guaranteed outside all allowed roots.
     # Linux/macOS: /_nltk_pathsec_test/secret.txt
     # Windows:     C:\_nltk_pathsec_test\secret.txt
     outside = os.path.join(os.path.abspath(os.sep), "_nltk_pathsec_test", "secret.txt")
     with pytest.raises((ValueError, PermissionError)):
-        target_open(outside, "r")
+        pathsec.open(outside, "r")
 
 
 # --- ZIP-SLIP TESTS ---
@@ -116,10 +107,9 @@ def create_malicious_zip(filename):
 def test_zip_slip_traversal(tmp_path):
     """
     Test standard ../ Zip-Slip traversal.
-    Will FAIL on PR #3520 because standard zipfile silently sanitizes/ignores
+    Will FAIL on vulnerable branches because standard zipfile silently sanitizes/ignores
     the traversal rather than proactively blocking it and raising an alert.
     """
-    # Dynamically grab the 'ZipFile' class NLTK's downloader is currently using
     TargetZipFile = getattr(nltk.downloader, "ZipFile", zipfile.ZipFile)
 
     malicious_zip = create_malicious_zip("../../../evil.sh")
@@ -131,7 +121,7 @@ def test_zip_slip_traversal(tmp_path):
 def test_zip_slip_absolute_path(tmp_path):
     """
     Test Zip-Slip using an absolute path.
-    Will FAIL on PR #3520 because standard zipfile silently ignores the absolute
+    Will FAIL on vulnerable branches because standard zipfile silently ignores the absolute
     root rather than proactively raising a security alert.
     """
     TargetZipFile = getattr(nltk.downloader, "ZipFile", zipfile.ZipFile)
@@ -140,3 +130,57 @@ def test_zip_slip_absolute_path(tmp_path):
     with pytest.raises((ValueError, PermissionError)):
         with TargetZipFile(malicious_zip, "r") as zf:
             zf.extractall(tmp_path)
+
+
+# --- PROXY & HANDLER TESTS ---
+
+
+def test_urlopen_honors_set_proxy_and_redirect_validation():
+    """
+    Regression test for Issue #3551.
+    Ensures that pathsec.urlopen inherits global proxy configurations
+    from urllib.request._opener, while still enforcing its own redirect validation.
+    """
+    test_proxy = "http://proxy.example.com:8080"
+
+    # Setup: Directly inject a ProxyHandler into the global opener
+    # to strictly test pathsec's inheritance, bypassing environment-dependent nltk.set_proxy behavior.
+    proxy_handler = urllib.request.ProxyHandler({"http": test_proxy})
+    global_opener = urllib.request.build_opener(proxy_handler)
+    urllib.request.install_opener(global_opener)
+
+    try:
+        captured_handlers = []
+
+        def spy_build_opener(*handlers):
+            captured_handlers.extend(handlers)
+            return MagicMock()
+
+        with patch("urllib.request.build_opener", side_effect=spy_build_opener):
+            pathsec.urlopen("http://safe.example.com/data.zip")
+
+        # 1. Verify ProxyHandler is present and contains our exact proxy
+        proxy_handlers = [
+            h for h in captured_handlers if isinstance(h, urllib.request.ProxyHandler)
+        ]
+        assert (
+            len(proxy_handlers) == 1
+        ), "ProxyHandler was not inherited by pathsec.urlopen"
+        assert "http" in proxy_handlers[0].proxies
+        assert proxy_handlers[0].proxies["http"] == test_proxy
+
+        # 2. Verify _ValidatingRedirectHandler is present for SSRF protection
+        redirect_handlers = [
+            h
+            for h in captured_handlers
+            if isinstance(h, pathsec._ValidatingRedirectHandler)
+        ]
+        assert len(redirect_handlers) == 1, "_ValidatingRedirectHandler is missing"
+
+        # 3. Verify the ProxyHandler was safely copied
+        assert (
+            proxy_handlers[0] is not proxy_handler
+        ), "ProxyHandler instance was reused instead of copied! This breaks the global opener."
+
+    finally:
+        urllib.request.install_opener(None)


### PR DESCRIPTION
Fix #3551: this PR resolves a regression introduced in PR #3522 where custom proxy configurations set via `nltk.set_proxy()` were being silently ignored.

**The Cause:** The security updates introduced `pathsec.urlopen`, which built a fresh `urllib.request.build_opener()` to enforce redirect validation. However, this bypassed the globally installed `urllib.request._opener` where `nltk.set_proxy()` stores its handlers.

**The Fix:** Updated `pathsec.urlopen` to check for an existing global opener and inherit its handlers (such as the custom `ProxyHandler`). It carefully filters out any existing redirect handlers to ensure the SSRF `_ValidatingRedirectHandler` still takes precedence, maintaining full security while restoring proxy functionality.