### PR TITLE
Fix TransitionParser sparse index dtype for scikit-learn 1.9

### DIFF
--- a/nltk/parse/transitionparser.py
+++ b/nltk/parse/transitionparser.py
@@ -523,6 +523,9 @@ class TransitionParser(ParserI):
             input_file.close()
             # Using the temporary file to train the libsvm classifier
             x_train, y_train = load_svmlight_file(input_file.name)
+            x_train = x_train.astype("float64")
+            x_train.indices = x_train.indices.astype("int32", copy=False)
+            x_train.indptr = x_train.indptr.astype("int32", copy=False)
             # The parameter is set according to the paper:
             # Algorithms for Deterministic Incremental Dependency Parsing by Joakim Nivre
             # Todo : because of probability = True => very slow due to


### PR DESCRIPTION
Closes #3589

## Summary
Cast the sparse training matrix index arrays to `int32` in `TransitionParser.train()` before calling `model.fit(...)`.

## Problem
Recent CI failures under newer dependency resolution hit:

`ValueError: Only sparse matrices with 32-bit integer indices are accepted. Got int64 indices.`

This comes from newer scikit-learn rejecting sparse matrices with `int64` indices in this code path.

## Fix
After `load_svmlight_file(...)`, convert the CSR matrix index arrays:
- `x_train.indices -> int32`
- `x_train.indptr -> int32`

This keeps the patch minimal and fixes training without changing behavior otherwise.

## Testing
No new tests added. Existing CI coverage already exercises this path, including:
- `nltk.parse.transitionparser.demo`
- `test_transitionparser_warns_on_model_unpickle`