### PR TITLE
fix(security): block path traversal in NKJPCorpusReader

### DIFF
--- a/nltk/corpus/reader/nkjp.py
+++ b/nltk/corpus/reader/nkjp.py
@@ -95,7 +95,8 @@ class NKJPCorpusReader(XMLCorpusReader):
 
     def add_root(self, fileid):
         """
-        Add root if necessary to specified fileid.
+        Add root if necessary to specified fileid, and verify the resulting
+        path stays inside the corpus root.
 
         Security (CWE-22): the NKJP views build file paths from the
         caller-supplied ``fileids`` and read them with the builtin
@@ -104,13 +105,27 @@ class NKJPCorpusReader(XMLCorpusReader):
         root, otherwise a ``..`` sequence or an absolute path in ``fileids``
         allows reading arbitrary files outside the corpus.
         """
-        if self.root in fileid:
+        # ``str(self.root)`` is the absolute corpus path (``self._root._path``).
+        # We rebuild the path from it rather than from ``self.root`` used as a
+        # raw string, because the latter keeps the *original* (un-normalised)
+        # constructor argument: on Windows its separators differ from the ones
+        # ``os.path.join`` produces, which broke the old substring/concatenation
+        # logic (it duplicated the root, yielding an invalid path).
+        root = os.path.abspath(str(self.root))
+        fileid = str(fileid)
+        if os.path.isabs(fileid):
             result = fileid
         else:
-            result = self.root + fileid
-        root = os.path.normpath(str(self.root))
-        resolved = os.path.normpath(str(result))
-        if resolved != root and not resolved.startswith(root + os.sep):
+            result = os.path.join(root, fileid)
+        resolved = os.path.abspath(result)
+        try:
+            contained = resolved == root or os.path.commonpath([root, resolved]) == root
+        except ValueError:
+            # Raised when the paths live on different drives (Windows) or mix
+            # absolute and relative parts -- in every such case the fileid is
+            # outside the corpus root.
+            contained = False
+        if not contained:
             raise ValueError(
                 f"NKJP fileid escapes the corpus root (path traversal blocked): {fileid!r}"
             )

--- a/nltk/corpus/reader/nkjp.py
+++ b/nltk/corpus/reader/nkjp.py
@@ -172,7 +172,7 @@ class NKJPCorpusReader(XMLCorpusReader):
                     self.add_root(fileid),
                     mode=NKJPCorpusReader.WORDS_MODE,
                     tags=tags,
-                    **kwargs
+                    **kwargs,
                 ).handle_query()
                 for fileid in fileids
             ]

--- a/nltk/corpus/reader/nkjp.py
+++ b/nltk/corpus/reader/nkjp.py
@@ -101,34 +101,31 @@ class NKJPCorpusReader(XMLCorpusReader):
         Security (CWE-22): the NKJP views build file paths from the
         caller-supplied ``fileids`` and read them with the builtin
         ``open()``, bypassing the ``CorpusReader.open()`` / ``nltk.pathsec``
