### PR TITLE
Cache WordNet max depth lazily for lch_similarity()

### DIFF
--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -900,7 +900,7 @@ class Synset(_WordNetObject):
             If you are using wordnet 1.6, a fake root will be added for nouns
             as well.
         :return: A score denoting the similarity of the two ``Synset`` objects,
-            normally greater than 0. None is returned if a connecting path
+            normally greater than 0. None is returned if no connecting path
             could be found. If a ``Synset`` is compared with itself, the
             maximum score is returned, which varies depending on the taxonomy
             depth.
@@ -1170,9 +1170,9 @@ class WordNetCorpusReader(CorpusReader):
         # Map from pos -> offset -> synset
         self._synset_offset_cache = defaultdict(dict)
 
-        # A lookup for the maximum depth of each part of speech.  Useful for
-        # the lch similarity metric.
-        self._max_depth = defaultdict(dict)
+        # A cache for the maximum depth used by the lch similarity metric.
+        # Keyed by (pos, need_root), where need_root indicates whether a simulated root is required..
+        self._max_depth = {}
 
         # Corpus reader containing omw data.
         self._omw_reader = omw_reader
@@ -1224,10 +1224,6 @@ class WordNetCorpusReader(CorpusReader):
 
         # Language data attributes
         self.lg_attrs = ["lemma", "of", "def", "exe"]
-
-        # A cache for the maximum depth used by the lch similarity metric.
-        # Keyed by (pos, simulate_root).
-        self._max_depth = {}
 
     def index_sense(self, version=None):
         """Read sense key to synset id mapping from index.sense file in corpus directory"""

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -900,7 +900,7 @@ class Synset(_WordNetObject):
             If you are using wordnet 1.6, a fake root will be added for nouns
             as well.
         :return: A score denoting the similarity of the two ``Synset`` objects,
-            normally greater than 0. None is returned if no connecting path
+            normally greater than 0. None is returned if a connecting path
             could be found. If a ``Synset`` is compared with itself, the
             maximum score is returned, which varies depending on the taxonomy
             depth.
@@ -913,11 +913,12 @@ class Synset(_WordNetObject):
             )
 
         need_root = self._needs_root()
+        key = (self._pos, need_root)
 
-        if self._pos not in self._wordnet_corpus_reader._max_depth:
+        if key not in self._wordnet_corpus_reader._max_depth:
             self._wordnet_corpus_reader._compute_max_depth(self._pos, need_root)
 
-        depth = self._wordnet_corpus_reader._max_depth[self._pos]
+        depth = self._wordnet_corpus_reader._max_depth[key]
 
         distance = self.shortest_path_distance(
             other, simulate_root=simulate_root and need_root
@@ -1224,6 +1225,10 @@ class WordNetCorpusReader(CorpusReader):
         # Language data attributes
         self.lg_attrs = ["lemma", "of", "def", "exe"]
 
+        # A cache for the maximum depth used by the lch similarity metric.
+        # Keyed by (pos, simulate_root).
+        self._max_depth = {}
+
     def index_sense(self, version=None):
         """Read sense key to synset id mapping from index.sense file in corpus directory"""
         fn = "index.sense"
@@ -1475,18 +1480,25 @@ class WordNetCorpusReader(CorpusReader):
 
     def _compute_max_depth(self, pos, simulate_root):
         """
-        Compute the max depth for the given part of speech.  This is
+        Compute the max depth for the given part of speech. This is
         used by the lch similarity metric.
         """
+        key = (pos, simulate_root)
+        if key in self._max_depth:
+            return self._max_depth[key]
+
         depth = 0
-        for ii in self.all_synsets(pos):
+        for ss in self.all_synsets(pos):
             try:
-                depth = max(depth, ii.max_depth())
+                depth = max(depth, ss.max_depth())
             except RuntimeError:
-                print(ii)
+                print(ss)
+
         if simulate_root:
             depth += 1
-        self._max_depth[pos] = depth
+
+        self._max_depth[key] = depth
+        return depth
 
     def get_version(self):
         fh = self._data_file(ADJ)


### PR DESCRIPTION
Closes #2273

## Summary

This PR speeds up `lch_similarity()` by caching maximum taxonomy depth lazily per `WordNetCorpusReader` instance, keyed by part of speech and whether that taxonomy requires a simulated root.

It addresses the same performance issue as #3584, but takes a different approach: instead of hardcoding precomputed depth constants for WordNet 3.0, it computes the values from the actually loaded corpus on first use and reuses them thereafter.

## Motivation

`lch_similarity()` depends on the maximum depth of the taxonomy for the relevant part of speech. Computing that value by iterating over all synsets is expensive, but it is also stable for a given loaded `WordNetCorpusReader` instance.

Because a reader instance is bound to a single underlying WordNet dataset, the maximum taxonomy depth does not need to be recomputed for repeated calls. Caching it lazily gives the same practical speedup as precomputing constants, while keeping the value derived from the real corpus data.

## Design

This PR changes the max-depth cache from a flat POS-based lookup to an instance-local lazy cache keyed by:

- `pos`
- `need_root`

This is enough to uniquely determine the value within a single `WordNetCorpusReader` instance.

The cache does **not** need to be keyed by WordNet version, because version is already implicit in the reader instance. Different simultaneously loaded readers naturally maintain separate caches.

## Why this approach

Compared to #3584, this design has a few advantages:

1. **No hardcoded constants**
   - Avoids embedding magic numbers such as noun=`19` and verb=`12`.
   - Removes the maintenance burden of keeping those constants in sync with the corpus.

2. **Derived from actual loaded data**
   - The cached values are computed from the real synsets exposed by the current reader.
   - This keeps the cache aligned with the dataset actually in use.

3. **Works for any WordNet version**
   - No special-casing for WordNet 3.0.
   - Supports other WordNet versions automatically, including multiple versions loaded at the same time in separate reader instances.

4. **Preserves existing semantics**
   - The cache is keyed by the same root-handling logic already used by `lch_similarity()`.
   - This keeps the optimization behavior-preserving rather than introducing a semantic change.

5. **Preserves lazy behavior**
   - The full scan still happens only when needed.
   - After the first computation, repeated similarity calls reuse the cached value.

## Notes

This PR is intended as an alternative implementation of the optimization proposed in #3584. Both PRs address the same hotspot, but this version prefers lazy caching from source data over hardcoded per-version constants.

## Testing

This change is intended to preserve the existing public behavior of `lch_similarity()` while improving performance.

Existing unit tests for `lch_similarity()` continue to cover representative cases in `nltk/test/unit/test_wordnet.py`, including:

- `S("dog.n.01").lch_similarity(S("cat.n.01"))`
- `S("big.a.01").lch_similarity(S("long.a.01"))`
- `S("long.a.01").lch_similarity(S("big.a.01"))`

No additional tests of the internal max-depth cache are necessary, since the existing `lch_similarity()` tests already provide sufficient proof that this change preserves behavior.