### PR TITLE
Allow data.find() to return zipped corpora

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -50,6 +50,7 @@
 - Alexis Dimitriadis
 - Nikhil Dinesh
 - Liang Dong
+- Steve Dougherty
 - David Doukhan
 - Rebecca Dridan
 - Pablo Duboue

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -478,13 +478,15 @@ class ZipFilePathPointer(PathPointer):
             try:
                 zipfile.getinfo(entry)
             except Exception as e:
-                # Sometimes directories aren't explicitly listed in
-                # the zip file.  So if `entry` is a directory name,
-                # then check if the zipfile contains any files that
-                # are under the given directory.
-                if entry.endswith("/") and [
-                    n for n in zipfile.namelist() if n.startswith(entry)
-                ]:
+                # Directories aren't always listed as explicit zip entries,
+                # and find()'s zip-rewrite fallback constructs a bare
+                # directory entry without a trailing slash (e.g. "wordnet"
+                # rather than "wordnet/" when resolving "corpora/wordnet"
+                # inside "corpora/wordnet.zip"). Accept the entry if any
+                # file in the zipfile lives under it, regardless of whether
+                # the caller supplied a trailing slash.
+                prefix = entry if entry.endswith("/") else entry + "/"
+                if any(n.startswith(prefix) for n in zipfile.namelist()):
                     pass  # zipfile contains a file in that directory.
                 else:
                     # Otherwise, complain.
@@ -598,11 +600,6 @@ def find(resource_name, paths=None):
         allows ``find()`` to map the resource name
         ``corpora/chat80/cities.pl`` to a zip file path pointer to
         ``corpora/chat80.zip/chat80/cities.pl``.
-
-      - When using ``find()`` to locate a directory contained in a
-        zipfile, the resource name must end with the forward slash
-        character.  Otherwise, ``find()`` will not locate the
-        directory.
 
     :type resource_name: str or unicode
     :param resource_name: The name of the resource to search for.

--- a/nltk/test/unit/test_open_datafile.py
+++ b/nltk/test/unit/test_open_datafile.py
@@ -2,6 +2,9 @@ import os
 import zipfile
 from tempfile import TemporaryDirectory
 
+import pytest
+
+import nltk.data
 from nltk.data import ZipFilePathPointer, open_datafile
 
 
@@ -18,6 +21,21 @@ def _create_test_zip(root_dir, rel_dir, file_name, contents: bytes):
         zf.writestr(arcname, contents)
 
     return zip_path, arcname
+
+
+def _create_zip_with_directory(root_dir, zip_name="pkg.zip"):
+    """
+    Create a zip file under root_dir containing an explicit 'pkg/' directory
+    entry and a 'pkg/data.txt' file. Return the full path to the zip file.
+
+    Some zip writers emit explicit directory entries, so this includes one.
+    See https://bugs.python.org/issue34738 for examples.
+    """
+    zip_path = os.path.join(root_dir, zip_name)
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("pkg/", "")
+        zf.writestr("pkg/data.txt", "hello")
+    return zip_path
 
 
 def test_open_datafile_directory_and_filename_from_zip():
@@ -80,3 +98,48 @@ def test_open_datafile_binary_mode_from_zip():
 
         assert isinstance(result, (bytes, bytearray))
         assert result == binary_data
+
+
+def test_zipfilepathpointer_accepts_bare_directory_entry():
+    """ZipFilePathPointer should accept a directory entry written without a trailing slash.
+
+    find()'s zip-rewrite fallback rewrites e.g. 'corpora/wordnet' to
+    'corpora/wordnet.zip/wordnet' -- a bare directory name with no trailing
+    slash. The constructor must accept it as long as the zipfile contains
+    files under that prefix; otherwise find('corpora/wordnet') never resolves
+    to a pre-staged corpora/wordnet.zip even when it exists on disk.
+    """
+    with TemporaryDirectory() as tmpdir:
+        zip_path = _create_zip_with_directory(tmpdir)
+        ptr = ZipFilePathPointer(zip_path, "pkg")
+        assert ptr is not None
+
+
+def test_zipfilepathpointer_accepts_directory_entry_with_slash():
+    """Regression: trailing-slash directory entries must continue to work."""
+    with TemporaryDirectory() as tmpdir:
+        zip_path = _create_zip_with_directory(tmpdir)
+        ptr = ZipFilePathPointer(zip_path, "pkg/")
+        assert ptr is not None
+
+
+def test_zipfilepathpointer_rejects_unrelated_entry():
+    """A bare name that isn't a directory prefix of any zip member must still raise."""
+    with TemporaryDirectory() as tmpdir:
+        zip_path = _create_zip_with_directory(tmpdir)
+        with pytest.raises(OSError):
+            ZipFilePathPointer(zip_path, "no_such_entry")
+
+
+def test_find_resolves_bare_directory_inside_zip():
+    """find('corpora/pkg') should resolve to corpora/pkg.zip on the data path,
+    even when 'pkg' is a directory rather than a file inside that zip. This
+    mirrors the documented zip-rewrite fallback for the directory case.
+    """
+    with TemporaryDirectory() as tmpdir:
+        corpora_dir = os.path.join(tmpdir, "corpora")
+        os.makedirs(corpora_dir)
+        _create_zip_with_directory(corpora_dir)
+
+        ptr = nltk.data.find("corpora/pkg", (tmpdir,))
+        assert "pkg.zip" in str(ptr)


### PR DESCRIPTION
This allows the following to work:

    rm -rf ~/nltk_data/corpora/wordnet ~/nltk_data/corpora/wordnet.zip  # and anywhere else on the path so it's gone
    python -m nltk.downloader wordnet
    python -c 'import nltk; nltk.data.find("corpora/wordnet")'

Without this change, it only works if it's manually unzipped.