### PR TITLE
Document NLTK's new security policy

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-Version 3.10.0 2026-06-XX
+Version 3.10.0 (unreleased)
 
 * Enforce the stricter `nltk.pathsec` security policy by default (`ENFORCE = True`)
 * Document the new default security policy, migration guidance, and resource-loading protections

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,34 @@
+Version 3.10.0 2026-06-XX
+
+* Enforce the stricter `nltk.pathsec` security policy by default (`ENFORCE = True`)
+* Document the new default security policy, migration guidance, and resource-loading protections
+* Harden resource loading against additional path traversal, SSRF, DNS-rebinding, downloader, and corpus-reader edge cases
+* Block URL-encoded traversal in `nltk:` resource URLs
+* Prevent DNS-rebinding SSRF in `pathsec.urlopen`
+* Close remaining pathsec gaps in corpus readers and downloader target-path handling
+* Re-validate downloader path containment across platforms and improve downloader concurrency/file locking behavior
+* Block XML entity expansion in the downloader
+* Warn on unpickling user-provided pickles
+* Add HuggingFace datasets integration (`nltk.huggingface`)
+* Align TnT with Brants (2000) specifications
+* Fix PorterStemmer irregular-form lowercasing in NLTK mode
+* Fix TransitionParser sparse index dtype for scikit-learn 1.9
+* Fix TextCat tie handling
+* Fix WordNet object comparisons for incompatible types
+* Cache WordNet max depth lazily for `lch_similarity()`
+* Fix CCG variable direction, substitution, type-raising, and related parser bugs
+* Fix Jaro similarity for single-character and empty-string cases
+* Improve CI and retest workflow support for branch and fork PRs
+* Update contributing and release-maintenance workflows
+
+Thanks to the following contributors to 3.10.0:
+13rac1, alvations, bowiechen, devesh-2002, ekaf, elias-ba,
+haosenwang1018, HyperPS, ihitamandal, jancallewaert, jhnwnstd,
+JuanIMartinezB, Lemm1, LinZiyuu, Mr-Neutr0n, PastelStorm,
+scruge1, Syzygy2048, ylwango613, yzhaoinuw
+
 Version 3.9.4 2026-03-24
+
 * Support Python 3.14
 * Fix bug in Levenshtein distance when substitution_cost > 2
 * Fix bug in Treebank detokeniser re quote ordering

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,13 +1,11 @@
-Version 3.10.0 (unreleased)
+Version 3.10.0 2026-06-11
 
-* Enforce the stricter `nltk.pathsec` security policy by default (`ENFORCE = True`)
-* Document the new default security policy, migration guidance, and resource-loading protections
-* Harden resource loading against additional path traversal, SSRF, DNS-rebinding, downloader, and corpus-reader edge cases
-* Block URL-encoded traversal in `nltk:` resource URLs
-* Prevent DNS-rebinding SSRF in `pathsec.urlopen`
-* Close remaining pathsec gaps in corpus readers and downloader target-path handling
-* Re-validate downloader path containment across platforms and improve downloader concurrency/file locking behavior
-* Block XML entity expansion in the downloader
+* Enforce the stricter `nltk.pathsec` security policy by default
+* Document the new security model and migration guidance
+* Harden resource loading against path traversal and SSRF/DNS-rebinding
+* Harden downloader path handling and block XML entity expansion
+* Close remaining corpus-reader security edge cases
+* Replace unsafe `exec()` usage in the utility CLI
 * Warn on unpickling user-provided pickles
 * Add HuggingFace datasets integration (`nltk.huggingface`)
 * Align TnT with Brants (2000) specifications
@@ -16,10 +14,9 @@ Version 3.10.0 (unreleased)
 * Fix TextCat tie handling
 * Fix WordNet object comparisons for incompatible types
 * Cache WordNet max depth lazily for `lch_similarity()`
