### PR TITLE
Align TnT with Brants (2000) specifications

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -312,6 +312,7 @@
 - Christopher Smith <https://github.com/smithct2>
 - Ryan Mannion <https://github.com/ryanamannion>
 - Peter Pollak <https://github.com/Syzygy2048/>
+- John Winstead <https://github.com/jhnwnstd/>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 

--- a/nltk/tag/tnt.py
+++ b/nltk/tag/tnt.py
@@ -12,6 +12,18 @@ Implementation of 'TnT - A Statistical Part of Speech Tagger'
 by Thorsten Brants
 
 https://aclanthology.org/A00-1031.pdf
+
+Where Brants (2000) is silent, the implementation makes principled
+choices flagged with ``Underspecified by Brants:`` in inline comments
+so future readers can tell paper-derived behavior from local policy:
+
+* ``_compute_lambda`` - even-split tie-breaking when multiple ``c_i``
+  reach the max, and zeroed weights on degenerate training input.
+* ``train`` - empty sentences contribute no EOS counts.
+* ``_expand_states`` - strict ``>`` beam tie-break, so the
+  first-encountered hypothesis wins. No clearly better policy is
+  known; future work on deterministic hypothesis recombination
+  could improve this.
 """
 
 from math import log2
@@ -164,9 +176,8 @@ class TnT(TaggerI):
         :type C: bool
         """
 
-        # Restricting N to a positive integer keeps the public contract
-        # narrow. The explicit bool check matters because ``bool`` is a
-        # subclass of ``int`` and would otherwise pass the type check.
+        # ``bool`` is an ``int`` subclass; the explicit bool check rejects
+        # True/False, which would otherwise pass the int type check.
         if isinstance(N, bool) or not isinstance(N, int) or N < 1:
             raise ValueError(f"N must be a positive integer, got {N!r}")
 
@@ -201,8 +212,7 @@ class TnT(TaggerI):
         self._trans_logp_bigram = {}
         self._trans_logp_trigram = {}
 
-        # The cache depends entirely on trained model state, so it starts
-        # empty here and is cleared whenever train() rebuilds the model.
+        # Cleared on every train() so contents always reflect current model state.
         self._candidate_tags_cache = {}
 
         self.unknown = 0
@@ -260,9 +270,9 @@ class TnT(TaggerI):
 
                 state_i_minus_2, state_i_minus_1 = state_i_minus_1, state_i
 
-            # EOS is treated as an ordinary next state in the n-gram model,
-            # but empty sentences are skipped so BOS does not acquire EOS as
-            # a spurious successor.
+            # Underspecified by Brants: EOS is treated as an ordinary next
+            # state in the n-gram model, but empty sentences are skipped
+            # so BOS does not acquire EOS as a spurious successor.
             if sent_has_tokens:
                 tag_unigrams[_EOS] += 1
                 tag_bigrams[state_i_minus_1][_EOS] += 1
@@ -353,8 +363,7 @@ class TnT(TaggerI):
         lambda2_mass = 0.0
         lambda3_mass = 0.0
 
-        # Sorting both iterations makes the lambda mass accumulation
-        # independent of training-data order.
+        # Sorted iteration makes lambda mass accumulation order-independent.
         for state_i_minus_2, state_i_minus_1 in sorted(tag_trigrams.conditions()):
             trigram_dist = tag_trigrams[(state_i_minus_2, state_i_minus_1)]
             bigram_dist = tag_bigrams[state_i_minus_1]
@@ -378,8 +387,9 @@ class TnT(TaggerI):
                 )
                 c3 = (count - 1) / trigram_n_minus_1 if trigram_n_minus_1 else 0.0
 
-                # The trigram's count is credited to the model order with the
-                # strongest held out estimate. Splitting ties evenly avoids
+                # Underspecified by Brants: the trigram's count is credited
+                # to the model order with the strongest held-out estimate.
+                # Splitting ties evenly across the winning lambdas avoids
                 # introducing an arbitrary preference between orders.
                 maxc = max(c1, c2, c3)
                 w1 = c1 == maxc
@@ -394,9 +404,10 @@ class TnT(TaggerI):
                 if w3:
                     lambda3_mass += share
 
-        # Normalization turns the accumulated winning mass into mixture
-        # weights. Keeping the zero case explicit prevents a degenerate
-        # training run from dividing by zero or reusing stale weights.
+        # Underspecified by Brants: normalization turns the accumulated
+        # winning mass into mixture weights. Zeroing on degenerate input
+        # (no positive trigram mass) avoids a divide-by-zero and prevents
+        # stale weights from a previous training run from leaking through.
         total_mass = lambda1_mass + lambda2_mass + lambda3_mass
         if total_mass > 0:
             self._lambda1 = lambda1_mass / total_mass
@@ -505,8 +516,7 @@ class TnT(TaggerI):
 
         tag_counts: dict = {}
         for (tag, _), count in sorted(tag_unigrams.items()):
-            # The suffix model predicts lexical tags, not boundary markers.
-            # Check the raw tag so EOS is excluded from all capitalization states.
+            # Exclude the EOS sentinel from all capitalization states.
             if tag == _EOS[0]:
                 continue
             tag_counts[tag] = tag_counts.get(tag, 0) + count
@@ -536,8 +546,7 @@ class TnT(TaggerI):
             True: ConditionalFreqDist(),
         }
 
-        # Sorting both iterations makes the suffix trie's per-bucket
-        # insertion order independent of training-data order.
+        # Sorted iteration makes suffix-trie insertion order-independent.
         for word in sorted(word_tag_freqs.conditions()):
             tag_freqs = word_tag_freqs[word]
             if not word or tag_freqs.N() > 10:
@@ -808,14 +817,14 @@ class TnT(TaggerI):
             states = {k: v for k, v in new_states.items() if v[0] >= cutoff}
             state_history.append(states)
 
-        # Inline ``count / N`` instead of the cache's ``count * (1/N)``
-        # keeps EOS bit-identical to the pre-cache decoder. EOS is scored
-        # once per sentence, so the cache speedup wouldn't matter here.
+        # EOS uses raw probabilities (not the logged cache) so the lambdas
+        # can interpolate across orders before ``log2``. Scored once per
+        # sentence, so skipping the cache is irrelevant for performance.
         tag_bigrams = self._tag_bigrams
         tag_trigrams = self._tag_trigrams
         lambda1, lambda2, lambda3 = self._lambda1, self._lambda2, self._lambda3
-        inv_num_tag_tokens = _safe_inverse(self._num_tag_tokens)
-        p_eos_unigram = tag_unigrams[_EOS] * inv_num_tag_tokens
+        num_tag_tokens = self._num_tag_tokens
+        p_eos_unigram = (tag_unigrams[_EOS] / num_tag_tokens) if num_tag_tokens else 0.0
 
         best_final_key = next(iter(states))
         best_final_logp = float("-inf")
@@ -930,8 +939,16 @@ class TnT(TaggerI):
                 path_logp = prefix_logp + (trans_logp + log_emit)
                 next_state = (state_i_minus_1, state_i)
 
-                # Once the last two states match, only the better prefix matters.
-                # All future transitions depend on this key alone.
+                # When two paths land on the same (state_{i-1}, state_i)
+                # key, only the higher-scoring prefix can matter going
+                # forward: future transitions depend on the key alone.
+                #
+                # Underspecified by Brants: on exact ties, strict ``>``
+                # keeps the first-encountered hypothesis. Sorted
+                # candidate construction upstream fixes the iteration
+                # order, so the tie-break is deterministic across reruns.
+                # In practice this branch never fires (0 hits in 100k+
+                # Treebank comparisons), so ``>`` vs ``>=`` is a no-op.
                 prev_best = new_states_get(next_state)
                 if prev_best is None or path_logp > prev_best[0]:
                     new_states[next_state] = (path_logp, state_i_minus_2)

--- a/nltk/tag/tnt.py
+++ b/nltk/tag/tnt.py
@@ -178,7 +178,7 @@ class TnT(TaggerI):
             state_i_minus_2 = _BOS
             state_i_minus_1 = _BOS
             for w, t in sent:
-                c_i = cap_on and w[0].isupper()
+                c_i = cap_on and bool(w) and w[0].isupper()
                 state_i = (t, c_i)
                 wd[w][t] += 1
                 uni[state_i] += 1
@@ -246,7 +246,7 @@ class TnT(TaggerI):
         }
         for word in self._word_tag_freqs.conditions():
             word_tag_freqs = self._word_tag_freqs[word]
-            if word_tag_freqs.N() > 10:
+            if word_tag_freqs.N() > 10 or not word:
                 continue
             trie = self._suffix_trie_by_cap[word[0].isupper()]
             for m in range(1, min(len(word), 10) + 1):
@@ -310,10 +310,14 @@ class TnT(TaggerI):
                 if w3:
                     lambda3_mass += share
 
+        # If no trigrams contributed (empty or pathological training input),
+        # leave the weights at their __init__ zero defaults rather than
+        # dividing by zero. Decode will fall back to the unigram emission.
         total_mass = lambda1_mass + lambda2_mass + lambda3_mass
-        self._lambda1 = lambda1_mass / total_mass
-        self._lambda2 = lambda2_mass / total_mass
-        self._lambda3 = lambda3_mass / total_mass
+        if total_mass > 0:
+            self._lambda1 = lambda1_mass / total_mass
+            self._lambda2 = lambda2_mass / total_mass
+            self._lambda3 = lambda3_mass / total_mass
 
     def _unknown_tag_scores(self, word):
         """
@@ -343,7 +347,7 @@ class TnT(TaggerI):
         if not tag_priors:
             return {}
 
-        is_capitalized = word[0].isupper()
+        is_capitalized = bool(word) and word[0].isupper()
         trie = self._suffix_trie_by_cap[is_capitalized]
         theta = self._theta
 
@@ -533,7 +537,7 @@ class TnT(TaggerI):
         state_history = [states]
 
         for word in sent:
-            c_i = cap_on and word[0].isupper()
+            c_i = cap_on and bool(word) and word[0].isupper()
             wd_word = word_tag_freqs.get(word)
             if wd_word is not None:
                 self.known += 1

--- a/nltk/tag/tnt.py
+++ b/nltk/tag/tnt.py
@@ -346,14 +346,16 @@ class TnT(TaggerI):
         lambda2_mass = 0.0
         lambda3_mass = 0.0
 
-        for state_i_minus_2, state_i_minus_1 in tag_trigrams.conditions():
+        # Sorting both iterations makes the lambda mass accumulation
+        # independent of training-data order.
+        for state_i_minus_2, state_i_minus_1 in sorted(tag_trigrams.conditions()):
             trigram_dist = tag_trigrams[(state_i_minus_2, state_i_minus_1)]
             bigram_dist = tag_bigrams[state_i_minus_1]
 
             trigram_n_minus_1 = trigram_dist.N() - 1
             bigram_n_minus_1 = bigram_dist.N() - 1
 
-            for state_i, count in trigram_dist.items():
+            for state_i, count in sorted(trigram_dist.items()):
                 # Subtracting one leaves the current event out, so each score
                 # asks which model order would best predict this tag if this
                 # occurrence were held out.
@@ -495,7 +497,7 @@ class TnT(TaggerI):
         word_tag_freqs = self._word_tag_freqs
 
         tag_counts: dict = {}
-        for (tag, _), count in tag_unigrams.items():
+        for (tag, _), count in sorted(tag_unigrams.items()):
             # The suffix model predicts lexical tags, not boundary markers.
             # Check the raw tag so EOS is excluded from all capitalization states.
             if tag == _EOS[0]:
@@ -527,7 +529,9 @@ class TnT(TaggerI):
             True: ConditionalFreqDist(),
         }
 
-        for word in word_tag_freqs.conditions():
+        # Sorting both iterations makes the suffix trie's per-bucket
+        # insertion order independent of training-data order.
+        for word in sorted(word_tag_freqs.conditions()):
             tag_freqs = word_tag_freqs[word]
             if not word or tag_freqs.N() > 10:
                 continue
@@ -537,7 +541,7 @@ class TnT(TaggerI):
 
             for m in range(1, max_suffix_len + 1):
                 suffix_dist = suffix_trie[word[-m:]]
-                for tag, count in tag_freqs.items():
+                for tag, count in sorted(tag_freqs.items()):
                     suffix_dist[tag] += count
 
         self._tag_prior_probs = tag_prior_probs
@@ -749,7 +753,7 @@ class TnT(TaggerI):
                         # Known words only consider tags actually seen with
                         # that surface form. The lexical term is P(word | tag).
                         entries = []
-                        for tag, tag_count in tag_freqs.items():
+                        for tag, tag_count in sorted(tag_freqs.items()):
                             state_i = (tag, c_i)
                             unigram_state_i = tag_unigrams[state_i]
                             unigram_logp = trans_logp_unigram_get(state_i, _LOG_FLOOR_2)

--- a/nltk/tag/tnt.py
+++ b/nltk/tag/tnt.py
@@ -29,10 +29,13 @@ class TnT(TaggerI):
 
     IMPORTANT NOTES:
 
-    * DOES NOT AUTOMATICALLY DEAL WITH UNSEEN WORDS
+    * HANDLES UNSEEN WORDS VIA BRANTS' SUFFIX MODEL
 
-      - It is possible to provide an untrained POS tagger to
-        create tags for unknown words, see __init__ function
+      - Unknown words are tagged using the suffix-based distribution
+        described in Brants (2000) section 2.3, smoothed by successive
+        abstraction and scored via Bayesian inversion.
+      - An external POS tagger may still be supplied via the ``unk``
+        parameter to override the suffix model, see __init__ function.
 
     * SHOULD BE USED WITH SENTENCE-DELIMITED INPUT
 
@@ -131,6 +134,13 @@ class TnT(TaggerI):
         self._uni_N = 0
         self._log2_N = 0.0
 
+        # Suffix model state for unknown words. Two tries split by word
+        # capitalization, plus the smoothing weight and tag priors used
+        # by the recursion at decode time.
+        self._suffix = {False: ConditionalFreqDist(), True: ConditionalFreqDist()}
+        self._tag_priors = {}
+        self._suffix_theta = 0.0
+
         self._unk = unk
 
         # statistical tools (ignore or delete me)
@@ -188,8 +198,56 @@ class TnT(TaggerI):
         self._uni_N = self._uni.N()
         self._log2_N = log2(self._N)
 
+        # Populate the suffix model used by the unknown-word path.
+        self._build_suffix_model()
+
         # Prevents repeat train() calls from retraining the optional unk tagger.
         self._T = True
+
+    def _build_suffix_model(self):
+        """
+        Populate the suffix tries, tag priors, and smoothing weight used by
+        the unknown-word model from Brants (2000), section 2.3.
+
+        Tag priors are over raw tags (summed across capitalization flags)
+        and exclude the EOS pseudo-tag. Suffix statistics are drawn only
+        from lexicon words with total count of 10 or fewer, matching the
+        paper's infrequent-words threshold.
+        """
+        # Tag priors over raw tags (excluding EOS), P(t) = f(t) / sum_t' f(t')
+        tag_counts = {}
+        for (t, _C), count in self._uni.items():
+            if t == "EOS":
+                continue
+            tag_counts[t] = tag_counts.get(t, 0) + count
+        total = sum(tag_counts.values())
+        if total > 0:
+            self._tag_priors = {t: c / total for t, c in tag_counts.items()}
+        else:
+            self._tag_priors = {}
+
+        # theta is the standard deviation of the unconditioned tag priors.
+        # This is the sample standard deviation per the paper's formula.
+        priors = list(self._tag_priors.values())
+        n = len(priors)
+        if n > 1:
+            mean = sum(priors) / n
+            self._suffix_theta = (sum((p - mean) ** 2 for p in priors) / (n - 1)) ** 0.5
+        else:
+            self._suffix_theta = 0.0
+
+        # Build the two suffix tries from infrequent lexicon words only.
+        self._suffix = {False: ConditionalFreqDist(), True: ConditionalFreqDist()}
+        for word in self._wd.conditions():
+            if self._wd[word].N() > 10:
+                continue
+            cap = word[0].isupper()
+            trie = self._suffix[cap]
+            max_m = min(len(word), 10)
+            for m in range(1, max_m + 1):
+                suffix = word[-m:]
+                for t, count in self._wd[word].items():
+                    trie[suffix][t] += count
 
     def _compute_lambda(self):
         """
@@ -286,6 +344,85 @@ class TnT(TaggerI):
         else:
             return v1 / v2
 
+    def _unknown_tag_scores(self, word):
+        """
+        Score candidate tags for an unknown word using the suffix model
+        from Brants (2000), section 2.3, with successive abstraction and
+        Bayesian inversion.
+
+        Starts from the unigram tag prior and absorbs one extra suffix
+        character at a time up to the longest known suffix (capped at
+        10 characters). The smoothing recursion is
+
+            P(t | l_{n-i+1}...l_n) = (P_hat + theta * P_prev) / (1 + theta)
+
+        Returns a mapping from raw tag to P(suffix | t) up to a constant.
+        The constant P(suffix) is dropped because it does not depend on
+        the tag and therefore does not affect the argmax. Tags with zero
+        prior are omitted.
+        """
+        if not self._tag_priors:
+            return {}
+
+        cap = word[0].isupper()
+        trie = self._suffix[cap]
+        theta = self._suffix_theta
+
+        # Find the longest known suffix by scanning from 10 down to 1.
+        # If none is found, the loop below leaves P at the unigram prior.
+        longest = 0
+        for m in range(min(len(word), 10), 0, -1):
+            if word[-m:] in trie:
+                longest = m
+                break
+
+        # Successive abstraction from the prior up to the longest suffix.
+        P = dict(self._tag_priors)
+        denom = 1.0 + theta
+        for i in range(1, longest + 1):
+            suffix_dist = trie[word[-i:]]
+            suffix_N = suffix_dist.N()
+            if suffix_N == 0:
+                continue
+            inv_N = 1.0 / suffix_N
+            P = {
+                t: (suffix_dist[t] * inv_N + theta * P[t]) / denom
+                for t in self._tag_priors
+            }
+
+        # Apply Bayesian inversion so the result ranks by P(suffix | t),
+        # which is proportional to P(t | suffix) / P(t).
+        return {t: P[t] / prior for t, prior in self._tag_priors.items() if prior > 0}
+
+    def _expand_beam(self, current_states, tag_info):
+        """
+        Expand each state in the beam over every candidate in tag_info.
+
+        tag_info is a list of (tC, p_uni, log_emit) triples where tC is
+        the candidate (tag, C) pair, p_uni is its unigram probability,
+        and log_emit is the per-tag emission term already in log2 space.
+        The transition uses the same deleted interpolation as everywhere
+        else, floored before log2 to avoid log(0) on an all-zero context.
+
+        Used by both the known-word and the suffix-based unknown-word
+        paths so the inner expansion only lives in one place.
+        """
+        l1, l2, l3 = self._l1, self._l2, self._l3
+        bi, tri = self._bi, self._tri
+        new_states = []
+        for history, curr_logp in current_states:
+            bi_dist = bi[history[-1]]
+            tri_dist = tri[(history[-2], history[-1])]
+            bi_N = bi_dist.N()
+            tri_N = tri_dist.N()
+            inv_bi = (1.0 / bi_N) if bi_N else 0.0
+            inv_tri = (1.0 / tri_N) if tri_N else 0.0
+            for tC, p_uni, log_emit in tag_info:
+                p = l1 * p_uni + l2 * bi_dist[tC] * inv_bi + l3 * tri_dist[tC] * inv_tri
+                lp = (log2(p) if p > 1e-300 else _LOG_FLOOR_2) + log_emit
+                new_states.append((history + [tC], curr_logp + lp))
+        return new_states
+
     def tagdata(self, data):
         """
         Tags each sentence in a list of sentences
@@ -381,37 +518,39 @@ class TnT(TaggerI):
                     p_uni = (uni_tC / uni_N) if uni_N else 0
                     tag_info.append((tC, p_uni, log2(wc / uni_tC)))
 
-                # Per-history hoists fetch the bi/tri dists and their sizes once per history iteration.
-                for history, curr_logp in current_states:
-                    bi_dist = bi[history[-1]]
-                    tri_dist = tri[(history[-2], history[-1])]
-                    bi_N = bi_dist.N()
-                    tri_N = tri_dist.N()
-                    inv_bi = (1.0 / bi_N) if bi_N else 0.0
-                    inv_tri = (1.0 / tri_N) if tri_N else 0.0
-                    for tC, p_uni, log_p_wd in tag_info:
-                        p = (
-                            l1 * p_uni
-                            + l2 * bi_dist[tC] * inv_bi
-                            + l3 * tri_dist[tC] * inv_tri
-                        )
-                        # Floor p so log2() is safe when all three n-gram components are zero for this (tag | context).
-                        lp = (log2(p) if p > 1e-300 else _LOG_FLOOR_2) + log_p_wd
-                        new_states.append((history + [tC], curr_logp + lp))
+                new_states = self._expand_beam(current_states, tag_info)
 
             else:
                 self.unknown += 1
 
-                # external tagger if provided, otherwise emit the literal tag "Unk"
-                if self._unk is None:
-                    tag = ("Unk", C)
-                else:
+                if self._unk is not None:
+                    # External unk tagger overrides the suffix model.
                     [(_w, t)] = self._unk.tag([word])
                     tag = (t, C)
-
-                for history, _ in current_states:
-                    history.append(tag)
-                new_states = current_states
+                    for history, _ in current_states:
+                        history.append(tag)
+                    new_states = current_states
+                else:
+                    # Score this unknown word against every candidate tag
+                    # using the Bayes-inverted suffix posterior, then
+                    # expand the beam the same way the known-word path does.
+                    tag_scores = self._unknown_tag_scores(word)
+                    if not tag_scores:
+                        # Fall back to a literal "Unk" tag when there is
+                        # no prior to score against, for example when the
+                        # tagger has not been trained.
+                        tag = ("Unk", C)
+                        for history, _ in current_states:
+                            history.append(tag)
+                        new_states = current_states
+                    else:
+                        tag_info = []
+                        for t, score in tag_scores.items():
+                            tC = (t, C)
+                            p_uni = (uni[tC] / uni_N) if uni_N else 0
+                            log_score = log2(score) if score > 1e-300 else _LOG_FLOOR_2
+                            tag_info.append((tC, p_uni, log_score))
+                        new_states = self._expand_beam(current_states, tag_info)
 
             # Sort by log prob and threshold-prune
             # drop states worse than the best by more than log2(N).
@@ -470,7 +609,6 @@ def basic_sent_chop(data, raw=True):
 
     new_data = []
     curr_sent = []
-    # Brants (2000) §2.1 lists [.!?;] as the sentence boundary set.
     sent_mark = [".", "!", "?", ";"]
 
     if raw:

--- a/nltk/tag/tnt.py
+++ b/nltk/tag/tnt.py
@@ -13,11 +13,14 @@ by Thorsten Brants
 https://aclanthology.org/A00-1031.pdf
 """
 
-from math import log
+from math import log2
 from operator import itemgetter
 
 from nltk.probability import ConditionalFreqDist, FreqDist
 from nltk.tag.api import TaggerI
+
+# Returned in place of log2(p) when p is zero; log2(1e-300) ~= -996.58.
+_LOG_FLOOR_2 = log2(1e-300)
 
 
 class TnT(TaggerI):
@@ -124,6 +127,10 @@ class TnT(TaggerI):
         self._C = C
         self._T = Trained
 
+        # cached after train() for the decode hot path
+        self._uni_N = 0
+        self._log2_N = 0.0
+
         self._unk = unk
 
         # statistical tools (ignore or delete me)
@@ -166,8 +173,8 @@ class TnT(TaggerI):
                 # set local flag C to false for the next word
                 C = False
 
-            # record EOS transition with deleted interpolation
-            # skip empty sentences to avoid attributing count to BOS
+            # Record EOS as a pseudo-tag in the n-gram counts. Empty sentences are skipped
+            # because their history[-1] is still BOS and would absorb the count.
             if sent:
                 eos = ("EOS", False)
                 self._uni[eos] += 1
@@ -177,8 +184,11 @@ class TnT(TaggerI):
         # compute lambda values from the trained frequency distributions
         self._compute_lambda()
 
-        # mark as trained so repeat train() calls don't retrain the
-        # optional unk tagger (see unk handling at the top of this method)
+        # cache constants used in the decode hot path
+        self._uni_N = self._uni.N()
+        self._log2_N = log2(self._N)
+
+        # Prevents repeat train() calls from retraining the optional unk tagger.
         self._T = True
 
     def _compute_lambda(self):
@@ -340,91 +350,96 @@ class TnT(TaggerI):
                                 associated with each tag combination
         :type current_states  : [([tag, ], logprob), ]
 
-        Tags the first word in the sentence and
-        recursively tags the reminder of sentence
+        Iteratively tags each word in the sentence, maintaining a beam of
+        candidate tag sequences and their log probabilities. After the last
+        word, scores the EOS transition and returns the best path.
 
         Uses formula specified above to calculate the probability
-        of a particular tag
+        of a particular tag.
         """
 
-        # if word marks end of sentence, score the EOS transition with the
-        # same deleted interpolation used for normal tags and return best path
-        if sent == []:
-            eos = ("EOS", False)
-            p_uni = self._uni.freq(eos)
-            best_h, best_logp = current_states[0][0], None
-            for history, logp in current_states:
-                p_bi = self._bi[history[-1]].freq(eos)
-                p_tri = self._tri[tuple(history[-2:])].freq(eos)
-                p = self._l1 * p_uni + self._l2 * p_bi + self._l3 * p_tri
-                logp += log(max(p, 1e-300), 2)
-                if best_logp is None or logp > best_logp:
-                    best_h, best_logp = history, logp
-            return best_h
+        # local bindings avoid repeated attribute lookups in the hot loop
+        wd = self._wd
+        bi = self._bi
+        tri = self._tri
+        uni = self._uni
+        uni_N = self._uni_N
+        l1, l2, l3 = self._l1, self._l2, self._l3
+        log2_N = self._log2_N
+        cap_on = self._C
 
-        # otherwise there are more words to be tagged
-        word = sent[0]
-        sent = sent[1:]
-        new_states = []
+        for word in sent:
+            new_states = []
+            C = cap_on and word[0].isupper()
 
-        # if the Capitalisation is requested,
-        # initialise the flag for this word
-        C = False
-        if self._C and word[0].isupper():
-            C = True
+            # if word is known, expand each state by each tag seen with it
+            if word in wd:
+                self.known += 1
+                wd_word = wd[word]
 
-        # if word is known
-        # compute the set of possible tags
-        # and their associated log probabilities
-        if word in self._wd:
-            self.known += 1
-
-            for history, curr_sent_logprob in current_states:
-                for t in self._wd[word].keys():
+                # Per-tag constants depend on the candidate tag, not on the history being extended.
+                tag_info = []
+                for t, wc in wd_word.items():
                     tC = (t, C)
-                    p_uni = self._uni.freq(tC)
-                    p_bi = self._bi[history[-1]].freq(tC)
-                    p_tri = self._tri[tuple(history[-2:])].freq(tC)
-                    p_wd = self._wd[word][t] / self._uni[tC]
-                    p = self._l1 * p_uni + self._l2 * p_bi + self._l3 * p_tri
-                    p2 = log(max(p, 1e-300), 2) + log(p_wd, 2)
+                    uni_tC = uni[tC]
+                    p_uni = (uni_tC / uni_N) if uni_N else 0
+                    tag_info.append((tC, p_uni, log2(wc / uni_tC)))
 
-                    # compute the result of appending each tag to this history
-                    new_states.append((history + [tC], curr_sent_logprob + p2))
+                # Per-history hoists fetch the bi/tri dists and their sizes once per history iteration.
+                for history, curr_logp in current_states:
+                    bi_dist = bi[history[-1]]
+                    tri_dist = tri[(history[-2], history[-1])]
+                    bi_N = bi_dist.N()
+                    tri_N = tri_dist.N()
+                    inv_bi = (1.0 / bi_N) if bi_N else 0.0
+                    inv_tri = (1.0 / tri_N) if tri_N else 0.0
+                    for tC, p_uni, log_p_wd in tag_info:
+                        p = (
+                            l1 * p_uni
+                            + l2 * bi_dist[tC] * inv_bi
+                            + l3 * tri_dist[tC] * inv_tri
+                        )
+                        # Floor p so log2() is safe when all three n-gram components are zero for this (tag | context).
+                        lp = (log2(p) if p > 1e-300 else _LOG_FLOOR_2) + log_p_wd
+                        new_states.append((history + [tC], curr_logp + lp))
 
-        # otherwise a new word, set of possible tags is unknown
-        else:
-            self.unknown += 1
-
-            # if no unknown word tagger has been specified
-            # then use the tag 'Unk'
-            if self._unk is None:
-                tag = ("Unk", C)
-
-            # otherwise apply the unknown word tagger
             else:
-                [(_w, t)] = list(self._unk.tag([word]))
-                tag = (t, C)
+                self.unknown += 1
 
-            for history, _ in current_states:
-                history.append(tag)
+                # external tagger if provided, otherwise emit the literal tag "Unk"
+                if self._unk is None:
+                    tag = ("Unk", C)
+                else:
+                    [(_w, t)] = self._unk.tag([word])
+                    tag = (t, C)
 
-            new_states = current_states
+                for history, _ in current_states:
+                    history.append(tag)
+                new_states = current_states
 
-        # now have computed a set of possible new_states
+            # Sort by log prob and threshold-prune
+            # drop states worse than the best by more than log2(N).
+            new_states.sort(reverse=True, key=itemgetter(1))
+            cutoff = new_states[0][1] - log2_N
+            current_states = [s for s in new_states if s[1] >= cutoff]
 
-        # sort states by log prob
-        # set is now ordered greatest to least log probability
-        new_states.sort(reverse=True, key=itemgetter(1))
-
-        # drop states worse than the best by more than log2(N)
-        best_logp = new_states[0][1]
-        cutoff = best_logp - log(self._N, 2)
-        new_states = [s for s in new_states if s[1] >= cutoff]
-
-        # compute the tags for the rest of the sentence
-        # return the best list of tags for the sentence
-        return self._tagword(sent, new_states)
+        # Score the EOS transition with the same deleted interpolation used for every tag, then return the best path.
+        eos = ("EOS", False)
+        p_uni_eos = (uni[eos] / uni_N) if uni_N else 0
+        best_h = current_states[0][0]
+        best_logp = float("-inf")
+        for history, logp in current_states:
+            bi_dist = bi[history[-1]]
+            tri_dist = tri[(history[-2], history[-1])]
+            bi_N = bi_dist.N()
+            tri_N = tri_dist.N()
+            p_bi = (bi_dist[eos] / bi_N) if bi_N else 0
+            p_tri = (tri_dist[eos] / tri_N) if tri_N else 0
+            p = l1 * p_uni_eos + l2 * p_bi + l3 * p_tri
+            logp += log2(p) if p > 1e-300 else _LOG_FLOOR_2
+            if logp > best_logp:
+                best_h, best_logp = history, logp
+        return best_h
 
 
 ########################################

--- a/nltk/tag/tnt.py
+++ b/nltk/tag/tnt.py
@@ -7,7 +7,7 @@
 # For license information, see LICENSE.TXT
 
 """
-Implementation of 'TnT - A Statisical Part of Speech Tagger'
+Implementation of 'TnT - A Statistical Part of Speech Tagger'
 by Thorsten Brants
 
 https://aclanthology.org/A00-1031.pdf
@@ -20,6 +20,12 @@ from nltk.tag.api import TaggerI
 
 # Returned in place of log2(p) when p is zero; log2(1e-300) ~= -996.58.
 _LOG_FLOOR_2 = log2(1e-300)
+
+# Sentinel tags used at sentence boundaries.
+_BOS = ("BOS", False)
+_EOS = ("EOS", False)
+
+_SENT_MARKS = (".", "!", "?", ";")
 
 
 class TnT(TaggerI):
@@ -89,124 +95,113 @@ class TnT(TaggerI):
 
     def __init__(self, unk=None, Trained=False, N=1000, C=False):
         """
-        Construct a TnT statistical tagger. Tagger must be trained
-        before being used to tag input.
+        Construct a TnT statistical tagger. The tagger must be trained
+        before it can be used to tag input.
 
-        :param unk: instance of a POS tagger, conforms to TaggerI
+        :param unk: instance of a POS tagger, conforms to TaggerI.
+                    When supplied, overrides the built-in suffix model
+                    on the unknown-word path.
         :type  unk: TaggerI
-        :param Trained: Indication that the POS tagger is trained or not
+        :param Trained: Indication that the POS tagger is trained or not.
+                        Set True to skip training the optional ``unk``
+                        tagger on the next train() call.
         :type  Trained: bool
-        :param N: Beam search pruning threshold
+        :param N: Beam search pruning threshold. After each Viterbi
+                  step any state whose log-probability is worse than
+                  the best by more than a factor of N is discarded.
+                  1000 is a good default.
         :type  N: int
-        :param C: Capitalization flag
+        :param C: Capitalization flag. When True, tags are differentiated
+                  by whether the source word is capitalized. This rarely
+                  improves accuracy in practice.
         :type  C: bool
-
-        Initializer, creates frequency distributions to be used
-        for tagging
-
-        _lx values represent the portion of the tri/bi/uni taggers
-        to be used to calculate the probability
-
-        N is the beam search pruning threshold: after scoring, any state
-        whose probability is worse than the best by more than a factor of
-        N is discarded. A good value for this is 1000.
-
-        C is a boolean value which specifies to use or
-        not use the Capitalization of the word as additional
-        information for tagging.
-        NOTE: using capitalization may not increase the accuracy
-        of the tagger
         """
 
-        self._uni = FreqDist()
-        self._bi = ConditionalFreqDist()
-        self._tri = ConditionalFreqDist()
-        self._wd = ConditionalFreqDist()
-        self._l1 = 0.0
-        self._l2 = 0.0
-        self._l3 = 0.0
-        self._N = N
-        self._C = C
-        self._T = Trained
+        self._tag_unigrams = FreqDist()
+        self._tag_bigrams = ConditionalFreqDist()
+        self._tag_trigrams = ConditionalFreqDist()
+        self._word_tag_freqs = ConditionalFreqDist()
+        self._lambda1 = 0.0
+        self._lambda2 = 0.0
+        self._lambda3 = 0.0
+        self._beam_threshold = N
+        self._use_capitalization = C
+        self._unk_trained = Trained
 
-        # cached after train() for the decode hot path
-        self._uni_N = 0
-        self._log2_N = 0.0
+        self._num_tag_tokens = 0
+        self._log2_beam_threshold = 0.0
 
         # Suffix model state for unknown words. Two tries split by word
         # capitalization, plus the smoothing weight and tag priors used
         # by the recursion at decode time.
-        self._suffix = {False: ConditionalFreqDist(), True: ConditionalFreqDist()}
-        self._tag_priors = {}
-        self._suffix_theta = 0.0
+        self._suffix_trie_by_cap = {
+            False: ConditionalFreqDist(),
+            True: ConditionalFreqDist(),
+        }
+        self._tag_prior_probs = {}
+        self._theta = 0.0
 
         self._unk = unk
 
-        # Memoizes per-word `tag_info` for the decode hot path. Cleared
-        # at the start of `train()` because the model state it derives
-        # from changes there. Keyed by `(word, capitalization_flag)`.
-        self._tag_info_cache = {}
+        # Cleared on train because model state changes.
+        self._candidate_tags_cache = {}
 
-        # statistical tools (ignore or delete me)
         self.unknown = 0
         self.known = 0
 
     def train(self, data):
         """
-        Uses a set of tagged data to train the tagger.
-        If an unknown word tagger is specified,
-        it is trained on the same data.
+        Trains the tagger on a list of tagged sentences. If an external
+        unknown-word tagger was passed via ``unk``, it is trained on the
+        same data on the first call only. Resets the decode cache and
+        populates the n-gram counts, the suffix model, and the
+        deleted-interpolation weights.
 
-        :param data: List of lists of (word, tag) tuples
-        :type data: tuple(str)
+        :param data: list of lists of (word, tag) tuples
+        :type  data: list[list[tuple[str, str]]]
         """
 
         # The decode cache is keyed off post-train state, so a fresh
         # train() invalidates every entry.
-        self._tag_info_cache.clear()
+        self._candidate_tags_cache.clear()
 
-        if self._unk is not None and not self._T:
+        if self._unk is not None and not self._unk_trained:
             self._unk.train(data)
 
-        # local bindings save repeated attribute lookups across the corpus
-        wd = self._wd
-        uni = self._uni
-        bi = self._bi
-        tri = self._tri
-        cap_on = self._C
+        wd = self._word_tag_freqs
+        uni = self._tag_unigrams
+        bi = self._tag_bigrams
+        tri = self._tag_trigrams
+        cap_on = self._use_capitalization
 
         for sent in data:
-            history = [("BOS", False), ("BOS", False)]
+            state_i_minus_2 = _BOS
+            state_i_minus_1 = _BOS
             for w, t in sent:
-                C = cap_on and w[0].isupper()
-                tC = (t, C)
+                c_i = cap_on and w[0].isupper()
+                state_i = (t, c_i)
                 wd[w][t] += 1
-                uni[tC] += 1
-                bi[history[1]][tC] += 1
-                tri[(history[0], history[1])][tC] += 1
+                uni[state_i] += 1
+                bi[state_i_minus_1][state_i] += 1
+                tri[(state_i_minus_2, state_i_minus_1)][state_i] += 1
+                state_i_minus_2, state_i_minus_1 = state_i_minus_1, state_i
 
-                history[0], history[1] = history[1], tC
-
-            # Record EOS as a pseudo-tag in the n-gram counts. Empty sentences are skipped
-            # because their history[-1] is still BOS and would absorb the count.
+            # Record EOS as a pseudo-tag in the n-gram counts. Skip empty
+            # sentences so we don't add an EOS count to the BOS state.
             if sent:
-                eos = ("EOS", False)
-                uni[eos] += 1
-                bi[history[-1]][eos] += 1
-                tri[tuple(history)][eos] += 1
+                uni[_EOS] += 1
+                bi[state_i_minus_1][_EOS] += 1
+                tri[(state_i_minus_2, state_i_minus_1)][_EOS] += 1
 
-        # compute lambda values from the trained frequency distributions
         self._compute_lambda()
 
-        # cache constants used in the decode hot path
-        self._uni_N = self._uni.N()
-        self._log2_N = log2(self._N)
+        self._num_tag_tokens = self._tag_unigrams.N()
+        self._log2_beam_threshold = log2(self._beam_threshold)
 
-        # Populate the suffix model used by the unknown-word path.
         self._build_suffix_model()
 
         # Prevents repeat train() calls from retraining the optional unk tagger.
-        self._T = True
+        self._unk_trained = True
 
     def _build_suffix_model(self):
         """
@@ -224,79 +219,82 @@ class TnT(TaggerI):
         """
         # Tag priors over raw tags (excluding EOS), P(t) = f(t) / sum_t' f(t')
         tag_counts = {}
-        for (t, _C), count in self._uni.items():
+        for (t, _), count in self._tag_unigrams.items():
             if t == "EOS":
                 continue
             tag_counts[t] = tag_counts.get(t, 0) + count
         total = sum(tag_counts.values())
         if total > 0:
-            self._tag_priors = {t: c / total for t, c in tag_counts.items()}
+            self._tag_prior_probs = {t: c / total for t, c in tag_counts.items()}
         else:
-            self._tag_priors = {}
+            self._tag_prior_probs = {}
 
         # theta is the standard deviation of the unconditioned tag priors.
         # This is the sample standard deviation per the paper's formula.
-        priors = list(self._tag_priors.values())
+        priors = list(self._tag_prior_probs.values())
         n = len(priors)
         if n > 1:
             mean = sum(priors) / n
-            self._suffix_theta = (sum((p - mean) ** 2 for p in priors) / (n - 1)) ** 0.5
+            self._theta = (sum((p - mean) ** 2 for p in priors) / (n - 1)) ** 0.5
         else:
-            self._suffix_theta = 0.0
+            self._theta = 0.0
 
         # Build the two suffix tries from infrequent lexicon words only.
-        self._suffix = {False: ConditionalFreqDist(), True: ConditionalFreqDist()}
-        for word in self._wd.conditions():
-            wd_word = self._wd[word]
-            if wd_word.N() > 10:
+        self._suffix_trie_by_cap = {
+            False: ConditionalFreqDist(),
+            True: ConditionalFreqDist(),
+        }
+        for word in self._word_tag_freqs.conditions():
+            word_tag_freqs = self._word_tag_freqs[word]
+            if word_tag_freqs.N() > 10:
                 continue
-            trie = self._suffix[word[0].isupper()]
+            trie = self._suffix_trie_by_cap[word[0].isupper()]
             for m in range(1, min(len(word), 10) + 1):
                 trie_suffix = trie[word[-m:]]
-                for t, count in wd_word.items():
+                for t, count in word_tag_freqs.items():
                     trie_suffix[t] += count
 
     def _compute_lambda(self):
         """
-        Compute the linear interpolation weights l1, l2, l3 via deleted interpolation.
+        Computes the deleted-interpolation weights l1, l2, l3 from the
+        observed tag n-grams. Tied maxima split the trigram count evenly
+        among the winning lambdas. Branches with a zero denominator
+        contribute zero.
 
-        For each tag trigram (t1, t2, t3) with positive count, compute
-        three deleted estimates
+        For each trigram (t1, t2, t3) with positive count we compare
 
             c1 = (f(t3) - 1) / (N - 1)
             c2 = (f(t2, t3) - 1) / (f(t2) - 1)
             c3 = (f(t1, t2, t3) - 1) / (f(t1, t2) - 1)
-
-        and add the trigram's count to the lambda corresponding to the
-        largest c. When two or three c values tie at the maximum, the
-        count is split equally among the tied lambdas.
         """
 
-        # temporary lambda variables
-        tl1 = 0.0
-        tl2 = 0.0
-        tl3 = 0.0
+        lambda1_mass = 0.0
+        lambda2_mass = 0.0
+        lambda3_mass = 0.0
 
-        bi = self._bi
-        uni = self._uni
-        uni_n_minus_1 = uni.N() - 1
+        tag_bigrams = self._tag_bigrams
+        tag_unigrams = self._tag_unigrams
+        unigram_n_minus_1 = tag_unigrams.N() - 1
 
-        # for each t1,t2 in system
-        for history in self._tri.conditions():
+        for history in self._tag_trigrams.conditions():
             _, h2 = history
-            tri_dist = self._tri[history]
-            tri_n_minus_1 = tri_dist.N() - 1
-            bi_dist = bi[h2]
-            bi_n_minus_1 = bi_dist.N() - 1
+            trigram_dist = self._tag_trigrams[history]
+            trigram_n_minus_1 = trigram_dist.N() - 1
+            bigram_dist = tag_bigrams[h2]
+            bigram_n_minus_1 = bigram_dist.N() - 1
 
-            # for each t3 given t1,t2 in system
-            for tC, count in tri_dist.items():
-                # Deleted estimates per Brants Figure 1. Each branch falls
-                # back to 0 when its denominator is zero, which mirrors
-                # the original `_safe_div` semantics.
-                c3 = (count - 1) / tri_n_minus_1 if tri_n_minus_1 else 0
-                c2 = (bi_dist[tC] - 1) / bi_n_minus_1 if bi_n_minus_1 else 0
-                c1 = (uni[tC] - 1) / uni_n_minus_1 if uni_n_minus_1 else 0
+            for state_i, count in trigram_dist.items():
+                c3 = (count - 1) / trigram_n_minus_1 if trigram_n_minus_1 else 0
+                c2 = (
+                    (bigram_dist[state_i] - 1) / bigram_n_minus_1
+                    if bigram_n_minus_1
+                    else 0
+                )
+                c1 = (
+                    (tag_unigrams[state_i] - 1) / unigram_n_minus_1
+                    if unigram_n_minus_1
+                    else 0
+                )
 
                 # Split the trigram's count equally among the lambdas
                 # whose c value ties for the maximum.
@@ -306,17 +304,16 @@ class TnT(TaggerI):
                 w3 = c3 == maxc
                 share = count / (w1 + w2 + w3)
                 if w1:
-                    tl1 += share
+                    lambda1_mass += share
                 if w2:
-                    tl2 += share
+                    lambda2_mass += share
                 if w3:
-                    tl3 += share
+                    lambda3_mass += share
 
-        # Lambda normalisation:
-        # ensures that l1+l2+l3 = 1
-        self._l1 = tl1 / (tl1 + tl2 + tl3)
-        self._l2 = tl2 / (tl1 + tl2 + tl3)
-        self._l3 = tl3 / (tl1 + tl2 + tl3)
+        total_mass = lambda1_mass + lambda2_mass + lambda3_mass
+        self._lambda1 = lambda1_mass / total_mass
+        self._lambda2 = lambda2_mass / total_mass
+        self._lambda3 = lambda3_mass / total_mass
 
     def _unknown_tag_scores(self, word):
         """
@@ -342,12 +339,13 @@ class TnT(TaggerI):
                  preserves the argmax without computing it. Tags with
                  zero prior are omitted.
         """
-        if not self._tag_priors:
+        tag_priors = self._tag_prior_probs
+        if not tag_priors:
             return {}
 
-        cap = word[0].isupper()
-        trie = self._suffix[cap]
-        theta = self._suffix_theta
+        is_capitalized = word[0].isupper()
+        trie = self._suffix_trie_by_cap[is_capitalized]
+        theta = self._theta
 
         # Find the longest known suffix by scanning from 10 down to 1.
         # If none is found, the loop below leaves P at the unigram prior.
@@ -358,8 +356,8 @@ class TnT(TaggerI):
                 break
 
         # Successive abstraction from the prior up to the longest suffix.
-        # Update P in place since we only touch existing keys.
-        P = dict(self._tag_priors)
+        # Update in place since we only touch existing keys.
+        p_t_given_suffix = dict(tag_priors)
         denom = 1.0 + theta
         for i in range(1, longest + 1):
             suffix_dist = trie[word[-i:]]
@@ -367,67 +365,85 @@ class TnT(TaggerI):
             if suffix_N == 0:
                 continue
             inv_N = 1.0 / suffix_N
-            for t in self._tag_priors:
-                P[t] = (suffix_dist[t] * inv_N + theta * P[t]) / denom
+            for t in tag_priors:
+                p_t_given_suffix[t] = (
+                    suffix_dist[t] * inv_N + theta * p_t_given_suffix[t]
+                ) / denom
 
         # Apply Bayesian inversion so the result ranks by P(suffix | t),
         # which is proportional to P(t | suffix) / P(t).
-        return {t: P[t] / prior for t, prior in self._tag_priors.items() if prior > 0}
+        return {
+            t: p_t_given_suffix[t] / prior
+            for t, prior in tag_priors.items()
+            if prior > 0
+        }
 
-    def _expand_states(self, states, tag_info):
+    def _expand_states(self, states, candidate_tags):
         """
-        Take one Viterbi step. For every predecessor state we score
-        each candidate `t_curr` from `tag_info` and accumulate the
-        results into a new state dict keyed by `(t_prev, t_curr)`.
-        When two predecessors land on the same key we keep the
-        higher-scoring one and discard the other. The second-order
-        Markov assumption means everything after this point depends
-        only on the last two tags, so the discarded path can never
-        beat the kept one.
+        Takes one Viterbi step. For every predecessor state we score
+        each candidate `state_i` from `candidate_tags` and accumulate
+        the results into a new state dict keyed by
+        `(state_i_minus_1, state_i)`. When two predecessors land on
+        the same key we keep the higher-scoring one and discard the
+        other. The second-order Markov assumption means everything
+        after this point depends only on the last two states, so the
+        discarded path can never beat the kept one.
 
-        `tag_info` is a list of `(tC, p_uni, log_emit)` triples for
-        the candidate `t_curr` values. Transitions use the same
-        deleted interpolation as on the known-word path, floored
-        before log2 to avoid blowing up on an all-zero context.
+        `candidate_tags` is a sequence of `(state_i, p_state_i,
+        log_emit)` triples. Transitions use the same deleted
+        interpolation as on the known-word path, floored before log2
+        to avoid blowing up on an all-zero context.
 
-        :return: dict mapping `(t_prev, t_curr)` to `(logp, t_prev2)`.
-                 `t_prev2` is the backpointer used to reconstruct the
-                 best path after the final EOS step.
+        :return: ``(new_states, best_logp)``. ``new_states`` maps
+                 `(state_i_minus_1, state_i)` to
+                 `(logp, state_i_minus_2)`, where `state_i_minus_2` is
+                 the backpointer used to reconstruct the best path
+                 after the final EOS step. `best_logp` is the maximum
+                 `logp` across `new_states`, returned so the caller
+                 can apply threshold pruning without a second pass.
         """
-        l1, l2, l3 = self._l1, self._l2, self._l3
-        bi, tri = self._bi, self._tri
+        l1, l2, l3 = self._lambda1, self._lambda2, self._lambda3
+        bi, tri = self._tag_bigrams, self._tag_trigrams
         new_states = {}
-        for (t_prev2, t_prev), (curr_logp, _) in states.items():
-            bi_dist = bi[t_prev]
-            tri_dist = tri[(t_prev2, t_prev)]
+        best_logp = float("-inf")
+        for (state_i_minus_2, state_i_minus_1), (curr_logp, _) in states.items():
+            bi_dist = bi[state_i_minus_1]
+            tri_dist = tri[(state_i_minus_2, state_i_minus_1)]
             bi_N = bi_dist.N()
             tri_N = tri_dist.N()
             inv_bi = (1.0 / bi_N) if bi_N else 0.0
             inv_tri = (1.0 / tri_N) if tri_N else 0.0
-            for tC, p_uni, log_emit in tag_info:
-                p = l1 * p_uni + l2 * bi_dist[tC] * inv_bi + l3 * tri_dist[tC] * inv_tri
-                lp = (log2(p) if p > 1e-300 else _LOG_FLOOR_2) + log_emit
+            for state_i, p_state_i, log_emit in candidate_tags:
+                p_state_i_given_history = (
+                    l1 * p_state_i
+                    + l2 * bi_dist[state_i] * inv_bi
+                    + l3 * tri_dist[state_i] * inv_tri
+                )
+                lp = (
+                    log2(p_state_i_given_history)
+                    if p_state_i_given_history > 1e-300
+                    else _LOG_FLOOR_2
+                ) + log_emit
                 total_logp = curr_logp + lp
-                new_key = (t_prev, tC)
+                if total_logp > best_logp:
+                    best_logp = total_logp
+                new_key = (state_i_minus_1, state_i)
                 existing = new_states.get(new_key)
                 if existing is None or total_logp > existing[0]:
-                    new_states[new_key] = (total_logp, t_prev2)
-        return new_states
+                    new_states[new_key] = (total_logp, state_i_minus_2)
+        return new_states, best_logp
 
     def tagdata(self, data, segment=False):
         """
-        Tags each sentence in a list of sentences
+        Tags a list of sentences. Each input sentence is a list of words;
+        each output sentence is a list of (word, tag) tuples.
 
-        :param data:list of list of words
-        :type data: [[string,],]
-        :param segment: forwarded to ``tag``; pass True to auto-split
-                        each input on internal [.!?;] punctuation
+        :param data: list of list of words
+        :type  data: list[list[str]]
+        :param segment: forwarded to ``tag``. Pass True to auto-split
+                        each input on internal [.!?;] punctuation.
         :type segment: bool
         :return: list of list of (word, tag) tuples
-
-        Invokes tag(sent) function for each sentence
-        compiles the results into a list of tagged sentences
-        each tagged sentence is a list of (word, tag) tuples
         """
         res = []
         for sent in data:
@@ -458,28 +474,34 @@ class TnT(TaggerI):
             return self._tag_segmented(tokens)
 
         sent = list(tokens)
-        tags = self._tagword(sent)
-        # Strip the [BOS, BOS] prefix and discard the per-tag capitalization flag.
-        return [(w, tag) for w, (tag, _) in zip(sent, tags[2:])]
+        if not sent:
+            return []
+        return self._pair_decoded(sent, self._tagword(sent))
 
     def _tag_segmented(self, tokens):
         """
-        Split `tokens` on [.!?;] and tag each segment as its own
+        Splits `tokens` on [.!?;] and tags each segment as its own
         sentence. Each sentence-final punctuation token stays inside
         the segment that ends with it. A trailing segment without a
         final punctuation is tagged on its own.
         """
-        sent_marks = (".", "!", "?", ";")
         res = []
         segment = []
         for tok in tokens:
             segment.append(tok)
-            if tok in sent_marks:
-                res.extend(self.tag(segment))
+            if tok in _SENT_MARKS:
+                res.extend(self._pair_decoded(segment, self._tagword(segment)))
                 segment = []
         if segment:
-            res.extend(self.tag(segment))
+            res.extend(self._pair_decoded(segment, self._tagword(segment)))
         return res
+
+    @staticmethod
+    def _pair_decoded(words, tags):
+        """Pair words with the tag part of each `_tagword` entry,
+        dropping the [BOS, BOS] prefix and the per-tag capitalization
+        flag."""
+        return [(w, t) for w, (t, _) in zip(words, tags[2:])]
 
     def _tagword(self, sent):
         """
@@ -491,31 +513,28 @@ class TnT(TaggerI):
 
         :param sent: words to tag
         :type sent: list[str]
-        :return: history list `[BOS, BOS, t_0, ..., t_{T-1}]` of
-                 `(tag, capitalization)` pairs.
+        :return: list shaped `[BOS, BOS, state_0, ..., state_{T-1}]`
+                 where each state is a `(tag, capitalization)` pair.
         """
-        BOS = ("BOS", False)
-        EOS = ("EOS", False)
-
         # local bindings avoid repeated attribute lookups in the hot loop
-        wd = self._wd
-        bi = self._bi
-        tri = self._tri
-        uni = self._uni
-        uni_N = self._uni_N
-        l1, l2, l3 = self._l1, self._l2, self._l3
-        log2_N = self._log2_N
-        cap_on = self._C
-        cache = self._tag_info_cache
+        word_tag_freqs = self._word_tag_freqs
+        tag_bigrams = self._tag_bigrams
+        tag_trigrams = self._tag_trigrams
+        tag_unigrams = self._tag_unigrams
+        num_tag_tokens = self._num_tag_tokens
+        l1, l2, l3 = self._lambda1, self._lambda2, self._lambda3
+        log2_beam_threshold = self._log2_beam_threshold
+        cap_on = self._use_capitalization
+        cache = self._candidate_tags_cache
 
-        # Viterbi states per level. Each level maps (tag_{i-1}, tag_i)
-        # to (logp, backpointer_tag_{i-2}).
-        states = {(BOS, BOS): (0.0, BOS)}
-        history = [states]
+        # Viterbi states per level. Each level maps (state_{i-1}, state_i)
+        # to (logp, backpointer_state_{i-2}).
+        states = {(_BOS, _BOS): (0.0, _BOS)}
+        state_history = [states]
 
         for word in sent:
-            C = cap_on and word[0].isupper()
-            wd_word = wd.get(word)
+            c_i = cap_on and word[0].isupper()
+            wd_word = word_tag_freqs.get(word)
             if wd_word is not None:
                 self.known += 1
             else:
@@ -524,24 +543,33 @@ class TnT(TaggerI):
             # External unk taggers may be stateful or context dependent,
             # so we evaluate them on every call rather than memoizing.
             # The known and suffix model paths are pure functions of
-            # `(word, C)` and the trained model state, so they cache.
+            # `(word, c_i)` and the trained model state, so they cache.
             if wd_word is None and self._unk is not None:
                 [(_w, t)] = self._unk.tag([word])
-                tC = (t, C)
-                p_uni = (uni[tC] / uni_N) if uni_N else 0
-                tag_info = [(tC, p_uni, 0.0)]
+                state_i = (t, c_i)
+                p_state_i = (
+                    (tag_unigrams[state_i] / num_tag_tokens) if num_tag_tokens else 0
+                )
+                candidate_tags = ((state_i, p_state_i, 0.0),)
             else:
-                key = (word, C)
-                tag_info = cache.get(key)
-                if tag_info is None:
+                key = (word, c_i)
+                candidate_tags = cache.get(key)
+                if candidate_tags is None:
                     if wd_word is not None:
                         # Per-tag constants depend only on the candidate tag.
-                        tag_info = []
+                        entries = []
                         for t, wc in wd_word.items():
-                            tC = (t, C)
-                            uni_tC = uni[tC]
-                            p_uni = (uni_tC / uni_N) if uni_N else 0
-                            tag_info.append((tC, p_uni, log2(wc / uni_tC)))
+                            state_i = (t, c_i)
+                            unigram_state_i = tag_unigrams[state_i]
+                            p_state_i = (
+                                (unigram_state_i / num_tag_tokens)
+                                if num_tag_tokens
+                                else 0
+                            )
+                            entries.append(
+                                (state_i, p_state_i, log2(wc / unigram_state_i))
+                            )
+                        candidate_tags = tuple(entries)
                     else:
                         # Score this unknown word against every candidate
                         # tag using the Bayes-inverted suffix posterior.
@@ -550,69 +578,82 @@ class TnT(TaggerI):
                             # Fall back to a literal "Unk" tag when there is
                             # no prior to score against, for example when
                             # the tagger has not been trained.
-                            tC = ("Unk", C)
-                            p_uni = (uni[tC] / uni_N) if uni_N else 0
-                            tag_info = [(tC, p_uni, 0.0)]
+                            state_i = ("Unk", c_i)
+                            p_state_i = (
+                                (tag_unigrams[state_i] / num_tag_tokens)
+                                if num_tag_tokens
+                                else 0
+                            )
+                            candidate_tags = ((state_i, p_state_i, 0.0),)
                         else:
-                            tag_info = []
+                            entries = []
                             for t, score in tag_scores.items():
-                                tC = (t, C)
-                                p_uni = (uni[tC] / uni_N) if uni_N else 0
+                                state_i = (t, c_i)
+                                p_state_i = (
+                                    (tag_unigrams[state_i] / num_tag_tokens)
+                                    if num_tag_tokens
+                                    else 0
+                                )
                                 log_score = (
                                     log2(score) if score > 1e-300 else _LOG_FLOOR_2
                                 )
-                                tag_info.append((tC, p_uni, log_score))
-                    cache[key] = tag_info
+                                entries.append((state_i, p_state_i, log_score))
+                            candidate_tags = tuple(entries)
+                    cache[key] = candidate_tags
 
-            new_states = self._expand_states(states, tag_info)
+            new_states, best_logp = self._expand_states(states, candidate_tags)
 
-            # Threshold prune: drop states worse than the best by more than log2(N).
-            best_logp = max(s[0] for s in new_states.values())
-            cutoff = best_logp - log2_N
+            # Threshold prune drops states worse than the best by more than log2(N).
+            cutoff = best_logp - log2_beam_threshold
             new_states = {k: v for k, v in new_states.items() if v[0] >= cutoff}
 
             states = new_states
-            history.append(states)
+            state_history.append(states)
 
         # Score the EOS transition with the same deleted interpolation
         # used for every other tag, then pick the best final state.
-        # `states` is non-empty by construction, so seeding the search
-        # with its first key keeps the type concrete.
-        p_uni_eos = (uni[EOS] / uni_N) if uni_N else 0
-        best_final_key = next(iter(states))
+        # `states` is non-empty by construction, so we seed with any
+        # key to avoid an Optional placeholder.
+        p_eos_unigram = (tag_unigrams[_EOS] / num_tag_tokens) if num_tag_tokens else 0
+        best_final_state = next(iter(states))
         best_final_logp = float("-inf")
-        for (t_prev2, t_prev), (curr_logp, _) in states.items():
-            bi_dist = bi[t_prev]
-            tri_dist = tri[(t_prev2, t_prev)]
-            bi_N = bi_dist.N()
-            tri_N = tri_dist.N()
-            p_bi = (bi_dist[EOS] / bi_N) if bi_N else 0
-            p_tri = (tri_dist[EOS] / tri_N) if tri_N else 0
-            p = l1 * p_uni_eos + l2 * p_bi + l3 * p_tri
-            eos_lp = log2(p) if p > 1e-300 else _LOG_FLOOR_2
+        for (state_i_minus_2, state_i_minus_1), (curr_logp, _) in states.items():
+            bigram_dist = tag_bigrams[state_i_minus_1]
+            trigram_dist = tag_trigrams[(state_i_minus_2, state_i_minus_1)]
+            bigram_N = bigram_dist.N()
+            trigram_N = trigram_dist.N()
+            p_bi = (bigram_dist[_EOS] / bigram_N) if bigram_N else 0
+            p_tri = (trigram_dist[_EOS] / trigram_N) if trigram_N else 0
+            p_eos_given_history = l1 * p_eos_unigram + l2 * p_bi + l3 * p_tri
+            eos_lp = (
+                log2(p_eos_given_history)
+                if p_eos_given_history > 1e-300
+                else _LOG_FLOOR_2
+            )
             final_logp = curr_logp + eos_lp
             if final_logp > best_final_logp:
                 best_final_logp = final_logp
-                best_final_key = (t_prev2, t_prev)
+                best_final_state = (state_i_minus_2, state_i_minus_1)
 
         # Reconstruct the best path by walking backpointers, collecting
-        # tags in reverse. At level L the key is (tag_{L-2}, tag_{L-1})
-        # and the stored backpointer is tag_{L-3}, so each iteration
-        # extends one tag toward the start of the sentence.
+        # states in reverse. At level L the key is
+        # (state_{L-2}, state_{L-1}) and the stored backpointer is
+        # state_{L-3}, so each iteration extends one state toward the
+        # start of the sentence.
         T = len(sent)
         if T == 0:
-            return [BOS, BOS]
+            return [_BOS, _BOS]
 
-        tags_reversed = [best_final_key[1]]
+        tags_reversed = [best_final_state[1]]
         if T >= 2:
-            tags_reversed.append(best_final_key[0])
-        current_key = best_final_key
+            tags_reversed.append(best_final_state[0])
+        current_key = best_final_state
         for level in range(T, 2, -1):
-            backpointer = history[level][current_key][1]
+            backpointer = state_history[level][current_key][1]
             tags_reversed.append(backpointer)
             current_key = (backpointer, current_key[0])
         tags_reversed.reverse()
-        return [BOS, BOS] + tags_reversed
+        return [_BOS, _BOS] + tags_reversed
 
 
 ########################################
@@ -647,18 +688,17 @@ def basic_sent_chop(data, raw=True):
 
     new_data = []
     curr_sent = []
-    sent_mark = [".", "!", "?", ";"]
 
     if raw:
         for word in data:
             curr_sent.append(word)
-            if word in sent_mark:
+            if word in _SENT_MARKS:
                 new_data.append(curr_sent)
                 curr_sent = []
     else:
         for word, tag in data:
             curr_sent.append((word, tag))
-            if word in sent_mark:
+            if word in _SENT_MARKS:
                 new_data.append(curr_sent)
                 curr_sent = []
 

--- a/nltk/tag/tnt.py
+++ b/nltk/tag/tnt.py
@@ -171,13 +171,14 @@ class TnT(TaggerI):
                 if self._C and w[0].isupper():
                     C = True
 
+                tC = (t, C)
                 self._wd[w][t] += 1
-                self._uni[(t, C)] += 1
-                self._bi[history[1]][(t, C)] += 1
-                self._tri[tuple(history)][(t, C)] += 1
+                self._uni[tC] += 1
+                self._bi[history[1]][tC] += 1
+                self._tri[(history[0], history[1])][tC] += 1
 
-                history.append((t, C))
-                history.pop(0)
+                history[0] = history[1]
+                history[1] = tC
 
                 # set local flag C to false for the next word
                 C = False
@@ -242,15 +243,14 @@ class TnT(TaggerI):
         # Build the two suffix tries from infrequent lexicon words only.
         self._suffix = {False: ConditionalFreqDist(), True: ConditionalFreqDist()}
         for word in self._wd.conditions():
-            if self._wd[word].N() > 10:
+            wd_word = self._wd[word]
+            if wd_word.N() > 10:
                 continue
-            cap = word[0].isupper()
-            trie = self._suffix[cap]
-            max_m = min(len(word), 10)
-            for m in range(1, max_m + 1):
-                suffix = word[-m:]
-                for t, count in self._wd[word].items():
-                    trie[suffix][t] += count
+            trie = self._suffix[word[0].isupper()]
+            for m in range(1, min(len(word), 10) + 1):
+                trie_suffix = trie[word[-m:]]
+                for t, count in wd_word.items():
+                    trie_suffix[t] += count
 
     def _compute_lambda(self):
         """
@@ -387,6 +387,7 @@ class TnT(TaggerI):
                 break
 
         # Successive abstraction from the prior up to the longest suffix.
+        # Update P in place since we only touch existing keys.
         P = dict(self._tag_priors)
         denom = 1.0 + theta
         for i in range(1, longest + 1):
@@ -395,10 +396,8 @@ class TnT(TaggerI):
             if suffix_N == 0:
                 continue
             inv_N = 1.0 / suffix_N
-            P = {
-                t: (suffix_dist[t] * inv_N + theta * P[t]) / denom
-                for t in self._tag_priors
-            }
+            for t in self._tag_priors:
+                P[t] = (suffix_dist[t] * inv_N + theta * P[t]) / denom
 
         # Apply Bayesian inversion so the result ranks by P(suffix | t),
         # which is proportional to P(t | suffix) / P(t).
@@ -444,12 +443,15 @@ class TnT(TaggerI):
                     new_states[new_key] = (total_logp, t_prev2)
         return new_states
 
-    def tagdata(self, data):
+    def tagdata(self, data, segment=False):
         """
         Tags each sentence in a list of sentences
 
         :param data:list of list of words
         :type data: [[string,],]
+        :param segment: forwarded to ``tag``; pass True to auto-split
+                        each input on internal [.!?;] punctuation
+        :type segment: bool
         :return: list of list of (word, tag) tuples
 
         Invokes tag(sent) function for each sentence
@@ -458,19 +460,32 @@ class TnT(TaggerI):
         """
         res = []
         for sent in data:
-            res1 = self.tag(sent)
+            res1 = self.tag(sent, segment=segment)
             res.append(res1)
         return res
 
-    def tag(self, tokens):
+    def tag(self, tokens, segment=False):
         """
         Tag a single sentence. Delegates the actual decode to
         `_tagword`, then pairs each chosen tag with its input token.
 
+        When `segment` is True, the input may contain mid-sequence
+        sentence punctuation [.!?;]. The decoder splits on those
+        tokens and re-seeds the BOS state for each segment.
+        The default is False because most NLTK callers pre-segment,
+        and auto-splitting on `.` would mis-handle abbreviations
+        like "Mr." in unsegmented input.
+
         :param tokens: words to tag
         :type tokens: list[str]
+        :param segment: split on [.!?;] and decode each segment with a
+                        fresh BOS state
+        :type segment: bool
         :return: list of `(word, tag)` tuples
         """
+        if segment:
+            return self._tag_segmented(tokens)
+
         sent = list(tokens)
         tags = self._tagword(sent)
         res = []
@@ -478,6 +493,25 @@ class TnT(TaggerI):
             # unpack and discard the C flags
             t, C = tags[i + 2]
             res.append((sent[i], t))
+        return res
+
+    def _tag_segmented(self, tokens):
+        """
+        Split `tokens` on [.!?;] and tag each segment as its own
+        sentence. Each sentence-final punctuation token stays inside
+        the segment that ends with it. A trailing segment without a
+        final punctuation is tagged on its own.
+        """
+        sent_marks = (".", "!", "?", ";")
+        res = []
+        segment = []
+        for tok in tokens:
+            segment.append(tok)
+            if tok in sent_marks:
+                res.extend(self.tag(segment))
+                segment = []
+        if segment:
+            res.extend(self.tag(segment))
         return res
 
     def _tagword(self, sent):
@@ -626,7 +660,7 @@ def basic_sent_chop(data, raw=True):
     This function can separate both tagged and raw sequences into
     basic sentences.
 
-    Sentence markers are the set of [,.!?]
+    Sentence markers are the set of [.!?;]
 
     This is a simple method which enhances the performance of the TnT
     tagger. Better sentence tokenization will further enhance the results.

--- a/nltk/tag/tnt.py
+++ b/nltk/tag/tnt.py
@@ -2,7 +2,7 @@
 #
 # Copyright (C) 2001-2026 NLTK Project
 # Author: Sam Huston <sjh900@gmail.com>
-# Major revisions: John Winstead <https://github.com/jhnwnstd>
+#         John Winstead <https://github.com/jhnwnstd>
 #
 # URL: <https://www.nltk.org/>
 # For license information, see LICENSE.TXT

--- a/nltk/tag/tnt.py
+++ b/nltk/tag/tnt.py
@@ -224,13 +224,8 @@ class TnT(TaggerI):
             # (NOTE: tag actually represents (tag,C))
             # However no effect within this function
             for tag in self._tri[history].keys():
-                # if there has only been 1 occurrence of this tag in the data
-                # then ignore this trigram.
-                if self._uni[tag] == 1:
-                    continue
-
                 # safe_div provides a safe floating point division
-                # it returns -1 if the denominator is 0
+                # it returns 0 if the denominator is 0
                 c3 = self._safe_div(
                     (self._tri[history][tag] - 1), (self._tri[history].N() - 1)
                 )
@@ -264,13 +259,14 @@ class TnT(TaggerI):
                     tl1 += self._tri[history][tag] / 2.0
                     tl3 += self._tri[history][tag] / 2.0
 
-                # if all three are equal (and not the safe_div -1 sentinel)
-                elif (c1 == c2) and (c2 == c3) and (c1 >= 0):
+                # if all three are equal
+                elif (c1 == c2) and (c2 == c3):
                     tl1 += self._tri[history][tag] / 3.0
                     tl2 += self._tri[history][tag] / 3.0
                     tl3 += self._tri[history][tag] / 3.0
 
-                # fallback for edge cases (all zero or sentinel values)
+                # otherwise there might be a problem
+                # eg: all values = 0
                 else:
                     pass
 
@@ -283,10 +279,10 @@ class TnT(TaggerI):
     def _safe_div(self, v1, v2):
         """
         Safe floating point division function, does not allow division by 0
-        returns -1 if the denominator is 0
+        returns 0 if the denominator is 0
         """
         if v2 == 0:
-            return -1
+            return 0
         else:
             return v1 / v2
 
@@ -474,7 +470,8 @@ def basic_sent_chop(data, raw=True):
 
     new_data = []
     curr_sent = []
-    sent_mark = [",", ".", "?", "!"]
+    # Brants (2000) §2.1 lists [.!?;] as the sentence boundary set.
+    sent_mark = [".", "!", "?", ";"]
 
     if raw:
         for word in data:

--- a/nltk/tag/tnt.py
+++ b/nltk/tag/tnt.py
@@ -47,103 +47,90 @@ def _safe_inverse(n):
 
 class TnT(TaggerI):
     """
-    TnT statistical POS tagger.
+    TnT statistical part of speech tagger.
 
-    TnT implements the second order hidden Markov model tagger described
-    by Brants (2000). Hidden states are part of speech tags, observed
-    symbols are word tokens, and each tag transition depends on the two
-    previous tag states.
+    This class implements the Trigrams'n'Tags tagger described by
+    Brants (2000). TnT is a second order hidden Markov model. Its
+    hidden states are part of speech tags, its observations are word
+    tokens, and each transition is conditioned on the two previous tag
+    states.
 
-    Important usage notes
+    Input
 
-    * Use sentence delimited input.
+    TnT estimates and scores sentence boundary transitions, so training
+    and tagging data should normally be sentence delimited.
 
-      TnT estimates and scores beginning of sentence and end of sentence
-      transitions. It works best when training and tagging data are already
-      split into sentences.
+    Training data should be a list of tagged sentences. Each sentence
+    should be a list of ``(word, tag)`` tuples.
 
-      Training input should be a list of sentences. Each sentence should
-      be a list of ``(word, tag)`` tuples.
+    ``tag()`` expects one tokenized sentence.
+    ``tagdata()`` expects a list of tokenized sentences.
 
-      ``tag()`` expects one tokenized sentence.
-      ``tagdata()`` expects a list of tokenized sentences.
-
-      For simple punctuation based segmentation of token streams, see
-      ``basic_sent_chop()``. It splits on the sentence final punctuation
-      used by Brants, namely ``.``, ``!``, ``?``, and ``;``.
-
-    * Unknown words use Brants's suffix model.
-
-      Words not observed during training are scored from suffix
-      distributions, as described in Brants (2000), section 2.3. The model
-      builds capitalization specific suffix tries from infrequent training
-      words, smooths suffix tag probabilities by successive abstraction,
-      and applies Bayesian inversion to obtain emission like scores.
-
-      A user supplied tagger may be passed with ``unk``. When supplied,
-      it overrides the built in suffix model for unknown words.
-
-    * Known words use a tag dictionary.
-
-      For a known word, candidate tags are restricted to the tags assigned
-      to that word in the training data. If a word was never seen with a
-      tag during training, that tag is not considered for that word at
-      decode time.
+    For simple punctuation based segmentation of token streams, use
+    ``basic_sent_chop()`` or pass ``segment=True`` to ``tag()``. The
+    punctuation tokens are ``.``, ``!``, ``?``, and ``;``, following
+    Brants's sentence boundary heuristic.
 
     Model
 
-      For a sentence of length ``T``, the decoder chooses the tag sequence
-      that maximizes
+    For a sentence of length ``T``, the decoder chooses the tag sequence
+    that maximizes
 
-          prod_i P(t_i | t_{i-1}, t_{i-2}) * P(w_i | t_i)
+        prod_i P(t_i | t_{i-1}, t_{i-2}) * P(w_i | t_i)
 
-      and then scores an explicit end of sentence transition
+    and then scores an explicit end of sentence transition. EOS is
+    recorded as an ordinary next state in the trained n-gram stream,
+    so its factor uses the same deleted interpolation as the body
+    transitions (unigram, bigram, and trigram tiers). This generalizes
+    Brants's printed factor ``P(t_{T+1} | t_T)``, which is bigram only.
 
-          P(EOS | t_{T-1}, t_T)
-
-      Decoding uses Viterbi search in log space over a trellis of
-      ``(t_{i-1}, t_i)`` state pairs.
-
-          argmax_{t_1..t_T} sum_i [
-              log P(t_i | t_{i-1}, t_{i-2})
-              + log P(w_i | t_i)
-          ] + log P(EOS | t_{T-1}, t_T)
+    Decoding runs in log space over a Viterbi trellis whose state is
+    the pair ``(t_{i-1}, t_i)``.
 
     Transition smoothing
 
-      The transition probability is a deleted interpolation of unigram,
-      bigram, and trigram tag models.
+    Transition probabilities use context independent deleted
+    interpolation of unigram, bigram, and trigram tag models.
 
-          P(t_i | t_{i-1}, t_{i-2})
-              = l1 * P(t_i)
-              + l2 * P(t_i | t_{i-1})
-              + l3 * P(t_i | t_{i-1}, t_{i-2})
+        P(t_i | t_{i-1}, t_{i-2})
+            = l1 * P(t_i)
+            + l2 * P(t_i | t_{i-1})
+            + l3 * P(t_i | t_{i-1}, t_{i-2})
 
-      The interpolation weights ``l1``, ``l2``, and ``l3`` are estimated
-      from the training data with the deleted interpolation procedure in
-      Brants (2000), section 2.2.
+    The interpolation weights ``l1``, ``l2``, and ``l3`` are estimated
+    from the training counts by the deleted interpolation procedure in
+    Brants (2000), section 2.2.
 
     Emissions
 
-      For known words, ``P(w_i | t_i)`` is the relative frequency of the
-      word and tag pair in the training lexicon.
+    Known words use a tag dictionary. For a known word, candidate tags
+    are restricted to the tags assigned to that word in the training
+    data. The emission probability is the relative frequency of the
+    word and tag pair in the training lexicon.
 
-      For unknown words, the emission like score is the Bayes inverted
-      suffix score described above.
+    Unknown words use Brants's suffix model by default. The model builds
+    capitalization specific suffix tries from infrequent training words,
+    using the threshold of at most 10 occurrences from Brants (2000),
+    section 2.3. At decode time it uses the longest suffix observed in
+    training, capped at 10 characters, smooths the suffix tag
+    distribution by successive abstraction, and applies Bayesian
+    inversion to obtain emission like scores.
+
+    A user supplied tagger may be passed with ``unk``. When supplied,
+    it overrides the built in suffix model for unknown words.
 
     Beam search
 
-      The decoder uses beam pruning to limit memory and runtime. After
-      each Viterbi step, states whose log probability is worse than the
-      current best state by more than ``log2(N)`` are discarded. The
-      default threshold ``N=1000`` follows the value reported by Brants.
+    The decoder uses beam pruning to limit memory and runtime. After
+    each Viterbi step, states whose log probability is worse than the
+    current best state by more than ``log2(N)`` are discarded. The
+    default threshold ``N=1000`` follows Brants (2000), section 2.5.
 
     Capitalization
 
-      When ``C=True``, capitalization is included in the tag state. This
-      is equivalent to using separate tag states for capitalized and
-      uncapitalized tokens. It can help when capitalization is informative,
-      but its effect depends on the language, corpus, and tagset.
+    When ``C=True``, capitalization is included in the tag state. This
+    is equivalent to splitting each tag into capitalized and
+    uncapitalized variants, as described by Brants (2000), section 2.4.
     """
 
     def __init__(self, unk=None, Trained=False, N=1000, C=False):
@@ -683,7 +670,9 @@ class TnT(TaggerI):
         external ``unk`` tagger or by the suffix model. After each word, the
         beam keeps only states whose score is within ``log2(N)`` of the best
         surviving path. The decode then scores an explicit EOS transition
-        and walks backpointers to recover the best state sequence.
+        using deleted interpolation over the unigram, bigram, and trigram
+        EOS counts, and walks backpointers to recover the best state
+        sequence.
 
         :param sent: words to tag
         :type sent: list[str]

--- a/nltk/tag/tnt.py
+++ b/nltk/tag/tnt.py
@@ -281,76 +281,124 @@ class TnT(TaggerI):
         self._num_tag_tokens = tag_unigrams.N()
         self._log2_beam_threshold = log2(self._beam_threshold)
 
-        self._build_suffix_model()
         self._build_transition_logp_cache()
+        self._build_suffix_model()
 
         self._unk_trained = True
 
-    def _build_suffix_model(self):
+    def tag(self, tokens, segment=False):
         """
-        Build the suffix model used for unseen words.
+        Tag a single sentence. Delegates the actual decode to
+        `_tagword`, then pairs each chosen tag with its input token.
 
-        The model stores three decode-time values: capitalization-split
-        suffix tries, the successive-abstraction weight theta, and raw
-        tag priors collapsed across capitalization.
+        When `segment` is True, the input may contain mid-sequence
+        sentence punctuation [.!?;]. The decoder splits on those
+        tokens and re-seeds the BOS state for each segment.
+        The default is False because most NLTK callers pre-segment,
+        and auto-splitting on `.` would mis-handle abbreviations
+        like "Mr." in unsegmented input.
 
-        EOS is excluded from the priors because it is a sequence marker,
-        not a lexical tag. Suffix counts come only from lexicon words
-        with total count at most 10, following Brants's infrequent-word
-        threshold for unknown-word modeling.
+        :param tokens: words to tag
+        :type tokens: list[str]
+        :param segment: split on [.!?;] and decode each segment with a
+                        fresh BOS state
+        :type segment: bool
+        :return: list of `(word, tag)` tuples
         """
+        if segment:
+            return self._tag_segmented(tokens)
+        if not (sent := list(tokens)):
+            return []
+        return self._pair_decoded(sent, self._tagword(sent))
+
+    def tagdata(self, data, segment=False):
+        """
+        Tags a list of sentences. Each input sentence is a list of words;
+        each output sentence is a list of (word, tag) tuples.
+
+        :param data: list of list of words
+        :type  data: list[list[str]]
+        :param segment: forwarded to ``tag``. Pass True to auto-split
+                        each input on internal [.!?;] punctuation.
+        :type segment: bool
+        :return: list of list of (word, tag) tuples
+        """
+        return [self.tag(sent, segment=segment) for sent in data]
+
+    def _compute_lambda(self):
+        """
+        Computes the deleted-interpolation weights l1, l2, l3 from the
+        observed tag n-grams. Tied maxima split the trigram count evenly
+        among the winning lambdas. Branches with a zero denominator
+        contribute zero.
+
+        For each trigram (t1, t2, t3) with positive count we compare
+
+            c1 = (f(t3) - 1) / (N - 1)
+            c2 = (f(t2, t3) - 1) / (f(t2) - 1)
+            c3 = (f(t1, t2, t3) - 1) / (f(t1, t2) - 1)
+        """
+
         tag_unigrams = self._tag_unigrams
-        word_tag_freqs = self._word_tag_freqs
+        tag_bigrams = self._tag_bigrams
+        tag_trigrams = self._tag_trigrams
+        unigram_n_minus_1 = tag_unigrams.N() - 1
 
-        tag_counts = {}
-        for (tag, _), count in tag_unigrams.items():
-            # The suffix model predicts lexical tags, not boundary markers.
-            # Check the raw tag so EOS is excluded from all capitalization states.
-            if tag == _EOS[0]:
-                continue
-            tag_counts[tag] = tag_counts.get(tag, 0) + count
+        lambda1_mass = 0.0
+        lambda2_mass = 0.0
+        lambda3_mass = 0.0
 
-        total = sum(tag_counts.values())
-        if total > 0:
-            tag_prior_probs = {tag: count / total for tag, count in tag_counts.items()}
+        for state_i_minus_2, state_i_minus_1 in tag_trigrams.conditions():
+            trigram_dist = tag_trigrams[(state_i_minus_2, state_i_minus_1)]
+            bigram_dist = tag_bigrams[state_i_minus_1]
+
+            trigram_n_minus_1 = trigram_dist.N() - 1
+            bigram_n_minus_1 = bigram_dist.N() - 1
+
+            for state_i, count in trigram_dist.items():
+                # Subtracting one leaves the current event out, so each score
+                # asks which model order would best predict this tag if this
+                # occurrence were held out.
+                c1 = (
+                    (tag_unigrams[state_i] - 1) / unigram_n_minus_1
+                    if unigram_n_minus_1
+                    else 0.0
+                )
+                c2 = (
+                    (bigram_dist[state_i] - 1) / bigram_n_minus_1
+                    if bigram_n_minus_1
+                    else 0.0
+                )
+                c3 = (count - 1) / trigram_n_minus_1 if trigram_n_minus_1 else 0.0
+
+                # The trigram's count is credited to the model order with the
+                # strongest held out estimate. Splitting ties evenly avoids
+                # introducing an arbitrary preference between orders.
+                maxc = max(c1, c2, c3)
+                w1 = c1 == maxc
+                w2 = c2 == maxc
+                w3 = c3 == maxc
+                share = count / (w1 + w2 + w3)
+
+                if w1:
+                    lambda1_mass += share
+                if w2:
+                    lambda2_mass += share
+                if w3:
+                    lambda3_mass += share
+
+        # Normalization turns the accumulated winning mass into mixture
+        # weights. Keeping the zero case explicit prevents a degenerate
+        # training run from dividing by zero or reusing stale weights.
+        total_mass = lambda1_mass + lambda2_mass + lambda3_mass
+        if total_mass > 0:
+            self._lambda1 = lambda1_mass / total_mass
+            self._lambda2 = lambda2_mass / total_mass
+            self._lambda3 = lambda3_mass / total_mass
         else:
-            tag_prior_probs = {}
-
-        # Theta controls how strongly the suffix recursion is pulled back
-        # toward the less specific estimate at each abstraction step.
-        priors = list(tag_prior_probs.values())
-        n_priors = len(priors)
-        if n_priors > 1:
-            mean = sum(priors) / n_priors
-            theta = (
-                sum((prior - mean) ** 2 for prior in priors) / (n_priors - 1)
-            ) ** 0.5
-        else:
-            theta = 0.0
-
-        # Each capitalization bucket stores every suffix length up to 10,
-        # so decode can walk from the shortest matched ending to the longest.
-        suffix_trie_by_cap = {
-            False: ConditionalFreqDist(),
-            True: ConditionalFreqDist(),
-        }
-
-        for word in word_tag_freqs.conditions():
-            tag_freqs = word_tag_freqs[word]
-            if not word or tag_freqs.N() > 10:
-                continue
-
-            suffix_trie = suffix_trie_by_cap[word[0].isupper()]
-            max_suffix_len = min(len(word), 10)
-
-            for m in range(1, max_suffix_len + 1):
-                suffix_dist = suffix_trie[word[-m:]]
-                for tag, count in tag_freqs.items():
-                    suffix_dist[tag] += count
-
-        self._tag_prior_probs = tag_prior_probs
-        self._theta = theta
-        self._suffix_trie_by_cap = suffix_trie_by_cap
+            self._lambda1 = 0.0
+            self._lambda2 = 0.0
+            self._lambda3 = 0.0
 
     def _build_transition_logp_cache(self):
         """
@@ -432,80 +480,71 @@ class TnT(TaggerI):
             }
         self._trans_logp_trigram = trigram_logp
 
-    def _compute_lambda(self):
+    def _build_suffix_model(self):
         """
-        Computes the deleted-interpolation weights l1, l2, l3 from the
-        observed tag n-grams. Tied maxima split the trigram count evenly
-        among the winning lambdas. Branches with a zero denominator
-        contribute zero.
+        Build the suffix model used for unseen words.
 
-        For each trigram (t1, t2, t3) with positive count we compare
+        The model stores three decode-time values: capitalization-split
+        suffix tries, the successive-abstraction weight theta, and raw
+        tag priors collapsed across capitalization.
 
-            c1 = (f(t3) - 1) / (N - 1)
-            c2 = (f(t2, t3) - 1) / (f(t2) - 1)
-            c3 = (f(t1, t2, t3) - 1) / (f(t1, t2) - 1)
+        EOS is excluded from the priors because it is a sequence marker,
+        not a lexical tag. Suffix counts come only from lexicon words
+        with total count at most 10, following Brants's infrequent-word
+        threshold for unknown-word modeling.
         """
-
         tag_unigrams = self._tag_unigrams
-        tag_bigrams = self._tag_bigrams
-        tag_trigrams = self._tag_trigrams
-        unigram_n_minus_1 = tag_unigrams.N() - 1
+        word_tag_freqs = self._word_tag_freqs
 
-        lambda1_mass = 0.0
-        lambda2_mass = 0.0
-        lambda3_mass = 0.0
+        tag_counts = {}
+        for (tag, _), count in tag_unigrams.items():
+            # The suffix model predicts lexical tags, not boundary markers.
+            # Check the raw tag so EOS is excluded from all capitalization states.
+            if tag == _EOS[0]:
+                continue
+            tag_counts[tag] = tag_counts.get(tag, 0) + count
 
-        for state_i_minus_2, state_i_minus_1 in tag_trigrams.conditions():
-            trigram_dist = tag_trigrams[(state_i_minus_2, state_i_minus_1)]
-            bigram_dist = tag_bigrams[state_i_minus_1]
-
-            trigram_n_minus_1 = trigram_dist.N() - 1
-            bigram_n_minus_1 = bigram_dist.N() - 1
-
-            for state_i, count in trigram_dist.items():
-                # Subtracting one leaves the current event out, so each score
-                # asks which model order would best predict this tag if this
-                # occurrence were held out.
-                c1 = (
-                    (tag_unigrams[state_i] - 1) / unigram_n_minus_1
-                    if unigram_n_minus_1
-                    else 0.0
-                )
-                c2 = (
-                    (bigram_dist[state_i] - 1) / bigram_n_minus_1
-                    if bigram_n_minus_1
-                    else 0.0
-                )
-                c3 = (count - 1) / trigram_n_minus_1 if trigram_n_minus_1 else 0.0
-
-                # The trigram's count is credited to the model order with the
-                # strongest held out estimate. Splitting ties evenly avoids
-                # introducing an arbitrary preference between orders.
-                maxc = max(c1, c2, c3)
-                w1 = c1 == maxc
-                w2 = c2 == maxc
-                w3 = c3 == maxc
-                share = count / (w1 + w2 + w3)
-
-                if w1:
-                    lambda1_mass += share
-                if w2:
-                    lambda2_mass += share
-                if w3:
-                    lambda3_mass += share
-
-        # Normalization turns the accumulated winning mass into mixture
-        # weights. Keeping the zero case explicit prevents a degenerate
-        # training run from dividing by zero or reusing stale weights.
-        total_mass = lambda1_mass + lambda2_mass + lambda3_mass
-        if total_mass > 0:
-            self._lambda1 = lambda1_mass / total_mass
-            self._lambda2 = lambda2_mass / total_mass
-            self._lambda3 = lambda3_mass / total_mass
+        total = sum(tag_counts.values())
+        if total > 0:
+            tag_prior_probs = {tag: count / total for tag, count in tag_counts.items()}
         else:
-            self._lambda1 = 0.0
-            self._lambda2 = 0.0
-            self._lambda3 = 0.0
+            tag_prior_probs = {}
+
+        # Theta controls how strongly the suffix recursion is pulled back
+        # toward the less specific estimate at each abstraction step.
+        priors = list(tag_prior_probs.values())
+        n_priors = len(priors)
+        if n_priors > 1:
+            mean = sum(priors) / n_priors
+            theta = (
+                sum((prior - mean) ** 2 for prior in priors) / (n_priors - 1)
+            ) ** 0.5
+        else:
+            theta = 0.0
+
+        # Each capitalization bucket stores every suffix length up to 10,
+        # so decode can walk from the shortest matched ending to the longest.
+        suffix_trie_by_cap = {
+            False: ConditionalFreqDist(),
+            True: ConditionalFreqDist(),
+        }
+
+        for word in word_tag_freqs.conditions():
+            tag_freqs = word_tag_freqs[word]
+            if not word or tag_freqs.N() > 10:
+                continue
+
+            suffix_trie = suffix_trie_by_cap[word[0].isupper()]
+            max_suffix_len = min(len(word), 10)
+
+            for m in range(1, max_suffix_len + 1):
+                suffix_dist = suffix_trie[word[-m:]]
+                for tag, count in tag_freqs.items():
+                    suffix_dist[tag] += count
+
+        self._tag_prior_probs = tag_prior_probs
+        self._theta = theta
+        self._suffix_trie_by_cap = suffix_trie_by_cap
 
     def _unknown_tag_scores(self, word):
         """
@@ -607,118 +646,6 @@ class TnT(TaggerI):
 
         return result
 
-    def _expand_states(self, states, candidate_tags):
-        """
-        Take one Viterbi step. For every predecessor state, score each
-        candidate `state_i` from `candidate_tags` and accumulate the
-        results into a new state dict keyed by
-        `(state_i_minus_1, state_i)`. When two predecessors land on the
-        same key, keep the higher-scoring one and discard the other. The
-        second-order Markov assumption means everything after this point
-        depends only on the last two states, so the discarded path can
-        never beat the kept one.
-
-        `candidate_tags` is a sequence of `(state_i, log_emit,
-        unigram_logp)` triples. `log_emit` is the lexical log-probability
-        for known words, the Bayes-inverted suffix score for unknown
-        words, or zero for an external unknown-word tagger.
-
-        `unigram_logp` is the precomputed unigram-tier transition
-        log-probability for `state_i`, used as the fallback when the
-        trigram and bigram caches both miss. Precomputing it once per
-        candidate removes a hot lookup from the inner loop on high-OOV
-        corpora.
-
-        :return: ``(new_states, best_logp)``. ``new_states`` maps
-                 `(state_i_minus_1, state_i)` to
-                 `(logp, state_i_minus_2)`, where `state_i_minus_2` is
-                 the backpointer used to reconstruct the best path after
-                 the final EOS step. `best_logp` is the maximum `logp`
-                 across `new_states`, returned so the caller can apply
-                 threshold pruning without a second pass.
-        """
-        trans_logp_trigram = self._trans_logp_trigram
-        trans_logp_bigram = self._trans_logp_bigram
-
-        new_states = {}
-        new_states_get = new_states.get
-        best_logp = float("-inf")
-
-        for predecessor_key, (prefix_logp, _) in states.items():
-            state_i_minus_2, state_i_minus_1 = predecessor_key
-
-            # Per-history caches are constant across the candidate loop;
-            # resolving them once and using ``_EMPTY_DICT`` for misses
-            # lets the inner ``.get`` calls run without ``None`` branches.
-            trigram_logp = trans_logp_trigram.get(predecessor_key, _EMPTY_DICT)
-            bigram_logp = trans_logp_bigram.get(state_i_minus_1, _EMPTY_DICT)
-            trigram_logp_get = trigram_logp.get
-            bigram_logp_get = bigram_logp.get
-
-            for state_i, log_emit, unigram_logp in candidate_tags:
-                trans_logp = trigram_logp_get(state_i)
-                if trans_logp is None:
-                    trans_logp = bigram_logp_get(state_i)
-                    if trans_logp is None:
-                        # The candidate tuple carries the unigram fallback,
-                        # including the floor for states never observed as
-                        # unigrams, so the inner loop avoids a third dict lookup.
-                        trans_logp = unigram_logp
-
-                # Parens match the previous ``step_logp + prefix_logp``
-                # order so the sum is bit-identical to the old decoder.
-                path_logp = prefix_logp + (trans_logp + log_emit)
-                next_state = (state_i_minus_1, state_i)
-
-                # Once the last two states match, only the better prefix matters.
-                # All future transitions depend on this key alone.
-                prev_best = new_states_get(next_state)
-                if prev_best is None or path_logp > prev_best[0]:
-                    new_states[next_state] = (path_logp, state_i_minus_2)
-                    if path_logp > best_logp:
-                        best_logp = path_logp
-
-        return new_states, best_logp
-
-    def tagdata(self, data, segment=False):
-        """
-        Tags a list of sentences. Each input sentence is a list of words;
-        each output sentence is a list of (word, tag) tuples.
-
-        :param data: list of list of words
-        :type  data: list[list[str]]
-        :param segment: forwarded to ``tag``. Pass True to auto-split
-                        each input on internal [.!?;] punctuation.
-        :type segment: bool
-        :return: list of list of (word, tag) tuples
-        """
-        return [self.tag(sent, segment=segment) for sent in data]
-
-    def tag(self, tokens, segment=False):
-        """
-        Tag a single sentence. Delegates the actual decode to
-        `_tagword`, then pairs each chosen tag with its input token.
-
-        When `segment` is True, the input may contain mid-sequence
-        sentence punctuation [.!?;]. The decoder splits on those
-        tokens and re-seeds the BOS state for each segment.
-        The default is False because most NLTK callers pre-segment,
-        and auto-splitting on `.` would mis-handle abbreviations
-        like "Mr." in unsegmented input.
-
-        :param tokens: words to tag
-        :type tokens: list[str]
-        :param segment: split on [.!?;] and decode each segment with a
-                        fresh BOS state
-        :type segment: bool
-        :return: list of `(word, tag)` tuples
-        """
-        if segment:
-            return self._tag_segmented(tokens)
-        if not (sent := list(tokens)):
-            return []
-        return self._pair_decoded(sent, self._tagword(sent))
-
     def _tag_segmented(self, tokens):
         """
         Tag ``tokens`` as one or more sentences split on ``[.!?;]``.
@@ -745,12 +672,6 @@ class TnT(TaggerI):
             extend(pair_decoded(segment, tagword(segment)))
 
         return tagged
-
-    @staticmethod
-    def _pair_decoded(words, states):
-        """Convert `_tagword` output into ``(word, tag)`` pairs by dropping
-        the two BOS entries and the capitalization flag from each state."""
-        return [(word, states[i + 2][0]) for i, word in enumerate(words)]
 
     def _tagword(self, sent):
         """
@@ -920,6 +841,85 @@ class TnT(TaggerI):
 
         states_reversed.reverse()
         return [_BOS, _BOS] + states_reversed
+
+    def _expand_states(self, states, candidate_tags):
+        """
+        Take one Viterbi step. For every predecessor state, score each
+        candidate `state_i` from `candidate_tags` and accumulate the
+        results into a new state dict keyed by
+        `(state_i_minus_1, state_i)`. When two predecessors land on the
+        same key, keep the higher-scoring one and discard the other. The
+        second-order Markov assumption means everything after this point
+        depends only on the last two states, so the discarded path can
+        never beat the kept one.
+
+        `candidate_tags` is a sequence of `(state_i, log_emit,
+        unigram_logp)` triples. `log_emit` is the lexical log-probability
+        for known words, the Bayes-inverted suffix score for unknown
+        words, or zero for an external unknown-word tagger.
+
+        `unigram_logp` is the precomputed unigram-tier transition
+        log-probability for `state_i`, used as the fallback when the
+        trigram and bigram caches both miss. Precomputing it once per
+        candidate removes a hot lookup from the inner loop on high-OOV
+        corpora.
+
+        :return: ``(new_states, best_logp)``. ``new_states`` maps
+                 `(state_i_minus_1, state_i)` to
+                 `(logp, state_i_minus_2)`, where `state_i_minus_2` is
+                 the backpointer used to reconstruct the best path after
+                 the final EOS step. `best_logp` is the maximum `logp`
+                 across `new_states`, returned so the caller can apply
+                 threshold pruning without a second pass.
+        """
+        trans_logp_trigram = self._trans_logp_trigram
+        trans_logp_bigram = self._trans_logp_bigram
+
+        new_states = {}
+        new_states_get = new_states.get
+        best_logp = float("-inf")
+
+        for predecessor_key, (prefix_logp, _) in states.items():
+            state_i_minus_2, state_i_minus_1 = predecessor_key
+
+            # Per-history caches are constant across the candidate loop;
+            # resolving them once and using ``_EMPTY_DICT`` for misses
+            # lets the inner ``.get`` calls run without ``None`` branches.
+            trigram_logp = trans_logp_trigram.get(predecessor_key, _EMPTY_DICT)
+            bigram_logp = trans_logp_bigram.get(state_i_minus_1, _EMPTY_DICT)
+            trigram_logp_get = trigram_logp.get
+            bigram_logp_get = bigram_logp.get
+
+            for state_i, log_emit, unigram_logp in candidate_tags:
+                trans_logp = trigram_logp_get(state_i)
+                if trans_logp is None:
+                    trans_logp = bigram_logp_get(state_i)
+                    if trans_logp is None:
+                        # The candidate tuple carries the unigram fallback,
+                        # including the floor for states never observed as
+                        # unigrams, so the inner loop avoids a third dict lookup.
+                        trans_logp = unigram_logp
+
+                # Parens match the previous ``step_logp + prefix_logp``
+                # order so the sum is bit-identical to the old decoder.
+                path_logp = prefix_logp + (trans_logp + log_emit)
+                next_state = (state_i_minus_1, state_i)
+
+                # Once the last two states match, only the better prefix matters.
+                # All future transitions depend on this key alone.
+                prev_best = new_states_get(next_state)
+                if prev_best is None or path_logp > prev_best[0]:
+                    new_states[next_state] = (path_logp, state_i_minus_2)
+                    if path_logp > best_logp:
+                        best_logp = path_logp
+
+        return new_states, best_logp
+
+    @staticmethod
+    def _pair_decoded(words, states):
+        """Convert `_tagword` output into ``(word, tag)`` pairs by dropping
+        the two BOS entries and the capitalization flag from each state."""
+        return [(word, states[i + 2][0]) for i, word in enumerate(words)]
 
 
 ########################################

--- a/nltk/tag/tnt.py
+++ b/nltk/tag/tnt.py
@@ -108,19 +108,18 @@ class TnT(TaggerI):
                         tagger on the next train() call.
         :type  Trained: bool
         :param N: Beam search pruning threshold. After each Viterbi
-                  step any state whose log-probability is worse than
-                  the best by more than a factor of N is discarded.
-                  1000 is a good default.
+                step any state whose log-probability is worse than
+                the best by more than a factor of N is discarded.
+                1000 is a good default.
         :type  N: int
         :param C: Capitalization flag. When True, tags are differentiated
-                  by whether the source word is capitalized. This rarely
-                  improves accuracy in practice.
+                by whether the source word is capitalized. This rarely
+                improves accuracy in practice.
         :type  C: bool
         """
 
-        # Reject N values that would break the log2() and pruning math
-        # later. The chained comparison rejects NaN (any compare with
-        # NaN is False) and both infinities, plus anything below 1.
+        # Beam thresholding uses log2(N), so N must be finite and at least 1.
+        # The explicit bool check matters because bool is a subclass of int.
         if (
             isinstance(N, bool)
             or not isinstance(N, (int, float))
@@ -142,9 +141,8 @@ class TnT(TaggerI):
         self._num_tag_tokens = 0
         self._log2_beam_threshold = 0.0
 
-        # Suffix model state for unknown words. Two tries split by word
-        # capitalization, plus the smoothing weight and tag priors used
-        # by the recursion at decode time.
+        # Unknown-word decoding uses a capitalization split suffix model, a
+        # raw tag prior, and theta for successive abstraction smoothing.
         self._suffix_trie_by_cap = {
             False: ConditionalFreqDist(),
             True: ConditionalFreqDist(),
@@ -154,7 +152,8 @@ class TnT(TaggerI):
 
         self._unk = unk
 
-        # Cleared on train because model state changes.
+        # The cache depends entirely on trained model state, so it starts
+        # empty here and is cleared whenever train() rebuilds the model.
         self._candidate_tags_cache = {}
 
         self.unknown = 0
@@ -177,11 +176,8 @@ class TnT(TaggerI):
         :type  data: list[list[tuple[str, str]]]
         """
 
-        # Reset the parts of the model state that accumulate during
-        # training. The suffix model state and lambda weights are
-        # rebuilt unconditionally further down, so they don't need an
-        # explicit reset here. `_unk_trained` is preserved so the
-        # external unk tagger trains only on the first call.
+        # These structures accumulate corpus statistics, so retraining must
+        # rebuild them from scratch rather than layer new counts on top.
         self._candidate_tags_cache.clear()
         self._tag_unigrams = FreqDist()
         self._tag_bigrams = ConditionalFreqDist()
@@ -209,8 +205,9 @@ class TnT(TaggerI):
                 tag_trigrams[(state_i_minus_2, state_i_minus_1)][state_i] += 1
                 state_i_minus_2, state_i_minus_1 = state_i_minus_1, state_i
 
-            # Record EOS as a pseudo-tag in the n-gram counts. Skip empty
-            # sentences so we don't add an EOS count to the BOS state.
+            # EOS is treated as an ordinary next state in the n-gram model,
+            # but empty sentences are skipped so BOS does not acquire EOS as
+            # a spurious successor.
             if sent:
                 tag_unigrams[_EOS] += 1
                 tag_bigrams[state_i_minus_1][_EOS] += 1
@@ -218,12 +215,13 @@ class TnT(TaggerI):
 
         self._compute_lambda()
 
+        # This total intentionally includes EOS because the unigram model
+        # and deleted interpolation are estimated over the same event stream.
         self._num_tag_tokens = self._tag_unigrams.N()
         self._log2_beam_threshold = log2(self._beam_threshold)
 
         self._build_suffix_model()
 
-        # Prevents repeat train() calls from retraining the optional unk tagger.
         self._unk_trained = True
 
     def _build_suffix_model(self):
@@ -240,7 +238,6 @@ class TnT(TaggerI):
         on the reasoning that frequent words tell us little about what
         unseen words might look like.
         """
-        # Tag priors over raw tags (excluding EOS), P(t) = f(t) / sum_t' f(t')
         tag_counts = {}
         for (tag, _), count in self._tag_unigrams.items():
             if tag == "EOS":
@@ -252,8 +249,8 @@ class TnT(TaggerI):
         else:
             self._tag_prior_probs = {}
 
-        # theta is the standard deviation of the unconditioned tag priors.
-        # This is the sample standard deviation per the paper's formula.
+        # Theta controls how strongly the suffix recursion is pulled back
+        # toward the less specific estimate at each abstraction step.
         priors = list(self._tag_prior_probs.values())
         n = len(priors)
         if n > 1:
@@ -262,7 +259,8 @@ class TnT(TaggerI):
         else:
             self._theta = 0.0
 
-        # Build the two suffix tries from infrequent lexicon words only.
+        # Each capitalization bucket stores every suffix length up to 10,
+        # so decode can walk from the shortest matched ending to the longest.
         self._suffix_trie_by_cap = {
             False: ConditionalFreqDist(),
             True: ConditionalFreqDist(),
@@ -306,6 +304,9 @@ class TnT(TaggerI):
             bigram_n_minus_1 = bigram_dist.N() - 1
 
             for state_i, count in trigram_dist.items():
+                # Subtracting one leaves the current event out, so each score
+                # asks which model order would best predict this tag if this
+                # occurrence were held out.
                 c3 = (count - 1) / trigram_n_minus_1 if trigram_n_minus_1 else 0
                 c2 = (
                     (bigram_dist[state_i] - 1) / bigram_n_minus_1
@@ -318,8 +319,9 @@ class TnT(TaggerI):
                     else 0
                 )
 
-                # Split the trigram's count equally among the lambdas
-                # whose c value ties for the maximum.
+                # The trigram's count is credited to the model order with the
+                # strongest held out estimate. Splitting ties evenly avoids
+                # introducing an arbitrary preference between orders.
                 maxc = max(c1, c2, c3)
                 w1 = c1 == maxc
                 w2 = c2 == maxc
@@ -332,10 +334,9 @@ class TnT(TaggerI):
                 if w3:
                     lambda3_mass += share
 
-        # If no trigrams contributed (empty or pathological training
-        # input), zero the weights explicitly rather than dividing by
-        # zero or leaving stale values from a prior train(). Decode
-        # will fall back to the unigram emission.
+        # Normalization turns the accumulated winning mass into mixture
+        # weights. Keeping the zero case explicit prevents a degenerate
+        # training run from dividing by zero or reusing stale weights.
         total_mass = lambda1_mass + lambda2_mass + lambda3_mass
         if total_mass > 0:
             self._lambda1 = lambda1_mass / total_mass
@@ -365,10 +366,10 @@ class TnT(TaggerI):
         the prior, which is the back-off case.
 
         :return: Bayes-inverted scores. Each raw tag maps to a quantity
-                 proportional to P(suffix | t). The P(suffix) constant
-                 drops out because it does not depend on the tag, which
-                 preserves the argmax without computing it. Tags with
-                 zero prior are omitted.
+                proportional to P(suffix | t). The P(suffix) constant
+                drops out because it does not depend on the tag, which
+                preserves the argmax without computing it. Tags with
+                zero prior are omitted.
         """
         tag_priors = self._tag_prior_probs
         if not tag_priors:
@@ -378,38 +379,68 @@ class TnT(TaggerI):
         suffix_trie = self._suffix_trie_by_cap[is_capitalized]
         theta = self._theta
 
-        # Find the longest known suffix by scanning from 10 down to 1.
-        # If none is found, the loop below leaves P at the unigram prior.
+        # The trie contains every suffix length up to the cutoff. Once the
+        # longest matching suffix is found, all shorter suffixes are also
+        # available for successive abstraction.
         longest = 0
         for m in range(min(len(word), 10), 0, -1):
             if word[-m:] in suffix_trie:
                 longest = m
                 break
 
-        # Successive abstraction from the prior up to the longest suffix.
-        # Update in place since we only touch existing keys. Skip suffix
-        # lengths whose tail is not in the trie rather than indexing in
-        # (which would insert an empty defaultdict entry on every miss).
-        p_t_given_suffix = dict(tag_priors)
-        denom = 1.0 + theta
-        for i in range(1, longest + 1):
-            suffix_key = word[-i:]
-            if suffix_key not in suffix_trie:
-                continue
-            suffix_dist = suffix_trie[suffix_key]
-            inv_suffix_N = 1.0 / suffix_dist.N()
-            for tag in tag_priors:
-                p_t_given_suffix[tag] = (
-                    suffix_dist[tag] * inv_suffix_N + theta * p_t_given_suffix[tag]
-                ) / denom
+        # No matched suffix means the estimate stays at the unigram prior.
+        # After Bayes inversion, every tag then receives the same score.
+        if longest == 0:
+            return {tag: 1.0 for tag, prior in tag_priors.items() if prior > 0}
 
-        # Apply Bayesian inversion so the result ranks by P(suffix | t),
-        # which is proportional to P(t | suffix) / P(t).
-        return {
-            tag: p_t_given_suffix[tag] / prior
-            for tag, prior in tag_priors.items()
-            if prior > 0
-        }
+        # With theta equal to zero there is no smoothing, so the estimate is
+        # just the empirical distribution of the longest matched suffix.
+        if theta == 0.0:
+            suffix_dist = suffix_trie[word[-longest:]]
+            inv_suffix_N = 1.0 / suffix_dist.N()
+            return {
+                tag: (suffix_dist[tag] * inv_suffix_N) / prior
+                for tag, prior in tag_priors.items()
+                if prior > 0
+            }
+
+        # Dense successive abstraction updates every tag at every suffix
+        # length. For tags absent from the current suffix bucket, that update
+        # is the same shared shrinkage. Factor that shared term into one
+        # scalar, and keep only tag specific corrections in delta.
+        denom = 1.0 + theta
+        miss_scale = theta / denom
+
+        global_scale = 1.0
+        delta = {}
+
+        for i in range(1, longest + 1):
+            suffix_dist = suffix_trie[word[-i:]]
+            inv_suffix_N = 1.0 / suffix_dist.N()
+
+            # Apply the shared shrinkage for all tags, then add the suffix
+            # evidence only for tags observed in this bucket.
+            global_scale *= miss_scale
+            corr_scale = inv_suffix_N / (denom * global_scale)
+
+            for tag, count in suffix_dist.items():
+                delta[tag] = delta.get(tag, 0.0) + count * corr_scale
+
+        # In the factored form, Bayes inversion becomes
+        #   P(t | suffix) / P(t) = global_scale * (1 + delta[t] / P(t)).
+        # Untouched tags share one score. Touched tags get a correction
+        # relative to their unigram prior.
+        result = {}
+        for tag, prior in tag_priors.items():
+            if prior <= 0:
+                continue
+            extra = delta.get(tag)
+            if extra is None:
+                result[tag] = global_scale
+            else:
+                result[tag] = global_scale * (1.0 + extra / prior)
+
+        return result
 
     def _expand_states(self, states, candidate_tags):
         """
@@ -463,6 +494,8 @@ class TnT(TaggerI):
                     best_logp = path_logp
                 next_state = (state_i_minus_1, state_i)
                 prev_best = new_states.get(next_state)
+                # Once the last two states match, only the better prefix matters.
+                # All future transitions depend on this key alone.
                 if prev_best is None or path_logp > prev_best[0]:
                     new_states[next_state] = (path_logp, state_i_minus_2)
         return new_states, best_logp
@@ -479,11 +512,7 @@ class TnT(TaggerI):
         :type segment: bool
         :return: list of list of (word, tag) tuples
         """
-        tagged_sents = []
-        for sent in data:
-            tagged_sent = self.tag(sent, segment=segment)
-            tagged_sents.append(tagged_sent)
-        return tagged_sents
+        return [self.tag(sent, segment=segment) for sent in data]
 
     def tag(self, tokens, segment=False):
         """
@@ -506,100 +535,115 @@ class TnT(TaggerI):
         """
         if segment:
             return self._tag_segmented(tokens)
-
-        sent = list(tokens)
-        if not sent:
+        if not (sent := list(tokens)):
             return []
         return self._pair_decoded(sent, self._tagword(sent))
 
     def _tag_segmented(self, tokens):
         """
-        Splits `tokens` on [.!?;] and tags each segment as its own
-        sentence. Each sentence-final punctuation token stays inside
-        the segment that ends with it. A trailing segment without a
-        final punctuation is tagged on its own.
+        Tag ``tokens`` as one or more sentences split on ``[.!?;]``.
+
+        Each sentence-final punctuation token stays with the segment it
+        closes, and a trailing fragment without sentence-final punctuation
+        is still tagged as its own segment.
         """
-        res = []
+        tagged = []
         segment = []
+
+        sent_marks = _SENT_MARKS
+        tagword = self._tagword
+        pair_decoded = self._pair_decoded
+        extend = tagged.extend
+
         for tok in tokens:
             segment.append(tok)
-            if tok in _SENT_MARKS:
-                res.extend(self._pair_decoded(segment, self._tagword(segment)))
-                segment = []
+            if tok in sent_marks:
+                extend(pair_decoded(segment, tagword(segment)))
+                segment.clear()
+
         if segment:
-            res.extend(self._pair_decoded(segment, self._tagword(segment)))
-        return res
+            extend(pair_decoded(segment, tagword(segment)))
+
+        return tagged
 
     @staticmethod
-    def _pair_decoded(words, tags):
-        """Pair words with the tag part of each `_tagword` entry,
-        dropping the [BOS, BOS] prefix and the per-tag capitalization
-        flag."""
-        return [(w, t) for w, (t, _) in zip(words, tags[2:])]
+    def _pair_decoded(words, states):
+        """Convert `_tagword` output into ``(word, tag)`` pairs by dropping
+        the two BOS entries and the capitalization flag from each state."""
+        return [(word, states[i + 2][0]) for i, word in enumerate(words)]
 
     def _tagword(self, sent):
         """
-        Tag a sentence by Viterbi decoding with second-order state
-        merging. The per-word work (scoring, expansion, merging) lives
-        in `_expand_states`. We threshold-prune after each word, then
-        score the EOS transition over the surviving states and walk
-        backpointers to reconstruct the best path.
+        Tag one sentence with second-order Viterbi decoding.
+
+        The lattice state is the last two tag states, so paths that share
+        ``(state_{i-1}, state_i)`` are merged immediately. Known words draw
+        candidates from the lexicon. Unknown words are scored either by the
+        external ``unk`` tagger or by the suffix model. After each word, the
+        beam keeps only states whose score is within ``log2(N)`` of the best
+        surviving path. The decode then scores an explicit EOS transition
+        and walks backpointers to recover the best state sequence.
 
         :param sent: words to tag
         :type sent: list[str]
-        :return: list shaped `[BOS, BOS, state_0, ..., state_{T-1}]`
-                 where each state is a `(tag, capitalization)` pair.
+        :return: list shaped ``[BOS, BOS, state_0, ..., state_{T-1}]``
+                where each state is a ``(tag, capitalization)`` pair.
         """
-        # local bindings avoid repeated attribute lookups in the hot loop
+        if not sent:
+            return [_BOS, _BOS]
+
+        # Local bindings keep the hot loop on plain locals rather than
+        # repeated attribute lookups.
         word_tag_freqs = self._word_tag_freqs
         tag_bigrams = self._tag_bigrams
         tag_trigrams = self._tag_trigrams
         tag_unigrams = self._tag_unigrams
-        num_tag_tokens = self._num_tag_tokens
+        inv_num_tag_tokens = (
+            (1.0 / self._num_tag_tokens) if self._num_tag_tokens else 0.0
+        )
         lambda1, lambda2, lambda3 = self._lambda1, self._lambda2, self._lambda3
         log2_beam_threshold = self._log2_beam_threshold
         cap_on = self._use_capitalization
+        unk = self._unk
         cache = self._candidate_tags_cache
+        expand_states = self._expand_states
 
-        # Viterbi states per level. Each level maps (state_{i-1}, state_i)
-        # to (logp, backpointer_state_{i-2}).
+        # Each level keeps only the best path reaching a given
+        # ``(state_{i-1}, state_i)`` key. The backpointer stores
+        # ``state_{i-2}`` so the best path can be reconstructed at the end.
         states = {(_BOS, _BOS): (0.0, _BOS)}
         state_history = [states]
 
         for word in sent:
             c_i = cap_on and bool(word) and word[0].isupper()
             tag_freqs = word_tag_freqs.get(word)
+
             if tag_freqs is not None:
                 self.known += 1
             else:
                 self.unknown += 1
 
-            # External unk taggers may be stateful or context dependent,
-            # so we evaluate them on every call rather than memoizing.
-            # The known and suffix model paths are pure functions of
-            # `(word, c_i)` and the trained model state, so they cache.
-            if tag_freqs is None and self._unk is not None:
-                [(_w, t)] = self._unk.tag([word])
-                state_i = (t, c_i)
-                p_state_i = (
-                    (tag_unigrams[state_i] / num_tag_tokens) if num_tag_tokens else 0
-                )
+            # External unknown-word taggers are treated as potentially
+            # stateful. The built-in known-word and suffix-model paths are
+            # pure given ``(word, c_i)`` and the trained model, so they cache.
+            if tag_freqs is None and unk is not None:
+                [(_word, tag)] = unk.tag([word])
+                state_i = (tag, c_i)
+                p_state_i = tag_unigrams[state_i] * inv_num_tag_tokens
                 candidate_tags = ((state_i, p_state_i, 0.0),)
             else:
                 cache_key = (word, c_i)
                 candidate_tags = cache.get(cache_key)
+
                 if candidate_tags is None:
                     if tag_freqs is not None:
-                        # Per-tag constants depend only on the candidate tag.
+                        # Known words only consider tags actually seen with
+                        # that surface form. The lexical term is P(word | tag).
                         entries = []
-                        for t, tag_count in tag_freqs.items():
-                            state_i = (t, c_i)
+                        for tag, tag_count in tag_freqs.items():
+                            state_i = (tag, c_i)
                             unigram_state_i = tag_unigrams[state_i]
-                            p_state_i = (
-                                (unigram_state_i / num_tag_tokens)
-                                if num_tag_tokens
-                                else 0
-                            )
+                            p_state_i = unigram_state_i * inv_num_tag_tokens
                             entries.append(
                                 (
                                     state_i,
@@ -609,52 +653,45 @@ class TnT(TaggerI):
                             )
                         candidate_tags = tuple(entries)
                     else:
-                        # Score this unknown word against every candidate
-                        # tag using the Bayes-inverted suffix posterior.
-                        tag_scores = self._unknown_tag_scores(word)
-                        if not tag_scores:
-                            # Fall back to a literal "Unk" tag when there is
-                            # no prior to score against, for example when
-                            # the tagger has not been trained.
+                        # Unknown words use the suffix model as their lexical
+                        # score. Bayes inversion turns the suffix posterior into
+                        # the emission-like quantity used by the decoder.
+                        suffix_scores = self._unknown_tag_scores(word)
+
+                        if not suffix_scores:
+                            # An untrained tagger has no suffix priors, so the
+                            # only safe fallback is a literal ``Unk`` state.
                             state_i = ("Unk", c_i)
-                            p_state_i = (
-                                (tag_unigrams[state_i] / num_tag_tokens)
-                                if num_tag_tokens
-                                else 0
-                            )
+                            p_state_i = tag_unigrams[state_i] * inv_num_tag_tokens
                             candidate_tags = ((state_i, p_state_i, 0.0),)
                         else:
                             entries = []
-                            for t, score in tag_scores.items():
-                                state_i = (t, c_i)
-                                p_state_i = (
-                                    (tag_unigrams[state_i] / num_tag_tokens)
-                                    if num_tag_tokens
-                                    else 0
-                                )
-                                log_score = (
+                            for tag, score in suffix_scores.items():
+                                state_i = (tag, c_i)
+                                p_state_i = tag_unigrams[state_i] * inv_num_tag_tokens
+                                log_emit = (
                                     log2(score) if score > 1e-300 else _LOG_FLOOR_2
                                 )
-                                entries.append((state_i, p_state_i, log_score))
+                                entries.append((state_i, p_state_i, log_emit))
                             candidate_tags = tuple(entries)
+
                     cache[cache_key] = candidate_tags
 
-            new_states, best_logp = self._expand_states(states, candidate_tags)
+            new_states, best_logp = expand_states(states, candidate_tags)
 
-            # Threshold prune drops states worse than the best by more than log2(N).
+            # Threshold pruning keeps the beam relative to the best current
+            # path, which is the pruning rule described in the paper.
             cutoff = best_logp - log2_beam_threshold
-            new_states = {k: v for k, v in new_states.items() if v[0] >= cutoff}
-
-            states = new_states
+            states = {k: v for k, v in new_states.items() if v[0] >= cutoff}
             state_history.append(states)
 
-        # Score the EOS transition with the same deleted interpolation
-        # used for every other tag, then pick the best final state.
-        # `states` is non-empty by construction, so we seed with any
-        # key to avoid an Optional placeholder.
-        p_eos_unigram = (tag_unigrams[_EOS] / num_tag_tokens) if num_tag_tokens else 0
-        best_final_state = next(iter(states))
+        # EOS is scored by the same interpolated transition model as every
+        # other step. The best final key is the state pair that maximizes
+        # the complete sentence score including the boundary transition.
+        p_eos_unigram = tag_unigrams[_EOS] * inv_num_tag_tokens
+        best_final_key = next(iter(states))
         best_final_logp = float("-inf")
+
         for (state_i_minus_2, state_i_minus_1), (prefix_logp, _) in states.items():
             bigram_dist = tag_bigrams[state_i_minus_1]
             trigram_dist = tag_trigrams[(state_i_minus_2, state_i_minus_1)]
@@ -675,26 +712,23 @@ class TnT(TaggerI):
             final_logp = prefix_logp + eos_logp
             if final_logp > best_final_logp:
                 best_final_logp = final_logp
-                best_final_state = (state_i_minus_2, state_i_minus_1)
+                best_final_key = (state_i_minus_2, state_i_minus_1)
 
-        # Walk backpointers to reconstruct the best path,
-        # collecting states in reverse. At level L the key
-        # is (state_{L-2}, state_{L-1}) and the backpointer
-        # is state_{L-3}, peeling off one state per step.
+        # Walking the stored ``state_{i-2}`` backpointers recovers the best
+        # full state sequence from the best final state pair.
         T = len(sent)
-        if T == 0:
-            return [_BOS, _BOS]
-
-        tags_reversed = [best_final_state[1]]
+        states_reversed = [best_final_key[1]]
         if T >= 2:
-            tags_reversed.append(best_final_state[0])
-        current_state = best_final_state
+            states_reversed.append(best_final_key[0])
+
+        current_key = best_final_key
         for level in range(T, 2, -1):
-            backpointer = state_history[level][current_state][1]
-            tags_reversed.append(backpointer)
-            current_state = (backpointer, current_state[0])
-        tags_reversed.reverse()
-        return [_BOS, _BOS] + tags_reversed
+            backpointer = state_history[level][current_key][1]
+            states_reversed.append(backpointer)
+            current_key = (backpointer, current_key[0])
+
+        states_reversed.reverse()
+        return [_BOS, _BOS] + states_reversed
 
 
 ########################################

--- a/nltk/tag/tnt.py
+++ b/nltk/tag/tnt.py
@@ -31,7 +31,7 @@ _SENT_MARKS = (".", "!", "?", ";")
 
 # Returned by transition-cache misses so inner-loop ``.get`` calls never
 # need an extra ``None`` check before the next lookup.
-_EMPTY_DICT = {}
+_EMPTY_DICT: dict = {}
 
 
 def _safe_log2(p):
@@ -494,7 +494,7 @@ class TnT(TaggerI):
         tag_unigrams = self._tag_unigrams
         word_tag_freqs = self._word_tag_freqs
 
-        tag_counts = {}
+        tag_counts: dict = {}
         for (tag, _), count in tag_unigrams.items():
             # The suffix model predicts lexical tags, not boundary markers.
             # Check the raw tag so EOS is excluded from all capitalization states.
@@ -614,7 +614,7 @@ class TnT(TaggerI):
         miss_scale = theta / denom
 
         global_scale = 1.0
-        delta = {}
+        delta: dict = {}
 
         for i in range(1, longest + 1):
             suffix_dist = suffix_trie[word[-i:]]
@@ -652,8 +652,8 @@ class TnT(TaggerI):
         closes, and a trailing fragment without sentence-final punctuation
         is still tagged as its own segment.
         """
-        tagged = []
-        segment = []
+        tagged: list = []
+        segment: list = []
 
         sent_marks = _SENT_MARKS
         tagword = self._tagword
@@ -713,6 +713,7 @@ class TnT(TaggerI):
         states = {(_BOS, _BOS): (0.0, _BOS)}
         state_history = [states]
 
+        candidate_tags: tuple
         for word in sent:
             c_i = cap_on and bool(word) and word[0].isupper()
             tag_freqs = word_tag_freqs.get(word)
@@ -741,9 +742,9 @@ class TnT(TaggerI):
                 candidate_tags = ((state_i, 0.0, unigram_logp),)
             else:
                 cache_key = (word, c_i)
-                candidate_tags = cache.get(cache_key)
+                cached = cache.get(cache_key)
 
-                if candidate_tags is None:
+                if cached is None:
                     if tag_freqs is not None:
                         # Known words only consider tags actually seen with
                         # that surface form. The lexical term is P(word | tag).
@@ -785,6 +786,8 @@ class TnT(TaggerI):
                             candidate_tags = tuple(entries)
 
                     cache[cache_key] = candidate_tags
+                else:
+                    candidate_tags = cached
 
             new_states, best_logp = expand_states(states, candidate_tags)
 
@@ -884,7 +887,7 @@ class TnT(TaggerI):
         trans_logp_trigram = self._trans_logp_trigram
         trans_logp_bigram = self._trans_logp_bigram
 
-        new_states = {}
+        new_states: dict = {}
         new_states_get = new_states.get
         best_logp = float("-inf")
 

--- a/nltk/tag/tnt.py
+++ b/nltk/tag/tnt.py
@@ -117,7 +117,6 @@ class TnT(TaggerI):
         self._bi = ConditionalFreqDist()
         self._tri = ConditionalFreqDist()
         self._wd = ConditionalFreqDist()
-        self._eos = ConditionalFreqDist()
         self._l1 = 0.0
         self._l2 = 0.0
         self._l3 = 0.0
@@ -167,12 +166,20 @@ class TnT(TaggerI):
                 # set local flag C to false for the next word
                 C = False
 
-            # Key EOS by last tag to match model; skip empty sentences
+            # record EOS transition with deleted interpolation
+            # skip empty sentences to avoid attributing count to BOS
             if sent:
-                self._eos[history[-1]]["EOS"] += 1
+                eos = ("EOS", False)
+                self._uni[eos] += 1
+                self._bi[history[-1]][eos] += 1
+                self._tri[tuple(history)][eos] += 1
 
         # compute lambda values from the trained frequency distributions
         self._compute_lambda()
+
+        # mark as trained so repeat train() calls don't retrain the
+        # optional unk tagger (see unk handling at the top of this method)
+        self._T = True
 
     def _compute_lambda(self):
         """
@@ -246,6 +253,12 @@ class TnT(TaggerI):
                 elif (c1 == c3) and (c1 > c2):
                     tl1 += self._tri[history][tag] / 2.0
                     tl3 += self._tri[history][tag] / 2.0
+
+                # if all three are equal (and not the safe_div -1 sentinel)
+                elif (c1 == c2) and (c2 == c3) and (c1 >= 0):
+                    tl1 += self._tri[history][tag] / 3.0
+                    tl2 += self._tri[history][tag] / 3.0
+                    tl3 += self._tri[history][tag] / 3.0
 
                 # fallback for edge cases (all zero or sentinel values)
                 else:
@@ -334,14 +347,17 @@ class TnT(TaggerI):
         of a particular tag
         """
 
-        # if word marks end of sentence, apply P(EOS | t_T) and return best tag
+        # if word marks end of sentence, score the EOS transition with the
+        # same deleted interpolation used for normal tags and return best path
         if sent == []:
+            eos = ("EOS", False)
+            p_uni = self._uni.freq(eos)
             best_h, best_logp = current_states[0][0], None
             for history, logp in current_states:
-                eos_count = self._eos[history[-1]]["EOS"]
-                tag_count = self._uni[history[-1]]
-                if eos_count > 0 and tag_count > 0:
-                    logp += log(eos_count / tag_count, 2)
+                p_bi = self._bi[history[-1]].freq(eos)
+                p_tri = self._tri[tuple(history[-2:])].freq(eos)
+                p = self._l1 * p_uni + self._l2 * p_bi + self._l3 * p_tri
+                logp += log(max(p, 1e-300), 2)
                 if best_logp is None or logp > best_logp:
                     best_h, best_logp = history, logp
             return best_h
@@ -364,8 +380,6 @@ class TnT(TaggerI):
             self.known += 1
 
             for history, curr_sent_logprob in current_states:
-                logprobs = []
-
                 for t in self._wd[word].keys():
                     tC = (t, C)
                     p_uni = self._uni.freq(tC)
@@ -373,7 +387,7 @@ class TnT(TaggerI):
                     p_tri = self._tri[tuple(history[-2:])].freq(tC)
                     p_wd = self._wd[word][t] / self._uni[tC]
                     p = self._l1 * p_uni + self._l2 * p_bi + self._l3 * p_tri
-                    p2 = log(p, 2) + log(p_wd, 2)
+                    p2 = log(max(p, 1e-300), 2) + log(p_wd, 2)
 
                     # compute the result of appending each tag to this history
                     new_states.append((history + [tC], curr_sent_logprob + p2))
@@ -381,12 +395,6 @@ class TnT(TaggerI):
         # otherwise a new word, set of possible tags is unknown
         else:
             self.unknown += 1
-
-            # since a set of possible tags,
-            # and the probability of each specific tag
-            # can not be returned from most classifiers:
-            # specify that any unknown words are tagged with certainty
-            p = 1
 
             # if no unknown word tagger has been specified
             # then use the tag 'Unk'
@@ -398,7 +406,7 @@ class TnT(TaggerI):
                 [(_w, t)] = list(self._unk.tag([word]))
                 tag = (t, C)
 
-            for history, logprob in current_states:
+            for history, _ in current_states:
                 history.append(tag)
 
             new_states = current_states

--- a/nltk/tag/tnt.py
+++ b/nltk/tag/tnt.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2001-2026 NLTK Project
 # Author: Sam Huston <sjh900@gmail.com>
+# Major revisions: John Winstead <https://github.com/jhnwnstd>
 #
 # URL: <https://www.nltk.org/>
 # For license information, see LICENSE.TXT

--- a/nltk/tag/tnt.py
+++ b/nltk/tag/tnt.py
@@ -132,7 +132,7 @@ class TnT(TaggerI):
         :param N: Beam search pruning threshold. After each Viterbi
                 step any state whose log-probability is worse than
                 the best by more than a factor of N is discarded.
-                1000 is a good default.
+                Must be a positive integer; 1000 is a good default.
         :type  N: int
         :param C: Capitalization flag. When True, tags are differentiated
                 by whether the source word is capitalized. This rarely
@@ -140,14 +140,11 @@ class TnT(TaggerI):
         :type  C: bool
         """
 
-        # Beam thresholding uses log2(N), so N must be finite and at least 1.
-        # The explicit bool check matters because bool is a subclass of int.
-        if (
-            isinstance(N, bool)
-            or not isinstance(N, (int, float))
-            or not (1 <= N < float("inf"))
-        ):
-            raise ValueError(f"N must be a finite number >= 1, got {N!r}")
+        # Restricting N to a positive integer keeps the public contract
+        # narrow. The explicit bool check matters because ``bool`` is a
+        # subclass of ``int`` and would otherwise pass the type check.
+        if isinstance(N, bool) or not isinstance(N, int) or N < 1:
+            raise ValueError(f"N must be a positive integer, got {N!r}")
 
         self._tag_unigrams = FreqDist()
         self._tag_bigrams = ConditionalFreqDist()
@@ -497,15 +494,18 @@ class TnT(TaggerI):
         if longest == 0:
             return {tag: 1.0 for tag, prior in tag_priors.items() if prior > 0}
 
-        # With theta equal to zero there is no smoothing, so the estimate is
-        # just the empirical distribution of the longest matched suffix.
+        # With theta equal to zero there is no smoothing, so the estimate
+        # is the empirical distribution of the longest matched suffix.
+        # Tags absent from that bucket would have score zero, so they are
+        # dropped from the result instead of being emitted as floor-only
+        # candidates that the beam would prune anyway.
         if theta == 0.0:
             suffix_dist = suffix_trie[word[-longest:]]
             inv_suffix_N = 1.0 / suffix_dist.N()
             return {
-                tag: (suffix_dist[tag] * inv_suffix_N) / prior
-                for tag, prior in tag_priors.items()
-                if prior > 0
+                tag: (count * inv_suffix_N) / tag_priors[tag]
+                for tag, count in suffix_dist.items()
+                if tag_priors.get(tag, 0) > 0
             }
 
         # Dense successive abstraction updates every tag at every suffix

--- a/nltk/tag/tnt.py
+++ b/nltk/tag/tnt.py
@@ -73,9 +73,9 @@ class TnT(TaggerI):
                              l3*P(t_i| t_i-1, t_i-2)
 
     A beam search is used to limit the memory usage of the algorithm.
-    The degree of the beam can be changed using N in the initialization.
-    N represents the maximum number of possible solutions to maintain
-    while tagging.
+    The beam is controlled by a pruning threshold N after each step,
+    states whose probability is worse than the best
+    by more than a factor of N are discarded.
 
     It is possible to differentiate the tags which are assigned to
     capitalized words. However this does not result in a significant
@@ -91,7 +91,7 @@ class TnT(TaggerI):
         :type  unk: TaggerI
         :param Trained: Indication that the POS tagger is trained or not
         :type  Trained: bool
-        :param N: Beam search degree (see above)
+        :param N: Beam search pruning threshold
         :type  N: int
         :param C: Capitalization flag
         :type  C: bool
@@ -102,8 +102,9 @@ class TnT(TaggerI):
         _lx values represent the portion of the tri/bi/uni taggers
         to be used to calculate the probability
 
-        N value is the number of possible solutions to maintain
-        while tagging. A good value for this is 1000
+        N is the beam search pruning threshold: after scoring, any state
+        whose probability is worse than the best by more than a factor of
+        N is discarded. A good value for this is 1000.
 
         C is a boolean value which specifies to use or
         not use the Capitalization of the word as additional
@@ -166,7 +167,9 @@ class TnT(TaggerI):
                 # set local flag C to false for the next word
                 C = False
 
-            self._eos[t]["EOS"] += 1
+            # Key EOS by last tag to match model; skip empty sentences
+            if sent:
+                self._eos[history[-1]]["EOS"] += 1
 
         # compute lambda values from the trained frequency distributions
         self._compute_lambda()
@@ -198,7 +201,7 @@ class TnT(TaggerI):
 
         # for each t1,t2 in system
         for history in self._tri.conditions():
-            (h1, h2) = history
+            h1, h2 = history
 
             # for each t3 given t1,t2 in system
             # (NOTE: tag actually represents (tag,C))
@@ -235,13 +238,16 @@ class TnT(TaggerI):
                     tl3 += self._tri[history][tag] / 2.0
 
                 # if c1, and c2 are equal and larger than c3
-                # this might be a dumb thing to do....(not sure yet)
                 elif (c2 == c1) and (c1 > c3):
                     tl1 += self._tri[history][tag] / 2.0
                     tl2 += self._tri[history][tag] / 2.0
 
-                # otherwise there might be a problem
-                # eg: all values = 0
+                # if c1, and c3 are equal and larger than c2
+                elif (c1 == c3) and (c1 > c2):
+                    tl1 += self._tri[history][tag] / 2.0
+                    tl3 += self._tri[history][tag] / 2.0
+
+                # fallback for edge cases (all zero or sentinel values)
                 else:
                     pass
 
@@ -279,12 +285,12 @@ class TnT(TaggerI):
             res.append(res1)
         return res
 
-    def tag(self, data):
+    def tag(self, tokens):
         """
         Tags a single sentence
 
-        :param data: list of words
-        :type data: [string,]
+        :param tokens: list of words
+        :type tokens: [string,]
 
         :return: [(word, tag),]
 
@@ -297,16 +303,17 @@ class TnT(TaggerI):
         returns a list of (word, tag) tuples
         """
 
-        current_state = [(["BOS", "BOS"], 0.0)]
+        # seed BOS in the same (tag, C) form stored during training
+        current_state = [([("BOS", False), ("BOS", False)], 0.0)]
 
-        sent = list(data)
+        sent = list(tokens)
 
         tags = self._tagword(sent, current_state)
 
         res = []
         for i in range(len(sent)):
             # unpack and discard the C flags
-            (t, C) = tags[i + 2]
+            t, C = tags[i + 2]
             res.append((sent[i], t))
 
         return res
@@ -327,11 +334,17 @@ class TnT(TaggerI):
         of a particular tag
         """
 
-        # if this word marks the end of the sentence,
-        # return the most probable tag
+        # if word marks end of sentence, apply P(EOS | t_T) and return best tag
         if sent == []:
-            (h, logp) = current_states[0]
-            return h
+            best_h, best_logp = current_states[0][0], None
+            for history, logp in current_states:
+                eos_count = self._eos[history[-1]]["EOS"]
+                tag_count = self._uni[history[-1]]
+                if eos_count > 0 and tag_count > 0:
+                    logp += log(eos_count / tag_count, 2)
+                if best_logp is None or logp > best_logp:
+                    best_h, best_logp = history, logp
+            return best_h
 
         # otherwise there are more words to be tagged
         word = sent[0]
@@ -396,10 +409,10 @@ class TnT(TaggerI):
         # set is now ordered greatest to least log probability
         new_states.sort(reverse=True, key=itemgetter(1))
 
-        # del everything after N (threshold)
-        # this is the beam search cut
-        if len(new_states) > self._N:
-            new_states = new_states[: self._N]
+        # drop states worse than the best by more than log2(N)
+        best_logp = new_states[0][1]
+        cutoff = best_logp - log(self._N, 2)
+        new_states = [s for s in new_states if s[1] >= cutoff]
 
         # compute the tags for the rest of the sentence
         # return the best list of tags for the sentence

--- a/nltk/tag/tnt.py
+++ b/nltk/tag/tnt.py
@@ -47,73 +47,103 @@ def _safe_inverse(n):
 
 class TnT(TaggerI):
     """
-    TnT - Statistical POS tagger
+    TnT statistical POS tagger.
 
-    IMPORTANT NOTES:
+    TnT implements the second order hidden Markov model tagger described
+    by Brants (2000). Hidden states are part of speech tags, observed
+    symbols are word tokens, and each tag transition depends on the two
+    previous tag states.
 
-    * HANDLES UNSEEN WORDS VIA BRANTS'S SUFFIX MODEL
+    Important usage notes
 
-      - Unknown words are tagged using the suffix-based distribution
-        described in Brants (2000) section 2.3, smoothed by successive
-        abstraction and scored via Bayesian inversion.
-      - An external POS tagger may still be supplied via the ``unk``
-        parameter to override the suffix model; see the ``__init__`` function.
+    * Use sentence delimited input.
 
-    * SHOULD BE USED WITH SENTENCE-DELIMITED INPUT
+      TnT estimates and scores beginning of sentence and end of sentence
+      transitions. It works best when training and tagging data are already
+      split into sentences.
 
-      - Due to the nature of this tagger, it works best when
-        trained over sentence-delimited input.
-      - However, it still produces good results if the training
-        data and testing data are separated on sentence-final
-        punctuation, e.g., [.!?;]
-      - Input for training is expected to be a list of sentences,
-        where each sentence is a list of (word, tag) tuples.
-      - Input for the ``tag`` function is a single sentence.
-        Input for the ``tagdata`` function is a list of sentences.
-        Output is of a similar form.
+      Training input should be a list of sentences. Each sentence should
+      be a list of ``(word, tag)`` tuples.
 
-    * Function provided to process text that is unsegmented
+      ``tag()`` expects one tokenized sentence.
+      ``tagdata()`` expects a list of tokenized sentences.
 
-      - Please see ``basic_sent_chop()``.
+      For simple punctuation based segmentation of token streams, see
+      ``basic_sent_chop()``. It splits on the sentence final punctuation
+      used by Brants, namely ``.``, ``!``, ``?``, and ``;``.
 
+    * Unknown words use Brants's suffix model.
 
-    TnT uses a second-order Markov model to score tag sequences. For
-    a sentence of length T, the decoder picks the tag sequence that
-    maximizes
+      Words not observed during training are scored from suffix
+      distributions, as described in Brants (2000), section 2.3. The model
+      builds capitalization specific suffix tries from infrequent training
+      words, smooths suffix tag probabilities by successive abstraction,
+      and applies Bayesian inversion to obtain emission like scores.
 
-      prod_i P(t_i | t_{i-1}, t_{i-2}) * P(w_i | t_i)
+      A user supplied tagger may be passed with ``unk``. When supplied,
+      it overrides the built in suffix model for unknown words.
 
-    with an explicit boundary factor P(EOS | t_{T-1}, t_T) at the end.
-    Decoding runs Viterbi in log space over a trellis of
-    ``(t_{i-1}, t_i)`` state pairs:
+    * Known words use a tag dictionary.
 
-      argmax_{t_1..t_T} sum_i [ log P(t_i | t_{i-1}, t_{i-2})
-                              + log P(w_i | t_i) ]
-                      + log P(EOS | t_{T-1}, t_T)
+      For a known word, candidate tags are restricted to the tags assigned
+      to that word in the training data. If a word was never seen with a
+      tag during training, that tag is not considered for that word at
+      decode time.
 
-    The transition probability is a deleted interpolation of zero-,
-    first-, and second-order tag models:
+    Model
 
-      P(t_i | t_{i-1}, t_{i-2}) = l1 * P(t_i)
-                                + l2 * P(t_i | t_{i-1})
-                                + l3 * P(t_i | t_{i-1}, t_{i-2})
+      For a sentence of length ``T``, the decoder chooses the tag sequence
+      that maximizes
 
-    The weights l1, l2, l3 are estimated from the training data by
-    the procedure in Brants (2000) section 2.2.
+          prod_i P(t_i | t_{i-1}, t_{i-2}) * P(w_i | t_i)
 
-    The emission probability P(w_i | t_i) for known words is the
-    relative frequency of (w_i, t_i) in the training lexicon. For
-    unknown words, it is the Bayes-inverted suffix score described in
-    section 2.3 (see HANDLES UNSEEN WORDS above). Candidate tags for
-    a known word are exactly the tags it was assigned in training.
+      and then scores an explicit end of sentence transition
 
-    A beam search limits memory: after each step, states whose log
-    probability is worse than the best surviving state by more than
-    log2(N) are discarded.
+          P(EOS | t_{T-1}, t_T)
 
-    It is possible to differentiate the tags that are assigned to
-    capitalized words. However, this does not result in a significant
-    gain in the accuracy of the results.
+      Decoding uses Viterbi search in log space over a trellis of
+      ``(t_{i-1}, t_i)`` state pairs.
+
+          argmax_{t_1..t_T} sum_i [
+              log P(t_i | t_{i-1}, t_{i-2})
+              + log P(w_i | t_i)
+          ] + log P(EOS | t_{T-1}, t_T)
+
+    Transition smoothing
+
+      The transition probability is a deleted interpolation of unigram,
+      bigram, and trigram tag models.
+
+          P(t_i | t_{i-1}, t_{i-2})
+              = l1 * P(t_i)
+              + l2 * P(t_i | t_{i-1})
+              + l3 * P(t_i | t_{i-1}, t_{i-2})
+
+      The interpolation weights ``l1``, ``l2``, and ``l3`` are estimated
+      from the training data with the deleted interpolation procedure in
+      Brants (2000), section 2.2.
+
+    Emissions
+
+      For known words, ``P(w_i | t_i)`` is the relative frequency of the
+      word and tag pair in the training lexicon.
+
+      For unknown words, the emission like score is the Bayes inverted
+      suffix score described above.
+
+    Beam search
+
+      The decoder uses beam pruning to limit memory and runtime. After
+      each Viterbi step, states whose log probability is worse than the
+      current best state by more than ``log2(N)`` are discarded. The
+      default threshold ``N=1000`` follows the value reported by Brants.
+
+    Capitalization
+
+      When ``C=True``, capitalization is included in the tag state. This
+      is equivalent to using separate tag states for capitalized and
+      uncapitalized tokens. It can help when capitalization is informative,
+      but its effect depends on the language, corpus, and tagset.
     """
 
     def __init__(self, unk=None, Trained=False, N=1000, C=False):

--- a/nltk/tag/tnt.py
+++ b/nltk/tag/tnt.py
@@ -1,8 +1,8 @@
 # Natural Language Toolkit: TnT Tagger
 #
 # Copyright (C) 2001-2026 NLTK Project
-# Author: Sam Huston <sjh900@gmail.com>
-#         John Winstead <https://github.com/jhnwnstd>
+# Author: John Winstead <https://github.com/jhnwnstd>
+#         Sam Huston <sjh900@gmail.com>
 #
 # URL: <https://www.nltk.org/>
 # For license information, see LICENSE.TXT
@@ -141,20 +141,20 @@ class TnT(TaggerI):
         :param unk: instance of a POS tagger, conforms to TaggerI.
                     When supplied, overrides the built-in suffix model
                     on the unknown-word path.
-        :type  unk: TaggerI
+        :type unk: TaggerI
         :param Trained: Indication that the POS tagger is trained or not.
                         Set True to skip training the optional ``unk``
                         tagger on the next train() call.
-        :type  Trained: bool
+        :type Trained: bool
         :param N: Beam search pruning threshold. After each Viterbi
                 step any state whose log-probability is worse than
                 the best by more than a factor of N is discarded.
                 Must be a positive integer; 1000 is a good default.
-        :type  N: int
+        :type N: int
         :param C: Capitalization flag. When True, tags are differentiated
                 by whether the source word is capitalized. This rarely
                 improves accuracy in practice.
-        :type  C: bool
+        :type C: bool
         """
 
         # Restricting N to a positive integer keeps the public contract
@@ -215,7 +215,7 @@ class TnT(TaggerI):
         new training set is rarely what callers want.
 
         :param data: list of lists of (word, tag) tuples
-        :type  data: list[list[tuple[str, str]]]
+        :type data: list[list[tuple[str, str]]]
         """
 
         # These structures accumulate corpus statistics, so retraining must
@@ -304,7 +304,7 @@ class TnT(TaggerI):
         each output sentence is a list of (word, tag) tuples.
 
         :param data: list of list of words
-        :type  data: list[list[str]]
+        :type data: list[list[str]]
         :param segment: forwarded to ``tag``. Pass True to auto-split
                         each input on internal [.!?;] punctuation.
         :type segment: bool
@@ -911,159 +911,156 @@ class TnT(TaggerI):
         return [(word, states[i + 2][0]) for i, word in enumerate(words)]
 
 
-########################################
-# helper function -- basic sentence tokenizer
-########################################
+# -----------------------------
+# Sentence segmentation helpers
+# -----------------------------
 
 
-def basic_sent_chop(data, raw=True):
+def basic_sent_chop(data, raw=True, sent_marks=_SENT_MARKS):
     """
-    Basic method for tokenizing input into sentences
-    for this tagger:
+    Split a flat token sequence into sentence-like segments.
 
-    :param data: list of tokens (words or (word, tag) tuples)
-    :type data: str or tuple(str, str)
-    :param raw: boolean flag marking the input data
-                as a list of words or a list of tagged words
-    :type raw: bool
-    :return: list of sentences
-             sentences are a list of tokens
-             tokens are the same as the input
+    Splits after tokens whose surface form appears in ``sent_marks``.
+    Works for raw tokens and tagged ``(word, tag)`` tokens.
 
-    Function takes a list of tokens and separates the tokens into lists
-    where each list represents a sentence fragment
-    This function can separate both tagged and raw sequences into
-    basic sentences.
-
-    Sentence markers are the set of [.!?;]
-
-    This is a simple method which enhances the performance of the TnT
-    tagger. Better sentence tokenization will further enhance the results.
+    :param data: flat sequence of tokens or ``(word, tag)`` tuples
+    :param raw: whether ``data`` contains raw tokens
+    :param sent_marks: token strings that end a sentence segment
+    :return: list of sentence segments with the same token shape as input
     """
+    sent_marks = set(sent_marks)
+    sentences = []
+    sentence = []
 
-    new_data = []
-    curr_sent = []
+    for token in data:
+        sentence.append(token)
+        word = token if raw else token[0]
+        if word in sent_marks:
+            sentences.append(sentence)
+            sentence = []
 
-    if raw:
-        for word in data:
-            curr_sent.append(word)
-            if word in _SENT_MARKS:
-                new_data.append(curr_sent)
-                curr_sent = []
-    else:
-        for word, tag in data:
-            curr_sent.append((word, tag))
-            if word in _SENT_MARKS:
-                new_data.append(curr_sent)
-                curr_sent = []
+    if sentence:
+        sentences.append(sentence)
 
-    if curr_sent:
-        new_data.append(curr_sent)
-
-    return new_data
+    return sentences
 
 
-def demo():
-    from nltk.corpus import brown
+# ------------
+# Demo helpers
+# ------------
 
-    sents = list(brown.tagged_sents())
-    test = list(brown.sents())
 
-    tagger = TnT()
-    tagger.train(sents[200:1000])
+def _treebank_demo_split(test_size=1000):
+    """Return train, held-out final Treebank slice, and train vocabulary."""
+    from nltk.corpus import treebank
 
-    tagged_data = tagger.tagdata(test[100:120])
+    sents = list(treebank.tagged_sents())
+    if not 0 < test_size < len(sents):
+        raise ValueError(
+            f"test_size must be between 1 and {len(sents) - 1}, got {test_size!r}"
+        )
 
-    for j in range(len(tagged_data)):
-        s = tagged_data[j]
-        t = sents[j + 100]
-        for i in range(len(s)):
-            print(s[i], "--", t[i])
+    cut = len(sents) - test_size
+    train_sents = sents[:cut]
+    test_sents = sents[cut:]
+    train_vocab = {word for sent in train_sents for word, _ in sent}
+    return train_sents, test_sents, train_vocab
+
+
+def _score_tagger(tagger, test_sents, train_vocab):
+    """Return overall, seen, and OOV scores for tagged sentences."""
+    correct = total = 0
+    seen_correct = seen_total = 0
+    oov_correct = oov_total = 0
+
+    for sent in test_sents:
+        words = [word for word, _ in sent]
+        gold = [tag for _, tag in sent]
+        pred = [tag for _, tag in tagger.tag(words)]
+
+        if len(pred) != len(gold):
+            raise ValueError(f"tagger returned {len(pred)} tags for {len(gold)} tokens")
+
+        for word, guess, truth in zip(words, pred, gold):
+            total += 1
+            hit = guess == truth
+            if hit:
+                correct += 1
+
+            if word in train_vocab:
+                seen_total += 1
+                if hit:
+                    seen_correct += 1
+            else:
+                oov_total += 1
+                if hit:
+                    oov_correct += 1
+
+    return {
+        "accuracy": correct / total if total else 0.0,
+        "seen_accuracy": seen_correct / seen_total if seen_total else None,
+        "oov_accuracy": oov_correct / oov_total if oov_total else None,
+        "oov_rate": oov_total / total if total else 0.0,
+        "total": total,
+        "seen_total": seen_total,
+        "oov_total": oov_total,
+    }
+
+
+def _format_score(score):
+    return "n/a" if score is None else f"{score:.4f}"
+
+
+# -----
+# Demos
+# -----
+
+
+def demo(test_size=1000):
+    """Evaluate TnT on a held-out Treebank slice."""
+    train_sents, test_sents, train_vocab = _treebank_demo_split(test_size)
+
+    for use_capitalization in (False, True):
+        tagger = TnT(N=1000, C=use_capitalization)
+        tagger.train(train_sents)
+        scores = _score_tagger(tagger, test_sents, train_vocab)
+
+        print(f"Capitalization: {use_capitalization}")
+        print(f"Accuracy:       {scores['accuracy']:.4f}")
+        print(f"Seen accuracy:  {_format_score(scores['seen_accuracy'])}")
+        print(f"OOV accuracy:   {_format_score(scores['oov_accuracy'])}")
+        print(f"OOV rate:       {scores['oov_rate']:.4f}")
         print()
 
 
-def demo2():
-    from nltk.corpus import treebank
+def demo_errors(limit=25, test_size=1000):
+    """Print the first ``limit`` errors from a held-out Treebank slice."""
+    if limit < 1:
+        raise ValueError(f"limit must be at least 1, got {limit!r}")
 
-    d = list(treebank.tagged_sents())
+    train_sents, test_sents, train_vocab = _treebank_demo_split(test_size)
 
-    t = TnT(N=1000, C=False)
-    s = TnT(N=1000, C=True)
-    t.train(d[(11) * 100 :])
-    s.train(d[(11) * 100 :])
+    tagger = TnT(N=1000, C=True)
+    tagger.train(train_sents)
 
-    for i in range(10):
-        tacc = t.accuracy(d[i * 100 : ((i + 1) * 100)])
-        tp_un = t.unknown / (t.known + t.unknown)
-        tp_kn = t.known / (t.known + t.unknown)
-        t.unknown = 0
-        t.known = 0
+    shown = 0
+    for sent in test_sents:
+        words = [word for word, _ in sent]
+        gold = [tag for _, tag in sent]
+        pred = [tag for _, tag in tagger.tag(words)]
 
-        print("Capitalization off:")
-        print("Accuracy:", tacc)
-        print("Percentage known:", tp_kn)
-        print("Percentage unknown:", tp_un)
+        if len(pred) != len(gold):
+            raise ValueError(f"tagger returned {len(pred)} tags for {len(gold)} tokens")
 
-        sacc = s.accuracy(d[i * 100 : ((i + 1) * 100)])
-        sp_un = s.unknown / (s.known + s.unknown)
-        sp_kn = s.known / (s.known + s.unknown)
-        s.unknown = 0
-        s.known = 0
+        for word, guess, truth in zip(words, pred, gold):
+            if guess == truth:
+                continue
 
-        print("Capitalization on:")
-        print("Accuracy:", sacc)
-        print("Percentage known:", sp_kn)
-        print("Percentage unknown:", sp_un)
+            status = "seen" if word in train_vocab else "OOV"
+            print(f"{word!r} ({status}): guessed {guess!r}, gold {truth!r}")
+            shown += 1
+            if shown >= limit:
+                return
 
-
-def demo3():
-    from nltk.corpus import brown, treebank
-
-    d = list(treebank.tagged_sents())
-    e = list(brown.tagged_sents())
-
-    d = d[:1000]
-    e = e[:1000]
-
-    d10 = int(len(d) * 0.1)
-    e10 = int(len(e) * 0.1)
-
-    tallacc = 0
-    sallacc = 0
-    tknown = 0
-    sknown = 0
-
-    for i in range(10):
-        t = TnT(N=1000, C=False)
-        s = TnT(N=1000, C=False)
-
-        dtest = d[(i * d10) : ((i + 1) * d10)]
-        etest = e[(i * e10) : ((i + 1) * e10)]
-
-        dtrain = d[: (i * d10)] + d[((i + 1) * d10) :]
-        etrain = e[: (i * e10)] + e[((i + 1) * e10) :]
-
-        t.train(dtrain)
-        s.train(etrain)
-
-        tacc = t.accuracy(dtest)
-        tp_un = t.unknown / (t.known + t.unknown)
-        tp_kn = t.known / (t.known + t.unknown)
-        tknown += tp_kn
-        t.unknown = 0
-        t.known = 0
-
-        sacc = s.accuracy(etest)
-        sp_un = s.unknown / (s.known + s.unknown)
-        sp_kn = s.known / (s.known + s.unknown)
-        sknown += sp_kn
-        s.unknown = 0
-        s.known = 0
-
-        tallacc += tacc
-        sallacc += sacc
-
-    print("brown   : overall accuracy:", 10 * tallacc)
-    print("        : words known:", 10 * tknown)
-    print("treebank: overall accuracy:", 10 * sallacc)
-    print("        : words known:", 10 * sknown)
+    if shown == 0:
+        print("No errors found.")

--- a/nltk/tag/tnt.py
+++ b/nltk/tag/tnt.py
@@ -117,6 +117,16 @@ class TnT(TaggerI):
         :type  C: bool
         """
 
+        # Reject N values that would break the log2() and pruning math
+        # later. The chained comparison rejects NaN (any compare with
+        # NaN is False) and both infinities, plus anything below 1.
+        if (
+            isinstance(N, bool)
+            or not isinstance(N, (int, float))
+            or not (1 <= N < float("inf"))
+        ):
+            raise ValueError(f"N must be a finite number >= 1, got {N!r}")
+
         self._tag_unigrams = FreqDist()
         self._tag_bigrams = ConditionalFreqDist()
         self._tag_trigrams = ConditionalFreqDist()
@@ -151,47 +161,59 @@ class TnT(TaggerI):
 
     def train(self, data):
         """
-        Trains the tagger on a list of tagged sentences. If an external
-        unknown-word tagger was passed via ``unk``, it is trained on the
-        same data on the first call only. Resets the decode cache and
-        populates the n-gram counts, the suffix model, and the
-        deleted-interpolation weights.
+        Trains the tagger on a list of tagged sentences. Each call
+        rebuilds the model from scratch on the supplied data. The
+        n-gram counts, word-tag lexicon, suffix model, and
+        deleted-interpolation weights are all replaced, and the decode
+        cache is cleared.
+
+        The optional external unknown-word tagger (``unk``) is trained
+        on the supplied data only the first time ``train()`` is called.
+        Subsequent calls leave it alone, since retraining it on each
+        new training set is rarely what callers want.
 
         :param data: list of lists of (word, tag) tuples
         :type  data: list[list[tuple[str, str]]]
         """
 
-        # The decode cache is keyed off post-train state, so a fresh
-        # train() invalidates every entry.
+        # Reset the parts of the model state that accumulate during
+        # training. The suffix model state and lambda weights are
+        # rebuilt unconditionally further down, so they don't need an
+        # explicit reset here. `_unk_trained` is preserved so the
+        # external unk tagger trains only on the first call.
         self._candidate_tags_cache.clear()
+        self._tag_unigrams = FreqDist()
+        self._tag_bigrams = ConditionalFreqDist()
+        self._tag_trigrams = ConditionalFreqDist()
+        self._word_tag_freqs = ConditionalFreqDist()
 
         if self._unk is not None and not self._unk_trained:
             self._unk.train(data)
 
-        wd = self._word_tag_freqs
-        uni = self._tag_unigrams
-        bi = self._tag_bigrams
-        tri = self._tag_trigrams
+        word_tag_freqs = self._word_tag_freqs
+        tag_unigrams = self._tag_unigrams
+        tag_bigrams = self._tag_bigrams
+        tag_trigrams = self._tag_trigrams
         cap_on = self._use_capitalization
 
         for sent in data:
             state_i_minus_2 = _BOS
             state_i_minus_1 = _BOS
-            for w, t in sent:
-                c_i = cap_on and bool(w) and w[0].isupper()
-                state_i = (t, c_i)
-                wd[w][t] += 1
-                uni[state_i] += 1
-                bi[state_i_minus_1][state_i] += 1
-                tri[(state_i_minus_2, state_i_minus_1)][state_i] += 1
+            for word, tag in sent:
+                c_i = cap_on and bool(word) and word[0].isupper()
+                state_i = (tag, c_i)
+                word_tag_freqs[word][tag] += 1
+                tag_unigrams[state_i] += 1
+                tag_bigrams[state_i_minus_1][state_i] += 1
+                tag_trigrams[(state_i_minus_2, state_i_minus_1)][state_i] += 1
                 state_i_minus_2, state_i_minus_1 = state_i_minus_1, state_i
 
             # Record EOS as a pseudo-tag in the n-gram counts. Skip empty
             # sentences so we don't add an EOS count to the BOS state.
             if sent:
-                uni[_EOS] += 1
-                bi[state_i_minus_1][_EOS] += 1
-                tri[(state_i_minus_2, state_i_minus_1)][_EOS] += 1
+                tag_unigrams[_EOS] += 1
+                tag_bigrams[state_i_minus_1][_EOS] += 1
+                tag_trigrams[(state_i_minus_2, state_i_minus_1)][_EOS] += 1
 
         self._compute_lambda()
 
@@ -219,13 +241,13 @@ class TnT(TaggerI):
         """
         # Tag priors over raw tags (excluding EOS), P(t) = f(t) / sum_t' f(t')
         tag_counts = {}
-        for (t, _), count in self._tag_unigrams.items():
-            if t == "EOS":
+        for (tag, _), count in self._tag_unigrams.items():
+            if tag == "EOS":
                 continue
-            tag_counts[t] = tag_counts.get(t, 0) + count
+            tag_counts[tag] = tag_counts.get(tag, 0) + count
         total = sum(tag_counts.values())
         if total > 0:
-            self._tag_prior_probs = {t: c / total for t, c in tag_counts.items()}
+            self._tag_prior_probs = {tag: c / total for tag, c in tag_counts.items()}
         else:
             self._tag_prior_probs = {}
 
@@ -245,14 +267,14 @@ class TnT(TaggerI):
             True: ConditionalFreqDist(),
         }
         for word in self._word_tag_freqs.conditions():
-            word_tag_freqs = self._word_tag_freqs[word]
-            if word_tag_freqs.N() > 10 or not word:
+            tag_freqs = self._word_tag_freqs[word]
+            if tag_freqs.N() > 10 or not word:
                 continue
-            trie = self._suffix_trie_by_cap[word[0].isupper()]
+            suffix_trie = self._suffix_trie_by_cap[word[0].isupper()]
             for m in range(1, min(len(word), 10) + 1):
-                trie_suffix = trie[word[-m:]]
-                for t, count in word_tag_freqs.items():
-                    trie_suffix[t] += count
+                suffix_dist = suffix_trie[word[-m:]]
+                for tag, count in tag_freqs.items():
+                    suffix_dist[tag] += count
 
     def _compute_lambda(self):
         """
@@ -276,11 +298,10 @@ class TnT(TaggerI):
         tag_unigrams = self._tag_unigrams
         unigram_n_minus_1 = tag_unigrams.N() - 1
 
-        for history in self._tag_trigrams.conditions():
-            _, h2 = history
-            trigram_dist = self._tag_trigrams[history]
+        for state_i_minus_2, state_i_minus_1 in self._tag_trigrams.conditions():
+            trigram_dist = self._tag_trigrams[(state_i_minus_2, state_i_minus_1)]
             trigram_n_minus_1 = trigram_dist.N() - 1
-            bigram_dist = tag_bigrams[h2]
+            bigram_dist = tag_bigrams[state_i_minus_1]
             bigram_n_minus_1 = bigram_dist.N() - 1
 
             for state_i, count in trigram_dist.items():
@@ -310,14 +331,19 @@ class TnT(TaggerI):
                 if w3:
                     lambda3_mass += share
 
-        # If no trigrams contributed (empty or pathological training input),
-        # leave the weights at their __init__ zero defaults rather than
-        # dividing by zero. Decode will fall back to the unigram emission.
+        # If no trigrams contributed (empty or pathological training
+        # input), zero the weights explicitly rather than dividing by
+        # zero or leaving stale values from a prior train(). Decode
+        # will fall back to the unigram emission.
         total_mass = lambda1_mass + lambda2_mass + lambda3_mass
         if total_mass > 0:
             self._lambda1 = lambda1_mass / total_mass
             self._lambda2 = lambda2_mass / total_mass
             self._lambda3 = lambda3_mass / total_mass
+        else:
+            self._lambda1 = 0.0
+            self._lambda2 = 0.0
+            self._lambda3 = 0.0
 
     def _unknown_tag_scores(self, word):
         """
@@ -348,14 +374,14 @@ class TnT(TaggerI):
             return {}
 
         is_capitalized = bool(word) and word[0].isupper()
-        trie = self._suffix_trie_by_cap[is_capitalized]
+        suffix_trie = self._suffix_trie_by_cap[is_capitalized]
         theta = self._theta
 
         # Find the longest known suffix by scanning from 10 down to 1.
         # If none is found, the loop below leaves P at the unigram prior.
         longest = 0
         for m in range(min(len(word), 10), 0, -1):
-            if word[-m:] in trie:
+            if word[-m:] in suffix_trie:
                 longest = m
                 break
 
@@ -364,21 +390,21 @@ class TnT(TaggerI):
         p_t_given_suffix = dict(tag_priors)
         denom = 1.0 + theta
         for i in range(1, longest + 1):
-            suffix_dist = trie[word[-i:]]
+            suffix_dist = suffix_trie[word[-i:]]
             suffix_N = suffix_dist.N()
             if suffix_N == 0:
                 continue
-            inv_N = 1.0 / suffix_N
-            for t in tag_priors:
-                p_t_given_suffix[t] = (
-                    suffix_dist[t] * inv_N + theta * p_t_given_suffix[t]
+            inv_suffix_N = 1.0 / suffix_N
+            for tag in tag_priors:
+                p_t_given_suffix[tag] = (
+                    suffix_dist[tag] * inv_suffix_N + theta * p_t_given_suffix[tag]
                 ) / denom
 
         # Apply Bayesian inversion so the result ranks by P(suffix | t),
         # which is proportional to P(t | suffix) / P(t).
         return {
-            t: p_t_given_suffix[t] / prior
-            for t, prior in tag_priors.items()
+            tag: p_t_given_suffix[tag] / prior
+            for tag, prior in tag_priors.items()
             if prior > 0
         }
 
@@ -406,35 +432,36 @@ class TnT(TaggerI):
                  `logp` across `new_states`, returned so the caller
                  can apply threshold pruning without a second pass.
         """
-        l1, l2, l3 = self._lambda1, self._lambda2, self._lambda3
-        bi, tri = self._tag_bigrams, self._tag_trigrams
+        lambda1, lambda2, lambda3 = self._lambda1, self._lambda2, self._lambda3
+        tag_bigrams = self._tag_bigrams
+        tag_trigrams = self._tag_trigrams
         new_states = {}
         best_logp = float("-inf")
-        for (state_i_minus_2, state_i_minus_1), (curr_logp, _) in states.items():
-            bi_dist = bi[state_i_minus_1]
-            tri_dist = tri[(state_i_minus_2, state_i_minus_1)]
-            bi_N = bi_dist.N()
-            tri_N = tri_dist.N()
-            inv_bi = (1.0 / bi_N) if bi_N else 0.0
-            inv_tri = (1.0 / tri_N) if tri_N else 0.0
+        for (state_i_minus_2, state_i_minus_1), (prefix_logp, _) in states.items():
+            bigram_dist = tag_bigrams[state_i_minus_1]
+            trigram_dist = tag_trigrams[(state_i_minus_2, state_i_minus_1)]
+            bigram_N = bigram_dist.N()
+            trigram_N = trigram_dist.N()
+            inv_bigram_N = (1.0 / bigram_N) if bigram_N else 0.0
+            inv_trigram_N = (1.0 / trigram_N) if trigram_N else 0.0
             for state_i, p_state_i, log_emit in candidate_tags:
                 p_state_i_given_history = (
-                    l1 * p_state_i
-                    + l2 * bi_dist[state_i] * inv_bi
-                    + l3 * tri_dist[state_i] * inv_tri
+                    lambda1 * p_state_i
+                    + lambda2 * bigram_dist[state_i] * inv_bigram_N
+                    + lambda3 * trigram_dist[state_i] * inv_trigram_N
                 )
-                lp = (
+                step_logp = (
                     log2(p_state_i_given_history)
                     if p_state_i_given_history > 1e-300
                     else _LOG_FLOOR_2
                 ) + log_emit
-                total_logp = curr_logp + lp
-                if total_logp > best_logp:
-                    best_logp = total_logp
-                new_key = (state_i_minus_1, state_i)
-                existing = new_states.get(new_key)
-                if existing is None or total_logp > existing[0]:
-                    new_states[new_key] = (total_logp, state_i_minus_2)
+                path_logp = prefix_logp + step_logp
+                if path_logp > best_logp:
+                    best_logp = path_logp
+                next_state = (state_i_minus_1, state_i)
+                prev_best = new_states.get(next_state)
+                if prev_best is None or path_logp > prev_best[0]:
+                    new_states[next_state] = (path_logp, state_i_minus_2)
         return new_states, best_logp
 
     def tagdata(self, data, segment=False):
@@ -449,11 +476,11 @@ class TnT(TaggerI):
         :type segment: bool
         :return: list of list of (word, tag) tuples
         """
-        res = []
+        tagged_sents = []
         for sent in data:
-            res1 = self.tag(sent, segment=segment)
-            res.append(res1)
-        return res
+            tagged_sent = self.tag(sent, segment=segment)
+            tagged_sents.append(tagged_sent)
+        return tagged_sents
 
     def tag(self, tokens, segment=False):
         """
@@ -526,7 +553,7 @@ class TnT(TaggerI):
         tag_trigrams = self._tag_trigrams
         tag_unigrams = self._tag_unigrams
         num_tag_tokens = self._num_tag_tokens
-        l1, l2, l3 = self._lambda1, self._lambda2, self._lambda3
+        lambda1, lambda2, lambda3 = self._lambda1, self._lambda2, self._lambda3
         log2_beam_threshold = self._log2_beam_threshold
         cap_on = self._use_capitalization
         cache = self._candidate_tags_cache
@@ -538,8 +565,8 @@ class TnT(TaggerI):
 
         for word in sent:
             c_i = cap_on and bool(word) and word[0].isupper()
-            wd_word = word_tag_freqs.get(word)
-            if wd_word is not None:
+            tag_freqs = word_tag_freqs.get(word)
+            if tag_freqs is not None:
                 self.known += 1
             else:
                 self.unknown += 1
@@ -548,7 +575,7 @@ class TnT(TaggerI):
             # so we evaluate them on every call rather than memoizing.
             # The known and suffix model paths are pure functions of
             # `(word, c_i)` and the trained model state, so they cache.
-            if wd_word is None and self._unk is not None:
+            if tag_freqs is None and self._unk is not None:
                 [(_w, t)] = self._unk.tag([word])
                 state_i = (t, c_i)
                 p_state_i = (
@@ -556,13 +583,13 @@ class TnT(TaggerI):
                 )
                 candidate_tags = ((state_i, p_state_i, 0.0),)
             else:
-                key = (word, c_i)
-                candidate_tags = cache.get(key)
+                cache_key = (word, c_i)
+                candidate_tags = cache.get(cache_key)
                 if candidate_tags is None:
-                    if wd_word is not None:
+                    if tag_freqs is not None:
                         # Per-tag constants depend only on the candidate tag.
                         entries = []
-                        for t, wc in wd_word.items():
+                        for t, tag_count in tag_freqs.items():
                             state_i = (t, c_i)
                             unigram_state_i = tag_unigrams[state_i]
                             p_state_i = (
@@ -571,7 +598,11 @@ class TnT(TaggerI):
                                 else 0
                             )
                             entries.append(
-                                (state_i, p_state_i, log2(wc / unigram_state_i))
+                                (
+                                    state_i,
+                                    p_state_i,
+                                    log2(tag_count / unigram_state_i),
+                                )
                             )
                         candidate_tags = tuple(entries)
                     else:
@@ -603,7 +634,7 @@ class TnT(TaggerI):
                                 )
                                 entries.append((state_i, p_state_i, log_score))
                             candidate_tags = tuple(entries)
-                    cache[key] = candidate_tags
+                    cache[cache_key] = candidate_tags
 
             new_states, best_logp = self._expand_states(states, candidate_tags)
 
@@ -621,20 +652,24 @@ class TnT(TaggerI):
         p_eos_unigram = (tag_unigrams[_EOS] / num_tag_tokens) if num_tag_tokens else 0
         best_final_state = next(iter(states))
         best_final_logp = float("-inf")
-        for (state_i_minus_2, state_i_minus_1), (curr_logp, _) in states.items():
+        for (state_i_minus_2, state_i_minus_1), (prefix_logp, _) in states.items():
             bigram_dist = tag_bigrams[state_i_minus_1]
             trigram_dist = tag_trigrams[(state_i_minus_2, state_i_minus_1)]
             bigram_N = bigram_dist.N()
             trigram_N = trigram_dist.N()
-            p_bi = (bigram_dist[_EOS] / bigram_N) if bigram_N else 0
-            p_tri = (trigram_dist[_EOS] / trigram_N) if trigram_N else 0
-            p_eos_given_history = l1 * p_eos_unigram + l2 * p_bi + l3 * p_tri
-            eos_lp = (
+            p_eos_bigram = (bigram_dist[_EOS] / bigram_N) if bigram_N else 0
+            p_eos_trigram = (trigram_dist[_EOS] / trigram_N) if trigram_N else 0
+            p_eos_given_history = (
+                lambda1 * p_eos_unigram
+                + lambda2 * p_eos_bigram
+                + lambda3 * p_eos_trigram
+            )
+            eos_logp = (
                 log2(p_eos_given_history)
                 if p_eos_given_history > 1e-300
                 else _LOG_FLOOR_2
             )
-            final_logp = curr_logp + eos_lp
+            final_logp = prefix_logp + eos_logp
             if final_logp > best_final_logp:
                 best_final_logp = final_logp
                 best_final_state = (state_i_minus_2, state_i_minus_1)
@@ -651,11 +686,11 @@ class TnT(TaggerI):
         tags_reversed = [best_final_state[1]]
         if T >= 2:
             tags_reversed.append(best_final_state[0])
-        current_key = best_final_state
+        current_state = best_final_state
         for level in range(T, 2, -1):
-            backpointer = state_history[level][current_key][1]
+            backpointer = state_history[level][current_state][1]
             tags_reversed.append(backpointer)
-            current_key = (backpointer, current_key[0])
+            current_state = (backpointer, current_state[0])
         tags_reversed.reverse()
         return [_BOS, _BOS] + tags_reversed
 

--- a/nltk/tag/tnt.py
+++ b/nltk/tag/tnt.py
@@ -176,17 +176,19 @@ class TnT(TaggerI):
         if isinstance(N, bool) or not isinstance(N, int) or N < 1:
             raise ValueError(f"N must be a positive integer, got {N!r}")
 
+        self._beam_threshold = N
+        self._use_capitalization = C
+        self._unk = unk
+        self._unk_trained = Trained
+
         self._tag_unigrams = FreqDist()
         self._tag_bigrams = ConditionalFreqDist()
         self._tag_trigrams = ConditionalFreqDist()
         self._word_tag_freqs = ConditionalFreqDist()
+
         self._lambda1 = 0.0
         self._lambda2 = 0.0
         self._lambda3 = 0.0
-        self._beam_threshold = N
-        self._use_capitalization = C
-        self._unk_trained = Trained
-
         self._num_tag_tokens = 0
         self._log2_beam_threshold = 0.0
 
@@ -204,8 +206,6 @@ class TnT(TaggerI):
         self._trans_logp_unigram = {}
         self._trans_logp_bigram = {}
         self._trans_logp_trigram = {}
-
-        self._unk = unk
 
         # The cache depends entirely on trained model state, so it starts
         # empty here and is cleared whenever train() rebuilds the model.
@@ -239,8 +239,9 @@ class TnT(TaggerI):
         self._tag_trigrams = ConditionalFreqDist()
         self._word_tag_freqs = ConditionalFreqDist()
 
-        if self._unk is not None and not self._unk_trained:
-            self._unk.train(data)
+        unk = self._unk
+        if unk is not None and not self._unk_trained:
+            unk.train(data)
 
         word_tag_freqs = self._word_tag_freqs
         tag_unigrams = self._tag_unigrams
@@ -251,19 +252,24 @@ class TnT(TaggerI):
         for sent in data:
             state_i_minus_2 = _BOS
             state_i_minus_1 = _BOS
+            sent_has_tokens = False
+
             for word, tag in sent:
+                sent_has_tokens = True
                 c_i = cap_on and bool(word) and word[0].isupper()
                 state_i = (tag, c_i)
+
                 word_tag_freqs[word][tag] += 1
                 tag_unigrams[state_i] += 1
                 tag_bigrams[state_i_minus_1][state_i] += 1
                 tag_trigrams[(state_i_minus_2, state_i_minus_1)][state_i] += 1
+
                 state_i_minus_2, state_i_minus_1 = state_i_minus_1, state_i
 
             # EOS is treated as an ordinary next state in the n-gram model,
             # but empty sentences are skipped so BOS does not acquire EOS as
             # a spurious successor.
-            if sent:
+            if sent_has_tokens:
                 tag_unigrams[_EOS] += 1
                 tag_bigrams[state_i_minus_1][_EOS] += 1
                 tag_trigrams[(state_i_minus_2, state_i_minus_1)][_EOS] += 1
@@ -272,7 +278,7 @@ class TnT(TaggerI):
 
         # This total intentionally includes EOS because the unigram model
         # and deleted interpolation are estimated over the same event stream.
-        self._num_tag_tokens = self._tag_unigrams.N()
+        self._num_tag_tokens = tag_unigrams.N()
         self._log2_beam_threshold = log2(self._beam_threshold)
 
         self._build_suffix_model()
@@ -293,44 +299,58 @@ class TnT(TaggerI):
         with total count at most 10, following Brants's infrequent-word
         threshold for unknown-word modeling.
         """
+        tag_unigrams = self._tag_unigrams
+        word_tag_freqs = self._word_tag_freqs
+
         tag_counts = {}
-        for (tag, _), count in self._tag_unigrams.items():
+        for (tag, _), count in tag_unigrams.items():
             # The suffix model predicts lexical tags, not boundary markers.
             # Check the raw tag so EOS is excluded from all capitalization states.
-            if tag == "EOS":
+            if tag == _EOS[0]:
                 continue
             tag_counts[tag] = tag_counts.get(tag, 0) + count
+
         total = sum(tag_counts.values())
         if total > 0:
-            self._tag_prior_probs = {tag: c / total for tag, c in tag_counts.items()}
+            tag_prior_probs = {tag: count / total for tag, count in tag_counts.items()}
         else:
-            self._tag_prior_probs = {}
+            tag_prior_probs = {}
 
         # Theta controls how strongly the suffix recursion is pulled back
         # toward the less specific estimate at each abstraction step.
-        priors = list(self._tag_prior_probs.values())
-        n = len(priors)
-        if n > 1:
-            mean = sum(priors) / n
-            self._theta = (sum((p - mean) ** 2 for p in priors) / (n - 1)) ** 0.5
+        priors = list(tag_prior_probs.values())
+        n_priors = len(priors)
+        if n_priors > 1:
+            mean = sum(priors) / n_priors
+            theta = (
+                sum((prior - mean) ** 2 for prior in priors) / (n_priors - 1)
+            ) ** 0.5
         else:
-            self._theta = 0.0
+            theta = 0.0
 
         # Each capitalization bucket stores every suffix length up to 10,
         # so decode can walk from the shortest matched ending to the longest.
-        self._suffix_trie_by_cap = {
+        suffix_trie_by_cap = {
             False: ConditionalFreqDist(),
             True: ConditionalFreqDist(),
         }
-        for word in self._word_tag_freqs.conditions():
-            tag_freqs = self._word_tag_freqs[word]
-            if tag_freqs.N() > 10 or not word:
+
+        for word in word_tag_freqs.conditions():
+            tag_freqs = word_tag_freqs[word]
+            if not word or tag_freqs.N() > 10:
                 continue
-            suffix_trie = self._suffix_trie_by_cap[word[0].isupper()]
-            for m in range(1, min(len(word), 10) + 1):
+
+            suffix_trie = suffix_trie_by_cap[word[0].isupper()]
+            max_suffix_len = min(len(word), 10)
+
+            for m in range(1, max_suffix_len + 1):
                 suffix_dist = suffix_trie[word[-m:]]
                 for tag, count in tag_freqs.items():
                     suffix_dist[tag] += count
+
+        self._tag_prior_probs = tag_prior_probs
+        self._theta = theta
+        self._suffix_trie_by_cap = suffix_trie_by_cap
 
     def _build_transition_logp_cache(self):
         """
@@ -364,8 +384,9 @@ class TnT(TaggerI):
         tag_unigrams = self._tag_unigrams
         tag_bigrams = self._tag_bigrams
         tag_trigrams = self._tag_trigrams
-        inv_total_N = _safe_inverse(self._num_tag_tokens)
+
         lambda1, lambda2, lambda3 = self._lambda1, self._lambda2, self._lambda3
+        inv_total_N = _safe_inverse(self._num_tag_tokens)
 
         # Computed once and reused below so the bigram and trigram caches
         # don't recompute the unigram contribution per (history, current).
@@ -381,6 +402,7 @@ class TnT(TaggerI):
         for prev1 in tag_bigrams.conditions():
             bigram_dist = tag_bigrams[prev1]
             inv_bigram_N = _safe_inverse(bigram_dist.N())
+
             bigram_logp[prev1] = {
                 current: _safe_log2(
                     unigram_part.get(current, 0.0) + lambda2 * count * inv_bigram_N
@@ -391,11 +413,15 @@ class TnT(TaggerI):
 
         trigram_logp = {}
         for prev_pair in tag_trigrams.conditions():
+            _, prev1 = prev_pair
+
             trigram_dist = tag_trigrams[prev_pair]
+            bigram_dist = tag_bigrams[prev1]
+
             inv_trigram_N = _safe_inverse(trigram_dist.N())
-            bigram_dist = tag_bigrams[prev_pair[1]]
             inv_bigram_N = _safe_inverse(bigram_dist.N())
             bigram_get = bigram_dist.get
+
             trigram_logp[prev_pair] = {
                 current: _safe_log2(
                     unigram_part.get(current, 0.0)
@@ -420,35 +446,37 @@ class TnT(TaggerI):
             c3 = (f(t1, t2, t3) - 1) / (f(t1, t2) - 1)
         """
 
+        tag_unigrams = self._tag_unigrams
+        tag_bigrams = self._tag_bigrams
+        tag_trigrams = self._tag_trigrams
+        unigram_n_minus_1 = tag_unigrams.N() - 1
+
         lambda1_mass = 0.0
         lambda2_mass = 0.0
         lambda3_mass = 0.0
 
-        tag_bigrams = self._tag_bigrams
-        tag_unigrams = self._tag_unigrams
-        unigram_n_minus_1 = tag_unigrams.N() - 1
-
-        for state_i_minus_2, state_i_minus_1 in self._tag_trigrams.conditions():
-            trigram_dist = self._tag_trigrams[(state_i_minus_2, state_i_minus_1)]
-            trigram_n_minus_1 = trigram_dist.N() - 1
+        for state_i_minus_2, state_i_minus_1 in tag_trigrams.conditions():
+            trigram_dist = tag_trigrams[(state_i_minus_2, state_i_minus_1)]
             bigram_dist = tag_bigrams[state_i_minus_1]
+
+            trigram_n_minus_1 = trigram_dist.N() - 1
             bigram_n_minus_1 = bigram_dist.N() - 1
 
             for state_i, count in trigram_dist.items():
                 # Subtracting one leaves the current event out, so each score
                 # asks which model order would best predict this tag if this
                 # occurrence were held out.
-                c3 = (count - 1) / trigram_n_minus_1 if trigram_n_minus_1 else 0
-                c2 = (
-                    (bigram_dist[state_i] - 1) / bigram_n_minus_1
-                    if bigram_n_minus_1
-                    else 0
-                )
                 c1 = (
                     (tag_unigrams[state_i] - 1) / unigram_n_minus_1
                     if unigram_n_minus_1
-                    else 0
+                    else 0.0
                 )
+                c2 = (
+                    (bigram_dist[state_i] - 1) / bigram_n_minus_1
+                    if bigram_n_minus_1
+                    else 0.0
+                )
+                c3 = (count - 1) / trigram_n_minus_1 if trigram_n_minus_1 else 0.0
 
                 # The trigram's count is credited to the model order with the
                 # strongest held out estimate. Splitting ties evenly avoids
@@ -458,6 +486,7 @@ class TnT(TaggerI):
                 w2 = c2 == maxc
                 w3 = c3 == maxc
                 share = count / (w1 + w2 + w3)
+
                 if w1:
                     lambda1_mass += share
                 if w2:
@@ -508,13 +537,13 @@ class TnT(TaggerI):
 
         is_capitalized = bool(word) and word[0].isupper()
         suffix_trie = self._suffix_trie_by_cap[is_capitalized]
-        theta = self._theta
+        max_suffix_len = min(len(word), 10)
 
         # The trie contains every suffix length up to the cutoff. Once the
         # longest matching suffix is found, all shorter suffixes are also
         # available for successive abstraction.
         longest = 0
-        for m in range(min(len(word), 10), 0, -1):
+        for m in range(max_suffix_len, 0, -1):
             if word[-m:] in suffix_trie:
                 longest = m
                 break
@@ -523,6 +552,8 @@ class TnT(TaggerI):
         # After Bayes inversion, every tag then receives the same score.
         if longest == 0:
             return {tag: 1.0 for tag, prior in tag_priors.items() if prior > 0}
+
+        theta = self._theta
 
         # With theta equal to zero there is no smoothing, so the estimate
         # is the empirical distribution of the longest matched suffix.
@@ -578,40 +609,44 @@ class TnT(TaggerI):
 
     def _expand_states(self, states, candidate_tags):
         """
-        Takes one Viterbi step. For every predecessor state we score
-        each candidate `state_i` from `candidate_tags` and accumulate
-        the results into a new state dict keyed by
-        `(state_i_minus_1, state_i)`. When two predecessors land on
-        the same key we keep the higher-scoring one and discard the
-        other. The second-order Markov assumption means everything
-        after this point depends only on the last two states, so the
-        discarded path can never beat the kept one.
+        Take one Viterbi step. For every predecessor state, score each
+        candidate `state_i` from `candidate_tags` and accumulate the
+        results into a new state dict keyed by
+        `(state_i_minus_1, state_i)`. When two predecessors land on the
+        same key, keep the higher-scoring one and discard the other. The
+        second-order Markov assumption means everything after this point
+        depends only on the last two states, so the discarded path can
+        never beat the kept one.
 
         `candidate_tags` is a sequence of `(state_i, log_emit,
         unigram_logp)` triples. `log_emit` is the lexical log-probability
         for known words, the Bayes-inverted suffix score for unknown
         words, or zero for an external unknown-word tagger.
+
         `unigram_logp` is the precomputed unigram-tier transition
         log-probability for `state_i`, used as the fallback when the
-        trigram and bigram caches both miss; precomputing it once per
-        candidate (rather than re-fetching it from
-        ``_trans_logp_unigram`` per predecessor) was the dominant
-        cost on high-OOV corpora.
+        trigram and bigram caches both miss. Precomputing it once per
+        candidate removes a hot lookup from the inner loop on high-OOV
+        corpora.
 
         :return: ``(new_states, best_logp)``. ``new_states`` maps
                  `(state_i_minus_1, state_i)` to
                  `(logp, state_i_minus_2)`, where `state_i_minus_2` is
-                 the backpointer used to reconstruct the best path
-                 after the final EOS step. `best_logp` is the maximum
-                 `logp` across `new_states`, returned so the caller
-                 can apply threshold pruning without a second pass.
+                 the backpointer used to reconstruct the best path after
+                 the final EOS step. `best_logp` is the maximum `logp`
+                 across `new_states`, returned so the caller can apply
+                 threshold pruning without a second pass.
         """
         trans_logp_trigram = self._trans_logp_trigram
         trans_logp_bigram = self._trans_logp_bigram
+
         new_states = {}
+        new_states_get = new_states.get
         best_logp = float("-inf")
+
         for predecessor_key, (prefix_logp, _) in states.items():
             state_i_minus_2, state_i_minus_1 = predecessor_key
+
             # Per-history caches are constant across the candidate loop;
             # resolving them once and using ``_EMPTY_DICT`` for misses
             # lets the inner ``.get`` calls run without ``None`` branches.
@@ -619,27 +654,30 @@ class TnT(TaggerI):
             bigram_logp = trans_logp_bigram.get(state_i_minus_1, _EMPTY_DICT)
             trigram_logp_get = trigram_logp.get
             bigram_logp_get = bigram_logp.get
+
             for state_i, log_emit, unigram_logp in candidate_tags:
                 trans_logp = trigram_logp_get(state_i)
                 if trans_logp is None:
                     trans_logp = bigram_logp_get(state_i)
                     if trans_logp is None:
-                        # Unigram fallback (with floor for states never
-                        # observed as a unigram) was precomputed when
-                        # the candidate tuple was built, so we just read
-                        # it instead of doing a third dict lookup.
+                        # The candidate tuple carries the unigram fallback,
+                        # including the floor for states never observed as
+                        # unigrams, so the inner loop avoids a third dict lookup.
                         trans_logp = unigram_logp
+
                 # Parens match the previous ``step_logp + prefix_logp``
                 # order so the sum is bit-identical to the old decoder.
                 path_logp = prefix_logp + (trans_logp + log_emit)
-                if path_logp > best_logp:
-                    best_logp = path_logp
                 next_state = (state_i_minus_1, state_i)
-                prev_best = new_states.get(next_state)
+
                 # Once the last two states match, only the better prefix matters.
                 # All future transitions depend on this key alone.
+                prev_best = new_states_get(next_state)
                 if prev_best is None or path_logp > prev_best[0]:
                     new_states[next_state] = (path_logp, state_i_minus_2)
+                    if path_logp > best_logp:
+                        best_logp = path_logp
+
         return new_states, best_logp
 
     def tagdata(self, data, segment=False):
@@ -697,9 +735,9 @@ class TnT(TaggerI):
         pair_decoded = self._pair_decoded
         extend = tagged.extend
 
-        for tok in tokens:
-            segment.append(tok)
-            if tok in sent_marks:
+        for token in tokens:
+            segment.append(token)
+            if token in sent_marks:
                 extend(pair_decoded(segment, tagword(segment)))
                 segment.clear()
 
@@ -734,16 +772,18 @@ class TnT(TaggerI):
         if not sent:
             return [_BOS, _BOS]
 
+        T = len(sent)
+
         # Local bindings keep the hot loop on plain locals rather than
         # repeated attribute lookups.
         word_tag_freqs = self._word_tag_freqs
         tag_unigrams = self._tag_unigrams
-        inv_num_tag_tokens = _safe_inverse(self._num_tag_tokens)
         trans_logp_unigram_get = self._trans_logp_unigram.get
         log2_beam_threshold = self._log2_beam_threshold
         cap_on = self._use_capitalization
         unk = self._unk
         cache = self._candidate_tags_cache
+        unknown_tag_scores = self._unknown_tag_scores
         expand_states = self._expand_states
 
         # Each level keeps only the best path reaching a given
@@ -794,7 +834,7 @@ class TnT(TaggerI):
                         # Unknown words use the suffix model as their lexical
                         # score. Bayes inversion turns the suffix posterior into
                         # the emission-like quantity used by the decoder.
-                        suffix_scores = self._unknown_tag_scores(word)
+                        suffix_scores = unknown_tag_scores(word)
 
                         if not suffix_scores:
                             # An untrained tagger has no suffix priors, so the
@@ -830,7 +870,9 @@ class TnT(TaggerI):
         tag_bigrams = self._tag_bigrams
         tag_trigrams = self._tag_trigrams
         lambda1, lambda2, lambda3 = self._lambda1, self._lambda2, self._lambda3
+        inv_num_tag_tokens = _safe_inverse(self._num_tag_tokens)
         p_eos_unigram = tag_unigrams[_EOS] * inv_num_tag_tokens
+
         best_final_key = next(iter(states))
         best_final_logp = float("-inf")
 
@@ -866,7 +908,6 @@ class TnT(TaggerI):
 
         # Walking the stored ``state_{i-2}`` backpointers recovers the best
         # full state sequence from the best final state pair.
-        T = len(sent)
         states_reversed = [best_final_key[1]]
         if T >= 2:
             states_reversed.append(best_final_key[0])

--- a/nltk/tag/tnt.py
+++ b/nltk/tag/tnt.py
@@ -387,15 +387,17 @@ class TnT(TaggerI):
                 break
 
         # Successive abstraction from the prior up to the longest suffix.
-        # Update in place since we only touch existing keys.
+        # Update in place since we only touch existing keys. Skip suffix
+        # lengths whose tail is not in the trie rather than indexing in
+        # (which would insert an empty defaultdict entry on every miss).
         p_t_given_suffix = dict(tag_priors)
         denom = 1.0 + theta
         for i in range(1, longest + 1):
-            suffix_dist = suffix_trie[word[-i:]]
-            suffix_N = suffix_dist.N()
-            if suffix_N == 0:
+            suffix_key = word[-i:]
+            if suffix_key not in suffix_trie:
                 continue
-            inv_suffix_N = 1.0 / suffix_N
+            suffix_dist = suffix_trie[suffix_key]
+            inv_suffix_N = 1.0 / suffix_dist.N()
             for tag in tag_priors:
                 p_t_given_suffix[tag] = (
                     suffix_dist[tag] * inv_suffix_N + theta * p_t_given_suffix[tag]
@@ -675,11 +677,10 @@ class TnT(TaggerI):
                 best_final_logp = final_logp
                 best_final_state = (state_i_minus_2, state_i_minus_1)
 
-        # Reconstruct the best path by walking backpointers, collecting
-        # states in reverse. At level L the key is
-        # (state_{L-2}, state_{L-1}) and the stored backpointer is
-        # state_{L-3}, so each iteration extends one state toward the
-        # start of the sentence.
+        # Walk backpointers to reconstruct the best path,
+        # collecting states in reverse. At level L the key
+        # is (state_{L-2}, state_{L-1}) and the backpointer
+        # is state_{L-3}, peeling off one state per step.
         T = len(sent)
         if T == 0:
             return [_BOS, _BOS]

--- a/nltk/tag/tnt.py
+++ b/nltk/tag/tnt.py
@@ -587,10 +587,16 @@ class TnT(TaggerI):
         after this point depends only on the last two states, so the
         discarded path can never beat the kept one.
 
-        `candidate_tags` is a sequence of `(state_i, log_emit)` pairs.
-        `log_emit` is the lexical log-probability for known words, the
-        Bayes-inverted suffix score for unknown words, or zero for an
-        external unknown-word tagger.
+        `candidate_tags` is a sequence of `(state_i, log_emit,
+        unigram_logp)` triples. `log_emit` is the lexical log-probability
+        for known words, the Bayes-inverted suffix score for unknown
+        words, or zero for an external unknown-word tagger.
+        `unigram_logp` is the precomputed unigram-tier transition
+        log-probability for `state_i`, used as the fallback when the
+        trigram and bigram caches both miss; precomputing it once per
+        candidate (rather than re-fetching it from
+        ``_trans_logp_unigram`` per predecessor) was the dominant
+        cost on high-OOV corpora.
 
         :return: ``(new_states, best_logp)``. ``new_states`` maps
                  `(state_i_minus_1, state_i)` to
@@ -602,7 +608,6 @@ class TnT(TaggerI):
         """
         trans_logp_trigram = self._trans_logp_trigram
         trans_logp_bigram = self._trans_logp_bigram
-        unigram_logp_get = self._trans_logp_unigram.get
         new_states = {}
         best_logp = float("-inf")
         for predecessor_key, (prefix_logp, _) in states.items():
@@ -614,16 +619,16 @@ class TnT(TaggerI):
             bigram_logp = trans_logp_bigram.get(state_i_minus_1, _EMPTY_DICT)
             trigram_logp_get = trigram_logp.get
             bigram_logp_get = bigram_logp.get
-            for state_i, log_emit in candidate_tags:
+            for state_i, log_emit, unigram_logp in candidate_tags:
                 trans_logp = trigram_logp_get(state_i)
                 if trans_logp is None:
                     trans_logp = bigram_logp_get(state_i)
                     if trans_logp is None:
-                        # If the candidate state was never observed as a
-                        # unigram, keep the path alive with the model floor.
-                        # This is smoothing for unseen states, not only
-                        # protection around log2(0).
-                        trans_logp = unigram_logp_get(state_i, _LOG_FLOOR_2)
+                        # Unigram fallback (with floor for states never
+                        # observed as a unigram) was precomputed when
+                        # the candidate tuple was built, so we just read
+                        # it instead of doing a third dict lookup.
+                        trans_logp = unigram_logp
                 # Parens match the previous ``step_logp + prefix_logp``
                 # order so the sum is bit-identical to the old decoder.
                 path_logp = prefix_logp + (trans_logp + log_emit)
@@ -734,6 +739,7 @@ class TnT(TaggerI):
         word_tag_freqs = self._word_tag_freqs
         tag_unigrams = self._tag_unigrams
         inv_num_tag_tokens = _safe_inverse(self._num_tag_tokens)
+        trans_logp_unigram_get = self._trans_logp_unigram.get
         log2_beam_threshold = self._log2_beam_threshold
         cap_on = self._use_capitalization
         unk = self._unk
@@ -760,7 +766,9 @@ class TnT(TaggerI):
             # pure given ``(word, c_i)`` and the trained model, so they cache.
             if tag_freqs is None and unk is not None:
                 [(_word, tag)] = unk.tag([word])
-                candidate_tags = (((tag, c_i), 0.0),)
+                state_i = (tag, c_i)
+                unigram_logp = trans_logp_unigram_get(state_i, _LOG_FLOOR_2)
+                candidate_tags = ((state_i, 0.0, unigram_logp),)
             else:
                 cache_key = (word, c_i)
                 candidate_tags = cache.get(cache_key)
@@ -773,7 +781,14 @@ class TnT(TaggerI):
                         for tag, tag_count in tag_freqs.items():
                             state_i = (tag, c_i)
                             unigram_state_i = tag_unigrams[state_i]
-                            entries.append((state_i, log2(tag_count / unigram_state_i)))
+                            unigram_logp = trans_logp_unigram_get(state_i, _LOG_FLOOR_2)
+                            entries.append(
+                                (
+                                    state_i,
+                                    log2(tag_count / unigram_state_i),
+                                    unigram_logp,
+                                )
+                            )
                         candidate_tags = tuple(entries)
                     else:
                         # Unknown words use the suffix model as their lexical
@@ -784,12 +799,20 @@ class TnT(TaggerI):
                         if not suffix_scores:
                             # An untrained tagger has no suffix priors, so the
                             # only safe fallback is a literal ``Unk`` state.
-                            candidate_tags = ((("Unk", c_i), 0.0),)
+                            state_i = ("Unk", c_i)
+                            unigram_logp = trans_logp_unigram_get(state_i, _LOG_FLOOR_2)
+                            candidate_tags = ((state_i, 0.0, unigram_logp),)
                         else:
-                            candidate_tags = tuple(
-                                ((tag, c_i), _safe_log2(score))
-                                for tag, score in suffix_scores.items()
-                            )
+                            entries = []
+                            for tag, score in suffix_scores.items():
+                                state_i = (tag, c_i)
+                                unigram_logp = trans_logp_unigram_get(
+                                    state_i, _LOG_FLOOR_2
+                                )
+                                entries.append(
+                                    (state_i, _safe_log2(score), unigram_logp)
+                                )
+                            candidate_tags = tuple(entries)
 
                     cache[cache_key] = candidate_tags
 

--- a/nltk/tag/tnt.py
+++ b/nltk/tag/tnt.py
@@ -292,6 +292,12 @@ class TnT(TaggerI):
         :type segment: bool
         :return: list of `(word, tag)` tuples
         """
+        # Catch "forgot to tokenize" mistake before it produces garbage tags.
+        if isinstance(tokens, (str, bytes)):
+            raise TypeError(
+                "tag() expects a list of tokens, not a single string or bytes. "
+                "Tokenize first (e.g. tokens.split() or word_tokenize(s))."
+            )
         if segment:
             return self._tag_segmented(tokens)
         if not (sent := list(tokens)):
@@ -310,6 +316,11 @@ class TnT(TaggerI):
         :type segment: bool
         :return: list of list of (word, tag) tuples
         """
+        if isinstance(data, (str, bytes)):
+            raise TypeError(
+                "tagdata() expects a list of tokenized sentences, "
+                "not a single string or bytes object."
+            )
         return [self.tag(sent, segment=segment) for sent in data]
 
     def _compute_lambda(self):
@@ -715,7 +726,16 @@ class TnT(TaggerI):
             # stateful. The built-in known-word and suffix-model paths are
             # pure given ``(word, c_i)`` and the trained model, so they cache.
             if tag_freqs is None and unk is not None:
-                [(_word, tag)] = unk.tag([word])
+                # Validate length before destructuring so a misbehaving
+                # external tagger surfaces a clear error instead of a
+                # cryptic "too many values to unpack" message.
+                unk_out = list(unk.tag([word]))
+                if len(unk_out) != 1:
+                    raise ValueError(
+                        f"unk tagger returned {len(unk_out)} tags for 1 word; "
+                        f"expected exactly 1"
+                    )
+                ((_word, tag),) = unk_out
                 state_i = (tag, c_i)
                 unigram_logp = trans_logp_unigram_get(state_i, _LOG_FLOOR_2)
                 candidate_tags = ((state_i, 0.0, unigram_logp),)

--- a/nltk/tag/tnt.py
+++ b/nltk/tag/tnt.py
@@ -131,6 +131,13 @@ class TnT(TaggerI):
     When ``C=True``, capitalization is included in the tag state. This
     is equivalent to splitting each tag into capitalized and
     uncapitalized variants, as described by Brants (2000), section 2.4.
+
+    Reproducibility
+
+    Training-time iteration is sorted in ``_compute_lambda``,
+    ``_build_suffix_model``, and ``_tagword``'s candidate construction,
+    so the trained model and decoded output are bit-identical across
+    reorderings of equivalent training data.
     """
 
     def __init__(self, unk=None, Trained=False, N=1000, C=False):
@@ -801,9 +808,9 @@ class TnT(TaggerI):
             states = {k: v for k, v in new_states.items() if v[0] >= cutoff}
             state_history.append(states)
 
-        # Scored inline rather than via the transition cache to preserve
-        # the previous decoder's floating-point evaluation order; per-call
-        # cost is small relative to the inner Viterbi loop.
+        # Inline ``count / N`` instead of the cache's ``count * (1/N)``
+        # keeps EOS bit-identical to the pre-cache decoder. EOS is scored
+        # once per sentence, so the cache speedup wouldn't matter here.
         tag_bigrams = self._tag_bigrams
         tag_trigrams = self._tag_trigrams
         lambda1, lambda2, lambda3 = self._lambda1, self._lambda2, self._lambda3
@@ -867,7 +874,9 @@ class TnT(TaggerI):
         same key, keep the higher-scoring one and discard the other. The
         second-order Markov assumption means everything after this point
         depends only on the last two states, so the discarded path can
-        never beat the kept one.
+        never beat the kept one. Ties (equal `path_logp`) are broken by
+        keeping the first-encountered path; sorted candidate construction
+        upstream makes that tie-break deterministic.
 
         `candidate_tags` is a sequence of `(state_i, log_emit,
         unigram_logp)` triples. `log_emit` is the lexical log-probability

--- a/nltk/tag/tnt.py
+++ b/nltk/tag/tnt.py
@@ -19,7 +19,8 @@ from math import log2
 from nltk.probability import ConditionalFreqDist, FreqDist
 from nltk.tag.api import TaggerI
 
-# Returned in place of log2(p) when p is zero; log2(1e-300) ~= -996.58.
+# Used in place of log2(p) when p underflows; log2(1e-300) ~= -996.58
+# is still well above the negative-inf result of log2(0).
 _LOG_FLOOR_2 = log2(1e-300)
 
 # Sentinel tags used at sentence boundaries.
@@ -28,6 +29,21 @@ _EOS = ("EOS", False)
 
 _SENT_MARKS = (".", "!", "?", ";")
 
+# Returned by transition-cache misses so inner-loop ``.get`` calls never
+# need an extra ``None`` check before the next lookup.
+_EMPTY_DICT = {}
+
+
+def _safe_log2(p):
+    """``log2(p)`` for a non-zero probability, ``_LOG_FLOOR_2`` otherwise."""
+    return log2(p) if p > 1e-300 else _LOG_FLOOR_2
+
+
+def _safe_inverse(n):
+    """``1/n`` for a non-zero ``n``, ``0.0`` otherwise so callers can use
+    multiplication without an inline guard."""
+    return (1.0 / n) if n else 0.0
+
 
 class TnT(TaggerI):
     """
@@ -35,62 +51,68 @@ class TnT(TaggerI):
 
     IMPORTANT NOTES:
 
-    * HANDLES UNSEEN WORDS VIA BRANTS' SUFFIX MODEL
+    * HANDLES UNSEEN WORDS VIA BRANTS'S SUFFIX MODEL
 
       - Unknown words are tagged using the suffix-based distribution
         described in Brants (2000) section 2.3, smoothed by successive
         abstraction and scored via Bayesian inversion.
       - An external POS tagger may still be supplied via the ``unk``
-        parameter to override the suffix model, see __init__ function.
+        parameter to override the suffix model; see the ``__init__`` function.
 
     * SHOULD BE USED WITH SENTENCE-DELIMITED INPUT
 
       - Due to the nature of this tagger, it works best when
-        trained over sentence delimited input.
-      - However it still produces good results if the training
-        data and testing data are separated on all punctuation eg: [,.?!]
-      - Input for training is expected to be a list of sentences
-        where each sentence is a list of (word, tag) tuples
-      - Input for tag function is a single sentence
-        Input for tagdata function is a list of sentences
-        Output is of a similar form
+        trained over sentence-delimited input.
+      - However, it still produces good results if the training
+        data and testing data are separated on sentence-final
+        punctuation, e.g., [.!?;]
+      - Input for training is expected to be a list of sentences,
+        where each sentence is a list of (word, tag) tuples.
+      - Input for the ``tag`` function is a single sentence.
+        Input for the ``tagdata`` function is a list of sentences.
+        Output is of a similar form.
 
     * Function provided to process text that is unsegmented
 
-      - Please see basic_sent_chop()
+      - Please see ``basic_sent_chop()``.
 
 
-    TnT uses a second order Markov model to produce tags for
-    a sequence of input, specifically:
+    TnT uses a second-order Markov model to score tag sequences. For
+    a sentence of length T, the decoder picks the tag sequence that
+    maximizes
 
-      argmax [Proj(P(t_i|t_i-1,t_i-2)P(w_i|t_i))] P(t_T+1 | t_T)
+      prod_i P(t_i | t_{i-1}, t_{i-2}) * P(w_i | t_i)
 
-    IE: the maximum projection of a set of probabilities
+    with an explicit boundary factor P(EOS | t_{T-1}, t_T) at the end.
+    Decoding runs Viterbi in log space over a trellis of
+    ``(t_{i-1}, t_i)`` state pairs:
 
-    The set of possible tags for a given word is derived
-    from the training data. It is the set of all tags
-    that exact word has been assigned.
+      argmax_{t_1..t_T} sum_i [ log P(t_i | t_{i-1}, t_{i-2})
+                              + log P(w_i | t_i) ]
+                      + log P(EOS | t_{T-1}, t_T)
 
-    To speed up and get more precision, we can use log addition
-    to instead multiplication, specifically:
+    The transition probability is a deleted interpolation of zero-,
+    first-, and second-order tag models:
 
-      argmax [Sigma(log(P(t_i|t_i-1,t_i-2))+log(P(w_i|t_i)))] +
-             log(P(t_T+1|t_T))
+      P(t_i | t_{i-1}, t_{i-2}) = l1 * P(t_i)
+                                + l2 * P(t_i | t_{i-1})
+                                + l3 * P(t_i | t_{i-1}, t_{i-2})
 
-    The probability of a tag for a given word is the linear
-    interpolation of 3 markov models; a zero-order, first-order,
-    and a second order model.
+    The weights l1, l2, l3 are estimated from the training data by
+    the procedure in Brants (2000) section 2.2.
 
-      P(t_i| t_i-1, t_i-2) = l1*P(t_i) + l2*P(t_i| t_i-1) +
-                             l3*P(t_i| t_i-1, t_i-2)
+    The emission probability P(w_i | t_i) for known words is the
+    relative frequency of (w_i, t_i) in the training lexicon. For
+    unknown words, it is the Bayes-inverted suffix score described in
+    section 2.3 (see HANDLES UNSEEN WORDS above). Candidate tags for
+    a known word are exactly the tags it was assigned in training.
 
-    A beam search is used to limit the memory usage of the algorithm.
-    The beam is controlled by a pruning threshold N after each step,
-    states whose probability is worse than the best
-    by more than a factor of N are discarded.
+    A beam search limits memory: after each step, states whose log
+    probability is worse than the best surviving state by more than
+    log2(N) are discarded.
 
-    It is possible to differentiate the tags which are assigned to
-    capitalized words. However this does not result in a significant
+    It is possible to differentiate the tags that are assigned to
+    capitalized words. However, this does not result in a significant
     gain in the accuracy of the results.
     """
 
@@ -149,6 +171,12 @@ class TnT(TaggerI):
         }
         self._tag_prior_probs = {}
         self._theta = 0.0
+
+        # Read by ``_expand_states`` instead of recomputing the deleted
+        # interpolation and ``log2`` per beam expansion.
+        self._trans_logp_unigram = {}
+        self._trans_logp_bigram = {}
+        self._trans_logp_trigram = {}
 
         self._unk = unk
 
@@ -221,25 +249,27 @@ class TnT(TaggerI):
         self._log2_beam_threshold = log2(self._beam_threshold)
 
         self._build_suffix_model()
+        self._build_transition_logp_cache()
 
         self._unk_trained = True
 
     def _build_suffix_model(self):
         """
-        Build the suffix-based language model TnT uses for unseen words.
-        Populates two capitalization-split suffix tries, the smoothing
-        weight `theta`, and a unigram tag prior. These are the three
-        pieces that `_unknown_tag_scores` reads at decode time.
+        Build the suffix model used for unseen words.
 
-        The priors exclude the EOS pseudo-tag (a sequence marker, not a
-        lexical tag) and sum across capitalization. Suffix statistics
-        come only from lexicon words with count of 10 or fewer, the
-        "infrequent words" threshold from Brants (2000) section 2.3,
-        on the reasoning that frequent words tell us little about what
-        unseen words might look like.
+        The model stores three decode-time values: capitalization-split
+        suffix tries, the successive-abstraction weight theta, and raw
+        tag priors collapsed across capitalization.
+
+        EOS is excluded from the priors because it is a sequence marker,
+        not a lexical tag. Suffix counts come only from lexicon words
+        with total count at most 10, following Brants's infrequent-word
+        threshold for unknown-word modeling.
         """
         tag_counts = {}
         for (tag, _), count in self._tag_unigrams.items():
+            # The suffix model predicts lexical tags, not boundary markers.
+            # Check the raw tag so EOS is excluded from all capitalization states.
             if tag == "EOS":
                 continue
             tag_counts[tag] = tag_counts.get(tag, 0) + count
@@ -274,6 +304,80 @@ class TnT(TaggerI):
                 suffix_dist = suffix_trie[word[-m:]]
                 for tag, count in tag_freqs.items():
                     suffix_dist[tag] += count
+
+    def _build_transition_logp_cache(self):
+        """
+        Precompute transition log probabilities for Viterbi expansion.
+
+        The decoder scores each transition with the same deleted
+        interpolation used by the model.
+
+            P(t_i | t_{i-2}, t_{i-1})
+              = l1 P(t_i)
+              + l2 P(t_i | t_{i-1})
+              + l3 P(t_i | t_{i-2}, t_{i-1})
+
+        Computing this value inside the beam loop repeats the same work
+        many times, so training builds caches for the observed unigram,
+        bigram, and trigram contexts. During decoding, ``_expand_states``
+        first tries the trigram cache, then the bigram cache, then the
+        unigram cache.
+
+        The caches store log2 probabilities.
+
+            ``_trans_logp_unigram[state]``
+            ``_trans_logp_bigram[prev1][state]``
+            ``_trans_logp_trigram[(prev2, prev1)][state]``
+
+        Bigram cache entries include the unigram and bigram interpolation
+        terms. Trigram cache entries include all three terms. The
+        parenthesization in the probability calculation is kept stable so
+        cached values match the previous per-call computation.
+        """
+        tag_unigrams = self._tag_unigrams
+        tag_bigrams = self._tag_bigrams
+        tag_trigrams = self._tag_trigrams
+        inv_total_N = _safe_inverse(self._num_tag_tokens)
+        lambda1, lambda2, lambda3 = self._lambda1, self._lambda2, self._lambda3
+
+        # Computed once and reused below so the bigram and trigram caches
+        # don't recompute the unigram contribution per (history, current).
+        unigram_part = {
+            state: lambda1 * (count * inv_total_N)
+            for state, count in tag_unigrams.items()
+        }
+        self._trans_logp_unigram = {
+            state: _safe_log2(p) for state, p in unigram_part.items()
+        }
+
+        bigram_logp = {}
+        for prev1 in tag_bigrams.conditions():
+            bigram_dist = tag_bigrams[prev1]
+            inv_bigram_N = _safe_inverse(bigram_dist.N())
+            bigram_logp[prev1] = {
+                current: _safe_log2(
+                    unigram_part.get(current, 0.0) + lambda2 * count * inv_bigram_N
+                )
+                for current, count in bigram_dist.items()
+            }
+        self._trans_logp_bigram = bigram_logp
+
+        trigram_logp = {}
+        for prev_pair in tag_trigrams.conditions():
+            trigram_dist = tag_trigrams[prev_pair]
+            inv_trigram_N = _safe_inverse(trigram_dist.N())
+            bigram_dist = tag_bigrams[prev_pair[1]]
+            inv_bigram_N = _safe_inverse(bigram_dist.N())
+            bigram_get = bigram_dist.get
+            trigram_logp[prev_pair] = {
+                current: _safe_log2(
+                    unigram_part.get(current, 0.0)
+                    + lambda2 * bigram_get(current, 0) * inv_bigram_N
+                    + lambda3 * count * inv_trigram_N
+                )
+                for current, count in trigram_dist.items()
+            }
+        self._trans_logp_trigram = trigram_logp
 
     def _compute_lambda(self):
         """
@@ -453,10 +557,10 @@ class TnT(TaggerI):
         after this point depends only on the last two states, so the
         discarded path can never beat the kept one.
 
-        `candidate_tags` is a sequence of `(state_i, p_state_i,
-        log_emit)` triples. Transitions use the same deleted
-        interpolation as on the known-word path, floored before log2
-        to avoid blowing up on an all-zero context.
+        `candidate_tags` is a sequence of `(state_i, log_emit)` pairs.
+        `log_emit` is the lexical log-probability for known words, the
+        Bayes-inverted suffix score for unknown words, or zero for an
+        external unknown-word tagger.
 
         :return: ``(new_states, best_logp)``. ``new_states`` maps
                  `(state_i_minus_1, state_i)` to
@@ -466,30 +570,33 @@ class TnT(TaggerI):
                  `logp` across `new_states`, returned so the caller
                  can apply threshold pruning without a second pass.
         """
-        lambda1, lambda2, lambda3 = self._lambda1, self._lambda2, self._lambda3
-        tag_bigrams = self._tag_bigrams
-        tag_trigrams = self._tag_trigrams
+        trans_logp_trigram = self._trans_logp_trigram
+        trans_logp_bigram = self._trans_logp_bigram
+        unigram_logp_get = self._trans_logp_unigram.get
         new_states = {}
         best_logp = float("-inf")
-        for (state_i_minus_2, state_i_minus_1), (prefix_logp, _) in states.items():
-            bigram_dist = tag_bigrams[state_i_minus_1]
-            trigram_dist = tag_trigrams[(state_i_minus_2, state_i_minus_1)]
-            bigram_N = bigram_dist.N()
-            trigram_N = trigram_dist.N()
-            inv_bigram_N = (1.0 / bigram_N) if bigram_N else 0.0
-            inv_trigram_N = (1.0 / trigram_N) if trigram_N else 0.0
-            for state_i, p_state_i, log_emit in candidate_tags:
-                p_state_i_given_history = (
-                    lambda1 * p_state_i
-                    + lambda2 * bigram_dist[state_i] * inv_bigram_N
-                    + lambda3 * trigram_dist[state_i] * inv_trigram_N
-                )
-                step_logp = (
-                    log2(p_state_i_given_history)
-                    if p_state_i_given_history > 1e-300
-                    else _LOG_FLOOR_2
-                ) + log_emit
-                path_logp = prefix_logp + step_logp
+        for predecessor_key, (prefix_logp, _) in states.items():
+            state_i_minus_2, state_i_minus_1 = predecessor_key
+            # Per-history caches are constant across the candidate loop;
+            # resolving them once and using ``_EMPTY_DICT`` for misses
+            # lets the inner ``.get`` calls run without ``None`` branches.
+            trigram_logp = trans_logp_trigram.get(predecessor_key, _EMPTY_DICT)
+            bigram_logp = trans_logp_bigram.get(state_i_minus_1, _EMPTY_DICT)
+            trigram_logp_get = trigram_logp.get
+            bigram_logp_get = bigram_logp.get
+            for state_i, log_emit in candidate_tags:
+                trans_logp = trigram_logp_get(state_i)
+                if trans_logp is None:
+                    trans_logp = bigram_logp_get(state_i)
+                    if trans_logp is None:
+                        # If the candidate state was never observed as a
+                        # unigram, keep the path alive with the model floor.
+                        # This is smoothing for unseen states, not only
+                        # protection around log2(0).
+                        trans_logp = unigram_logp_get(state_i, _LOG_FLOOR_2)
+                # Parens match the previous ``step_logp + prefix_logp``
+                # order so the sum is bit-identical to the old decoder.
+                path_logp = prefix_logp + (trans_logp + log_emit)
                 if path_logp > best_logp:
                     best_logp = path_logp
                 next_state = (state_i_minus_1, state_i)
@@ -595,13 +702,8 @@ class TnT(TaggerI):
         # Local bindings keep the hot loop on plain locals rather than
         # repeated attribute lookups.
         word_tag_freqs = self._word_tag_freqs
-        tag_bigrams = self._tag_bigrams
-        tag_trigrams = self._tag_trigrams
         tag_unigrams = self._tag_unigrams
-        inv_num_tag_tokens = (
-            (1.0 / self._num_tag_tokens) if self._num_tag_tokens else 0.0
-        )
-        lambda1, lambda2, lambda3 = self._lambda1, self._lambda2, self._lambda3
+        inv_num_tag_tokens = _safe_inverse(self._num_tag_tokens)
         log2_beam_threshold = self._log2_beam_threshold
         cap_on = self._use_capitalization
         unk = self._unk
@@ -628,9 +730,7 @@ class TnT(TaggerI):
             # pure given ``(word, c_i)`` and the trained model, so they cache.
             if tag_freqs is None and unk is not None:
                 [(_word, tag)] = unk.tag([word])
-                state_i = (tag, c_i)
-                p_state_i = tag_unigrams[state_i] * inv_num_tag_tokens
-                candidate_tags = ((state_i, p_state_i, 0.0),)
+                candidate_tags = (((tag, c_i), 0.0),)
             else:
                 cache_key = (word, c_i)
                 candidate_tags = cache.get(cache_key)
@@ -643,14 +743,7 @@ class TnT(TaggerI):
                         for tag, tag_count in tag_freqs.items():
                             state_i = (tag, c_i)
                             unigram_state_i = tag_unigrams[state_i]
-                            p_state_i = unigram_state_i * inv_num_tag_tokens
-                            entries.append(
-                                (
-                                    state_i,
-                                    p_state_i,
-                                    log2(tag_count / unigram_state_i),
-                                )
-                            )
+                            entries.append((state_i, log2(tag_count / unigram_state_i)))
                         candidate_tags = tuple(entries)
                     else:
                         # Unknown words use the suffix model as their lexical
@@ -661,19 +754,12 @@ class TnT(TaggerI):
                         if not suffix_scores:
                             # An untrained tagger has no suffix priors, so the
                             # only safe fallback is a literal ``Unk`` state.
-                            state_i = ("Unk", c_i)
-                            p_state_i = tag_unigrams[state_i] * inv_num_tag_tokens
-                            candidate_tags = ((state_i, p_state_i, 0.0),)
+                            candidate_tags = ((("Unk", c_i), 0.0),)
                         else:
-                            entries = []
-                            for tag, score in suffix_scores.items():
-                                state_i = (tag, c_i)
-                                p_state_i = tag_unigrams[state_i] * inv_num_tag_tokens
-                                log_emit = (
-                                    log2(score) if score > 1e-300 else _LOG_FLOOR_2
-                                )
-                                entries.append((state_i, p_state_i, log_emit))
-                            candidate_tags = tuple(entries)
+                            candidate_tags = tuple(
+                                ((tag, c_i), _safe_log2(score))
+                                for tag, score in suffix_scores.items()
+                            )
 
                     cache[cache_key] = candidate_tags
 
@@ -685,34 +771,45 @@ class TnT(TaggerI):
             states = {k: v for k, v in new_states.items() if v[0] >= cutoff}
             state_history.append(states)
 
-        # EOS is scored by the same interpolated transition model as every
-        # other step. The best final key is the state pair that maximizes
-        # the complete sentence score including the boundary transition.
+        # Scored inline rather than via the transition cache to preserve
+        # the previous decoder's floating-point evaluation order; per-call
+        # cost is small relative to the inner Viterbi loop.
+        tag_bigrams = self._tag_bigrams
+        tag_trigrams = self._tag_trigrams
+        lambda1, lambda2, lambda3 = self._lambda1, self._lambda2, self._lambda3
         p_eos_unigram = tag_unigrams[_EOS] * inv_num_tag_tokens
         best_final_key = next(iter(states))
         best_final_logp = float("-inf")
 
-        for (state_i_minus_2, state_i_minus_1), (prefix_logp, _) in states.items():
-            bigram_dist = tag_bigrams[state_i_minus_1]
-            trigram_dist = tag_trigrams[(state_i_minus_2, state_i_minus_1)]
-            bigram_N = bigram_dist.N()
-            trigram_N = trigram_dist.N()
-            p_eos_bigram = (bigram_dist[_EOS] / bigram_N) if bigram_N else 0
-            p_eos_trigram = (trigram_dist[_EOS] / trigram_N) if trigram_N else 0
+        for predecessor_key, (prefix_logp, _) in states.items():
+            state_i_minus_1 = predecessor_key[1]
+
+            # ``ConditionalFreqDist.__getitem__`` would create empty entries
+            # for unseen keys, mutating the trained model during decode. Use
+            # ``.get`` so an unseen history just contributes zero.
+            bigram_dist = tag_bigrams.get(state_i_minus_1)
+            if bigram_dist is None:
+                p_eos_bigram = 0.0
+            else:
+                bigram_N = bigram_dist.N()
+                p_eos_bigram = (bigram_dist[_EOS] / bigram_N) if bigram_N else 0.0
+
+            trigram_dist = tag_trigrams.get(predecessor_key)
+            if trigram_dist is None:
+                p_eos_trigram = 0.0
+            else:
+                trigram_N = trigram_dist.N()
+                p_eos_trigram = (trigram_dist[_EOS] / trigram_N) if trigram_N else 0.0
+
             p_eos_given_history = (
                 lambda1 * p_eos_unigram
                 + lambda2 * p_eos_bigram
                 + lambda3 * p_eos_trigram
             )
-            eos_logp = (
-                log2(p_eos_given_history)
-                if p_eos_given_history > 1e-300
-                else _LOG_FLOOR_2
-            )
-            final_logp = prefix_logp + eos_logp
+            final_logp = prefix_logp + _safe_log2(p_eos_given_history)
             if final_logp > best_final_logp:
                 best_final_logp = final_logp
-                best_final_key = (state_i_minus_2, state_i_minus_1)
+                best_final_key = predecessor_key
 
         # Walking the stored ``state_{i-2}`` backpointers recovers the best
         # full state sequence from the best final state pair.
@@ -823,7 +920,6 @@ def demo2():
         print("Accuracy:", tacc)
         print("Percentage known:", tp_kn)
         print("Percentage unknown:", tp_un)
-        print("Accuracy over known words:", (tacc / tp_kn))
 
         sacc = s.accuracy(d[i * 100 : ((i + 1) * 100)])
         sp_un = s.unknown / (s.known + s.unknown)
@@ -835,7 +931,6 @@ def demo2():
         print("Accuracy:", sacc)
         print("Percentage known:", sp_kn)
         print("Percentage unknown:", sp_un)
-        print("Accuracy over known words:", (sacc / sp_kn))
 
 
 def demo3():
@@ -850,8 +945,6 @@ def demo3():
     d10 = int(len(d) * 0.1)
     e10 = int(len(e) * 0.1)
 
-    tknacc = 0
-    sknacc = 0
     tallacc = 0
     sallacc = 0
     tknown = 0
@@ -884,14 +977,10 @@ def demo3():
         s.unknown = 0
         s.known = 0
 
-        tknacc += tacc / tp_kn
-        sknacc += sacc / sp_kn
         tallacc += tacc
         sallacc += sacc
 
-    print("brown: acc over words known:", 10 * tknacc)
-    print("     : overall accuracy:", 10 * tallacc)
-    print("     : words known:", 10 * tknown)
-    print("treebank: acc over words known:", 10 * sknacc)
-    print("        : overall accuracy:", 10 * sallacc)
+    print("brown   : overall accuracy:", 10 * tallacc)
+    print("        : words known:", 10 * tknown)
+    print("treebank: overall accuracy:", 10 * sallacc)
     print("        : words known:", 10 * sknown)

--- a/nltk/tag/tnt.py
+++ b/nltk/tag/tnt.py
@@ -142,6 +142,11 @@ class TnT(TaggerI):
 
         self._unk = unk
 
+        # Memoizes per-word `tag_info` for the decode hot path. Cleared
+        # at the start of `train()` because the model state it derives
+        # from changes there. Keyed by `(word, capitalization_flag)`.
+        self._tag_info_cache = {}
+
         # statistical tools (ignore or delete me)
         self.unknown = 0
         self.known = 0
@@ -156,40 +161,39 @@ class TnT(TaggerI):
         :type data: tuple(str)
         """
 
-        # Ensure that local C flag is initialized before use
-        C = False
+        # The decode cache is keyed off post-train state, so a fresh
+        # train() invalidates every entry.
+        self._tag_info_cache.clear()
 
         if self._unk is not None and not self._T:
             self._unk.train(data)
 
+        # local bindings save repeated attribute lookups across the corpus
+        wd = self._wd
+        uni = self._uni
+        bi = self._bi
+        tri = self._tri
+        cap_on = self._C
+
         for sent in data:
             history = [("BOS", False), ("BOS", False)]
             for w, t in sent:
-                # if capitalization is requested,
-                # and the word begins with a capital
-                # set local flag C to True
-                if self._C and w[0].isupper():
-                    C = True
-
+                C = cap_on and w[0].isupper()
                 tC = (t, C)
-                self._wd[w][t] += 1
-                self._uni[tC] += 1
-                self._bi[history[1]][tC] += 1
-                self._tri[(history[0], history[1])][tC] += 1
+                wd[w][t] += 1
+                uni[tC] += 1
+                bi[history[1]][tC] += 1
+                tri[(history[0], history[1])][tC] += 1
 
-                history[0] = history[1]
-                history[1] = tC
-
-                # set local flag C to false for the next word
-                C = False
+                history[0], history[1] = history[1], tC
 
             # Record EOS as a pseudo-tag in the n-gram counts. Empty sentences are skipped
             # because their history[-1] is still BOS and would absorb the count.
             if sent:
                 eos = ("EOS", False)
-                self._uni[eos] += 1
-                self._bi[history[-1]][eos] += 1
-                self._tri[tuple(history)][eos] += 1
+                uni[eos] += 1
+                bi[history[-1]][eos] += 1
+                tri[tuple(history)][eos] += 1
 
         # compute lambda values from the trained frequency distributions
         self._compute_lambda()
@@ -254,22 +258,18 @@ class TnT(TaggerI):
 
     def _compute_lambda(self):
         """
-        creates lambda values based upon training data
+        Compute the linear interpolation weights l1, l2, l3 via deleted interpolation.
 
-        NOTE: no need to explicitly reference C,
-        it is contained within the tag variable :: tag == (tag,C)
+        For each tag trigram (t1, t2, t3) with positive count, compute
+        three deleted estimates
 
-        for each tag trigram (t1, t2, t3)
-        depending on the maximum value of
-        - f(t1,t2,t3)-1 / f(t1,t2)-1
-        - f(t2,t3)-1 / f(t2)-1
-        - f(t3)-1 / N-1
+            c1 = (f(t3) - 1) / (N - 1)
+            c2 = (f(t2, t3) - 1) / (f(t2) - 1)
+            c3 = (f(t1, t2, t3) - 1) / (f(t1, t2) - 1)
 
-        increment l3,l2, or l1 by f(t1,t2,t3)
-
-        ISSUES -- Resolutions:
-        if 2 values are equal, increment both lambda values
-        by (f(t1,t2,t3) / 2)
+        and add the trigram's count to the lambda corresponding to the
+        largest c. When two or three c values tie at the maximum, the
+        count is split equally among the tied lambdas.
         """
 
         # temporary lambda variables
@@ -277,75 +277,46 @@ class TnT(TaggerI):
         tl2 = 0.0
         tl3 = 0.0
 
+        bi = self._bi
+        uni = self._uni
+        uni_n_minus_1 = uni.N() - 1
+
         # for each t1,t2 in system
         for history in self._tri.conditions():
-            h1, h2 = history
+            _, h2 = history
+            tri_dist = self._tri[history]
+            tri_n_minus_1 = tri_dist.N() - 1
+            bi_dist = bi[h2]
+            bi_n_minus_1 = bi_dist.N() - 1
 
             # for each t3 given t1,t2 in system
-            # (NOTE: tag actually represents (tag,C))
-            # However no effect within this function
-            for tag in self._tri[history].keys():
-                # safe_div provides a safe floating point division
-                # it returns 0 if the denominator is 0
-                c3 = self._safe_div(
-                    (self._tri[history][tag] - 1), (self._tri[history].N() - 1)
-                )
-                c2 = self._safe_div((self._bi[h2][tag] - 1), (self._bi[h2].N() - 1))
-                c1 = self._safe_div((self._uni[tag] - 1), (self._uni.N() - 1))
+            for tC, count in tri_dist.items():
+                # Deleted estimates per Brants Figure 1. Each branch falls
+                # back to 0 when its denominator is zero, which mirrors
+                # the original `_safe_div` semantics.
+                c3 = (count - 1) / tri_n_minus_1 if tri_n_minus_1 else 0
+                c2 = (bi_dist[tC] - 1) / bi_n_minus_1 if bi_n_minus_1 else 0
+                c1 = (uni[tC] - 1) / uni_n_minus_1 if uni_n_minus_1 else 0
 
-                # if c1 is the maximum value:
-                if (c1 > c3) and (c1 > c2):
-                    tl1 += self._tri[history][tag]
-
-                # if c2 is the maximum value
-                elif (c2 > c3) and (c2 > c1):
-                    tl2 += self._tri[history][tag]
-
-                # if c3 is the maximum value
-                elif (c3 > c2) and (c3 > c1):
-                    tl3 += self._tri[history][tag]
-
-                # if c3, and c2 are equal and larger than c1
-                elif (c3 == c2) and (c3 > c1):
-                    tl2 += self._tri[history][tag] / 2.0
-                    tl3 += self._tri[history][tag] / 2.0
-
-                # if c1, and c2 are equal and larger than c3
-                elif (c2 == c1) and (c1 > c3):
-                    tl1 += self._tri[history][tag] / 2.0
-                    tl2 += self._tri[history][tag] / 2.0
-
-                # if c1, and c3 are equal and larger than c2
-                elif (c1 == c3) and (c1 > c2):
-                    tl1 += self._tri[history][tag] / 2.0
-                    tl3 += self._tri[history][tag] / 2.0
-
-                # if all three are equal
-                elif (c1 == c2) and (c2 == c3):
-                    tl1 += self._tri[history][tag] / 3.0
-                    tl2 += self._tri[history][tag] / 3.0
-                    tl3 += self._tri[history][tag] / 3.0
-
-                # otherwise there might be a problem
-                # eg: all values = 0
-                else:
-                    pass
+                # Split the trigram's count equally among the lambdas
+                # whose c value ties for the maximum.
+                maxc = max(c1, c2, c3)
+                w1 = c1 == maxc
+                w2 = c2 == maxc
+                w3 = c3 == maxc
+                share = count / (w1 + w2 + w3)
+                if w1:
+                    tl1 += share
+                if w2:
+                    tl2 += share
+                if w3:
+                    tl3 += share
 
         # Lambda normalisation:
         # ensures that l1+l2+l3 = 1
         self._l1 = tl1 / (tl1 + tl2 + tl3)
         self._l2 = tl2 / (tl1 + tl2 + tl3)
         self._l3 = tl3 / (tl1 + tl2 + tl3)
-
-    def _safe_div(self, v1, v2):
-        """
-        Safe floating point division function, does not allow division by 0
-        returns 0 if the denominator is 0
-        """
-        if v2 == 0:
-            return 0
-        else:
-            return v1 / v2
 
     def _unknown_tag_scores(self, word):
         """
@@ -488,12 +459,8 @@ class TnT(TaggerI):
 
         sent = list(tokens)
         tags = self._tagword(sent)
-        res = []
-        for i in range(len(sent)):
-            # unpack and discard the C flags
-            t, C = tags[i + 2]
-            res.append((sent[i], t))
-        return res
+        # Strip the [BOS, BOS] prefix and discard the per-tag capitalization flag.
+        return [(w, tag) for w, (tag, _) in zip(sent, tags[2:])]
 
     def _tag_segmented(self, tokens):
         """
@@ -539,6 +506,7 @@ class TnT(TaggerI):
         l1, l2, l3 = self._l1, self._l2, self._l3
         log2_N = self._log2_N
         cap_on = self._C
+        cache = self._tag_info_cache
 
         # Viterbi states per level. Each level maps (tag_{i-1}, tag_i)
         # to (logp, backpointer_tag_{i-2}).
@@ -547,43 +515,54 @@ class TnT(TaggerI):
 
         for word in sent:
             C = cap_on and word[0].isupper()
-
-            if word in wd:
+            wd_word = wd.get(word)
+            if wd_word is not None:
                 self.known += 1
-                wd_word = wd[word]
-                # Per-tag constants depend only on the candidate tag.
-                tag_info = []
-                for t, wc in wd_word.items():
-                    tC = (t, C)
-                    uni_tC = uni[tC]
-                    p_uni = (uni_tC / uni_N) if uni_N else 0
-                    tag_info.append((tC, p_uni, log2(wc / uni_tC)))
             else:
                 self.unknown += 1
-                if self._unk is not None:
-                    # External unk tagger overrides the suffix model.
-                    [(_w, t)] = self._unk.tag([word])
-                    tC = (t, C)
-                    p_uni = (uni[tC] / uni_N) if uni_N else 0
-                    tag_info = [(tC, p_uni, 0.0)]
-                else:
-                    # Score this unknown word against every candidate
-                    # tag using the Bayes-inverted suffix posterior.
-                    tag_scores = self._unknown_tag_scores(word)
-                    if not tag_scores:
-                        # Fall back to a literal "Unk" tag when there is
-                        # no prior to score against, for example when
-                        # the tagger has not been trained.
-                        tC = ("Unk", C)
-                        p_uni = (uni[tC] / uni_N) if uni_N else 0
-                        tag_info = [(tC, p_uni, 0.0)]
-                    else:
+
+            # External unk taggers may be stateful or context dependent,
+            # so we evaluate them on every call rather than memoizing.
+            # The known and suffix model paths are pure functions of
+            # `(word, C)` and the trained model state, so they cache.
+            if wd_word is None and self._unk is not None:
+                [(_w, t)] = self._unk.tag([word])
+                tC = (t, C)
+                p_uni = (uni[tC] / uni_N) if uni_N else 0
+                tag_info = [(tC, p_uni, 0.0)]
+            else:
+                key = (word, C)
+                tag_info = cache.get(key)
+                if tag_info is None:
+                    if wd_word is not None:
+                        # Per-tag constants depend only on the candidate tag.
                         tag_info = []
-                        for t, score in tag_scores.items():
+                        for t, wc in wd_word.items():
                             tC = (t, C)
+                            uni_tC = uni[tC]
+                            p_uni = (uni_tC / uni_N) if uni_N else 0
+                            tag_info.append((tC, p_uni, log2(wc / uni_tC)))
+                    else:
+                        # Score this unknown word against every candidate
+                        # tag using the Bayes-inverted suffix posterior.
+                        tag_scores = self._unknown_tag_scores(word)
+                        if not tag_scores:
+                            # Fall back to a literal "Unk" tag when there is
+                            # no prior to score against, for example when
+                            # the tagger has not been trained.
+                            tC = ("Unk", C)
                             p_uni = (uni[tC] / uni_N) if uni_N else 0
-                            log_score = log2(score) if score > 1e-300 else _LOG_FLOOR_2
-                            tag_info.append((tC, p_uni, log_score))
+                            tag_info = [(tC, p_uni, 0.0)]
+                        else:
+                            tag_info = []
+                            for t, score in tag_scores.items():
+                                tC = (t, C)
+                                p_uni = (uni[tC] / uni_N) if uni_N else 0
+                                log_score = (
+                                    log2(score) if score > 1e-300 else _LOG_FLOOR_2
+                                )
+                                tag_info.append((tC, p_uni, log_score))
+                    cache[key] = tag_info
 
             new_states = self._expand_states(states, tag_info)
 
@@ -672,21 +651,20 @@ def basic_sent_chop(data, raw=True):
 
     if raw:
         for word in data:
+            curr_sent.append(word)
             if word in sent_mark:
-                curr_sent.append(word)
                 new_data.append(curr_sent)
                 curr_sent = []
-            else:
-                curr_sent.append(word)
-
     else:
         for word, tag in data:
+            curr_sent.append((word, tag))
             if word in sent_mark:
-                curr_sent.append((word, tag))
                 new_data.append(curr_sent)
                 curr_sent = []
-            else:
-                curr_sent.append((word, tag))
+
+    if curr_sent:
+        new_data.append(curr_sent)
+
     return new_data
 
 
@@ -792,11 +770,9 @@ def demo3():
         s.known = 0
 
         tknacc += tacc / tp_kn
-        sknacc += sacc / tp_kn
+        sknacc += sacc / sp_kn
         tallacc += tacc
         sallacc += sacc
-
-        # print(i+1, (tacc / tp_kn), i+1, (sacc / tp_kn), i+1, tacc, i+1, sacc)
 
     print("brown: acc over words known:", 10 * tknacc)
     print("     : overall accuracy:", 10 * tallacc)

--- a/nltk/tag/tnt.py
+++ b/nltk/tag/tnt.py
@@ -14,7 +14,6 @@ https://aclanthology.org/A00-1031.pdf
 """
 
 from math import log2
-from operator import itemgetter
 
 from nltk.probability import ConditionalFreqDist, FreqDist
 from nltk.tag.api import TaggerI
@@ -206,13 +205,17 @@ class TnT(TaggerI):
 
     def _build_suffix_model(self):
         """
-        Populate the suffix tries, tag priors, and smoothing weight used by
-        the unknown-word model from Brants (2000), section 2.3.
+        Build the suffix-based language model TnT uses for unseen words.
+        Populates two capitalization-split suffix tries, the smoothing
+        weight `theta`, and a unigram tag prior. These are the three
+        pieces that `_unknown_tag_scores` reads at decode time.
 
-        Tag priors are over raw tags (summed across capitalization flags)
-        and exclude the EOS pseudo-tag. Suffix statistics are drawn only
-        from lexicon words with total count of 10 or fewer, matching the
-        paper's infrequent-words threshold.
+        The priors exclude the EOS pseudo-tag (a sequence marker, not a
+        lexical tag) and sum across capitalization. Suffix statistics
+        come only from lexicon words with count of 10 or fewer, the
+        "infrequent words" threshold from Brants (2000) section 2.3,
+        on the reasoning that frequent words tell us little about what
+        unseen words might look like.
         """
         # Tag priors over raw tags (excluding EOS), P(t) = f(t) / sum_t' f(t')
         tag_counts = {}
@@ -346,20 +349,27 @@ class TnT(TaggerI):
 
     def _unknown_tag_scores(self, word):
         """
-        Score candidate tags for an unknown word using the suffix model
-        from Brants (2000), section 2.3, with successive abstraction and
-        Bayesian inversion.
+        Score candidate tags for an unknown word using Brants's suffix
+        model.
 
-        Starts from the unigram tag prior and absorbs one extra suffix
-        character at a time up to the longest known suffix (capped at
-        10 characters). The smoothing recursion is
+        The intuition is that a word's last few characters predict its
+        tag well, since `-able` words tend to be adjectives, `-ing`
+        words tend to be participles, and so on. Starting from the
+        unigram tag prior, we walk one suffix character at a time up
+        to the longest suffix we saw during training (capped at 10
+        characters), blending each suffix's tag distribution into the
+        running estimate via the successive abstraction recursion
 
             P(t | l_{n-i+1}...l_n) = (P_hat + theta * P_prev) / (1 + theta)
 
-        Returns a mapping from raw tag to P(suffix | t) up to a constant.
-        The constant P(suffix) is dropped because it does not depend on
-        the tag and therefore does not affect the argmax. Tags with zero
-        prior are omitted.
+        If the word's tail is unfamiliar, the recursion never gets past
+        the prior, which is the back-off case.
+
+        :return: Bayes-inverted scores. Each raw tag maps to a quantity
+                 proportional to P(suffix | t). The P(suffix) constant
+                 drops out because it does not depend on the tag, which
+                 preserves the argmax without computing it. Tags with
+                 zero prior are omitted.
         """
         if not self._tag_priors:
             return {}
@@ -394,25 +404,32 @@ class TnT(TaggerI):
         # which is proportional to P(t | suffix) / P(t).
         return {t: P[t] / prior for t, prior in self._tag_priors.items() if prior > 0}
 
-    def _expand_beam(self, current_states, tag_info):
+    def _expand_states(self, states, tag_info):
         """
-        Expand each state in the beam over every candidate in tag_info.
+        Take one Viterbi step. For every predecessor state we score
+        each candidate `t_curr` from `tag_info` and accumulate the
+        results into a new state dict keyed by `(t_prev, t_curr)`.
+        When two predecessors land on the same key we keep the
+        higher-scoring one and discard the other. The second-order
+        Markov assumption means everything after this point depends
+        only on the last two tags, so the discarded path can never
+        beat the kept one.
 
-        tag_info is a list of (tC, p_uni, log_emit) triples where tC is
-        the candidate (tag, C) pair, p_uni is its unigram probability,
-        and log_emit is the per-tag emission term already in log2 space.
-        The transition uses the same deleted interpolation as everywhere
-        else, floored before log2 to avoid log(0) on an all-zero context.
+        `tag_info` is a list of `(tC, p_uni, log_emit)` triples for
+        the candidate `t_curr` values. Transitions use the same
+        deleted interpolation as on the known-word path, floored
+        before log2 to avoid blowing up on an all-zero context.
 
-        Used by both the known-word and the suffix-based unknown-word
-        paths so the inner expansion only lives in one place.
+        :return: dict mapping `(t_prev, t_curr)` to `(logp, t_prev2)`.
+                 `t_prev2` is the backpointer used to reconstruct the
+                 best path after the final EOS step.
         """
         l1, l2, l3 = self._l1, self._l2, self._l3
         bi, tri = self._bi, self._tri
-        new_states = []
-        for history, curr_logp in current_states:
-            bi_dist = bi[history[-1]]
-            tri_dist = tri[(history[-2], history[-1])]
+        new_states = {}
+        for (t_prev2, t_prev), (curr_logp, _) in states.items():
+            bi_dist = bi[t_prev]
+            tri_dist = tri[(t_prev2, t_prev)]
             bi_N = bi_dist.N()
             tri_N = tri_dist.N()
             inv_bi = (1.0 / bi_N) if bi_N else 0.0
@@ -420,7 +437,11 @@ class TnT(TaggerI):
             for tC, p_uni, log_emit in tag_info:
                 p = l1 * p_uni + l2 * bi_dist[tC] * inv_bi + l3 * tri_dist[tC] * inv_tri
                 lp = (log2(p) if p > 1e-300 else _LOG_FLOOR_2) + log_emit
-                new_states.append((history + [tC], curr_logp + lp))
+                total_logp = curr_logp + lp
+                new_key = (t_prev, tC)
+                existing = new_states.get(new_key)
+                if existing is None or total_logp > existing[0]:
+                    new_states[new_key] = (total_logp, t_prev2)
         return new_states
 
     def tagdata(self, data):
@@ -443,53 +464,37 @@ class TnT(TaggerI):
 
     def tag(self, tokens):
         """
-        Tags a single sentence
+        Tag a single sentence. Delegates the actual decode to
+        `_tagword`, then pairs each chosen tag with its input token.
 
-        :param tokens: list of words
-        :type tokens: [string,]
-
-        :return: [(word, tag),]
-
-        Calls recursive function '_tagword'
-        to produce a list of tags
-
-        Associates the sequence of returned tags
-        with the correct words in the input sequence
-
-        returns a list of (word, tag) tuples
+        :param tokens: words to tag
+        :type tokens: list[str]
+        :return: list of `(word, tag)` tuples
         """
-
-        # seed BOS in the same (tag, C) form stored during training
-        current_state = [([("BOS", False), ("BOS", False)], 0.0)]
-
         sent = list(tokens)
-
-        tags = self._tagword(sent, current_state)
-
+        tags = self._tagword(sent)
         res = []
         for i in range(len(sent)):
             # unpack and discard the C flags
             t, C = tags[i + 2]
             res.append((sent[i], t))
-
         return res
 
-    def _tagword(self, sent, current_states):
+    def _tagword(self, sent):
         """
-        :param sent : List of words remaining in the sentence
-        :type sent  : [word,]
-        :param current_states : List of possible tag combinations for
-                                the sentence so far, and the log probability
-                                associated with each tag combination
-        :type current_states  : [([tag, ], logprob), ]
+        Tag a sentence by Viterbi decoding with second-order state
+        merging. The per-word work (scoring, expansion, merging) lives
+        in `_expand_states`. We threshold-prune after each word, then
+        score the EOS transition over the surviving states and walk
+        backpointers to reconstruct the best path.
 
-        Iteratively tags each word in the sentence, maintaining a beam of
-        candidate tag sequences and their log probabilities. After the last
-        word, scores the EOS transition and returns the best path.
-
-        Uses formula specified above to calculate the probability
-        of a particular tag.
+        :param sent: words to tag
+        :type sent: list[str]
+        :return: history list `[BOS, BOS, t_0, ..., t_{T-1}]` of
+                 `(tag, capitalization)` pairs.
         """
+        BOS = ("BOS", False)
+        EOS = ("EOS", False)
 
         # local bindings avoid repeated attribute lookups in the hot loop
         wd = self._wd
@@ -501,48 +506,43 @@ class TnT(TaggerI):
         log2_N = self._log2_N
         cap_on = self._C
 
+        # Viterbi states per level. Each level maps (tag_{i-1}, tag_i)
+        # to (logp, backpointer_tag_{i-2}).
+        states = {(BOS, BOS): (0.0, BOS)}
+        history = [states]
+
         for word in sent:
-            new_states = []
             C = cap_on and word[0].isupper()
 
-            # if word is known, expand each state by each tag seen with it
             if word in wd:
                 self.known += 1
                 wd_word = wd[word]
-
-                # Per-tag constants depend on the candidate tag, not on the history being extended.
+                # Per-tag constants depend only on the candidate tag.
                 tag_info = []
                 for t, wc in wd_word.items():
                     tC = (t, C)
                     uni_tC = uni[tC]
                     p_uni = (uni_tC / uni_N) if uni_N else 0
                     tag_info.append((tC, p_uni, log2(wc / uni_tC)))
-
-                new_states = self._expand_beam(current_states, tag_info)
-
             else:
                 self.unknown += 1
-
                 if self._unk is not None:
                     # External unk tagger overrides the suffix model.
                     [(_w, t)] = self._unk.tag([word])
-                    tag = (t, C)
-                    for history, _ in current_states:
-                        history.append(tag)
-                    new_states = current_states
+                    tC = (t, C)
+                    p_uni = (uni[tC] / uni_N) if uni_N else 0
+                    tag_info = [(tC, p_uni, 0.0)]
                 else:
-                    # Score this unknown word against every candidate tag
-                    # using the Bayes-inverted suffix posterior, then
-                    # expand the beam the same way the known-word path does.
+                    # Score this unknown word against every candidate
+                    # tag using the Bayes-inverted suffix posterior.
                     tag_scores = self._unknown_tag_scores(word)
                     if not tag_scores:
                         # Fall back to a literal "Unk" tag when there is
-                        # no prior to score against, for example when the
-                        # tagger has not been trained.
-                        tag = ("Unk", C)
-                        for history, _ in current_states:
-                            history.append(tag)
-                        new_states = current_states
+                        # no prior to score against, for example when
+                        # the tagger has not been trained.
+                        tC = ("Unk", C)
+                        p_uni = (uni[tC] / uni_N) if uni_N else 0
+                        tag_info = [(tC, p_uni, 0.0)]
                     else:
                         tag_info = []
                         for t, score in tag_scores.items():
@@ -550,31 +550,56 @@ class TnT(TaggerI):
                             p_uni = (uni[tC] / uni_N) if uni_N else 0
                             log_score = log2(score) if score > 1e-300 else _LOG_FLOOR_2
                             tag_info.append((tC, p_uni, log_score))
-                        new_states = self._expand_beam(current_states, tag_info)
 
-            # Sort by log prob and threshold-prune
-            # drop states worse than the best by more than log2(N).
-            new_states.sort(reverse=True, key=itemgetter(1))
-            cutoff = new_states[0][1] - log2_N
-            current_states = [s for s in new_states if s[1] >= cutoff]
+            new_states = self._expand_states(states, tag_info)
 
-        # Score the EOS transition with the same deleted interpolation used for every tag, then return the best path.
-        eos = ("EOS", False)
-        p_uni_eos = (uni[eos] / uni_N) if uni_N else 0
-        best_h = current_states[0][0]
-        best_logp = float("-inf")
-        for history, logp in current_states:
-            bi_dist = bi[history[-1]]
-            tri_dist = tri[(history[-2], history[-1])]
+            # Threshold prune: drop states worse than the best by more than log2(N).
+            best_logp = max(s[0] for s in new_states.values())
+            cutoff = best_logp - log2_N
+            new_states = {k: v for k, v in new_states.items() if v[0] >= cutoff}
+
+            states = new_states
+            history.append(states)
+
+        # Score the EOS transition with the same deleted interpolation
+        # used for every other tag, then pick the best final state.
+        # `states` is non-empty by construction, so seeding the search
+        # with its first key keeps the type concrete.
+        p_uni_eos = (uni[EOS] / uni_N) if uni_N else 0
+        best_final_key = next(iter(states))
+        best_final_logp = float("-inf")
+        for (t_prev2, t_prev), (curr_logp, _) in states.items():
+            bi_dist = bi[t_prev]
+            tri_dist = tri[(t_prev2, t_prev)]
             bi_N = bi_dist.N()
             tri_N = tri_dist.N()
-            p_bi = (bi_dist[eos] / bi_N) if bi_N else 0
-            p_tri = (tri_dist[eos] / tri_N) if tri_N else 0
+            p_bi = (bi_dist[EOS] / bi_N) if bi_N else 0
+            p_tri = (tri_dist[EOS] / tri_N) if tri_N else 0
             p = l1 * p_uni_eos + l2 * p_bi + l3 * p_tri
-            logp += log2(p) if p > 1e-300 else _LOG_FLOOR_2
-            if logp > best_logp:
-                best_h, best_logp = history, logp
-        return best_h
+            eos_lp = log2(p) if p > 1e-300 else _LOG_FLOOR_2
+            final_logp = curr_logp + eos_lp
+            if final_logp > best_final_logp:
+                best_final_logp = final_logp
+                best_final_key = (t_prev2, t_prev)
+
+        # Reconstruct the best path by walking backpointers, collecting
+        # tags in reverse. At level L the key is (tag_{L-2}, tag_{L-1})
+        # and the stored backpointer is tag_{L-3}, so each iteration
+        # extends one tag toward the start of the sentence.
+        T = len(sent)
+        if T == 0:
+            return [BOS, BOS]
+
+        tags_reversed = [best_final_key[1]]
+        if T >= 2:
+            tags_reversed.append(best_final_key[0])
+        current_key = best_final_key
+        for level in range(T, 2, -1):
+            backpointer = history[level][current_key][1]
+            tags_reversed.append(backpointer)
+            current_key = (backpointer, current_key[0])
+        tags_reversed.reverse()
+        return [BOS, BOS] + tags_reversed
 
 
 ########################################

--- a/nltk/test/unit/test_tnt.py
+++ b/nltk/test/unit/test_tnt.py
@@ -6,7 +6,15 @@ import math
 
 import pytest
 
-from nltk.tag.tnt import _BOS, _EOS, TnT, basic_sent_chop
+from nltk.tag.tnt import (
+    _BOS,
+    _EOS,
+    _LOG_FLOOR_2,
+    TnT,
+    _safe_inverse,
+    _safe_log2,
+    basic_sent_chop,
+)
 
 # Synthetic corpus covering the tag classes used below.
 _TRAIN = [
@@ -269,6 +277,26 @@ def test_unknown_word_falls_back_to_unk_when_priors_empty():
     assert t.tag(["xyzzy"]) == [("xyzzy", "Unk")]
 
 
+def test_external_unk_returning_unseen_tag_survives_decode():
+    """An external ``unk`` tagger may return a tag that was never seen
+    during training. The candidate state has no unigram entry, so the
+    transition cache falls through to the model floor; the path stays
+    alive and the tag appears in the decoder's output."""
+
+    class ConstantUnk:
+        def train(self, _data):
+            pass
+
+        def tag(self, toks):
+            return [(w, "NONESUCH") for w in toks]
+
+    t = TnT(unk=ConstantUnk())
+    t.train(_TRAIN)
+    [(word, tag)] = t.tag(["xyzzy"])
+    assert word == "xyzzy"
+    assert tag == "NONESUCH"
+
+
 # ---------------------------------------------------------------------
 # Lambdas
 # ---------------------------------------------------------------------
@@ -399,6 +427,80 @@ def test_unknown_word_decode_does_not_grow_suffix_trie(tagger):
         tagger.tag([word])
     after = set(trie.conditions())
     assert after == before
+
+
+def test_decode_does_not_grow_ngram_conditions(tagger):
+    """Tagging must not add conditions to ``_tag_bigrams`` or
+    ``_tag_trigrams``. ``ConditionalFreqDist`` subscript access creates
+    empty entries for unseen keys, which would silently mutate the
+    trained model and break the read-only-decode contract."""
+    before_bigrams = set(tagger._tag_bigrams.conditions())
+    before_trigrams = set(tagger._tag_trigrams.conditions())
+    tagger.tag(["xyzzy", "phlogiston", "doodad"])
+    assert set(tagger._tag_bigrams.conditions()) == before_bigrams
+    assert set(tagger._tag_trigrams.conditions()) == before_trigrams
+
+
+def test_transition_logp_cache_matches_direct_formula(tagger):
+    """The cached transition log-probabilities equal the direct
+    interpolated formula at every tier (trigram, bigram, unigram), and
+    completely unseen states fall through to ``_LOG_FLOOR_2``."""
+    l1, l2, l3 = tagger._lambda1, tagger._lambda2, tagger._lambda3
+    inv_total = _safe_inverse(tagger._num_tag_tokens)
+
+    def direct(prev2, prev1, current):
+        bigram_dist = tagger._tag_bigrams.get(prev1)
+        trigram_dist = tagger._tag_trigrams.get((prev2, prev1))
+        p = l1 * (tagger._tag_unigrams[current] * inv_total)
+        if bigram_dist is not None:
+            p += l2 * bigram_dist.get(current, 0) * _safe_inverse(bigram_dist.N())
+        if trigram_dist is not None:
+            p += l3 * trigram_dist.get(current, 0) * _safe_inverse(trigram_dist.N())
+        return _safe_log2(p)
+
+    def cached(prev2, prev1, current):
+        v = tagger._trans_logp_trigram.get((prev2, prev1), {}).get(current)
+        if v is not None:
+            return v
+        v = tagger._trans_logp_bigram.get(prev1, {}).get(current)
+        if v is not None:
+            return v
+        return tagger._trans_logp_unigram.get(current, _LOG_FLOOR_2)
+
+    # Case 1: observed trigram (cache hits at the trigram tier).
+    sampled_any = False
+    for prev_pair, dist in tagger._tag_trigrams.items():
+        prev2, prev1 = prev_pair
+        for current in dist:
+            assert cached(prev2, prev1, current) == direct(prev2, prev1, current)
+            sampled_any = True
+    assert sampled_any, "fixture should expose observed trigrams"
+
+    # Case 2: observed bigram with a fabricated prev2 that was never
+    # paired with prev1; cache falls through to the bigram tier.
+    bogus_prev2 = ("BOGUS_PREV2", False)
+    for prev1, dist in tagger._tag_bigrams.items():
+        if (bogus_prev2, prev1) in tagger._tag_trigrams:
+            continue
+        for current in dist:
+            assert cached(bogus_prev2, prev1, current) == direct(
+                bogus_prev2, prev1, current
+            )
+
+    # Case 3: observed unigram with fabricated history; cache falls
+    # through to the unigram tier.
+    bogus_prev1 = ("BOGUS_PREV1", False)
+    assert bogus_prev1 not in tagger._tag_bigrams.conditions()
+    for state in tagger._tag_unigrams:
+        assert cached(bogus_prev2, bogus_prev1, state) == direct(
+            bogus_prev2, bogus_prev1, state
+        )
+
+    # Case 4: completely unseen state. Cache returns the floor; the
+    # direct formula reaches the same floor since p collapses to 0.
+    bogus_state = ("NEVER_SEEN", False)
+    assert cached(bogus_prev2, bogus_prev1, bogus_state) == _LOG_FLOOR_2
+    assert direct(bogus_prev2, bogus_prev1, bogus_state) == _LOG_FLOOR_2
 
 
 # ---------------------------------------------------------------------

--- a/nltk/test/unit/test_tnt.py
+++ b/nltk/test/unit/test_tnt.py
@@ -35,9 +35,9 @@ _AMBIGUITY_TRAIN = [
     [("a", "DT"), ("bark", "NN"), ("echoed", "VBD"), (".", ".")],
 ]
 
-_OOV_WORDS = ["xyzzy", "friendo", "doodad", "phlogiston"]
+_OOV_WORDS = ["xyzzy", "friendo", "diogenes", "phlogiston"]
 _OOV_HEAVY_SENT = ["doodad", "watched", "friendo", "playing", "happily", "."]
-_LONG_AMBIGUOUS_SENT = ["dogs", "run", "bark"] * 334 + ["."]
+_LONG_AMBIGUOUS_SENT = ["dogs", "run", "bark"] * 334 + ["."]  # 1003 tokens
 
 _MODEL_STATE_FIELDS = (
     "_lambda1",
@@ -107,7 +107,9 @@ class _EmptyOutputUnk:
         return []
 
 
-def _trained_tagger(train_data=_TRAIN, **kwargs):
+def _trained_tagger(train_data=None, **kwargs):
+    if train_data is None:
+        train_data = _TRAIN
     t = TnT(**kwargs)
     t.train(train_data)
     return t
@@ -159,6 +161,9 @@ def _model_state(tagger):
 
 
 def _assert_model_state_equal(a, b):
+    assert a._beam_threshold == b._beam_threshold
+    assert a._use_capitalization == b._use_capitalization
+    assert a._unk_trained == b._unk_trained
     assert dict(a._tag_unigrams) == dict(b._tag_unigrams)
     assert _cfd_snapshot(a._tag_bigrams) == _cfd_snapshot(b._tag_bigrams)
     assert _cfd_snapshot(a._tag_trigrams) == _cfd_snapshot(b._tag_trigrams)
@@ -169,19 +174,11 @@ def _assert_model_state_equal(a, b):
 
 def _decode_mutation_snapshot(tagger):
     return (
-        set(tagger._suffix_trie_by_cap[False].conditions()),
-        set(tagger._tag_bigrams.conditions()),
-        set(tagger._tag_trigrams.conditions()),
-    )
-
-
-def _count_snapshot(tagger):
-    return (
-        tagger._tag_unigrams.N(),
-        sum(d.N() for d in tagger._tag_bigrams.values()),
-        sum(d.N() for d in tagger._tag_trigrams.values()),
-        len(tagger._word_tag_freqs.conditions()),
-        tagger._num_tag_tokens,
+        dict(tagger._tag_unigrams),
+        _cfd_snapshot(tagger._tag_bigrams),
+        _cfd_snapshot(tagger._tag_trigrams),
+        _cfd_snapshot(tagger._word_tag_freqs),
+        _suffix_snapshot(tagger),
     )
 
 
@@ -289,10 +286,14 @@ def test_empty_training_zeroes_lambdas():
 
 
 def test_repeated_train_rebuilds_state():
-    t = _trained_tagger()
-    before = _count_snapshot(t)
+    t = _trained_tagger(_AMBIGUITY_TRAIN)
+    t.tag(["doodad"])
+    assert t._candidate_tags_cache
+
     t.train(_TRAIN)
-    assert _count_snapshot(t) == before
+
+    assert not t._candidate_tags_cache
+    _assert_model_state_equal(t, _trained_tagger(_TRAIN))
 
 
 @pytest.mark.parametrize(
@@ -321,7 +322,7 @@ def test_eos_follows_sentence_final_punctuation(tagger):
     dot_state = _state(tagger, ".", ".")
 
     expected_bigram_count = 0
-    expected_trigram_counts: dict = {}
+    expected_trigram_counts = {}
 
     for sent in _TRAIN:
         if not sent or sent[-1][0] != ".":
@@ -342,7 +343,7 @@ def test_empty_sentences_do_not_record_eos_at_bos():
     assert _EOS not in t._tag_trigrams[(_BOS, _BOS)]
 
 
-def test_decode_does_not_grow_trained_structures(tagger):
+def test_decode_does_not_mutate_trained_state(tagger):
     before = _decode_mutation_snapshot(tagger)
 
     for word in _OOV_WORDS:
@@ -497,9 +498,6 @@ def test_trained_tagger_round_trips_through_pickle(tagger):
 
     restored = pickle.loads(pickle.dumps(tagger))
     _assert_model_state_equal(restored, tagger)
-    assert restored._beam_threshold == tagger._beam_threshold
-    assert restored._use_capitalization == tagger._use_capitalization
-    assert restored._unk_trained == tagger._unk_trained
 
     for sent in _TRAIN:
         assert restored.tag(_words(sent)) == tagger.tag(_words(sent))

--- a/nltk/test/unit/test_tnt.py
+++ b/nltk/test/unit/test_tnt.py
@@ -529,12 +529,25 @@ def test_tag_sents_matches_per_sentence_tag(tagger):
 
 
 def test_trained_tagger_round_trips_through_pickle(tagger):
-    """A trained ``TnT`` instance must survive a ``pickle`` round trip
-    with identical decode behavior. NLTK users routinely serialize
-    trained taggers, so this is a real contract."""
+    """A trained ``TnT`` must survive a ``pickle`` round trip with
+    identical trained state and identical decode behavior. NLTK users
+    routinely serialize trained taggers, so the contract covers every
+    field that contributes to decoding, not just the resulting tags."""
     import pickle
 
     restored = pickle.loads(pickle.dumps(tagger))
+
+    assert (tagger._lambda1, tagger._lambda2, tagger._lambda3) == (
+        restored._lambda1,
+        restored._lambda2,
+        restored._lambda3,
+    )
+    assert tagger._tag_prior_probs == restored._tag_prior_probs
+    assert tagger._theta == restored._theta
+    assert tagger._trans_logp_unigram == restored._trans_logp_unigram
+    assert tagger._trans_logp_bigram == restored._trans_logp_bigram
+    assert tagger._trans_logp_trigram == restored._trans_logp_trigram
+
     for sent in _TRAIN:
         words = [w for w, _ in sent]
         assert restored.tag(words) == tagger.tag(words)
@@ -661,13 +674,18 @@ def test_decode_is_repeat_stable_under_near_tie_beam():
     assert all(out == outputs[0] for out in outputs)
 
 
-def test_decode_handles_oov_heavy_sentence_with_shared_suffixes():
+@pytest.mark.parametrize(
+    "train",
+    [pytest.param(_TRAIN, id="full"), pytest.param(_TRAIN[:1], id="one_sent")],
+)
+def test_decode_handles_oov_heavy_sentence_with_shared_suffixes(train):
     """An all-OOV sentence forces every token through the suffix model.
-    The full path must still produce well-formed output drawn from the
-    trained tagset and remain stable across repeated decoding."""
+    The path must produce well-formed output drawn from the trained
+    tagset and remain stable across repeated decoding, including when
+    the training set is too small to populate the suffix model densely."""
     t = TnT()
-    t.train(_TRAIN)
-    trained_tags = {tag for sent in _TRAIN for _, tag in sent}
+    t.train(train)
+    trained_tags = {tag for sent in train for _, tag in sent}
 
     words = ["John", "watched", "friendo", "playing", "happily", "."]
     out = t.tag(words)

--- a/nltk/test/unit/test_tnt.py
+++ b/nltk/test/unit/test_tnt.py
@@ -635,3 +635,115 @@ def test_candidate_cache_stable_across_repeated_sentence(tagger):
     tagger.tag(sent)
     size_after_second = len(tagger._candidate_tags_cache)
     assert size_after_first == size_after_second
+
+
+# ---------------------------------------------------------------------
+# Edge cases for beam and OOV logic
+# ---------------------------------------------------------------------
+
+
+def test_decode_is_repeat_stable_under_near_tie_beam():
+    """Tie-breaking in ``_expand_states`` is implicit (strict ``>`` keeps
+    the first-encountered path). Repeated decoding on the same input
+    must therefore agree even when several paths land within the beam
+    threshold of each other."""
+    train = [
+        [("the", "DT"), ("fish", "NN"), ("swims", "VBZ"), (".", ".")],
+        [("the", "DT"), ("fish", "NN"), ("swims", "NNS"), (".", ".")],
+        [("a", "DT"), ("cat", "NN"), ("naps", "VBZ"), (".", ".")],
+        [("a", "DT"), ("cat", "NN"), ("naps", "NNS"), (".", ".")],
+    ]
+    t = TnT(N=1000)
+    t.train(train)
+    words = ["the", "fish", "swims", "."]
+
+    outputs = [t.tag(words) for _ in range(10)]
+    assert all(out == outputs[0] for out in outputs)
+
+
+def test_decode_handles_oov_heavy_sentence_with_shared_suffixes():
+    """An all-OOV sentence forces every token through the suffix model.
+    The full path must still produce well-formed output drawn from the
+    trained tagset and remain stable across repeated decoding."""
+    t = TnT()
+    t.train(_TRAIN)
+    trained_tags = {tag for sent in _TRAIN for _, tag in sent}
+
+    words = ["John", "watched", "friendo", "play", "happily", "."]
+    out = t.tag(words)
+
+    _assert_tag_output(words, out)
+    assert all(tag in trained_tags for _, tag in out)
+
+    again = t.tag(words)
+    assert out == again
+
+
+def test_decode_handles_long_ambiguous_sentence():
+    """Beam pruning across many steps is where any iteration-order or
+    accumulation bug would surface. A long sentence built from
+    NN/VB-ambiguous tokens must still decode to completion and produce
+    consistent output across runs."""
+    train = [
+        [("the", "DT"), ("dogs", "NNS"), ("run", "VBP"), (".", ".")],
+        [("the", "DT"), ("dogs", "NNS"), ("bark", "VBP"), (".", ".")],
+        [("dogs", "NNS"), ("run", "VBP"), ("fast", "RB"), (".", ".")],
+        [("the", "DT"), ("run", "NN"), ("ended", "VBD"), (".", ".")],
+        [("a", "DT"), ("bark", "NN"), ("echoed", "VBD"), (".", ".")],
+    ]
+    t = TnT(N=1000)
+    t.train(train)
+
+    words = ["dogs", "run", "bark"] * 40 + ["."]
+    out = t.tag(words)
+
+    _assert_tag_output(words, out)
+    again = t.tag(words)
+    assert out == again
+
+
+def test_train_order_invariance_at_model_level():
+    """Reordering training sentences must not change the trained model.
+    Sorted iteration in ``_compute_lambda`` and ``_build_suffix_model``
+    makes every float-accumulating step bit-stable, so the weights, the
+    suffix-model priors, and the transition cache are all bit-identical
+    across training-data reorderings."""
+    a = TnT()
+    a.train(_TRAIN)
+
+    b = TnT()
+    b.train(list(reversed(_TRAIN)))
+
+    assert dict(a._tag_unigrams) == dict(b._tag_unigrams)
+    assert {prev: dict(dist) for prev, dist in a._tag_bigrams.items()} == {
+        prev: dict(dist) for prev, dist in b._tag_bigrams.items()
+    }
+    assert {prev: dict(dist) for prev, dist in a._tag_trigrams.items()} == {
+        prev: dict(dist) for prev, dist in b._tag_trigrams.items()
+    }
+    assert (a._lambda1, a._lambda2, a._lambda3) == (
+        b._lambda1,
+        b._lambda2,
+        b._lambda3,
+    )
+    assert a._tag_prior_probs == b._tag_prior_probs
+    assert a._theta == b._theta
+    assert a._trans_logp_unigram == b._trans_logp_unigram
+    assert a._trans_logp_bigram == b._trans_logp_bigram
+    assert a._trans_logp_trigram == b._trans_logp_trigram
+
+
+def test_decode_is_bit_stable_across_train_data_reorderings():
+    """Beyond the model state, decoded output must match across training
+    reorderings. With the trained model bit-identical, sorted candidate
+    construction in ``_tagword`` keeps the beam tie-breaking order
+    independent of input-data order."""
+    a = TnT()
+    a.train(_TRAIN)
+
+    b = TnT()
+    b.train(list(reversed(_TRAIN)))
+
+    for sent in _TRAIN:
+        words = [w for w, _ in sent]
+        assert a.tag(words) == b.tag(words)

--- a/nltk/test/unit/test_tnt.py
+++ b/nltk/test/unit/test_tnt.py
@@ -15,8 +15,6 @@ from nltk.tag.tnt import (
     _safe_log2,
 )
 
-# --- Shared fixtures, corpora, helpers, and unk mocks ---
-
 _TRAIN = [
     [("the", "DT"), ("cat", "NN"), ("ran", "VBD"), (".", ".")],
     [("the", "DT"), ("running", "VBG"), ("dog", "NN"), ("barked", "VBD"), (".", ".")],
@@ -178,7 +176,7 @@ def _decode_mutation_snapshot(tagger):
     )
 
 
-def _direct_logp(tagger, prev2, prev1, current):
+def _deleted_interpolation_logp(tagger, prev2, prev1, current):
     """Reference deleted-interpolation transition log-prob from the
     trained n-gram counts (the formula the cache should match)."""
     l1, l2, l3 = tagger._lambda1, tagger._lambda2, tagger._lambda3
@@ -205,7 +203,7 @@ def _cached_logp(tagger, prev2, prev1, current):
 
 
 def _assert_transition_match(tagger, prev2, prev1, current):
-    assert _cached_logp(tagger, prev2, prev1, current) == _direct_logp(
+    assert _cached_logp(tagger, prev2, prev1, current) == _deleted_interpolation_logp(
         tagger, prev2, prev1, current
     )
 
@@ -247,7 +245,8 @@ def _assert_transition_cache_matches_formula(tagger):
         _cached_logp(tagger, _BOGUS_PREV2, _BOGUS_PREV1, _BOGUS_STATE) == _LOG_FLOOR_2
     )
     assert (
-        _direct_logp(tagger, _BOGUS_PREV2, _BOGUS_PREV1, _BOGUS_STATE) == _LOG_FLOOR_2
+        _deleted_interpolation_logp(tagger, _BOGUS_PREV2, _BOGUS_PREV1, _BOGUS_STATE)
+        == _LOG_FLOOR_2
     )
 
 
@@ -264,9 +263,6 @@ def reordered_taggers(request):
     )
 
 
-# --- Constructor and training semantics ---
-
-
 @pytest.mark.parametrize(
     "bad",
     [0, -1, 0.5, math.nan, math.inf, -math.inf, True, False, "1000", None, [1000]],
@@ -276,20 +272,20 @@ def test_invalid_n_raises_value_error(bad):
         TnT(N=bad)
 
 
-def test_empty_training_zeroes_lambdas():
+def test_empty_training_resets_interpolation_weights():
     t = _trained_tagger([])
     assert (t._lambda1, t._lambda2, t._lambda3) == (0.0, 0.0, 0.0)
 
 
-def test_lambdas_are_non_negative_and_sum_to_one(tagger):
+def test_interpolation_weights_are_normalized(tagger):
     lambdas = (tagger._lambda1, tagger._lambda2, tagger._lambda3)
     assert all(x >= 0 for x in lambdas)
     assert math.isclose(sum(lambdas), 1.0, abs_tol=1e-12)
 
 
-def test_repeated_train_rebuilds_state():
+def test_repeated_train_rebuilds_state_and_clears_decode_cache():
     t = _trained_tagger(_AMBIGUITY_TRAIN)
-    t.tag(["doodad"])
+    t.tag(["xyzzy"])
     assert t._candidate_tags_cache
 
     t.train(_TRAIN)
@@ -303,7 +299,7 @@ def test_repeated_train_rebuilds_state():
     [(False, 1), (True, 0)],
     ids=["default", "trained_flag"],
 )
-def test_external_unk_is_trained_only_when_needed(trained_flag, expected_calls):
+def test_external_unk_train_respects_trained_flag(trained_flag, expected_calls):
     cu = _CountingUnk()
     t = _trained_tagger(unk=cu, Trained=trained_flag)
     assert cu.train_calls == expected_calls
@@ -311,10 +307,7 @@ def test_external_unk_is_trained_only_when_needed(trained_flag, expected_calls):
     assert cu.train_calls == expected_calls
 
 
-# --- Boundary counts and read-only decode state ---
-
-
-def test_eos_follows_sentence_final_punctuation(tagger):
+def test_train_records_eos_after_sentence_final_tag(tagger):
     """EOS is folded into unigram/bigram/trigram counts and attributed
     to the actual final-tag history from training, not a hardcoded
     predecessor."""
@@ -345,7 +338,7 @@ def test_empty_sentences_do_not_record_eos_at_bos():
     assert _EOS not in t._tag_trigrams[(_BOS, _BOS)]
 
 
-def test_decode_does_not_mutate_trained_state(tagger):
+def test_tagging_oov_words_does_not_mutate_trained_counts(tagger):
     before = _decode_mutation_snapshot(tagger)
 
     for word in _OOV_WORDS:
@@ -354,14 +347,11 @@ def test_decode_does_not_mutate_trained_state(tagger):
     assert _decode_mutation_snapshot(tagger) == before
 
 
-# --- Unknown-word and external-unk handling ---
-
-
-def test_unknown_word_falls_back_to_unk_when_priors_empty():
+def test_untrained_tagger_tags_unknown_word_as_unk():
     assert TnT().tag(["xyzzy"]) == [("xyzzy", "Unk")]
 
 
-def test_external_unk_returning_unseen_tag_survives_decode():
+def test_external_unk_unseen_tag_uses_transition_floor():
     """An external ``unk`` may return a tag never seen during training;
     the transition cache falls through to the model floor and the path
     stays alive."""
@@ -369,7 +359,7 @@ def test_external_unk_returning_unseen_tag_survives_decode():
     assert t.tag(["xyzzy"]) == [("xyzzy", "NONESUCH")]
 
 
-def test_external_unk_bypasses_decode_cache():
+def test_external_unk_is_not_cached():
     """Stateful ``unk`` taggers must be invoked on every call; otherwise
     caching collapses their varying output into a single result."""
     t = _trained_tagger(unk=_AlternatingUnk())
@@ -382,20 +372,14 @@ def test_external_unk_bypasses_decode_cache():
     [(_ExtraTagsUnk, 2), (_EmptyOutputUnk, 0)],
     ids=["extra_tags", "no_tags"],
 )
-def test_external_unk_returning_wrong_count_raises_clear_error(unk_class, expected_n):
+def test_external_unk_wrong_length_output_raises_clear_error(unk_class, expected_n):
     t = _trained_tagger(unk=unk_class())
     with pytest.raises(ValueError, match=f"returned {expected_n} tags for 1 word"):
         t.tag(["xyzzy"])
 
 
-# --- Transition probabilities and cache correctness ---
-
-
-def test_transition_logp_cache_matches_direct_formula(tagger):
+def test_transition_logp_cache_matches_deleted_interpolation_formula(tagger):
     _assert_transition_cache_matches_formula(tagger)
-
-
-# --- Decode shape, pruning, and stability ---
 
 
 def test_known_words_decode_to_their_only_seen_tag(tagger):
@@ -403,13 +387,13 @@ def test_known_words_decode_to_their_only_seen_tag(tagger):
         assert tagger.tag(_words(sent)) == sent
 
 
-def test_threshold_pruning_does_not_empty_beam_under_ambiguity():
+def test_threshold_pruning_keeps_viable_ambiguous_beam():
     t = _trained_tagger(_AMBIGUITY_TRAIN, N=2)
     words = ["the", "dogs", "."]
     _assert_tag_output(words, t.tag(words))
 
 
-def test_decode_is_repeat_stable_under_near_tie_beam():
+def test_decode_tie_breaking_is_repeat_stable():
     t = _trained_tagger(_AMBIGUITY_TRAIN, N=1000)
     _assert_decode_stable(t, ["the", "fish", "swims", "."], repeats=10)
 
@@ -418,7 +402,7 @@ def test_decode_is_repeat_stable_under_near_tie_beam():
     "train",
     [pytest.param(_TRAIN, id="full"), pytest.param(_TRAIN[:1], id="one_sent")],
 )
-def test_decode_handles_oov_heavy_sentence_with_shared_suffixes(train):
+def test_suffix_model_decodes_oov_heavy_sentence_repeatably(train):
     t = _trained_tagger(train)
     out = _assert_decode_stable(t, _OOV_HEAVY_SENT)
 
@@ -426,7 +410,7 @@ def test_decode_handles_oov_heavy_sentence_with_shared_suffixes(train):
     assert all(tag in _trained_tags(train) for _, tag in out)
 
 
-def test_decode_handles_long_ambiguous_sentence():
+def test_iterative_decode_handles_long_ambiguous_sentence():
     """Long ambiguous input must decode iteratively and repeatably. The
     length is above Python's default recursion limit, so a recursive
     decoder would fail here."""
@@ -435,15 +419,12 @@ def test_decode_handles_long_ambiguous_sentence():
     _assert_tag_output(_LONG_AMBIGUOUS_SENT, out)
 
 
-def test_candidate_cache_stable_across_repeated_sentence(tagger):
+def test_candidate_cache_does_not_grow_on_repeated_sentence(tagger):
     sent = _OOV_WORDS[:2] + ["the", "cat"]
     tagger.tag(sent)
     size_after_first = len(tagger._candidate_tags_cache)
     tagger.tag(sent)
     assert len(tagger._candidate_tags_cache) == size_after_first
-
-
-# --- Segmentation and input-shape guards ---
 
 
 @pytest.mark.parametrize(
@@ -455,7 +436,7 @@ def test_candidate_cache_stable_across_repeated_sentence(tagger):
         (["the", "cat", ".", "the", "dog"], True, 5),
     ],
 )
-def test_segmentation_shapes(tagger, words, segment, expected_len):
+def test_segmented_tagging_preserves_output_shape(tagger, words, segment, expected_len):
     out = tagger.tag(words, segment=segment)
     assert len(out) == expected_len
     if expected_len > 0:
@@ -467,7 +448,7 @@ def test_segment_true_matches_segment_false_on_single_sentence(tagger):
     assert tagger.tag(words) == tagger.tag(words, segment=True)
 
 
-def test_tagdata_segment_kwarg_forwards_to_tag(tagger):
+def test_tagdata_forwards_segment_kwarg_to_tag(tagger):
     inputs = [
         ["the", "cat", ".", "the", "dog", "."],
         ["beagles", "are", "happy", "to", "rest", "."],
@@ -482,7 +463,7 @@ def test_tagdata_segment_kwarg_forwards_to_tag(tagger):
     [("tag", "list of tokens"), ("tagdata", "list of tokenized sentences")],
 )
 @pytest.mark.parametrize("bad", ["the cat sat", b"the cat sat"])
-def test_string_or_bytes_input_is_rejected(tagger, bad, method, match):
+def test_tag_and_tagdata_reject_string_or_bytes_input(tagger, bad, method, match):
     """``str`` would iterate over characters and ``bytes`` over ints; each
     method catches the common 'forgot to tokenize' mistake at its own
     boundary."""
@@ -490,10 +471,7 @@ def test_string_or_bytes_input_is_rejected(tagger, bad, method, match):
         getattr(tagger, method)(bad)
 
 
-# --- Serialization and reproducibility ---
-
-
-def test_trained_tagger_round_trips_through_pickle(tagger):
+def test_pickle_round_trip_preserves_model_state_and_tags(tagger):
     import pickle
 
     restored = pickle.loads(pickle.dumps(tagger))
@@ -503,11 +481,11 @@ def test_trained_tagger_round_trips_through_pickle(tagger):
         assert restored.tag(_words(sent)) == tagger.tag(_words(sent))
 
 
-def test_train_order_invariance_at_model_level(reordered_taggers):
+def test_training_data_reordering_preserves_model_state(reordered_taggers):
     _assert_model_state_equal(*reordered_taggers)
 
 
-def test_decode_is_bit_stable_across_train_data_reorderings(reordered_taggers):
+def test_training_data_reordering_preserves_decoded_output(reordered_taggers):
     a, b = reordered_taggers
     for sent in _TRAIN:
         assert a.tag(_words(sent)) == b.tag(_words(sent))

--- a/nltk/test/unit/test_tnt.py
+++ b/nltk/test/unit/test_tnt.py
@@ -15,50 +15,36 @@ from nltk.tag.tnt import (
     _safe_log2,
 )
 
-# --- Shared fixtures: training corpora, helpers, and unk mocks ---
+# --- Shared fixtures, corpora, helpers, and unk mocks ---
 
 _TRAIN = [
     [("the", "DT"), ("cat", "NN"), ("ran", "VBD"), (".", ".")],
-    [("the", "DT"), ("dog", "NN"), ("jumped", "VBD"), (".", ".")],
-    [("the", "DT"), ("happy", "JJ"), ("cat", "NN"), ("slept", "VBD"), (".", ".")],
     [("the", "DT"), ("running", "VBG"), ("dog", "NN"), ("barked", "VBD"), (".", ".")],
     [("Dianne", "NNP"), ("loves", "VBZ"), ("to", "TO"), ("hug", "VB"), (".", ".")],
     [("Pappy", "NNP"), ("is", "VBZ"), ("very", "RB"), ("loyal", "JJ"), (".", ".")],
-    [
-        ("beagles", "NNS"),
-        ("are", "VBP"),
-        ("happy", "JJ"),
-        ("to", "TO"),
-        ("rest", "VB"),
-        (".", "."),
-    ],
 ]
 
-_AMBIGUOUS_TRAIN = [
+_AMBIGUITY_TRAIN = [
     [("the", "DT"), ("dogs", "NNS"), (".", ".")],
     [("the", "DT"), ("dogs", "VBZ"), (".", ".")],
-    [("a", "DT"), ("cat", "NN"), (".", ".")],
-]
-
-_NEAR_TIE_TRAIN = [
     [("the", "DT"), ("fish", "NN"), ("swims", "VBZ"), (".", ".")],
     [("the", "DT"), ("fish", "NN"), ("swims", "NNS"), (".", ".")],
-    [("a", "DT"), ("cat", "NN"), ("naps", "VBZ"), (".", ".")],
-    [("a", "DT"), ("cat", "NN"), ("naps", "NNS"), (".", ".")],
-]
-
-_NN_VB_AMBIGUITY_TRAIN = [
-    [("the", "DT"), ("dogs", "NNS"), ("run", "VBP"), (".", ".")],
-    [("the", "DT"), ("dogs", "NNS"), ("bark", "VBP"), (".", ".")],
     [("dogs", "NNS"), ("run", "VBP"), ("fast", "RB"), (".", ".")],
     [("the", "DT"), ("run", "NN"), ("ended", "VBD"), (".", ".")],
+    [("dogs", "NNS"), ("bark", "VBP"), ("loudly", "RB"), (".", ".")],
     [("a", "DT"), ("bark", "NN"), ("echoed", "VBD"), (".", ".")],
 ]
+
+_OOV_WORDS = ["xyzzy", "friendo", "doodad", "phlogiston"]
+_OOV_HEAVY_SENT = ["doodad", "watched", "friendo", "playing", "happily", "."]
+_LONG_AMBIGUOUS_SENT = ["dogs", "run", "bark"] * 334 + ["."]
 
 _MODEL_STATE_FIELDS = (
     "_lambda1",
     "_lambda2",
     "_lambda3",
+    "_num_tag_tokens",
+    "_log2_beam_threshold",
     "_tag_prior_probs",
     "_theta",
     "_trans_logp_unigram",
@@ -127,6 +113,14 @@ def _trained_tagger(train_data=_TRAIN, **kwargs):
     return t
 
 
+def _trained_tags(train):
+    return {tag for sent in train for _, tag in sent}
+
+
+def _words(sent):
+    return [word for word, _ in sent]
+
+
 def _assert_tag_output(words, out):
     assert len(out) == len(words)
     assert all(isinstance(pair, tuple) and len(pair) == 2 for pair in out)
@@ -135,10 +129,14 @@ def _assert_tag_output(words, out):
 
 
 def _assert_decode_stable(tagger, words, repeats=2):
-    first = tagger.tag(words)
-    for _ in range(repeats - 1):
-        assert tagger.tag(words) == first
-    return first
+    known, unknown = tagger.known, tagger.unknown
+    try:
+        first = tagger.tag(words)
+        for _ in range(repeats - 1):
+            assert tagger.tag(words) == first
+        return first
+    finally:
+        tagger.known, tagger.unknown = known, unknown
 
 
 def _state(tagger, word, tag):
@@ -149,8 +147,42 @@ def _cfd_snapshot(cfd):
     return {condition: dict(dist) for condition, dist in cfd.items()}
 
 
+def _suffix_snapshot(tagger):
+    return {
+        cap: _cfd_snapshot(suffix_trie)
+        for cap, suffix_trie in tagger._suffix_trie_by_cap.items()
+    }
+
+
 def _model_state(tagger):
     return {field: getattr(tagger, field) for field in _MODEL_STATE_FIELDS}
+
+
+def _assert_model_state_equal(a, b):
+    assert dict(a._tag_unigrams) == dict(b._tag_unigrams)
+    assert _cfd_snapshot(a._tag_bigrams) == _cfd_snapshot(b._tag_bigrams)
+    assert _cfd_snapshot(a._tag_trigrams) == _cfd_snapshot(b._tag_trigrams)
+    assert _cfd_snapshot(a._word_tag_freqs) == _cfd_snapshot(b._word_tag_freqs)
+    assert _suffix_snapshot(a) == _suffix_snapshot(b)
+    assert _model_state(a) == _model_state(b)
+
+
+def _decode_mutation_snapshot(tagger):
+    return (
+        set(tagger._suffix_trie_by_cap[False].conditions()),
+        set(tagger._tag_bigrams.conditions()),
+        set(tagger._tag_trigrams.conditions()),
+    )
+
+
+def _count_snapshot(tagger):
+    return (
+        tagger._tag_unigrams.N(),
+        sum(d.N() for d in tagger._tag_bigrams.values()),
+        sum(d.N() for d in tagger._tag_trigrams.values()),
+        len(tagger._word_tag_freqs.conditions()),
+        tagger._num_tag_tokens,
+    )
 
 
 def _direct_logp(tagger, prev2, prev1, current):
@@ -208,32 +240,75 @@ def _assert_unigram_fallbacks_match(tagger, bogus_prev2, bogus_prev1):
         _assert_transition_match(tagger, bogus_prev2, bogus_prev1, state)
 
 
+_BOGUS_PREV2 = ("BOGUS_PREV2", False)
+_BOGUS_PREV1 = ("BOGUS_PREV1", False)
+_BOGUS_STATE = ("NEVER_SEEN", False)
+
+
+def _assert_transition_cache_matches_formula(tagger):
+    _assert_observed_trigrams_match(tagger)
+    _assert_bigram_fallbacks_match(tagger, _BOGUS_PREV2)
+    _assert_unigram_fallbacks_match(tagger, _BOGUS_PREV2, _BOGUS_PREV1)
+
+    assert (
+        _cached_logp(tagger, _BOGUS_PREV2, _BOGUS_PREV1, _BOGUS_STATE) == _LOG_FLOOR_2
+    )
+    assert (
+        _direct_logp(tagger, _BOGUS_PREV2, _BOGUS_PREV1, _BOGUS_STATE) == _LOG_FLOOR_2
+    )
+
+
 @pytest.fixture
 def tagger():
     return _trained_tagger()
 
 
-@pytest.fixture
-def reordered_taggers():
-    return _trained_tagger(), _trained_tagger(list(reversed(_TRAIN)))
+@pytest.fixture(params=[False, True], ids=["C_False", "C_True"])
+def reordered_taggers(request):
+    return (
+        _trained_tagger(C=request.param),
+        _trained_tagger(list(reversed(_TRAIN)), C=request.param),
+    )
 
 
-# --- Decode shape and beam pruning ---
+# --- Constructor and training semantics ---
 
 
-def test_known_words_decode_to_their_only_seen_tag(tagger):
-    for sent in _TRAIN:
-        words = [w for w, _ in sent]
-        assert tagger.tag(words) == sent
+@pytest.mark.parametrize(
+    "bad",
+    [0, -1, 0.5, math.nan, math.inf, -math.inf, True, False, "1000", None, [1000]],
+)
+def test_invalid_n_raises_value_error(bad):
+    with pytest.raises(ValueError):
+        TnT(N=bad)
 
 
-def test_threshold_pruning_does_not_empty_beam_under_ambiguity():
-    t = _trained_tagger(_AMBIGUOUS_TRAIN, N=2)
-    words = ["the", "dogs", "."]
-    _assert_tag_output(words, t.tag(words))
+def test_empty_training_zeroes_lambdas():
+    t = _trained_tagger([])
+    assert (t._lambda1, t._lambda2, t._lambda3) == (0.0, 0.0, 0.0)
 
 
-# --- EOS handling ---
+def test_repeated_train_rebuilds_state():
+    t = _trained_tagger()
+    before = _count_snapshot(t)
+    t.train(_TRAIN)
+    assert _count_snapshot(t) == before
+
+
+@pytest.mark.parametrize(
+    ("trained_flag", "expected_calls"),
+    [(False, 1), (True, 0)],
+    ids=["default", "trained_flag"],
+)
+def test_external_unk_is_trained_only_when_needed(trained_flag, expected_calls):
+    cu = _CountingUnk()
+    t = _trained_tagger(unk=cu, Trained=trained_flag)
+    assert cu.train_calls == expected_calls
+    t.train(_TRAIN)
+    assert cu.train_calls == expected_calls
+
+
+# --- Boundary counts and read-only decode state ---
 
 
 def test_eos_follows_sentence_final_punctuation(tagger):
@@ -267,49 +342,16 @@ def test_empty_sentences_do_not_record_eos_at_bos():
     assert _EOS not in t._tag_trigrams[(_BOS, _BOS)]
 
 
-# --- Training semantics ---
+def test_decode_does_not_grow_trained_structures(tagger):
+    before = _decode_mutation_snapshot(tagger)
+
+    for word in _OOV_WORDS:
+        tagger.tag([word])
+
+    assert _decode_mutation_snapshot(tagger) == before
 
 
-def test_repeated_train_rebuilds_state():
-    def snapshot(t):
-        return (
-            t._tag_unigrams.N(),
-            sum(d.N() for d in t._tag_bigrams.values()),
-            sum(d.N() for d in t._tag_trigrams.values()),
-            len(t._word_tag_freqs.conditions()),
-            t._num_tag_tokens,
-        )
-
-    t = _trained_tagger()
-    before = snapshot(t)
-    t.train(_TRAIN)
-    assert snapshot(t) == before
-
-
-@pytest.mark.parametrize(
-    ("trained_flag", "expected_calls"),
-    [(False, 1), (True, 0)],
-    ids=["default", "trained_flag"],
-)
-def test_external_unk_train_invocations_match_trained_flag(
-    trained_flag, expected_calls
-):
-    cu = _CountingUnk()
-    t = _trained_tagger(unk=cu, Trained=trained_flag)
-    assert cu.train_calls == expected_calls
-    t.train(_TRAIN)
-    assert cu.train_calls == expected_calls
-
-
-def test_external_unk_bypasses_decode_cache():
-    """Stateful ``unk`` taggers must be invoked on every call; otherwise
-    caching collapses their varying output into a single result."""
-    t = _trained_tagger(unk=_AlternatingUnk())
-    seen = [t.tag(["xyzzy"])[0][1] for _ in range(3)]
-    assert seen == ["NN", "JJ", "NN"]
-
-
-# --- Unknown-word handling ---
+# --- Unknown-word and external-unk handling ---
 
 
 def test_unknown_word_falls_back_to_unk_when_priors_empty():
@@ -324,27 +366,88 @@ def test_external_unk_returning_unseen_tag_survives_decode():
     assert t.tag(["xyzzy"]) == [("xyzzy", "NONESUCH")]
 
 
-# --- Lambdas ---
-
-
-def test_empty_training_zeroes_lambdas():
-    t = _trained_tagger([])
-    assert (t._lambda1, t._lambda2, t._lambda3) == (0.0, 0.0, 0.0)
-
-
-# --- N validation ---
+def test_external_unk_bypasses_decode_cache():
+    """Stateful ``unk`` taggers must be invoked on every call; otherwise
+    caching collapses their varying output into a single result."""
+    t = _trained_tagger(unk=_AlternatingUnk())
+    seen = [t.tag(["xyzzy"])[0][1] for _ in range(3)]
+    assert seen == ["NN", "JJ", "NN"]
 
 
 @pytest.mark.parametrize(
-    "bad",
-    [0, -1, 0.5, math.nan, math.inf, -math.inf, True, False, "1000", None, [1000]],
+    ("unk_class", "expected_n"),
+    [(_ExtraTagsUnk, 2), (_EmptyOutputUnk, 0)],
+    ids=["extra_tags", "no_tags"],
 )
-def test_invalid_n_raises_value_error(bad):
-    with pytest.raises(ValueError):
-        TnT(N=bad)
+def test_external_unk_returning_wrong_count_raises_clear_error(unk_class, expected_n):
+    """A misbehaving external ``unk`` must raise ``ValueError`` with the
+    actual count, not a cryptic ``too many values to unpack``."""
+    t = _trained_tagger(unk=unk_class())
+    with pytest.raises(ValueError, match=f"returned {expected_n} tags for 1 word"):
+        t.tag(["xyzzy"])
 
 
-# --- Segmentation ---
+# --- Transition probabilities and cache correctness ---
+
+
+def test_transition_logp_cache_matches_direct_formula(tagger):
+    _assert_transition_cache_matches_formula(tagger)
+
+
+# --- Decode shape, pruning, and stability ---
+
+
+def test_known_words_decode_to_their_only_seen_tag(tagger):
+    for sent in _TRAIN:
+        assert tagger.tag(_words(sent)) == sent
+
+
+def test_threshold_pruning_does_not_empty_beam_under_ambiguity():
+    t = _trained_tagger(_AMBIGUITY_TRAIN, N=2)
+    words = ["the", "dogs", "."]
+    _assert_tag_output(words, t.tag(words))
+
+
+def test_decode_is_repeat_stable_under_near_tie_beam():
+    """Strict ``>`` keeps the first encountered path when scores tie."""
+    t = _trained_tagger(_AMBIGUITY_TRAIN, N=1000)
+    _assert_decode_stable(t, ["the", "fish", "swims", "."], repeats=10)
+
+
+@pytest.mark.parametrize(
+    "train",
+    [pytest.param(_TRAIN, id="full"), pytest.param(_TRAIN[:1], id="one_sent")],
+)
+def test_decode_handles_oov_heavy_sentence_with_shared_suffixes(train):
+    """OOV-heavy input should be well-formed, trained-tagset bounded,
+    and repeat-stable even with tiny training data."""
+    t = _trained_tagger(train)
+    out = _assert_decode_stable(t, _OOV_HEAVY_SENT)
+
+    _assert_tag_output(_OOV_HEAVY_SENT, out)
+    assert all(tag in _trained_tags(train) for _, tag in out)
+
+
+def test_decode_handles_long_ambiguous_sentence():
+    """Long ambiguous input must decode iteratively and repeatably. The
+    length is above Python's default recursion limit, so a recursive
+    decoder would fail here."""
+    t = _trained_tagger(_AMBIGUITY_TRAIN, N=1000)
+    out = _assert_decode_stable(t, _LONG_AMBIGUOUS_SENT)
+    _assert_tag_output(_LONG_AMBIGUOUS_SENT, out)
+
+
+def test_candidate_cache_stable_across_repeated_sentence(tagger):
+    """The candidate-tags cache should not grow on a repeat pass over
+    the same sentence."""
+    sent = _OOV_WORDS[:2] + ["the", "cat"]
+    tagger.tag(sent)
+    size_after_first = len(tagger._candidate_tags_cache)
+    tagger.tag(sent)
+    assert len(tagger._candidate_tags_cache) == size_after_first
+
+
+# --- Segmentation and input-shape guards ---
 
 
 @pytest.mark.parametrize(
@@ -366,61 +469,11 @@ def test_segmentation_shapes(tagger, words, segment, expected_len):
 def test_tagdata_segment_kwarg_forwards_to_tag(tagger):
     inputs = [
         ["the", "cat", ".", "the", "dog", "."],
-        ["the", "cat", "ran", "."],
+        ["beagles", "are", "happy", "to", "rest", "."],
     ]
     assert tagger.tagdata(inputs, segment=True) == [
         tagger.tag(s, segment=True) for s in inputs
     ]
-
-
-# --- Long-sentence and suffix-trie regressions ---
-
-
-def test_decode_does_not_mutate_trained_state(tagger):
-    """Decode must be read-only — defaultdict-style subscript access
-    during suffix scoring or n-gram lookup would silently grow the
-    trained model."""
-    trie = tagger._suffix_trie_by_cap[False]
-    before_trie = set(trie.conditions())
-    before_bigrams = set(tagger._tag_bigrams.conditions())
-    before_trigrams = set(tagger._tag_trigrams.conditions())
-
-    for word in ["xyzzy", "friendo", "doodad", "phlogiston"]:
-        tagger.tag([word])
-
-    assert set(trie.conditions()) == before_trie
-    assert set(tagger._tag_bigrams.conditions()) == before_bigrams
-    assert set(tagger._tag_trigrams.conditions()) == before_trigrams
-
-
-def test_transition_logp_cache_matches_direct_formula(tagger):
-    bogus_prev2 = ("BOGUS_PREV2", False)
-    bogus_prev1 = ("BOGUS_PREV1", False)
-    bogus_state = ("NEVER_SEEN", False)
-
-    _assert_observed_trigrams_match(tagger)
-    _assert_bigram_fallbacks_match(tagger, bogus_prev2)
-    _assert_unigram_fallbacks_match(tagger, bogus_prev2, bogus_prev1)
-
-    assert _cached_logp(tagger, bogus_prev2, bogus_prev1, bogus_state) == _LOG_FLOOR_2
-    assert _direct_logp(tagger, bogus_prev2, bogus_prev1, bogus_state) == _LOG_FLOOR_2
-
-
-# --- Public API contracts ---
-
-
-def test_trained_tagger_round_trips_through_pickle(tagger):
-    import pickle
-
-    restored = pickle.loads(pickle.dumps(tagger))
-    assert _model_state(restored) == _model_state(tagger)
-
-    for sent in _TRAIN:
-        words = [w for w, _ in sent]
-        assert restored.tag(words) == tagger.tag(words)
-
-
-# --- Input shape guards ---
 
 
 @pytest.mark.parametrize(
@@ -436,85 +489,29 @@ def test_string_or_bytes_input_is_rejected(tagger, bad, method, match):
         getattr(tagger, method)(bad)
 
 
-@pytest.mark.parametrize(
-    ("unk_class", "expected_n"),
-    [(_ExtraTagsUnk, 2), (_EmptyOutputUnk, 0)],
-    ids=["extra_tags", "no_tags"],
-)
-def test_external_unk_returning_wrong_count_raises_clear_error(unk_class, expected_n):
-    """A misbehaving external ``unk`` must raise ``ValueError`` with the
-    actual count, not a cryptic ``too many values to unpack``."""
-    t = _trained_tagger(unk=unk_class())
-    with pytest.raises(ValueError, match=f"returned {expected_n} tags"):
-        t.tag(["xyzzy"])
+# --- Serialization and reproducibility ---
 
 
-def test_candidate_cache_stable_across_repeated_sentence(tagger):
-    """The candidate-tags cache should not grow on a repeat pass over
-    the same sentence."""
-    sent = ["xyzzy", "asdfgh", "the", "cat"]
-    tagger.tag(sent)
-    size_after_first = len(tagger._candidate_tags_cache)
-    tagger.tag(sent)
-    assert len(tagger._candidate_tags_cache) == size_after_first
+def test_trained_tagger_round_trips_through_pickle(tagger):
+    import pickle
 
+    restored = pickle.loads(pickle.dumps(tagger))
+    _assert_model_state_equal(restored, tagger)
+    assert restored._beam_threshold == tagger._beam_threshold
+    assert restored._use_capitalization == tagger._use_capitalization
+    assert restored._unk_trained == tagger._unk_trained
 
-# --- Edge cases for beam and OOV logic ---
-
-
-def test_decode_is_repeat_stable_under_near_tie_beam():
-    """Tie-breaking in ``_expand_states`` is implicit (strict ``>`` keeps
-    the first-encountered path); repeat decoding must still agree."""
-    t = _trained_tagger(_NEAR_TIE_TRAIN, N=1000)
-    _assert_decode_stable(t, ["the", "fish", "swims", "."], repeats=10)
-
-
-@pytest.mark.parametrize(
-    "train",
-    [pytest.param(_TRAIN, id="full"), pytest.param(_TRAIN[:1], id="one_sent")],
-)
-def test_decode_handles_oov_heavy_sentence_with_shared_suffixes(train):
-    """An all-OOV sentence forces every token through the suffix model;
-    output must be drawn from the trained tagset and stable across
-    repeated decoding even when training is too small to populate the
-    suffix model densely."""
-    t = _trained_tagger(train)
-    trained_tags = {tag for sent in train for _, tag in sent}
-
-    words = ["John", "watched", "friendo", "playing", "happily", "."]
-    out = _assert_decode_stable(t, words)
-
-    _assert_tag_output(words, out)
-    assert all(tag in trained_tags for _, tag in out)
-
-
-def test_decode_handles_long_ambiguous_sentence():
-    """Beam pruning across many steps surfaces iteration-order bugs; the
-    sentence length (>1000 tokens) also forces an iterative decode — a
-    recursive implementation would raise ``RecursionError`` past
-    Python's default recursion limit."""
-    t = _trained_tagger(_NN_VB_AMBIGUITY_TRAIN, N=1000)
-    words = ["dogs", "run", "bark"] * 400 + ["."]
-    out = _assert_decode_stable(t, words)
-    _assert_tag_output(words, out)
+    for sent in _TRAIN:
+        assert restored.tag(_words(sent)) == tagger.tag(_words(sent))
 
 
 def test_train_order_invariance_at_model_level(reordered_taggers):
-    """Reordering training sentences must not change the trained model.
-    Sorted iteration in ``_compute_lambda`` and ``_build_suffix_model``
-    keeps every float-accumulating step bit-stable."""
-    a, b = reordered_taggers
-
-    assert dict(a._tag_unigrams) == dict(b._tag_unigrams)
-    assert _cfd_snapshot(a._tag_bigrams) == _cfd_snapshot(b._tag_bigrams)
-    assert _cfd_snapshot(a._tag_trigrams) == _cfd_snapshot(b._tag_trigrams)
-    assert _model_state(a) == _model_state(b)
+    """Reordering training sentences must not change the trained model."""
+    _assert_model_state_equal(*reordered_taggers)
 
 
 def test_decode_is_bit_stable_across_train_data_reorderings(reordered_taggers):
-    """With the trained model bit-identical, sorted candidate construction
-    in ``_tagword`` keeps decoded output independent of input-data order."""
+    """Decoded output is bit-stable across equivalent training-data orderings."""
     a, b = reordered_taggers
     for sent in _TRAIN:
-        words = [w for w, _ in sent]
-        assert a.tag(words) == b.tag(words)
+        assert a.tag(_words(sent)) == b.tag(_words(sent))

--- a/nltk/test/unit/test_tnt.py
+++ b/nltk/test/unit/test_tnt.py
@@ -54,8 +54,6 @@ _MODEL_STATE_FIELDS = (
 
 
 class _CountingUnk:
-    """External ``unk`` mock that records ``train()`` calls."""
-
     def __init__(self):
         self.train_calls = 0
 
@@ -67,8 +65,6 @@ class _CountingUnk:
 
 
 class _AlternatingUnk:
-    """Returns NN, then JJ, then NN, ... — used to detect cache reuse."""
-
     def __init__(self):
         self.flip = False
 
@@ -387,8 +383,6 @@ def test_external_unk_bypasses_decode_cache():
     ids=["extra_tags", "no_tags"],
 )
 def test_external_unk_returning_wrong_count_raises_clear_error(unk_class, expected_n):
-    """A misbehaving external ``unk`` must raise ``ValueError`` with the
-    actual count, not a cryptic ``too many values to unpack``."""
     t = _trained_tagger(unk=unk_class())
     with pytest.raises(ValueError, match=f"returned {expected_n} tags for 1 word"):
         t.tag(["xyzzy"])
@@ -416,7 +410,6 @@ def test_threshold_pruning_does_not_empty_beam_under_ambiguity():
 
 
 def test_decode_is_repeat_stable_under_near_tie_beam():
-    """Strict ``>`` keeps the first encountered path when scores tie."""
     t = _trained_tagger(_AMBIGUITY_TRAIN, N=1000)
     _assert_decode_stable(t, ["the", "fish", "swims", "."], repeats=10)
 
@@ -426,8 +419,6 @@ def test_decode_is_repeat_stable_under_near_tie_beam():
     [pytest.param(_TRAIN, id="full"), pytest.param(_TRAIN[:1], id="one_sent")],
 )
 def test_decode_handles_oov_heavy_sentence_with_shared_suffixes(train):
-    """OOV-heavy input should be well-formed, trained-tagset bounded,
-    and repeat-stable even with tiny training data."""
     t = _trained_tagger(train)
     out = _assert_decode_stable(t, _OOV_HEAVY_SENT)
 
@@ -445,8 +436,6 @@ def test_decode_handles_long_ambiguous_sentence():
 
 
 def test_candidate_cache_stable_across_repeated_sentence(tagger):
-    """The candidate-tags cache should not grow on a repeat pass over
-    the same sentence."""
     sent = _OOV_WORDS[:2] + ["the", "cat"]
     tagger.tag(sent)
     size_after_first = len(tagger._candidate_tags_cache)
@@ -515,12 +504,10 @@ def test_trained_tagger_round_trips_through_pickle(tagger):
 
 
 def test_train_order_invariance_at_model_level(reordered_taggers):
-    """Reordering training sentences must not change the trained model."""
     _assert_model_state_equal(*reordered_taggers)
 
 
 def test_decode_is_bit_stable_across_train_data_reorderings(reordered_taggers):
-    """Decoded output is bit-stable across equivalent training-data orderings."""
     a, b = reordered_taggers
     for sent in _TRAIN:
         assert a.tag(_words(sent)) == b.tag(_words(sent))

--- a/nltk/test/unit/test_tnt.py
+++ b/nltk/test/unit/test_tnt.py
@@ -538,3 +538,100 @@ def test_trained_tagger_round_trips_through_pickle(tagger):
     for sent in _TRAIN:
         words = [w for w, _ in sent]
         assert restored.tag(words) == tagger.tag(words)
+
+
+# ---------------------------------------------------------------------
+# Input shape guards
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad", ["the cat sat", b"the cat sat"])
+def test_tag_rejects_string_or_bytes_input(tagger, bad):
+    """``tag()`` accepts any iterable, but ``str`` would iterate over
+    characters and ``bytes`` would iterate over ints. Catch the common
+    "forgot to tokenize" mistake at the boundary."""
+    with pytest.raises(TypeError, match="list of tokens"):
+        tagger.tag(bad)
+
+
+@pytest.mark.parametrize("bad", ["the cat sat", b"the cat sat"])
+def test_tagdata_rejects_string_or_bytes_input(tagger, bad):
+    """``tagdata()`` expects a list of tokenized sentences. A bare
+    ``str`` or ``bytes`` would otherwise be interpreted as a sequence
+    of one-character or one-int sentences."""
+    with pytest.raises(TypeError, match="list of tokenized sentences"):
+        tagger.tagdata(bad)
+
+
+def test_external_unk_returning_extra_tags_raises_clear_error():
+    """A misbehaving external ``unk`` tagger that returns more than one
+    tagged token for a single input word must raise a clear
+    ``ValueError`` instead of an unrelated ``too many values to unpack``
+    from tuple destructuring."""
+
+    class ExtraUnk:
+        def train(self, _data):
+            pass
+
+        def tag(self, toks):
+            return [(toks[0], "X"), ("extra", "X")]
+
+    t = TnT(unk=ExtraUnk())
+    t.train(_TRAIN)
+    with pytest.raises(ValueError, match="returned 2 tags"):
+        t.tag(["xyzzy"])
+
+
+def test_external_unk_returning_no_tags_raises_clear_error():
+    """An external ``unk`` tagger that returns an empty list for a
+    single-word input must also raise a clear ``ValueError``."""
+
+    class EmptyUnk:
+        def train(self, _data):
+            pass
+
+        def tag(self, _toks):
+            return []
+
+    t = TnT(unk=EmptyUnk())
+    t.train(_TRAIN)
+    with pytest.raises(ValueError, match="returned 0 tags"):
+        t.tag(["xyzzy"])
+
+
+def test_external_unk_called_for_each_occurrence_not_cached():
+    """Repeated OOV occurrences must invoke the external ``unk`` tagger
+    each time. The unk path is intentionally uncached because user-
+    supplied taggers may carry state or have side effects, so caching
+    a single-token output could silently change behavior."""
+
+    class CountingUnk:
+        def __init__(self):
+            self.calls = 0
+
+        def train(self, _data):
+            pass
+
+        def tag(self, toks):
+            self.calls += 1
+            return [(toks[0], "UNK")]
+
+    unk = CountingUnk()
+    t = TnT(unk=unk)
+    t.train(_TRAIN)
+    t.tag(["xyzzy"])
+    t.tag(["xyzzy"])
+    t.tag(["xyzzy"])
+    assert unk.calls == 3
+
+
+def test_candidate_cache_stable_across_repeated_sentence(tagger):
+    """The candidate-tags cache should not grow after a repeated pass
+    over the same sentence. The first pass may add entries; the second
+    pass should be pure cache hits for the same ``(word, c_i)`` keys."""
+    sent = ["xyzzy", "asdfgh", "the", "cat"]
+    tagger.tag(sent)
+    size_after_first = len(tagger._candidate_tags_cache)
+    tagger.tag(sent)
+    size_after_second = len(tagger._candidate_tags_cache)
+    assert size_after_first == size_after_second

--- a/nltk/test/unit/test_tnt.py
+++ b/nltk/test/unit/test_tnt.py
@@ -13,16 +13,10 @@ from nltk.tag.tnt import (
     TnT,
     _safe_inverse,
     _safe_log2,
-    basic_sent_chop,
 )
 
-# ---------------------------------------------------------------------
-# Shared fixtures: training corpora, helpers, and unk mocks
-# ---------------------------------------------------------------------
+# --- Shared fixtures: training corpora, helpers, and unk mocks ---
 
-# Synthetic corpus covering the tag classes used below. ``Dianne`` and
-# ``Pappy`` exercise the ``NNP`` (capitalized) path, ``beagles`` the
-# ``NNS`` plural path, and the rest cover ``DT/NN/VBD/JJ/VBG/VBZ/TO/RB/VB``.
 _TRAIN = [
     [("the", "DT"), ("cat", "NN"), ("ran", "VBD"), (".", ".")],
     [("the", "DT"), ("dog", "NN"), ("jumped", "VBD"), (".", ".")],
@@ -40,16 +34,12 @@ _TRAIN = [
     ],
 ]
 
-# ``dogs`` appears with two tags so the beam keeps multiple paths alive
-# under tight pruning.
 _AMBIGUOUS_TRAIN = [
     [("the", "DT"), ("dogs", "NNS"), (".", ".")],
     [("the", "DT"), ("dogs", "VBZ"), (".", ".")],
     [("a", "DT"), ("cat", "NN"), (".", ".")],
 ]
 
-# Symmetric: ``swims`` and ``naps`` each appear equally as VBZ and NNS,
-# so their paths land within a small log-prob margin of each other.
 _NEAR_TIE_TRAIN = [
     [("the", "DT"), ("fish", "NN"), ("swims", "VBZ"), (".", ".")],
     [("the", "DT"), ("fish", "NN"), ("swims", "NNS"), (".", ".")],
@@ -57,8 +47,6 @@ _NEAR_TIE_TRAIN = [
     [("a", "DT"), ("cat", "NN"), ("naps", "NNS"), (".", ".")],
 ]
 
-# ``run`` and ``bark`` appear as both NN and VB, so every step of a
-# repeated trigram has NN/VB ambiguity for the decoder to resolve.
 _NN_VB_AMBIGUITY_TRAIN = [
     [("the", "DT"), ("dogs", "NNS"), ("run", "VBP"), (".", ".")],
     [("the", "DT"), ("dogs", "NNS"), ("bark", "VBP"), (".", ".")],
@@ -67,19 +55,28 @@ _NN_VB_AMBIGUITY_TRAIN = [
     [("a", "DT"), ("bark", "NN"), ("echoed", "VBD"), (".", ".")],
 ]
 
+_MODEL_STATE_FIELDS = (
+    "_lambda1",
+    "_lambda2",
+    "_lambda3",
+    "_tag_prior_probs",
+    "_theta",
+    "_trans_logp_unigram",
+    "_trans_logp_bigram",
+    "_trans_logp_trigram",
+)
+
 
 class _CountingUnk:
-    """External ``unk`` mock that records ``train()`` and ``tag()`` calls."""
+    """External ``unk`` mock that records ``train()`` calls."""
 
     def __init__(self):
         self.train_calls = 0
-        self.tag_calls = 0
 
     def train(self, _data):
         self.train_calls += 1
 
     def tag(self, toks):
-        self.tag_calls += 1
         return [(w, "NN") for w in toks]
 
 
@@ -98,8 +95,6 @@ class _AlternatingUnk:
 
 
 class _ConstantTagUnk:
-    """Returns a constant tag for every input token."""
-
     def __init__(self, tag="NONESUCH"):
         self._constant = tag
 
@@ -111,8 +106,6 @@ class _ConstantTagUnk:
 
 
 class _ExtraTagsUnk:
-    """Returns 2 tags for a 1-word input — wrong cardinality."""
-
     def train(self, _data):
         pass
 
@@ -121,8 +114,6 @@ class _ExtraTagsUnk:
 
 
 class _EmptyOutputUnk:
-    """Returns no tags at all — wrong cardinality."""
-
     def train(self, _data):
         pass
 
@@ -131,15 +122,12 @@ class _EmptyOutputUnk:
 
 
 def _trained_tagger(train_data=_TRAIN, **kwargs):
-    """Construct a ``TnT`` and immediately train it. Keyword args go to
-    the constructor."""
     t = TnT(**kwargs)
     t.train(train_data)
     return t
 
 
 def _assert_tag_output(words, out):
-    """Check basic decode shape invariants."""
     assert len(out) == len(words)
     assert all(isinstance(pair, tuple) and len(pair) == 2 for pair in out)
     assert [w for w, _ in out] == words
@@ -147,8 +135,6 @@ def _assert_tag_output(words, out):
 
 
 def _assert_decode_stable(tagger, words, repeats=2):
-    """Decode the same input ``repeats`` times; assert all outputs match.
-    Returns the (shared) output for further inspection."""
     first = tagger.tag(words)
     for _ in range(repeats - 1):
         assert tagger.tag(words) == first
@@ -156,13 +142,20 @@ def _assert_decode_stable(tagger, words, repeats=2):
 
 
 def _state(tagger, word, tag):
-    """``(tag, capitalization)`` pair used as a decoder state."""
     return (tag, tagger._use_capitalization and bool(word) and word[0].isupper())
 
 
+def _cfd_snapshot(cfd):
+    return {condition: dict(dist) for condition, dist in cfd.items()}
+
+
+def _model_state(tagger):
+    return {field: getattr(tagger, field) for field in _MODEL_STATE_FIELDS}
+
+
 def _direct_logp(tagger, prev2, prev1, current):
-    """Reference deleted-interpolation transition log-probability,
-    computed directly from the trained n-gram counts."""
+    """Reference deleted-interpolation transition log-prob from the
+    trained n-gram counts (the formula the cache should match)."""
     l1, l2, l3 = tagger._lambda1, tagger._lambda2, tagger._lambda3
     inv_total = _safe_inverse(tagger._num_tag_tokens)
     bigram_dist = tagger._tag_bigrams.get(prev1)
@@ -186,59 +179,70 @@ def _cached_logp(tagger, prev2, prev1, current):
     return tagger._trans_logp_unigram.get(current, _LOG_FLOOR_2)
 
 
+def _assert_transition_match(tagger, prev2, prev1, current):
+    assert _cached_logp(tagger, prev2, prev1, current) == _direct_logp(
+        tagger, prev2, prev1, current
+    )
+
+
+def _assert_observed_trigrams_match(tagger):
+    seen = False
+    for (prev2, prev1), dist in tagger._tag_trigrams.items():
+        for current in dist:
+            _assert_transition_match(tagger, prev2, prev1, current)
+            seen = True
+    assert seen, "fixture should expose observed trigrams"
+
+
+def _assert_bigram_fallbacks_match(tagger, bogus_prev2):
+    for prev1, dist in tagger._tag_bigrams.items():
+        if (bogus_prev2, prev1) in tagger._tag_trigrams:
+            continue
+        for current in dist:
+            _assert_transition_match(tagger, bogus_prev2, prev1, current)
+
+
+def _assert_unigram_fallbacks_match(tagger, bogus_prev2, bogus_prev1):
+    assert bogus_prev1 not in tagger._tag_bigrams.conditions()
+    for state in tagger._tag_unigrams:
+        _assert_transition_match(tagger, bogus_prev2, bogus_prev1, state)
+
+
 @pytest.fixture
 def tagger():
-    """A ``TnT`` instance trained on the shared synthetic corpus."""
     return _trained_tagger()
 
 
 @pytest.fixture
 def reordered_taggers():
-    """Two taggers trained on ``_TRAIN`` and ``reversed(_TRAIN)``,
-    used by the train-order invariance tests."""
     return _trained_tagger(), _trained_tagger(list(reversed(_TRAIN)))
 
 
-# ---------------------------------------------------------------------
-# Decode shape and beam pruning
-# ---------------------------------------------------------------------
+# --- Decode shape and beam pruning ---
 
 
-@pytest.mark.parametrize("sent", _TRAIN, ids=lambda s: " ".join(w for w, _ in s))
-def test_known_words_decode_to_their_only_seen_tag(tagger, sent):
-    """Sanity check on the unambiguous decode path. Each word in
-    ``_TRAIN`` has a single observed tag, so any deviation points at a
-    broken Viterbi pass rather than a modeling choice."""
-    words = [w for w, _ in sent]
-    assert tagger.tag(words) == sent
+def test_known_words_decode_to_their_only_seen_tag(tagger):
+    for sent in _TRAIN:
+        words = [w for w, _ in sent]
+        assert tagger.tag(words) == sent
 
 
 def test_threshold_pruning_does_not_empty_beam_under_ambiguity():
-    """With local tag ambiguity and a tight beam, decode still returns
-    a full tag sequence."""
     t = _trained_tagger(_AMBIGUOUS_TRAIN, N=2)
     words = ["the", "dogs", "."]
     _assert_tag_output(words, t.tag(words))
 
 
-# ---------------------------------------------------------------------
-# EOS handling
-# ---------------------------------------------------------------------
-
-
-def test_eos_recorded_in_all_three_ngrams(tagger):
-    """EOS is folded into the same n-gram model as every other tag, so
-    it appears in unigram, bigram, and trigram counts. The unigram
-    count must equal the number of non-empty training sentences."""
-    expected_unigram = sum(1 for sent in _TRAIN if sent)
-    assert tagger._tag_unigrams[_EOS] == expected_unigram
-    assert any(_EOS in dist for dist in tagger._tag_bigrams.values())
-    assert any(_EOS in dist for dist in tagger._tag_trigrams.values())
+# --- EOS handling ---
 
 
 def test_eos_follows_sentence_final_punctuation(tagger):
-    """EOS is attributed to the actual final tag history from the
-    training data, not to a hardcoded predecessor context."""
+    """EOS is folded into unigram/bigram/trigram counts and attributed
+    to the actual final-tag history from training, not a hardcoded
+    predecessor."""
+    expected_unigram = sum(1 for sent in _TRAIN if sent)
+    assert tagger._tag_unigrams[_EOS] == expected_unigram
+
     dot_state = _state(tagger, ".", ".")
 
     expected_bigram_count = 0
@@ -258,22 +262,15 @@ def test_eos_follows_sentence_final_punctuation(tagger):
 
 
 def test_empty_sentences_do_not_record_eos_at_bos():
-    """EOS is not recorded with BOS as its bigram or trigram history,
-    which would correspond to an empty sentence."""
     t = _trained_tagger([[], [("the", "DT"), ("cat", "NN"), (".", ".")], []])
     assert _EOS not in t._tag_bigrams[_BOS]
     assert _EOS not in t._tag_trigrams[(_BOS, _BOS)]
 
 
-# ---------------------------------------------------------------------
-# Training semantics
-# ---------------------------------------------------------------------
+# --- Training semantics ---
 
 
 def test_repeated_train_rebuilds_state():
-    """``train()`` rebuilds internal state on each call rather than
-    accumulating, so retraining on the same data is idempotent."""
-
     def snapshot(t):
         return (
             t._tag_unigrams.N(),
@@ -289,92 +286,53 @@ def test_repeated_train_rebuilds_state():
     assert snapshot(t) == before
 
 
-def test_external_unk_tagger_trains_once():
-    """The optional ``unk`` tagger is trained only on the first
-    ``train()`` call. Subsequent calls leave it alone so caller-managed
-    state is preserved across passes."""
+@pytest.mark.parametrize(
+    ("trained_flag", "expected_calls"),
+    [(False, 1), (True, 0)],
+    ids=["default", "trained_flag"],
+)
+def test_external_unk_train_invocations_match_trained_flag(
+    trained_flag, expected_calls
+):
     cu = _CountingUnk()
-    t = _trained_tagger(unk=cu)
-    assert cu.train_calls == 1
+    t = _trained_tagger(unk=cu, Trained=trained_flag)
+    assert cu.train_calls == expected_calls
     t.train(_TRAIN)
-    assert cu.train_calls == 1
-
-
-def test_trained_constructor_flag_skips_external_unk_training():
-    """``Trained=True`` tells the constructor that the optional ``unk``
-    tagger is already trained, so subsequent ``train()`` calls do not
-    retrain it."""
-    cu = _CountingUnk()
-    _trained_tagger(unk=cu, Trained=True)
-    assert cu.train_calls == 0
+    assert cu.train_calls == expected_calls
 
 
 def test_external_unk_bypasses_decode_cache():
-    """Stateful ``unk`` taggers are invoked on every call rather than
-    memoized, otherwise caching collapses their varying output into a
-    single result."""
+    """Stateful ``unk`` taggers must be invoked on every call; otherwise
+    caching collapses their varying output into a single result."""
     t = _trained_tagger(unk=_AlternatingUnk())
     seen = [t.tag(["xyzzy"])[0][1] for _ in range(3)]
     assert seen == ["NN", "JJ", "NN"]
 
 
-# ---------------------------------------------------------------------
-# Unknown-word handling
-# ---------------------------------------------------------------------
-
-
-def test_unknown_word_uses_suffix_model_not_literal_unk(tagger):
-    """The suffix model is the actual unknown-word path. The literal
-    ``"Unk"`` string is only a last-resort fallback for taggers with
-    no priors, so a trained tagger should never reach it."""
-    [(word, tag)] = tagger.tag(["xyzzy"])
-    assert word == "xyzzy"
-    assert tag in tagger._tag_prior_probs
-    assert tag != "Unk"
+# --- Unknown-word handling ---
 
 
 def test_unknown_word_falls_back_to_unk_when_priors_empty():
-    """Without training, the suffix model has no priors and tagging
-    falls back to the literal ``"Unk"`` string. This keeps the API
-    safe on unconfigured taggers."""
     assert TnT().tag(["xyzzy"]) == [("xyzzy", "Unk")]
 
 
 def test_external_unk_returning_unseen_tag_survives_decode():
-    """An external ``unk`` tagger may return a tag that was never seen
-    during training. The candidate state has no unigram entry, so the
-    transition cache falls through to the model floor; the path stays
-    alive and the tag appears in the decoder's output."""
+    """An external ``unk`` may return a tag never seen during training;
+    the transition cache falls through to the model floor and the path
+    stays alive."""
     t = _trained_tagger(unk=_ConstantTagUnk("NONESUCH"))
     assert t.tag(["xyzzy"]) == [("xyzzy", "NONESUCH")]
 
 
-# ---------------------------------------------------------------------
-# Lambdas
-# ---------------------------------------------------------------------
+# --- Lambdas ---
 
 
 def test_empty_training_zeroes_lambdas():
-    """``_compute_lambda()`` zeroes the weights on empty input rather
-    than dividing by zero."""
     t = _trained_tagger([])
     assert (t._lambda1, t._lambda2, t._lambda3) == (0.0, 0.0, 0.0)
 
 
-def test_lambdas_are_non_negative_and_sum_to_one(tagger):
-    """On normal input, the deleted-interpolation weights form a valid
-    probability distribution."""
-    assert tagger._lambda1 >= 0
-    assert tagger._lambda2 >= 0
-    assert tagger._lambda3 >= 0
-    assert math.isclose(
-        tagger._lambda1 + tagger._lambda2 + tagger._lambda3, 1.0, abs_tol=1e-12
-    )
-
-
-# ---------------------------------------------------------------------
-# N validation
-# ---------------------------------------------------------------------
+# --- N validation ---
 
 
 @pytest.mark.parametrize(
@@ -382,20 +340,11 @@ def test_lambdas_are_non_negative_and_sum_to_one(tagger):
     [0, -1, 0.5, math.nan, math.inf, -math.inf, True, False, "1000", None, [1000]],
 )
 def test_invalid_n_raises_value_error(bad):
-    """Invalid ``N`` values raise ``ValueError`` at construction time."""
     with pytest.raises(ValueError):
         TnT(N=bad)
 
 
-@pytest.mark.parametrize("ok", [1, 2, 1000, 1_000_000])
-def test_valid_n_is_accepted(ok):
-    """Integer ``N >= 1`` is accepted."""
-    TnT(N=ok)
-
-
-# ---------------------------------------------------------------------
-# Segmentation
-# ---------------------------------------------------------------------
+# --- Segmentation ---
 
 
 @pytest.mark.parametrize(
@@ -408,40 +357,13 @@ def test_valid_n_is_accepted(ok):
     ],
 )
 def test_segmentation_shapes(tagger, words, segment, expected_len):
-    """Segmented tagging preserves output shape across empty, split,
-    and trailing-fragment inputs."""
     out = tagger.tag(words, segment=segment)
     assert len(out) == expected_len
     if expected_len > 0:
         _assert_tag_output(words, out)
 
 
-def test_segment_true_matches_segment_false_for_single_segment(tagger):
-    """Without mid-sequence punctuation, the segmented and unsegmented
-    decode paths produce the same tag sequence."""
-    words = [w for w, _ in _TRAIN[0]]
-    assert tagger.tag(words) == tagger.tag(words, segment=True)
-
-
-def test_basic_sent_chop_emits_trailing_fragment():
-    """Without this, sentences that lack a final marker would be
-    silently dropped during segmentation, costing real evaluation
-    data."""
-    assert basic_sent_chop(["a", "b", ".", "c", "d"]) == [["a", "b", "."], ["c", "d"]]
-
-
-def test_basic_sent_chop_with_tagged_input():
-    """``basic_sent_chop(raw=False)`` segments a list of ``(word, tag)`` tuples."""
-    tagged = [("a", "DT"), ("b", "NN"), (".", "."), ("c", "DT"), ("d", "NN")]
-    assert basic_sent_chop(tagged, raw=False) == [
-        [("a", "DT"), ("b", "NN"), (".", ".")],
-        [("c", "DT"), ("d", "NN")],
-    ]
-
-
 def test_tagdata_segment_kwarg_forwards_to_tag(tagger):
-    """Without forwarding, ``tagdata`` would silently ignore
-    ``segment`` even though it accepts the kwarg."""
     inputs = [
         ["the", "cat", ".", "the", "dog", "."],
         ["the", "cat", "ran", "."],
@@ -451,148 +373,67 @@ def test_tagdata_segment_kwarg_forwards_to_tag(tagger):
     ]
 
 
-# ---------------------------------------------------------------------
-# Long-sentence and suffix-trie regressions
-# ---------------------------------------------------------------------
+# --- Long-sentence and suffix-trie regressions ---
 
 
-def test_long_sentence_does_not_recurse(tagger):
-    """Decode is iterative; a recursive implementation would raise
-    ``RecursionError`` on long real-world inputs once the sentence
-    exceeds Python's default recursion limit."""
-    words = ["the", "cat"] * 1000
-    _assert_tag_output(words, tagger.tag(words))
-
-
-def test_unknown_word_decode_does_not_grow_suffix_trie(tagger):
-    """Defaultdict-style access during suffix scoring could otherwise
-    grow the trie unboundedly across calls, leaking memory and
-    perturbing decode behavior on later inputs."""
+def test_decode_does_not_mutate_trained_state(tagger):
+    """Decode must be read-only — defaultdict-style subscript access
+    during suffix scoring or n-gram lookup would silently grow the
+    trained model."""
     trie = tagger._suffix_trie_by_cap[False]
-    before = set(trie.conditions())
-    for word in ["xyzzy", "friendo", "doodad", "phlogiston"]:
-        tagger.tag([word])
-    assert set(trie.conditions()) == before
-
-
-def test_decode_does_not_grow_ngram_conditions(tagger):
-    """Tagging must not add conditions to ``_tag_bigrams`` or
-    ``_tag_trigrams``. ``ConditionalFreqDist`` subscript access creates
-    empty entries for unseen keys, which would silently mutate the
-    trained model and break the read-only-decode contract."""
+    before_trie = set(trie.conditions())
     before_bigrams = set(tagger._tag_bigrams.conditions())
     before_trigrams = set(tagger._tag_trigrams.conditions())
-    tagger.tag(["xyzzy", "phlogiston", "doodad"])
+
+    for word in ["xyzzy", "friendo", "doodad", "phlogiston"]:
+        tagger.tag([word])
+
+    assert set(trie.conditions()) == before_trie
     assert set(tagger._tag_bigrams.conditions()) == before_bigrams
     assert set(tagger._tag_trigrams.conditions()) == before_trigrams
 
 
 def test_transition_logp_cache_matches_direct_formula(tagger):
-    """The cached transition log-probabilities equal the direct
-    interpolated formula at every tier (trigram, bigram, unigram), and
-    completely unseen states fall through to ``_LOG_FLOOR_2``."""
     bogus_prev2 = ("BOGUS_PREV2", False)
     bogus_prev1 = ("BOGUS_PREV1", False)
     bogus_state = ("NEVER_SEEN", False)
 
-    def assert_match(prev2, prev1, current):
-        assert _cached_logp(tagger, prev2, prev1, current) == _direct_logp(
-            tagger, prev2, prev1, current
-        )
+    _assert_observed_trigrams_match(tagger)
+    _assert_bigram_fallbacks_match(tagger, bogus_prev2)
+    _assert_unigram_fallbacks_match(tagger, bogus_prev2, bogus_prev1)
 
-    # Case 1: observed trigram (cache hits at the trigram tier).
-    sampled_any = False
-    for (prev2, prev1), dist in tagger._tag_trigrams.items():
-        for current in dist:
-            assert_match(prev2, prev1, current)
-            sampled_any = True
-    assert sampled_any, "fixture should expose observed trigrams"
-
-    # Case 2: observed bigram + fabricated prev2 -> bigram-tier fallback.
-    for prev1, dist in tagger._tag_bigrams.items():
-        if (bogus_prev2, prev1) in tagger._tag_trigrams:
-            continue
-        for current in dist:
-            assert_match(bogus_prev2, prev1, current)
-
-    # Case 3: observed unigram + fabricated history -> unigram fallback.
-    assert bogus_prev1 not in tagger._tag_bigrams.conditions()
-    for state in tagger._tag_unigrams:
-        assert_match(bogus_prev2, bogus_prev1, state)
-
-    # Case 4: completely unseen state -> floor.
     assert _cached_logp(tagger, bogus_prev2, bogus_prev1, bogus_state) == _LOG_FLOOR_2
     assert _direct_logp(tagger, bogus_prev2, bogus_prev1, bogus_state) == _LOG_FLOOR_2
 
 
-# ---------------------------------------------------------------------
-# Public API contracts
-# ---------------------------------------------------------------------
-
-
-def test_two_taggers_trained_on_same_data_are_deterministic():
-    """Catches non-determinism from iteration over sets or unordered
-    dicts in training or decode, which would make trained taggers
-    unreproducible across runs."""
-    a, b = _trained_tagger(), _trained_tagger()
-    for sent in _TRAIN:
-        words = [w for w, _ in sent]
-        assert a.tag(words) == b.tag(words)
-
-
-def test_tag_sents_matches_per_sentence_tag(tagger):
-    """``tag_sents()`` (inherited from ``TaggerI``) must produce the
-    same result as iterating ``tag()`` per sentence."""
-    sents = [[w for w, _ in s] for s in _TRAIN[:3]]
-    assert tagger.tag_sents(sents) == [tagger.tag(s) for s in sents]
+# --- Public API contracts ---
 
 
 def test_trained_tagger_round_trips_through_pickle(tagger):
-    """A trained ``TnT`` must survive a ``pickle`` round trip with
-    identical trained state and identical decode behavior. NLTK users
-    routinely serialize trained taggers, so the contract covers every
-    field that contributes to decoding, not just the resulting tags."""
     import pickle
 
     restored = pickle.loads(pickle.dumps(tagger))
-
-    assert (tagger._lambda1, tagger._lambda2, tagger._lambda3) == (
-        restored._lambda1,
-        restored._lambda2,
-        restored._lambda3,
-    )
-    assert tagger._tag_prior_probs == restored._tag_prior_probs
-    assert tagger._theta == restored._theta
-    assert tagger._trans_logp_unigram == restored._trans_logp_unigram
-    assert tagger._trans_logp_bigram == restored._trans_logp_bigram
-    assert tagger._trans_logp_trigram == restored._trans_logp_trigram
+    assert _model_state(restored) == _model_state(tagger)
 
     for sent in _TRAIN:
         words = [w for w, _ in sent]
         assert restored.tag(words) == tagger.tag(words)
 
 
-# ---------------------------------------------------------------------
-# Input shape guards
-# ---------------------------------------------------------------------
+# --- Input shape guards ---
 
 
+@pytest.mark.parametrize(
+    ("method", "match"),
+    [("tag", "list of tokens"), ("tagdata", "list of tokenized sentences")],
+)
 @pytest.mark.parametrize("bad", ["the cat sat", b"the cat sat"])
-def test_tag_rejects_string_or_bytes_input(tagger, bad):
-    """``tag()`` accepts any iterable, but ``str`` would iterate over
-    characters and ``bytes`` would iterate over ints. Catch the common
-    "forgot to tokenize" mistake at the boundary."""
-    with pytest.raises(TypeError, match="list of tokens"):
-        tagger.tag(bad)
-
-
-@pytest.mark.parametrize("bad", ["the cat sat", b"the cat sat"])
-def test_tagdata_rejects_string_or_bytes_input(tagger, bad):
-    """``tagdata()`` expects a list of tokenized sentences. A bare
-    ``str`` or ``bytes`` would otherwise be interpreted as a sequence
-    of one-character or one-int sentences."""
-    with pytest.raises(TypeError, match="list of tokenized sentences"):
-        tagger.tagdata(bad)
+def test_string_or_bytes_input_is_rejected(tagger, bad, method, match):
+    """``str`` would iterate over characters and ``bytes`` over ints; each
+    method catches the common 'forgot to tokenize' mistake at its own
+    boundary."""
+    with pytest.raises(TypeError, match=match):
+        getattr(tagger, method)(bad)
 
 
 @pytest.mark.parametrize(
@@ -601,31 +442,16 @@ def test_tagdata_rejects_string_or_bytes_input(tagger, bad):
     ids=["extra_tags", "no_tags"],
 )
 def test_external_unk_returning_wrong_count_raises_clear_error(unk_class, expected_n):
-    """A misbehaving external ``unk`` tagger that returns ``!= 1`` tag
-    for a 1-word input must raise ``ValueError`` with the actual count,
-    instead of an unrelated ``too many values to unpack`` from
-    destructuring."""
+    """A misbehaving external ``unk`` must raise ``ValueError`` with the
+    actual count, not a cryptic ``too many values to unpack``."""
     t = _trained_tagger(unk=unk_class())
     with pytest.raises(ValueError, match=f"returned {expected_n} tags"):
         t.tag(["xyzzy"])
 
 
-def test_external_unk_called_for_each_occurrence_not_cached():
-    """Repeated OOV occurrences must invoke the external ``unk`` tagger
-    each time. The unk path is intentionally uncached because user-
-    supplied taggers may carry state or have side effects, so caching
-    a single-token output could silently change behavior."""
-    unk = _CountingUnk()
-    t = _trained_tagger(unk=unk)
-    for _ in range(3):
-        t.tag(["xyzzy"])
-    assert unk.tag_calls == 3
-
-
 def test_candidate_cache_stable_across_repeated_sentence(tagger):
-    """The candidate-tags cache should not grow after a repeated pass
-    over the same sentence. The first pass may add entries; the second
-    pass should be pure cache hits for the same ``(word, c_i)`` keys."""
+    """The candidate-tags cache should not grow on a repeat pass over
+    the same sentence."""
     sent = ["xyzzy", "asdfgh", "the", "cat"]
     tagger.tag(sent)
     size_after_first = len(tagger._candidate_tags_cache)
@@ -633,16 +459,12 @@ def test_candidate_cache_stable_across_repeated_sentence(tagger):
     assert len(tagger._candidate_tags_cache) == size_after_first
 
 
-# ---------------------------------------------------------------------
-# Edge cases for beam and OOV logic
-# ---------------------------------------------------------------------
+# --- Edge cases for beam and OOV logic ---
 
 
 def test_decode_is_repeat_stable_under_near_tie_beam():
     """Tie-breaking in ``_expand_states`` is implicit (strict ``>`` keeps
-    the first-encountered path). Repeated decoding on the same input
-    must therefore agree even when several paths land within the beam
-    threshold of each other."""
+    the first-encountered path); repeat decoding must still agree."""
     t = _trained_tagger(_NEAR_TIE_TRAIN, N=1000)
     _assert_decode_stable(t, ["the", "fish", "swims", "."], repeats=10)
 
@@ -652,10 +474,10 @@ def test_decode_is_repeat_stable_under_near_tie_beam():
     [pytest.param(_TRAIN, id="full"), pytest.param(_TRAIN[:1], id="one_sent")],
 )
 def test_decode_handles_oov_heavy_sentence_with_shared_suffixes(train):
-    """An all-OOV sentence forces every token through the suffix model.
-    The path must produce well-formed output drawn from the trained
-    tagset and remain stable across repeated decoding, including when
-    the training set is too small to populate the suffix model densely."""
+    """An all-OOV sentence forces every token through the suffix model;
+    output must be drawn from the trained tagset and stable across
+    repeated decoding even when training is too small to populate the
+    suffix model densely."""
     t = _trained_tagger(train)
     trained_tags = {tag for sent in train for _, tag in sent}
 
@@ -667,12 +489,12 @@ def test_decode_handles_oov_heavy_sentence_with_shared_suffixes(train):
 
 
 def test_decode_handles_long_ambiguous_sentence():
-    """Beam pruning across many steps is where any iteration-order or
-    accumulation bug would surface. A long sentence built from
-    NN/VB-ambiguous tokens must still decode to completion and produce
-    consistent output across runs."""
+    """Beam pruning across many steps surfaces iteration-order bugs; the
+    sentence length (>1000 tokens) also forces an iterative decode — a
+    recursive implementation would raise ``RecursionError`` past
+    Python's default recursion limit."""
     t = _trained_tagger(_NN_VB_AMBIGUITY_TRAIN, N=1000)
-    words = ["dogs", "run", "bark"] * 40 + ["."]
+    words = ["dogs", "run", "bark"] * 400 + ["."]
     out = _assert_decode_stable(t, words)
     _assert_tag_output(words, out)
 
@@ -680,35 +502,18 @@ def test_decode_handles_long_ambiguous_sentence():
 def test_train_order_invariance_at_model_level(reordered_taggers):
     """Reordering training sentences must not change the trained model.
     Sorted iteration in ``_compute_lambda`` and ``_build_suffix_model``
-    makes every float-accumulating step bit-stable, so the weights, the
-    suffix-model priors, and the transition cache are all bit-identical
-    across training-data reorderings."""
+    keeps every float-accumulating step bit-stable."""
     a, b = reordered_taggers
 
     assert dict(a._tag_unigrams) == dict(b._tag_unigrams)
-    assert {prev: dict(dist) for prev, dist in a._tag_bigrams.items()} == {
-        prev: dict(dist) for prev, dist in b._tag_bigrams.items()
-    }
-    assert {prev: dict(dist) for prev, dist in a._tag_trigrams.items()} == {
-        prev: dict(dist) for prev, dist in b._tag_trigrams.items()
-    }
-    assert (a._lambda1, a._lambda2, a._lambda3) == (
-        b._lambda1,
-        b._lambda2,
-        b._lambda3,
-    )
-    assert a._tag_prior_probs == b._tag_prior_probs
-    assert a._theta == b._theta
-    assert a._trans_logp_unigram == b._trans_logp_unigram
-    assert a._trans_logp_bigram == b._trans_logp_bigram
-    assert a._trans_logp_trigram == b._trans_logp_trigram
+    assert _cfd_snapshot(a._tag_bigrams) == _cfd_snapshot(b._tag_bigrams)
+    assert _cfd_snapshot(a._tag_trigrams) == _cfd_snapshot(b._tag_trigrams)
+    assert _model_state(a) == _model_state(b)
 
 
 def test_decode_is_bit_stable_across_train_data_reorderings(reordered_taggers):
-    """Beyond the model state, decoded output must match across training
-    reorderings. With the trained model bit-identical, sorted candidate
-    construction in ``_tagword`` keeps the beam tie-breaking order
-    independent of input-data order."""
+    """With the trained model bit-identical, sorted candidate construction
+    in ``_tagword`` keeps decoded output independent of input-data order."""
     a, b = reordered_taggers
     for sent in _TRAIN:
         words = [w for w, _ in sent]

--- a/nltk/test/unit/test_tnt.py
+++ b/nltk/test/unit/test_tnt.py
@@ -669,7 +669,7 @@ def test_decode_handles_oov_heavy_sentence_with_shared_suffixes():
     t.train(_TRAIN)
     trained_tags = {tag for sent in _TRAIN for _, tag in sent}
 
-    words = ["John", "watched", "friendo", "play", "happily", "."]
+    words = ["John", "watched", "friendo", "playing", "happily", "."]
     out = t.tag(words)
 
     _assert_tag_output(words, out)

--- a/nltk/test/unit/test_tnt.py
+++ b/nltk/test/unit/test_tnt.py
@@ -16,48 +16,20 @@ from nltk.tag.tnt import (
     basic_sent_chop,
 )
 
-# Synthetic corpus covering the tag classes used below.
+# ---------------------------------------------------------------------
+# Shared fixtures: training corpora, helpers, and unk mocks
+# ---------------------------------------------------------------------
+
+# Synthetic corpus covering the tag classes used below. ``Dianne`` and
+# ``Pappy`` exercise the ``NNP`` (capitalized) path, ``beagles`` the
+# ``NNS`` plural path, and the rest cover ``DT/NN/VBD/JJ/VBG/VBZ/TO/RB/VB``.
 _TRAIN = [
-    [
-        ("the", "DT"),
-        ("cat", "NN"),
-        ("ran", "VBD"),
-        (".", "."),
-    ],
-    [
-        ("the", "DT"),
-        ("dog", "NN"),
-        ("jumped", "VBD"),
-        (".", "."),
-    ],
-    [
-        ("the", "DT"),
-        ("happy", "JJ"),
-        ("cat", "NN"),
-        ("slept", "VBD"),
-        (".", "."),
-    ],
-    [
-        ("the", "DT"),
-        ("running", "VBG"),
-        ("dog", "NN"),
-        ("barked", "VBD"),
-        (".", "."),
-    ],
-    [
-        ("Dianne", "NNP"),
-        ("loves", "VBZ"),
-        ("to", "TO"),
-        ("hug", "VB"),
-        (".", "."),
-    ],
-    [
-        ("Pappy", "NNP"),
-        ("is", "VBZ"),
-        ("very", "RB"),
-        ("loyal", "JJ"),
-        (".", "."),
-    ],
+    [("the", "DT"), ("cat", "NN"), ("ran", "VBD"), (".", ".")],
+    [("the", "DT"), ("dog", "NN"), ("jumped", "VBD"), (".", ".")],
+    [("the", "DT"), ("happy", "JJ"), ("cat", "NN"), ("slept", "VBD"), (".", ".")],
+    [("the", "DT"), ("running", "VBG"), ("dog", "NN"), ("barked", "VBD"), (".", ".")],
+    [("Dianne", "NNP"), ("loves", "VBZ"), ("to", "TO"), ("hug", "VB"), (".", ".")],
+    [("Pappy", "NNP"), ("is", "VBZ"), ("very", "RB"), ("loyal", "JJ"), (".", ".")],
     [
         ("beagles", "NNS"),
         ("are", "VBP"),
@@ -68,25 +40,101 @@ _TRAIN = [
     ],
 ]
 
+# ``dogs`` appears with two tags so the beam keeps multiple paths alive
+# under tight pruning.
+_AMBIGUOUS_TRAIN = [
+    [("the", "DT"), ("dogs", "NNS"), (".", ".")],
+    [("the", "DT"), ("dogs", "VBZ"), (".", ".")],
+    [("a", "DT"), ("cat", "NN"), (".", ".")],
+]
+
+# Symmetric: ``swims`` and ``naps`` each appear equally as VBZ and NNS,
+# so their paths land within a small log-prob margin of each other.
+_NEAR_TIE_TRAIN = [
+    [("the", "DT"), ("fish", "NN"), ("swims", "VBZ"), (".", ".")],
+    [("the", "DT"), ("fish", "NN"), ("swims", "NNS"), (".", ".")],
+    [("a", "DT"), ("cat", "NN"), ("naps", "VBZ"), (".", ".")],
+    [("a", "DT"), ("cat", "NN"), ("naps", "NNS"), (".", ".")],
+]
+
+# ``run`` and ``bark`` appear as both NN and VB, so every step of a
+# repeated trigram has NN/VB ambiguity for the decoder to resolve.
+_NN_VB_AMBIGUITY_TRAIN = [
+    [("the", "DT"), ("dogs", "NNS"), ("run", "VBP"), (".", ".")],
+    [("the", "DT"), ("dogs", "NNS"), ("bark", "VBP"), (".", ".")],
+    [("dogs", "NNS"), ("run", "VBP"), ("fast", "RB"), (".", ".")],
+    [("the", "DT"), ("run", "NN"), ("ended", "VBD"), (".", ".")],
+    [("a", "DT"), ("bark", "NN"), ("echoed", "VBD"), (".", ".")],
+]
+
 
 class _CountingUnk:
-    """Counts how many times ``train()`` is called."""
+    """External ``unk`` mock that records ``train()`` and ``tag()`` calls."""
 
     def __init__(self):
         self.train_calls = 0
+        self.tag_calls = 0
 
     def train(self, _data):
         self.train_calls += 1
 
     def tag(self, toks):
+        self.tag_calls += 1
         return [(w, "NN") for w in toks]
 
 
-@pytest.fixture
-def tagger():
-    """A ``TnT`` instance trained on the shared synthetic corpus."""
-    t = TnT()
-    t.train(_TRAIN)
+class _AlternatingUnk:
+    """Returns NN, then JJ, then NN, ... — used to detect cache reuse."""
+
+    def __init__(self):
+        self.flip = False
+
+    def train(self, _data):
+        pass
+
+    def tag(self, toks):
+        self.flip = not self.flip
+        return [(w, "NN" if self.flip else "JJ") for w in toks]
+
+
+class _ConstantTagUnk:
+    """Returns a constant tag for every input token."""
+
+    def __init__(self, tag="NONESUCH"):
+        self._constant = tag
+
+    def train(self, _data):
+        pass
+
+    def tag(self, toks):
+        return [(w, self._constant) for w in toks]
+
+
+class _ExtraTagsUnk:
+    """Returns 2 tags for a 1-word input — wrong cardinality."""
+
+    def train(self, _data):
+        pass
+
+    def tag(self, toks):
+        return [(toks[0], "X"), ("extra", "X")]
+
+
+class _EmptyOutputUnk:
+    """Returns no tags at all — wrong cardinality."""
+
+    def train(self, _data):
+        pass
+
+    def tag(self, _toks):
+        return []
+
+
+def _trained_tagger(train_data=_TRAIN, **kwargs):
+    """Construct a ``TnT`` and immediately train it. Keyword args go to
+    the constructor."""
+    t = TnT(**kwargs)
+    t.train(train_data)
     return t
 
 
@@ -96,6 +144,59 @@ def _assert_tag_output(words, out):
     assert all(isinstance(pair, tuple) and len(pair) == 2 for pair in out)
     assert [w for w, _ in out] == words
     assert all(isinstance(tag, str) for _, tag in out)
+
+
+def _assert_decode_stable(tagger, words, repeats=2):
+    """Decode the same input ``repeats`` times; assert all outputs match.
+    Returns the (shared) output for further inspection."""
+    first = tagger.tag(words)
+    for _ in range(repeats - 1):
+        assert tagger.tag(words) == first
+    return first
+
+
+def _state(tagger, word, tag):
+    """``(tag, capitalization)`` pair used as a decoder state."""
+    return (tag, tagger._use_capitalization and bool(word) and word[0].isupper())
+
+
+def _direct_logp(tagger, prev2, prev1, current):
+    """Reference deleted-interpolation transition log-probability,
+    computed directly from the trained n-gram counts."""
+    l1, l2, l3 = tagger._lambda1, tagger._lambda2, tagger._lambda3
+    inv_total = _safe_inverse(tagger._num_tag_tokens)
+    bigram_dist = tagger._tag_bigrams.get(prev1)
+    trigram_dist = tagger._tag_trigrams.get((prev2, prev1))
+    p = l1 * (tagger._tag_unigrams[current] * inv_total)
+    if bigram_dist is not None:
+        p += l2 * bigram_dist.get(current, 0) * _safe_inverse(bigram_dist.N())
+    if trigram_dist is not None:
+        p += l3 * trigram_dist.get(current, 0) * _safe_inverse(trigram_dist.N())
+    return _safe_log2(p)
+
+
+def _cached_logp(tagger, prev2, prev1, current):
+    """Tier-by-tier lookup against the precomputed transition cache."""
+    v = tagger._trans_logp_trigram.get((prev2, prev1), {}).get(current)
+    if v is not None:
+        return v
+    v = tagger._trans_logp_bigram.get(prev1, {}).get(current)
+    if v is not None:
+        return v
+    return tagger._trans_logp_unigram.get(current, _LOG_FLOOR_2)
+
+
+@pytest.fixture
+def tagger():
+    """A ``TnT`` instance trained on the shared synthetic corpus."""
+    return _trained_tagger()
+
+
+@pytest.fixture
+def reordered_taggers():
+    """Two taggers trained on ``_TRAIN`` and ``reversed(_TRAIN)``,
+    used by the train-order invariance tests."""
+    return _trained_tagger(), _trained_tagger(list(reversed(_TRAIN)))
 
 
 # ---------------------------------------------------------------------
@@ -115,16 +216,9 @@ def test_known_words_decode_to_their_only_seen_tag(tagger, sent):
 def test_threshold_pruning_does_not_empty_beam_under_ambiguity():
     """With local tag ambiguity and a tight beam, decode still returns
     a full tag sequence."""
-    train = [
-        [("the", "DT"), ("dogs", "NNS"), (".", ".")],
-        [("the", "DT"), ("dogs", "VBZ"), (".", ".")],
-        [("a", "DT"), ("cat", "NN"), (".", ".")],
-    ]
-    t = TnT(N=2)
-    t.train(train)
+    t = _trained_tagger(_AMBIGUOUS_TRAIN, N=2)
     words = ["the", "dogs", "."]
-    out = t.tag(words)
-    _assert_tag_output(words, out)
+    _assert_tag_output(words, t.tag(words))
 
 
 # ---------------------------------------------------------------------
@@ -142,13 +236,6 @@ def test_eos_recorded_in_all_three_ngrams(tagger):
     assert any(_EOS in dist for dist in tagger._tag_trigrams.values())
 
 
-def _state(tagger, word, tag):
-    return (
-        tag,
-        tagger._use_capitalization and bool(word) and word[0].isupper(),
-    )
-
-
 def test_eos_follows_sentence_final_punctuation(tagger):
     """EOS is attributed to the actual final tag history from the
     training data, not to a hardcoded predecessor context."""
@@ -160,15 +247,12 @@ def test_eos_follows_sentence_final_punctuation(tagger):
     for sent in _TRAIN:
         if not sent or sent[-1][0] != ".":
             continue
-
         expected_bigram_count += 1
-
         prev_state = _state(tagger, sent[-2][0], sent[-2][1])
         history = (prev_state, dot_state)
         expected_trigram_counts[history] = expected_trigram_counts.get(history, 0) + 1
 
     assert tagger._tag_bigrams[dot_state][_EOS] == expected_bigram_count
-
     for history, count in expected_trigram_counts.items():
         assert tagger._tag_trigrams[history][_EOS] == count
 
@@ -176,8 +260,7 @@ def test_eos_follows_sentence_final_punctuation(tagger):
 def test_empty_sentences_do_not_record_eos_at_bos():
     """EOS is not recorded with BOS as its bigram or trigram history,
     which would correspond to an empty sentence."""
-    t = TnT()
-    t.train([[], [("the", "DT"), ("cat", "NN"), (".", ".")], []])
+    t = _trained_tagger([[], [("the", "DT"), ("cat", "NN"), (".", ".")], []])
     assert _EOS not in t._tag_bigrams[_BOS]
     assert _EOS not in t._tag_trigrams[(_BOS, _BOS)]
 
@@ -190,24 +273,20 @@ def test_empty_sentences_do_not_record_eos_at_bos():
 def test_repeated_train_rebuilds_state():
     """``train()`` rebuilds internal state on each call rather than
     accumulating, so retraining on the same data is idempotent."""
-    t = TnT()
+
+    def snapshot(t):
+        return (
+            t._tag_unigrams.N(),
+            sum(d.N() for d in t._tag_bigrams.values()),
+            sum(d.N() for d in t._tag_trigrams.values()),
+            len(t._word_tag_freqs.conditions()),
+            t._num_tag_tokens,
+        )
+
+    t = _trained_tagger()
+    before = snapshot(t)
     t.train(_TRAIN)
-    snapshot = (
-        t._tag_unigrams.N(),
-        sum(d.N() for d in t._tag_bigrams.values()),
-        sum(d.N() for d in t._tag_trigrams.values()),
-        len(t._word_tag_freqs.conditions()),
-        t._num_tag_tokens,
-    )
-    t.train(_TRAIN)
-    after = (
-        t._tag_unigrams.N(),
-        sum(d.N() for d in t._tag_bigrams.values()),
-        sum(d.N() for d in t._tag_trigrams.values()),
-        len(t._word_tag_freqs.conditions()),
-        t._num_tag_tokens,
-    )
-    assert snapshot == after
+    assert snapshot(t) == before
 
 
 def test_external_unk_tagger_trains_once():
@@ -215,8 +294,7 @@ def test_external_unk_tagger_trains_once():
     ``train()`` call. Subsequent calls leave it alone so caller-managed
     state is preserved across passes."""
     cu = _CountingUnk()
-    t = TnT(unk=cu)
-    t.train(_TRAIN)
+    t = _trained_tagger(unk=cu)
     assert cu.train_calls == 1
     t.train(_TRAIN)
     assert cu.train_calls == 1
@@ -227,8 +305,7 @@ def test_trained_constructor_flag_skips_external_unk_training():
     tagger is already trained, so subsequent ``train()`` calls do not
     retrain it."""
     cu = _CountingUnk()
-    t = TnT(unk=cu, Trained=True)
-    t.train(_TRAIN)
+    _trained_tagger(unk=cu, Trained=True)
     assert cu.train_calls == 0
 
 
@@ -236,20 +313,7 @@ def test_external_unk_bypasses_decode_cache():
     """Stateful ``unk`` taggers are invoked on every call rather than
     memoized, otherwise caching collapses their varying output into a
     single result."""
-
-    class AlternatingUnk:
-        def __init__(self):
-            self.flip = False
-
-        def train(self, _data):
-            pass
-
-        def tag(self, toks):
-            self.flip = not self.flip
-            return [(w, "NN" if self.flip else "JJ") for w in toks]
-
-    t = TnT(unk=AlternatingUnk())
-    t.train(_TRAIN)
+    t = _trained_tagger(unk=_AlternatingUnk())
     seen = [t.tag(["xyzzy"])[0][1] for _ in range(3)]
     assert seen == ["NN", "JJ", "NN"]
 
@@ -273,8 +337,7 @@ def test_unknown_word_falls_back_to_unk_when_priors_empty():
     """Without training, the suffix model has no priors and tagging
     falls back to the literal ``"Unk"`` string. This keeps the API
     safe on unconfigured taggers."""
-    t = TnT()
-    assert t.tag(["xyzzy"]) == [("xyzzy", "Unk")]
+    assert TnT().tag(["xyzzy"]) == [("xyzzy", "Unk")]
 
 
 def test_external_unk_returning_unseen_tag_survives_decode():
@@ -282,19 +345,8 @@ def test_external_unk_returning_unseen_tag_survives_decode():
     during training. The candidate state has no unigram entry, so the
     transition cache falls through to the model floor; the path stays
     alive and the tag appears in the decoder's output."""
-
-    class ConstantUnk:
-        def train(self, _data):
-            pass
-
-        def tag(self, toks):
-            return [(w, "NONESUCH") for w in toks]
-
-    t = TnT(unk=ConstantUnk())
-    t.train(_TRAIN)
-    [(word, tag)] = t.tag(["xyzzy"])
-    assert word == "xyzzy"
-    assert tag == "NONESUCH"
+    t = _trained_tagger(unk=_ConstantTagUnk("NONESUCH"))
+    assert t.tag(["xyzzy"]) == [("xyzzy", "NONESUCH")]
 
 
 # ---------------------------------------------------------------------
@@ -305,8 +357,7 @@ def test_external_unk_returning_unseen_tag_survives_decode():
 def test_empty_training_zeroes_lambdas():
     """``_compute_lambda()`` zeroes the weights on empty input rather
     than dividing by zero."""
-    t = TnT()
-    t.train([])
+    t = _trained_tagger([])
     assert (t._lambda1, t._lambda2, t._lambda3) == (0.0, 0.0, 0.0)
 
 
@@ -317,9 +368,7 @@ def test_lambdas_are_non_negative_and_sum_to_one(tagger):
     assert tagger._lambda2 >= 0
     assert tagger._lambda3 >= 0
     assert math.isclose(
-        tagger._lambda1 + tagger._lambda2 + tagger._lambda3,
-        1.0,
-        abs_tol=1e-12,
+        tagger._lambda1 + tagger._lambda2 + tagger._lambda3, 1.0, abs_tol=1e-12
     )
 
 
@@ -384,8 +433,7 @@ def test_basic_sent_chop_emits_trailing_fragment():
 def test_basic_sent_chop_with_tagged_input():
     """``basic_sent_chop(raw=False)`` segments a list of ``(word, tag)`` tuples."""
     tagged = [("a", "DT"), ("b", "NN"), (".", "."), ("c", "DT"), ("d", "NN")]
-    chopped = basic_sent_chop(tagged, raw=False)
-    assert chopped == [
+    assert basic_sent_chop(tagged, raw=False) == [
         [("a", "DT"), ("b", "NN"), (".", ".")],
         [("c", "DT"), ("d", "NN")],
     ]
@@ -413,8 +461,7 @@ def test_long_sentence_does_not_recurse(tagger):
     ``RecursionError`` on long real-world inputs once the sentence
     exceeds Python's default recursion limit."""
     words = ["the", "cat"] * 1000
-    out = tagger.tag(words)
-    _assert_tag_output(words, out)
+    _assert_tag_output(words, tagger.tag(words))
 
 
 def test_unknown_word_decode_does_not_grow_suffix_trie(tagger):
@@ -425,8 +472,7 @@ def test_unknown_word_decode_does_not_grow_suffix_trie(tagger):
     before = set(trie.conditions())
     for word in ["xyzzy", "friendo", "doodad", "phlogiston"]:
         tagger.tag([word])
-    after = set(trie.conditions())
-    assert after == before
+    assert set(trie.conditions()) == before
 
 
 def test_decode_does_not_grow_ngram_conditions(tagger):
@@ -445,62 +491,38 @@ def test_transition_logp_cache_matches_direct_formula(tagger):
     """The cached transition log-probabilities equal the direct
     interpolated formula at every tier (trigram, bigram, unigram), and
     completely unseen states fall through to ``_LOG_FLOOR_2``."""
-    l1, l2, l3 = tagger._lambda1, tagger._lambda2, tagger._lambda3
-    inv_total = _safe_inverse(tagger._num_tag_tokens)
+    bogus_prev2 = ("BOGUS_PREV2", False)
+    bogus_prev1 = ("BOGUS_PREV1", False)
+    bogus_state = ("NEVER_SEEN", False)
 
-    def direct(prev2, prev1, current):
-        bigram_dist = tagger._tag_bigrams.get(prev1)
-        trigram_dist = tagger._tag_trigrams.get((prev2, prev1))
-        p = l1 * (tagger._tag_unigrams[current] * inv_total)
-        if bigram_dist is not None:
-            p += l2 * bigram_dist.get(current, 0) * _safe_inverse(bigram_dist.N())
-        if trigram_dist is not None:
-            p += l3 * trigram_dist.get(current, 0) * _safe_inverse(trigram_dist.N())
-        return _safe_log2(p)
-
-    def cached(prev2, prev1, current):
-        v = tagger._trans_logp_trigram.get((prev2, prev1), {}).get(current)
-        if v is not None:
-            return v
-        v = tagger._trans_logp_bigram.get(prev1, {}).get(current)
-        if v is not None:
-            return v
-        return tagger._trans_logp_unigram.get(current, _LOG_FLOOR_2)
+    def assert_match(prev2, prev1, current):
+        assert _cached_logp(tagger, prev2, prev1, current) == _direct_logp(
+            tagger, prev2, prev1, current
+        )
 
     # Case 1: observed trigram (cache hits at the trigram tier).
     sampled_any = False
-    for prev_pair, dist in tagger._tag_trigrams.items():
-        prev2, prev1 = prev_pair
+    for (prev2, prev1), dist in tagger._tag_trigrams.items():
         for current in dist:
-            assert cached(prev2, prev1, current) == direct(prev2, prev1, current)
+            assert_match(prev2, prev1, current)
             sampled_any = True
     assert sampled_any, "fixture should expose observed trigrams"
 
-    # Case 2: observed bigram with a fabricated prev2 that was never
-    # paired with prev1; cache falls through to the bigram tier.
-    bogus_prev2 = ("BOGUS_PREV2", False)
+    # Case 2: observed bigram + fabricated prev2 -> bigram-tier fallback.
     for prev1, dist in tagger._tag_bigrams.items():
         if (bogus_prev2, prev1) in tagger._tag_trigrams:
             continue
         for current in dist:
-            assert cached(bogus_prev2, prev1, current) == direct(
-                bogus_prev2, prev1, current
-            )
+            assert_match(bogus_prev2, prev1, current)
 
-    # Case 3: observed unigram with fabricated history; cache falls
-    # through to the unigram tier.
-    bogus_prev1 = ("BOGUS_PREV1", False)
+    # Case 3: observed unigram + fabricated history -> unigram fallback.
     assert bogus_prev1 not in tagger._tag_bigrams.conditions()
     for state in tagger._tag_unigrams:
-        assert cached(bogus_prev2, bogus_prev1, state) == direct(
-            bogus_prev2, bogus_prev1, state
-        )
+        assert_match(bogus_prev2, bogus_prev1, state)
 
-    # Case 4: completely unseen state. Cache returns the floor; the
-    # direct formula reaches the same floor since p collapses to 0.
-    bogus_state = ("NEVER_SEEN", False)
-    assert cached(bogus_prev2, bogus_prev1, bogus_state) == _LOG_FLOOR_2
-    assert direct(bogus_prev2, bogus_prev1, bogus_state) == _LOG_FLOOR_2
+    # Case 4: completely unseen state -> floor.
+    assert _cached_logp(tagger, bogus_prev2, bogus_prev1, bogus_state) == _LOG_FLOOR_2
+    assert _direct_logp(tagger, bogus_prev2, bogus_prev1, bogus_state) == _LOG_FLOOR_2
 
 
 # ---------------------------------------------------------------------
@@ -512,10 +534,7 @@ def test_two_taggers_trained_on_same_data_are_deterministic():
     """Catches non-determinism from iteration over sets or unordered
     dicts in training or decode, which would make trained taggers
     unreproducible across runs."""
-    a = TnT()
-    a.train(_TRAIN)
-    b = TnT()
-    b.train(_TRAIN)
+    a, b = _trained_tagger(), _trained_tagger()
     for sent in _TRAIN:
         words = [w for w, _ in sent]
         assert a.tag(words) == b.tag(words)
@@ -576,39 +595,18 @@ def test_tagdata_rejects_string_or_bytes_input(tagger, bad):
         tagger.tagdata(bad)
 
 
-def test_external_unk_returning_extra_tags_raises_clear_error():
-    """A misbehaving external ``unk`` tagger that returns more than one
-    tagged token for a single input word must raise a clear
-    ``ValueError`` instead of an unrelated ``too many values to unpack``
-    from tuple destructuring."""
-
-    class ExtraUnk:
-        def train(self, _data):
-            pass
-
-        def tag(self, toks):
-            return [(toks[0], "X"), ("extra", "X")]
-
-    t = TnT(unk=ExtraUnk())
-    t.train(_TRAIN)
-    with pytest.raises(ValueError, match="returned 2 tags"):
-        t.tag(["xyzzy"])
-
-
-def test_external_unk_returning_no_tags_raises_clear_error():
-    """An external ``unk`` tagger that returns an empty list for a
-    single-word input must also raise a clear ``ValueError``."""
-
-    class EmptyUnk:
-        def train(self, _data):
-            pass
-
-        def tag(self, _toks):
-            return []
-
-    t = TnT(unk=EmptyUnk())
-    t.train(_TRAIN)
-    with pytest.raises(ValueError, match="returned 0 tags"):
+@pytest.mark.parametrize(
+    ("unk_class", "expected_n"),
+    [(_ExtraTagsUnk, 2), (_EmptyOutputUnk, 0)],
+    ids=["extra_tags", "no_tags"],
+)
+def test_external_unk_returning_wrong_count_raises_clear_error(unk_class, expected_n):
+    """A misbehaving external ``unk`` tagger that returns ``!= 1`` tag
+    for a 1-word input must raise ``ValueError`` with the actual count,
+    instead of an unrelated ``too many values to unpack`` from
+    destructuring."""
+    t = _trained_tagger(unk=unk_class())
+    with pytest.raises(ValueError, match=f"returned {expected_n} tags"):
         t.tag(["xyzzy"])
 
 
@@ -617,25 +615,11 @@ def test_external_unk_called_for_each_occurrence_not_cached():
     each time. The unk path is intentionally uncached because user-
     supplied taggers may carry state or have side effects, so caching
     a single-token output could silently change behavior."""
-
-    class CountingUnk:
-        def __init__(self):
-            self.calls = 0
-
-        def train(self, _data):
-            pass
-
-        def tag(self, toks):
-            self.calls += 1
-            return [(toks[0], "UNK")]
-
-    unk = CountingUnk()
-    t = TnT(unk=unk)
-    t.train(_TRAIN)
-    t.tag(["xyzzy"])
-    t.tag(["xyzzy"])
-    t.tag(["xyzzy"])
-    assert unk.calls == 3
+    unk = _CountingUnk()
+    t = _trained_tagger(unk=unk)
+    for _ in range(3):
+        t.tag(["xyzzy"])
+    assert unk.tag_calls == 3
 
 
 def test_candidate_cache_stable_across_repeated_sentence(tagger):
@@ -646,8 +630,7 @@ def test_candidate_cache_stable_across_repeated_sentence(tagger):
     tagger.tag(sent)
     size_after_first = len(tagger._candidate_tags_cache)
     tagger.tag(sent)
-    size_after_second = len(tagger._candidate_tags_cache)
-    assert size_after_first == size_after_second
+    assert len(tagger._candidate_tags_cache) == size_after_first
 
 
 # ---------------------------------------------------------------------
@@ -660,18 +643,8 @@ def test_decode_is_repeat_stable_under_near_tie_beam():
     the first-encountered path). Repeated decoding on the same input
     must therefore agree even when several paths land within the beam
     threshold of each other."""
-    train = [
-        [("the", "DT"), ("fish", "NN"), ("swims", "VBZ"), (".", ".")],
-        [("the", "DT"), ("fish", "NN"), ("swims", "NNS"), (".", ".")],
-        [("a", "DT"), ("cat", "NN"), ("naps", "VBZ"), (".", ".")],
-        [("a", "DT"), ("cat", "NN"), ("naps", "NNS"), (".", ".")],
-    ]
-    t = TnT(N=1000)
-    t.train(train)
-    words = ["the", "fish", "swims", "."]
-
-    outputs = [t.tag(words) for _ in range(10)]
-    assert all(out == outputs[0] for out in outputs)
+    t = _trained_tagger(_NEAR_TIE_TRAIN, N=1000)
+    _assert_decode_stable(t, ["the", "fish", "swims", "."], repeats=10)
 
 
 @pytest.mark.parametrize(
@@ -683,18 +656,14 @@ def test_decode_handles_oov_heavy_sentence_with_shared_suffixes(train):
     The path must produce well-formed output drawn from the trained
     tagset and remain stable across repeated decoding, including when
     the training set is too small to populate the suffix model densely."""
-    t = TnT()
-    t.train(train)
+    t = _trained_tagger(train)
     trained_tags = {tag for sent in train for _, tag in sent}
 
     words = ["John", "watched", "friendo", "playing", "happily", "."]
-    out = t.tag(words)
+    out = _assert_decode_stable(t, words)
 
     _assert_tag_output(words, out)
     assert all(tag in trained_tags for _, tag in out)
-
-    again = t.tag(words)
-    assert out == again
 
 
 def test_decode_handles_long_ambiguous_sentence():
@@ -702,35 +671,19 @@ def test_decode_handles_long_ambiguous_sentence():
     accumulation bug would surface. A long sentence built from
     NN/VB-ambiguous tokens must still decode to completion and produce
     consistent output across runs."""
-    train = [
-        [("the", "DT"), ("dogs", "NNS"), ("run", "VBP"), (".", ".")],
-        [("the", "DT"), ("dogs", "NNS"), ("bark", "VBP"), (".", ".")],
-        [("dogs", "NNS"), ("run", "VBP"), ("fast", "RB"), (".", ".")],
-        [("the", "DT"), ("run", "NN"), ("ended", "VBD"), (".", ".")],
-        [("a", "DT"), ("bark", "NN"), ("echoed", "VBD"), (".", ".")],
-    ]
-    t = TnT(N=1000)
-    t.train(train)
-
+    t = _trained_tagger(_NN_VB_AMBIGUITY_TRAIN, N=1000)
     words = ["dogs", "run", "bark"] * 40 + ["."]
-    out = t.tag(words)
-
+    out = _assert_decode_stable(t, words)
     _assert_tag_output(words, out)
-    again = t.tag(words)
-    assert out == again
 
 
-def test_train_order_invariance_at_model_level():
+def test_train_order_invariance_at_model_level(reordered_taggers):
     """Reordering training sentences must not change the trained model.
     Sorted iteration in ``_compute_lambda`` and ``_build_suffix_model``
     makes every float-accumulating step bit-stable, so the weights, the
     suffix-model priors, and the transition cache are all bit-identical
     across training-data reorderings."""
-    a = TnT()
-    a.train(_TRAIN)
-
-    b = TnT()
-    b.train(list(reversed(_TRAIN)))
+    a, b = reordered_taggers
 
     assert dict(a._tag_unigrams) == dict(b._tag_unigrams)
     assert {prev: dict(dist) for prev, dist in a._tag_bigrams.items()} == {
@@ -751,17 +704,12 @@ def test_train_order_invariance_at_model_level():
     assert a._trans_logp_trigram == b._trans_logp_trigram
 
 
-def test_decode_is_bit_stable_across_train_data_reorderings():
+def test_decode_is_bit_stable_across_train_data_reorderings(reordered_taggers):
     """Beyond the model state, decoded output must match across training
     reorderings. With the trained model bit-identical, sorted candidate
     construction in ``_tagword`` keeps the beam tie-breaking order
     independent of input-data order."""
-    a = TnT()
-    a.train(_TRAIN)
-
-    b = TnT()
-    b.train(list(reversed(_TRAIN)))
-
+    a, b = reordered_taggers
     for sent in _TRAIN:
         words = [w for w, _ in sent]
         assert a.tag(words) == b.tag(words)

--- a/nltk/test/unit/test_tnt.py
+++ b/nltk/test/unit/test_tnt.py
@@ -1,0 +1,438 @@
+"""
+Regression tests for ``nltk.tag.tnt.TnT``.
+"""
+
+import math
+
+import pytest
+
+from nltk.tag.tnt import _BOS, _EOS, TnT, basic_sent_chop
+
+# Synthetic corpus covering the tag classes used below.
+_TRAIN = [
+    [
+        ("the", "DT"),
+        ("cat", "NN"),
+        ("ran", "VBD"),
+        (".", "."),
+    ],
+    [
+        ("the", "DT"),
+        ("dog", "NN"),
+        ("jumped", "VBD"),
+        (".", "."),
+    ],
+    [
+        ("the", "DT"),
+        ("happy", "JJ"),
+        ("cat", "NN"),
+        ("slept", "VBD"),
+        (".", "."),
+    ],
+    [
+        ("the", "DT"),
+        ("running", "VBG"),
+        ("dog", "NN"),
+        ("barked", "VBD"),
+        (".", "."),
+    ],
+    [
+        ("Dianne", "NNP"),
+        ("loves", "VBZ"),
+        ("to", "TO"),
+        ("hug", "VB"),
+        (".", "."),
+    ],
+    [
+        ("Pappy", "NNP"),
+        ("is", "VBZ"),
+        ("very", "RB"),
+        ("loyal", "JJ"),
+        (".", "."),
+    ],
+    [
+        ("beagles", "NNS"),
+        ("are", "VBP"),
+        ("happy", "JJ"),
+        ("to", "TO"),
+        ("rest", "VB"),
+        (".", "."),
+    ],
+]
+
+
+class _CountingUnk:
+    """Counts how many times ``train()`` is called."""
+
+    def __init__(self):
+        self.train_calls = 0
+
+    def train(self, _data):
+        self.train_calls += 1
+
+    def tag(self, toks):
+        return [(w, "NN") for w in toks]
+
+
+@pytest.fixture
+def tagger():
+    """A ``TnT`` instance trained on the shared synthetic corpus."""
+    t = TnT()
+    t.train(_TRAIN)
+    return t
+
+
+def _assert_tag_output(words, out):
+    """Check basic decode shape invariants."""
+    assert len(out) == len(words)
+    assert all(isinstance(pair, tuple) and len(pair) == 2 for pair in out)
+    assert [w for w, _ in out] == words
+    assert all(isinstance(tag, str) for _, tag in out)
+
+
+# ---------------------------------------------------------------------
+# Decode shape and beam pruning
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("sent", _TRAIN, ids=lambda s: " ".join(w for w, _ in s))
+def test_known_words_decode_to_their_only_seen_tag(tagger, sent):
+    """Sanity check on the unambiguous decode path. Each word in
+    ``_TRAIN`` has a single observed tag, so any deviation points at a
+    broken Viterbi pass rather than a modeling choice."""
+    words = [w for w, _ in sent]
+    assert tagger.tag(words) == sent
+
+
+def test_threshold_pruning_does_not_empty_beam_under_ambiguity():
+    """With local tag ambiguity and a tight beam, decode still returns
+    a full tag sequence."""
+    train = [
+        [("the", "DT"), ("dogs", "NNS"), (".", ".")],
+        [("the", "DT"), ("dogs", "VBZ"), (".", ".")],
+        [("a", "DT"), ("cat", "NN"), (".", ".")],
+    ]
+    t = TnT(N=2)
+    t.train(train)
+    words = ["the", "dogs", "."]
+    out = t.tag(words)
+    _assert_tag_output(words, out)
+
+
+# ---------------------------------------------------------------------
+# EOS handling
+# ---------------------------------------------------------------------
+
+
+def test_eos_recorded_in_all_three_ngrams(tagger):
+    """EOS is folded into the same n-gram model as every other tag, so
+    it appears in unigram, bigram, and trigram counts. The unigram
+    count must equal the number of non-empty training sentences."""
+    expected_unigram = sum(1 for sent in _TRAIN if sent)
+    assert tagger._tag_unigrams[_EOS] == expected_unigram
+    assert any(_EOS in dist for dist in tagger._tag_bigrams.values())
+    assert any(_EOS in dist for dist in tagger._tag_trigrams.values())
+
+
+def _state(tagger, word, tag):
+    return (
+        tag,
+        tagger._use_capitalization and bool(word) and word[0].isupper(),
+    )
+
+
+def test_eos_follows_sentence_final_punctuation(tagger):
+    """EOS is attributed to the actual final tag history from the
+    training data, not to a hardcoded predecessor context."""
+    dot_state = _state(tagger, ".", ".")
+
+    expected_bigram_count = 0
+    expected_trigram_counts = {}
+
+    for sent in _TRAIN:
+        if not sent or sent[-1][0] != ".":
+            continue
+
+        expected_bigram_count += 1
+
+        prev_state = _state(tagger, sent[-2][0], sent[-2][1])
+        history = (prev_state, dot_state)
+        expected_trigram_counts[history] = expected_trigram_counts.get(history, 0) + 1
+
+    assert tagger._tag_bigrams[dot_state][_EOS] == expected_bigram_count
+
+    for history, count in expected_trigram_counts.items():
+        assert tagger._tag_trigrams[history][_EOS] == count
+
+
+def test_empty_sentences_do_not_record_eos_at_bos():
+    """EOS is not recorded with BOS as its bigram or trigram history,
+    which would correspond to an empty sentence."""
+    t = TnT()
+    t.train([[], [("the", "DT"), ("cat", "NN"), (".", ".")], []])
+    assert _EOS not in t._tag_bigrams[_BOS]
+    assert _EOS not in t._tag_trigrams[(_BOS, _BOS)]
+
+
+# ---------------------------------------------------------------------
+# Training semantics
+# ---------------------------------------------------------------------
+
+
+def test_repeated_train_rebuilds_state():
+    """``train()`` rebuilds internal state on each call rather than
+    accumulating, so retraining on the same data is idempotent."""
+    t = TnT()
+    t.train(_TRAIN)
+    snapshot = (
+        t._tag_unigrams.N(),
+        sum(d.N() for d in t._tag_bigrams.values()),
+        sum(d.N() for d in t._tag_trigrams.values()),
+        len(t._word_tag_freqs.conditions()),
+        t._num_tag_tokens,
+    )
+    t.train(_TRAIN)
+    after = (
+        t._tag_unigrams.N(),
+        sum(d.N() for d in t._tag_bigrams.values()),
+        sum(d.N() for d in t._tag_trigrams.values()),
+        len(t._word_tag_freqs.conditions()),
+        t._num_tag_tokens,
+    )
+    assert snapshot == after
+
+
+def test_external_unk_tagger_trains_once():
+    """The optional ``unk`` tagger is trained only on the first
+    ``train()`` call. Subsequent calls leave it alone so caller-managed
+    state is preserved across passes."""
+    cu = _CountingUnk()
+    t = TnT(unk=cu)
+    t.train(_TRAIN)
+    assert cu.train_calls == 1
+    t.train(_TRAIN)
+    assert cu.train_calls == 1
+
+
+def test_trained_constructor_flag_skips_external_unk_training():
+    """``Trained=True`` tells the constructor that the optional ``unk``
+    tagger is already trained, so subsequent ``train()`` calls do not
+    retrain it."""
+    cu = _CountingUnk()
+    t = TnT(unk=cu, Trained=True)
+    t.train(_TRAIN)
+    assert cu.train_calls == 0
+
+
+def test_external_unk_bypasses_decode_cache():
+    """Stateful ``unk`` taggers are invoked on every call rather than
+    memoized, otherwise caching collapses their varying output into a
+    single result."""
+
+    class AlternatingUnk:
+        def __init__(self):
+            self.flip = False
+
+        def train(self, _data):
+            pass
+
+        def tag(self, toks):
+            self.flip = not self.flip
+            return [(w, "NN" if self.flip else "JJ") for w in toks]
+
+    t = TnT(unk=AlternatingUnk())
+    t.train(_TRAIN)
+    seen = [t.tag(["xyzzy"])[0][1] for _ in range(3)]
+    assert seen == ["NN", "JJ", "NN"]
+
+
+# ---------------------------------------------------------------------
+# Unknown-word handling
+# ---------------------------------------------------------------------
+
+
+def test_unknown_word_uses_suffix_model_not_literal_unk(tagger):
+    """The suffix model is the actual unknown-word path. The literal
+    ``"Unk"`` string is only a last-resort fallback for taggers with
+    no priors, so a trained tagger should never reach it."""
+    [(word, tag)] = tagger.tag(["xyzzy"])
+    assert word == "xyzzy"
+    assert tag in tagger._tag_prior_probs
+    assert tag != "Unk"
+
+
+def test_unknown_word_falls_back_to_unk_when_priors_empty():
+    """Without training, the suffix model has no priors and tagging
+    falls back to the literal ``"Unk"`` string. This keeps the API
+    safe on unconfigured taggers."""
+    t = TnT()
+    assert t.tag(["xyzzy"]) == [("xyzzy", "Unk")]
+
+
+# ---------------------------------------------------------------------
+# Lambdas
+# ---------------------------------------------------------------------
+
+
+def test_empty_training_zeroes_lambdas():
+    """``_compute_lambda()`` zeroes the weights on empty input rather
+    than dividing by zero."""
+    t = TnT()
+    t.train([])
+    assert (t._lambda1, t._lambda2, t._lambda3) == (0.0, 0.0, 0.0)
+
+
+def test_lambdas_are_non_negative_and_sum_to_one(tagger):
+    """On normal input, the deleted-interpolation weights form a valid
+    probability distribution."""
+    assert tagger._lambda1 >= 0
+    assert tagger._lambda2 >= 0
+    assert tagger._lambda3 >= 0
+    assert math.isclose(
+        tagger._lambda1 + tagger._lambda2 + tagger._lambda3,
+        1.0,
+        abs_tol=1e-12,
+    )
+
+
+# ---------------------------------------------------------------------
+# N validation
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [0, -1, 0.5, math.nan, math.inf, -math.inf, True, False, "1000", None, [1000]],
+)
+def test_invalid_n_raises_value_error(bad):
+    """Invalid ``N`` values raise ``ValueError`` at construction time."""
+    with pytest.raises(ValueError):
+        TnT(N=bad)
+
+
+@pytest.mark.parametrize("ok", [1, 2, 1000, 1_000_000])
+def test_valid_n_is_accepted(ok):
+    """Integer ``N >= 1`` is accepted."""
+    TnT(N=ok)
+
+
+# ---------------------------------------------------------------------
+# Segmentation
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("words", "segment", "expected_len"),
+    [
+        ([], False, 0),
+        ([], True, 0),
+        (["the", "cat", ".", "the", "dog", "."], True, 6),
+        (["the", "cat", ".", "the", "dog"], True, 5),
+    ],
+)
+def test_segmentation_shapes(tagger, words, segment, expected_len):
+    """Segmented tagging preserves output shape across empty, split,
+    and trailing-fragment inputs."""
+    out = tagger.tag(words, segment=segment)
+    assert len(out) == expected_len
+    if expected_len > 0:
+        _assert_tag_output(words, out)
+
+
+def test_segment_true_matches_segment_false_for_single_segment(tagger):
+    """Without mid-sequence punctuation, the segmented and unsegmented
+    decode paths produce the same tag sequence."""
+    words = [w for w, _ in _TRAIN[0]]
+    assert tagger.tag(words) == tagger.tag(words, segment=True)
+
+
+def test_basic_sent_chop_emits_trailing_fragment():
+    """Without this, sentences that lack a final marker would be
+    silently dropped during segmentation, costing real evaluation
+    data."""
+    assert basic_sent_chop(["a", "b", ".", "c", "d"]) == [["a", "b", "."], ["c", "d"]]
+
+
+def test_basic_sent_chop_with_tagged_input():
+    """``basic_sent_chop(raw=False)`` segments a list of ``(word, tag)`` tuples."""
+    tagged = [("a", "DT"), ("b", "NN"), (".", "."), ("c", "DT"), ("d", "NN")]
+    chopped = basic_sent_chop(tagged, raw=False)
+    assert chopped == [
+        [("a", "DT"), ("b", "NN"), (".", ".")],
+        [("c", "DT"), ("d", "NN")],
+    ]
+
+
+def test_tagdata_segment_kwarg_forwards_to_tag(tagger):
+    """Without forwarding, ``tagdata`` would silently ignore
+    ``segment`` even though it accepts the kwarg."""
+    inputs = [
+        ["the", "cat", ".", "the", "dog", "."],
+        ["the", "cat", "ran", "."],
+    ]
+    assert tagger.tagdata(inputs, segment=True) == [
+        tagger.tag(s, segment=True) for s in inputs
+    ]
+
+
+# ---------------------------------------------------------------------
+# Long-sentence and suffix-trie regressions
+# ---------------------------------------------------------------------
+
+
+def test_long_sentence_does_not_recurse(tagger):
+    """Decode is iterative; a recursive implementation would raise
+    ``RecursionError`` on long real-world inputs once the sentence
+    exceeds Python's default recursion limit."""
+    words = ["the", "cat"] * 1000
+    out = tagger.tag(words)
+    _assert_tag_output(words, out)
+
+
+def test_unknown_word_decode_does_not_grow_suffix_trie(tagger):
+    """Defaultdict-style access during suffix scoring could otherwise
+    grow the trie unboundedly across calls, leaking memory and
+    perturbing decode behavior on later inputs."""
+    trie = tagger._suffix_trie_by_cap[False]
+    before = set(trie.conditions())
+    for word in ["xyzzy", "friendo", "doodad", "phlogiston"]:
+        tagger.tag([word])
+    after = set(trie.conditions())
+    assert after == before
+
+
+# ---------------------------------------------------------------------
+# Public API contracts
+# ---------------------------------------------------------------------
+
+
+def test_two_taggers_trained_on_same_data_are_deterministic():
+    """Catches non-determinism from iteration over sets or unordered
+    dicts in training or decode, which would make trained taggers
+    unreproducible across runs."""
+    a = TnT()
+    a.train(_TRAIN)
+    b = TnT()
+    b.train(_TRAIN)
+    for sent in _TRAIN:
+        words = [w for w, _ in sent]
+        assert a.tag(words) == b.tag(words)
+
+
+def test_tag_sents_matches_per_sentence_tag(tagger):
+    """``tag_sents()`` (inherited from ``TaggerI``) must produce the
+    same result as iterating ``tag()`` per sentence."""
+    sents = [[w for w, _ in s] for s in _TRAIN[:3]]
+    assert tagger.tag_sents(sents) == [tagger.tag(s) for s in sents]
+
+
+def test_trained_tagger_round_trips_through_pickle(tagger):
+    """A trained ``TnT`` instance must survive a ``pickle`` round trip
+    with identical decode behavior. NLTK users routinely serialize
+    trained taggers, so this is a real contract."""
+    import pickle
+
+    restored = pickle.loads(pickle.dumps(tagger))
+    for sent in _TRAIN:
+        words = [w for w, _ in sent]
+        assert restored.tag(words) == tagger.tag(words)

--- a/nltk/test/unit/test_tnt.py
+++ b/nltk/test/unit/test_tnt.py
@@ -155,7 +155,7 @@ def test_eos_follows_sentence_final_punctuation(tagger):
     dot_state = _state(tagger, ".", ".")
 
     expected_bigram_count = 0
-    expected_trigram_counts = {}
+    expected_trigram_counts: dict = {}
 
     for sent in _TRAIN:
         if not sent or sent[-1][0] != ".":

--- a/nltk/test/unit/test_tnt.py
+++ b/nltk/test/unit/test_tnt.py
@@ -285,6 +285,12 @@ def test_empty_training_zeroes_lambdas():
     assert (t._lambda1, t._lambda2, t._lambda3) == (0.0, 0.0, 0.0)
 
 
+def test_lambdas_are_non_negative_and_sum_to_one(tagger):
+    lambdas = (tagger._lambda1, tagger._lambda2, tagger._lambda3)
+    assert all(x >= 0 for x in lambdas)
+    assert math.isclose(sum(lambdas), 1.0, abs_tol=1e-12)
+
+
 def test_repeated_train_rebuilds_state():
     t = _trained_tagger(_AMBIGUITY_TRAIN)
     t.tag(["doodad"])
@@ -465,6 +471,11 @@ def test_segmentation_shapes(tagger, words, segment, expected_len):
     assert len(out) == expected_len
     if expected_len > 0:
         _assert_tag_output(words, out)
+
+
+def test_segment_true_matches_segment_false_on_single_sentence(tagger):
+    words = ["the", "cat", "ran", "."]
+    assert tagger.tag(words) == tagger.tag(words, segment=True)
 
 
 def test_tagdata_segment_kwarg_forwards_to_tag(tagger):


### PR DESCRIPTION
## Summary

`nltk.tag.tnt.TnT` now follows the tagger design described in Brants (2000).

This PR fixes BOS/EOS handling, replaces top `N` truncation with threshold pruning, adds the Brants suffix-based unknown-word model, rewrites decode as second-order Viterbi with state merging, and hardens edge cases.

Compared with current `develop`, this PR improves accuracy across all 26 corpora in the latest comparison. It also gives large throughput gains on most corpora. Some high OOV corpora remain slower because the tagger performs suffix-based unknown-word scoring instead of assigning `Unk`.

## Main changes

### Brants suffix model for unknown words

The literal `"Unk"` fallback is replaced with the suffix model. Two capitalization-split suffix tries are built from infrequent lexicon words with count at most 10. Unknown words are scored by successive abstraction up to the longest matched suffix, then Bayes-inverted so tags are ranked by `P(suffix | t)`.

### Viterbi state merging

Decode is a second-order Viterbi loop with state merging instead of the previous recursive path-based decode. This removes recursion depth limits on long sentences, avoids repeated path copying, and makes pruning operate over merged states rather than whole paths.

### Beam pruning and EOS scoring

Beam pruning uses the paper’s threshold rule instead of top `N` truncation. EOS is folded into the same n-gram model used for every other tag, and the final EOS transition is scored explicitly during decode. `tag()` and `tagdata()` also gain an opt-in `segment` kwarg so input can be split on Brants’s sentence punctuation when needed.

### Hardening

`N` is validated at construction time. `_compute_lambda()` handles empty or pathological input. `train()` rebuilds counts from scratch on each call. Unknown-word scoring no longer grows the suffix trie through empty lookups. Sorted training-time iteration and sorted candidate construction make equivalent training-data reorderings produce bit identical model state and decoded output.

### Paper underspecification

Sites where Brants (2000) is silent on an implementation choice are explicitly flagged in the code with `Underspecified by Brants:` markers and summarized in the module docstring.

* `_compute_lambda`: when multiple `c_i` values tie for the max, the trigram count is split evenly across the winning lambdas. On degenerate input with no positive trigram mass, the interpolation weights zero out instead of dividing by zero or carrying stale weights from a prior training call.
* `train`: empty sentences do not contribute EOS counts, so BOS does not acquire EOS as a spurious successor.
* `_expand_states`: per-key Viterbi tie-breaking uses strict `>`, so the first encountered hypothesis wins when scores tie. Combined with the sorted training-time iteration above and sorted candidate construction at decode, the encounter order is deterministic across reruns.

An ablation on the `_expand_states` tie break confirmed the choice is empirically a no-op. Across `C in {False, True}`, `N in {10, 1000}`, and 500 to 1500 sentence Treebank slices, exact `path_logp` ties hit 0 of 135k+ comparisons. `>` and `>=` produced byte identical output on those runs.

### Naming and cleanup

Internal names, docstrings, and comments were audited to track Brants terminology more closely. Public constructor parameters are unchanged.

## Validation

Validation was done with targeted checks and corpus runs. A regression testing suite `test_tnt.py` is also now included.

### Functional checks

* repeated `train()` calls rebuild the model instead of accumulating counts
* `("EOS", False)` is recorded in all three n-gram counts after training on at least one non-empty sentence
* `N` validation rejects non-positive and non-integer values, including `bool`
* external unknown-word taggers train once and bypass the decode cache, so stateful taggers stay correct
* unknown words decode through the suffix model rather than literal `Unk`
* equivalent training data reorderings produce bit identical model state and decoded output
* decode is repeat stable under near-tie beam conditions, OOV-heavy inputs, and long ambiguous inputs

### Accuracy

10 fold contiguous cross validation on `treebank.tagged_sents()` at `N=1000`

* `C=False` gives known `0.9697`, unknown `0.7815`, OOV rate `9.6%`, overall `0.9517`
* `C=True` gives known `0.9700`, unknown `0.7930`, OOV rate `9.6%`, overall `0.9530`

Known-word accuracy with `C=True` matches the `0.97` figure reported by Brants (2000). The remaining overall gap is driven by the much higher OOV rate in the NLTK distributed Treebank sample.

### Comparison against other taggers

This comparison covers 26 corpora. Standard corpora use a contiguous 90/10 split capped at 60k train tokens and 8k test tokens; Universal Treebank corpora use predefined splits with the same caps. Macro is the mean of per-corpus accuracies, micro pools all test tokens, and mean OOV is accuracy on tokens unseen in that corpus training split. Warm tok/s is measured after one cold pass. Wins count tied top scores; in this run, ties only occurred between TnT C=T and TnT C=F.

| Rank | Tagger | Macro acc | Micro acc | Mean OOV acc | Wins | Median train | Median warm tok/s |
|---:|---|---:|---:|---:|---:|---:|---:|
| 1 | TnT C=T | 89.65% | 91.02% | 71.06% | 14 | 0.36s | 91,022 |
| 2 | TnT C=F | 89.52% | 90.85% | 70.53% | 7 | 0.36s | 79,536 |
| 3 | Perceptron | 88.98% | 90.53% | 73.46% | 9 | 9.19s | 31,135 |
| 4 | CRF | 87.45% | 88.98% | 72.94% | 0 | 4.77s | 200,676 |
| 5 | ClassNB | 83.56% | 85.57% | 54.36% | 0 | 0.97s | 3,126 |
| 6 | Brill | 83.52% | 85.19% | 39.66% | 0 | 1.28s | 215,161 |
| 7 | Ngram chain | 82.54% | 84.05% | 37.91% | 0 | 0.54s | 676,055 |
| 8 | Unigram | 81.85% | 83.38% | 37.91% | 0 | 0.14s | 2,259,573 |
| 9 | HMM | 80.46% | 82.60% | 33.71% | 0 | 0.08s | 5,499 |
| 10 | Affix | 34.54% | 32.48% | 53.27% | 0 | 0.06s | 1,974,278 |
| 11 | Majority | 23.49% | 21.72% | 37.91% | 0 | 0.00s | 3,711,410 |

### Benchmark comparison against `develop`

This compares current `develop` against this PR. Both sides use `C=True` where possible. Rows marked `*` use develop `C=False` because develop `C=True` crashed on that corpus. `Acc gain` is in percentage points.

| Corpus | Develop acc | PR C=T acc | Acc gain, pp | Develop warm tok/s | PR warm tok/s | Speed up |
|---|---:|---:|---:|---:|---:|---:|
| treebank | 84.01% | 94.03% | +10.02 | 679 | 116,828 | 172x |
| conll2000 | 84.43% | 94.77% | +10.34 | 1,355 | 120,133 | 89x |
| brown | 78.24% | 90.42% | +12.18 | 478 | 28,876 | 60x |
| alpino | 78.41% | 91.72% | +13.31 | 202 | 83,064 | 411x |
| cess_esp | 73.48% | 88.60% | +15.12 | 1,204 | 20,643 | 17x |
| cess_cat | 79.72% | 89.21% | +9.49 | 689 | 28,803 | 42x |
| sinica | 67.08% | 77.29% | +10.21 | 3,521 | 2,738 | 0.78x |
| mac_morpho | 67.48% | 87.46% | +19.98 | 153 | 33,915 | 222x |
| floresta | 72.80% | 84.37% | +11.57 | 153 | 11,529 | 75x |
| conll2002 nl | 79.63% | 94.16% | +14.53 | 734 | 147,732 | 201x |
| conll2002 es | 81.60% | 92.94% | +11.34 | 1,008 | 81,899 | 81x |
| indian hindi | 81.11% | 89.25% | +8.14 | 1,008 | 102,820 | 102x |
| indian bangla* | 47.41% | 69.83% | +22.42 | 11,454 | 13,805 | 1.21x |
| indian marathi* | 59.48% | 80.54% | +21.06 | 4,741 | 40,194 | 8.5x |
| indian telugu | 50.90% | 79.30% | +28.40 | 62,313 | 36,356 | 0.58x |
| nps_chat* | 83.78% | 89.40% | +5.62 | 1,932 | 37,626 | 19.5x |
| switchboard | 91.54% | 93.75% | +2.21 | 409 | 98,980 | 242x |
| ud-de | 81.27% | 94.88% | +13.61 | 1,339 | 163,354 | 122x |
| ud-es | 79.31% | 92.41% | +13.10 | 311 | 158,082 | 508x |
| ud-fr | 82.55% | 92.73% | +10.18 | 444 | 163,407 | 368x |
| ud-it | 81.51% | 94.21% | +12.70 | 1,159 | 172,956 | 149x |
| ud-pt-br | 82.94% | 95.55% | +12.61 | 640 | 177,622 | 278x |
| ud-sv | 81.69% | 95.26% | +13.57 | 2,125 | 178,048 | 84x |
| ud-ja | 44.49% | 89.46% | +44.97 | 281,739 | 55,021 | 0.20x |
| ud-ko | 80.39% | 95.48% | +15.09 | 140,135 | 129,809 | 0.93x |
| ud-id | 79.31% | 93.81% | +14.50 | 1,142 | 166,287 | 146x |

The rows below 1.00x throughput are the main caveat. `ud-ja` is the largest slowdown, but develop is only 44.49% accurate there; this PR reaches 89.46%. `sinica` and `indian telugu` also remain below develop throughput.

Accuracy is up on every corpus in the comparison, and most corpora see large throughput gains.

Closes #3563