### PR TITLE
fix(security): block path traversal in FramenetCorpusReader.frame()

### DIFF
--- a/nltk/corpus/reader/framenet.py
+++ b/nltk/corpus/reader/framenet.py
@@ -1362,6 +1362,12 @@ warnings(True) to display corpus consistency warnings when loading data
         except KeyError as e:  # probably means that fn_docid was not in the index
             raise FramenetError(f"Unknown document id: {fn_docid}") from e
 
+        # Security (CWE-22): defend against a malicious corpus index whose
+        # filename field contains path-traversal sequences (the file is read with
+        # the builtin open() via XMLCorpusView, bypassing nltk.pathsec).
+        if os.sep in xmlfname or "/" in xmlfname or "\\" in xmlfname or ".." in xmlfname:
+            raise FramenetError(f"Invalid document filename: {xmlfname!r}")
+
         # construct the path name for the xml file containing the document info
         locpath = os.path.join(f"{self._root}", self._fulltext_dir, xmlfname)
 
@@ -1451,6 +1457,14 @@ warnings(True) to display corpus consistency warnings when loading data
             return self._frame_idx[self._cached_frames[fn_fname]]
         elif not self._frame_idx:
             self._buildframeindex()
+
+        # Security (CWE-22): the frame name is interpolated into the XML file
+        # path, which is then read with the builtin open() (via XMLCorpusView),
+        # bypassing the CorpusReader.open() / nltk.pathsec sandbox.  Reject names
+        # containing path separators or parent-directory references so a crafted
+        # name cannot escape the corpus root and read arbitrary files.
+        if os.sep in fn_fname or "/" in fn_fname or "\\" in fn_fname or ".." in fn_fname:
+            raise FramenetError(f"Invalid frame name: {fn_fname!r}")
 
         # construct the path name for the xml file containing the Frame info
         locpath = os.path.join(f"{self._root}", self._frame_dir, fn_fname + ".xml")

--- a/nltk/corpus/reader/framenet.py
+++ b/nltk/corpus/reader/framenet.py
@@ -1824,6 +1824,18 @@ warnings(True) to display corpus consistency warnings when loading data
         """
         fn_luid = lu.ID
 
+        # Security (CWE-22): the LU id comes from corpus data (a <lexUnit ID="...">
+        # attribute) and is interpolated into the XML file path read with the
+        # builtin open() via XMLCorpusView, bypassing nltk.pathsec.  A non-numeric
+        # id can carry path-traversal sequences; reject separators / parent refs.
+        if (
+            os.sep in str(fn_luid)
+            or "/" in str(fn_luid)
+            or "\\" in str(fn_luid)
+            or ".." in str(fn_luid)
+        ):
+            raise FramenetError(f"Invalid LU id: {fn_luid!r}")
+
         fname = f"lu{fn_luid}.xml"
         locpath = os.path.join(f"{self._root}", self._lu_dir, fname)
         # print(locpath, file=sys.stderr)

--- a/nltk/corpus/reader/framenet.py
+++ b/nltk/corpus/reader/framenet.py
@@ -1365,7 +1365,12 @@ warnings(True) to display corpus consistency warnings when loading data
         # Security (CWE-22): defend against a malicious corpus index whose
         # filename field contains path-traversal sequences (the file is read with
         # the builtin open() via XMLCorpusView, bypassing nltk.pathsec).
-        if os.sep in xmlfname or "/" in xmlfname or "\\" in xmlfname or ".." in xmlfname:
+        if (
+            os.sep in xmlfname
+            or "/" in xmlfname
+            or "\\" in xmlfname
+            or ".." in xmlfname
+        ):
             raise FramenetError(f"Invalid document filename: {xmlfname!r}")
 
         # construct the path name for the xml file containing the document info
@@ -1463,7 +1468,12 @@ warnings(True) to display corpus consistency warnings when loading data
         # bypassing the CorpusReader.open() / nltk.pathsec sandbox.  Reject names
         # containing path separators or parent-directory references so a crafted
         # name cannot escape the corpus root and read arbitrary files.
-        if os.sep in fn_fname or "/" in fn_fname or "\\" in fn_fname or ".." in fn_fname:
+        if (
+            os.sep in fn_fname
+            or "/" in fn_fname
+            or "\\" in fn_fname
+            or ".." in fn_fname
+        ):
             raise FramenetError(f"Invalid frame name: {fn_fname!r}")
 
         # construct the path name for the xml file containing the Frame info

--- a/nltk/corpus/reader/framenet.py
+++ b/nltk/corpus/reader/framenet.py
@@ -12,6 +12,7 @@ Corpus reader for the FrameNet 1.7 lexicon and corpus.
 """
 
 import itertools
