### PR TITLE
Handle terminal siblings in CNF transforms

### DIFF
--- a/nltk/test/unit/test_treetransforms.py
+++ b/nltk/test/unit/test_treetransforms.py
@@ -12,6 +12,7 @@ producing identical output for any tree in Chomsky Normal Form.
 
 import multiprocessing
 import os
+from copy import deepcopy
 
 from nltk.tree import Tree
 from nltk.tree.transforms import chomsky_normal_form, un_chomsky_normal_form
@@ -39,6 +40,19 @@ def test_un_chomsky_collapses_artificial_node():
     tree = Tree.fromstring("(S (A a) (S|<B-C> (B b) (C c)))")
     un_chomsky_normal_form(tree)
     assert tree == Tree.fromstring("(S (A a) (B b) (C c))")
+
+
+def test_chomsky_normal_form_handles_terminal_siblings():
+    tree = Tree.fromstring("(S (S 1) + (S 2))")
+    original = deepcopy(tree)
+
+    chomsky_normal_form(tree)
+
+    assert tree == Tree.fromstring("(S (S 1) (S|<+-S> + (S 2)))")
+
+    un_chomsky_normal_form(tree)
+
+    assert tree == original
 
 
 def _un_chomsky_worker(n):

--- a/nltk/tree/transforms.py
+++ b/nltk/tree/transforms.py
@@ -145,7 +145,10 @@ def chomsky_normal_form(
 
             # chomsky normal form factorization
             if len(node) > 2:
-                childNodes = [child.label() for child in node]
+                childNodes = [
+                    child.label() if isinstance(child, Tree) else str(child)
+                    for child in node
+                ]
                 nodeCopy = node.copy()
                 node[0:] = []  # delete the children
 


### PR DESCRIPTION
## Summary
- allow CNF binarization to derive artificial node labels when a node has terminal siblings
- preserve the existing transformation behavior for tree children while handling leaf children safely
- add a regression test for `(S (S 1) + (S 2))` and verify round-tripping through `un_chomsky_normal_form`

## Root cause
The CNF transform assumed every child of a node had a `.label()` method when building artificial node names. Mixed terminal and nonterminal children violated that assumption and raised `AttributeError` before binarization could complete.

Fixes #1883

## Testing
- `python -m pytest nltk/test/unit/test_treetransforms.py -q`