### PR TITLE
fix(security): prevent ReDoS in TextTilingTokenizer paragraph-break regex (CWE-1333)

### DIFF
--- a/nltk/test/unit/test_texttiling_security.py
+++ b/nltk/test/unit/test_texttiling_security.py
@@ -1,0 +1,106 @@
+"""Regression tests for ReDoS in TextTilingTokenizer (CWE-1333).
+
+``_mark_paragraph_breaks`` scans the input for blank-line paragraph breaks with
+``[ \\t\\r\\f\\v]*\\n[ \\t\\r\\f\\v]*\\n[ \\t\\r\\f\\v]*``. With the plain greedy
+``re`` pattern, ``finditer`` rescans a long horizontal-whitespace run that has no
+blank line quadratically, so a crafted whitespace blob hangs ``tokenize()``. The
+pattern now uses possessive quantifiers (regex module), making the scan linear.
+The whitespace class does not overlap ``"\\n"``, so the matches are unchanged.
+
+The "must not hang" tests run the work in a separate process (spawn) with a hard
+timeout and ``terminate()`` on overrun, so a regression to a quadratic regex
+cannot keep burning CPU for the rest of the suite, and any exception in the
+worker is propagated back to the assertions instead of being swallowed.
+"""
+
+import multiprocessing
+import queue
+
+from nltk.tokenize.texttiling import TextTilingTokenizer
+
+# A long horizontal-whitespace run with no blank line: ~256 KB. Linear with the
+# possessive pattern (sub-millisecond); ~quadratic and tens of seconds with the
+# old greedy one.
+_CRAFTED_TEXT = " \t" * 128_000
+_TIMEOUT = 15
+
+# stopwords are passed explicitly so constructing the tokenizer needs no corpus
+# download; the vulnerable scan is in _mark_paragraph_breaks, before any
+# stopword use.
+_STOPWORDS = ["the", "a", "of", "and", "to"]
+
+
+def _tokenizer():
+    return TextTilingTokenizer(stopwords=_STOPWORDS)
+
+
+def _mark_worker(result_q):
+    try:
+        result_q.put(("ok", _tokenizer()._mark_paragraph_breaks(_CRAFTED_TEXT)))
+    except BaseException as exc:  # surface to the parent process
+        result_q.put(("error", repr(exc)))
+
+
+def _tokenize_worker(result_q):
+    try:
+        # A whitespace blob has no paragraph breaks, so tokenize() legitimately
+        # raises ValueError after the (now linear) scan. Either outcome means the
+        # call terminated rather than hanging.
+        try:
+            _tokenizer().tokenize(_CRAFTED_TEXT)
+        except ValueError:
+            pass
+        result_q.put(("ok", "terminated"))
+    except BaseException as exc:
+        result_q.put(("error", repr(exc)))
+
+
+def _run_in_process(target):
+    """Run ``target(result_q)`` in a spawned process with a timeout.
+
+    Returns ``(finished, status, payload)``. If the worker overruns ``_TIMEOUT``
+    it is terminated (no lingering CPU) and ``finished`` is ``False``.
+    """
+    ctx = multiprocessing.get_context("spawn")
+    result_q = ctx.Queue()
+    proc = ctx.Process(target=target, args=(result_q,))
+    proc.start()
+    proc.join(_TIMEOUT)
+    if proc.is_alive():
+        proc.terminate()
+        proc.join()
+        return False, None, None
+    try:
+        status, payload = result_q.get_nowait()
+    except queue.Empty:
+        return True, "error", "worker produced no result"
+    return True, status, payload
+
+
+def test_mark_paragraph_breaks_preserves_behavior():
+    """The possessive pattern must find the same paragraph breaks as before."""
+    tt = _tokenizer()
+    # a blank line between two paragraphs >= MIN_PARAGRAPH (100) apart is a break
+    assert tt._mark_paragraph_breaks("x" * 120 + "\n\n" + "y" * 120) == [0, 120]
+    # horizontal whitespace inside the break does not change the break position
+    # (the match still starts where the trailing whitespace of para one begins)
+    assert tt._mark_paragraph_breaks("x" * 120 + "  \n  \n  " + "y" * 120) == [0, 120]
+    # no blank line -> only the implicit break at position 0
+    assert tt._mark_paragraph_breaks("a single line with no breaks") == [0]
+    # breaks closer than MIN_PARAGRAPH (100) are not recorded
+    assert tt._mark_paragraph_breaks("x" * 50 + "\n\n" + "y" * 50) == [0]
+
+
+def test_mark_paragraph_breaks_is_linear_on_whitespace_blob():
+    """A long whitespace run with no blank line must not blow up (ReDoS)."""
+    finished, status, payload = _run_in_process(_mark_worker)
+    assert finished, "_mark_paragraph_breaks hung on a whitespace blob (ReDoS)"
+    assert status == "ok", f"worker raised: {payload}"
+    assert payload == [0]
+
+
+def test_tokenize_does_not_hang_on_whitespace_blob():
+    """End-to-end: tokenizing a whitespace blob must terminate (not hang)."""
+    finished, status, payload = _run_in_process(_tokenize_worker)
+    assert finished, "TextTilingTokenizer.tokenize hung on a whitespace blob (ReDoS)"
+    assert status == "ok", f"tokenize raised in worker: {payload}"

