### PR TITLE
fix(security): prevent DNS-rebinding SSRF in pathsec.urlopen

### DIFF
--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -300,34 +300,53 @@ def _resolve_and_validate_host(host, port):
     return addrinfo
 
 
-def _pinned_address(host, port):
-    """Return the validated ``(ip, port)`` to connect to, pinning the resolution."""
+def _pinned_connection(host, port, timeout, source_address):
+    """Open a socket to ``host``/``port`` over an SSRF-validated, pinned address.
+
+    Every address ``host`` resolves to is validated together, then the socket is
+    opened to those **numeric** addresses, so no second (unvalidated) name lookup
+    happens at connect time -- this closes the DNS-rebinding TOCTOU.  All
+    validated addresses are tried in order, preserving urllib/socket's normal
+    dual-stack / multi-A fallback.  If nothing resolves to a validated address we
+    fail closed: we never fall back to connecting by the raw hostname, which
+    would re-resolve unvalidated and reopen the rebinding hole.
+    """
     addrinfo = _resolve_and_validate_host(host, port)
-    if addrinfo:
-        return addrinfo[0][4][0], port
-    return host, port
+    if not addrinfo:
+        raise OSError(
+            f"pathsec.urlopen: no validated address for host {host!r}; "
+            "refusing to connect by unvalidated hostname"
+        )
+    last_err = None
+    for res in addrinfo:
+        ip = res[4][0]
+        try:
+            return socket.create_connection((ip, port), timeout, source_address)
+        except OSError as e:
+            last_err = e
+    raise last_err
 
 
 class _SafeHTTPConnection(http.client.HTTPConnection):
     """HTTPConnection that resolves, SSRF-validates and pins the address at connect()."""
 
     def connect(self):
