### PR TITLE
Enable ENFORCE by default and harden downloader concurrency

### DIFF
--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -678,20 +678,9 @@ class Downloader:
         yield StartPackageMessage(info)
         yield ProgressMessage(0)
 
-        # Do we already have the current version?
-        status = self.status(info, download_dir)
-        if not force and status == self.INSTALLED:
-            yield UpToDateMessage(info)
-            yield ProgressMessage(100)
-            yield FinishPackageMessage(info)
-            return
-
-        # Remove the package from our status cache
-        self._status_cache.pop(info.id, None)
-
-        # Check for (and remove) any old/stale version.
         filepath = os.path.join(download_dir, info.filename)
         tmp_filepath = filepath + ".tmp"
+        lock_filepath = filepath + ".lock"
 
         # Defense-in-depth: verify filepath stays within download_dir
         real_download = os.path.realpath(os.path.abspath(download_dir))
@@ -704,131 +693,162 @@ class Downloader:
             )
             return
 
+        unzipdir = filepath[:-4] if filepath.endswith(".zip") else None
         MAX_ZOMBIE_TIME = 60
-        POLL_INTERVAL = 2
+        POLL_INTERVAL = 1
 
-        # 1. Cooperative Wait Loop
-        while True:
+        def _safe_remove(path):
+            try:
+                os.remove(path)
+            except FileNotFoundError:
+                pass
+            except OSError:
+                pass
+
+        def _safe_rmtree(path):
+            if not os.path.isdir(path):
+                return
+            for root, dirs, files in os.walk(path, topdown=False):
+                for name in files:
+                    try:
+                        os.remove(os.path.join(root, name))
+                    except OSError:
+                        pass
+                for name in dirs:
+                    try:
+                        os.rmdir(os.path.join(root, name))
+                    except OSError:
+                        pass
+            try:
+                os.rmdir(path)
+            except OSError:
+                pass
+
+        def _touch_lock():
+            try:
+                os.utime(lock_filepath, None)
+            except OSError:
+                pass
+
+        def _status_now():
             self._status_cache.pop(info.id, None)
-            status = self.status(info, download_dir)
+            return self.status(info, download_dir)
 
-            if not force and status == self.INSTALLED:
+        def _installed_now():
+            return _status_now() == self.INSTALLED
+
+        os.makedirs(download_dir, exist_ok=True)
+        os.makedirs(os.path.join(download_dir, info.subdir), exist_ok=True)
+
+        # Fast path before taking the lock.
+        if not force and _installed_now():
+            yield UpToDateMessage(info)
+            yield ProgressMessage(100)
+            yield FinishPackageMessage(info)
+            return
+
+        # Acquire a package-wide install lock that covers download + unzip.
+        while True:
+            if not force and _installed_now():
                 yield UpToDateMessage(info)
                 yield ProgressMessage(100)
                 yield FinishPackageMessage(info)
                 return
 
             try:
-                if os.path.exists(tmp_filepath):
-                    before_stat = os.stat(tmp_filepath)
-                    last_size = before_stat.st_size
-
-                    time.sleep(POLL_INTERVAL)
-
-                    if os.path.exists(tmp_filepath):
-                        after_stat = os.stat(tmp_filepath)
-                        new_size = after_stat.st_size
-                        new_mtime = after_stat.st_mtime
-
-                        if new_size > last_size:
-                            continue
-
-                        if (time.time() - new_mtime) < MAX_ZOMBIE_TIME:
-                            continue
-
-                        # ZOMBIE RECOVERY FIX: Remove the dead file so it can be claimed
-                        try:
-                            os.remove(tmp_filepath)
-                        except OSError:
-                            pass
-            except (FileNotFoundError, OSError):
-                pass
-
-            # 2. Atomic Claim
-            try:
-                # Ensure the download_dir exists
-                os.makedirs(download_dir, exist_ok=True)
-                os.makedirs(os.path.join(download_dir, info.subdir), exist_ok=True)
-
-                fd = os.open(tmp_filepath, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+                fd = os.open(lock_filepath, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
                 os.close(fd)
                 break
             except FileExistsError:
-                continue
-
-        # 3. Post-Lock Verification (Double-Check)
-        self._status_cache.pop(info.id, None)
-        status = self.status(info, download_dir)
-        if not force and status == self.INSTALLED:
-            if os.path.exists(tmp_filepath):
                 try:
-                    os.remove(tmp_filepath)
+                    age = time.time() - os.stat(lock_filepath).st_mtime
+                    if age >= MAX_ZOMBIE_TIME:
+                        _safe_remove(lock_filepath)
+                        continue
                 except FileNotFoundError:
-                    pass
-            yield UpToDateMessage(info)
-            yield ProgressMessage(100)
-            yield FinishPackageMessage(info)
-            return
-
-        if os.path.exists(filepath):
-            if status == self.STALE:
-                yield StaleMessage(info)
-            try:
-                os.remove(filepath)
-            except FileNotFoundError:
-                pass
-
-        # 5. Download Leader
-        yield StartDownloadMessage(info)
-        yield ProgressMessage(5)
+                    continue
+                time.sleep(POLL_INTERVAL)
 
         try:
-            infile = urlopen(info.url)
-            with open(tmp_filepath, "wb") as outfile:
-                num_blocks = max(1, info.size / (1024 * 16))
-                for block in itertools.count():
-                    s = infile.read(1024 * 16)
-                    if not s:
-                        break
-                    outfile.write(s)
-                    if block % 10 == 0:
-                        os.utime(tmp_filepath, None)
-                        yield ProgressMessage(min(80, 5 + 75 * (block / num_blocks)))
-            infile.close()
+            # Recheck after lock acquisition in case another process completed first.
+            if not force and _installed_now():
+                yield UpToDateMessage(info)
+                yield ProgressMessage(100)
+                yield FinishPackageMessage(info)
+                return
 
-            os.replace(tmp_filepath, filepath)
-            self._status_cache.pop(info.id, None)
+            status = _status_now()
 
-        except OSError as e:
-            if os.path.exists(tmp_filepath):
+            # Only the lock holder may clean stale state.
+            if status == self.STALE:
+                yield StaleMessage(info)
+                _safe_remove(tmp_filepath)
+                _safe_remove(filepath)
+                if unzipdir:
+                    _safe_rmtree(unzipdir)
+                self._status_cache.pop(info.id, None)
+
+            # Download if needed.
+            if force or not os.path.exists(filepath):
+                yield StartDownloadMessage(info)
+                yield ProgressMessage(5)
+
                 try:
-                    os.remove(tmp_filepath)
-                except FileNotFoundError:
-                    pass
-            yield ErrorMessage(
-                info,
-                "Error downloading %r from <%s>:" "\n  %s" % (info.id, info.url, e),
-            )
-            return
+                    infile = urlopen(info.url)
+                    with open(tmp_filepath, "wb") as outfile:
+                        num_blocks = max(1, info.size / (1024 * 16))
+                        for block in itertools.count():
+                            s = infile.read(1024 * 16)
+                            if not s:
+                                break
+                            outfile.write(s)
+                            if block % 2 == 0:
+                                _touch_lock()
+                                yield ProgressMessage(
+                                    min(80, 5 + 75 * (block / num_blocks))
+                                )
+                    infile.close()
+                    os.replace(tmp_filepath, filepath)
+                    self._status_cache.pop(info.id, None)
+                except OSError as e:
+                    _safe_remove(tmp_filepath)
+                    yield ErrorMessage(
+                        info,
+                        "Error downloading %r from <%s>:"
+                        "\n  %s" % (info.id, info.url, e),
+                    )
+                    return
 
-        yield FinishDownloadMessage(info)
-        yield ProgressMessage(80)
+                yield FinishDownloadMessage(info)
+                yield ProgressMessage(80)
 
-        # Check if it needs to be unzipped.
-        if info.filename.endswith(".zip"):
-            zipdir = os.path.join(download_dir, info.subdir)
+            # Unzip while still holding the same install lock.
+            if info.filename.endswith(".zip"):
+                zipdir = os.path.join(download_dir, info.subdir)
+                if info.unzip or os.path.exists(os.path.join(zipdir, info.id)):
+                    yield StartUnzipMessage(info)
+                    for msg in _unzip_iter(filepath, zipdir, verbose=False):
+                        _touch_lock()
+                        msg.package = info
+                        yield msg
+                        if isinstance(msg, ErrorMessage):
+                            return
+                    yield FinishUnzipMessage(info)
 
-            # Unzip if we're unzipping by default; *or* if it's already
-            # been unzipped (presumably a previous version).
-            if info.unzip or os.path.exists(os.path.join(zipdir, info.id)):
-                yield StartUnzipMessage(info)
-                for msg in _unzip_iter(filepath, zipdir, verbose=False):
-                    # Somewhat of a hack, but we need a proper package reference
-                    msg.package = info
-                    yield msg
-                yield FinishUnzipMessage(info)
+            # Final verification: followers should only ever observe INSTALLED.
+            if not _installed_now():
+                yield ErrorMessage(
+                    info,
+                    f"Package {info.id!r} did not reach installed state "
+                    f"(final status: {_status_now()})",
+                )
+                return
 
-        yield FinishPackageMessage(info)
+            yield FinishPackageMessage(info)
+
+        finally:
+            _safe_remove(tmp_filepath)
+            _safe_remove(lock_filepath)
 
     def download(
         self,
@@ -1514,7 +1534,7 @@ class DownloaderGUI:
         self._download_abort_queue = []
         self._downloading = False
 
-        # For tkinter after callbacks:
+        # For tkinter after zcallbacks:
         self._afterid = {}
 
         # A message log.

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -730,6 +730,9 @@ class Downloader:
             except OSError:
                 pass
 
+        def _lock_exists():
+            return os.path.exists(lock_filepath)
+
         def _status_now():
             self._status_cache.pop(info.id, None)
             return self.status(info, download_dir)
@@ -741,7 +744,8 @@ class Downloader:
         os.makedirs(os.path.join(download_dir, info.subdir), exist_ok=True)
 
         # Fast path before taking the lock.
-        if not force and _installed_now():
+        # Do not return "up to date" while another process still holds the install lock.
+        if not force and _installed_now() and not _lock_exists():
             yield UpToDateMessage(info)
             yield ProgressMessage(100)
             yield FinishPackageMessage(info)
@@ -749,7 +753,7 @@ class Downloader:
 
         # Acquire a package-wide install lock that covers download + unzip.
         while True:
-            if not force and _installed_now():
+            if not force and _installed_now() and not _lock_exists():
                 yield UpToDateMessage(info)
                 yield ProgressMessage(100)
                 yield FinishPackageMessage(info)
@@ -1534,7 +1538,7 @@ class DownloaderGUI:
         self._download_abort_queue = []
         self._downloading = False
 
-        # For tkinter after zcallbacks:
+        # For tkinter after callbacks:
         self._afterid = {}
 
         # A message log.

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -209,6 +209,15 @@ def validate_network_url(url_input, context="NetworkIO"):
 
         if parsed.scheme == "file":
             file_path = unquote(parsed.path)
+            netloc = parsed.netloc
+
+            # Only local file:// URIs are allowed.
+            # Reject remote/UNC-style authorities so validation matches actual access.
+            if netloc not in ("", "localhost"):
+                raise OSError(
+                    f"Security Violation [{context}.file_scheme]: "
+                    f"Non-local file URI authority not allowed: {netloc!r}"
+                )
 
             # Windows file:// URIs arrive like /C:/path/to/file
             # Convert them to a native absolute path before validation.

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -21,7 +21,8 @@ from pathlib import Path
 from urllib.parse import unquote, urlparse
 
 # Security Enforcement Toggle
-ENFORCE = False
+# ENFORCE = False
+ENFORCE = True
 
 _ALLOWED_ROOTS_CACHE = None
 _LAST_DATA_PATHS = None

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -206,8 +206,21 @@ def validate_network_url(url_input, context="NetworkIO"):
         return
     try:
         parsed = urlparse(str(url_input))
+
         if parsed.scheme == "file":
-            validate_path(unquote(parsed.path), context=f"{context}.file_scheme")
+            file_path = unquote(parsed.path)
+
+            # Windows file:// URIs arrive like /C:/path/to/file
+            # Convert them to a native absolute path before validation.
+            if (
+                os.name == "nt"
+                and len(file_path) >= 3
+                and file_path[0] == "/"
+                and file_path[2] == ":"
+            ):
+                file_path = file_path[1:]
+
+            validate_path(file_path, context=f"{context}.file_scheme")
             return
 
         if parsed.scheme not in ("http", "https"):

--- a/nltk/test/unit/test_downloader_atomic.py
+++ b/nltk/test/unit/test_downloader_atomic.py
@@ -1,110 +1,196 @@
 import hashlib
-import io
 import multiprocessing
 import os
 import shutil
 import tempfile
-import threading
 import time
 import unittest
 import zipfile
 from concurrent.futures import ProcessPoolExecutor
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from unittest.mock import patch
 
+import nltk.data
+import nltk.pathsec
 from nltk.downloader import Downloader, Package
 
-# 1. Dynamically generate a valid, minimal ZIP file in memory
-zip_buffer = io.BytesIO()
-with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_STORED) as zf:
-    zf.writestr("abc/dummy.txt", b"real zip payload")
-ZIP_BYTES = zip_buffer.getvalue()
-ZIP_SIZE = len(ZIP_BYTES)
-ZIP_MD5 = hashlib.md5(ZIP_BYTES).hexdigest()
+BIG_PAYLOAD = b"x" * (1024 * 1024)
 
 
-# Create a custom server class to safely track requests
-class TrackingServer(HTTPServer):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.request_count = 0
+def _build_source_zip(source_dir):
+    os.makedirs(source_dir, exist_ok=True)
+    zip_path = os.path.join(source_dir, "abc.zip")
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_STORED) as zf:
+        zf.writestr("abc/dummy.txt", BIG_PAYLOAD)
+    return zip_path
 
 
-class TrackingHandler(BaseHTTPRequestHandler):
-    def do_GET(self):
-        self.server.request_count += 1
+def _zip_metadata(zip_path):
+    with open(zip_path, "rb") as f:
+        data = f.read()
+    with zipfile.ZipFile(zip_path, "r") as zf:
+        unzipped_size = sum(info.file_size for info in zf.infolist())
+    return {
+        "size": len(data),
+        "md5": hashlib.md5(data).hexdigest(),
+        "sha256": hashlib.sha256(data).hexdigest(),
+        "unzipped_size": unzipped_size,
+    }
 
-        # Artificial delay to guarantee multiple processes hit the lock logic
-        # while the file is actively downloading.
-        time.sleep(0.1)
 
-        self.send_response(200)
-        self.send_header("Content-type", "application/zip")
-        self.send_header("Content-Length", str(ZIP_SIZE))
-        self.end_headers()
-        self.wfile.write(ZIP_BYTES)
+class SlowResponse:
+    def __init__(self, wrapped, delay=0.02):
+        self._wrapped = wrapped
+        self._delay = delay
 
-    def log_message(self, format, *args):
-        pass  # Suppress console logging during the test run
+    def read(self, n=-1):
+        data = self._wrapped.read(n)
+        if data:
+            time.sleep(self._delay)
+        return data
+
+    def close(self):
+        return self._wrapped.close()
+
+    def __getattr__(self, name):
+        return getattr(self._wrapped, name)
+
+
+def _download_with_file_url(download_dir, pkg, fetch_count, fetch_lock):
+    real_pathsec_urlopen = nltk.pathsec.urlopen
+
+    def counting_urlopen(url, *args, **kwargs):
+        with fetch_lock:
+            fetch_count.value += 1
+        wrapped = real_pathsec_urlopen(url, *args, **kwargs)
+        return SlowResponse(wrapped, delay=0.02)
+
+    dl = Downloader(download_dir=download_dir)
+    with patch("nltk.downloader.urlopen", side_effect=counting_urlopen):
+        return dl.download(pkg, quiet=True)
+
+
+def _collect_debug(download_dir, pkg):
+    dl = Downloader(download_dir=download_dir)
+    zip_path = os.path.join(download_dir, pkg.filename)
+    unzipdir = zip_path[:-4] if zip_path.endswith(".zip") else None
+
+    data = {
+        "pkg_filename": pkg.filename,
+        "zip_path": zip_path,
+        "zip_exists": os.path.exists(zip_path),
+        "zip_size": os.path.getsize(zip_path) if os.path.exists(zip_path) else None,
+        "unzipdir": unzipdir,
+        "unzipdir_exists": os.path.exists(unzipdir) if unzipdir else None,
+        "unzipdir_is_dir": os.path.isdir(unzipdir) if unzipdir else None,
+        "files": [],
+        "total_unzipped_size": 0,
+        "expected_size": int(pkg.size),
+        "expected_unzipped_size": int(pkg.unzipped_size),
+        "expected_md5": pkg.checksum,
+        "expected_sha256": getattr(pkg, "sha256_checksum", None),
+        "status": dl.status(pkg, download_dir),
+    }
+
+    if os.path.exists(zip_path):
+        with open(zip_path, "rb") as f:
+            content = f.read()
+        data["zip_md5"] = hashlib.md5(content).hexdigest()
+        data["zip_sha256"] = hashlib.sha256(content).hexdigest()
+
+    if unzipdir and os.path.isdir(unzipdir):
+        for root, _dirs, files in os.walk(unzipdir):
+            for name in sorted(files):
+                path = os.path.join(root, name)
+                rel = os.path.relpath(path, unzipdir)
+                size = os.path.getsize(path)
+                data["files"].append((rel, size))
+                data["total_unzipped_size"] += size
+
+    return data
 
 
 class TestDownloaderAtomic(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        # Start a local server on a random open port
-        cls.server = TrackingServer(("127.0.0.1", 0), TrackingHandler)
-        cls.port = cls.server.server_port
-        cls.server_thread = threading.Thread(target=cls.server.serve_forever)
-        cls.server_thread.daemon = True
-        cls.server_thread.start()
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.server.shutdown()
-        cls.server.server_close()
-        cls.server_thread.join()
-
     def setUp(self):
         self.test_dir = tempfile.mkdtemp()
-        self.server.request_count = 0  # Reset count for each test
+        self.source_dir = tempfile.mkdtemp()
+
+        # Allow strict pathsec access to our temp roots.
+        self._old_nltk_data_path = list(nltk.data.path)
+        resolved_test_dir = str(Path(self.test_dir).resolve())
+        resolved_source_dir = str(Path(self.source_dir).resolve())
+        if resolved_test_dir not in nltk.data.path:
+            nltk.data.path.append(resolved_test_dir)
+        if resolved_source_dir not in nltk.data.path:
+            nltk.data.path.append(resolved_source_dir)
+
+        self.source_zip_path = _build_source_zip(self.source_dir)
+        meta = _zip_metadata(self.source_zip_path)
 
         self.pkg = Package(
             id="abc",
-            url=f"http://127.0.0.1:{self.port}/abc.zip",
-            size=ZIP_SIZE,
-            unzipped_size=16,  # Length of b"real zip payload"
-            filename="abc.zip",
-            checksum=ZIP_MD5,
+            url=Path(self.source_zip_path).resolve().as_uri(),
+            subdir="corpora",
+            size=meta["size"],
+            unzipped_size=meta["unzipped_size"],
+            checksum=meta["md5"],
+            sha256_checksum=meta["sha256"],
             unzip=True,
         )
 
     def tearDown(self):
+        nltk.data.path[:] = self._old_nltk_data_path
         if os.path.exists(self.test_dir):
             shutil.rmtree(self.test_dir)
+        if os.path.exists(self.source_dir):
+            shutil.rmtree(self.source_dir)
 
     def test_concurrent_downloads_cooperate(self):
-        """Verify multiple parallel processes result in exactly ONE network request."""
-        dl = Downloader(download_dir=self.test_dir)
+        """Verify multiple parallel processes cooperate under ENFORCE=True."""
         num_concurrent = 3
-
-        # Use 'spawn' to prevent deadlocks from forking a process that already has running threads
         mp_ctx = multiprocessing.get_context("spawn")
-        with ProcessPoolExecutor(
-            max_workers=num_concurrent, mp_context=mp_ctx
-        ) as executor:
-            futures = [
-                executor.submit(dl.download, self.pkg, quiet=True)
-                for _ in range(num_concurrent)
-            ]
-            results = [f.result() for f in futures]
 
-        # All processes should report success
-        self.assertTrue(all(results))
+        with mp_ctx.Manager() as manager:
+            fetch_count = manager.Value("i", 0)
+            fetch_lock = manager.Lock()
 
-        # PROOF 1: The local server should have only received 1 request
-        self.assertEqual(self.server.request_count, 1)
+            with ProcessPoolExecutor(
+                max_workers=num_concurrent, mp_context=mp_ctx
+            ) as executor:
+                futures = [
+                    executor.submit(
+                        _download_with_file_url,
+                        self.test_dir,
+                        self.pkg,
+                        fetch_count,
+                        fetch_lock,
+                    )
+                    for _ in range(num_concurrent)
+                ]
+                results = [f.result() for f in futures]
 
-        # PROOF 2: The zip file exists and is valid
-        self.assertTrue(os.path.exists(os.path.join(self.test_dir, "abc.zip")))
+            debug = _collect_debug(self.test_dir, self.pkg)
 
-        # PROOF 3: NLTK successfully unzipped the file without throwing BadZipFile
-        self.assertTrue(os.path.exists(os.path.join(self.test_dir, "abc", "dummy.txt")))
+            self.assertTrue(
+                all(results),
+                msg=f"results={results}, fetch_count={fetch_count.value}, debug={debug}",
+            )
+            self.assertEqual(
+                fetch_count.value,
+                1,
+                msg=f"Expected exactly one fetch, got {fetch_count.value}; debug={debug}",
+            )
+
+            zip_path = os.path.join(self.test_dir, self.pkg.filename)
+            extracted_file = os.path.join(self.test_dir, "corpora", "abc", "dummy.txt")
+
+            self.assertTrue(os.path.exists(zip_path), msg=f"debug={debug}")
+            self.assertTrue(os.path.exists(extracted_file), msg=f"debug={debug}")
+
+            with open(extracted_file, "rb") as f:
+                self.assertEqual(f.read(), BIG_PAYLOAD, msg=f"debug={debug}")
+
+            dl = Downloader(download_dir=self.test_dir)
+            self.assertEqual(
+                dl.status(self.pkg, self.test_dir), dl.INSTALLED, msg=f"debug={debug}"
+            )


### PR DESCRIPTION
## Summary

This PR prepares NLTK for enabling strict path security by default.

## Changes

- set `nltk.pathsec.ENFORCE = True`
- harden `Downloader._download_package()` so one process owns the full install lifecycle:
  - download
  - atomic zip publish
  - unzip
  - final verification
- replace the old localhost-based atomic downloader test with a strict-policy-compatible `file://` concurrency test that works under `ENFORCE=True`

## Why

PR #3549 improved concurrent download handling, but the old test depended on loopback HTTP (`127.0.0.1`), which is intentionally blocked when strict path security is enabled. This PR updates the test so it remains meaningful under `ENFORCE=True` and closes the remaining race window around unzip/install completion.

## Validation

All downloader and path security tests pass locally, including the updated concurrent downloader test under strict enforcement.

## Notes

This PR is intended both to enable `ENFORCE=True` by default and to help assess compatibility of recently approved changes with strict enforcement behavior.
So we need to expedite this PR, so that we can retest CI on #3575, #3579, #3581, #3582 and #3583, to verify these PRs are compatble with the forthcoming stricter policy.