--- a/nltk/tokenize/texttiling.py
+++ b/nltk/tokenize/texttiling.py
@@ -9,6 +9,8 @@
 import math
 import re
 
+import regex
+
 try:
     import numpy
 except ImportError:
@@ -283,7 +285,12 @@ class TextTilingTokenizer(TokenizerI):
         """Identifies indented text or line breaks as the beginning of
         paragraphs"""
         MIN_PARAGRAPH = 100
-        pattern = re.compile("[ \t\r\f\v]*\n[ \t\r\f\v]*\n[ \t\r\f\v]*")
+        # Possessive quantifiers (regex module) prevent catastrophic backtracking
+        # (ReDoS, CWE-1333): with the plain greedy `re` pattern, finditer rescans
+        # a long horizontal-whitespace run with no blank line quadratically. The
+        # whitespace class does not overlap "\n", so making each run possessive is
+        # match-for-match identical while making the scan linear.
+        pattern = regex.compile(r"[ \t\r\f\v]*+\n[ \t\r\f\v]*+\n[ \t\r\f\v]*+")
         matches = pattern.finditer(text)
 
         last_break = 0


### PR DESCRIPTION
## Summary
`TextTilingTokenizer._mark_paragraph_breaks` scans the input for blank-line
paragraph breaks. The pattern was a plain greedy `re` regex, so `finditer`
rescans a long horizontal-whitespace run that has **no blank line**
quadratically — a crafted whitespace blob hangs the public `tokenize()`
(ReDoS, CWE-1333). This is the same class as **CVE-2021-3828** and
**CVE-2021-43854** (ReDoS in NLTK tokenizers/readers).

## Details
```python
# nltk/tokenize/texttiling.py — _mark_paragraph_breaks()
pattern = re.compile("[ \t\r\f\v]*\n[ \t\r\f\v]*\n[ \t\r\f\v]*")
matches = pattern.finditer(text)
```
`tokenize()` calls `_mark_paragraph_breaks(text)` first, on the raw, untrusted
text. For an input that is a long run of horizontal whitespace with no `\n\n`,
`finditer` retries at every position and the leading `[ \t\r\f\v]*` greedily
expands the run before failing — O(n) positions × O(n) expansion = **O(n²)**.

## Proof of concept (before this change)
```python
from nltk.tokenize.texttiling import TextTilingTokenizer
tt = TextTilingTokenizer(stopwords=["the", "a", "of"])
tt.tokenize(" \t" * 64000)   # ~128 KB whitespace -> hangs (quadratic)
```
Measured (`_mark_paragraph_breaks`, same input size): 16 KB → 0.17 s, 32 KB →
0.74 s, 64 KB → 2.86 s, 128 KB → 11.3 s (clean quadratic); ordinary prose of the
same size returns in ~0.002 s.

## Fix
Compile the pattern with the `regex` module (already a hard dependency,
`regex>=2021.8.3`) using **possessive quantifiers** `*+`, so each whitespace run
is non-backtracking. The whitespace class does not overlap `\n`, so a successful
match never needs to backtrack into the whitespace — the possessive form is
**match-for-match identical** to the greedy one (verified identical `finditer`
output on representative inputs), while the wasted backtracking on failed
positions is eliminated and the scan becomes linear.

```python
pattern = regex.compile(r"[ \t\r\f\v]*+\n[ \t\r\f\v]*+\n[ \t\r\f\v]*+")
```

## Tests
`nltk/test/unit/test_texttiling_security.py`:
- `_mark_paragraph_breaks` still returns the same break positions on normal text
  (including breaks containing horizontal whitespace);
- the same ~256 KB whitespace blob completes well within a 15 s timeout, both at
  `_mark_paragraph_breaks` and end-to-end via `tokenize()` (run in a spawned
  process with a hard timeout so a quadratic regression fails fast and cannot
  keep burning CPU for the rest of the suite), where the previous regex takes
  tens of seconds.
