### PR TITLE
fix PorterStemmer not using lowercased word in stem() for irregular forms in NLTK mode

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -314,6 +314,7 @@
 - Ryan Mannion <https://github.com/ryanamannion>
 - Peter Pollak <https://github.com/Syzygy2048/>
 - Bradley Erickson <https://github.com/13rac1>
+- Volodymyr Matsko <https://github.com/Lemm1>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 

--- a/nltk/stem/porter.py
+++ b/nltk/stem/porter.py
@@ -659,7 +659,7 @@ class PorterStemmer(StemmerI):
         """
         stem = word.lower() if to_lowercase else word
 
-        if self.mode == self.NLTK_EXTENSIONS and word in self.pool:
+        if self.mode == self.NLTK_EXTENSIONS and stem in self.pool:
             return self.pool[stem]
 
         if self.mode != self.ORIGINAL_ALGORITHM and len(word) <= 2:

--- a/nltk/test/unit/test_stem.py
+++ b/nltk/test/unit/test_stem.py
@@ -155,3 +155,17 @@ class PorterTest(unittest.TestCase):
         assert porter.stem("I", to_lowercase=False) == "I"
         assert porter.stem("Github") == "github"
         assert porter.stem("Github", to_lowercase=False) == "Github"
+
+    def test_lowercase_irregular_forms_pool(self):
+        """Test for bug: https://github.com/nltk/nltk/issues/3567
+
+        Ensures that all stems are lowercased when `to_lowercase=True` and NLTK_EXTENSIONS is enabled
+        """
+        porter = PorterStemmer()
+
+        assert porter.stem("News") == "news"
+        assert porter.stem("News", to_lowercase=False) == "New"
+        assert porter.stem("Howe") == "howe"
+        assert porter.stem("Howe", to_lowercase=False) == "How"
+        assert porter.stem("Sky") == "sky"
+        assert porter.stem("Sky", to_lowercase=False) == "Ski"


### PR DESCRIPTION
Changes:
- Fix PorterStemmer to use the normalized lowercase form when checking irregular forms in NLTK_EXTENSIONS mode. This resolves incorrect stemming for mixed-case irregular inputs (for example, News, Howe, Sky) when to_lowercase=True (default) (see #3567).
- Add a regression test covering irregular-form casing behavior to prevent future regressions.
- Add contributor entry to AUTHORS.md.

Fixes: #3567 

I did run tests via `pytest` it seems that they are passing:
<details> 
  <summary>test.log</summary>
============================= test session starts ==============================
platform linux -- Python 3.13.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/lemm/git/nltk
plugins: xdist-3.8.0, cov-7.1.0, mock-3.15.1
collected 762 items

nltk/test/test_filestring_sandbox.py .....                               [  0%]
nltk/test/unit/lm/test_counter.py ...............                        [  2%]
nltk/test/unit/lm/test_models.py ....................................... [  7%]
.....................x.......x.......x.......x.......x.......x.......x.. [ 17%]
.....x.......x.......                                                    [ 19%]
nltk/test/unit/lm/test_preprocessing.py .                                [ 20%]
nltk/test/unit/lm/test_vocabulary.py .....s..............                [ 22%]
nltk/test/unit/test_aline.py ............................                [ 26%]
nltk/test/unit/test_bllip.py ss                                          [ 26%]
nltk/test/unit/test_brill.py s.                                          [ 26%]
nltk/test/unit/test_ccg_dir.py ......                                    [ 27%]
nltk/test/unit/test_cfd_mutation.py ...                                  [ 28%]
nltk/test/unit/test_cfg2chomsky.py ..                                    [ 28%]
nltk/test/unit/test_chunk.py .                                           [ 28%]
nltk/test/unit/test_classify.py ss                                       [ 28%]
nltk/test/unit/test_collocations.py ...                                  [ 29%]
nltk/test/unit/test_concordance.py ....                                  [ 29%]
nltk/test/unit/test_corenlp.py ssssss                                    [ 30%]
nltk/test/unit/test_corpora.py ............ssssssss                      [ 33%]
nltk/test/unit/test_corpus_reader.py .                                   [ 33%]
nltk/test/unit/test_corpus_util.py ......                                [ 33%]
nltk/test/unit/test_corpus_views.py ..                                   [ 34%]
nltk/test/unit/test_data.py ...                                          [ 34%]
nltk/test/unit/test_data_security.py .........                           [ 35%]
nltk/test/unit/test_disagreement.py .....                                [ 36%]
nltk/test/unit/test_distance.py ........................................ [ 41%]
..............................                                           [ 45%]
nltk/test/unit/test_downloader.py ....                                   [ 46%]
nltk/test/unit/test_downloader_atomic.py .                               [ 46%]
nltk/test/unit/test_downloader_unzip.py ................s..              [ 48%]
nltk/test/unit/test_downloader_xxe.py ..                                 [ 49%]
nltk/test/unit/test_freqdist.py .                                        [ 49%]
nltk/test/unit/test_hmm.py ...                                           [ 49%]
nltk/test/unit/test_json2csv_corpus.py ............                      [ 51%]
nltk/test/unit/test_json_serialization.py ......                         [ 51%]
nltk/test/unit/test_metrics.py ...                                       [ 52%]
nltk/test/unit/test_naivebayes.py .                                      [ 52%]
nltk/test/unit/test_nombank.py ...                                       [ 52%]
nltk/test/unit/test_open_datafile.py ...                                 [ 53%]
nltk/test/unit/test_pathsec.py .........                                 [ 54%]
nltk/test/unit/test_pickle_load_warnings.py ...                          [ 54%]
nltk/test/unit/test_pl196x.py .                                          [ 54%]
nltk/test/unit/test_pos_tag.py ..........                                [ 56%]
nltk/test/unit/test_ribes.py .....                                       [ 56%]
nltk/test/unit/test_rte_classify.py ...s                                 [ 57%]
nltk/test/unit/test_seekable_unicode_stream_reader.py ......             [ 58%]
nltk/test/unit/test_segmentation.py ............                         [ 59%]
nltk/test/unit/test_senna.py ssss                                        [ 60%]
nltk/test/unit/test_stem.py ...........                                  [ 61%]
nltk/test/unit/test_tag.py .                                             [ 61%]
nltk/test/unit/test_texttiling.py ..............                         [ 63%]
nltk/test/unit/test_tgrep.py .............................               [ 67%]
nltk/test/unit/test_tokenize.py ............ss.......................... [ 72%]
..................................                                       [ 77%]
nltk/test/unit/test_twitter_auth.py ..........                           [ 78%]
nltk/test/unit/test_util.py .....                                        [ 79%]
nltk/test/unit/test_verbnet.py ......................................... [ 84%]
.sssssssssssssssssssssssssssssssssss                                     [ 89%]
nltk/test/unit/test_wordnet.py ...............                           [ 91%]
nltk/test/unit/translate/test_bleu.py ...............                    [ 93%]
nltk/test/unit/translate/test_gdfa.py .                                  [ 93%]
nltk/test/unit/translate/test_ibm1.py ...                                [ 93%]
nltk/test/unit/translate/test_ibm2.py ...                                [ 94%]
nltk/test/unit/translate/test_ibm3.py ...                                [ 94%]
nltk/test/unit/translate/test_ibm4.py ...                                [ 95%]
nltk/test/unit/translate/test_ibm5.py ....                               [ 95%]
nltk/test/unit/translate/test_ibm_model.py ............                  [ 97%]
nltk/test/unit/translate/test_meteor.py ...                              [ 97%]
nltk/test/unit/translate/test_nist.py .                                  [ 97%]
nltk/test/unit/translate/test_stack_decoder.py ..................        [100%]

=============================== warnings summary ===============================
nltk/test/unit/test_tokenize.py:26
  /home/lemm/git/nltk/nltk/test/unit/test_tokenize.py:26: DeprecationWarning: 
  The StanfordTokenizer will be deprecated in version 3.2.5.
  Please use [91mnltk.parse.corenlp.CoreNLPTokenizer[0m instead.'
    seg = StanfordSegmenter()

nltk/test/unit/test_tgrep.py: 199 warnings
  /home/lemm/git/nltk/nltk/tgrep.py:855: PyparsingDeprecationWarning: 'quoteChar' argument is deprecated, use 'quote_char'
    tgrep_qstring = pyparsing.QuotedString(

nltk/test/unit/test_tgrep.py: 199 warnings
  /home/lemm/git/nltk/nltk/tgrep.py:855: PyparsingDeprecationWarning: 'escChar' argument is deprecated, use 'esc_char'
    tgrep_qstring = pyparsing.QuotedString(

nltk/test/unit/test_tgrep.py: 199 warnings
  /home/lemm/git/nltk/nltk/tgrep.py:855: PyparsingDeprecationWarning: 'unquoteResults' argument is deprecated, use 'unquote_results'
    tgrep_qstring = pyparsing.QuotedString(

nltk/test/unit/test_tgrep.py: 199 warnings
  /home/lemm/git/nltk/nltk/tgrep.py:858: PyparsingDeprecationWarning: 'quoteChar' argument is deprecated, use 'quote_char'
    tgrep_node_regex = pyparsing.QuotedString(

nltk/test/unit/test_tgrep.py: 199 warnings
  /home/lemm/git/nltk/nltk/tgrep.py:858: PyparsingDeprecationWarning: 'escChar' argument is deprecated, use 'esc_char'
    tgrep_node_regex = pyparsing.QuotedString(

nltk/test/unit/test_tgrep.py: 199 warnings
  /home/lemm/git/nltk/nltk/tgrep.py:858: PyparsingDeprecationWarning: 'unquoteResults' argument is deprecated, use 'unquote_results'
    tgrep_node_regex = pyparsing.QuotedString(

nltk/test/unit/test_tgrep.py: 199 warnings
  /home/lemm/git/nltk/nltk/tgrep.py:873: PyparsingDeprecationWarning: 'delimitedList' deprecated - use 'DelimitedList'
    pyparsing.delimitedList(pyparsing.Word(pyparsing.nums), delim=",")

nltk/test/unit/test_tgrep.py: 199 warnings
  /home/lemm/git/nltk/nltk/tgrep.py:884: PyparsingDeprecationWarning: 'setWhitespaceChars' deprecated - use 'set_whitespace_chars'
    macro_name.setWhitespaceChars("")

nltk/test/unit/test_tgrep.py: 199 warnings
  /home/lemm/git/nltk/nltk/tgrep.py:899: PyparsingDeprecationWarning: 'setWhitespaceChars' deprecated - use 'set_whitespace_chars'
    + pyparsing.Literal("=").setWhitespaceChars("")

nltk/test/unit/test_tgrep.py: 199 warnings
  /home/lemm/git/nltk/nltk/tgrep.py:900: PyparsingDeprecationWarning: 'setWhitespaceChars' deprecated - use 'set_whitespace_chars'
    + tgrep_node_label.copy().setWhitespaceChars("")

nltk/test/unit/test_tgrep.py: 110 warnings
  /home/lemm/git/nltk/nltk/tgrep.py:930: PyparsingDeprecationWarning: 'setParseAction' deprecated - use 'set_parse_action'
    tgrep_node_label_use.setParseAction(_tgrep_node_label_use_action)

nltk/test/unit/test_tgrep.py: 110 warnings
  /home/lemm/git/nltk/nltk/tgrep.py:931: PyparsingDeprecationWarning: 'setParseAction' deprecated - use 'set_parse_action'
    tgrep_node_label_use_pred.setParseAction(_tgrep_node_label_pred_use_action)

nltk/test/unit/test_tgrep.py: 110 warnings
  /home/lemm/git/nltk/nltk/tgrep.py:932: PyparsingDeprecationWarning: 'setParseAction' deprecated - use 'set_parse_action'
    macro_use.setParseAction(_tgrep_macro_use_action)

nltk/test/unit/test_tgrep.py: 110 warnings
  /home/lemm/git/nltk/nltk/tgrep.py:933: PyparsingDeprecationWarning: 'setParseAction' deprecated - use 'set_parse_action'
    tgrep_node.setParseAction(_tgrep_node_action)

nltk/test/unit/test_tgrep.py: 110 warnings
  /home/lemm/git/nltk/nltk/tgrep.py:934: PyparsingDeprecationWarning: 'setParseAction' deprecated - use 'set_parse_action'
    tgrep_node_expr2.setParseAction(_tgrep_bind_node_label_action)

nltk/test/unit/test_tgrep.py: 110 warnings
  /home/lemm/git/nltk/nltk/tgrep.py:935: PyparsingDeprecationWarning: 'setParseAction' deprecated - use 'set_parse_action'
    tgrep_parens.setParseAction(_tgrep_parens_action)

nltk/test/unit/test_tgrep.py: 110 warnings
  /home/lemm/git/nltk/nltk/tgrep.py:936: PyparsingDeprecationWarning: 'setParseAction' deprecated - use 'set_parse_action'
    tgrep_nltk_tree_pos.setParseAction(_tgrep_nltk_tree_pos_action)

nltk/test/unit/test_tgrep.py: 110 warnings
  /home/lemm/git/nltk/nltk/tgrep.py:937: PyparsingDeprecationWarning: 'setParseAction' deprecated - use 'set_parse_action'
    tgrep_relation.setParseAction(_tgrep_relation_action)

nltk/test/unit/test_tgrep.py: 110 warnings
  /home/lemm/git/nltk/nltk/tgrep.py:938: PyparsingDeprecationWarning: 'setParseAction' deprecated - use 'set_parse_action'
    tgrep_rel_conjunction.setParseAction(_tgrep_conjunction_action)

nltk/test/unit/test_tgrep.py: 110 warnings
  /home/lemm/git/nltk/nltk/tgrep.py:939: PyparsingDeprecationWarning: 'setParseAction' deprecated - use 'set_parse_action'
    tgrep_relations.setParseAction(_tgrep_rel_disjunction_action)

nltk/test/unit/test_tgrep.py: 110 warnings
  /home/lemm/git/nltk/nltk/tgrep.py:940: PyparsingDeprecationWarning: 'setParseAction' deprecated - use 'set_parse_action'
    macro_defn.setParseAction(_macro_defn_action)

nltk/test/unit/test_tgrep.py: 110 warnings
  /home/lemm/git/nltk/nltk/tgrep.py:944: PyparsingDeprecationWarning: 'setParseAction' deprecated - use 'set_parse_action'
    tgrep_expr.setParseAction(_tgrep_conjunction_action)

nltk/test/unit/test_tgrep.py: 110 warnings
  /home/lemm/git/nltk/nltk/tgrep.py:945: PyparsingDeprecationWarning: 'setParseAction' deprecated - use 'set_parse_action'
    tgrep_expr_labeled.setParseAction(_tgrep_segmented_pattern_action)

nltk/test/unit/test_tgrep.py: 110 warnings
  /home/lemm/git/nltk/nltk/tgrep.py:946: PyparsingDeprecationWarning: 'setParseAction' deprecated - use 'set_parse_action'
    tgrep_expr2.setParseAction(

nltk/test/unit/test_tgrep.py: 110 warnings
  /home/lemm/git/nltk/nltk/tgrep.py:949: PyparsingDeprecationWarning: 'setParseAction' deprecated - use 'set_parse_action'
    tgrep_exprs.setParseAction(_tgrep_exprs_action)

nltk/test/unit/test_tgrep.py: 110 warnings
  /home/lemm/git/nltk/nltk/tgrep.py:971: PyparsingDeprecationWarning: 'parseString' deprecated - use 'parse_string'
    return list(parser.parseString(tgrep_string, parseAll=True))[0]

nltk/test/unit/test_tgrep.py: 110 warnings
  /home/lemm/git/nltk/venv/lib/python3.13/site-packages/pyparsing/util.py:466: PyparsingDeprecationWarning: 'parseAll' argument is deprecated, use 'parse_all'
    return fn(self, *args, **kwargs)

nltk/test/unit/test_tgrep.py: 89 warnings
  /home/lemm/git/nltk/nltk/tgrep.py:960: PyparsingDeprecationWarning: 'parseString' deprecated - use 'parse_string'
    return list(parser.parseString(tgrep_string))

nltk/test/unit/translate/test_bleu.py::TestBLEU::test_partial_matches_hypothesis_longer_than_reference
nltk/test/unit/translate/test_bleu.py::TestBLEUFringeCases::test_case_where_n_is_bigger_than_hypothesis_length
nltk/test/unit/translate/test_bleu.py::TestBLEUFringeCases::test_case_where_n_is_bigger_than_hypothesis_length
nltk/test/unit/translate/test_bleu.py::TestBLEUFringeCases::test_reference_or_hypothesis_shorter_than_fourgrams
  /home/lemm/git/nltk/nltk/translate/bleu_score.py:577: UserWarning: 
  The hypothesis contains 0 counts of 4-gram overlaps.
  Therefore the BLEU score evaluates to 0, independently of
  how many N-gram overlaps of lower order it contains.
  Consider using lower n-gram order or use SmoothingFunction()
    warnings.warn(_msg)

nltk/test/unit/translate/test_bleu.py::TestBLEUFringeCases::test_reference_or_hypothesis_shorter_than_fourgrams
  /home/lemm/git/nltk/nltk/translate/bleu_score.py:577: UserWarning: 
  The hypothesis contains 0 counts of 2-gram overlaps.
  Therefore the BLEU score evaluates to 0, independently of
  how many N-gram overlaps of lower order it contains.
  Consider using lower n-gram order or use SmoothingFunction()
    warnings.warn(_msg)

nltk/test/unit/translate/test_bleu.py::TestBLEUFringeCases::test_reference_or_hypothesis_shorter_than_fourgrams
  /home/lemm/git/nltk/nltk/translate/bleu_score.py:577: UserWarning: 
  The hypothesis contains 0 counts of 3-gram overlaps.
  Therefore the BLEU score evaluates to 0, independently of
  how many N-gram overlaps of lower order it contains.
  Consider using lower n-gram order or use SmoothingFunction()
    warnings.warn(_msg)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========== 690 passed, 63 skipped, 9 xfailed, 3956 warnings in 19.00s ==========

</details>