### PR TITLE
fix(security): use defusedxml in corpus readers to block XML entity-expansion DoS (CWE-776)

### DIFF
--- a/nltk/corpus/reader/bnc.py
+++ b/nltk/corpus/reader/bnc.py
@@ -7,8 +7,10 @@
 
 """Corpus reader for the XML version of the British National Corpus."""
 
+from defusedxml.ElementTree import parse as safe_parse
+
 from nltk.corpus.reader.util import concat
-from nltk.corpus.reader.xmldocs import ElementTree, XMLCorpusReader, XMLCorpusView
+from nltk.corpus.reader.xmldocs import XMLCorpusReader, XMLCorpusView
 
 
 class BNCCorpusReader(XMLCorpusReader):
@@ -113,7 +115,7 @@ class BNCCorpusReader(XMLCorpusReader):
         """
         result = []
 
-        xmldoc = ElementTree.parse(fileid).getroot()
+        xmldoc = safe_parse(fileid).getroot()
         for xmlsent in xmldoc.findall(".//s"):
             sent = []
             for xmlword in _all_xmlwords_in(xmlsent):

--- a/nltk/corpus/reader/bnc.py
+++ b/nltk/corpus/reader/bnc.py
@@ -115,7 +115,8 @@ class BNCCorpusReader(XMLCorpusReader):
         """
         result = []
 
-        xmldoc = safe_parse(fileid).getroot()
+        with fileid.open() as fp:
+            xmldoc = safe_parse(fp).getroot()
         for xmlsent in xmldoc.findall(".//s"):
             sent = []
             for xmlword in _all_xmlwords_in(xmlsent):

--- a/nltk/corpus/reader/childes.py
+++ b/nltk/corpus/reader/childes.py
@@ -15,8 +15,10 @@ __docformat__ = "epytext en"
 import re
 from collections import defaultdict
 
+from defusedxml.ElementTree import parse as safe_parse
+
 from nltk.corpus.reader.util import concat
-from nltk.corpus.reader.xmldocs import ElementTree, XMLCorpusReader
+from nltk.corpus.reader.xmldocs import XMLCorpusReader
 from nltk.util import LazyConcatenation, LazyMap, flatten
 
 # to resolve the namespace issue
@@ -216,7 +218,7 @@ class CHILDESCorpusReader(XMLCorpusReader):
 
     def _get_corpus(self, fileid):
         results = dict()
-        xmldoc = ElementTree.parse(fileid).getroot()
+        xmldoc = safe_parse(fileid).getroot()
         for key, value in xmldoc.items():
             results[key] = value
         return results
@@ -236,7 +238,7 @@ class CHILDESCorpusReader(XMLCorpusReader):
         def dictOfDicts():
             return defaultdict(dictOfDicts)
 
-        xmldoc = ElementTree.parse(fileid).getroot()
+        xmldoc = safe_parse(fileid).getroot()
         # getting participants' data
         pat = dictOfDicts()
         for participant in xmldoc.findall(
@@ -262,7 +264,7 @@ class CHILDESCorpusReader(XMLCorpusReader):
         return LazyMap(get_age, self.abspaths(fileids))
 
     def _get_age(self, fileid, speaker, month):
-        xmldoc = ElementTree.parse(fileid).getroot()
+        xmldoc = safe_parse(fileid).getroot()
         for pat in xmldoc.findall(f".//{{{NS}}}Participants/{{{NS}}}participant"):
             try:
                 if pat.get("id") == speaker:
@@ -354,7 +356,7 @@ class CHILDESCorpusReader(XMLCorpusReader):
             isinstance(speaker, str) and speaker != "ALL"
         ):  # ensure we have a list of speakers
             speaker = [speaker]
-        xmldoc = ElementTree.parse(fileid).getroot()
+        xmldoc = safe_parse(fileid).getroot()
         # processing each xml doc
         results = []
         for xmlsent in xmldoc.findall(".//{%s}u" % NS):

--- a/nltk/corpus/reader/childes.py
+++ b/nltk/corpus/reader/childes.py
@@ -218,7 +218,8 @@ class CHILDESCorpusReader(XMLCorpusReader):
 
     def _get_corpus(self, fileid):
         results = dict()
-        xmldoc = safe_parse(fileid).getroot()
+        with fileid.open() as fp:
+            xmldoc = safe_parse(fp).getroot()
         for key, value in xmldoc.items():
             results[key] = value
         return results
@@ -238,7 +239,8 @@ class CHILDESCorpusReader(XMLCorpusReader):
         def dictOfDicts():
             return defaultdict(dictOfDicts)
 
