### PR TITLE
Fix _create_token_table skipping last paragraph break transition + regression test

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -312,6 +312,7 @@
 - Christopher Smith <https://github.com/smithct2>
 - Ryan Mannion <https://github.com/ryanamannion>
 - Peter Pollak <https://github.com/Syzygy2048/>
+- Bradley Erickson <https://github.com/13rac1>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 

--- a/nltk/test/unit/test_texttiling.py
+++ b/nltk/test/unit/test_texttiling.py
@@ -153,6 +153,33 @@ class TestTextTilingVocabIntroduction:
         ), f"Average later score {avg_later} too high for repeated text"
 
 
+class TestCreateTokenTable:
+    """Tests for _create_token_table internals."""
+
+    def test_par_count_across_last_paragraph_break(self):
+        """Words spanning the last paragraph break should have par_count=2.
+
+        Regression test: when a word position exceeds the final paragraph
+        break, next(pb_iter) raises StopIteration before current_par is
+        incremented, so par_count is never updated for that transition.
+        """
+        from nltk.tokenize.texttiling import TokenSequence
+
+        tt = TextTilingTokenizer(w=20, k=10, stopwords=[])
+        # Two token sequences: "dog" appears in both, with positions
+        # that straddle a paragraph break at position 150.
+        seqs = [
+            TokenSequence(index=0, wrdindex_list=[("cat", 0), ("dog", 4)]),
+            TokenSequence(index=1, wrdindex_list=[("dog", 200), ("fish", 204)]),
+        ]
+        par_breaks = [0, 150]
+        table = tt._create_token_table(seqs, par_breaks)
+        assert table["dog"].par_count == 2, (
+            f"Expected par_count=2 for 'dog' spanning last paragraph break, "
+            f"got {table['dog'].par_count}"
+        )
+
+
 class TestTextTilingCommon:
     """Tests common to both methods."""
 

--- a/nltk/tokenize/texttiling.py
+++ b/nltk/tokenize/texttiling.py
@@ -327,8 +327,8 @@ class TextTilingTokenizer(TokenizerI):
             for word, index in ts.wrdindex_list:
                 try:
                     while index > current_par_break:
-                        current_par_break = next(pb_iter)
                         current_par += 1
+                        current_par_break = next(pb_iter)
                 except StopIteration:
                     # hit bottom
                     pass


### PR DESCRIPTION
When a word position exceeds the final paragraph break, `next(pb_iter)` raises `StopIteration` before `current_par` is incremented. This causes `par_count` to be undercounted for any word that spans the last paragraph boundary. Fix by incrementing `current_par` before advancing the iterator.

Note: This bug was found with AI assistance and has been reproduced in the regression test.