### PR TITLE
Fix remaining post-merge issues from #3477 and #3498

### DIFF
--- a/nltk/lm/models.py
+++ b/nltk/lm/models.py
@@ -76,7 +76,9 @@ class StupidBackoff(LanguageModel):
     def unmasked_score(self, word, context=None):
         if context:
             max_ctx = self.order - 1
-            if len(context) > max_ctx:
+            if max_ctx <= 0:
+                context = ()
+            elif len(context) > max_ctx:
                 context = context[-max_ctx:]
 
         if not context:
@@ -108,7 +110,9 @@ class InterpolatedLanguageModel(LanguageModel):
     def unmasked_score(self, word, context=None):
         if context:
             max_ctx = self.order - 1
-            if len(context) > max_ctx:
+            if max_ctx <= 0:
+                context = ()
+            elif len(context) > max_ctx:
                 context = context[-max_ctx:]
 
         if not context:

--- a/nltk/test/unit/lm/test_models.py
+++ b/nltk/test/unit/lm/test_models.py
@@ -609,3 +609,19 @@ def test_generate_None_text_seed(mle_trigram_model):
     assert mle_trigram_model.generate(
         text_seed=None, random_seed=3
     ) == mle_trigram_model.generate(random_seed=3)
+
+
+def test_stupid_backoff_unigram_long_context_matches_empty_context(vocabulary):
+    model = StupidBackoff(order=1, vocabulary=vocabulary)
+    model.fit([[("a",)], [("b",)], [("a",)]])
+
+    long_context = tuple("x" for _ in range(10000))
+    assert model.score("a", long_context) == model.score("a", ())
+
+
+def test_witten_bell_unigram_long_context_matches_empty_context(vocabulary):
+    model = WittenBellInterpolated(order=1, vocabulary=vocabulary)
+    model.fit([[("a",)], [("b",)], [("a",)]])
+
+    long_context = tuple("x" for _ in range(10000))
+    assert model.score("a", long_context) == model.score("a", ())