-* Fix CCG variable direction, substitution, type-raising, and related parser bugs
+* Fix CCG variable direction, substitution, and type-raising bugs
 * Fix Jaro similarity for single-character and empty-string cases
-* Improve CI and retest workflow support for branch and fork PRs
-* Update contributing and release-maintenance workflows
+* Improve CI and release-maintenance workflows
 
 Thanks to the following contributors to 3.10.0:
 13rac1, alvations, bowiechen, devesh-2002, ekaf, elias-ba,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,81 +7,117 @@ Please report security issues to `nltk.team@gmail.com`
 ## Security Hardening
 
 NLTK includes a centralized I/O security module (`nltk.pathsec`) that
-validates file paths, network URLs, and zip archives. During the initial
-transition phase, it operates by default in **warn-only mode**, to avoid
-breaking existing workflows. In a later release, it will be switched to
-enforce the stricter security policy by default.
+validates file paths, network URLs, and zip archives.
 
-### Enabling strict enforcement
+As of NLTK 3.10.0, strict enforcement is enabled by default
+(`ENFORCE=True`). In normal operation, NLTK applies the stricter
+`pathsec` policy unless a caller explicitly opts out.
 
-If you are running NLTK in a security-sensitive environment (web
-applications, multi-tenant pipelines, CI/CD systems, or any context
-where untrusted input may reach NLTK), you should enable strict
-enforcement:
+Under enforcement, unauthorized file access, SSRF attempts, and zip-slip
+style path escapes raise `PermissionError` instead of emitting warnings.
 
-```python
-import nltk.pathsec
-nltk.pathsec.ENFORCE = True
-```
+### Resource-loading security model
 
-With `ENFORCE = True`, unauthorized file access, SSRF attempts, and
-zip-slip attacks will raise `PermissionError` instead of emitting
-warnings.
+NLTK's resource-loading protections are designed to reduce common risks
+when NLTK is used with untrusted input or in shared environments such as
+web applications, services, notebooks, CI/CD systems, and multi-tenant
+pipelines.
 
+In particular, the current policy reduces the risk of:
 
-### Current Working Directory (CWD) Access
+- **Arbitrary local file access through NLTK resource loading** by
+  requiring filesystem access to remain within allowed NLTK data
+  directories.
+- **SSRF to non-public destinations** by resolving network targets and
+  blocking loopback, private, link-local, and multicast addresses.
+- **Redirect-based bypasses** by re-validating redirects at each hop.
+- **Zip-slip attacks** by validating extraction targets before writing
+  files.
 
-To maintain a "zero-friction" experience for students and researchers,
-NLTK permits access to resources located in the process's current
-working directory by default.
+These protections apply to NLTK's own resource-loading paths and URL
+handling. They are not a general operating-system sandbox, and they do
+not prevent all unsafe behavior an application might perform outside
+NLTK.
 
-* **Standard Mode (`ENFORCE=False`):** Accessing data in the CWD is
-permitted but triggers a `RuntimeWarning` to alert users that this
-behavior may be insecure in shared or server-side environments.
+### Local file access
 
-* **Strict Mode (`ENFORCE=True`):** Implicit CWD access is **disabled**.
-To authorize the local directory in strict mode, users must explicitly
-append it to the search path:
-  ```python
-  import nltk
-  nltk.data.path.append('.')
-  ```
+`file:` URLs are not a general-purpose mechanism for loading arbitrary
+local files.
 
-
-### What is protected
-
-- **Path traversal**: file access is validated against allowed NLTK
-  data directories (`nltk.data.path`, `NLTK_DATA` environment
-  variable, and standard system locations).
-- **SSRF prevention**: `urlopen` resolves hostnames via DNS and blocks
-  requests to loopback, private, link-local, and multicast IP ranges,
-  including obfuscated forms (e.g. decimal IP notation).
-- **Zip-slip protection**: zip extraction validates that member paths
-  stay within the target directory.
-- **Pickle safety**: `nltk.data.load()` uses `RestrictedUnpickler`
-  which blocks all class/function globals. Other pickle loading uses
-  `pickle_load()` which emits a security warning.
-
-### Configuring allowed data paths
-
-NLTK determines allowed data directories from:
+With strict enforcement enabled (`ENFORCE=True`), file-backed resources
+must resolve inside allowed NLTK data directories. By default these
+directories are derived from:
 
 1. `nltk.data.path` (configurable at runtime)
 2. `NLTK_DATA` environment variable
 3. Standard locations (`~/nltk_data`, `/usr/share/nltk_data`, etc.)