-        sandbox.  Reject any fileid whose resulting path escapes the corpus
-        root, otherwise a ``..`` sequence or an absolute path in ``fileids``
-        allows reading arbitrary files outside the corpus.
+        sandbox.  Route the resulting path through
+        ``nltk.pathsec.validate_path()`` with the corpus root as
+        ``required_root`` -- the same symlink-resolving containment guard used
+        by ``CorpusReader.open()`` (PR #3528) -- so that a ``..`` sequence, an
+        absolute path, or a symlink in ``fileids`` cannot escape the corpus
+        root.
         """
-        # ``str(self.root)`` is the absolute corpus path (``self._root._path``).
-        # We rebuild the path from it rather than from ``self.root`` used as a
-        # raw string, because the latter keeps the *original* (un-normalised)
-        # constructor argument: on Windows its separators differ from the ones
-        # ``os.path.join`` produces, which broke the old substring/concatenation
-        # logic (it duplicated the root, yielding an invalid path).
+        from nltk.pathsec import validate_path
+
+        # ``str(self.root)`` is the original (un-normalised) constructor
+        # argument; abspath() gives the platform-native absolute root that
+        # ``os.path.join`` expects (the old substring/concatenation logic
+        # duplicated the root on Windows, where the separators differ).
         root = os.path.abspath(str(self.root))
         fileid = str(fileid)
         if os.path.isabs(fileid):
             result = fileid
         else:
             result = os.path.join(root, fileid)
-        resolved = os.path.abspath(result)
-        try:
-            contained = resolved == root or os.path.commonpath([root, resolved]) == root
-        except ValueError:
-            # Raised when the paths live on different drives (Windows) or mix
-            # absolute and relative parts -- in every such case the fileid is
-            # outside the corpus root.
-            contained = False
-        if not contained:
-            raise ValueError(
-                f"NKJP fileid escapes the corpus root (path traversal blocked): {fileid!r}"
-            )
+        # Symlink-aware containment: validate_path() resolves both the
+        # candidate path and the root (``Path(...).resolve()``) before
+        # comparing, and raises ValueError if the resolved path leaves the
+        # corpus root -- unlike os.path.abspath(), which does not follow
+        # symlinks, so an in-root symlink could otherwise point outside.
+        validate_path(result, context="NKJPCorpusReader", required_root=self.root)
         return result
 
     @_parse_args

--- a/nltk/corpus/reader/nkjp.py
+++ b/nltk/corpus/reader/nkjp.py
@@ -96,10 +96,25 @@ class NKJPCorpusReader(XMLCorpusReader):
     def add_root(self, fileid):
         """
         Add root if necessary to specified fileid.
+
+        Security (CWE-22): the NKJP views build file paths from the
+        caller-supplied ``fileids`` and read them with the builtin
+        ``open()``, bypassing the ``CorpusReader.open()`` / ``nltk.pathsec``
+        sandbox.  Reject any fileid whose resulting path escapes the corpus
+        root, otherwise a ``..`` sequence or an absolute path in ``fileids``
+        allows reading arbitrary files outside the corpus.
         """
         if self.root in fileid:
-            return fileid
-        return self.root + fileid
+            result = fileid
+        else:
+            result = self.root + fileid
+        root = os.path.normpath(str(self.root))
+        resolved = os.path.normpath(str(result))
+        if resolved != root and not resolved.startswith(root + os.sep):
+            raise ValueError(
+                f"NKJP fileid escapes the corpus root (path traversal blocked): {fileid!r}"
+            )
+        return result
 
     @_parse_args
     def header(self, fileids=None, **kwargs):

--- a/nltk/test/unit/test_nkjp_security.py
+++ b/nltk/test/unit/test_nkjp_security.py
@@ -2,8 +2,10 @@
 
 The NKJP views build file paths from the caller-supplied ``fileids`` and read
 them with the builtin ``open()``, bypassing the ``CorpusReader.open()`` /
-``nltk.pathsec`` sandbox.  A ``..`` sequence (or an absolute path) in
-``fileids`` must not be allowed to escape the corpus root.
+``nltk.pathsec`` sandbox.  A ``..`` sequence, an absolute path, or an in-root
+symlink in ``fileids`` must not be allowed to escape the corpus root.  The
+containment check is symlink-aware (``nltk.pathsec.validate_path`` resolves the
+path before comparing), so ``os.path.abspath`` is not enough to fool it.
 
 The paths below are built with ``os.sep`` / ``os.path.join`` / ``os.pardir``
 so the tests behave identically on POSIX and Windows.
@@ -64,3 +66,30 @@ def test_nkjp_words_rejects_traversal_fileid(tmp_path):
     evil = os.path.join(str(root), os.pardir, "outside") + os.sep
     with pytest.raises(ValueError):
         reader.words(fileids=[evil])
+
+
+def test_nkjp_header_rejects_inroot_symlink_escape(tmp_path):
+    """A symlink *inside* the corpus root that points outside must be rejected.
+
+    This is the case ``os.path.abspath`` cannot catch: the candidate path is
+    lexically in-root, so only resolving the symlink (as ``validate_path``
+    does) reveals that it escapes. Skipped where symlinks are unavailable.
+    """
+    root = _make_corpus(tmp_path)
+
+    secret_dir = tmp_path / "outside"
+    secret_dir.mkdir()
+    (secret_dir / "header.xml").write_text(_HEADER.format(title="SECRET"))
+
+    link = root / "evil"
+    try:
+        os.symlink(secret_dir, link, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported on this platform")
+
+    reader = _reader(root)
+    # `link` is lexically inside the corpus root, so abspath()-based
+    # containment would wrongly allow it; the resolved path is in `outside`.
+    evil = str(link) + os.sep
+    with pytest.raises(ValueError):
+        reader.header(fileids=[evil])

--- a/nltk/test/unit/test_nkjp_security.py
+++ b/nltk/test/unit/test_nkjp_security.py
@@ -4,6 +4,9 @@ The NKJP views build file paths from the caller-supplied ``fileids`` and read
 them with the builtin ``open()``, bypassing the ``CorpusReader.open()`` /
 ``nltk.pathsec`` sandbox.  A ``..`` sequence (or an absolute path) in
 ``fileids`` must not be allowed to escape the corpus root.
+
+The paths below are built with ``os.sep`` / ``os.path.join`` / ``os.pardir``
+so the tests behave identically on POSIX and Windows.
 """
 
 import os
@@ -26,10 +29,15 @@ def _make_corpus(tmp_path):
     return root
 
 
+def _reader(root):
+    # The trailing separator is added with os.sep, so the root keeps the shape
+    # the reader is normally given without hard-coding a POSIX "/".
+    return NKJPCorpusReader(root=str(root) + os.sep, fileids="sample")
+
+
 def test_nkjp_header_default_fileids_still_works(tmp_path):
     """The legitimate (in-root) flow must keep working after the fix."""
-    root = _make_corpus(tmp_path)
-    reader = NKJPCorpusReader(root=str(root) + "/", fileids="sample")
+    reader = _reader(_make_corpus(tmp_path))
     out = reader.header()
     assert out and out[0]["title"] == "IN-ROOT"
 
@@ -42,8 +50,9 @@ def test_nkjp_header_rejects_traversal_fileid(tmp_path):
     secret_dir.mkdir()
     (secret_dir / "header.xml").write_text(_HEADER.format(title="SECRET"))
 
-    reader = NKJPCorpusReader(root=str(root) + "/", fileids="sample")
-    evil = str(root) + "/../../../../../.." + str(secret_dir) + "/"
+    reader = _reader(root)
+    # Climb out of the corpus root into the sibling "outside" directory.
+    evil = os.path.join(str(root), os.pardir, "outside") + os.sep
     with pytest.raises(ValueError):
         reader.header(fileids=[evil])
 
@@ -51,7 +60,7 @@ def test_nkjp_header_rejects_traversal_fileid(tmp_path):
 def test_nkjp_words_rejects_traversal_fileid(tmp_path):
     """All NKJP read modes funnel through add_root(); words() must reject too."""
     root = _make_corpus(tmp_path)
-    reader = NKJPCorpusReader(root=str(root) + "/", fileids="sample")
-    evil = str(root) + "/../../../../../../etc/"
+    reader = _reader(root)
+    evil = os.path.join(str(root), os.pardir, "outside") + os.sep
     with pytest.raises(ValueError):
         reader.words(fileids=[evil])

--- a/nltk/test/unit/test_nkjp_security.py
+++ b/nltk/test/unit/test_nkjp_security.py
@@ -1,0 +1,57 @@
+"""Regression tests for path traversal in NKJPCorpusReader (CWE-22).
+
+The NKJP views build file paths from the caller-supplied ``fileids`` and read
+them with the builtin ``open()``, bypassing the ``CorpusReader.open()`` /
+``nltk.pathsec`` sandbox.  A ``..`` sequence (or an absolute path) in
+``fileids`` must not be allowed to escape the corpus root.
+"""
+
+import os
+
+import pytest
+
+from nltk.corpus.reader.nkjp import NKJPCorpusReader
+
+_HEADER = (
+    "<teiHeader><fileDesc><sourceDesc><bibl>"
+    "<title>{title}</title>"
+    "</bibl></sourceDesc></fileDesc></teiHeader>"
+)
+
+
+def _make_corpus(tmp_path):
+    root = tmp_path / "corpus"
+    (root / "sample").mkdir(parents=True)
+    (root / "sample" / "header.xml").write_text(_HEADER.format(title="IN-ROOT"))
+    return root
+
+
+def test_nkjp_header_default_fileids_still_works(tmp_path):
+    """The legitimate (in-root) flow must keep working after the fix."""
+    root = _make_corpus(tmp_path)
+    reader = NKJPCorpusReader(root=str(root) + "/", fileids="sample")
+    out = reader.header()
+    assert out and out[0]["title"] == "IN-ROOT"
+
+
+def test_nkjp_header_rejects_traversal_fileid(tmp_path):
+    """A ../ traversal in fileids must be rejected, not read from disk."""
+    root = _make_corpus(tmp_path)
+
+    secret_dir = tmp_path / "outside"
+    secret_dir.mkdir()
+    (secret_dir / "header.xml").write_text(_HEADER.format(title="SECRET"))
+
+    reader = NKJPCorpusReader(root=str(root) + "/", fileids="sample")
+    evil = str(root) + "/../../../../../.." + str(secret_dir) + "/"
+    with pytest.raises(ValueError):
+        reader.header(fileids=[evil])
+
+
+def test_nkjp_words_rejects_traversal_fileid(tmp_path):
+    """All NKJP read modes funnel through add_root(); words() must reject too."""
+    root = _make_corpus(tmp_path)
+    reader = NKJPCorpusReader(root=str(root) + "/", fileids="sample")
+    evil = str(root) + "/../../../../../../etc/"
+    with pytest.raises(ValueError):
+        reader.words(fileids=[evil])


### PR DESCRIPTION
## Summary
`NKJPCorpusReader`'s public read methods (`header`, `raw`, `words`, `sents`,
`tagged_words`) build file paths from the caller-supplied `fileids` and read
them with the **builtin `open()`**, bypassing the `CorpusReader.open()` /
`nltk.pathsec` sandbox — including the strict `ENFORCE = True` mode documented
in `SECURITY.md`. A `..` sequence or an absolute path in `fileids` escapes the
corpus root, allowing arbitrary file reads.

