### PR TITLE
fix(security): cap zip decompression to prevent decompression-bomb DoS (CWE-409)

### DIFF
--- a/nltk/data.py
+++ b/nltk/data.py
@@ -550,15 +550,16 @@ def _check_decompression_bomb(info):
     if (
         file_size >= MAX_UNZIP_ACTIVATION
         and compress_size > 0
-        and file_size / compress_size > MAX_UNZIP_RATIO
+        # integer comparison (no float rounding at the threshold)
+        and file_size > MAX_UNZIP_RATIO * compress_size
     ):
         raise ValueError(
-            "Refusing to decompress suspected zip bomb %r: it expands %dx "
+            "Refusing to decompress suspected zip bomb %r: it expands %.1fx "
             "(%d -> %d bytes), above nltk.data.MAX_UNZIP_RATIO=%d. "
             "Raise nltk.data.MAX_UNZIP_RATIO if this data is trusted."
             % (
                 name,
-                file_size // compress_size,
+                file_size / compress_size,
                 compress_size,
                 file_size,
                 MAX_UNZIP_RATIO,

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -506,6 +506,66 @@ class GzipFileSystemPathPointer(FileSystemPathPointer):
         return stream
 
 
+#: Maximum allowed ratio of a zip member's uncompressed size to its stored
+#: (compressed) size before it is treated as a decompression bomb (CWE-409).
+#: DEFLATE's maximum ratio is ~1032x, reached only by runs of identical bytes,
+#: i.e. payloads crafted purely to maximize expansion; legitimate text/markup
+#: corpora compress a few-fold to a few-hundred-fold at most, well under this.
+#: A member that expands beyond this ratio is rejected. Configurable.
+MAX_UNZIP_RATIO = 1000
+
+#: Optional hard cap (in bytes) on a single zip member's uncompressed size.
+#: ``None`` disables it (the default, so legitimately large corpora are not
+#: affected); set it for a strict absolute limit in hardened deployments.
+MAX_UNZIP_SIZE = None
+
+#: The ratio check is only applied once a member's declared uncompressed size
+#: exceeds this activation threshold, so small files (which cannot exhaust
+#: resources regardless of ratio) are never rejected.
+MAX_UNZIP_ACTIVATION = 32 * 1024 * 1024  # 32 MiB
+
+
+def _check_decompression_bomb(info):
+    """
+    Reject a zip member that looks like a decompression bomb (CWE-409).
+
+    ``info`` is a ``zipfile.ZipInfo``. A member is refused when its declared
+    uncompressed size exceeds the optional hard cap ``MAX_UNZIP_SIZE``, or when
+    that size is both large (>= ``MAX_UNZIP_ACTIVATION``) and expands by more
+    than ``MAX_UNZIP_RATIO`` over its stored compressed size. This guards the
+    read-into-memory paths (``ZipFilePathPointer.open``,
+    ``OpenOnDemandZipFile.read``) and the on-disk extraction path
+    (``nltk.downloader``) against tiny archives that exhaust RAM or disk.
+    """
+    compress_size = getattr(info, "compress_size", 0) or 0
+    file_size = getattr(info, "file_size", 0) or 0
+    name = getattr(info, "filename", "<member>")
+
+    if MAX_UNZIP_SIZE is not None and file_size > MAX_UNZIP_SIZE:
+        raise ValueError(
+            "Refusing to decompress zip member %r: uncompressed size %d bytes "
+            "exceeds nltk.data.MAX_UNZIP_SIZE=%d." % (name, file_size, MAX_UNZIP_SIZE)
+        )
+
+    if (
+        file_size >= MAX_UNZIP_ACTIVATION
+        and compress_size > 0
+        and file_size / compress_size > MAX_UNZIP_RATIO
+    ):
+        raise ValueError(
+            "Refusing to decompress suspected zip bomb %r: it expands %dx "
+            "(%d -> %d bytes), above nltk.data.MAX_UNZIP_RATIO=%d. "
+            "Raise nltk.data.MAX_UNZIP_RATIO if this data is trusted."
+            % (
+                name,
+                file_size // compress_size,
+                compress_size,
+                file_size,
+                MAX_UNZIP_RATIO,
+            )
+        )
+
+
 class ZipFilePathPointer(PathPointer):
     """
     A path pointer that identifies a file contained within a zipfile,
@@ -564,6 +624,7 @@ class ZipFilePathPointer(PathPointer):
         return self._entry
 
     def open(self, encoding=None):
+        _check_decompression_bomb(self._zipfile.getinfo(self._entry))
         data = self._zipfile.read(self._entry)
         stream = BytesIO(data)
         if self._entry.endswith(".gz"):
@@ -1266,6 +1327,7 @@ class OpenOnDemandZipFile(ZipFile):
 
     def read(self, name):
         assert self.fp is None
+        _check_decompression_bomb(self.getinfo(name))
         # This will be validated by pathsec.open
         self.fp = _secure_open(self.filename, "rb")
         value = zipfile.ZipFile.read(self, name)

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -2600,6 +2600,14 @@ def _unzip_iter(filename, root, verbose=True):
                 yield ErrorMessage(filename, error)
                 has_violations = True
                 continue
+            # Decompression-bomb check belongs in Phase 1: a bomb member must be
+            # rejected before any (earlier, benign) member is written to disk, so
+            # the validate-then-extract / nothing-is-written contract holds.
+            try:
+                _check_decompression_bomb(zf.getinfo(member))
+            except ValueError as e:
+                yield ErrorMessage(filename, str(e))
+                has_violations = True
 
         if has_violations:
             return
@@ -2617,7 +2625,6 @@ def _unzip_iter(filename, root, verbose=True):
                 yield ErrorMessage(filename, f"{error} (during extraction)")
                 return
             try:
-                _check_decompression_bomb(zf.getinfo(member))
                 zf.extract(member, root_abs)
             except Exception as e:
                 yield ErrorMessage(filename, f"Extraction error for {member}: {e}")

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -176,6 +176,7 @@ from xml.etree import ElementTree
 from defusedxml.ElementTree import parse as safe_parse
 
 import nltk
+from nltk.data import _check_decompression_bomb
 from nltk.pathsec import ZipFile
 from nltk.pathsec import open as pathsec_open
 from nltk.pathsec import urlopen, validate_path
@@ -2616,6 +2617,7 @@ def _unzip_iter(filename, root, verbose=True):
                 yield ErrorMessage(filename, f"{error} (during extraction)")
                 return
             try:
+                _check_decompression_bomb(zf.getinfo(member))
                 zf.extract(member, root_abs)
             except Exception as e:
                 yield ErrorMessage(filename, f"Extraction error for {member}: {e}")

--- a/nltk/test/unit/test_zipbomb_security.py
+++ b/nltk/test/unit/test_zipbomb_security.py
@@ -1,0 +1,75 @@
+"""Regression tests for decompression-bomb protection in NLTK (CWE-409).
+
+NLTK reads whole zip members into memory (``ZipFilePathPointer.open`` /
+``OpenOnDemandZipFile.read``) and extracts them to disk (``nltk.downloader``)
+without any cap, so a tiny archive whose member decompresses to gigabytes
+exhausts RAM or disk. ``nltk.data._check_decompression_bomb`` now rejects a
+member that expands beyond ``MAX_UNZIP_RATIO`` (above an activation size) or past
+the optional absolute cap ``MAX_UNZIP_SIZE``. Ordinary corpora compress only a
+few-fold, so the guard does not affect legitimate data.
+"""
+
+import os
+import zipfile
+
+import pytest
+
+import nltk.data as data
+from nltk.data import ZipFilePathPointer
+from nltk.downloader import ErrorMessage, _unzip_iter
+
+
+@pytest.fixture(autouse=True)
+def _restore_limits():
+    """Snapshot and restore the configurable limits around each test."""
+    saved = (data.MAX_UNZIP_RATIO, data.MAX_UNZIP_SIZE, data.MAX_UNZIP_ACTIVATION)
+    yield
+    data.MAX_UNZIP_RATIO, data.MAX_UNZIP_SIZE, data.MAX_UNZIP_ACTIVATION = saved
+
+
+def _make_zip(path, member, payload):
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(member, payload)
+    return path
+
+
+def test_ratio_guard_blocks_bomb(tmp_path):
+    """A member expanding past MAX_UNZIP_RATIO (above activation) is refused."""
+    data.MAX_UNZIP_ACTIVATION = 1024 * 1024  # 1 MiB
+    data.MAX_UNZIP_RATIO = 100
+    z = _make_zip(tmp_path / "bomb.zip", "m", b"\0" * (2 * 1024 * 1024))  # ~1000x
+    with pytest.raises(ValueError, match="zip bomb"):
+        ZipFilePathPointer(str(z), "m").open().read()
+
+
+def test_low_ratio_member_passes(tmp_path):
+    """Incompressible / low-ratio data is never rejected (no false positive)."""
+    z = _make_zip(tmp_path / "ok.zip", "m", os.urandom(2 * 1024 * 1024))
+    assert len(ZipFilePathPointer(str(z), "m").open().read()) == 2 * 1024 * 1024
+
+
+def test_small_high_ratio_member_passes(tmp_path):
+    """A small member below the activation size passes regardless of ratio."""
+    # 1 MiB of zeros (huge ratio) but below the default 32 MiB activation.
+    z = _make_zip(tmp_path / "small.zip", "m", b"\0" * (1024 * 1024))
+    assert len(ZipFilePathPointer(str(z), "m").open().read()) == 1024 * 1024
+
+
+def test_absolute_cap_blocks_oversize(tmp_path):
+    """The optional MAX_UNZIP_SIZE hard cap refuses oversize members."""
+    data.MAX_UNZIP_SIZE = 1024 * 1024  # 1 MiB
+    z = _make_zip(tmp_path / "big.zip", "m", os.urandom(2 * 1024 * 1024))
+    with pytest.raises(ValueError, match="MAX_UNZIP_SIZE"):
+        ZipFilePathPointer(str(z), "m").open().read()
+
+
+def test_downloader_extract_blocks_bomb(tmp_path):
+    """The on-disk extraction path refuses a bomb member before writing it."""
+    data.MAX_UNZIP_ACTIVATION = 1024 * 1024  # 1 MiB
+    data.MAX_UNZIP_RATIO = 100
+    z = _make_zip(tmp_path / "pkg.zip", "pkg/big.txt", b"\0" * (2 * 1024 * 1024))
+    dest = tmp_path / "out"
+    messages = list(_unzip_iter(str(z), str(dest), verbose=False))
+    assert any(isinstance(m, ErrorMessage) for m in messages), messages
+    # nothing was written to disk
+    assert not (dest / "pkg" / "big.txt").exists()

--- a/nltk/test/unit/test_zipbomb_security.py
+++ b/nltk/test/unit/test_zipbomb_security.py
@@ -73,3 +73,20 @@ def test_downloader_extract_blocks_bomb(tmp_path):
     assert any(isinstance(m, ErrorMessage) for m in messages), messages
     # nothing was written to disk
     assert not (dest / "pkg" / "big.txt").exists()
+
+
+def test_downloader_writes_nothing_when_a_later_member_is_a_bomb(tmp_path):
+    """A bomb after benign members must be caught before *anything* is written
+    (validate-then-extract contract)."""
+    data.MAX_UNZIP_ACTIVATION = 1024 * 1024  # 1 MiB
+    data.MAX_UNZIP_RATIO = 100
+    zp = tmp_path / "pkg.zip"
+    with zipfile.ZipFile(zp, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("pkg/safe.txt", b"hello")  # benign member, comes first
+        zf.writestr("pkg/big.txt", b"\0" * (2 * 1024 * 1024))  # bomb, comes later
+    dest = tmp_path / "out"
+    messages = list(_unzip_iter(str(zp), str(dest), verbose=False))
+    assert any(isinstance(m, ErrorMessage) for m in messages), messages
+    # neither the benign member nor the bomb was written
+    assert not (dest / "pkg" / "safe.txt").exists()
+    assert not (dest / "pkg" / "big.txt").exists()


### PR DESCRIPTION
## Summary
NLTK reads a whole zip member into memory (`ZipFilePathPointer.open`,
`OpenOnDemandZipFile.read`) and extracts members to disk (`nltk.downloader`)
with **no size limit**, so a tiny archive whose member decompresses to gigabytes
exhausts RAM or disk — a classic **decompression bomb** (CWE-409). The compressed
and declared uncompressed sizes are known at read time but were never checked.

## Details
```python
# nltk/data.py — ZipFilePathPointer.open()
data = self._zipfile.read(self._entry)     # whole member -> RAM, no cap
# nltk/data.py — OpenOnDemandZipFile.read()
value = zipfile.ZipFile.read(self, name)   # whole member -> RAM, no cap
# nltk/downloader.py — _unzip_iter()
zf.extract(member, root_abs)               # member -> disk, no cap
```
Reachable via `nltk.data.load(format="raw"/"pickle"/text)` and
`CorpusReader.raw()` (memory), and `nltk.download()` extraction (disk), with an
untrusted or oversized zip corpus (a malicious/compromised data mirror, or a
planted `.zip` in a shared `nltk_data`) — the scenario covered by NLTK's
SECURITY.md ("untrusted input … shared environments … multi-tenant pipelines").

## Proof of concept (before this change)
```python
import zipfile
zf = zipfile.ZipFile("evil.zip", "w", zipfile.ZIP_DEFLATED)
zf.writestr("evilcorp/big.txt", b"\0" * (512 * 1024 * 1024))  # ~510 KB archive
zf.close()

from nltk.data import ZipFilePathPointer
ZipFilePathPointer("evil.zip", "evilcorp/big.txt").open().read()  # pulls 512 MiB into RAM
```
Measured: a ~510 KB archive → 512 MiB read into memory (~1029x); the downloader
extract path writes 1 GiB to disk from a 1 MB archive. No error, no cap.

## Fix
Add `nltk.data._check_decompression_bomb(info)`, applied at the three sinks
(`ZipFilePathPointer.open`, `OpenOnDemandZipFile.read`, and the downloader's
extract loop). It refuses a member whose declared uncompressed size:
- exceeds the optional absolute cap `MAX_UNZIP_SIZE` (default `None`, off — so
  legitimately large corpora are never affected), **or**
- is both large (≥ `MAX_UNZIP_ACTIVATION`, default 32 MiB) **and** expands beyond
  `MAX_UNZIP_RATIO` (default 1000) over its stored compressed size.

DEFLATE's maximum ratio is ~1032x, reached only by runs of identical bytes
(payloads crafted purely to maximize expansion); legitimate text/markup corpora
compress a few-fold to a few-hundred-fold at most, well under 1000x, so the guard
does not affect them. All limits are module-level and configurable
(`nltk.data.MAX_UNZIP_RATIO` / `MAX_UNZIP_SIZE` / `MAX_UNZIP_ACTIVATION`).

## Tests
`nltk/test/unit/test_zipbomb_security.py`:
- a member expanding past the ratio (above activation) is rejected at the
  read-into-memory path and at the downloader extract path (nothing is written);
- incompressible / low-ratio data and small high-ratio files below the
  activation size are **not** rejected (no false positives);
- the optional `MAX_UNZIP_SIZE` hard cap rejects oversize members.

Existing `test_data.py` / `test_downloader.py` / `test_pathsec.py` pass unchanged.