-        xmldoc = safe_parse(fileid).getroot()
+        with fileid.open() as fp:
+            xmldoc = safe_parse(fp).getroot()
         # getting participants' data
         pat = dictOfDicts()
         for participant in xmldoc.findall(
@@ -264,7 +266,8 @@ class CHILDESCorpusReader(XMLCorpusReader):
         return LazyMap(get_age, self.abspaths(fileids))
 
     def _get_age(self, fileid, speaker, month):
-        xmldoc = safe_parse(fileid).getroot()
+        with fileid.open() as fp:
+            xmldoc = safe_parse(fp).getroot()
         for pat in xmldoc.findall(f".//{{{NS}}}Participants/{{{NS}}}participant"):
             try:
                 if pat.get("id") == speaker:
@@ -356,7 +359,8 @@ class CHILDESCorpusReader(XMLCorpusReader):
             isinstance(speaker, str) and speaker != "ALL"
         ):  # ensure we have a list of speakers
             speaker = [speaker]
-        xmldoc = safe_parse(fileid).getroot()
+        with fileid.open() as fp:
+            xmldoc = safe_parse(fp).getroot()
         # processing each xml doc
         results = []
         for xmlsent in xmldoc.findall(".//{%s}u" % NS):

--- a/nltk/corpus/reader/nombank.py
+++ b/nltk/corpus/reader/nombank.py
@@ -7,7 +7,8 @@
 # For license information, see LICENSE.TXT
 
 from functools import total_ordering
-from xml.etree import ElementTree
+
+from defusedxml.ElementTree import parse as safe_parse
 
 from nltk.corpus.reader.api import *
 from nltk.corpus.reader.util import *
@@ -108,7 +109,7 @@ class NombankCorpusReader(CorpusReader):
         # n.b.: The encoding for XML fileids is specified by the file
         # itself; so we ignore self._encoding here.
         with self.abspath(framefile).open() as fp:
-            etree = ElementTree.parse(fp).getroot()
+            etree = safe_parse(fp).getroot()
         for roleset in etree.findall("predicate/roleset"):
             if roleset.attrib["id"] == roleset_id:
                 return roleset
@@ -131,7 +132,7 @@ class NombankCorpusReader(CorpusReader):
             # n.b.: The encoding for XML fileids is specified by the file
             # itself; so we ignore self._encoding here.
             with self.abspath(framefile).open() as fp:
-                etree = ElementTree.parse(fp).getroot()
+                etree = safe_parse(fp).getroot()
             rsets.append(etree.findall("predicate/roleset"))
         return LazyConcatenation(rsets)
 

--- a/nltk/corpus/reader/propbank.py
+++ b/nltk/corpus/reader/propbank.py
@@ -7,7 +7,8 @@
 
 import re
 from functools import total_ordering
-from xml.etree import ElementTree
+
+from defusedxml.ElementTree import parse as safe_parse
 
 from nltk.corpus.reader.api import *
 from nltk.corpus.reader.util import *
@@ -104,7 +105,7 @@ class PropbankCorpusReader(CorpusReader):
         # n.b.: The encoding for XML fileids is specified by the file
         # itself; so we ignore self._encoding here.
         with self.abspath(framefile).open() as fp:
-            etree = ElementTree.parse(fp).getroot()
+            etree = safe_parse(fp).getroot()
         for roleset in etree.findall("predicate/roleset"):
             if roleset.attrib["id"] == roleset_id:
                 return roleset
@@ -127,7 +128,7 @@ class PropbankCorpusReader(CorpusReader):
             # n.b.: The encoding for XML fileids is specified by the file
             # itself; so we ignore self._encoding here.
             with self.abspath(framefile).open() as fp:
-                etree = ElementTree.parse(fp).getroot()
+                etree = safe_parse(fp).getroot()
             rsets.append(etree.findall("predicate/roleset"))
         return LazyConcatenation(rsets)
 

--- a/nltk/corpus/reader/semcor.py
+++ b/nltk/corpus/reader/semcor.py
@@ -11,6 +11,8 @@ Corpus reader for the SemCor Corpus.
 
 __docformat__ = "epytext en"
 
+from defusedxml.ElementTree import parse as safe_parse
+
 from nltk.corpus.reader.api import *
 from nltk.corpus.reader.xmldocs import XMLCorpusReader, XMLCorpusView
 from nltk.tree import Tree
@@ -124,7 +126,7 @@ class SemcorCorpusReader(XMLCorpusReader):
         assert unit in ("token", "word", "chunk")
         result = []
 