-4. System temp directory
+4. The system temp directory
 
-If you use a custom data location, add it to `nltk.data.path`:
+If you use a custom resource directory, explicitly add it to
+`nltk.data.path`:
 
 ```python
 import nltk
 nltk.data.path.append('/my/custom/data')
 ```
 
+Then load resources by NLTK resource path rather than relying on access
+to arbitrary filesystem locations.
+
+### Current Working Directory (CWD) access
+
+Implicit access to the current working directory is not allowed under
+strict enforcement (`ENFORCE=True`) unless that directory has been
+explicitly added to `nltk.data.path`.
+
+If you intentionally want to trust the current directory, authorize it
+explicitly:
+
+```python
+import nltk
+nltk.data.path.append('.')
+```
+
+This makes the trust decision explicit and avoids surprising behavior in
+server-side or shared execution environments.
+
+### Network URL validation
+
+NLTK permits network resource loading only for `http:` and `https:`
+URLs.
+
+Before a request is made, NLTK validates the resolved destination and
+blocks requests to:
+
+- loopback addresses
+- private RFC1918 ranges
+- link-local addresses
+- multicast addresses
+
+Redirects are re-validated at each hop, so a public URL cannot bypass
+the policy by redirecting to a blocked destination.
+
+In practice, ordinary public URLs continue to work, while destinations
+such as `127.0.0.1`, `10.0.0.0/8`, and `169.254.169.254` are rejected.
+
+### What is protected
+
+- **Path traversal**: file access is validated against allowed NLTK
+  data directories (`nltk.data.path`, `NLTK_DATA`, and standard system
+  locations).
+- **SSRF prevention**: `urlopen` resolves hostnames via DNS and blocks
+  requests to loopback, private, link-local, and multicast IP ranges,
+  including obfuscated forms where applicable.
+- **Zip-slip protection**: zip extraction validates that member paths
+  stay within the target directory.
+- **Pickle safety**: `nltk.data.load()` uses `RestrictedUnpickler`
+  which blocks all class/function globals. Other pickle loading uses
+  `pickle_load()` which emits a security warning.
+
 ### Note on symlinks
 
 NLTK's corpus readers perform lexical path containment checks when
-joining file paths. These checks do not resolve symlinks. If your
-threat model includes attackers who can place symlinks inside your
-NLTK data directories, enable `ENFORCE = True` for full path
-resolution and validation.
+joining file paths. These checks do not resolve symlinks. If your threat
+model includes attackers who can place symlinks inside trusted NLTK data
+directories, keep strict enforcement enabled so paths are fully resolved
+and validated.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ As of NLTK 3.10.0, strict enforcement is enabled by default
 `pathsec` policy unless a caller explicitly opts out.
 
 Under enforcement, unauthorized file access, SSRF attempts, and zip-slip
-style path escapes raise `PermissionError` instead of emitting warnings.
+style path escapes raise exceptions (typically `PermissionError`) instead of emitting warnings.
 
 ### Resource-loading security model
 

--- a/nltk/lm/models.py
+++ b/nltk/lm/models.py
@@ -76,7 +76,9 @@ class StupidBackoff(LanguageModel):
     def unmasked_score(self, word, context=None):
         if context:
             max_ctx = self.order - 1
-            if len(context) > max_ctx:
+            if max_ctx <= 0:
+                context = ()
+            elif len(context) > max_ctx:
                 context = context[-max_ctx:]
 
         if not context:
@@ -108,7 +110,9 @@ class InterpolatedLanguageModel(LanguageModel):
     def unmasked_score(self, word, context=None):
         if context:
             max_ctx = self.order - 1
-            if len(context) > max_ctx:
+            if max_ctx <= 0:
+                context = ()
+            elif len(context) > max_ctx:
                 context = context[-max_ctx:]
 
         if not context:

--- a/nltk/sem/util.py
+++ b/nltk/sem/util.py
@@ -270,8 +270,11 @@ def demo():
         sentsfile = options.sentences
     if options.grammar:
         gramfile = options.grammar
+
     if options.model:
-        exec("import %s as model" % options.model)
+        opts.error(
+            "--model is currently unsupported in demo(); the CLI always uses the built-in demo model"
+        )
 
     if sents is None:
         sents = read_sents(sentsfile)

--- a/nltk/test/unit/lm/test_models.py
+++ b/nltk/test/unit/lm/test_models.py
@@ -609,3 +609,19 @@ def test_generate_None_text_seed(mle_trigram_model):
     assert mle_trigram_model.generate(
         text_seed=None, random_seed=3
     ) == mle_trigram_model.generate(random_seed=3)
+
+
+def test_stupid_backoff_unigram_long_context_matches_empty_context(vocabulary):
+    model = StupidBackoff(order=1, vocabulary=vocabulary)
+    model.fit([[("a",)], [("b",)], [("a",)]])
+
+    long_context = tuple("x" for _ in range(10000))
+    assert model.score("a", long_context) == model.score("a", ())
+
+
+def test_witten_bell_unigram_long_context_matches_empty_context(vocabulary):
+    model = WittenBellInterpolated(order=1, vocabulary=vocabulary)
+    model.fit([[("a",)], [("b",)], [("a",)]])
+
+    long_context = tuple("x" for _ in range(10000))
+    assert model.score("a", long_context) == model.score("a", ())

--- a/nltk/test/unit/test_sem_util.py
+++ b/nltk/test/unit/test_sem_util.py
@@ -1,0 +1,22 @@
+from nltk.sem.util import demo
+
+
+def test_demo_model_injection_safeguard(tmp_path, monkeypatch):
+    """
+    Ensure that passing a malicious payload with newlines to the --model flag
+    raises an appropriate error instead of executing arbitrary code.
+    """
+    sentinel_file = tmp_path / "vulnerable_trigger.txt"
+    malicious_payload = f"os\nopen(r'{sentinel_file}', 'w').close()\nimport os"
+
+    monkeypatch.setattr("sys.argv", ["test", "-m", malicious_payload, "--no-eval"])
+
+    try:
+        demo()
+    except SystemExit:
+        pass
+
+    assert not sentinel_file.exists(), (
+        "CRITICAL SECURITY REGRESSION: Code injection vulnerability re-introduced "
+        "in nltk.sem.util.demo()"
+    )

