### PR TITLE
Use os.name for Windows path handling

### DIFF
--- a/nltk/data.py
+++ b/nltk/data.py
@@ -120,6 +120,10 @@ from nltk.internals import deprecated
 
 textwrap_indent = functools.partial(textwrap.indent, prefix="  ")
 
+
+def _is_windows():
+    return os.name == "nt"
+
 ######################################################################
 # Search Path
 ######################################################################
@@ -137,7 +141,7 @@ path += [d for d in _paths_from_env if d]
 if "APPENGINE_RUNTIME" not in os.environ and os.path.expanduser("~/") != "~/":
     path.append(os.path.expanduser("~/nltk_data"))
 
-if sys.platform.startswith("win"):
+if _is_windows():
     # Common locations on Windows:
     path += [
         os.path.join(sys.prefix, "nltk_data"),
@@ -336,7 +340,7 @@ def normalize_resource_name(resource_name, allow_relative=True, relative_path=No
     is_dir = bool(re.search(r"[\\/.]$", resource_name)) or resource_name.endswith(
         os.path.sep
     )
-    if sys.platform.startswith("win"):
+    if _is_windows():
         resource_name = resource_name.lstrip("/")
     else:
         resource_name = re.sub(r"^/+", "/", resource_name)
@@ -347,7 +351,7 @@ def normalize_resource_name(resource_name, allow_relative=True, relative_path=No
             relative_path = os.curdir
         resource_name = os.path.abspath(os.path.join(relative_path, resource_name))
     resource_name = resource_name.replace("\\", "/").replace(os.path.sep, "/")
-    if sys.platform.startswith("win") and os.path.isabs(resource_name):
+    if _is_windows() and os.path.isabs(resource_name):
         resource_name = "/" + resource_name
     if is_dir and not resource_name.endswith("/"):
         resource_name += "/"

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -125,6 +125,18 @@ def _is_windows():
     return os.name == "nt"
 
 
+def _windows_data_paths():
+    return [
+        os.path.join(sys.prefix, "nltk_data"),
+        os.path.join(sys.prefix, "share", "nltk_data"),
+        os.path.join(sys.prefix, "lib", "nltk_data"),
+        os.path.join(os.environ.get("APPDATA", "C:\\"), "nltk_data"),
+        r"C:\nltk_data",
+        r"D:\nltk_data",
+        r"E:\nltk_data",
+    ]
+
+
 ######################################################################
 # Search Path
 ######################################################################
@@ -144,15 +156,7 @@ if "APPENGINE_RUNTIME" not in os.environ and os.path.expanduser("~/") != "~/":
 
 if _is_windows():
     # Common locations on Windows:
-    path += [
-        os.path.join(sys.prefix, "nltk_data"),
-        os.path.join(sys.prefix, "share", "nltk_data"),
-        os.path.join(sys.prefix, "lib", "nltk_data"),
-        os.path.join(os.environ.get("APPDATA", "C:\\"), "nltk_data"),
-        r"C:\nltk_data",
-        r"D:\nltk_data",
-        r"E:\nltk_data",
-    ]
+    path += _windows_data_paths()
 else:
     # Common locations on UNIX & OS X:
     path += [

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -124,6 +124,7 @@ textwrap_indent = functools.partial(textwrap.indent, prefix="  ")
 def _is_windows():
     return os.name == "nt"
 
+
 ######################################################################
 # Search Path
 ######################################################################
@@ -188,7 +189,7 @@ def split_resource_url(resource_url):
     """
     Splits a resource url into "<protocol>:<path>".
 
-    >>> windows = sys.platform.startswith('win')
+    >>> windows = _is_windows()
     >>> split_resource_url('nltk:home/nltk')
     ('nltk', 'home/nltk')
     >>> split_resource_url('nltk:/home/nltk')
@@ -226,7 +227,7 @@ def normalize_resource_url(resource_url):
     r"""
     Normalizes a resource url
 
-    >>> windows = sys.platform.startswith('win')
+    >>> windows = _is_windows()
     >>> os.path.normpath(split_resource_url(normalize_resource_url('file:grammar.fcfg'))[1]) == \
     ... ('\\' if windows else '') + os.path.abspath(os.path.join(os.curdir, 'grammar.fcfg'))
     True
@@ -319,7 +320,7 @@ def normalize_resource_name(resource_name, allow_relative=True, relative_path=No
         be converted to a platform-appropriate path separator.
         Directory trailing slashes are preserved
 
-    >>> windows = sys.platform.startswith('win')
+    >>> windows = _is_windows()
     >>> normalize_resource_name('.', True)
     './'
     >>> normalize_resource_name('./', True)

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -1229,7 +1229,7 @@ class Downloader:
                 return nltkdir
 
         # On Windows, use %APPDATA%
-        if sys.platform == "win32" and "APPDATA" in os.environ:
+        if os.name == "nt" and "APPDATA" in os.environ:
             homedir = os.environ["APPDATA"]
 
         # Otherwise, install in the user's home directory.

--- a/nltk/parse/malt.py
+++ b/nltk/parse/malt.py
@@ -247,11 +247,9 @@ class MaltParser(ParserI):
 
         cmd = ["java"]
         cmd += self.additional_java_args  # Adds additional java arguments
-        # Joins classpaths with ";" if on Windows and on Linux/Mac use ":"
-        classpaths_separator = ";" if sys.platform.startswith("win") else ":"
         cmd += [
             "-cp",
-            classpaths_separator.join(self.malt_jars),
+            os.pathsep.join(self.malt_jars),
         ]  # Adds classpaths for jars
         cmd += ["org.maltparser.Malt"]  # Adds the main function.
 

--- a/nltk/test/unit/test_platform_detection.py
+++ b/nltk/test/unit/test_platform_detection.py
@@ -1,0 +1,54 @@
+import importlib
+import os
+
+import nltk.data
+import nltk.downloader
+from nltk.parse.malt import MaltParser
+
+
+def test_normalize_resource_name_treats_nt_as_windows(monkeypatch):
+    monkeypatch.setattr(nltk.data.os, "name", "nt")
+    monkeypatch.setattr(nltk.data.sys, "platform", "cli")
+
+    assert nltk.data.normalize_resource_name("C:/dir/file", False, "/") == "/C:/dir/file"
+
+
+def test_default_download_dir_uses_os_name_for_windows(monkeypatch):
+    monkeypatch.setattr(nltk.downloader.os, "name", "nt")
+    monkeypatch.setattr(nltk.downloader.sys, "platform", "cli")
+    monkeypatch.setenv("APPDATA", r"C:\Users\Codex\AppData\Roaming")
+    monkeypatch.setattr(nltk.data, "path", [])
+
+    downloader = nltk.downloader.Downloader(download_dir="stub")
+
+    assert (
+        downloader.default_download_dir()
+        == r"C:\Users\Codex\AppData\Roaming\nltk_data"
+    )
+
+
+def test_nltk_data_path_uses_os_name_for_windows(monkeypatch):
+    with monkeypatch.context() as patched:
+        patched.setattr(nltk.data.os, "name", "nt")
+        patched.setattr(nltk.data.sys, "platform", "cli")
+        patched.setenv("APPDATA", r"C:\Users\Codex\AppData\Roaming")
+        patched.delenv("APPENGINE_RUNTIME", raising=False)
+        reloaded = importlib.reload(nltk.data)
+        try:
+            assert r"C:\Users\Codex\AppData\Roaming\nltk_data" in reloaded.path
+        finally:
+            importlib.reload(reloaded)
+
+
+def test_maltparser_command_uses_os_pathsep(monkeypatch):
+    monkeypatch.setattr(os, "pathsep", ";")
+    monkeypatch.setattr("nltk.parse.malt.sys.platform", "cli")
+
+    parser = MaltParser.__new__(MaltParser)
+    parser.additional_java_args = []
+    parser.malt_jars = ["a.jar", "b.jar"]
+    parser.model = "model.mco"
+
+    cmd = parser.generate_malt_command("input.conll", mode="learn")
+
+    assert cmd[2] == "a.jar;b.jar"

--- a/nltk/test/unit/test_platform_detection.py
+++ b/nltk/test/unit/test_platform_detection.py
@@ -1,4 +1,5 @@
 import importlib
+import ntpath
 import os
 
 import nltk.data
@@ -8,22 +9,22 @@ from nltk.parse.malt import MaltParser
 
 def test_normalize_resource_name_treats_nt_as_windows(monkeypatch):
     monkeypatch.setattr(nltk.data.os, "name", "nt")
-    monkeypatch.setattr(nltk.data.sys, "platform", "cli")
+    monkeypatch.setattr(nltk.data.os, "path", ntpath)
 
-    assert nltk.data.normalize_resource_name("C:/dir/file", False, "/") == "/C:/dir/file"
+    assert (
+        nltk.data.normalize_resource_name("C:/dir/file", False, "/") == "/C:/dir/file"
+    )
 
 
 def test_default_download_dir_uses_os_name_for_windows(monkeypatch):
     monkeypatch.setattr(nltk.downloader.os, "name", "nt")
-    monkeypatch.setattr(nltk.downloader.sys, "platform", "cli")
     monkeypatch.setenv("APPDATA", r"C:\Users\Codex\AppData\Roaming")
     monkeypatch.setattr(nltk.data, "path", [])
 
     downloader = nltk.downloader.Downloader(download_dir="stub")
 
     assert (
-        downloader.default_download_dir()
-        == r"C:\Users\Codex\AppData\Roaming\nltk_data"
+        downloader.default_download_dir() == r"C:\Users\Codex\AppData\Roaming\nltk_data"
     )
 
 
@@ -31,18 +32,17 @@ def test_nltk_data_path_uses_os_name_for_windows(monkeypatch):
     with monkeypatch.context() as patched:
         patched.setattr(nltk.data.os, "name", "nt")
         patched.setattr(nltk.data.sys, "platform", "cli")
+        patched.setattr(nltk.data.os, "path", ntpath)
         patched.setenv("APPDATA", r"C:\Users\Codex\AppData\Roaming")
         patched.delenv("APPENGINE_RUNTIME", raising=False)
         reloaded = importlib.reload(nltk.data)
-        try:
-            assert r"C:\Users\Codex\AppData\Roaming\nltk_data" in reloaded.path
-        finally:
-            importlib.reload(reloaded)
+        assert r"C:\Users\Codex\AppData\Roaming\nltk_data" in reloaded.path
+
+    importlib.reload(reloaded)
 
 
 def test_maltparser_command_uses_os_pathsep(monkeypatch):
     monkeypatch.setattr(os, "pathsep", ";")
-    monkeypatch.setattr("nltk.parse.malt.sys.platform", "cli")
 
     parser = MaltParser.__new__(MaltParser)
     parser.additional_java_args = []

--- a/nltk/test/unit/test_platform_detection.py
+++ b/nltk/test/unit/test_platform_detection.py
@@ -1,6 +1,6 @@
-import importlib
 import ntpath
 import os
+from types import SimpleNamespace
 
 import nltk.data
 import nltk.downloader
@@ -17,8 +17,12 @@ def test_normalize_resource_name_treats_nt_as_windows(monkeypatch):
 
 
 def test_default_download_dir_uses_os_name_for_windows(monkeypatch):
-    monkeypatch.setattr(nltk.downloader.os, "name", "nt")
-    monkeypatch.setenv("APPDATA", r"C:\Users\Codex\AppData\Roaming")
+    windows_os = SimpleNamespace(
+        environ={"APPDATA": r"C:\Users\Codex\AppData\Roaming"},
+        name="nt",
+        path=ntpath,
+    )
+    monkeypatch.setattr(nltk.downloader, "os", windows_os)
     monkeypatch.setattr(nltk.data, "path", [])
 
     downloader = nltk.downloader.Downloader(download_dir="stub")
@@ -28,17 +32,13 @@ def test_default_download_dir_uses_os_name_for_windows(monkeypatch):
     )
 
 
-def test_nltk_data_path_uses_os_name_for_windows(monkeypatch):
-    with monkeypatch.context() as patched:
-        patched.setattr(nltk.data.os, "name", "nt")
-        patched.setattr(nltk.data.sys, "platform", "cli")
-        patched.setattr(nltk.data.os, "path", ntpath)
-        patched.setenv("APPDATA", r"C:\Users\Codex\AppData\Roaming")
-        patched.delenv("APPENGINE_RUNTIME", raising=False)
-        reloaded = importlib.reload(nltk.data)
-        assert r"C:\Users\Codex\AppData\Roaming\nltk_data" in reloaded.path
+def test_windows_data_paths_include_appdata(monkeypatch):
+    appdata = r"C:\Users\Codex\AppData\Roaming"
+    expected = ntpath.join(appdata, "nltk_data")
+    monkeypatch.setattr(nltk.data.os, "path", ntpath)
+    monkeypatch.setitem(nltk.data.os.environ, "APPDATA", appdata)
 
-    importlib.reload(reloaded)
+    assert expected in nltk.data._windows_data_paths()
 
 
 def test_maltparser_command_uses_os_pathsep(monkeypatch):


### PR DESCRIPTION
## Summary
- use `os.name == "nt"` for active Windows-specific path handling in `nltk.data` and the downloader
- use `os.pathsep` instead of `sys.platform` when joining MaltParser classpaths
- add regression tests that simulate the IronPython-style `sys.platform="cli"`, `os.name="nt"` case

## Root cause
Several active code paths used `sys.platform.startswith("win")` or `sys.platform == "win32"` as a proxy for Windows filesystem behavior. That misses runtimes such as IronPython, where `sys.platform` is not `win*` even though `os.name` is `nt` and Windows path semantics still apply.

Partial fix for #1700

## Testing
- `python -m pytest nltk/test/unit/test_data.py nltk/test/unit/test_platform_detection.py -q`