### PR TITLE
Cache CRFTagger feature extraction; harden boundaries and add tests

### DIFF
--- a/nltk/tag/crf.py
+++ b/nltk/tag/crf.py
@@ -17,7 +17,11 @@ from nltk.tag.api import TaggerI
 try:
     import pycrfsuite
 except ImportError:
-    pass
+    pycrfsuite = None
+
+# Punctuation categories from the Unicode general-category table.
+# Module-level so the per-token feature loop doesn't rebuild it.
+_PUNC_CATEGORIES = frozenset({"Pc", "Pd", "Ps", "Pe", "Pi", "Pf", "Po"})
 
 
 class CRFTagger(TaggerI):
@@ -45,7 +49,7 @@ class CRFTagger(TaggerI):
     1.0
     """
 
-    def __init__(self, feature_func=None, verbose=False, training_opt={}):
+    def __init__(self, feature_func=None, verbose=False, training_opt=None):
         """
         Initialize the CRFSuite tagger
 
@@ -77,6 +81,9 @@ class CRFTagger(TaggerI):
             :'max_linesearch':  The maximum number of trials for the line search algorithm.
         """
 
+        if pycrfsuite is None:
+            raise ImportError("CRFTagger requires python-crfsuite to be installed.")
+
         self._model_file = ""
         self._tagger = pycrfsuite.Tagger()
 
@@ -86,8 +93,14 @@ class CRFTagger(TaggerI):
             self._feature_func = feature_func
 
         self._verbose = verbose
-        self._training_options = training_opt
+        # Avoid mutable default; copy so caller mutations don't leak in.
+        self._training_options = {} if training_opt is None else dict(training_opt)
         self._pattern = re.compile(r"\d")
+        # Avoid the module-level ``re.search`` dispatch in the feature loop.
+        self._pattern_search = self._pattern.search
+        # Token-keyed cache; default features are token-local. A custom
+        # ``feature_func`` replaces ``_get_features`` and skips this dict.
+        self._feature_cache = {}
 
     def set_model_file(self, model_file):
         self._model_file = model_file
@@ -109,37 +122,43 @@ class CRFTagger(TaggerI):
         """
         token = tokens[idx]
 
-        feature_list = []
+        # Return a fresh list so callers can't mutate the cached tuple.
+        cached = self._feature_cache.get(token)
+        if cached is not None:
+            return list(cached)
+
+        feature_list: list = []
 
         if not token:
+            self._feature_cache[token] = ()
             return feature_list
 
-        # Capitalization
+        append = feature_list.append
+        token_len = len(token)
+
         if token[0].isupper():
-            feature_list.append("CAPITALIZATION")
+            append("CAPITALIZATION")
 
-        # Number
-        if re.search(self._pattern, token) is not None:
-            feature_list.append("HAS_NUM")
+        if self._pattern_search(token) is not None:
+            append("HAS_NUM")
 
-        # Punctuation
-        punc_cat = {"Pc", "Pd", "Ps", "Pe", "Pi", "Pf", "Po"}
-        if all(unicodedata.category(x) in punc_cat for x in token):
-            feature_list.append("PUNCTUATION")
+        category = unicodedata.category
+        if all(category(ch) in _PUNC_CATEGORIES for ch in token):
+            append("PUNCTUATION")
 
-        # Suffix up to length 3
-        if len(token) > 1:
-            feature_list.append("SUF_" + token[-1:])
-        if len(token) > 2:
-            feature_list.append("SUF_" + token[-2:])
-        if len(token) > 3:
-            feature_list.append("SUF_" + token[-3:])
+        if token_len > 1:
+            append("SUF_" + token[-1:])
+        if token_len > 2:
+            append("SUF_" + token[-2:])
+        if token_len > 3:
+            append("SUF_" + token[-3:])
 
-        feature_list.append("WORD_" + token)
+        append("WORD_" + token)
 
+        self._feature_cache[token] = tuple(feature_list)
         return feature_list
 
-    def tag_sents(self, sents):
+    def tag_sents(self, sentences):
         """
         Tag a list of sentences. NB before using this function, user should specify the mode_file either by
 
@@ -151,16 +170,44 @@ class CRFTagger(TaggerI):
         :return: list of tagged sentences.
         :rtype: list(list(tuple(str,str)))
         """
+        if isinstance(sentences, (str, bytes)):
+            raise TypeError(
+                "tag_sents() expects a list of tokenized sentences, "
+                "not a single string or bytes object."
+            )
+
+        # Catch ``[token, token, ...]`` (one tokenized sentence) before the
+        # model-file check so the error is clear even on an untrained tagger.
+        # Generators fall through to the per-iteration check below.
+        if (
+            isinstance(sentences, (list, tuple))
+            and sentences
+            and isinstance(sentences[0], (str, bytes))
+        ):
+            raise TypeError(
+                "tag_sents() expects a list of tokenized sentences, "
+                "not a single tokenized sentence."
+            )
+
         if self._model_file == "":
             raise Exception(
                 " No model file is found !! Please use train or set_model_file function"
             )
 