--- a/nltk/test/unit/test_tokenize.py
+++ b/nltk/test/unit/test_tokenize.py
@@ -3,6 +3,8 @@ Unit tests for nltk.tokenize.
 See also nltk/test/tokenize.doctest
 """
 
+import hashlib
+import os
 from typing import List, Tuple
 
 import pytest
@@ -943,6 +945,80 @@ class TestTokenize:
             (9, 10),
             (10, 11),
         ]
+
+
+class TestStanfordSegmenterClasspathValidation:
+    def _make_segmenter(self, classpath):
+        seg = StanfordSegmenter.__new__(StanfordSegmenter)
+        seg._stanford_jar = classpath
+        seg._jar_sha256_cache = {}
+        return seg
+
+    def _write_jar(self, tmp_path, name, data):
+        path = tmp_path / name
+        path.write_bytes(data)
+        return path
+
+    def _sha256(self, path):
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+
+    def test_validate_classpath_allows_all_approved(self, monkeypatch, tmp_path):
+        jar1 = self._write_jar(tmp_path, "segmenter.jar", b"jar-one")
+        jar2 = self._write_jar(tmp_path, "slf4j.jar", b"jar-two")
+        seg = self._make_segmenter(os.pathsep.join([str(jar1), str(jar2)]))
+
+        monkeypatch.setenv(
+            "NLTK_SEGMENTER_ALLOW_SHA256",
+            ",".join([self._sha256(jar1), self._sha256(jar2)]),
+        )
+
+        seg._validate_classpath()
+
+    def test_validate_classpath_blocks_unapproved_entry(self, monkeypatch, tmp_path):
+        jar1 = self._write_jar(tmp_path, "segmenter.jar", b"jar-one")
+        jar2 = self._write_jar(tmp_path, "slf4j.jar", b"jar-two")
+        seg = self._make_segmenter(os.pathsep.join([str(jar1), str(jar2)]))
+
+        monkeypatch.setenv("NLTK_SEGMENTER_ALLOW_SHA256", self._sha256(jar1))
+
+        with pytest.raises(LookupError, match=r"\[SECURITY BLOCKED\]"):
+            seg._validate_classpath()
+
+    def test_validate_classpath_does_not_trust_path_substrings(
+        self, monkeypatch, tmp_path
+    ):
+        jar = self._write_jar(
+            tmp_path, "stanford-segmenter-malicious.jar", b"not-approved"
+        )
+        seg = self._make_segmenter(str(jar))
+        monkeypatch.setenv("NLTK_SEGMENTER_ALLOW_SHA256", "")
+
+        with pytest.raises(LookupError) as excinfo:
+            seg._validate_classpath()
+
+        assert "stanford-segmenter-malicious.jar" in str(excinfo.value)
+
+    def test_sha256sum_invalidates_cache_when_file_changes(self, tmp_path):
+        jar = self._write_jar(tmp_path, "segmenter.jar", b"original")
+        seg = self._make_segmenter(str(jar))
+
+        first_digest = seg._sha256sum(str(jar))
+        jar.write_bytes(b"modified and definitely different")
+        second_digest = seg._sha256sum(str(jar))
+
+        assert first_digest != second_digest
+
+    def test_validate_classpath_error_includes_guidance(self, monkeypatch, tmp_path):
+        jar = self._write_jar(tmp_path, "segmenter.jar", b"jar-one")
+        seg = self._make_segmenter(str(jar))
+        monkeypatch.setenv("NLTK_SEGMENTER_ALLOW_SHA256", "")
+
+        with pytest.raises(LookupError) as excinfo:
+            seg._validate_classpath()
+
+        message = str(excinfo.value)
+        assert "NLTK_SEGMENTER_ALLOW_SHA256" in message
+        assert "SHA256:" in message
 
 
 class TestPunktTrainer:

--- a/nltk/tokenize/stanford_segmenter.py
+++ b/nltk/tokenize/stanford_segmenter.py
@@ -10,6 +10,7 @@
 # URL: <https://www.nltk.org/>
 # For license information, see LICENSE.TXT
 
+import hashlib
 import json
 import os
 import tempfile
@@ -120,6 +121,7 @@ class StanfordSegmenter(TokenizerI):
         self._options_cmd = ",".join(
             f"{key}={json.dumps(val)}" for key, val in options.items()
         )
+        self._jar_sha256_cache = {}
 
     def default_config(self, lang):
         """
@@ -269,6 +271,48 @@ class StanfordSegmenter(TokenizerI):
 
         return stdout
 