+import ntpath
 import os
 import re
 import sys
@@ -756,6 +757,28 @@ class FramenetError(Exception):
     """An exception class for framenet-related errors."""
 
 
+def _reject_unsafe_path_component(value, kind):
+    """Reject a corpus-/caller-supplied name that could escape the corpus root.
+
+    ``doc()``, ``frame_by_name()`` and ``_lu_file()`` interpolate a name into an
+    XML file path (CWE-22).  Besides POSIX/Windows separators and ``..``, this
+    also rejects a Windows drive- or UNC-qualified name such as ``C:evil`` or
+    ``\\\\host\\share``: it contains no separator, yet ``os.path.join`` discards
+    the corpus root when the name carries a drive on Windows.
+    ``ntpath.splitdrive`` is used rather than ``os.path.splitdrive`` so the
+    check applies on every platform (and stays testable off Windows).
+    """
+    value = str(value)
+    if (
+        os.sep in value
+        or "/" in value
+        or "\\" in value
+        or ".." in value
+        or ntpath.splitdrive(value)[0]
+    ):
+        raise FramenetError(f"Invalid {kind}: {value!r}")
+
+
 class AttrDict(dict):
     """A class that wraps a dict and allows accessing the keys of the
     dict as if they were attributes. Taken from here:
@@ -1363,18 +1386,14 @@ warnings(True) to display corpus consistency warnings when loading data
             raise FramenetError(f"Unknown document id: {fn_docid}") from e
 
         # Security (CWE-22): defend against a malicious corpus index whose
-        # filename field contains path-traversal sequences (the file is read with
-        # the builtin open() via XMLCorpusView, bypassing nltk.pathsec).
-        if (
-            os.sep in xmlfname
-            or "/" in xmlfname
-            or "\\" in xmlfname
-            or ".." in xmlfname
-        ):
-            raise FramenetError(f"Invalid document filename: {xmlfname!r}")
+        # filename field contains path-traversal sequences.  Reject the unsafe
+        # name and resolve the path through self.abspath() so the file is read
+        # via the PathPointer / nltk.pathsec sandbox instead of the builtin
+        # open() that a bare string path would use in XMLCorpusView.
+        _reject_unsafe_path_component(xmlfname, "document filename")
 
         # construct the path name for the xml file containing the document info
-        locpath = os.path.join(f"{self._root}", self._fulltext_dir, xmlfname)
+        locpath = self.abspath(os.path.join(self._fulltext_dir, xmlfname))
 
         # Grab the top-level xml element containing the fulltext annotation
         with XMLCorpusView(locpath, "fullTextAnnotation") as view:
@@ -1464,23 +1483,15 @@ warnings(True) to display corpus consistency warnings when loading data
             self._buildframeindex()
 
         # Security (CWE-22): the frame name is interpolated into the XML file
-        # path, which is then read with the builtin open() (via XMLCorpusView),
-        # bypassing the CorpusReader.open() / nltk.pathsec sandbox.  Reject names
-        # containing path separators or parent-directory references so a crafted
-        # name cannot escape the corpus root and read arbitrary files.
-        if (
-            os.sep in fn_fname
-            or "/" in fn_fname
-            or "\\" in fn_fname
-            or ".." in fn_fname
-        ):
-            raise FramenetError(f"Invalid frame name: {fn_fname!r}")
+        # path.  Reject crafted names, then resolve through self.abspath() so the
+        # file is read via the PathPointer / nltk.pathsec sandbox rather than the
+        # builtin open() that a bare string path would use in XMLCorpusView.
+        _reject_unsafe_path_component(fn_fname, "frame name")
 
         # construct the path name for the xml file containing the Frame info
-        locpath = os.path.join(f"{self._root}", self._frame_dir, fn_fname + ".xml")
-        # print(locpath, file=sys.stderr)
         # Grab the xml for the frame
         try:
+            locpath = self.abspath(os.path.join(self._frame_dir, fn_fname + ".xml"))
             with XMLCorpusView(locpath, "frame") as view:
                 elt = view[0]
         except OSError as e:
@@ -1825,24 +1836,18 @@ warnings(True) to display corpus consistency warnings when loading data
         fn_luid = lu.ID
 
         # Security (CWE-22): the LU id comes from corpus data (a <lexUnit ID="...">
-        # attribute) and is interpolated into the XML file path read with the
-        # builtin open() via XMLCorpusView, bypassing nltk.pathsec.  A non-numeric
-        # id can carry path-traversal sequences; reject separators / parent refs.
-        if (
-            os.sep in str(fn_luid)
-            or "/" in str(fn_luid)
-            or "\\" in str(fn_luid)
-            or ".." in str(fn_luid)
-        ):
-            raise FramenetError(f"Invalid LU id: {fn_luid!r}")
+        # attribute) and is interpolated into the XML file path.  A non-numeric
+        # id can carry path-traversal sequences; reject it, then resolve through
+        # self.abspath() so the file is read via the PathPointer / nltk.pathsec
+        # sandbox rather than the builtin open() used for a bare string path.
+        _reject_unsafe_path_component(fn_luid, "LU id")
 
         fname = f"lu{fn_luid}.xml"
-        locpath = os.path.join(f"{self._root}", self._lu_dir, fname)
-        # print(locpath, file=sys.stderr)
         if not self._lu_idx:
             self._buildluindex()
 
         try:
+            locpath = self.abspath(os.path.join(self._lu_dir, fname))
             with XMLCorpusView(locpath, "lexUnit") as view:
                 elt = view[0]
         except OSError as e:

--- a/nltk/test/unit/test_framenet_security.py
+++ b/nltk/test/unit/test_framenet_security.py
@@ -1,0 +1,58 @@
+"""Regression tests for path traversal in FramenetCorpusReader (CWE-22).
+
+``frame(name)`` interpolates the caller-supplied frame name into an XML file
+path which is then read with the builtin ``open()`` (via ``XMLCorpusView``),
+bypassing the ``CorpusReader.open()`` / ``nltk.pathsec`` sandbox.  A ``..``
+sequence in the name must not be allowed to escape the corpus root.
+"""
+
+import builtins
+import os
+
+import pytest
+
+from nltk.corpus.reader.framenet import FramenetCorpusReader, FramenetError
+
+
+def _make_corpus(tmp_path):
+    root = tmp_path / "framenet"
+    for d in ("frame", "fulltext", "lu"):
+        (root / d).mkdir(parents=True)
+    (root / "frameIndex.xml").write_text('<?xml version="1.0"?><frameIndex></frameIndex>')
+    (root / "frRelation.xml").write_text(
+        '<?xml version="1.0"?><frameRelations></frameRelations>'
+    )
+    return root
+
+
+def test_framenet_rejects_traversal_frame_name(tmp_path):
+    """A ../ traversal in the frame name must be rejected before any file read."""
+    root = _make_corpus(tmp_path)
+
+    secret_dir = tmp_path / "outside"
+    secret_dir.mkdir()
+    (secret_dir / "pwn.xml").write_text("<frame ID='1' name='x'><definition>S</definition></frame>")
+
+    fn = FramenetCorpusReader(str(root), [])
+
+    opened = []
+    real_open = builtins.open
+    builtins.open = lambda f, *a, **k: (opened.append(str(f)), real_open(f, *a, **k))[1]
+    try:
+        with pytest.raises(FramenetError):
+            fn.frame("../../../../../.." + str(secret_dir) + "/pwn")
+    finally:
+        builtins.open = real_open
+
+    assert not any("outside" in p for p in opened), "traversal reached the filesystem"
+
+
+def test_framenet_allows_normal_frame_name(tmp_path):
+    """A normal frame name must pass validation (and only fail as 'unknown')."""
+    root = _make_corpus(tmp_path)
+    fn = FramenetCorpusReader(str(root), [])
+    # No such frame file exists -> FramenetError("Unknown frame: ..."), NOT the
+    # "Invalid frame name" rejection. This proves legitimate lookups still work.
+    with pytest.raises(FramenetError) as exc:
+        fn.frame("NoSuchFrame")
+    assert "Invalid frame name" not in str(exc.value)

--- a/nltk/test/unit/test_framenet_security.py
+++ b/nltk/test/unit/test_framenet_security.py
@@ -18,7 +18,9 @@ def _make_corpus(tmp_path):
     root = tmp_path / "framenet"
     for d in ("frame", "fulltext", "lu"):
         (root / d).mkdir(parents=True)
-    (root / "frameIndex.xml").write_text('<?xml version="1.0"?><frameIndex></frameIndex>')
+    (root / "frameIndex.xml").write_text(
+        '<?xml version="1.0"?><frameIndex></frameIndex>'
+    )
     (root / "frRelation.xml").write_text(
         '<?xml version="1.0"?><frameRelations></frameRelations>'
     )
@@ -31,7 +33,9 @@ def test_framenet_rejects_traversal_frame_name(tmp_path):
 
     secret_dir = tmp_path / "outside"
     secret_dir.mkdir()
-    (secret_dir / "pwn.xml").write_text("<frame ID='1' name='x'><definition>S</definition></frame>")
+    (secret_dir / "pwn.xml").write_text(
+        "<frame ID='1' name='x'><definition>S</definition></frame>"
+    )
 
     fn = FramenetCorpusReader(str(root), [])
 

--- a/nltk/test/unit/test_framenet_security.py
+++ b/nltk/test/unit/test_framenet_security.py
@@ -60,3 +60,31 @@ def test_framenet_allows_normal_frame_name(tmp_path):
     with pytest.raises(FramenetError) as exc:
         fn.frame("NoSuchFrame")
     assert "Invalid frame name" not in str(exc.value)
+
+
+def test_framenet_lu_file_rejects_traversal_id(tmp_path):
+    """A non-numeric LU id from corpus data must not escape the corpus root."""
+    from nltk.corpus.reader.framenet import AttrDict
+
+    root = _make_corpus(tmp_path)
+    (root / "luIndex.xml").write_text('<?xml version="1.0"?><luIndex></luIndex>')
+
+    secret_dir = tmp_path / "outside"
+    secret_dir.mkdir()
+    (secret_dir / "SECRET.xml").write_text("<lexUnit>x</lexUnit>")
+
+    fn = FramenetCorpusReader(str(root), [])
+    lu = AttrDict({"ID": "/../../../../../.." + str(secret_dir) + "/SECRET"})
+
+    opened = []
+    real_open = builtins.open
+    builtins.open = lambda f, *a, **k: (opened.append(str(f)), real_open(f, *a, **k))[1]
+    try:
+        with pytest.raises(FramenetError):
+            fn._lu_file(lu)
+    finally:
+        builtins.open = real_open
+
+    assert not any(
+        "outside" in p for p in opened
+    ), "LU-id traversal reached the filesystem"

--- a/nltk/test/unit/test_framenet_security.py
+++ b/nltk/test/unit/test_framenet_security.py
@@ -1,9 +1,14 @@
 """Regression tests for path traversal in FramenetCorpusReader (CWE-22).
 