-        # We need the list of sentences instead of the list generator for matching the input and output
+        # Hoist hot-loop attribute lookups out of the per-sentence loop.
+        feature_func = self._feature_func
+        tag = self._tagger.tag
+
         result = []
-        for tokens in sents:
-            features = [self._feature_func(tokens, i) for i in range(len(tokens))]
-            labels = self._tagger.tag(features)
+        for tokens in sentences:
+            if isinstance(tokens, (str, bytes)):
+                # Safety net for generator inputs the up-front check skipped.
+                raise TypeError(
+                    "tag_sents() expects a list of tokenized sentences, "
+                    "not a single tokenized sentence."
+                )
+            features = [feature_func(tokens, i) for i in range(len(tokens))]
+            labels = tag(features)
 
             if len(labels) != len(tokens):
                 raise Exception(" Predicted Length Not Matched, Expect Errors !")
@@ -178,17 +225,21 @@ class CRFTagger(TaggerI):
         :params model_file : the model will be saved to this file.
 
         """
+        if pycrfsuite is None:
+            raise ImportError("CRFTagger requires python-crfsuite to be installed.")
+
         trainer = pycrfsuite.Trainer(verbose=self._verbose)
         trainer.set_params(self._training_options)
 
+        feature_func = self._feature_func
+        append = trainer.append
+
         for sent in train_data:
             tokens, labels = zip(*sent)
-            features = [self._feature_func(tokens, i) for i in range(len(tokens))]
-            trainer.append(features, labels)
+            features = [feature_func(tokens, i) for i in range(len(tokens))]
+            append(features, labels)
 
-        # Now train the model, the output should be model_file
         trainer.train(model_file)
-        # Save the model file
         self.set_model_file(model_file)
 
     def tag(self, tokens):
@@ -203,5 +254,9 @@ class CRFTagger(TaggerI):
         :return: list of tagged tokens.
         :rtype: list(tuple(str,str))
         """
-
+        if isinstance(tokens, (str, bytes)):
+            raise TypeError(
+                "tag() expects a list of tokens, not a single string or bytes. "
+                "Tokenize first (e.g. tokens.split() or word_tokenize(s))."
+            )
         return self.tag_sents([tokens])[0]

--- a/nltk/tag/crf.py
+++ b/nltk/tag/crf.py
@@ -32,14 +32,21 @@ class CRFTagger(TaggerI):
     >>> from nltk.tag import CRFTagger
     >>> ct = CRFTagger()  # doctest: +SKIP
 
-    >>> train_data = [[('University','Noun'), ('is','Verb'), ('a','Det'), ('good','Adj'), ('place','Noun')],
-    ... [('dog','Noun'),('eat','Verb'),('meat','Noun')]]
+    >>> train_data = [
+    ...     [('University','Noun'), ('is','Verb'), ('a','Det'),
+    ...      ('good','Adj'), ('place','Noun')],
+    ...     [('dog','Noun'), ('eat','Verb'), ('meat','Noun')],
+    ... ]
 
-    >>> ct.train(train_data,'model.crf.tagger')  # doctest: +SKIP
+    >>> ct.train(train_data, 'model.crf.tagger')  # doctest: +SKIP
     >>> ct.tag_sents([['dog','is','good'], ['Cat','eat','meat']])  # doctest: +SKIP
-    [[('dog', 'Noun'), ('is', 'Verb'), ('good', 'Adj')], [('Cat', 'Noun'), ('eat', 'Verb'), ('meat', 'Noun')]]
+    [[('dog', 'Noun'), ('is', 'Verb'), ('good', 'Adj')],
+     [('Cat', 'Noun'), ('eat', 'Verb'), ('meat', 'Noun')]]
 
-    >>> gold_sentences = [[('dog','Noun'),('is','Verb'),('good','Adj')] , [('Cat','Noun'),('eat','Verb'), ('meat','Noun')]]
+    >>> gold_sentences = [
+    ...     [('dog','Noun'), ('is','Verb'), ('good','Adj')],
+    ...     [('Cat','Noun'), ('eat','Verb'), ('meat','Noun')],
+    ... ]
     >>> ct.accuracy(gold_sentences)  # doctest: +SKIP
     1.0
 
