### PR TITLE
fix: block shared address space in SSRF guard

### DIFF
--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -221,7 +221,13 @@ def validate_network_url(url_input, context="NetworkIO"):
 
         for result in _resolve_hostname(parsed.hostname or ""):
             ip = ipaddress.ip_address(result[4][0])
-            if ip.is_loopback or ip.is_link_local or ip.is_multicast or ip.is_private:
+            if (
+                ip.is_loopback
+                or ip.is_link_local
+                or ip.is_multicast
+                or ip.is_private
+                or not ip.is_global
+            ):
                 msg = f"Security Violation [{context}]: SSRF attempt to restricted IP {ip}"
                 if ENFORCE:
                     raise PermissionError(msg)

--- a/nltk/test/unit/test_pathsec.py
+++ b/nltk/test/unit/test_pathsec.py
@@ -55,6 +55,12 @@ def test_ssrf_cloud_metadata_link_local():
         dl.index()
 
 
+def test_ssrf_shared_address_space():
+    dl = Downloader(server_index_url="http://100.64.0.1/internal")
+    with pytest.raises((ValueError, PermissionError)):
+        dl.index()
+
+
 def test_ssrf_ip_obfuscation():
     """Will FAIL on vulnerable branches (on Unix) because string-matching misses the decimal IP."""
     dl = Downloader(server_index_url="http://2852039166/latest/meta-data/")


### PR DESCRIPTION
## Summary

This tightens `pathsec.validate_network_url()` so the SSRF guard blocks resolved targets that are not globally routable, including shared address space such as `100.64.0.0/10`.

Python's `ipaddress` module does not classify shared address space as `is_private`, so the existing loopback/link-local/multicast/private checks allowed URLs such as `http://100.64.0.1/` when `pathsec.ENFORCE = True`. That range is not public Internet space and can represent internal carrier-grade NAT infrastructure, so it should be rejected by a network fetch helper intended to block internal/non-public targets.

## Changes

- Treat `not ip.is_global` as unsafe in `validate_network_url()`.
- Add a regression test for `http://100.64.0.1/internal`.

## Security classification

- CWE-918: Server-Side Request Forgery (SSRF)

## Test

- `.venv/bin/pytest nltk/test/unit/test_pathsec.py -q`
