### PR TITLE
Add HuggingFace datasets integration (nltk.huggingface)

### DIFF
--- a/nltk/corpus/reader/util.py
+++ b/nltk/corpus/reader/util.py
@@ -740,6 +740,11 @@ def find_corpus_fileids(root, regexp):
                 subdirs.remove(".svn")
         return sorted(items)
 
+    # HuggingFace PathPointer: delegate to its fileids() method (duck typing,
+    # avoids a circular import of nltk.huggingface.dataset here).
+    elif hasattr(root, "fileids"):
+        return [fid for fid in root.fileids() if re.match(regexp, fid)]
+
     else:
         raise AssertionError("Don't know how to handle %r" % root)
 

--- a/nltk/corpus/reader/wordlist.py
+++ b/nltk/corpus/reader/wordlist.py
@@ -5,6 +5,8 @@
 #         Edward Loper <edloper@gmail.com>
 # URL: <https://www.nltk.org/>
 # For license information, see LICENSE.TXT
+import os
+
 from nltk.corpus.reader.api import *
 from nltk.corpus.reader.util import *
 from nltk.tokenize import line_tokenize
@@ -15,7 +17,19 @@ class WordListCorpusReader(CorpusReader):
     List of words, one per line.  Blank lines are ignored.
     """
 
-    def words(self, fileids=None, ignore_lines_startswith="\n"):
+    def words(self, fileids=None, ignore_lines_startswith="\n", hf=False):
+        if hf:
+            from nltk.huggingface.dataset import load_data
+            corpus_id = (
+                self._root.corpus_id
+                if hasattr(self._root, "corpus_id")
+                else os.path.basename(self._root.path.rstrip("/"))
+            )
+            content = load_data(corpus_id, fileid=fileids)
+            return [
+                line for line in content.splitlines()
+                if line and not line.startswith(ignore_lines_startswith)
+            ]
         return [
             line
             for line in line_tokenize(self.raw(fileids))

--- a/nltk/corpus/reader/wordlist.py
+++ b/nltk/corpus/reader/wordlist.py
@@ -20,6 +20,7 @@ class WordListCorpusReader(CorpusReader):
     def words(self, fileids=None, ignore_lines_startswith="\n", hf=False):
         if hf:
             from nltk.huggingface.dataset import load_data
+
             corpus_id = (
                 self._root.corpus_id
                 if hasattr(self._root, "corpus_id")
@@ -27,7 +28,8 @@ class WordListCorpusReader(CorpusReader):
             )
             content = load_data(corpus_id, fileid=fileids)
             return [
-                line for line in content.splitlines()
+                line
+                for line in content.splitlines()
                 if line and not line.startswith(ignore_lines_startswith)
             ]
         return [

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -700,6 +700,16 @@ def find(resource_name, paths=None):
     if resource_zipname.endswith(".zip"):
         resource_zipname = resource_zipname.rpartition(".")[0]
 
+    # HuggingFace fallback: if the corpus is in the HF registry and has
+    # already been downloaded to the HF datasets cache, serve it from there.
+    # Uses local_files_only=True so no network request is made here.
+    try:
+        from nltk.huggingface.dataset import REGISTRY, HFDatasetPathPointer, _is_cached
+        if resource_zipname in REGISTRY and _is_cached(resource_zipname):
+            return HFDatasetPathPointer(resource_zipname)
+    except ImportError:
+        pass
+
     # Display a friendly error message if the resource wasn't found.
     # If the package appears present but the specific entry is missing, keep
     # the download hint as a secondary suggestion.

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -705,6 +705,7 @@ def find(resource_name, paths=None):
     # Uses local_files_only=True so no network request is made here.
     try:
         from nltk.huggingface.dataset import REGISTRY, HFDatasetPathPointer, _is_cached
+
         if resource_zipname in REGISTRY and _is_cached(resource_zipname):
             return HFDatasetPathPointer(resource_zipname)
     except ImportError:

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -840,7 +840,13 @@ class Downloader:
         halt_on_error=True,
         raise_on_error=False,
         print_error_to=sys.stderr,
+        hf=False,
     ):
+        # Delegate to HuggingFace downloader when hf=True.
+        if hf and info_or_id is not None:
+            from nltk.huggingface.dataset import download as hf_download
+            return hf_download(info_or_id, quiet=quiet)
+
         print_to = functools.partial(print, file=print_error_to)
         # If no info or id is given, then use the interactive shell.
         if info_or_id is None:

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -845,6 +845,7 @@ class Downloader:
         # Delegate to HuggingFace downloader when hf=True.
         if hf and info_or_id is not None:
             from nltk.huggingface.dataset import download as hf_download
+
             return hf_download(info_or_id, quiet=quiet)
 
         print_to = functools.partial(print, file=print_error_to)

--- a/nltk/huggingface/__init__.py
+++ b/nltk/huggingface/__init__.py
@@ -1,0 +1,9 @@
+# Natural Language Toolkit: HuggingFace dataset integration
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+from nltk.huggingface.dataset import download
+
+__all__ = ["download"]

--- a/nltk/huggingface/dataset.py
+++ b/nltk/huggingface/dataset.py
@@ -91,6 +91,7 @@ REGISTRY = {
 # Cache detection (no network)
 # ---------------------------------------------------------------------------
 
+
 def _is_cached(corpus_id):
     """Return True if the corpus parquet exists in the local HF datasets cache."""
     info = REGISTRY.get(corpus_id)
@@ -98,6 +99,7 @@ def _is_cached(corpus_id):
         return False
     try:
         from huggingface_hub import try_to_load_from_cache
+
         result = try_to_load_from_cache(
             repo_id=info["repo"],
             filename=info["cache_probe"],
@@ -111,6 +113,7 @@ def _is_cached(corpus_id):
 # ---------------------------------------------------------------------------
 # Content serialisation
 # ---------------------------------------------------------------------------
+
 
 def _serialise(ds, info, fileid=None):
     """