`NKJPCorpusReader` never goes through `nltk.data.find()` or
`CorpusReader.open()`; it concatenates the path itself in `add_root()` and reads
it with the builtin `open()`. As a result it bypasses the corpus-reader
path-traversal hardening added in #3479 (`CorpusReader.open()` CWE-22 guard),
#3480 (`FileSystemPathPointer` containment), #3522 (the `nltk.pathsec` central
sentinel) and #3528 (symlink containment) — none of those protect this reader.

## Details
In `nltk/corpus/reader/nkjp.py`:
- `add_root()` builds the path by plain string concatenation with no
  containment check (`return self.root + fileid`).
- The views then read it with the builtin `open()` (`XML_Tool` →
  `os.path.join(root, filename)` + `open()`; `NKJPCorpus_Header_View` →
  `filename + "header.xml"` opened via `StreamBackedCorpusView`).

Because the builtin `open()` is used (not `PathPointer.open()` /
`CorpusReader.open()`), `nltk.pathsec.validate_path()` is never invoked, so
`ENFORCE = True` does not block the access.

PoC (before this change), with `nltk.pathsec.ENFORCE = True`:
```python
from nltk.corpus.reader.nkjp import NKJPCorpusReader
r = NKJPCorpusReader(root="/path/to/corpora/nkjp/", fileids="sample")
r.header(fileids=["/path/to/corpora/nkjp/../../../../../../etc/"])
# -> opens /etc/header.xml via builtin open() and returns its parsed content
```

## Fix
Harden `add_root()` to reject any fileid whose resolved path leaves the corpus
root, matching the containment guarantee already provided by
`CorpusReader.open()`. The legitimate in-root flow (default `fileids` and
absolute fileids that stay within the corpus) is unchanged.

## Tests
Adds `nltk/test/unit/test_nkjp_security.py`:
- legitimate `header()` (default in-root fileids) still works;
- `header()` and `words()` raise `ValueError` on a `../` traversal fileid.