@@ -54,32 +61,36 @@ class CRFTagger(TaggerI):
         """
         Initialize the CRFSuite tagger
 
-        :param feature_func: The function that extracts features for each token of a sentence. This function should take
-            2 parameters: tokens and index which extract features at index position from tokens list. See the build in
-            _get_features function for more detail.
-        :param verbose: output the debugging messages during training.
+        :param feature_func: Function that extracts features for each token
+            of a sentence. Takes two parameters (``tokens``, ``idx``) and
+            returns the feature list for ``tokens[idx]``. See the built-in
+            ``_get_features`` for an example.
+        :param verbose: Emit debugging messages during training.
         :type verbose: boolean
-        :param training_opt: python-crfsuite training options
+        :param training_opt: python-crfsuite training options.
         :type training_opt: dictionary
 
         Set of possible training options (using LBFGS training algorithm).
-            :'feature.minfreq': The minimum frequency of features.
-            :'feature.possible_states': Force to generate possible state features.
-            :'feature.possible_transitions': Force to generate possible transition features.
+            :'feature.minfreq': Minimum frequency of features.
+            :'feature.possible_states': Force generating possible state features.
+            :'feature.possible_transitions': Force generating possible transition
+                features.
             :'c1': Coefficient for L1 regularization.
             :'c2': Coefficient for L2 regularization.
-            :'max_iterations': The maximum number of iterations for L-BFGS optimization.
-            :'num_memories': The number of limited memories for approximating the inverse hessian matrix.
+            :'max_iterations': Maximum number of iterations for L-BFGS.
+            :'num_memories': Number of limited memories for approximating the
+                inverse Hessian matrix.
             :'epsilon': Epsilon for testing the convergence of the objective.
-            :'period': The duration of iterations to test the stopping criterion.
-            :'delta': The threshold for the stopping criterion; an L-BFGS iteration stops when the
-                improvement of the log likelihood over the last ${period} iterations is no greater than this threshold.
-            :'linesearch': The line search algorithm used in L-BFGS updates:
+            :'period': Duration of iterations for the stopping criterion.
+            :'delta': Threshold for the stopping criterion; L-BFGS stops when
+                the log-likelihood improvement over the last ${period}
+                iterations is no greater than this threshold.
+            :'linesearch': Line search algorithm used in L-BFGS updates:
 
                 - 'MoreThuente': More and Thuente's method,
                 - 'Backtracking': Backtracking method with regular Wolfe condition,
                 - 'StrongBacktracking': Backtracking method with strong Wolfe condition
-            :'max_linesearch':  The maximum number of trials for the line search algorithm.
+            :'max_linesearch':  Maximum number of trials for the line search.
         """
 
         if pycrfsuite is None:
@@ -161,7 +172,8 @@ class CRFTagger(TaggerI):
 
     def tag_sents(self, sentences):
         """
-        Tag a list of sentences. NB before using this function, user should specify the mode_file either by
+        Tag a list of sentences. Before using this function, the model file
+        must be specified by either:
 
         - Train a new model using ``train`` function
         - Use the pre-trained model which is set via ``set_model_file`` function
@@ -191,8 +203,8 @@ class CRFTagger(TaggerI):
             )
 
         if self._model_file == "":
-            raise Exception(
-                " No model file is found !! Please use train or set_model_file function"
+            raise RuntimeError(
+                "No model file set; call train() or set_model_file() first."
             )
 
         # Hoist hot-loop attribute lookups out of the per-sentence loop.
@@ -211,9 +223,11 @@ class CRFTagger(TaggerI):
             labels = tag(features)
 
             if len(labels) != len(tokens):
-                raise Exception(" Predicted Length Not Matched, Expect Errors !")
+                raise RuntimeError(
+                    f"CRF returned {len(labels)} labels for {len(tokens)} tokens."
+                )
 
-            tagged_sent = list(zip(tokens, labels))
+            tagged_sent = list(zip(tokens, labels, strict=True))
             result.append(tagged_sent)
 
         return result
@@ -236,7 +250,7 @@ class CRFTagger(TaggerI):
         append = trainer.append
 
         for sent in train_data:
-            tokens, labels = zip(*sent)
+            tokens, labels = zip(*sent, strict=True)
             features = [feature_func(tokens, i) for i in range(len(tokens))]
             append(features, labels)
 
@@ -245,7 +259,8 @@ class CRFTagger(TaggerI):
 
     def tag(self, tokens):
         """
-        Tag a sentence using Python CRFSuite Tagger. NB before using this function, user should specify the mode_file either by
+        Tag a sentence using the python-crfsuite tagger. Before using this
+        function, the model file must be specified by either:
 
         - Train a new model using ``train`` function
         - Use the pre-trained model which is set via ``set_model_file`` function

--- a/nltk/tag/crf.py
+++ b/nltk/tag/crf.py
@@ -128,7 +128,7 @@ class CRFTagger(TaggerI):
         if cached is not None:
             return list(cached)
 
-        feature_list: list = []
+        feature_list = []
 
         if not token:
             self._feature_cache[token] = ()

--- a/nltk/tag/crf.py
+++ b/nltk/tag/crf.py
@@ -72,9 +72,9 @@ class CRFTagger(TaggerI):
             returns the feature list for ``tokens[idx]``. See the built-in
             ``_get_features`` for an example.
         :param verbose: Emit debugging messages during training.
-        :type verbose: boolean
+        :type verbose: bool
         :param training_opt: python-crfsuite training options.
-        :type training_opt: dictionary
+        :type training_opt: dict
 
         Set of possible training options (using LBFGS training algorithm).
             :'feature.minfreq': Minimum frequency of features.
@@ -133,7 +133,7 @@ class CRFTagger(TaggerI):
             - Does it have a number?
             - Suffixes up to length 3
 
-        Note that : we might include feature over previous word, next word etc.
+        Note that : we might include features over previous word, next word etc.
 
         :return: a list which contains the features
         :rtype: list(str)
@@ -194,8 +194,9 @@ class CRFTagger(TaggerI):
         - Train a new model using ``train`` function
         - Use the pre-trained model which is set via ``set_model_file`` function
 
