### PR TITLE
Fix Direction.__init__ to normalize tuple restrictions

### DIFF
--- a/nltk/ccg/api.py
+++ b/nltk/ccg/api.py
@@ -154,6 +154,12 @@ class Direction:
     """
 
     def __init__(self, dir, restrictions):
+        # The lexicon's APP_RE yields a 2-slot capture tuple (e.g. ("_", ""))
+        # for the modifier. Collapse it to a string so `is_variable()` — which
+        # tests `_restrs == "_"` — behaves the same for parsed and
+        # hand-constructed Directions.
+        if isinstance(restrictions, tuple):
+            restrictions = "".join(restrictions)
         self._dir = dir
         self._restrs = restrictions
         self._comparison_key = (dir, tuple(restrictions))

--- a/nltk/test/unit/test_ccg.py
+++ b/nltk/test/unit/test_ccg.py
@@ -1,0 +1,46 @@
+"""
+Tests for the CCG (Combinatory Categorial Grammar) module.
+"""
+
+import unittest
+
+from nltk.ccg.api import Direction
+
+
+class TestDirectionTupleRestrictions(unittest.TestCase):
+    """`Direction.__init__` must treat a raw regex-capture tuple (as produced
+    by the lexicon's `APP_RE`) as equivalent to its collapsed string form.
+    Otherwise variable directions parsed from strings never test as variable.
+    """
+
+    def test_tuple_restrictions_normalize_to_string(self):
+        """Regression test: previously, passing `('_', '')` left `_restrs`
+        as a tuple, so `is_variable()` always returned False for parsed
+        variable directions.
+        """
+        parsed = Direction("\\", ("_", ""))
+        self.assertTrue(parsed.is_variable())
+        self.assertEqual(parsed.restrs(), "_")
+
+    def test_tuple_and_string_directions_are_equal(self):
+        """Directions built from a tuple and from a string should compare
+        and hash identically once normalized.
+        """
+        from_parser = Direction("\\", ("_", ""))
+        from_user = Direction("\\", "_")
+        self.assertEqual(from_parser, from_user)
+        self.assertEqual(hash(from_parser), hash(from_user))
+
+    def test_tuple_concrete_modifier_preserved(self):
+        """A concrete modifier captured as a tuple (e.g. ('.', '')) should
+        normalize to '.', not read as variable.
+        """
+        d = Direction("/", (".", ""))
+        self.assertFalse(d.is_variable())
+        self.assertEqual(d.restrs(), ".")
+
+    def test_empty_tuple_restrictions(self):
+        """An empty modifier tuple should behave like no restrictions."""
+        d = Direction("/", ("", ""))
+        self.assertFalse(d.is_variable())
+        self.assertEqual(d.restrs(), "")


### PR DESCRIPTION
Addresses the second of three bugs in #3555 (the `Direction.__init__` tuple handling).

## What's going on

`lexicon.py`'s `parseApplication` passes the two-slot `APP_RE` capture tuple (e.g. `('_', '')`) directly into `Direction` as the `restrictions` argument:

```python
def parseApplication(app):
    return Direction(app[0], app[1:])
```

`Direction.__init__` stores it verbatim. `is_variable()` then tests `self._restrs == "_"` — which is always False for a tuple — so every variable direction recovered from a string silently reads as non-variable. Equality and hashing also diverge between parsed Directions and hand-constructed ones, even when they represent the same thing.

## The fix

Collapse tuple restrictions to a string at construction time:

```python
def __init__(self, dir, restrictions):
    if isinstance(restrictions, tuple):
        restrictions = "".join(restrictions)
    ...
```

The string and list call paths (user construction, `substitute`, `__neg__`) are unaffected.

## Scope

This fix is self-contained, but its visible effect depends on #3558 (the `APP_RE` regex fix) landing first — without #3558, the parser can't produce a variable direction at all. The fix here is still correct independently: it pins a consistent `Direction` contract so that whenever a tuple does arrive, `is_variable()` and comparisons behave correctly.

## Tests

Added 4 unit tests covering:
- Tuple with `_` normalizes and reads as variable.
- Parsed and hand-constructed variable Directions compare and hash equal.
- Concrete modifier tuples (`('.', '')`) normalize without being misread as variable.
- Empty-tuple restrictions behave as no-restrictions.

All four tests fail on current `develop` and pass with this fix. Tests are intentionally independent of #3558 — they construct tuples directly rather than going through the parser.