### PR TITLE
Treat missing unzip output as stale

### DIFF
--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -1177,7 +1177,7 @@ class Downloader:
         if filepath.endswith(".zip"):
             unzipdir = filepath[:-4]
             if not os.path.exists(unzipdir):
-                return self.INSTALLED  # but not unzipped -- ok!
+                return self.NOT_INSTALLED if info.unzip else self.INSTALLED
             if not os.path.isdir(unzipdir):
                 return self.STALE
 

--- a/nltk/test/unit/test_downloader_atomic.py
+++ b/nltk/test/unit/test_downloader_atomic.py
@@ -343,3 +343,48 @@ class TestDownloaderAtomic(unittest.TestCase):
 
         finally:
             shutil.rmtree(srv_dir, ignore_errors=True)
+
+    def test_missing_unzipdir_is_not_installed_for_packages_that_require_unzip(self):
+        dl = Downloader(download_dir=self.test_dir)
+        zip_path = os.path.join(self.test_dir, self.pkg.filename)
+
+        os.makedirs(os.path.dirname(zip_path), exist_ok=True)
+        shutil.copyfile(self.source_zip_path, zip_path)
+
+        self.assertEqual(dl.status(self.pkg, self.test_dir), dl.NOT_INSTALLED)
+
+    def test_missing_unzipdir_is_installed_for_packages_kept_zipped(self):
+        dl = Downloader(download_dir=self.test_dir)
+
+        pkg = Package(
+            id=self.pkg.id,
+            url=self.pkg.url,
+            subdir=self.pkg.subdir,
+            size=self.pkg.size,
+            unzipped_size=self.pkg.unzipped_size,
+            checksum=self.pkg.checksum,
+            sha256_checksum=self.pkg.sha256_checksum,
+            unzip=False,
+        )
+        zip_path = os.path.join(self.test_dir, pkg.filename)
+
+        os.makedirs(os.path.dirname(zip_path), exist_ok=True)
+        shutil.copyfile(self.source_zip_path, zip_path)
+
+        self.assertEqual(dl.status(pkg, self.test_dir), dl.INSTALLED)
+
+    def test_stale_zip_exists_unzips_without_redownload(self):
+        dl = Downloader(download_dir=self.test_dir)
+        zip_path = os.path.join(self.test_dir, self.pkg.filename)
+        extracted_file = os.path.join(self.test_dir, "corpora", "abc", "dummy.txt")
+
+        os.makedirs(os.path.dirname(zip_path), exist_ok=True)
+        shutil.copyfile(self.source_zip_path, zip_path)
+
+        with patch("nltk.downloader.urlopen") as urlopen_mock:
+            ok = dl.download(self.pkg, quiet=True)
+
+        self.assertTrue(ok)
+        urlopen_mock.assert_not_called()
+        self.assertTrue(os.path.exists(extracted_file))
+        self.assertEqual(dl.status(self.pkg, self.test_dir), dl.INSTALLED)


### PR DESCRIPTION
## Summary
- mark zip packages as stale when they are expected to be unzipped but their extraction directory is missing
- preserve the existing installed status for packages that intentionally remain zipped
- add downloader regression tests for both cases

## Root cause
The downloader status check treated an existing zip file as `INSTALLED` even when `info.unzip` was true and the extracted directory was missing. That meant interrupted or failed unzip operations could leave a package appearing up to date on the next run, preventing recovery.

Fixes #3208

## Testing
- `python -m pytest nltk/test/unit/test_downloader_atomic.py -q`