-``frame(name)`` interpolates the caller-supplied frame name into an XML file
-path which is then read with the builtin ``open()`` (via ``XMLCorpusView``),
-bypassing the ``CorpusReader.open()`` / ``nltk.pathsec`` sandbox.  A ``..``
-sequence in the name must not be allowed to escape the corpus root.
+``doc()``, ``frame_by_name()`` and ``_lu_file()`` interpolate a caller- or
+corpus-supplied name into an XML file path that is then read via
+``XMLCorpusView``.  A ``..`` sequence, an absolute path, or a Windows drive/UNC
+prefix in that name must be rejected *before* any file is opened, while a
+legitimate name must still resolve and read correctly through ``self.abspath()``
+(the ``nltk.pathsec`` sandbox).
+
+Paths are built with ``os.path.join`` / ``os.pardir`` so the tests behave the
+same on POSIX and Windows.
 """
 
 import builtins
@@ -11,7 +16,19 @@ import os
 
 import pytest
 
-from nltk.corpus.reader.framenet import FramenetCorpusReader, FramenetError
+from nltk.corpus.reader.framenet import (
+    AttrDict,
+    FramenetCorpusReader,
+    FramenetError,
+    _reject_unsafe_path_component,
+)
+
+_FRAME_XML = (
+    '<?xml version="1.0" encoding="UTF-8"?>\n'
+    '<frame xmlns="http://framenet.icsi.berkeley.edu" ID="42" name="{name}">\n'
+    "<definition>A minimal test frame.</definition>\n"
+    "</frame>\n"
+)
 
 
 def _make_corpus(tmp_path):
@@ -27,64 +44,117 @@ def _make_corpus(tmp_path):
     return root
 
 
-def test_framenet_rejects_traversal_frame_name(tmp_path):
-    """A ../ traversal in the frame name must be rejected before any file read."""
-    root = _make_corpus(tmp_path)
-
-    secret_dir = tmp_path / "outside"
-    secret_dir.mkdir()
-    (secret_dir / "pwn.xml").write_text(
-        "<frame ID='1' name='x'><definition>S</definition></frame>"
-    )
-
-    fn = FramenetCorpusReader(str(root), [])
-
+def _record_opens(monkeypatch):
+    """Spy on builtin open() so a test can assert nothing outside the corpus
+    was ever opened."""
     opened = []
     real_open = builtins.open
-    builtins.open = lambda f, *a, **k: (opened.append(str(f)), real_open(f, *a, **k))[1]
-    try:
-        with pytest.raises(FramenetError):
-            fn.frame("../../../../../.." + str(secret_dir) + "/pwn")
-    finally:
-        builtins.open = real_open
 
-    assert not any("outside" in p for p in opened), "traversal reached the filesystem"
+    def spy(file, *args, **kwargs):
+        opened.append(str(file))
+        return real_open(file, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", spy)
+    return opened
+
+
+# --- legitimate flow still works (guards against the abspath() refactor) -------
+
+
+def test_framenet_frame_reads_legitimate_file(tmp_path):
+    """A real in-root frame must still parse after routing through abspath()."""
+    root = _make_corpus(tmp_path)
+    (root / "frame" / "TestFrame.xml").write_text(_FRAME_XML.format(name="TestFrame"))
+
+    fn = FramenetCorpusReader(str(root), [])
+    f = fn.frame("TestFrame")
+    assert f.name == "TestFrame"
+    assert str(f.ID) == "42"
 
 
 def test_framenet_allows_normal_frame_name(tmp_path):
-    """A normal frame name must pass validation (and only fail as 'unknown')."""
-    root = _make_corpus(tmp_path)
-    fn = FramenetCorpusReader(str(root), [])
-    # No such frame file exists -> FramenetError("Unknown frame: ..."), NOT the
-    # "Invalid frame name" rejection. This proves legitimate lookups still work.
+    """A normal but absent frame name fails as 'unknown', not 'invalid'."""
+    fn = FramenetCorpusReader(str(_make_corpus(tmp_path)), [])
     with pytest.raises(FramenetError) as exc:
         fn.frame("NoSuchFrame")
     assert "Invalid frame name" not in str(exc.value)
+    assert "Unknown frame" in str(exc.value)
 
 
-def test_framenet_lu_file_rejects_traversal_id(tmp_path):
-    """A non-numeric LU id from corpus data must not escape the corpus root."""
-    from nltk.corpus.reader.framenet import AttrDict
+# --- frame_by_name(): traversal + Windows drive rejection ----------------------
 
+
+def test_framenet_rejects_traversal_frame_name(tmp_path, monkeypatch):
+    """A ../ traversal in the frame name is rejected before any file read."""
     root = _make_corpus(tmp_path)
-    (root / "luIndex.xml").write_text('<?xml version="1.0"?><luIndex></luIndex>')
-
-    secret_dir = tmp_path / "outside"
-    secret_dir.mkdir()
-    (secret_dir / "SECRET.xml").write_text("<lexUnit>x</lexUnit>")
+    secret = tmp_path / "outside"
+    secret.mkdir()
+    (secret / "pwn.xml").write_text(_FRAME_XML.format(name="pwned"))
 
     fn = FramenetCorpusReader(str(root), [])
-    lu = AttrDict({"ID": "/../../../../../.." + str(secret_dir) + "/SECRET"})
+    opened = _record_opens(monkeypatch)
+    evil = os.path.join(os.pardir, os.pardir, "outside", "pwn")
+    with pytest.raises(FramenetError, match="Invalid frame name"):
+        fn.frame(evil)
+    assert not any("outside" in p for p in opened), "traversal reached the filesystem"
 
-    opened = []
-    real_open = builtins.open
-    builtins.open = lambda f, *a, **k: (opened.append(str(f)), real_open(f, *a, **k))[1]
-    try:
-        with pytest.raises(FramenetError):
-            fn._lu_file(lu)
-    finally:
-        builtins.open = real_open
 
-    assert not any(
-        "outside" in p for p in opened
-    ), "LU-id traversal reached the filesystem"
+def test_framenet_rejects_drive_prefixed_frame_name(tmp_path):
+    """A Windows drive-qualified name (no separator, no '..') is rejected."""
+    fn = FramenetCorpusReader(str(_make_corpus(tmp_path)), [])
+    with pytest.raises(FramenetError, match="Invalid frame name"):
+        fn.frame("C:evil")
+
+
+# --- doc(): the fulltext filename comes from the (untrusted) corpus index ------
+
+
+def test_framenet_doc_rejects_traversal_filename(tmp_path, monkeypatch):
+    root = _make_corpus(tmp_path)
+    fn = FramenetCorpusReader(str(root), [])
+    # Simulate a crafted corpus index whose document filename traverses out.
+    evil = os.path.join(os.pardir, os.pardir, "outside", "pwn")
+    fn._fulltext_idx = {7: AttrDict({"filename": evil})}
+
+    opened = _record_opens(monkeypatch)
+    with pytest.raises(FramenetError, match="Invalid document filename"):
+        fn.doc(7)
+    assert not any("outside" in p for p in opened), "traversal reached the filesystem"
+
+
+def test_framenet_doc_rejects_drive_prefixed_filename(tmp_path):
+    fn = FramenetCorpusReader(str(_make_corpus(tmp_path)), [])
+    fn._fulltext_idx = {7: AttrDict({"filename": "C:evil"})}
+    with pytest.raises(FramenetError, match="Invalid document filename"):
+        fn.doc(7)
+
+
+# --- _lu_file(): the LU id comes from corpus data ------------------------------
+
+
+def test_framenet_lu_file_rejects_traversal_id(tmp_path, monkeypatch):
+    root = _make_corpus(tmp_path)
+    fn = FramenetCorpusReader(str(root), [])
+    lu = AttrDict({"ID": os.path.join(os.pardir, os.pardir, "outside", "SECRET")})
+
+    opened = _record_opens(monkeypatch)
+    with pytest.raises(FramenetError, match="Invalid LU id"):
+        fn._lu_file(lu)
+    assert not any("outside" in p for p in opened), "traversal reached the filesystem"
+
+
+# --- the validation helper itself ---------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["../x", "a/b", "a\\b", "..", "C:evil", r"\\host\share\x", "/abs.xml"],
+)
+def test_reject_unsafe_path_component_blocks(bad):
+    with pytest.raises(FramenetError):
+        _reject_unsafe_path_component(bad, "frame name")
+
+
+@pytest.mark.parametrize("ok", ["TestFrame", "Apply_heat", "lu123", "a.b-c"])
+def test_reject_unsafe_path_component_allows_normal(ok):
+    _reject_unsafe_path_component(ok, "frame name")  # must not raise


### PR DESCRIPTION
## Summary
`FramenetCorpusReader.frame(name)` (→ `frame_by_name()`) interpolates the
caller-supplied frame **name** into an XML file path that is then read with the
**builtin `open()`** (via `XMLCorpusView`), bypassing the `CorpusReader.open()` /
`nltk.pathsec` sandbox — including the strict `ENFORCE = True` mode documented in
`SECURITY.md`. A `..` sequence in the name escapes the corpus root, giving an
arbitrary file read whose content is returned to the caller.

This is the same class as the `CorpusReader` path-traversal hardening already
landed in #3479 / #3480 / #3522 / #3528: `frame()` never goes through
`CorpusReader.open()`, so none of that protection applies.

## Details
`nltk/corpus/reader/framenet.py`, `frame_by_name()`:

```python
locpath = os.path.join(f"{self._root}", self._frame_dir, fn_fname + ".xml")
with XMLCorpusView(locpath, "frame") as view:   # string path -> builtin open()
    elt = view[0]
```

`fn_fname` comes straight from the public API `frame(fn_fid_or_fname)` (a string
is dispatched to `frame_by_name`) with no containment check. Because
`XMLCorpusView` is constructed with a *string* path, it reads the file with the
builtin `open()` (`XMLCorpusView._detect_encoding` / `StreamBackedCorpusView._open`),
so `nltk.pathsec.validate_path()` is never invoked.

## PoC (before this change), with `nltk.pathsec.ENFORCE = True`
```python
from nltk.corpus import framenet as fn
# attacker-controlled frame name escapes the corpus root:
f = fn.frame("../../../../../../some/dir/secret")   # reads <root>/frame/../../.../secret.xml
print(f["definition"])                              # -> contents of the out-of-root file
```
Verified end-to-end in strict mode: NLTK opens a file outside the corpus root
via the builtin `open()` (no `PermissionError`, no warning) and `frame()` returns
its `<definition>` to the caller.

Constraint: a fixed `.xml` basename is appended, so the attacker chooses the
directory freely; full content disclosure requires the target to be frame-shaped
XML.

## Fix
Reject frame names that contain path separators or parent-directory references
before building the path, consistent with the validation already used elsewhere
in NLTK (e.g. the downloader's package-id check). Also harden `doc()` against a
malicious corpus index whose `filename` field contains traversal sequences.

## Tests
Adds `nltk/test/unit/test_framenet_security.py`:
- a `../` traversal frame name is rejected and never reaches the filesystem;
- a normal frame name still passes validation (fails only as "Unknown frame").