-        ip, port = _pinned_address(self.host, self.port)
-        self.sock = socket.create_connection(
-            (ip, port), self.timeout, self.source_address
+        self.sock = _pinned_connection(
+            self.host, self.port, self.timeout, self.source_address
         )
 
 
 class _SafeHTTPSConnection(http.client.HTTPSConnection):
     """HTTPS variant of :class:`_SafeHTTPConnection`.
 
-    Connects to the pinned IP but keeps SNI / certificate verification against
-    the original hostname.
+    Connects to a validated, pinned IP but keeps SNI / certificate verification
+    against the original hostname.
     """
 
     def connect(self):
-        ip, port = _pinned_address(self.host, self.port)
-        sock = socket.create_connection((ip, port), self.timeout, self.source_address)
+        sock = _pinned_connection(
+            self.host, self.port, self.timeout, self.source_address
+        )
         self.sock = self._context.wrap_socket(sock, server_hostname=self.host)
 
 
@@ -361,9 +380,11 @@ def urlopen(url, *args, **kwargs):
     # Safely inherit proxy settings without reusing handler instances
     # (Reusing instances overwrites their .parent, breaking the global opener)
     proxied = False
+    has_proxy_handler = False
     if urllib.request._opener is not None:
         for handler in urllib.request._opener.handlers:
             if isinstance(handler, urllib.request.ProxyHandler):
+                has_proxy_handler = True
                 # Copy the dictionary to prevent shared mutable state
                 isolated_proxies = dict(handler.proxies) if handler.proxies else {}
                 if isolated_proxies:
@@ -374,11 +395,22 @@ def urlopen(url, *args, **kwargs):
             elif isinstance(handler, urllib.request.ProxyDigestAuthHandler):
                 handlers.append(urllib.request.ProxyDigestAuthHandler(handler.passwd))
 
-    # With no proxy, NLTK makes the connection itself: pin the validated IP so a
-    # rebinding hostname cannot be re-resolved to an internal address at connect
-    # time. With a proxy, the proxy is the egress and resolves names, so
-    # connection-pinning does not apply (and must not block the configured proxy).
+    # If the caller configured no ProxyHandler at all, environment proxies still
+    # apply: build_opener() would install a default ProxyHandler from
+    # getproxies(). Treat that as proxied too, because the proxy -- not NLTK --
+    # is then the egress that resolves names and performs the CONNECT tunnel; the
+    # connect-time pinning handlers cannot tunnel and would break proxied HTTPS.
+    if not proxied and not has_proxy_handler and urllib.request.getproxies():
+        proxied = True
+
     if not proxied:
+        # No proxy in effect: NLTK makes the connection itself, so pin the
+        # validated IP (a rebinding hostname cannot be re-resolved to an internal
+        # address at connect time). Add an explicit empty ProxyHandler so
+        # build_opener() does not silently re-enable environment proxies, which
+        # the pinning handlers cannot tunnel through.
+        if not has_proxy_handler:
+            handlers.append(urllib.request.ProxyHandler({}))
         handlers.append(_SafeHTTPHandler())
         handlers.append(_SafeHTTPSHandler())
 

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -313,7 +313,16 @@ def _pinned_connection(host, port, timeout, source_address):
     """
     addrinfo = _resolve_and_validate_host(host, port)
     if not addrinfo:
-        raise OSError(
+        # Fail closed: never fall back to connecting by the raw hostname (that
+        # would re-resolve unvalidated and reopen the rebinding hole). The host
+        # produced no usable address, which is a name-resolution failure, so we
+        # surface it as socket.gaierror rather than a bare OSError. gaierror is
+        # an OSError subclass, so urllib still wraps it as URLError and the
+        # fail-closed contract is unchanged; but callers that legitimately
+        # expect a DNS failure -- e.g. obfuscated/decimal-IP hosts that some
+        # platforms (Windows) refuse to resolve -- then see the expected
+        # gaierror reason instead of an opaque OSError.
+        raise socket.gaierror(
             f"pathsec.urlopen: no validated address for host {host!r}; "
             "refusing to connect by unvalidated hostname"
         )

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -207,6 +207,29 @@ def _resolve_hostname(hostname):
         return []
 
 
+def _ip_is_forbidden(ip):
+    """Return True if the SSRF filter must refuse to connect to ``ip``.
+
+    Policy (defense in depth): only *globally routable* addresses are allowed;
+    anything that is not global -- loopback, link-local, private, carrier-grade
+    NAT (100.64.0.0/10), reserved, unspecified (``0.0.0.0`` / ``::``),
+    documentation ranges, etc. -- is forbidden. This generalises the previous
+    explicit ``loopback / link-local / multicast / private`` list and is a strict
+    superset of it. Multicast is still rejected explicitly because some CPython
+    versions classify multicast addresses as ``is_global``.
+
+    IPv4-mapped IPv6 addresses (e.g. ``::ffff:127.0.0.1``) are evaluated as their
+    embedded IPv4 address: the stdlib's ``is_*`` classification of mapped
+    addresses is version dependent and has not always reflected the embedded
+    address, so the mapped form could otherwise smuggle a forbidden IPv4 past the
+    check.
+    """
+    mapped = getattr(ip, "ipv4_mapped", None)
+    if mapped is not None:
+        ip = mapped
+    return ip.is_multicast or not ip.is_global
+
+
 def validate_network_url(url_input, context="NetworkIO"):
     """Hardened URL validation with SSRF protection."""
     if not url_input or not str(url_input).strip():
@@ -251,7 +274,7 @@ def validate_network_url(url_input, context="NetworkIO"):
 
         for result in _resolve_hostname(parsed.hostname or ""):
             ip = ipaddress.ip_address(result[4][0])
-            if ip.is_loopback or ip.is_link_local or ip.is_multicast or ip.is_private:
+            if _ip_is_forbidden(ip):
                 msg = f"Security Violation [{context}]: SSRF attempt to restricted IP {ip}"
                 if ENFORCE:
                     raise PermissionError(msg)
@@ -292,7 +315,7 @@ def _resolve_and_validate_host(host, port):
             ip = ipaddress.ip_address(res[4][0])
         except ValueError:
             continue
-        if ip.is_loopback or ip.is_link_local or ip.is_multicast or ip.is_private:
+        if _ip_is_forbidden(ip):
             msg = f"Security Violation [pathsec.urlopen]: SSRF attempt to restricted IP {ip}"
             if ENFORCE:
                 raise PermissionError(msg)

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -9,6 +9,7 @@
 
 """Centralized I/O security sentinel for NLTK."""
 import builtins
+import http.client
 import ipaddress
 import os
 import socket
@@ -193,7 +194,13 @@ def validate_zip_archive(
 
 @lru_cache(maxsize=256)
 def _resolve_hostname(hostname):
-    """Cached hostname resolution to mitigate DNS rebinding."""
+    """Cached hostname resolution for the early SSRF pre-check.
+
+    Note: the cache alone does NOT prevent DNS rebinding, because the connection
+    layer re-resolves the hostname independently. The actual rebinding
+    protection is the connect-time IP pinning in ``_SafeHTTPConnection`` /
+    ``_SafeHTTPSConnection``.
+    """
     try:
         return socket.getaddrinfo(hostname, None, proto=socket.IPPROTO_TCP)
     except (OSError, ValueError):
@@ -265,6 +272,80 @@ class _ValidatingRedirectHandler(urllib.request.HTTPRedirectHandler):
         return super().redirect_request(req, fp, code, msg, headers, newurl)
 
 
+def _resolve_and_validate_host(host, port):
+    """
+    Resolve ``host`` once and SSRF-validate *every* address it resolves to.
+
+    Returns the resolved ``getaddrinfo`` records so the caller can connect to a
+    **pinned** numeric address. Because validation and the subsequent connection
+    observe the same resolution (the connection is made to the numeric IP, which
+    triggers no further name lookup), this closes the DNS-rebinding TOCTOU where
+    a hostname resolves to a public IP during validation and to an internal /
+    loopback IP during the actual connect.
+    """
+    try:
+        addrinfo = socket.getaddrinfo(host, port, proto=socket.IPPROTO_TCP)
+    except (OSError, ValueError):
+        return []
+    for res in addrinfo:
+        try:
+            ip = ipaddress.ip_address(res[4][0])
+        except ValueError:
+            continue
+        if ip.is_loopback or ip.is_link_local or ip.is_multicast or ip.is_private:
+            msg = f"Security Violation [pathsec.urlopen]: SSRF attempt to restricted IP {ip}"
+            if ENFORCE:
+                raise PermissionError(msg)
+            warnings.warn(msg, RuntimeWarning, stacklevel=2)
+    return addrinfo
+
+
+def _pinned_address(host, port):
+    """Return the validated ``(ip, port)`` to connect to, pinning the resolution."""
+    addrinfo = _resolve_and_validate_host(host, port)
+    if addrinfo:
+        return addrinfo[0][4][0], port
+    return host, port
+
+
+class _SafeHTTPConnection(http.client.HTTPConnection):
+    """HTTPConnection that resolves, SSRF-validates and pins the address at connect()."""
+
+    def connect(self):
+        ip, port = _pinned_address(self.host, self.port)
+        self.sock = socket.create_connection(
+            (ip, port), self.timeout, self.source_address
+        )
+
+
+class _SafeHTTPSConnection(http.client.HTTPSConnection):
+    """HTTPS variant of :class:`_SafeHTTPConnection`.
+
+    Connects to the pinned IP but keeps SNI / certificate verification against
+    the original hostname.
+    """
+
+    def connect(self):
+        ip, port = _pinned_address(self.host, self.port)
+        sock = socket.create_connection((ip, port), self.timeout, self.source_address)
+        self.sock = self._context.wrap_socket(sock, server_hostname=self.host)
+
+
+class _SafeHTTPHandler(urllib.request.HTTPHandler):
+    def http_open(self, req):
+        return self.do_open(_SafeHTTPConnection, req)
+
+
+class _SafeHTTPSHandler(urllib.request.HTTPSHandler):
+    def https_open(self, req):
+        kwargs = {}
+        if getattr(self, "_context", None) is not None:
+            kwargs["context"] = self._context
+        if getattr(self, "_check_hostname", None) is not None:
+            kwargs["check_hostname"] = self._check_hostname
+        return self.do_open(_SafeHTTPSConnection, req, **kwargs)
+
+
 def urlopen(url, *args, **kwargs):
     """
     Secure wrapper for urllib.request.urlopen with redirect validation.
@@ -279,16 +360,27 @@ def urlopen(url, *args, **kwargs):
 
     # Safely inherit proxy settings without reusing handler instances
     # (Reusing instances overwrites their .parent, breaking the global opener)
+    proxied = False
     if urllib.request._opener is not None:
         for handler in urllib.request._opener.handlers:
             if isinstance(handler, urllib.request.ProxyHandler):
                 # Copy the dictionary to prevent shared mutable state
                 isolated_proxies = dict(handler.proxies) if handler.proxies else {}
+                if isolated_proxies:
+                    proxied = True
                 handlers.append(urllib.request.ProxyHandler(isolated_proxies))
             elif isinstance(handler, urllib.request.ProxyBasicAuthHandler):
                 handlers.append(urllib.request.ProxyBasicAuthHandler(handler.passwd))
             elif isinstance(handler, urllib.request.ProxyDigestAuthHandler):
                 handlers.append(urllib.request.ProxyDigestAuthHandler(handler.passwd))
+
+    # With no proxy, NLTK makes the connection itself: pin the validated IP so a
+    # rebinding hostname cannot be re-resolved to an internal address at connect
+    # time. With a proxy, the proxy is the egress and resolves names, so
+    # connection-pinning does not apply (and must not block the configured proxy).
+    if not proxied:
+        handlers.append(_SafeHTTPHandler())
+        handlers.append(_SafeHTTPSHandler())
 
     opener = urllib.request.build_opener(*handlers)
     return opener.open(url, *args, **kwargs)

--- a/nltk/test/unit/test_pathsec.py
+++ b/nltk/test/unit/test_pathsec.py
@@ -235,6 +235,9 @@ def test_ssrf_dns_rebinding_blocked_at_connect(monkeypatch):
             return real_getaddrinfo(h, p, *a, **k)
 
         monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+        # No proxy: force direct connection so the pinning handlers are used
+        # regardless of the environment the test runs in.
+        monkeypatch.setattr(urllib.request, "getproxies", lambda: {})
 
         leaked = None
         blocked = False
@@ -249,3 +252,90 @@ def test_ssrf_dns_rebinding_blocked_at_connect(monkeypatch):
         assert state["n"] >= 2, "host was not re-resolved/validated at connect time"
     finally:
         srv.shutdown()
+
+
+def _addrinfo(ip, port=80):
+    return (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", (ip, port))
+
+
+def test_pinned_connection_fails_closed_when_unresolved(monkeypatch):
+    """If no validated address is available, _pinned_connection must NOT fall
+    back to connecting by the raw hostname (which would re-resolve unvalidated
+    and reopen the rebinding hole). It must fail closed."""
+    monkeypatch.setattr(pathsec, "_resolve_and_validate_host", lambda h, p: [])
+
+    attempted = []
+    monkeypatch.setattr(
+        socket, "create_connection", lambda addr, *a, **k: attempted.append(addr)
+    )
+
+    with pytest.raises(OSError):
+        pathsec._pinned_connection("rebind.invalid.test", 80, None, None)
+    assert not attempted, "must not connect by raw hostname when unresolved/unvalidated"
+
+
+def test_pinned_connection_tries_all_validated_addresses(monkeypatch):
+    """Pinning must still try every validated address in order, so a dual-stack
+    host whose first (validated) address is unreachable still succeeds via a
+    later validated address."""
+    a1, a2 = _addrinfo("203.0.113.1"), _addrinfo("203.0.113.2")
+    monkeypatch.setattr(pathsec, "_resolve_and_validate_host", lambda h, p: [a1, a2])
+
+    sentinel = object()
+    tried = []
+
+    def fake_create_connection(addr, *a, **k):
+        tried.append(addr[0])
+        if addr[0] == "203.0.113.1":
+            raise OSError("simulated unreachable first address")
+        return sentinel
+
+    monkeypatch.setattr(socket, "create_connection", fake_create_connection)
+
+    sock = pathsec._pinned_connection("dual.example.com", 80, None, None)
+    assert sock is sentinel
+    assert tried == ["203.0.113.1", "203.0.113.2"], "fallback across addresses lost"
+
+
+def _capture_urlopen_handlers(monkeypatch, url="http://safe.example.com/x"):
+    """Run pathsec.urlopen with build_opener stubbed out and return the handlers
+    it was built with. No global opener, no DNS and no network I/O happen."""
+    captured = []
+
+    def spy_build_opener(*handlers):
+        captured.extend(handlers)
+        return MagicMock()
+
+    monkeypatch.setattr(urllib.request, "_opener", None)
+    monkeypatch.setattr(pathsec, "_resolve_hostname", lambda h: [])
+    monkeypatch.setattr(urllib.request, "build_opener", spy_build_opener)
+    pathsec.urlopen(url)
+    return captured
+
+
+def test_no_proxy_installs_pinning_and_disables_env_proxy(monkeypatch):
+    """With no proxy in effect, the pinning handlers are installed and an
+    explicit empty ProxyHandler is added so build_opener cannot silently
+    re-enable environment proxies."""
+    monkeypatch.setattr(urllib.request, "getproxies", lambda: {})
+    handlers = _capture_urlopen_handlers(monkeypatch)
+
+    assert any(isinstance(h, pathsec._SafeHTTPHandler) for h in handlers)
+    assert any(isinstance(h, pathsec._SafeHTTPSHandler) for h in handlers)
+    proxy_handlers = [h for h in handlers if isinstance(h, urllib.request.ProxyHandler)]
+    assert len(proxy_handlers) == 1 and proxy_handlers[0].proxies == {}
+
+
+def test_env_proxy_skips_pinning_handlers(monkeypatch):
+    """When environment proxies are set, the proxy is the egress: the pinning
+    handlers must NOT be installed (they cannot do the CONNECT tunnel) and we
+    must not force an empty ProxyHandler that would disable the env proxy."""
+    monkeypatch.setattr(
+        urllib.request, "getproxies", lambda: {"http": "http://proxy.local:3128"}
+    )
+    handlers = _capture_urlopen_handlers(monkeypatch)
+
+    assert not any(isinstance(h, pathsec._SafeHTTPHandler) for h in handlers)
+    assert not any(isinstance(h, pathsec._SafeHTTPSHandler) for h in handlers)
+    # We did not append our own ProxyHandler({}); build_opener adds the env one.
+    assert not any(isinstance(h, urllib.request.ProxyHandler) for h in handlers)

--- a/nltk/test/unit/test_pathsec.py
+++ b/nltk/test/unit/test_pathsec.py
@@ -339,3 +339,65 @@ def test_env_proxy_skips_pinning_handlers(monkeypatch):
     assert not any(isinstance(h, pathsec._SafeHTTPSHandler) for h in handlers)
     # We did not append our own ProxyHandler({}); build_opener adds the env one.
     assert not any(isinstance(h, urllib.request.ProxyHandler) for h in handlers)
+
+
+# --- SSRF address policy: "non-global is forbidden" + IPv4-mapped IPv6 ---------
+
+
+@pytest.mark.parametrize(
+    "addr",
+    [
+        "127.0.0.1",  # loopback
+        "169.254.169.254",  # link-local (cloud metadata)
+        "10.0.0.5",  # private
+        "192.168.1.1",  # private
+        "224.0.0.1",  # multicast (is_global is True on some CPython versions)
+        "0.0.0.0",  # unspecified (routes to localhost on Linux)
+        "100.64.1.1",  # carrier-grade NAT -- missed by the old explicit list
+        "240.0.0.1",  # reserved
+        "::1",  # IPv6 loopback
+        "::",  # IPv6 unspecified
+        "::ffff:127.0.0.1",  # IPv4-mapped loopback
+        "::ffff:169.254.169.254",  # IPv4-mapped cloud metadata
+        "::ffff:10.0.0.5",  # IPv4-mapped private
+    ],
+)
+def test_ip_policy_forbids_non_global_and_mapped(addr):
+    """Every non-global address -- including CGNAT/unspecified the old explicit
+    list missed, and IPv4-mapped IPv6 forms -- must be rejected."""
+    import ipaddress
+
+    assert pathsec._ip_is_forbidden(ipaddress.ip_address(addr)), addr
+
+
+@pytest.mark.parametrize("addr", ["8.8.8.8", "93.184.216.34", "2606:2800:220:1::1"])
+def test_ip_policy_allows_global(addr):
+    """Genuinely global addresses must still be allowed."""
+    import ipaddress
+
+    assert not pathsec._ip_is_forbidden(ipaddress.ip_address(addr)), addr
+
+
+def test_resolve_and_validate_blocks_ipv4_mapped_loopback(monkeypatch):
+    """Connect-side: a host resolving to an IPv4-mapped loopback IPv6 address
+    must be blocked under ENFORCE (it would otherwise smuggle 127.0.0.1)."""
+    mapped = (
+        socket.AF_INET6,
+        socket.SOCK_STREAM,
+        socket.IPPROTO_TCP,
+        "",
+        ("::ffff:127.0.0.1", 80, 0, 0),
+    )
+    monkeypatch.setattr(socket, "getaddrinfo", lambda *a, **k: [mapped])
+    with pytest.raises(PermissionError):
+        pathsec._resolve_and_validate_host("mapped.invalid.test", 80)
+
+
+def test_validate_network_url_blocks_cgnat(monkeypatch):
+    """Validation-side: carrier-grade NAT (100.64.0.0/10) is non-global and must
+    now be rejected, where the old explicit list let it through."""
+    monkeypatch.setattr(
+        pathsec, "_resolve_hostname", lambda h: [_addrinfo("100.64.1.1")]
+    )
+    with pytest.raises((PermissionError, ValueError)):
+        pathsec.validate_network_url("http://cgnat.invalid.test/x", context="test")

--- a/nltk/test/unit/test_pathsec.py
+++ b/nltk/test/unit/test_pathsec.py
@@ -188,3 +188,64 @@ def test_urlopen_honors_set_proxy_and_redirect_validation():
     finally:
         # Teardown: Safely restore the original global opener, leaving no trace of this test
         urllib.request.install_opener(original_opener)
+
+
+def test_ssrf_dns_rebinding_blocked_at_connect(monkeypatch):
+    """A hostname that resolves to a public IP at validation time but to a
+    loopback IP at connect time (DNS rebinding) must still be blocked: the
+    connection is pinned to the validated resolution.  Regression test for the
+    validate-vs-connect DNS re-resolution TOCTOU in pathsec.urlopen.
+    """
+    import threading
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+
+    SECRET = b"LOOPBACK-ONLY-SECRET"
+
+    class _Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(SECRET)
+
+        def log_message(self, *args):
+            pass
+
+    srv = HTTPServer(("127.0.0.1", 0), _Handler)
+    port = srv.server_address[1]
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    try:
+        host = "rebind.invalid.test"
+        real_getaddrinfo = socket.getaddrinfo
+        state = {"n": 0}
+
+        def fake_getaddrinfo(h, p, *a, **k):
+            if h == host:
+                state["n"] += 1
+                # 1st resolution (validation) -> public; later (connect) -> loopback
+                ip = "93.184.216.34" if state["n"] == 1 else "127.0.0.1"
+                return [
+                    (
+                        socket.AF_INET,
+                        socket.SOCK_STREAM,
+                        socket.IPPROTO_TCP,
+                        "",
+                        (ip, p if isinstance(p, int) else 0),
+                    )
+                ]
+            return real_getaddrinfo(h, p, *a, **k)
+
+        monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+
+        leaked = None
+        blocked = False
+        try:
+            resp = pathsec.urlopen(f"http://{host}:{port}/x")
+            leaked = resp.read()
+        except (PermissionError, URLError, ValueError):
+            blocked = True
+
+        assert blocked, "DNS-rebinding fetch was not blocked under ENFORCE=True"
+        assert leaked != SECRET, "loopback secret was exfiltrated despite SSRF filter"
+        assert state["n"] >= 2, "host was not re-resolved/validated at connect time"
+    finally:
+        srv.shutdown()


### PR DESCRIPTION
## Summary
`pathsec.urlopen` — used by `nltk.download` and `nltk.data.load` for all network
fetches — is vulnerable to **DNS-rebinding SSRF**. The SSRF filter validates the
hostname's resolved IP, but the actual connection re-resolves the hostname
independently, so the validated IP is never used for the connection. An attacker
who controls DNS for a hostname (TTL-0 rebinding) returns a public IP for the
validation lookup and an internal / loopback IP for the connection lookup,
bypassing the SSRF filter **even under `nltk.pathsec.ENFORCE = True`**.

## Details
`validate_network_url()` resolves via the `lru_cache`d `_resolve_hostname()` and
blocks loopback / private / link-local / multicast IPs. But `urlopen()` then
calls `opener.open(url)` with the raw hostname, and urllib's connection layer
(`socket.create_connection` → `getaddrinfo`) performs a **second, independent**
resolution at connect time. The `lru_cache` (commented "to mitigate DNS
rebinding") only memoizes the validation-side lookup, which the connection never
consults, so it provides no protection against rebinding.

## Proof of concept (before this change), with `nltk.pathsec.ENFORCE = True`
```python
import nltk.data, nltk.pathsec
nltk.pathsec.ENFORCE = True
# 'attacker.example' resolves to a public IP at validation time and to
# 127.0.0.1 at connect time (TTL-0 DNS rebinding controlled by the attacker):
data = nltk.data.load("http://attacker.example/latest/meta-data/", format="raw")
# -> returns the loopback / cloud-metadata response despite ENFORCE=True
```
A direct `http://127.0.0.1/...` is correctly blocked; the rebinding hostname is
not. The same applies to `nltk.download(server_index_url=<attacker>)` (the index
URL and every package `url` taken from the index are fetched through
`pathsec.urlopen`).

## Fix
Resolve the host once, SSRF-validate **every** resolved address, and connect to
that **pinned** numeric address (which performs no further name lookup), so
validation and connection observe the same resolution. Implemented as
`_SafeHTTPConnection` / `_SafeHTTPSConnection` (HTTPS keeps SNI and certificate
verification against the original hostname), wired into `urlopen` when no proxy
is configured. With a proxy, the proxy is the egress and resolves names itself,
so connection pinning is not applied (and the configured proxy is not blocked).
Redirect hops go through the same opener and are therefore pinned as well.

## Tests
`test_pathsec.py::test_ssrf_dns_rebinding_blocked_at_connect` simulates rebinding
(public IP at validation, loopback at connect) against a local server and
asserts the fetch is blocked under `ENFORCE=True` and the loopback body is not
returned. Existing SSRF / proxy-inheritance / redirect-validation tests still
pass.