@@ -173,6 +176,7 @@ def _load_hf_dataset(info, fileid=None):
 # HFDatasetPathPointer
 # ---------------------------------------------------------------------------
 
+
 class HFDatasetPathPointer:
     """
     A ``PathPointer``-compatible object backed by a HuggingFace dataset
@@ -215,9 +219,11 @@ class HFDatasetPathPointer:
         try:
             if structure == "multi_config":
                 from datasets import get_dataset_config_names
+
                 return sorted(get_dataset_config_names(info["repo"]))
             if structure == "flat":
                 from datasets import load_dataset
+
                 ds = load_dataset(info["repo"], split=info["split"])
                 return sorted(ds.unique(info["fileid_column"]))
             return [info["split"]]  # single
@@ -242,9 +248,11 @@ class HFDatasetPathPointer:
 def _register_path_pointer():
     try:
         from nltk.data import PathPointer
+
         PathPointer.register(HFDatasetPathPointer)
     except Exception:
         pass
+
 
 _register_path_pointer()
 
@@ -252,6 +260,7 @@ _register_path_pointer()
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
+
 
 def download(corpus_id, token=None, quiet=False):
     """
@@ -277,6 +286,7 @@ def download(corpus_id, token=None, quiet=False):
 
     if structure == "multi_config":
         from datasets import get_dataset_config_names
+
         configs = get_dataset_config_names(info["repo"])
         result = {
             cfg: load_dataset(info["repo"], cfg, split=info["split"], **kwargs)
@@ -284,15 +294,19 @@ def download(corpus_id, token=None, quiet=False):
         }
         if not quiet:
             total = sum(len(d) for d in result.values())
-            print(f"[nltk_hf] '{corpus_id}' downloaded from {info['repo']} "
-                  f"({len(configs)} configs, {total:,} rows)")
+            print(
+                f"[nltk_hf] '{corpus_id}' downloaded from {info['repo']} "
+                f"({len(configs)} configs, {total:,} rows)"
+            )
         return result
 
     else:  # flat or single
         ds = load_dataset(info["repo"], split=info["split"], **kwargs)
         if not quiet:
-            print(f"[nltk_hf] '{corpus_id}' downloaded from {info['repo']} "
-                  f"({len(ds):,} rows)")
+            print(
+                f"[nltk_hf] '{corpus_id}' downloaded from {info['repo']} "
+                f"({len(ds):,} rows)"
+            )
         return ds
 
 

--- a/nltk/huggingface/dataset.py
+++ b/nltk/huggingface/dataset.py
@@ -1,0 +1,320 @@
+# Natural Language Toolkit: HuggingFace dataset integration
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""
+HuggingFace datasets integration for NLTK.
+
+Provides a PathPointer subclass that reads directly from the HuggingFace
+datasets cache, and a ``download()`` function that populates that cache.
+
+Usage::
+
+    import nltk
+    nltk.download('stopwords', hf=True)            # download to HF cache
+    nltk.corpus.stopwords.words('portuguese')      # HF fallback if not in ~/nltk_data
+    nltk.corpus.stopwords.words('portuguese', hf=True)  # HF cache directly
+
+Registry schema
+---------------
+Each entry in ``REGISTRY`` must declare:
+
+``repo`` (str)
+    HuggingFace dataset repo id, e.g. ``"nltk-data-hub/stopwords"``.
+
+``split`` (str)
+    HF split name to load, e.g. ``"stopwords"``, ``"train"``.
+
+``structure`` (str)
+    How the corpus is organised on HF:
+
+    ``"multi_config"``
+        One HF config per NLTK fileid.  No assumption about what that
+        dimension represents (language, category, author, etc.).
+        ``fileid`` → config name.
+
+    ``"flat"``
+        Single config, flat table.  A ``fileid_column`` value is used
+        to select rows for a given fileid.
+
+    ``"single"``
+        Single config, no sub-selection.  The whole split is the corpus.
+
+``content_type`` (str)
+    How rows are serialised to the byte/text stream NLTK readers expect:
+
+    ``"word_list"``
+        Each row is one entry; ``text_column`` holds the string.
+        Serialised as one entry per line.
+
+    ``"raw_text"``
+        Rows have a ``text_column`` with full document text.  When a
+        fileid is given, rows are filtered by ``fileid_column``.
+        Serialised as the raw text string.
+
+    (Add new types here as more corpora are onboarded.)
+
+``cache_probe`` (str)
+    A single parquet path inside the repo used to detect whether the
+    corpus has already been downloaded locally.  No network request is
+    made; ``huggingface_hub.try_to_load_from_cache`` inspects the local
+    filesystem only.
+
+Optional keys (required by certain content types):
+
+``text_column``    column that holds the main text / word value.
+``fileid_column``  column that identifies which NLTK fileid a row belongs to.
+``label_column``   column for classification labels (future use).
+"""
+
+import io
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+REGISTRY = {
+    "stopwords": {
+        "repo": "nltk-data-hub/stopwords",
+        "split": "stopwords",
+        "structure": "multi_config",
+        "content_type": "word_list",
+        "text_column": "word",
+        "cache_probe": "data/english/stopwords.parquet",
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Cache detection (no network)
+# ---------------------------------------------------------------------------
+
+def _is_cached(corpus_id):
+    """Return True if the corpus parquet exists in the local HF datasets cache."""
+    info = REGISTRY.get(corpus_id)
+    if info is None:
+        return False
+    try:
+        from huggingface_hub import try_to_load_from_cache
+        result = try_to_load_from_cache(
+            repo_id=info["repo"],
+            filename=info["cache_probe"],
+            repo_type="dataset",
+        )
+        return result is not None and result != "no_connection"
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Content serialisation
+# ---------------------------------------------------------------------------
+
+def _serialise(ds, info, fileid=None):
+    """
+    Convert an HF dataset ``ds`` to the byte/text content that an NLTK
+    corpus reader would find in a plain file.
+
+    :param ds: ``datasets.Dataset`` already filtered/selected for this corpus.
+    :param info: REGISTRY entry for the corpus.
+    :param fileid: the NLTK fileid being requested (used by some types).
+    :returns: str — file content as NLTK expects it.
+    """
+    content_type = info.get("content_type", "raw_text")
+
+    if content_type == "word_list":
+        return "\n".join(ds[info["text_column"]])
+
+    if content_type == "raw_text":
+        col = info["text_column"]
+        texts = ds[col]
+        return "\n".join(texts) if len(texts) > 1 else (texts[0] if texts else "")
+
+    raise NotImplementedError(
+        f"content_type={content_type!r} is not implemented. "
+        "Add a handler in nltk.huggingface.dataset._serialise()."
+    )
+
+
+def _load_hf_dataset(info, fileid=None):
+    """
+    Load the appropriate HF dataset slice for *fileid*, respecting structure.
+
+    :param info: REGISTRY entry.
+    :param fileid: NLTK fileid (may be None for single-structure corpora).
+    :returns: ``datasets.Dataset``.
+    """
+    from datasets import load_dataset
+
+    structure = info.get("structure", "single")
+
+    if structure == "multi_config":
+        if fileid is None:
+            raise ValueError(
+                "fileid is required for multi_config corpora. "
+                "Pass the config name (e.g. a language or category)."
+            )
+        return load_dataset(info["repo"], fileid, split=info["split"])
+
+    if structure == "flat":
+        ds = load_dataset(info["repo"], split=info["split"])
+        if fileid is not None:
+            col = info["fileid_column"]
+            ds = ds.filter(lambda row: row[col] == fileid)
+        return ds
+
+    # single
+    return load_dataset(info["repo"], split=info["split"])
+
+
+# ---------------------------------------------------------------------------
+# HFDatasetPathPointer
+# ---------------------------------------------------------------------------
+
+class HFDatasetPathPointer:
+    """
+    A ``PathPointer``-compatible object backed by a HuggingFace dataset
+    stored in the local HF datasets cache (~/.cache/huggingface/datasets/).
+
+    Satisfies the NLTK PathPointer interface (``open`` / ``file_size`` /
+    ``join``) so that existing corpus readers work unchanged after
+    ``nltk.download(..., hf=True)``.
+    """
+
+    def __init__(self, corpus_id, fileid=None):
+        self.corpus_id = corpus_id
+        self.fileid = fileid
+
+    # -- PathPointer interface -----------------------------------------------
+
+    def open(self, encoding=None):
+        """Return a stream of file content as NLTK corpus readers expect."""
+        info = REGISTRY[self.corpus_id]
+        ds = _load_hf_dataset(info, fileid=self.fileid)
+        content = _serialise(ds, info, fileid=self.fileid)
+        if encoding:
+            return io.StringIO(content)
+        return io.BytesIO(content.encode("utf-8"))
+
+    def file_size(self):
+        return 0
+
+    def join(self, fileid):
+        return HFDatasetPathPointer(self.corpus_id, fileid)
+
+    # -- fileids (duck-typed by find_corpus_fileids) -------------------------
+
+    def fileids(self):
+        """Return sorted list of fileids available for this corpus."""
+        info = REGISTRY.get(self.corpus_id)
+        if info is None or not _is_cached(self.corpus_id):
+            return []
+        structure = info.get("structure", "single")
+        try:
+            if structure == "multi_config":
+                from datasets import get_dataset_config_names
+                return sorted(get_dataset_config_names(info["repo"]))
+            if structure == "flat":
+                from datasets import load_dataset
+                ds = load_dataset(info["repo"], split=info["split"])
+                return sorted(ds.unique(info["fileid_column"]))
+            return [info["split"]]  # single
+        except Exception:
+            return []
+
+    # -- repr / path ---------------------------------------------------------
+
+    @property
+    def path(self):
+        repo = REGISTRY.get(self.corpus_id, {}).get("repo", self.corpus_id)
+        return f"hf://{repo}"
+
+    def __str__(self):
+        return f"{self.path}/{self.fileid}" if self.fileid else self.path
+
+    def __repr__(self):
+        return f"HFDatasetPathPointer({self.corpus_id!r}, {self.fileid!r})"
+
+
+# Register as virtual subclass of PathPointer — avoids circular import at load
+def _register_path_pointer():
+    try:
+        from nltk.data import PathPointer
+        PathPointer.register(HFDatasetPathPointer)
+    except Exception:
+        pass
+
+_register_path_pointer()
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def download(corpus_id, token=None, quiet=False):
+    """
+    Download an NLTK corpus from HuggingFace into the HF datasets cache
+    (``~/.cache/huggingface/datasets/``).
+
+    :param corpus_id: NLTK corpus id, e.g. ``'stopwords'``.
+    :param token: optional HuggingFace API token for private repos.
+    :param quiet: suppress progress output.
+    :raises ValueError: if *corpus_id* is not in the HF registry.
+    """
+    info = REGISTRY.get(corpus_id)
+    if info is None:
+        raise ValueError(
+            f"Corpus {corpus_id!r} is not available on HuggingFace.\n"
+            f"Available: {sorted(REGISTRY)}"
+        )
+
+    from datasets import load_dataset
+
+    kwargs = {"token": token} if token else {}
+    structure = info.get("structure", "single")
+
+    if structure == "multi_config":
+        from datasets import get_dataset_config_names
+        configs = get_dataset_config_names(info["repo"])
+        result = {
+            cfg: load_dataset(info["repo"], cfg, split=info["split"], **kwargs)
+            for cfg in configs
+        }
+        if not quiet:
+            total = sum(len(d) for d in result.values())
+            print(f"[nltk_hf] '{corpus_id}' downloaded from {info['repo']} "
+                  f"({len(configs)} configs, {total:,} rows)")
+        return result
+
+    else:  # flat or single
+        ds = load_dataset(info["repo"], split=info["split"], **kwargs)
+        if not quiet:
+            print(f"[nltk_hf] '{corpus_id}' downloaded from {info['repo']} "
+                  f"({len(ds):,} rows)")
+        return ds
+
+
+def load_data(corpus_id, fileid=None):
+    """
+    Load data for *corpus_id* directly from the HF datasets cache and return
+    it as a string in the format NLTK corpus readers expect.
+
+    :param corpus_id: NLTK corpus id, e.g. ``'stopwords'``.
+    :param fileid: sub-resource identifier (config name, category, fileid, …).
+    :returns: str.
+    :raises LookupError: if the corpus is not in the registry or not cached.
+    """
+    info = REGISTRY.get(corpus_id)
+    if info is None:
+        raise LookupError(
+            f"Corpus {corpus_id!r} is not in the HuggingFace NLTK registry."
+        )
+    if not _is_cached(corpus_id):
+        raise LookupError(
+            f"Corpus {corpus_id!r} not found in HF datasets cache. "
+            f"Run: nltk.download({corpus_id!r}, hf=True)"
+        )
+    ds = _load_hf_dataset(info, fileid=fileid)
+    return _serialise(ds, info, fileid=fileid)

--- a/tools/huggingface/push_stopwords.py
+++ b/tools/huggingface/push_stopwords.py
@@ -1,0 +1,203 @@
+"""Push NLTK stopwords to nltk-data-hub/stopwords on HuggingFace.
+
+One config per language, one parquet file per language.
+The HF dataset viewer shows each language as a separate tab.
+
+Usage:
+    python push_stopwords.py <hf_token>
+"""
+import os
+import sys
+import shutil
+import pandas as pd
+from huggingface_hub import HfApi
+
+REPO_ID = "nltk-data-hub/stopwords"
+
+# BCP-47 codes for NLTK language names
+LANG_CODES = {
+    "albanian": "sq", "arabic": "ar", "azerbaijani": "az",
+    "basque": "eu", "belarusian": "be", "bengali": "bn",
+    "catalan": "ca", "chinese": "zh", "danish": "da",
+    "dutch": "nl", "english": "en", "finnish": "fi",
+    "french": "fr", "german": "de", "greek": "el",
+    "hebrew": "he", "hinglish": "hi", "hungarian": "hu",
+    "indonesian": "id", "italian": "it", "kazakh": "kk",
+    "nepali": "ne", "norwegian": "no", "portuguese": "pt",
+    "romanian": "ro", "russian": "ru", "slovene": "sl",
+    "spanish": "es", "swedish": "sv", "tajik": "tg",
+    "tamil": "ta", "turkish": "tr", "uzbek": "uz",
+}
+
+README_TEMPLATE = """\
+---
+language:
+{lang_yaml}
+configs:
+{configs_yaml}
+license: other
+task_categories:
+- text-classification
+- token-classification
+pretty_name: NLTK Stopwords
+---
+
+# NLTK Stopwords
+
+Stopword lists from [NLTK](https://www.nltk.org/), covering {n_langs} languages.
+
+Each language is a separate config. Each row is one stopword.
+
+## Usage
+
+```python
+from datasets import load_dataset
+
+# Load one language
+ds = load_dataset("nltk-data-hub/stopwords", "portuguese")
+words = ds["stopwords"]["word"]
+
+# Load all languages
+for lang in {lang_list_repr}:
+    ds = load_dataset("nltk-data-hub/stopwords", lang)
+    print(lang, ds["stopwords"].num_rows)
+```
+
+## Schema
+
+| Column | Type | Description |
+|---|---|---|
+| `word` | `string` | The stopword |
+
+## Languages and word counts
+
+| Language | BCP-47 | Count |
+|---|---|---|
+{lang_stats}
+
+## Source
+
+Originally distributed as part of `nltk.download('stopwords')`.
+Converted to Parquet for use with the HuggingFace `datasets` library.
+
+## Citation
+
+```bibtex
+@book{nltk,
+  author    = {Bird, Steven and Klein, Ewan and Loper, Edward},
+  title     = {Natural Language Processing with Python},
+  publisher = {O'Reilly Media},
+  year      = {2009},
+  url       = {https://www.nltk.org/}
+}
+```
+"""
+
+
+def build_per_language(outdir):
+    """Write one parquet file per language under outdir/<lang>/stopwords.parquet."""
+    from nltk.corpus import stopwords as sw
+
+    langs = sorted(sw.fileids())
+    counts = {}
+    for lang in langs:
+        words = sw.words(lang)
+        df = pd.DataFrame({"word": words})
+        lang_dir = os.path.join(outdir, lang)
+        os.makedirs(lang_dir, exist_ok=True)
+        df.to_parquet(os.path.join(lang_dir, "stopwords.parquet"), index=False)
+        counts[lang] = len(words)
+        print(f"  {lang}: {len(words)} words")
+
+    return langs, counts
+
+
+def build_readme(langs, counts):
+    lang_yaml = "\n".join(f"- {LANG_CODES.get(l, l)}" for l in langs)
+
+    configs_yaml = "\n".join(
+        f"- config_name: {lang}\n"
+        f"  data_files:\n"
+        f"  - split: stopwords\n"
+        f"    path: data/{lang}/stopwords.parquet"
+        for lang in langs
+    )
+
+    lang_stats = "\n".join(
+        f"| {lang} | {LANG_CODES.get(lang, '?')} | {counts[lang]:,} |"
+        for lang in langs
+    )
+
+    lang_list_repr = repr(langs)
+
+    return (README_TEMPLATE
+        .replace("{lang_yaml}", lang_yaml)
+        .replace("{configs_yaml}", configs_yaml)
+        .replace("{n_langs}", str(len(langs)))
+        .replace("{lang_list_repr}", lang_list_repr)
+        .replace("{lang_stats}", lang_stats)
+    )
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python push_stopwords.py <hf_token>")
+        sys.exit(1)
+
+    token = sys.argv[1]
+    api = HfApi(token=token)
+
+    outdir = "/tmp/nltk_stopwords_v2"
+    if os.path.exists(outdir):
+        shutil.rmtree(outdir)
+    os.makedirs(outdir)
+
+    print("Building per-language parquet files...")
+    langs, counts = build_per_language(os.path.join(outdir, "data"))
+    print(f"  {len(langs)} languages, {sum(counts.values()):,} total words")
+
+    print("Building README.md...")
+    readme = build_readme(langs, counts)
+    readme_path = os.path.join(outdir, "README.md")
+    open(readme_path, "w").write(readme)
+
+    # Create / ensure repo exists
+    print(f"\nCreating repo {REPO_ID}...")
+    api.create_repo(repo_id=REPO_ID, repo_type="dataset", exist_ok=True)
+
+    # Delete old flat parquet if present
+    print("Removing old flat data/stopwords.parquet...")
+    try:
+        api.delete_file(
+            path_in_repo="data/stopwords.parquet",
+            repo_id=REPO_ID,
+            repo_type="dataset",
+        )
+    except Exception:
+        pass  # didn't exist, fine
+
+    # Upload all per-language parquets
+    print("Uploading per-language parquet files...")
+    for lang in langs:
+        local_path = os.path.join(outdir, "data", lang, "stopwords.parquet")
+        api.upload_file(
+            path_or_fileobj=local_path,
+            path_in_repo=f"data/{lang}/stopwords.parquet",
+            repo_id=REPO_ID,
+            repo_type="dataset",
+        )
+        print(f"  uploaded {lang}")
+
+    print("Uploading README.md...")
+    api.upload_file(
+        path_or_fileobj=readme_path,
+        path_in_repo="README.md",
+        repo_id=REPO_ID,
+        repo_type="dataset",
+    )
+
+    print(f"\nDone: https://huggingface.co/datasets/{REPO_ID}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/huggingface/push_stopwords.py
+++ b/tools/huggingface/push_stopwords.py
@@ -6,9 +6,11 @@ The HF dataset viewer shows each language as a separate tab.
 Usage:
     python push_stopwords.py <hf_token>
 """
+
 import os
-import sys
 import shutil
+import sys
+
 import pandas as pd
 from huggingface_hub import HfApi
 
@@ -16,17 +18,39 @@ REPO_ID = "nltk-data-hub/stopwords"
 
 # BCP-47 codes for NLTK language names
 LANG_CODES = {
-    "albanian": "sq", "arabic": "ar", "azerbaijani": "az",
-    "basque": "eu", "belarusian": "be", "bengali": "bn",
-    "catalan": "ca", "chinese": "zh", "danish": "da",
-    "dutch": "nl", "english": "en", "finnish": "fi",
-    "french": "fr", "german": "de", "greek": "el",
-    "hebrew": "he", "hinglish": "hi", "hungarian": "hu",
-    "indonesian": "id", "italian": "it", "kazakh": "kk",
-    "nepali": "ne", "norwegian": "no", "portuguese": "pt",
-    "romanian": "ro", "russian": "ru", "slovene": "sl",
-    "spanish": "es", "swedish": "sv", "tajik": "tg",
-    "tamil": "ta", "turkish": "tr", "uzbek": "uz",
+    "albanian": "sq",
+    "arabic": "ar",
+    "azerbaijani": "az",
+    "basque": "eu",
+    "belarusian": "be",
+    "bengali": "bn",
+    "catalan": "ca",
+    "chinese": "zh",
+    "danish": "da",
+    "dutch": "nl",
+    "english": "en",
+    "finnish": "fi",
+    "french": "fr",
+    "german": "de",
+    "greek": "el",
+    "hebrew": "he",
+    "hinglish": "hi",
+    "hungarian": "hu",
+    "indonesian": "id",
+    "italian": "it",
+    "kazakh": "kk",
+    "nepali": "ne",
+    "norwegian": "no",
+    "portuguese": "pt",
+    "romanian": "ro",
+    "russian": "ru",
+    "slovene": "sl",
+    "spanish": "es",
+    "swedish": "sv",
+    "tajik": "tg",
+    "tamil": "ta",
+    "turkish": "tr",
+    "uzbek": "uz",
 }
 
 README_TEMPLATE = """\
@@ -124,14 +148,13 @@ def build_readme(langs, counts):
     )
 
     lang_stats = "\n".join(
-        f"| {lang} | {LANG_CODES.get(lang, '?')} | {counts[lang]:,} |"
-        for lang in langs
+        f"| {lang} | {LANG_CODES.get(lang, '?')} | {counts[lang]:,} |" for lang in langs
     )
 
     lang_list_repr = repr(langs)
 
-    return (README_TEMPLATE
-        .replace("{lang_yaml}", lang_yaml)
+    return (
+        README_TEMPLATE.replace("{lang_yaml}", lang_yaml)
         .replace("{configs_yaml}", configs_yaml)
         .replace("{n_langs}", str(len(langs)))
         .replace("{lang_list_repr}", lang_list_repr)


### PR DESCRIPTION
## Summary

This PR introduces [huggingface datasets](https://pypi.org/project/datasets/) as our data hub provider. As a start, we start with the stopwords corpus at https://huggingface.co/datasets/nltk-data-hub/stopwords. To the end user, nothing would change other than `nltk.download("stopwords", hf=True)` to download the corpus and all underlying methods to use the stopwords doesn't change.

P/S: This code was co-written with my coding agent but I've designed it, checked it and made sure the test ran.

<details>

- Adds `nltk/huggingface/dataset.py` — a HuggingFace datasets integration that lets users download and load NLTK corpora from the HF datasets cache (`~/.cache/huggingface/datasets/`) as an alternative to the NLTK servers
- `nltk.download('stopwords', hf=True)` downloads to HF cache; `~/nltk_data` is never touched
- `nltk.corpus.stopwords.words('portuguese')` transparently falls back to HF cache if the corpus is not in the normal NLTK data directories
- `nltk.corpus.stopwords.words('portuguese', hf=True)` reads directly from HF cache, bypassing the filesystem lookup entirely
</details>

## Changes

| File | Change |
|---|---|
| `nltk/huggingface/dataset.py` | New — `HFDatasetPathPointer`, `download()`, `load_data()`, `REGISTRY` |
| `nltk/huggingface/__init__.py` | New — package init |
| `nltk/downloader.py` | Add `hf=False` to `Downloader.download()`; delegates to HF when `True` |
| `nltk/data.py` | HF fallback in `find()` — checks local HF cache before raising `LookupError` |
| `nltk/corpus/reader/wordlist.py` | Add `hf=False` to `WordListCorpusReader.words()` |
| `nltk/corpus/reader/util.py` | Duck-typed branch in `find_corpus_fileids()` for HF-backed roots |
| `tools/huggingface/push_stopwords.py` | Script to upload stopwords to `nltk-data-hub/stopwords` on HF Hub |

## Design

The `REGISTRY` in `dataset.py` drives all behaviour — each entry declares `structure` (`multi_config` / `flat` / `single`) and `content_type` (`word_list` / `raw_text` / …) so the integration is generic across corpus types, not tied to word lists or multilingual data. Adding a new corpus is one `REGISTRY` entry plus a push script.

`HFDatasetPathPointer` satisfies the existing `PathPointer` interface (`open` / `file_size` / `join`), so all existing corpus readers work unchanged.

## Demo

```python
import nltk

# Download to HF cache — ~/nltk_data untouched
nltk.download('stopwords', hf=True)

# Existing code works unchanged — HF cache used as fallback
nltk.corpus.stopwords.words('portuguese')

# Explicit HF fast-path
nltk.corpus.stopwords.words('portuguese', hf=True)
```