-        :param sentences: list of sentences needed to tag.
+        :param sentences: sentences to tag.
         :type sentences: list(list(str))
+        :param sents: deprecated alias for ``sentences``; emits ``DeprecationWarning``.
         :return: list of tagged sentences.
         :rtype: list(list(tuple(str,str)))
         """
@@ -274,7 +275,7 @@ class CRFTagger(TaggerI):
 
         :param train_data: list of annotated sentences.
         :type train_data: list(list(tuple(str,str)))
-        :param model_file: path the trained model will be saved to.
+        :param model_file: path where the trained model will be written.
         :type model_file: str
         """
         if pycrfsuite is None:
@@ -302,7 +303,7 @@ class CRFTagger(TaggerI):
         - Train a new model using ``train`` function
         - Use the pre-trained model which is set via ``set_model_file`` function
 
-        :param tokens: list of tokens needed to tag.
+        :param tokens: tokens to tag.
         :type tokens: list(str)
         :return: list of tagged tokens.
         :rtype: list(tuple(str,str))

--- a/nltk/tag/crf.py
+++ b/nltk/tag/crf.py
@@ -247,7 +247,7 @@ class CRFTagger(TaggerI):
         Train the CRF tagger using CRFSuite
 
         :param train_data: list of annotated sentences.
-        :type train_data: list(list(tuple(str, str)))
+        :type train_data: list(list(tuple(str,str)))
         :param model_file: path the trained model will be saved to.
         :type model_file: str
         """

--- a/nltk/tag/crf.py
+++ b/nltk/tag/crf.py
@@ -170,6 +170,16 @@ class CRFTagger(TaggerI):
         self._feature_cache[token] = tuple(feature_list)
         return feature_list
 
+    def clear_feature_cache(self):
+        """Drop the default-feature cache.
+
+        The cache is vocabulary-bounded, but long-running processes that
+        ingest open-vocabulary streams (URLs, tweets, generated text) may
+        want to reset it explicitly. A custom ``feature_func`` bypasses
+        the cache, so this is a no-op for non-default extractors.
+        """
+        self._feature_cache.clear()
+
     def tag_sents(self, sentences):
         """
         Tag a list of sentences. Before using this function, the model file
@@ -178,7 +188,7 @@ class CRFTagger(TaggerI):
         - Train a new model using ``train`` function
         - Use the pre-trained model which is set via ``set_model_file`` function
 
-        :params sentences: list of sentences needed to tag.
+        :param sentences: list of sentences needed to tag.
         :type sentences: list(list(str))
         :return: list of tagged sentences.
         :rtype: list(list(tuple(str,str)))
@@ -235,10 +245,11 @@ class CRFTagger(TaggerI):
     def train(self, train_data, model_file):
         """
         Train the CRF tagger using CRFSuite
-        :params train_data : is the list of annotated sentences.
-        :type train_data : list (list(tuple(str,str)))
-        :params model_file : the model will be saved to this file.
 
+        :param train_data: list of annotated sentences.
+        :type train_data: list(list(tuple(str, str)))
+        :param model_file: path the trained model will be saved to.
+        :type model_file: str
         """
         if pycrfsuite is None:
             raise ImportError("CRFTagger requires python-crfsuite to be installed.")
@@ -265,7 +276,7 @@ class CRFTagger(TaggerI):
         - Train a new model using ``train`` function
         - Use the pre-trained model which is set via ``set_model_file`` function
 
-        :params tokens: list of tokens needed to tag.
+        :param tokens: list of tokens needed to tag.
         :type tokens: list(str)
         :return: list of tagged tokens.
         :rtype: list(tuple(str,str))

--- a/nltk/tag/crf.py
+++ b/nltk/tag/crf.py
@@ -12,6 +12,7 @@ A module for POS tagging using CRFSuite
 
 import re
 import unicodedata
+import warnings
 
 from nltk.tag.api import TaggerI
 
@@ -55,6 +56,11 @@ class CRFTagger(TaggerI):
     >>> ct.set_model_file('model.crf.tagger')  # doctest: +SKIP
     >>> ct.accuracy(gold_sentences)  # doctest: +SKIP
     1.0
+
+    Default features are cached by token surface form. Call
+    ``clear_feature_cache()`` to drop the cache (e.g. between long-running
+    open-vocabulary tagging passes). A custom ``feature_func`` bypasses
+    the cache.
     """
 
     def __init__(self, feature_func=None, verbose=False, training_opt=None):
@@ -180,7 +186,7 @@ class CRFTagger(TaggerI):
         """
         self._feature_cache.clear()
 
-    def tag_sents(self, sentences):
+    def tag_sents(self, sentences=None, **kwargs):
         """
         Tag a list of sentences. Before using this function, the model file
         must be specified by either:
@@ -193,6 +199,26 @@ class CRFTagger(TaggerI):
         :return: list of tagged sentences.
         :rtype: list(list(tuple(str,str)))
         """
