### PR TITLE
Fix remaining corpus reader pathsec gaps before ENFORCE=True RC

### DIFF
--- a/nltk/corpus/reader/util.py
+++ b/nltk/corpus/reader/util.py
@@ -21,6 +21,7 @@ from nltk.data import (
     ZipFilePathPointer,
 )
 from nltk.internals import slice_bounds
+from nltk.pathsec import open as _secure_open
 from nltk.tokenize import wordpunct_tokenize
 from nltk.util import AbstractLazySequence, LazyConcatenation, LazySubsequence
 
@@ -209,10 +210,10 @@ class StreamBackedCorpusView(AbstractLazySequence):
             self._stream = self._fileid.open(self._encoding)
         elif self._encoding:
             self._stream = SeekableUnicodeStreamReader(
-                open(self._fileid, "rb"), self._encoding
+                _secure_open(self._fileid, "rb"), self._encoding
             )
         else:
-            self._stream = open(self._fileid, "rb")
+            self._stream = _secure_open(self._fileid, "rb")
 
     def close(self):
         """
@@ -724,20 +725,46 @@ def find_corpus_fileids(root, regexp):
         items = [name for name in fileids if re.match(regexp, name)]
         return sorted(items)
 
-    # Find fileids in a directory: use os.walk to search all (proper
-    # or symlinked) subdirectories, and match paths against the regexp.
+    # Find fileids in a directory: use os.walk to search subdirectories,
+    # but do not descend into symlinked directories that resolve outside
+    # the corpus root.
     elif isinstance(root, FileSystemPathPointer):
         items = []
+        resolved_root = os.path.realpath(root.path)
+
         for dirname, subdirs, fileids in os.walk(root.path):
+            dirname_real = os.path.realpath(dirname)
+            try:
+                if os.path.commonpath([resolved_root, dirname_real]) != resolved_root:
+                    subdirs[:] = []
+                    continue
+            except ValueError:
+                subdirs[:] = []
+                continue
+
+            pruned_subdirs = []
+            for subdir in subdirs:
+                full_subdir = os.path.join(dirname, subdir)
+                subdir_real = os.path.realpath(full_subdir)
+                try:
+                    inside_root = (
+                        os.path.commonpath([resolved_root, subdir_real])
+                        == resolved_root
+                    )
+                except ValueError:
+                    inside_root = False
+
+                if inside_root and subdir != ".svn":
+                    pruned_subdirs.append(subdir)
+
+            subdirs[:] = pruned_subdirs
+
             prefix = "".join("%s/" % p for p in _path_from(root.path, dirname))
             items += [
                 prefix + fileid
                 for fileid in fileids
                 if re.match(regexp, prefix + fileid)
             ]
-            # Don't visit svn directories:
-            if ".svn" in subdirs:
-                subdirs.remove(".svn")
         return sorted(items)
 
     # HuggingFace PathPointer: delegate to its fileids() method (duck typing,

--- a/nltk/test/unit/test_corpus_reader.py
+++ b/nltk/test/unit/test_corpus_reader.py
@@ -3,6 +3,8 @@ import os
 import pytest
 
 from nltk.corpus.reader.plaintext import PlaintextCorpusReader
+from nltk.corpus.reader.util import find_corpus_fileids
+from nltk.data import FileSystemPathPointer
 
 
 @pytest.mark.skipif(not hasattr(os, "symlink"), reason="requires os.symlink")
@@ -28,3 +30,26 @@ def test_corpusreader_open_blocks_symlink_escape(tmp_path):
     # Act + Assert: opening via the symlinked path must be blocked by corpus-root sandboxing
     with pytest.raises((ValueError, PermissionError, OSError)):
         reader.open("outside_link/secret.txt").read()
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="requires os.symlink")
+def test_find_corpus_fileids_skips_symlink_escape(tmp_path):
+    corpus_root = tmp_path / "corpus"
+    corpus_root.mkdir()
+
+    inside_file = corpus_root / "inside.txt"
+    inside_file.write_text("inside", encoding="utf-8")
+
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+
+    secret = outside_dir / "secret.txt"
+    secret.write_text("secret", encoding="utf-8")
+
+    escaping_link = corpus_root / "outside_link"
+    os.symlink(str(outside_dir), str(escaping_link))
+
+    fileids = find_corpus_fileids(FileSystemPathPointer(str(corpus_root)), r".*")
+
+    assert "inside.txt" in fileids
+    assert "outside_link/secret.txt" not in fileids

--- a/nltk/test/unit/test_pathsec.py
+++ b/nltk/test/unit/test_pathsec.py
@@ -190,12 +190,18 @@ def test_urlopen_honors_set_proxy_and_redirect_validation():
         urllib.request.install_opener(original_opener)
 
 
-def test_streambackedcorpusview_string_fileid_uses_pathsec():
+def test_streambackedcorpusview_string_fileid_uses_pathsec(tmp_path, monkeypatch):
+    from pathlib import Path
+
     from nltk.corpus.reader.util import StreamBackedCorpusView
 
-    outside = os.path.join(os.path.abspath(os.sep), "_nltk_pathsec_test", "secret.txt")
+    blocked_file = tmp_path / "secret.txt"
+    blocked_file.write_text("secret", encoding="utf-8")
 
-    view = StreamBackedCorpusView(outside, block_reader=lambda stream: [])
+    monkeypatch.setattr(pathsec, "_get_allowed_roots", lambda: set())
+    monkeypatch.setattr(os, "getcwd", lambda: str(Path(tmp_path).parent / "elsewhere"))
+
+    view = StreamBackedCorpusView(str(blocked_file), block_reader=lambda stream: [])
 
     with pytest.raises((ValueError, PermissionError)):
         view._open()

--- a/nltk/test/unit/test_pathsec.py
+++ b/nltk/test/unit/test_pathsec.py
@@ -188,3 +188,14 @@ def test_urlopen_honors_set_proxy_and_redirect_validation():
     finally:
         # Teardown: Safely restore the original global opener, leaving no trace of this test
         urllib.request.install_opener(original_opener)
+
+
+def test_streambackedcorpusview_string_fileid_uses_pathsec():
+    from nltk.corpus.reader.util import StreamBackedCorpusView
+
+    outside = os.path.join(os.path.abspath(os.sep), "_nltk_pathsec_test", "secret.txt")
+
+    view = StreamBackedCorpusView(outside, block_reader=lambda stream: [])
+
+    with pytest.raises((ValueError, PermissionError)):
+        view._open()

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -10,6 +10,6 @@ pytest-mock
 pytest-xdist[psutil]
 pyyaml
 regex
-scikit-learn
+scikit-learn==1.7.2
 tqdm
 twython

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -10,6 +10,6 @@ pytest-mock
 pytest-xdist[psutil]
 pyyaml
 regex
-scikit-learn==1.7.2
+scikit-learn
 tqdm
 twython


### PR DESCRIPTION
## Summary

Closes #3587.

This patch tightens two remaining path-handling gaps before the upcoming RC that is expected to switch `nltk.pathsec.ENFORCE` to `True`:

- `find_corpus_fileids()` no longer enumerates through symlinked directories that resolve outside the corpus root
- `StreamBackedCorpusView._open()` now uses the centralized `pathsec` wrapper for plain string fileids

## Tests

- add regression test ensuring symlink escapes are not enumerated by `find_corpus_fileids()`
- add regression test ensuring `StreamBackedCorpusView` with a plain string path is subject to path validation