### PR TITLE
Use commonpath for downloader path containment on Windows

### DIFF
--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -683,9 +683,19 @@ class Downloader:
         lock_filepath = filepath + ".lock"
 
         # Defense-in-depth: verify filepath stays within download_dir
-        real_download = os.path.realpath(os.path.abspath(download_dir))
-        real_filepath = os.path.realpath(os.path.abspath(filepath))
-        if not real_filepath.startswith(real_download + os.sep):
+        real_download = os.path.normcase(
+            os.path.realpath(os.path.abspath(download_dir))
+        )
+        real_filepath = os.path.normcase(os.path.realpath(os.path.abspath(filepath)))
+        try:
+            if os.path.commonpath([real_download, real_filepath]) != real_download:
+                yield ErrorMessage(
+                    info,
+                    f"Path traversal blocked: package '{info.id}' attempted to "
+                    f"write outside download directory (subdir='{info.subdir}')",
+                )
+                return
+        except ValueError:
             yield ErrorMessage(
                 info,
                 f"Path traversal blocked: package '{info.id}' attempted to "


### PR DESCRIPTION
## Summary

This follow-up fixes a Windows-specific false positive in the downloader path-containment guard introduced in #3593.

## Change

- replace the `startswith()`-based containment check in `Downloader._download_package()` with a `normcase(realpath(...)) + commonpath(...)` check

## Why

The previous guard was too brittle on Windows and could misclassify valid child paths as escaping the download directory due to path normalization differences such as short-name aliases, case differences, or path representation changes. This showed up in CI on Windows with Python 3.13.

## Impact

This keeps the defense-in-depth path traversal protection while making it robust across Windows path semantics, allowing the stricter enforcement work from #3593 to benefit dependent pending PRs.