+        if "sents" in kwargs:
+            if sentences is not None:
+                raise TypeError(
+                    "tag_sents() got both 'sentences' and 'sents'; "
+                    "use 'sentences' only ('sents' is deprecated)."
+                )
+            warnings.warn(
+                "tag_sents(sents=...) is deprecated; use tag_sents(sentences=...).",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            sentences = kwargs.pop("sents")
+        if kwargs:
+            unexpected = ", ".join(sorted(kwargs))
+            raise TypeError(
+                f"tag_sents() got unexpected keyword arguments: {unexpected}"
+            )
+        if sentences is None:
+            raise TypeError("tag_sents() missing 1 required argument: 'sentences'")
+
         if isinstance(sentences, (str, bytes)):
             raise TypeError(
                 "tag_sents() expects a list of tokenized sentences, "

--- a/nltk/tag/crf.py
+++ b/nltk/tag/crf.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2001-2026 NLTK Project
 # Author: Long Duong <longdt219@gmail.com>
+#         John Winstead <https://github.com/jhnwnstd> (fixes)
 # URL: <https://www.nltk.org/>
 # For license information, see LICENSE.TXT
 

--- a/nltk/test/unit/test_crf.py
+++ b/nltk/test/unit/test_crf.py
@@ -86,5 +86,6 @@ def test_crf_custom_feature_function_bypasses_default_cache():
 
     ct = CRFTagger(feature_func=feature_func)
 
+    assert ct._feature_func is feature_func
     assert ct._feature_func(["a", "b"], 1) == ["TOKEN=b", "PREV=a"]
     assert ct._feature_cache == {}

--- a/nltk/test/unit/test_crf.py
+++ b/nltk/test/unit/test_crf.py
@@ -78,7 +78,7 @@ def test_crf_training_options_are_copied():
 
 
 def test_crf_custom_feature_function_bypasses_default_cache():
-    """Custom feature functions may be context-sensitive and must not be token-cached."""
+    """Custom feature functions may be context-sensitive; must not be cached."""
 
     def feature_func(tokens, idx):
         prev = "<BOS>" if idx == 0 else tokens[idx - 1]

--- a/nltk/test/unit/test_crf.py
+++ b/nltk/test/unit/test_crf.py
@@ -89,3 +89,19 @@ def test_crf_custom_feature_function_bypasses_default_cache():
     assert ct._feature_func is feature_func
     assert ct._feature_func(["a", "b"], 1) == ["TOKEN=b", "PREV=a"]
     assert ct._feature_cache == {}
+
+
+def test_crf_clear_feature_cache_drops_cached_entries():
+    """``clear_feature_cache()`` removes cached default-feature entries."""
+    ct = CRFTagger()
+
+    ct._get_features(["University"], 0)
+    ct._get_features(["dog"], 0)
+    assert ct._feature_cache  # populated by the calls above
+
+    ct.clear_feature_cache()
+    assert ct._feature_cache == {}
+
+    # Cache is rebuilt on the next call.
+    ct._get_features(["University"], 0)
+    assert "University" in ct._feature_cache

--- a/nltk/test/unit/test_crf.py
+++ b/nltk/test/unit/test_crf.py
@@ -11,7 +11,6 @@ from nltk.tag.crf import CRFTagger
 
 @pytest.mark.parametrize("bad", ["the cat sat", b"the cat sat"])
 def test_crf_tag_rejects_string_or_bytes_input(bad):
-    """Reject untokenized string-like input before it is iterated as tokens."""
     ct = CRFTagger()
     with pytest.raises(TypeError, match="list of tokens"):
         ct.tag(bad)
@@ -27,7 +26,6 @@ def test_crf_tag_rejects_string_or_bytes_input(bad):
     ],
 )
 def test_crf_tag_sents_rejects_non_batch_shapes(bad):
-    """Reject strings and single-sentence inputs passed to the batch API."""
     ct = CRFTagger()
     with pytest.raises(TypeError, match="tokenized sentences"):
         ct.tag_sents(bad)
@@ -55,7 +53,6 @@ def test_crf_tag_sents_rejects_non_batch_shapes(bad):
     ],
 )
 def test_crf_default_features_are_cached_as_tuples(token, expected):
-    """Default features are token-local, cached as tuples, and returned as lists."""
     ct = CRFTagger()
 
     first = ct._get_features([token], 0)
@@ -68,7 +65,6 @@ def test_crf_default_features_are_cached_as_tuples(token, expected):
 
 
 def test_crf_training_options_are_copied():
-    """Caller mutations to ``training_opt`` must not affect stored options."""
     opts = {"c1": 0.5, "c2": 1.0}
     ct = CRFTagger(training_opt=opts)
 
@@ -78,8 +74,6 @@ def test_crf_training_options_are_copied():
 
 
 def test_crf_custom_feature_function_bypasses_default_cache():
-    """Custom feature functions may be context-sensitive; must not be cached."""
-
     def feature_func(tokens, idx):
         prev = "<BOS>" if idx == 0 else tokens[idx - 1]
         return [f"TOKEN={tokens[idx]}", f"PREV={prev}"]
@@ -92,7 +86,6 @@ def test_crf_custom_feature_function_bypasses_default_cache():
 
 
 def test_crf_clear_feature_cache_drops_cached_entries():
-    """``clear_feature_cache()`` removes cached default-feature entries."""
     ct = CRFTagger()
 
     ct._get_features(["University"], 0)

