### PR TITLE
Avoid retaining bllip import exceptions

### DIFF
--- a/nltk/parse/bllip.py
+++ b/nltk/parse/bllip.py
@@ -91,9 +91,12 @@ try:
         pass
 
 except ImportError as ie:
+    _bllip_import_error_message = str(ie)
 
-    def _ensure_bllip_import_or_error(ie=ie):
-        raise ImportError("Couldn't import bllipparser module: %s" % ie)
+    def _ensure_bllip_import_or_error():
+        raise ImportError(
+            "Couldn't import bllipparser module: %s" % _bllip_import_error_message
+        )
 
 
 def _ensure_ascii(words):

--- a/nltk/test/unit/test_bllip_importerror.py
+++ b/nltk/test/unit/test_bllip_importerror.py
@@ -1,0 +1,34 @@
+import builtins
+import importlib.util
+import uuid
+from pathlib import Path
+
+import pytest
+
+
+def _load_bllip_module_without_bllipparser(monkeypatch):
+    original_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "bllipparser" or name.startswith("bllipparser."):
+            raise ModuleNotFoundError("No module named 'bllipparser'")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    module_path = Path(__file__).resolve().parents[2] / "parse" / "bllip.py"
+    module_name = f"_nltk_bllip_importerror_probe_{uuid.uuid4().hex}"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_bllip_import_error_helper_does_not_retain_import_exception(monkeypatch):
+    module = _load_bllip_module_without_bllipparser(monkeypatch)
+    message = "Couldn't import bllipparser module: No module named 'bllipparser'"
+
+    assert module._ensure_bllip_import_or_error.__defaults__ is None
+
+    with pytest.raises(ImportError, match=message):
+        module._ensure_bllip_import_or_error()

--- a/nltk/test/unit/test_bllip_importerror.py
+++ b/nltk/test/unit/test_bllip_importerror.py
@@ -1,5 +1,6 @@
 import builtins
 import importlib.util
+import re
 import uuid
 from pathlib import Path
 
@@ -19,6 +20,8 @@ def _load_bllip_module_without_bllipparser(monkeypatch):
     module_path = Path(__file__).resolve().parents[2] / "parse" / "bllip.py"
     module_name = f"_nltk_bllip_importerror_probe_{uuid.uuid4().hex}"
     spec = importlib.util.spec_from_file_location(module_name, module_path)
+    assert spec is not None, f"Failed to create import spec for {module_path}"
+    assert spec.loader is not None, f"Import spec for {module_path} is missing a loader"
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
@@ -26,9 +29,11 @@ def _load_bllip_module_without_bllipparser(monkeypatch):
 
 def test_bllip_import_error_helper_does_not_retain_import_exception(monkeypatch):
     module = _load_bllip_module_without_bllipparser(monkeypatch)
-    message = "Couldn't import bllipparser module: No module named 'bllipparser'"
 
     assert module._ensure_bllip_import_or_error.__defaults__ is None
 
-    with pytest.raises(ImportError, match=message):
+    with pytest.raises(
+        ImportError,
+        match=re.escape("Couldn't import bllipparser module:") + r".*bllipparser",
+    ):
         module._ensure_bllip_import_or_error()


### PR DESCRIPTION
## Summary
- stop capturing the missing bllipparser ImportError in a function default
- retain only the import error message and raise a fresh ImportError on demand
- add a regression test that forces bllipparser imports to fail and verifies no exception object is retained

## Root cause
When bllipparser is missing, `nltk.parse.bllip` stored the ImportError instance in `_ensure_bllip_import_or_error.__defaults__`. That retained the exception traceback and could pin frames from the first import site for the lifetime of the process.

Fixes #3554

## Testing
- `python -m pytest nltk/test/unit/test_bllip.py nltk/test/unit/test_bllip_importerror.py -q`