+    def _sha256sum(self, file_path):
+        stat = os.stat(file_path)
+        cached = self._jar_sha256_cache.get(file_path)
+        cache_key = (stat.st_mtime_ns, stat.st_size)
+        if cached is not None:
+            cached_key, cached_digest = cached
+            if cached_key == cache_key:
+                return cached_digest
+
+        h = hashlib.sha256()
+        with open(file_path, "rb") as f:
+            for chunk in iter(lambda: f.read(4096), b""):
+                h.update(chunk)
+        digest = h.hexdigest()
+        self._jar_sha256_cache[file_path] = (cache_key, digest)
+        return digest
+
+    def _validate_classpath(self):
+        user_checksums = {
+            value.strip()
+            for value in os.environ.get("NLTK_SEGMENTER_ALLOW_SHA256", "").split(",")
+            if value.strip()
+        }
+
+        for jar_path in (p for p in self._stanford_jar.split(os.pathsep) if p):
+            jar_checksum = self._sha256sum(jar_path)
+
+            if jar_checksum not in user_checksums:
+                raise LookupError(
+                    "\n[SECURITY BLOCKED] Unverified Stanford Segmenter JAR detected:\n"
+                    f"  -> {jar_path}\n"
+                    f"  SHA256: {jar_checksum}\n\n"
+                    "This prevents arbitrary code execution via malicious JAR injection.\n"
+                    "To allow execution, verify and approve this checksum,\n"
+                    "then add it to the NLTK_SEGMENTER_ALLOW_SHA256 environment variable.\n\n"
+                    "Examples:\n"
+                    f'  Unix/macOS (bash/zsh): export NLTK_SEGMENTER_ALLOW_SHA256="{jar_checksum}"\n'
+                    f'  Windows PowerShell:    $env:NLTK_SEGMENTER_ALLOW_SHA256="{jar_checksum}"\n'
+                    f"  Windows cmd.exe:       set NLTK_SEGMENTER_ALLOW_SHA256={jar_checksum}\n\n"
+                    "Multiple approved checksums may be supplied as a comma-separated list."
+                )
+
     def _execute(self, cmd, verbose=False):
         encoding = self._encoding
         cmd.extend(["-inputEncoding", encoding])
@@ -278,33 +322,7 @@ class StanfordSegmenter(TokenizerI):
 
         default_options = " ".join(_java_options)
 
-        # ------------------- Security Validation ------------------- #
-        import hashlib
-        import os
-
-        jar_path = self._stanford_jar
-        trusted_paths = ["stanford-segmenter", "stanford-corenlp", "nltk"]
-
-        def sha256sum(file):
-            h = hashlib.sha256()
-            with open(file, "rb") as f:
-                for chunk in iter(lambda: f.read(4096), b""):
-                    h.update(chunk)
-            return h.hexdigest()
-
-        if not any(p in jar_path for p in trusted_paths):
-            user_checksum = os.environ.get("NLTK_SEGMENTER_ALLOW_SHA256")
-            jar_checksum = sha256sum(jar_path)
-
-            if user_checksum != jar_checksum:
-                raise RuntimeError(
-                    "\n[SECURITY BLOCKED] Unverified Stanford Segmenter JAR detected:\n"
-                    f"  → {jar_path}\n\n"
-                    "This prevents arbitrary code execution via malicious JAR injection.\n"
-                    "To allow execution, verify and approve its SHA256 checksum:\n\n"
-                    f'  export NLTK_SEGMENTER_ALLOW_SHA256="{jar_checksum}"\n'
-                )
-        # ------------------------------------------------------------ #
+        self._validate_classpath()
 
         # Configure java.
         config_java(options=self.java_options, verbose=verbose)

--- a/web/news.rst
+++ b/web/news.rst
@@ -11,7 +11,7 @@ NLTK 3.10.0 release: June 2026
 - Local resources must resolve inside allowed NLTK data directories such as ``nltk.data.path`` or ``NLTK_DATA``
 - ``http:`` and ``https:`` resource loading now goes through centralized validation with SSRF protections
 - Redirects are re-validated at each hop during network access
-- Disallowed local paths and blocked network destinations now raise ``PermissionError``
+- Disallowed local paths and blocked network destinations raise ``PermissionError`` (and some corpus-reader validations raise ``ValueError``)
 
 Migration note:
 