-        xmldoc = ElementTree.parse(fileid).getroot()
+        xmldoc = safe_parse(fileid).getroot()
         for xmlsent in xmldoc.findall(".//s"):
             sent = []
             for xmlword in _all_xmlwords_in(xmlsent):

--- a/nltk/corpus/reader/semcor.py
+++ b/nltk/corpus/reader/semcor.py
@@ -126,7 +126,8 @@ class SemcorCorpusReader(XMLCorpusReader):
         assert unit in ("token", "word", "chunk")
         result = []
 
-        xmldoc = safe_parse(fileid).getroot()
+        with fileid.open() as fp:
+            xmldoc = safe_parse(fp).getroot()
         for xmlsent in xmldoc.findall(".//s"):
             sent = []
             for xmlword in _all_xmlwords_in(xmlsent):

--- a/nltk/corpus/reader/senseval.py
+++ b/nltk/corpus/reader/senseval.py
@@ -23,7 +23,8 @@ is tagged with a sense identifier, and supplied with context.
 """
 
 import re
-from xml.etree import ElementTree
+
+from defusedxml.ElementTree import fromstring as safe_fromstring
 
 from nltk.corpus.reader.api import *
 from nltk.corpus.reader.util import *
@@ -111,7 +112,7 @@ class SensevalCorpusView(StreamBackedCorpusView):
             if line.lstrip().startswith("</instance"):
                 xml_block = "\n".join(instance_lines)
                 xml_block = _fixXML(xml_block)
-                inst = ElementTree.fromstring(xml_block)
+                inst = safe_fromstring(xml_block)
                 return [self._parse_instance(inst, lexelt)]
 
     def _parse_instance(self, instance, lexelt):

--- a/nltk/corpus/reader/xmldocs.py
+++ b/nltk/corpus/reader/xmldocs.py
@@ -12,7 +12,14 @@ Corpus reader for corpora whose documents are xml files.
 """
 
 import codecs
-from xml.etree import ElementTree
+
+# Parse untrusted corpus XML with defusedxml, which forbids the custom-entity
+# definitions used by XML entity-expansion (Billion Laughs, CWE-776) attacks
+# while leaving ordinary XML (including the standard &amp; &lt; ... entities)
+# unaffected. See issue #3545 / PR #3544, which applied the same guard to the
+# downloader's remote index.
+from defusedxml.ElementTree import fromstring as safe_fromstring
+from defusedxml.ElementTree import parse as safe_parse
 
 from nltk.corpus.reader.api import CorpusReader
 from nltk.corpus.reader.util import *
@@ -40,9 +47,9 @@ class XMLCorpusReader(CorpusReader):
             fileid = self._fileids[0]
         if not isinstance(fileid, str):
             raise TypeError("Expected a single file identifier string")
-        # Read the XML in using ElementTree.
+        # Read the XML in using defusedxml's ElementTree.
         with self.abspath(fileid).open() as fp:
-            elt = ElementTree.parse(fp).getroot()
+            elt = safe_parse(fp).getroot()
         # If requested, wrap it.
         if self._wrap_etree:
             elt = ElementWrapper(elt)
