### PR TITLE
Fix _WordNetObject comparison with non-WordNet types (#1944)

### DIFF
--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -211,12 +211,18 @@ class _WordNetObject:
         return hash(self._name)
 
     def __eq__(self, other):
+        if not isinstance(other, _WordNetObject):
+            return NotImplemented
         return self._name == other._name
 
     def __ne__(self, other):
+        if not isinstance(other, _WordNetObject):
+            return NotImplemented
         return self._name != other._name
 
     def __lt__(self, other):
+        if not isinstance(other, _WordNetObject):
+            return NotImplemented
         return self._name < other._name
 
 

--- a/nltk/test/unit/test_wordnet.py
+++ b/nltk/test/unit/test_wordnet.py
@@ -290,3 +290,33 @@ class WordnNetDemo(unittest.TestCase):
         # Tags that should yield None (not mapped in WordNet)
         self.assertIsNone(wn.tag2pos("PPL", tagset="en-brown"))
         self.assertIsNone(wn.tag2pos("(", tagset="en-brown"))
+
+    def test_wordnet_object_comparisons(self):
+        dog_synset = S("dog.n.01")
+        dog_lemma = L("dog.n.01.dog")
+
+        # Test equality with other types
+        self.assertFalse(dog_synset == "dog.n.01")
+        self.assertFalse(dog_synset == None)
+        self.assertFalse(dog_lemma == "dog.n.01.dog")
+        self.assertFalse(dog_lemma == None)
+
+        # Test inequality with other types
+        self.assertTrue(dog_synset != "dog.n.01")
+        self.assertTrue(dog_synset != None)
+        self.assertTrue(dog_lemma != "dog.n.01.dog")
+        self.assertTrue(dog_lemma != None)
+
+        # Test inequality with other objects (e.g. synset != lemma)
+        self.assertTrue(dog_synset != dog_lemma)
+        self.assertFalse(dog_synset == dog_lemma)
+
+        # Test ordered comparison raises TypeError
+        with self.assertRaises(TypeError):
+            _ = dog_synset < "dog.n.01"
+        with self.assertRaises(TypeError):
+            _ = dog_synset > "dog.n.01"
+        with self.assertRaises(TypeError):
+            _ = dog_lemma < "dog.n.01.dog"
+        with self.assertRaises(TypeError):
+            _ = dog_lemma > "dog.n.01.dog"


### PR DESCRIPTION
Fixes #1944
Currently, comparing a Synset or Lemma to other types (such as strings or None) causes an AttributeError because the code expects the other object to have a `_name` attribute.
This PR updates the comparison methods (`__eq__`, `__ne__`, `__lt__`) in `_WordNetObject` to return `NotImplemented` if the other object is not a `_WordNetObject`. This lets Python fall back to standard comparison behavior (returning False for == and raising a TypeError for <).
Unit tests have been added to verify this behavior.