--- a/nltk/test/unit/test_tokenize.py
+++ b/nltk/test/unit/test_tokenize.py
@@ -3,6 +3,8 @@ Unit tests for nltk.tokenize.
 See also nltk/test/tokenize.doctest
 """
 
+import hashlib
+import os
 from typing import List, Tuple
 
 import pytest
@@ -943,6 +945,80 @@ class TestTokenize:
             (9, 10),
             (10, 11),
         ]
+
+
+class TestStanfordSegmenterClasspathValidation:
+    def _make_segmenter(self, classpath):
+        seg = StanfordSegmenter.__new__(StanfordSegmenter)
+        seg._stanford_jar = classpath
+        seg._jar_sha256_cache = {}
+        return seg
+
+    def _write_jar(self, tmp_path, name, data):
+        path = tmp_path / name
+        path.write_bytes(data)
+        return path
+
+    def _sha256(self, path):
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+
+    def test_validate_classpath_allows_all_approved(self, monkeypatch, tmp_path):
+        jar1 = self._write_jar(tmp_path, "segmenter.jar", b"jar-one")
+        jar2 = self._write_jar(tmp_path, "slf4j.jar", b"jar-two")
+        seg = self._make_segmenter(os.pathsep.join([str(jar1), str(jar2)]))
+
+        monkeypatch.setenv(
+            "NLTK_SEGMENTER_ALLOW_SHA256",
+            ",".join([self._sha256(jar1), self._sha256(jar2)]),
+        )
+
+        seg._validate_classpath()
+
+    def test_validate_classpath_blocks_unapproved_entry(self, monkeypatch, tmp_path):
+        jar1 = self._write_jar(tmp_path, "segmenter.jar", b"jar-one")
+        jar2 = self._write_jar(tmp_path, "slf4j.jar", b"jar-two")
+        seg = self._make_segmenter(os.pathsep.join([str(jar1), str(jar2)]))
+
+        monkeypatch.setenv("NLTK_SEGMENTER_ALLOW_SHA256", self._sha256(jar1))
+
+        with pytest.raises(LookupError, match=r"\[SECURITY BLOCKED\]"):
+            seg._validate_classpath()
+
+    def test_validate_classpath_does_not_trust_path_substrings(
+        self, monkeypatch, tmp_path
+    ):
+        jar = self._write_jar(
+            tmp_path, "stanford-segmenter-malicious.jar", b"not-approved"
+        )
+        seg = self._make_segmenter(str(jar))
+        monkeypatch.setenv("NLTK_SEGMENTER_ALLOW_SHA256", "")
+
+        with pytest.raises(LookupError) as excinfo:
+            seg._validate_classpath()
+
+        assert "stanford-segmenter-malicious.jar" in str(excinfo.value)
+
+    def test_sha256sum_invalidates_cache_when_file_changes(self, tmp_path):
+        jar = self._write_jar(tmp_path, "segmenter.jar", b"original")
+        seg = self._make_segmenter(str(jar))
+
+        first_digest = seg._sha256sum(str(jar))
+        jar.write_bytes(b"modified and definitely different")
+        second_digest = seg._sha256sum(str(jar))
+
+        assert first_digest != second_digest
+
+    def test_validate_classpath_error_includes_guidance(self, monkeypatch, tmp_path):
+        jar = self._write_jar(tmp_path, "segmenter.jar", b"jar-one")
+        seg = self._make_segmenter(str(jar))
+        monkeypatch.setenv("NLTK_SEGMENTER_ALLOW_SHA256", "")
+
+        with pytest.raises(LookupError) as excinfo:
+            seg._validate_classpath()
+
+        message = str(excinfo.value)
+        assert "NLTK_SEGMENTER_ALLOW_SHA256" in message
+        assert "SHA256:" in message
 
 
 class TestPunktTrainer:

--- a/nltk/tokenize/stanford_segmenter.py
+++ b/nltk/tokenize/stanford_segmenter.py
@@ -281,40 +281,45 @@ class StanfordSegmenter(TokenizerI):
         default_options = " ".join(_java_options)
 
         # ------------------- Security Validation ------------------- #
-        trusted_paths = ["stanford-segmenter", "stanford-corenlp", "nltk"]
-
         def sha256sum(file_path):
+            stat = os.stat(file_path)
             cached = self._jar_sha256_cache.get(file_path)
+            cache_key = (stat.st_mtime_ns, stat.st_size)
             if cached is not None:
-                return cached
+                cached_key, cached_digest = cached
+                if cached_key == cache_key:
+                    return cached_digest
 
             h = hashlib.sha256()
             with open(file_path, "rb") as f:
                 for chunk in iter(lambda: f.read(4096), b""):
                     h.update(chunk)
             digest = h.hexdigest()
-            self._jar_sha256_cache[file_path] = digest
+            self._jar_sha256_cache[file_path] = (cache_key, digest)
             return digest
 
-        user_checksum = os.environ.get("NLTK_SEGMENTER_ALLOW_SHA256")
-        for jar_path in (p for p in self._stanford_jar.split(os.pathsep) if p):
-            if any(p in jar_path for p in trusted_paths):
-                continue
+        user_checksums = {
+            value.strip()
+            for value in os.environ.get("NLTK_SEGMENTER_ALLOW_SHA256", "").split(",")
+            if value.strip()
+        }
 
+        for jar_path in (p for p in self._stanford_jar.split(os.pathsep) if p):
             jar_checksum = sha256sum(jar_path)
 
-            if user_checksum != jar_checksum:
+            if jar_checksum not in user_checksums:
                 raise LookupError(
                     "\n[SECURITY BLOCKED] Unverified Stanford Segmenter JAR detected:\n"
                     f"  -> {jar_path}\n"
                     f"  SHA256: {jar_checksum}\n\n"
                     "This prevents arbitrary code execution via malicious JAR injection.\n"
-                    "To allow execution, verify and approve its SHA256 checksum,\n"
-                    "then set the NLTK_SEGMENTER_ALLOW_SHA256 environment variable.\n\n"
+                    "To allow execution, verify and approve this checksum,\n"
+                    "then add it to the NLTK_SEGMENTER_ALLOW_SHA256 environment variable.\n\n"
                     "Examples:\n"
                     f'  Unix/macOS (bash/zsh): export NLTK_SEGMENTER_ALLOW_SHA256="{jar_checksum}"\n'
                     f'  Windows PowerShell:    $env:NLTK_SEGMENTER_ALLOW_SHA256="{jar_checksum}"\n'
-                    f"  Windows cmd.exe:       set NLTK_SEGMENTER_ALLOW_SHA256={jar_checksum}\n"
+                    f"  Windows cmd.exe:       set NLTK_SEGMENTER_ALLOW_SHA256={jar_checksum}\n\n"
+                    "Multiple approved checksums may be supplied as a comma-separated list."
                 )
         # ------------------------------------------------------------ #
 

--- a/nltk/tokenize/stanford_segmenter.py
+++ b/nltk/tokenize/stanford_segmenter.py
@@ -271,33 +271,24 @@ class StanfordSegmenter(TokenizerI):
 
         return stdout
 
-    def _execute(self, cmd, verbose=False):
-        encoding = self._encoding
-        cmd.extend(["-inputEncoding", encoding])
-        _options_cmd = self._options_cmd
-        if _options_cmd:
-            cmd.extend(["-options", self._options_cmd])
+    def _sha256sum(self, file_path):
+        stat = os.stat(file_path)
+        cached = self._jar_sha256_cache.get(file_path)
+        cache_key = (stat.st_mtime_ns, stat.st_size)
+        if cached is not None:
+            cached_key, cached_digest = cached
+            if cached_key == cache_key:
+                return cached_digest
 
-        default_options = " ".join(_java_options)
+        h = hashlib.sha256()
+        with open(file_path, "rb") as f:
+            for chunk in iter(lambda: f.read(4096), b""):
+                h.update(chunk)
+        digest = h.hexdigest()
+        self._jar_sha256_cache[file_path] = (cache_key, digest)
+        return digest
 
-        # ------------------- Security Validation ------------------- #
-        def sha256sum(file_path):
-            stat = os.stat(file_path)
-            cached = self._jar_sha256_cache.get(file_path)
-            cache_key = (stat.st_mtime_ns, stat.st_size)
-            if cached is not None:
-                cached_key, cached_digest = cached
-                if cached_key == cache_key:
-                    return cached_digest
-
-            h = hashlib.sha256()
-            with open(file_path, "rb") as f:
-                for chunk in iter(lambda: f.read(4096), b""):
-                    h.update(chunk)
-            digest = h.hexdigest()
-            self._jar_sha256_cache[file_path] = (cache_key, digest)
-            return digest
-
+    def _validate_classpath(self):
         user_checksums = {
             value.strip()
             for value in os.environ.get("NLTK_SEGMENTER_ALLOW_SHA256", "").split(",")
@@ -305,7 +296,7 @@ class StanfordSegmenter(TokenizerI):
         }
 
         for jar_path in (p for p in self._stanford_jar.split(os.pathsep) if p):
-            jar_checksum = sha256sum(jar_path)
+            jar_checksum = self._sha256sum(jar_path)
 
             if jar_checksum not in user_checksums:
                 raise LookupError(
@@ -321,7 +312,17 @@ class StanfordSegmenter(TokenizerI):
                     f"  Windows cmd.exe:       set NLTK_SEGMENTER_ALLOW_SHA256={jar_checksum}\n\n"
                     "Multiple approved checksums may be supplied as a comma-separated list."
                 )
-        # ------------------------------------------------------------ #
+
+    def _execute(self, cmd, verbose=False):
+        encoding = self._encoding
+        cmd.extend(["-inputEncoding", encoding])
+        _options_cmd = self._options_cmd
+        if _options_cmd:
+            cmd.extend(["-options", self._options_cmd])
+
+        default_options = " ".join(_java_options)
+
+        self._validate_classpath()
 
         # Configure java.
         config_java(options=self.java_options, verbose=verbose)

--- a/nltk/tokenize/stanford_segmenter.py
+++ b/nltk/tokenize/stanford_segmenter.py
@@ -10,6 +10,7 @@
 # URL: <https://www.nltk.org/>
 # For license information, see LICENSE.TXT
 
+import hashlib
 import json
 import os
 import tempfile
@@ -120,6 +121,7 @@ class StanfordSegmenter(TokenizerI):
         self._options_cmd = ",".join(
             f"{key}={json.dumps(val)}" for key, val in options.items()
         )
+        self._jar_sha256_cache = {}
 
     def default_config(self, lang):
         """