@@ -40,7 +40,7 @@ Network loading is now subject to centralized validation.
 - Redirects are re-validated at each hop
 - Violations raise ``PermissionError``
 
-In practice, normal public URLs continue to work, but URLs such as ``https://127.0.0.1/...``, ``https://10.x.x.x/...`` and ``https://169.254.169.254/...`` are rejected.
+In practice, normal public URLs continue to work, but URLs such as ``https://127.0.0.1/...``, ``https://10.0.0.1/...`` and ``https://169.254.169.254/...`` are rejected.
 
 Documentation has also been updated to remove recommendations for arbitrary ``file:`` loading and to clarify that both local and network resource access now go through ``pathsec`` validation.
 

--- a/web/news.rst
+++ b/web/news.rst
@@ -4,6 +4,47 @@ Release Notes
 2026
 ----
 
+NLTK 3.10.0 release: June 2026
+
+- Enforce the stricter ``nltk.pathsec`` policy by default (``ENFORCE = True``)
+- ``file:`` URLs are no longer a general-purpose way to load arbitrary local files
+- Local resources must resolve inside allowed NLTK data directories such as ``nltk.data.path`` or ``NLTK_DATA``
+- ``http:`` and ``https:`` resource loading now goes through centralized validation with SSRF protections
+- Redirects are re-validated at each hop during network access
+- Disallowed local paths and blocked network destinations now raise ``PermissionError``
+
+Migration note:
+
+NLTK 3.10.0 enforces the stricter ``pathsec`` policy by default.
+
+Local files (``file:``)
+^^^^^^^^^^^^^^^^^^^^^^^
+
+``file:`` URLs are no longer a general-purpose way to load arbitrary local files.
+
+Under enforcement:
+
+- Files must resolve inside allowed NLTK data directories, including locations from ``nltk.data.path`` and ``NLTK_DATA``
+- Access to arbitrary locations, including the current working directory unless explicitly added, is blocked by default
+- Disallowed paths raise ``PermissionError``
+
+If you load custom local resources, move them into a directory on ``NLTK_DATA`` or explicitly add a trusted directory via ``nltk.data.path.append(...)``, then load them by NLTK resource path.
+
+Network URLs (``http:`` / ``https:``)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Network loading is now subject to centralized validation.
+
+- Only ``http`` and ``https`` URLs are allowed
+- Requests are blocked if the resolved host is loopback, private, link-local, or multicast
+- Redirects are re-validated at each hop
+- Violations raise ``PermissionError``
+
+In practice, normal public URLs continue to work, but URLs such as ``https://127.0.0.1/...``, ``https://10.x.x.x/...`` and ``https://169.254.169.254/...`` are rejected.
+
+Documentation has also been updated to remove recommendations for arbitrary ``file:`` loading and to clarify that both local and network resource access now go through ``pathsec`` validation.
+
+
 NLTK 3.9.3 release: February 2026
 
 - Security fix for CVE-2025-14009 (Zip-Slip/RCE)


### PR DESCRIPTION
Closes #3565.

This PR documents NLTK's finalized resource-loading security policy now that the stricter `nltk.pathsec.ENFORCE = True` behavior and related security hardening have been merged.

Changes:
- add a definitive NLTK 3.10.0 migration note to `web/news.rst`
- update `SECURITY.md` to describe the current default enforcement behavior and NLTK's resource-loading security model
- add a release-quality `Version 3.10.0` entry to `ChangeLog`, including contributor credits for merged PRs since 3.9.4

Documented behavior includes:
- `file:` is no longer a general-purpose mechanism for arbitrary local file loading
- local resources must resolve inside allowed NLTK data directories
- network loading is limited to `http:` / `https:` and validated centrally
- loopback/private/link-local/multicast destinations are blocked
- redirects are re-validated at each hop
- violations raise `PermissionError`

This also includes migration guidance for users who load custom local resources.