@@ -390,7 +397,7 @@ class XMLCorpusView(StreamBackedCorpusView):
 
         return [
             elt_handler(
-                ElementTree.fromstring(elt.encode("ascii", "xmlcharrefreplace")),
+                safe_fromstring(elt.encode("ascii", "xmlcharrefreplace")),
                 context,
             )
             for (elt, context) in elts

--- a/nltk/test/unit/test_xml_entity_expansion_security.py
+++ b/nltk/test/unit/test_xml_entity_expansion_security.py
@@ -1,0 +1,46 @@
+"""Regression tests for XML entity-expansion (Billion Laughs) in corpus readers (CWE-776).
+
+NLTK's XML corpus readers parsed untrusted corpus XML with the stdlib
+``xml.etree.ElementTree``, which performs entity expansion and is vulnerable to a
+Billion-Laughs denial of service. They now parse via ``defusedxml`` (``safe_parse``
+/ ``safe_fromstring``), which forbids the custom-entity definitions such an attack
+relies on while leaving ordinary XML unaffected. This mirrors the fix applied to
+the downloader's remote index in issue #3545 / PR #3544.
+"""
+
+import pytest
+from defusedxml.common import EntitiesForbidden
+
+from nltk.corpus.reader.xmldocs import XMLCorpusReader
+
+# A Billion-Laughs payload: a tiny file whose nested entities would expand to a
+# huge string with the stdlib parser.
+_BOMB = (
+    '<?xml version="1.0"?>\n'
+    "<!DOCTYPE doc [\n"
+    '  <!ENTITY a0 "AAAAAAAAAA">\n'
+    '  <!ENTITY a1 "&a0;&a0;&a0;&a0;&a0;&a0;&a0;&a0;&a0;&a0;">\n'
+    '  <!ENTITY a2 "&a1;&a1;&a1;&a1;&a1;&a1;&a1;&a1;&a1;&a1;">\n'
+    '  <!ENTITY a3 "&a2;&a2;&a2;&a2;&a2;&a2;&a2;&a2;&a2;&a2;">\n'
+    "]>\n"
+    "<doc>&a3;</doc>"
+)
+
+
+def test_xmlcorpusreader_blocks_entity_bomb(tmp_path):
+    """A malicious corpus file with a nested-entity DTD must be refused."""
+    (tmp_path / "evil.xml").write_text(_BOMB)
+    reader = XMLCorpusReader(str(tmp_path), ["evil.xml"])
+    with pytest.raises(EntitiesForbidden):
+        reader.xml("evil.xml")
+
+
+def test_xmlcorpusreader_parses_normal_xml(tmp_path):
+    """Ordinary XML, including the standard &amp;/&lt; entities, still parses."""
+    (tmp_path / "ok.xml").write_text(
+        '<doc><w pos="NN">cat</w> &amp; <w pos="NN">dog</w></doc>'
+    )
+    reader = XMLCorpusReader(str(tmp_path), ["ok.xml"])
+    elt = reader.xml("ok.xml")
+    assert elt.tag == "doc"
+    assert reader.words("ok.xml") == ["cat", "dog"]


### PR DESCRIPTION
## Summary
NLTK's XML corpus readers parse untrusted corpus XML with the stdlib
`xml.etree.ElementTree`, which performs entity expansion and is vulnerable to an
**XML entity-expansion / Billion-Laughs** denial of service (CWE-776): a tiny
corpus file with a nested-entity DTD expands to gigabytes and exhausts memory.

The downloader's remote index was hardened with `defusedxml` in #3544
(issue #3545), but the corpus readers — which parse arbitrary corpus files —
were left on the unsafe parser. This PR completes that coverage.

## Details
```python
# e.g. nltk/corpus/reader/xmldocs.py — XMLCorpusReader.xml()
elt = ElementTree.parse(fp).getroot()        # stdlib, expands entities
```
Reachable via the public reader APIs (`xml()`, `words()`, `raw()`,
`instances()`, …) with the untrusted corpus file content as input — the
"untrusted input … shared / multi-tenant environments" threat model documented
in `SECURITY.md`.

Affected sites (one root cause — raw `ElementTree` on untrusted corpus XML):
`xmldocs.py` (`XMLCorpusReader`, base class), `propbank.py`, `nombank.py`,
`childes.py`, `bnc.py`, `semcor.py`, `senseval.py`.

## Proof of concept (before this change)
```python
import os, tempfile
from nltk.corpus.reader.xmldocs import XMLCorpusReader
d = tempfile.mkdtemp()
open(os.path.join(d, "evil.xml"), "w").write(BILLION_LAUGHS_XML)  # ~1 KB file
XMLCorpusReader(d, ["evil.xml"]).xml("evil.xml")   # expands to GBs / OOM
```
Measured via the public `XMLCorpusReader.xml()`: an 8 MiB malicious corpus file
expands to ~720 MiB (~90x) on current expat (which caps the ratio); on older /
unconfigured expat the expansion is unbounded, exactly as reported for the
downloader in #3545. Only internal entity expansion applies — the stdlib parser
does not resolve external entities, so there is no file-read/SSRF XXE.

## Fix
Route the readers through `defusedxml` (`safe_parse` / `safe_fromstring`), which
forbids the custom-entity definitions (`<!ENTITY ...>`) a Billion-Laughs attack
relies on, while leaving ordinary XML — including the standard `&amp; &lt; &gt;
&quot; &apos;` entities — unaffected. This is independent of the system expat
version, and is the same guard the downloader already uses. `defusedxml` is
already a dependency.

```python
from defusedxml.ElementTree import parse as safe_parse
...
elt = safe_parse(fp).getroot()
```

## Tests
`nltk/test/unit/test_xml_entity_expansion_security.py`:
- a malicious corpus file with a nested-entity DTD is refused
  (`defusedxml.common.EntitiesForbidden`) via `XMLCorpusReader.xml()`;
- ordinary XML, including the standard `&amp;` entities, still parses and
  `words()` returns the expected tokens (no false positives).

black `25.11.0` / isort `6.1.0` / ruff `0.15.6` clean.