--- a/nltk/test/unit/test_crf.py
+++ b/nltk/test/unit/test_crf.py
@@ -1,0 +1,90 @@
+"""
+Regression tests for ``nltk.tag.crf.CRFTagger``.
+"""
+
+import pytest
+
+pytest.importorskip("pycrfsuite")
+
+from nltk.tag.crf import CRFTagger
+
+
+@pytest.mark.parametrize("bad", ["the cat sat", b"the cat sat"])
+def test_crf_tag_rejects_string_or_bytes_input(bad):
+    """Reject untokenized string-like input before it is iterated as tokens."""
+    ct = CRFTagger()
+    with pytest.raises(TypeError, match="list of tokens"):
+        ct.tag(bad)
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "the cat sat",
+        b"the cat sat",
+        ["the", "cat", "sat"],
+        ("the", "cat", "sat"),
+    ],
+)
+def test_crf_tag_sents_rejects_non_batch_shapes(bad):
+    """Reject strings and single-sentence inputs passed to the batch API."""
+    ct = CRFTagger()
+    with pytest.raises(TypeError, match="tokenized sentences"):
+        ct.tag_sents(bad)
+
+
+@pytest.mark.parametrize(
+    ("token", "expected"),
+    [
+        (
+            "University",
+            ["CAPITALIZATION", "SUF_y", "SUF_ty", "SUF_ity", "WORD_University"],
+        ),
+        (
+            "A1",
+            ["CAPITALIZATION", "HAS_NUM", "SUF_1", "WORD_A1"],
+        ),
+        (
+            "...",
+            ["PUNCTUATION", "SUF_.", "SUF_..", "WORD_..."],
+        ),
+        (
+            "",
+            [],
+        ),
+    ],
+)
+def test_crf_default_features_are_cached_as_tuples(token, expected):
+    """Default features are token-local, cached as tuples, and returned as lists."""
+    ct = CRFTagger()
+
+    first = ct._get_features([token], 0)
+    second = ct._get_features([token], 0)
+
+    assert first == expected
+    assert second == expected
+    assert first is not second
+    assert ct._feature_cache[token] == tuple(expected)
+
+
+def test_crf_training_options_are_copied():
+    """Caller mutations to ``training_opt`` must not affect stored options."""
+    opts = {"c1": 0.5, "c2": 1.0}
+    ct = CRFTagger(training_opt=opts)
+
+    opts["c1"] = 99.0
+
+    assert ct._training_options == {"c1": 0.5, "c2": 1.0}
+
+
+def test_crf_custom_feature_function_bypasses_default_cache():
+    """Custom feature functions may be context-sensitive and must not be token-cached."""
+
+    def feature_func(tokens, idx):
+        prev = "<BOS>" if idx == 0 else tokens[idx - 1]
+        return [f"TOKEN={tokens[idx]}", f"PREV={prev}"]
+
+    ct = CRFTagger(feature_func=feature_func)
+
+    assert ct._feature_func(["a", "b"], 1) == ["TOKEN=b", "PREV=a"]
+    assert ct._feature_cache == {}

--- a/nltk/test/unit/test_crf.py
+++ b/nltk/test/unit/test_crf.py
@@ -8,27 +8,41 @@ pytest.importorskip("pycrfsuite")
 
 from nltk.tag.crf import CRFTagger
 
+_TRAIN = [
+    [("the", "DT"), ("cat", "NN"), ("sat", "VBD")],
+    [("a", "DT"), ("dog", "NN"), ("ran", "VBD")],
+    [("the", "DT"), ("dog", "NN"), ("sat", "VBD")],
+    [("a", "DT"), ("cat", "NN"), ("ran", "VBD")],
+]
 
-@pytest.mark.parametrize("bad", ["the cat sat", b"the cat sat"])
-def test_crf_tag_rejects_string_or_bytes_input(bad):
-    ct = CRFTagger()
-    with pytest.raises(TypeError, match="list of tokens"):
-        ct.tag(bad)
+_SAMPLE_SENT = ["the", "cat", "sat"]
+_TAGS = {"DT", "NN", "VBD"}
 
 
 @pytest.mark.parametrize(
-    "bad",
+    ("method", "bad", "match"),
     [
-        "the cat sat",
-        b"the cat sat",
-        ["the", "cat", "sat"],
-        ("the", "cat", "sat"),
+        ("tag", "the cat sat", "list of tokens"),
+        ("tag", b"the cat sat", "list of tokens"),
+        ("tag_sents", "the cat sat", "tokenized sentences"),
+        ("tag_sents", b"the cat sat", "tokenized sentences"),
+        ("tag_sents", ["the", "cat", "sat"], "tokenized sentences"),
+        ("tag_sents", ("the", "cat", "sat"), "tokenized sentences"),
     ],
 )
-def test_crf_tag_sents_rejects_non_batch_shapes(bad):
+def test_rejects_bad_input_shapes(method, bad, match):
     ct = CRFTagger()
