### PR TITLE
fix(translate): guard ZeroDivisionError in corpus_chrf, sentence_ribes and corpus_ribes on empty inputs

### DIFF
--- a/nltk/translate/chrf_score.py
+++ b/nltk/translate/chrf_score.py
@@ -218,4 +218,8 @@ def corpus_chrf(
     total_scores = [sum(fscores) for n, fscores in ngram_fscores.items()]
 
     # macro-average over n-gram orders and over all sentences
+    if num_sents == 0:
+        return 0.0
+    if num_ngram_sizes == 0:
+        return 0.0
     return (sum(total_scores) / num_ngram_sizes) / num_sents

--- a/nltk/translate/ribes_score.py
+++ b/nltk/translate/ribes_score.py
@@ -47,6 +47,8 @@ def sentence_ribes(references, hypothesis, alpha=0.25, beta=0.10):
     :rtype: float
     """
     best_ribes = -1.0
+    if not hypothesis:
+        return 0.0
     # Calculates RIBES for each reference and returns the best score.
     for reference in references:
         # Collects the *worder* from the ranked correlation alignments.
@@ -116,6 +118,8 @@ def corpus_ribes(list_of_references, hypotheses, alpha=0.25, beta=0.10):
     # Iterate through each hypothesis and their corresponding references.
     for references, hypothesis in zip(list_of_references, hypotheses):
         corpus_best_ribes += sentence_ribes(references, hypothesis, alpha, beta)
+    if not hypotheses:
+        return 0.0
     return corpus_best_ribes / len(hypotheses)
 
 

--- a/nltk/translate/test_translate_empty_inputs.py
+++ b/nltk/translate/test_translate_empty_inputs.py
@@ -1,0 +1,69 @@
+"""
+Regression tests for ZeroDivisionError in NLTK translate metrics
+when called with empty sequences.
+
+Bugs fixed:
+  1. corpus_chrf([], [])                    -> ZeroDivisionError (num_sents == 0)
+  2. corpus_chrf(refs, hyps, min_len=N, max_len=M) where N > M
+                                            -> ZeroDivisionError (num_ngram_sizes == 0)
+  3. sentence_ribes(refs, [])               -> ZeroDivisionError (len(hypothesis) == 0)
+  4. corpus_ribes([], [])                   -> ZeroDivisionError (len(hypotheses) == 0)
+
+All four functions now return 0.0 for degenerate inputs instead of crashing.
+"""
+import pytest
+
+from nltk.translate.chrf_score import corpus_chrf
+from nltk.translate.ribes_score import corpus_ribes, sentence_ribes
+
+
+# ── corpus_chrf ────────────────────────────────────────────────────────────────
+
+
+def test_corpus_chrf_empty_corpus_returns_zero():
+    """corpus_chrf([], []) must return 0.0 not raise ZeroDivisionError."""
+    assert corpus_chrf([], []) == 0.0
+
+
+def test_corpus_chrf_min_len_greater_than_max_len_returns_zero():
+    """corpus_chrf with min_len > max_len produces no n-gram orders; must not crash."""
+    ref = ["hello", "world"]
+    hyp = ["hello", "world"]
+    assert corpus_chrf([ref], [hyp], min_len=4, max_len=3) == 0.0
+
+
+def test_corpus_chrf_identical_sentences_returns_one():
+    """Regression: corpus_chrf on identical sentences must still return 1.0."""
+    sent = "It is a guide to action".split()
+    result = corpus_chrf([sent], [sent])
+    assert result == pytest.approx(1.0)
+
+
+# ── sentence_ribes ─────────────────────────────────────────────────────────────
+
+
+def test_sentence_ribes_empty_hypothesis_returns_zero():
+    """sentence_ribes with empty hypothesis must return 0.0 not raise ZeroDivisionError."""
+    assert sentence_ribes([["hello", "world"]], []) == 0.0
+
+
+def test_sentence_ribes_identical_returns_one():
+    """Regression: sentence_ribes on identical sentences must still return 1.0."""
+    sent = ["hello", "world"]
+    result = sentence_ribes([sent], sent)
+    assert result == pytest.approx(1.0)
+
+
+# ── corpus_ribes ───────────────────────────────────────────────────────────────
+
+
+def test_corpus_ribes_empty_corpus_returns_zero():
+    """corpus_ribes([], []) must return 0.0 not raise ZeroDivisionError."""
+    assert corpus_ribes([], []) == 0.0
+
+
+def test_corpus_ribes_identical_returns_one():
+    """Regression: corpus_ribes on identical sentences must still return 1.0."""
+    sent = ["hello", "world"]
+    result = corpus_ribes([[sent]], [sent])
+    assert result == pytest.approx(1.0)


### PR DESCRIPTION
## Summary

Fixes four `ZeroDivisionError` crashes in the machine translation metrics module when called with empty sequences.

## Bugs Fixed

### 1. `corpus_chrf([], [])` → `ZeroDivisionError`

```python
corpus_chrf([], [])
# ZeroDivisionError: division by zero  (num_sents == 0)
```

**Fix**: early-return `0.0` when `num_sents == 0`.

### 2. `corpus_chrf(refs, hyps, min_len=N, max_len=M)` where `N > M` → `ZeroDivisionError`

```python
corpus_chrf([ref], [hyp], min_len=4, max_len=3)
# ZeroDivisionError: division by zero  (num_ngram_sizes == 0)
```

**Fix**: early-return `0.0` when `num_ngram_sizes == 0`.

### 3. `sentence_ribes(references, [])` → `ZeroDivisionError`

```python
sentence_ribes([["hello", "world"]], [])
# ZeroDivisionError: division by zero  (len(hypothesis) == 0)
```

**Fix**: early-return `0.0` when `hypothesis` is empty.

### 4. `corpus_ribes([], [])` → `ZeroDivisionError`

```python
corpus_ribes([], [])
# ZeroDivisionError: float division by zero  (len(hypotheses) == 0)
```

**Fix**: early-return `0.0` when `hypotheses` is empty.

## Files Changed

| File | Change |
|---|---|
| `nltk/translate/chrf_score.py` | Guard `num_sents == 0` and `num_ngram_sizes == 0` in `corpus_chrf` |
| `nltk/translate/ribes_score.py` | Guard empty `hypothesis` in `sentence_ribes`; guard empty `hypotheses` in `corpus_ribes` |
| `nltk/translate/test_translate_empty_inputs.py` | 7 unit tests covering all 4 bugs + regression |

## Tests

7 tests — all pass:
- `test_corpus_chrf_empty_corpus_returns_zero`
- `test_corpus_chrf_min_len_greater_than_max_len_returns_zero`
- `test_corpus_chrf_identical_sentences_returns_one` (regression)
- `test_sentence_ribes_empty_hypothesis_returns_zero`
- `test_sentence_ribes_identical_returns_one` (regression)
- `test_corpus_ribes_empty_corpus_returns_zero`
- `test_corpus_ribes_identical_returns_one` (regression)