### PR TITLE
Fix FunctionalCategory.can_unify dropping direction substitution

### DIFF
--- a/nltk/ccg/api.py
+++ b/nltk/ccg/api.py
@@ -341,7 +341,7 @@ class FunctionalCategory(AbstractCCGCategory):
             if sa is not None and sd is not None:
                 sb = self._arg.substitute(sa).can_unify(other.arg().substitute(sa))
                 if sb is not None:
-                    return sa + sb
+                    return sa + sd + sb
         return None
 
     # Constituent accessors

--- a/nltk/test/unit/test_ccg.py
+++ b/nltk/test/unit/test_ccg.py
@@ -1,0 +1,61 @@
+"""
+Tests for the CCG (Combinatory Categorial Grammar) module.
+"""
+
+import unittest
+
+from nltk.ccg.api import Direction, FunctionalCategory, PrimitiveCategory
+
+
+class TestFunctionalCategoryCanUnifyDirection(unittest.TestCase):
+    """`FunctionalCategory.can_unify` must propagate direction substitutions
+    produced by `Direction.can_unify`. Without this, unifying a variable
+    direction against a concrete one silently drops the binding, and the
+    variable is never resolved during parsing.
+    """
+
+    def test_variable_direction_substitution_is_returned(self):
+        """Regression test: previously, `can_unify` computed the direction
+        substitution (`sd`) but its return statement omitted it
+        (`return sa + sb`), so the caller never saw the `_` binding.
+        """
+        S = PrimitiveCategory("S")
+        NP = PrimitiveCategory("NP")
+
+        variable_cat = FunctionalCategory(S, NP, Direction("\\", "_"))
+        concrete_cat = FunctionalCategory(S, NP, Direction("\\", ""))
+
+        subs = variable_cat.can_unify(concrete_cat)
+
+        self.assertIsNotNone(subs)
+        self.assertIn(("_", ""), subs)
+
+    def test_variable_direction_binds_to_concrete_modifier(self):
+        """When the concrete side has a modifier (e.g. `.`), the `_` should
+        bind to that modifier rather than an empty string.
+        """
+        S = PrimitiveCategory("S")
+        NP = PrimitiveCategory("NP")
+
+        variable_cat = FunctionalCategory(S, NP, Direction("/", "_"))
+        concrete_cat = FunctionalCategory(S, NP, Direction("/", "."))
+
+        subs = variable_cat.can_unify(concrete_cat)
+
+        self.assertIsNotNone(subs)
+        self.assertIn(("_", "."), subs)
+
+    def test_matching_concrete_directions_still_unify(self):
+        """Two matching concrete directions should still unify (returning
+        no direction substitution), confirming the fix doesn't regress the
+        non-variable path.
+        """
+        S = PrimitiveCategory("S")
+        NP = PrimitiveCategory("NP")
+
+        left = FunctionalCategory(S, NP, Direction("\\", ""))
+        right = FunctionalCategory(S, NP, Direction("\\", ""))
+
+        subs = left.can_unify(right)
+
+        self.assertEqual(subs, [])


### PR DESCRIPTION
Addresses the third of three bugs in #3555 (the `can_unify` direction drop).

## What's going on

`FunctionalCategory.can_unify` computes three substitution lists — from the result (`sa`), the direction (`sd`), and the argument (`sb`) — but the return statement only concatenates `sa` and `sb`, dropping `sd` entirely:

```python
sa = self._res.can_unify(other.res())
sd = self._dir.can_unify(other.dir())
if sa is not None and sd is not None:
    sb = self._arg.substitute(sa).can_unify(other.arg().substitute(sa))
    if sb is not None:
        return sa + sb   # sd is silently discarded
```

Because `sd` is the only place a variable direction's `_` binding appears, the caller ends up with an empty substitution for every variable direction. `substitute()` then has nothing to apply, so the variable survives intact through a parse even when unification should have resolved it.

## The fix

Include `sd` in the returned list:

```python
return sa + sd + sb
```

The concrete-direction path is unchanged: when both sides already match, `Direction.can_unify` returns `[]`, so `sd` contributes nothing.

## Scope

Deliberately minimal — the one-line return fix. The end-to-end payoff (parsing sentences like `john quickly walked` with a polymorphic `quickly => (S\_NP)/(S\_NP)`) only surfaces once the full stack is in: #3547 (`substitute` direction bug), #3558 (`APP_RE` regex), #3559 (`Direction` tuple handling), and this PR.

## Tests

Added 3 unit tests covering:
- Variable direction unifying with a concrete one surfaces the `_` binding in the returned subs.
- The binding carries the concrete side's modifier (e.g. `.`), not just an empty string.
- Matching concrete directions still unify to an empty list (regression guard for the non-variable path).

The first two fail on current `develop` and pass with this fix. All three are self-contained — they construct categories via the API directly, so no dependency on the other PRs.