### PR TITLE
Fix WordNetObject comparisons for incompatible types

### DIFF
--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -211,12 +211,13 @@ class _WordNetObject:
         return hash(self._name)
 
     def __eq__(self, other):
+        if not isinstance(other, _WordNetObject):
+            return NotImplemented
         return self._name == other._name
 
-    def __ne__(self, other):
-        return self._name != other._name
-
     def __lt__(self, other):
+        if not isinstance(other, _WordNetObject):
+            return NotImplemented
         return self._name < other._name
 
 

--- a/nltk/test/unit/test_wordnet.py
+++ b/nltk/test/unit/test_wordnet.py
@@ -17,7 +17,12 @@ class WordnNetDemo(unittest.TestCase):
 
     def test_value_equality_for_distinct_instances(self):
         # Guards against deleting __eq__ and falling back to identity equality.
-        self.assertEqual(S("dog.n.01"), S("dog.n.01"))
+        synset = S("dog.n.01")
+        distinct_synset = type(synset)(wn)
+        distinct_synset._name = synset._name
+
+        self.assertIsNot(synset, distinct_synset)
+        self.assertEqual(synset, distinct_synset)
 
     def test_equality_with_incompatible_type_is_false(self):
         # User-visible behavior: no AttributeError, just a normal failed equality.

--- a/nltk/test/unit/test_wordnet.py
+++ b/nltk/test/unit/test_wordnet.py
@@ -14,6 +14,20 @@ L = wn.lemma
 
 
 class WordnNetDemo(unittest.TestCase):
+
+    def test_value_equality_for_distinct_instances(self):
+        # Guards against deleting __eq__ and falling back to identity equality.
+        self.assertEqual(S("dog.n.01"), S("dog.n.01"))
+
+    def test_equality_with_incompatible_type_is_false(self):
+        # User-visible behavior: no AttributeError, just a normal failed equality.
+        self.assertNotEqual(S("dog.n.01"), "dog.n.01")
+
+    def test_ordering_with_incompatible_type_raises_typeerror(self):
+        # User-visible behavior for unsupported ordering comparisons.
+        with self.assertRaises(TypeError):
+            S("dog.n.01") < "dog.n.01"
+
     def test_retrieve_synset(self):
         move_synset = S("go.v.21")
         self.assertEqual(move_synset.name(), "move.v.15")


### PR DESCRIPTION
Fix #1944, an issue still open after several years, although three PRs attempted to close it (#1951, #3514, and #3562). This PR implements the consensus that emerged through the previous discussions, making `_WordNetObject` comparisons follow normal Python comparison semantics.

### Changes
- remove the redundant `__ne__` implementation
- keep value-based `__eq__` for WordNet objects
- make `__eq__` and `__lt__` return `NotImplemented` for incompatible types

### Why
Previously, comparing a WordNet object with an incompatible type could raise `AttributeError` by accessing `other._name`. Returning `NotImplemented` lets Python handle these cases correctly:
- `==` / `!=` behave normally for incompatible types
- ordering comparisons such as `<` raise `TypeError` instead of failing internally

This also preserves the existing equality behavior relied on by current tests, where distinct WordNet objects with the same name compare equal.

### Tests
Added minimal unit tests covering:
- value-based equality for distinct `Synset` instances with the same name
- mixed-type equality returning unequal rather than crashing
- mixed-type ordering raising `TypeError`
