### PR TITLE
Fix APP_RE to accept variable direction underscore

### DIFF
--- a/nltk/ccg/lexicon.py
+++ b/nltk/ccg/lexicon.py
@@ -26,8 +26,10 @@ PRIM_RE = re.compile(r"""([A-Za-z]+)(\[[A-Za-z,]+\])?""")
 # string
 NEXTPRIM_RE = re.compile(r"""([A-Za-z]+(?:\[[A-Za-z,]+\])?)(.*)""")
 
-# Separates the next application operator from the remainder
-APP_RE = re.compile(r"""([\\/])([.,]?)([.,]?)(.*)""")
+# Separates the next application operator from the remainder.
+# The modifier slot also accepts `_`, marking a variable direction
+# (e.g. `(S\_NP)/(S\_NP)` for a polymorphic adverb).
+APP_RE = re.compile(r"""([\\/])([.,_]?)([.,]?)(.*)""")
 
 # Parses the definition of the right-hand side (rhs) of either a word or a family
 LEX_RE = re.compile(r"""([\S_]+)\s*(::|[-=]+>)\s*(.+)""", re.UNICODE)

--- a/nltk/test/unit/test_ccg.py
+++ b/nltk/test/unit/test_ccg.py
@@ -1,0 +1,38 @@
+"""
+Tests for the CCG (Combinatory Categorial Grammar) module.
+"""
+
+import unittest
+
+from nltk.ccg import lexicon
+from nltk.ccg.api import FunctionalCategory
+
+
+class TestLexiconVariableDirection(unittest.TestCase):
+    """Test that `lexicon.fromstring` accepts variable direction markers (`\\_`)
+    in slash modifiers, as used in polymorphic categories like `(S\\_NP)/(S\\_NP)`.
+    """
+
+    def test_fromstring_parses_variable_direction(self):
+        """Regression test: previously, APP_RE rejected `_` as a modifier,
+        causing the lexer to raise AttributeError on any variable direction.
+        """
+        lex = lexicon.fromstring(
+            r"""
+            :- S, NP
+            quickly => (S\_NP)/(S\_NP)
+            """
+        )
+
+        categories = lex.categories("quickly")
+        self.assertEqual(len(categories), 1)
+
+        cat = categories[0].categ()
+        self.assertIsInstance(cat, FunctionalCategory)
+        # Outer structure: (S\_NP) / (S\_NP)
+        self.assertTrue(cat.dir().is_forward())
+        self.assertIsInstance(cat.res(), FunctionalCategory)
+        self.assertIsInstance(cat.arg(), FunctionalCategory)
+        # Inner direction carries the variable marker
+        self.assertIn("_", str(cat.res().dir()))
+        self.assertTrue(cat.res().dir().is_backward())


### PR DESCRIPTION
Addresses the first of three bugs in #3555 (the `APP_RE` lexer failure).

## What's going on

`APP_RE` only accepted `.` and `,` as slash modifiers, so parsing any variable direction (e.g. `(S\_NP)/(S\_NP)`) crashed:

```
AttributeError: 'NoneType' object has no attribute 'groups'
```

The `_` fell through the modifier slots into the remainder, where `NEXTPRIM_RE` rejected it.

## The fix

Extend the first modifier character class to include `_`:

```python
APP_RE = re.compile(r"""([\\/])([.,_]?)([.,]?)(.*)""")
```

## Scope

Deliberately narrow. After this fix, `lexicon.fromstring(r"quickly => (S\_NP)/(S\_NP)")` succeeds and produces a `FunctionalCategory` with the `_` captured in the inner direction. It does **not** yet make `Direction.is_variable()` return `True` for those parsed directions — that requires fixing `Direction.__init__`'s handling of raw regex tuples, which is the second bug in #3555 and will come in a separate PR.

Keeping the PRs one-per-root-cause as discussed on #3555.

## Tests

Added `test_ccg.py` with a regression test that parses `(S\_NP)/(S\_NP)` via `lexicon.fromstring` and asserts the resulting structure. Verified it fails on the old regex with the exact `AttributeError` from the issue, and passes with the fix.