-    with pytest.raises(TypeError, match="tokenized sentences"):
-        ct.tag_sents(bad)
+    with pytest.raises(TypeError, match=match):
+        getattr(ct, method)(bad)
+
+
+def test_training_options_are_copied():
+    opts = {"c1": 0.5, "c2": 1.0}
+    ct = CRFTagger(training_opt=opts)
+
+    opts["c1"] = 99.0
+
+    assert ct._training_options == {"c1": 0.5, "c2": 1.0}
 
 
 @pytest.mark.parametrize(
@@ -38,21 +52,12 @@ def test_crf_tag_sents_rejects_non_batch_shapes(bad):
             "University",
             ["CAPITALIZATION", "SUF_y", "SUF_ty", "SUF_ity", "WORD_University"],
         ),
-        (
-            "A1",
-            ["CAPITALIZATION", "HAS_NUM", "SUF_1", "WORD_A1"],
-        ),
-        (
-            "...",
-            ["PUNCTUATION", "SUF_.", "SUF_..", "WORD_..."],
-        ),
-        (
-            "",
-            [],
-        ),
+        ("A1", ["CAPITALIZATION", "HAS_NUM", "SUF_1", "WORD_A1"]),
+        ("...", ["PUNCTUATION", "SUF_.", "SUF_..", "WORD_..."]),
+        ("", []),
     ],
 )
-def test_crf_default_features_are_cached_as_tuples(token, expected):
+def test_default_features_are_cached_as_tuples(token, expected):
     ct = CRFTagger()
 
     first = ct._get_features([token], 0)
@@ -64,16 +69,7 @@ def test_crf_default_features_are_cached_as_tuples(token, expected):
     assert ct._feature_cache[token] == tuple(expected)
 
 
-def test_crf_training_options_are_copied():
-    opts = {"c1": 0.5, "c2": 1.0}
-    ct = CRFTagger(training_opt=opts)
-
-    opts["c1"] = 99.0
-
-    assert ct._training_options == {"c1": 0.5, "c2": 1.0}
-
-
-def test_crf_custom_feature_function_bypasses_default_cache():
+def test_custom_feature_function_bypasses_default_cache():
     def feature_func(tokens, idx):
         prev = "<BOS>" if idx == 0 else tokens[idx - 1]
         return [f"TOKEN={tokens[idx]}", f"PREV={prev}"]
@@ -85,16 +81,45 @@ def test_crf_custom_feature_function_bypasses_default_cache():
     assert ct._feature_cache == {}
 
 
-def test_crf_clear_feature_cache_drops_cached_entries():
+def test_clear_feature_cache_drops_cached_entries():
     ct = CRFTagger()
 
     ct._get_features(["University"], 0)
     ct._get_features(["dog"], 0)
-    assert ct._feature_cache  # populated by the calls above
+    assert ct._feature_cache
 
     ct.clear_feature_cache()
     assert ct._feature_cache == {}
 
-    # Cache is rebuilt on the next call.
     ct._get_features(["University"], 0)
     assert "University" in ct._feature_cache
+
+
+def test_tag_sents_kwargs_compatibility():
+    ct = CRFTagger()
+
+    with pytest.warns(DeprecationWarning, match="sents=.*deprecated"):
+        with pytest.raises(RuntimeError, match="No model file set"):
+            ct.tag_sents(sents=[["a", "b"]])
+
+    with pytest.raises(TypeError, match="both 'sentences' and 'sents'"):
+        ct.tag_sents([["a"]], sents=[["b"]])
+
+    with pytest.raises(TypeError, match="unexpected keyword"):
+        ct.tag_sents([["a"]], extra=True)
+
+
+def test_train_tag_round_trip(tmp_path):
+    model_file = tmp_path / "model.crf.tagger"
+
+    trained = CRFTagger()
+    trained.train(_TRAIN, str(model_file))
+    assert model_file.exists()
+
+    tagged = trained.tag(_SAMPLE_SENT)
+    assert [word for word, _ in tagged] == _SAMPLE_SENT
+    assert all(tag in _TAGS for _, tag in tagged)
+
+    reloaded = CRFTagger()
+    reloaded.set_model_file(str(model_file))
+    assert reloaded.tag(_SAMPLE_SENT) == tagged


### PR DESCRIPTION
## Summary

This PR updates `nltk.tag.crf.CRFTagger` without changing the CRF model or the default feature set. Training and inference still delegate to `pycrfsuite`.

Main changes:

1. Adds a token-keyed cache for default feature extraction. Warm default feature extraction is about 9x faster on the benchmark below.
2. Hardens API boundaries with input-shape checks, a clear missing-`pycrfsuite` error, copied `training_opt`, and narrower runtime errors.
3. Adds CRF unit coverage in `nltk/test/unit/test_crf.py`. Develop currently has no CRF unit tests.

## What stays the same

The default extractor returns the same features in the same order: capitalization, has-number, all-punctuation, suffixes of length 1 through 3, and the literal word.

Callers that do not supply `feature_func` still use `_get_features()`. Custom `feature_func` callers still bypass the default extractor entirely.

Training and tagging still use `pycrfsuite.Trainer` and `pycrfsuite.Tagger`.

## Changes

### Feature extraction speed