@@ -279,30 +281,40 @@ class StanfordSegmenter(TokenizerI):
         default_options = " ".join(_java_options)
 
         # ------------------- Security Validation ------------------- #
-        import hashlib
-        import os
-
-        jar_path = self._stanford_jar
         trusted_paths = ["stanford-segmenter", "stanford-corenlp", "nltk"]
 
-        def sha256sum(file):
+        def sha256sum(file_path):
+            cached = self._jar_sha256_cache.get(file_path)
+            if cached is not None:
+                return cached
+
             h = hashlib.sha256()
-            with open(file, "rb") as f:
+            with open(file_path, "rb") as f:
                 for chunk in iter(lambda: f.read(4096), b""):
                     h.update(chunk)
-            return h.hexdigest()
+            digest = h.hexdigest()
+            self._jar_sha256_cache[file_path] = digest
+            return digest
 
-        if not any(p in jar_path for p in trusted_paths):
-            user_checksum = os.environ.get("NLTK_SEGMENTER_ALLOW_SHA256")
+        user_checksum = os.environ.get("NLTK_SEGMENTER_ALLOW_SHA256")
+        for jar_path in (p for p in self._stanford_jar.split(os.pathsep) if p):
+            if any(p in jar_path for p in trusted_paths):
+                continue
+
             jar_checksum = sha256sum(jar_path)
 
             if user_checksum != jar_checksum:
-                raise RuntimeError(
+                raise LookupError(
                     "\n[SECURITY BLOCKED] Unverified Stanford Segmenter JAR detected:\n"
-                    f"  → {jar_path}\n\n"
+                    f"  -> {jar_path}\n"
+                    f"  SHA256: {jar_checksum}\n\n"
                     "This prevents arbitrary code execution via malicious JAR injection.\n"
-                    "To allow execution, verify and approve its SHA256 checksum:\n\n"
-                    f'  export NLTK_SEGMENTER_ALLOW_SHA256="{jar_checksum}"\n'
+                    "To allow execution, verify and approve its SHA256 checksum,\n"
+                    "then set the NLTK_SEGMENTER_ALLOW_SHA256 environment variable.\n\n"
+                    "Examples:\n"
+                    f'  Unix/macOS (bash/zsh): export NLTK_SEGMENTER_ALLOW_SHA256="{jar_checksum}"\n'
+                    f'  Windows PowerShell:    $env:NLTK_SEGMENTER_ALLOW_SHA256="{jar_checksum}"\n'
+                    f"  Windows cmd.exe:       set NLTK_SEGMENTER_ALLOW_SHA256={jar_checksum}\n"
                 )
         # ------------------------------------------------------------ #
 


### PR DESCRIPTION
Closes #3598

## Summary

This PR addresses the two issues from the review of recent merged PRs that were still relevant on the current `develop` branch:

- fixes the unigram `max_ctx == 0` bug in the language-model recursion guard introduced by #3498
- fixes Stanford Segmenter JAR validation so it handles Java classpaths correctly, avoids re-hashing unchanged files, and raises a lookup-style error with platform-neutral guidance, addressing the still-relevant concerns from #3477

## What changed

### Language models (`#3498`)
In `nltk/lm/models.py`:

- `StupidBackoff.unmasked_score()` now treats `order == 1` as having an empty context instead of slicing with `context[-0:]`
- `InterpolatedLanguageModel.unmasked_score()` now does the same

This ensures the recursion-depth bound actually applies to unigram models.

In `nltk/test/unit/lm/test_models.py`:

- added regression tests showing that very long contexts for unigram models behave the same as an empty context

### Stanford Segmenter (`#3477`)
In `nltk/tokenize/stanford_segmenter.py`:

- validate each classpath entry separately instead of treating `self._stanford_jar` as a single file path
- remove the path-substring trust heuristic and rely on explicit SHA256 approval for each classpath entry
- cache SHA256 checksums with file-metadata validation to avoid re-hashing unchanged JARs on repeated calls
- allow multiple approved checksums via `NLTK_SEGMENTER_ALLOW_SHA256`
- raise `LookupError` instead of `RuntimeError` for blocked/unavailable JARs
- improve the error message so the environment-variable instructions are platform-neutral


## Testing

Passed:

```bash
python -m pytest nltk/test/unit/lm/test_models.py nltk/test/unit/test_tokenize.py
```