### PR TITLE
Fix perfect-agreement edge cases in agreement metrics

### DIFF
--- a/nltk/metrics/agreement.py
+++ b/nltk/metrics/agreement.py
@@ -70,6 +70,7 @@ Expected results from the Artstein and Poesio survey paper:
 """
 
 import logging
+import math
 from itertools import groupby
 from operator import itemgetter
 
@@ -207,6 +208,12 @@ class AnnotationTask:
         ret = total / n
         return ret
 
+    def _chance_corrected_agreement(self, observed, expected):
+        """Handle degenerate perfect-agreement cases consistently."""
+        if math.isclose(expected, 1.0):
+            return 1.0 if math.isclose(observed, 1.0) else 0.0
+        return (observed - expected) / (1.0 - expected)
+
     def avg_Ao(self):
         """Average observed agreement across all coders and items."""
         ret = self._pairwise_average(self.Ao)
@@ -237,8 +244,7 @@ class AnnotationTask:
     def S(self):
         """Bennett, Albert and Goldstein 1954"""
         Ae = 1.0 / len(self.K)
-        ret = (self.avg_Ao() - Ae) / (1.0 - Ae)
-        return ret
+        return self._chance_corrected_agreement(self.avg_Ao(), Ae)
 
     def pi(self):
         """Scott 1955; here, multi-pi.
@@ -250,7 +256,7 @@ class AnnotationTask:
         for k, f in label_freqs.items():
             total += f**2
         Ae = total / ((len(self.I) * len(self.C)) ** 2)
-        return (self.avg_Ao() - Ae) / (1 - Ae)
+        return self._chance_corrected_agreement(self.avg_Ao(), Ae)
 
     def Ae_kappa(self, cA, cB):
         Ae = 0.0
@@ -263,7 +269,7 @@ class AnnotationTask:
     def kappa_pairwise(self, cA, cB):
         """ """
         Ae = self.Ae_kappa(cA, cB)
-        ret = (self.Ao(cA, cB) - Ae) / (1.0 - Ae)
+        ret = self._chance_corrected_agreement(self.Ao(cA, cB), Ae)
         log.debug("Expected agreement between %s and %s: %f", cA, cB, Ae)
         return ret
 
@@ -280,7 +286,7 @@ class AnnotationTask:
 
         """
         Ae = self._pairwise_average(self.Ae_kappa)
-        return (self.avg_Ao() - Ae) / (1.0 - Ae)
+        return self._chance_corrected_agreement(self.avg_Ao(), Ae)
 
     def Disagreement(self, label_freqs):
         total_labels = sum(label_freqs.values())

--- a/nltk/metrics/agreement.py
+++ b/nltk/metrics/agreement.py
@@ -447,7 +447,7 @@ if __name__ == "__main__":
         action="store_true",
         help="calculate agreement for every subset of the annotators",
     )
-    (options, remainder) = parser.parse_args()
+    options, remainder = parser.parse_args()
 
     if not options.file:
         parser.print_help()
@@ -485,4 +485,3 @@ if __name__ == "__main__":
         print(getattr(task, options.agreement)())
 
     logging.shutdown()
-

--- a/nltk/metrics/agreement.py
+++ b/nltk/metrics/agreement.py
@@ -209,9 +209,21 @@ class AnnotationTask:
         return ret
 
     def _chance_corrected_agreement(self, observed, expected):
-        """Handle degenerate perfect-agreement cases consistently."""
+        """Handle degenerate perfect-agreement cases consistently.
+
+        When expected agreement is 1.0 and observed agreement is also 1.0,
+        returns 1.0 (perfect agreement). Raises ValueError if expected is 1.0
+        but observed is not, since that indicates a violated distance contract
+        (distance(l, l) must be 0) or otherwise undefined coefficient semantics.
+        """
         if math.isclose(expected, 1.0):
-            return 1.0 if math.isclose(observed, 1.0) else 0.0
+            if math.isclose(observed, 1.0):
+                return 1.0
+            raise ValueError(
+                f"Expected agreement is 1.0 but observed agreement is {observed:.4f}. "
+                "This indicates a distance function that violates distance(l, l) = 0, "
+                "or otherwise undefined coefficient semantics."
+            )
         return (observed - expected) / (1.0 - expected)
 
     def avg_Ao(self):
@@ -243,6 +255,8 @@ class AnnotationTask:
     # Agreement Coefficients
     def S(self):
         """Bennett, Albert and Goldstein 1954"""
+        if len(self.K) == 0:
+            raise ValueError("Cannot calculate S, no data present!")
         Ae = 1.0 / len(self.K)
         return self._chance_corrected_agreement(self.avg_Ao(), Ae)
 
@@ -471,3 +485,4 @@ if __name__ == "__main__":
         print(getattr(task, options.agreement)())
 
     logging.shutdown()
+

--- a/nltk/test/unit/test_disagreement.py
+++ b/nltk/test/unit/test_disagreement.py
@@ -57,6 +57,20 @@ class TestDisagreement(unittest.TestCase):
         annotation_task = AnnotationTask(data)
         self.assertAlmostEqual(annotation_task.alpha(), 1.0)
 
+    def test_perfect_agreement_coefficients(self):
+        data = [
+            ("coder1", "1", "YES"),
+            ("coder2", "1", "YES"),
+            ("coder1", "2", "YES"),
+            ("coder2", "2", "YES"),
+        ]
+        annotation_task = AnnotationTask(data)
+
+        self.assertAlmostEqual(annotation_task.S(), 1.0)
+        self.assertAlmostEqual(annotation_task.pi(), 1.0)
+        self.assertAlmostEqual(annotation_task.kappa(), 1.0)
+        self.assertAlmostEqual(annotation_task.multi_kappa(), 1.0)
+
     def test_advanced(self):
         """
         More advanced test, based on


### PR DESCRIPTION
Fixes #2940.

## Summary
- handle degenerate perfect-agreement cases where expected agreement is 1.0
- return 1.0 instead of raising ZeroDivisionError for S, pi, kappa, and multi_kappa
- add regression coverage for the shared perfect-agreement path

## Testing
- python -m pytest nltk/test/unit/test_disagreement.py -q