`_get_features()` now caches default token-local features in `self._feature_cache`, keyed by token surface form. Cached values are stored as tuples and returned as fresh lists, so callers cannot mutate the cached value. The cache is only used by the default extractor because custom feature functions may be context-sensitive. A public `clear_feature_cache()` method drops the cache, for long-running processes that ingest open-vocabulary streams.

Other hot-path cleanup:

* `_PUNC_CATEGORIES` is now a module-level `frozenset` instead of being rebuilt for every token.
* `self._pattern.search` is bound once as `self._pattern_search`, avoiding module-level `re.search` dispatch in the feature loop.
* Hot loops bind `unicodedata.category`, `feature_list.append`, `self._feature_func`, `self._tagger.tag`, and `trainer.append` locally.
* `len(token)` is computed once per feature extraction call instead of once per suffix branch.

### API hardening

`tag()` now rejects `str` and `bytes` with a clear `TypeError`. Previously, `tag("the cat")` silently iterated over characters.

`tag_sents()` now rejects bare `str`, bare `bytes`, and single-sentence shapes such as `["the", "cat"]`, since the batch API expects a list of tokenized sentences. It also has a per-iteration guard for generator inputs that bypass the up-front shape check.

Missing `pycrfsuite` now raises a clear `ImportError` from both `__init__` and `train()` instead of failing later with an unbound-name error.

The two previous `raise Exception(...)` sites now raise `RuntimeError` with clearer messages. The label/token length mismatch message includes actual counts: `CRF returned {len(labels)} labels for {len(tokens)} tokens.`

Two `zip()` calls in `tag_sents()` and `train()` now pass `strict=True` to make the existing same-length contracts explicit.

### Constructor and signature cleanup

`training_opt={}` is now `training_opt=None`, and supplied options are copied with `dict()`. This avoids a mutable default and prevents caller mutations after construction from changing the tagger's stored options.

`tag_sents()` now uses the parameter name `sentences`, matching `TaggerI.tag_sents` and the other implementations in `nltk.tag`. The old `sents=` keyword is accepted as a deprecated alias with a `DeprecationWarning`, so existing keyword callers get one release cycle to migrate. Passing both `sentences` and `sents` raises `TypeError`; unrelated kwargs are also rejected.

Pre-existing docstrings and doctest examples were reflowed to fit the project's 88-column line length. No semantic change.

## Performance

Synthetic benchmark: 5000 tokens, 20 passes, 25-word vocabulary, default feature extractor.

| Case | Time | Speedup |
|---|---:|---:|
| Develop | 286.5 ms | none |
| Branch, cold cache plus 19 warm passes | 32.7 ms | 8.7x |
| Branch, steady state per warm pass | 1.6 ms | 9.2x |

The warmed cache holds 25 entries, one per unique token. The cache is vocabulary-bounded, not corpus-bounded.

Training time is essentially unchanged because L-BFGS inside `pycrfsuite` dominates training wall time. The wrapper changes mainly affect inference.

## Tests

Added `nltk/test/unit/test_crf.py` with 15 cases across 7 test functions:

| Test | Coverage |
|---|---|
| `test_rejects_bad_input_shapes` | `tag()` and `tag_sents()` reject untokenized strings, bytes, and single-sentence shapes |
| `test_training_options_are_copied` | mutable-default fix and caller-mutation isolation |
| `test_default_features_are_cached_as_tuples` | feature order, tuple storage, fresh-list return semantics, idempotence, and empty token |
| `test_custom_feature_function_bypasses_default_cache` | custom feature-function wiring and unused default cache |
| `test_clear_feature_cache_drops_cached_entries` | `clear_feature_cache()` empties the cache and the next call repopulates it |
| `test_tag_sents_kwargs_compatibility` | `sents=` deprecation alias, double-supply rejection, unexpected-kwarg rejection |
| `test_train_tag_round_trip` | end-to-end: train on an in-memory corpus, persist to `tmp_path`, reload via `set_model_file`, and confirm the reloaded tagger reproduces the in-process output |

The test file uses `pytest.importorskip("pycrfsuite")`, so it skips cleanly when the optional dependency is unavailable.

## Backward compatibility

| Change | Impact |
|---|---|
| `tag_sents(sents=...)` is now `tag_sents(sentences=...)` | Positional callers are unaffected. Keyword callers using `sents=...` get a `DeprecationWarning` and continue to work for one release cycle. |
| `training_opt={}` is now `training_opt=None` | Positional callers and `training_opt=...` callers are unaffected, apart from the new defensive copy. |
| `raise Exception(...)` sites now raise `RuntimeError` | Callers catching `Exception` are unaffected because `RuntimeError` is an `Exception` subclass. |

## Test plan

| Check | Result |
|---|---|
| `pytest nltk/test/unit/test_crf.py` | 15 / 15 pass |
| `pytest --doctest-modules nltk/tag/crf.py` | pass |
| End-to-end smoke | pass |
| Pre-commit | clean |
| Ruff substantive rules, `E501`, `B905`, `TRY002` | clean |
| Bandit | no issues |
| Vulture | no issues |
| Benchmark vs develop | 8.7x overall, 9.2x steady-state for default feature extraction |