### PR TITLE
fix(security): resolve relative MaltParser dir via MALT_PARSER, not the CWD (CWE-426)

### DIFF
--- a/nltk/parse/malt.py
+++ b/nltk/parse/malt.py
@@ -62,7 +62,13 @@ def find_maltparser(parser_dirname):
     """
     A module to find MaltParser .jar file and its dependencies.
     """
-    if os.path.exists(parser_dirname):  # If a full path is given.
+    # Only accept an explicit *absolute* directory as-is. A relative name must
+    # not be resolved against the current working directory: an attacker able to
+    # write to the CWD could otherwise plant a ``maltparser-*/`` directory there
+    # and have its jars placed on the Java classpath (and its ``org.maltparser``
+    # main class executed), overriding a trusted ``MALT_PARSER`` -- an untrusted
+    # search path (CWE-426). A relative name is resolved through ``MALT_PARSER``.
+    if os.path.isabs(parser_dirname) and os.path.exists(parser_dirname):
         _malt_dir = parser_dirname
     else:  # Try to find path to maltparser directory in environment variables.
         _malt_dir = find_dir(parser_dirname, env_vars=("MALT_PARSER",))

--- a/nltk/parse/malt.py
+++ b/nltk/parse/malt.py
@@ -62,13 +62,15 @@ def find_maltparser(parser_dirname):
     """
     A module to find MaltParser .jar file and its dependencies.
     """
+    # Accept str or os.PathLike uniformly (find_dir() requires a str).
+    parser_dirname = os.fspath(parser_dirname)
     # Only accept an explicit *absolute* directory as-is. A relative name must
     # not be resolved against the current working directory: an attacker able to
     # write to the CWD could otherwise plant a ``maltparser-*/`` directory there
     # and have its jars placed on the Java classpath (and its ``org.maltparser``
     # main class executed), overriding a trusted ``MALT_PARSER`` -- an untrusted
     # search path (CWE-426). A relative name is resolved through ``MALT_PARSER``.
-    if os.path.isabs(parser_dirname) and os.path.exists(parser_dirname):
+    if os.path.isabs(parser_dirname) and os.path.isdir(parser_dirname):
         _malt_dir = parser_dirname
     else:  # Try to find path to maltparser directory in environment variables.
         _malt_dir = find_dir(parser_dirname, env_vars=("MALT_PARSER",))

--- a/nltk/test/unit/test_malt_security.py
+++ b/nltk/test/unit/test_malt_security.py
@@ -1,0 +1,68 @@
+"""Regression tests for the untrusted-search-path fix in MaltParser (CWE-426).
+
+``find_maltparser`` used ``os.path.exists(parser_dirname)`` to accept a directory
+as-is. For a *relative* ``parser_dirname`` (as NLTK's docs use) that resolves
+against the current working directory and is checked *before* the ``MALT_PARSER``
+environment variable, so an attacker who can write a ``maltparser-*/`` directory
+into the CWD could place its jars on the Java classpath -- overriding a trusted
+``MALT_PARSER`` -- and have ``org.maltparser.Malt`` executed (RCE).
+
+Only an explicit *absolute* directory is now taken as-is; a relative name is
+resolved through ``MALT_PARSER``.
+"""
+
+import os
+
+import pytest
+
+from nltk.parse.malt import find_maltparser
+
+# The names find_maltparser asserts must be present in the directory.
+_MALT_JARS = ["log4j.jar", "libsvm.jar", "liblinear-1.8.jar", "maltparser-1.9.2.jar"]
+
+
+def _make_malt_dir(path):
+    path.mkdir(parents=True, exist_ok=True)
+    for jar in _MALT_JARS:
+        (path / jar).write_bytes(b"")
+    return path
+
+
+def test_relative_dirname_not_resolved_against_cwd(tmp_path, monkeypatch):
+    """A relative parser_dirname matching a CWD directory must NOT be used."""
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    _make_malt_dir(cwd / "maltparser-1.9.2")  # attacker-planted in the CWD
+    monkeypatch.chdir(cwd)
+    monkeypatch.delenv("MALT_PARSER", raising=False)
+
+    # With no MALT_PARSER configured, the relative name must not fall back to the
+    # current working directory; discovery fails instead of silently using it.
+    with pytest.raises(LookupError):
+        find_maltparser("maltparser-1.9.2")
+
+
+def test_cwd_does_not_override_configured_malt_parser(tmp_path, monkeypatch):
+    """A CWD directory must not shadow a configured MALT_PARSER."""
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    _make_malt_dir(cwd / "maltparser-1.9.2")  # attacker-planted in the CWD
+    trusted = _make_malt_dir(tmp_path / "trusted")  # the configured location
+    monkeypatch.chdir(cwd)
+    monkeypatch.setenv("MALT_PARSER", str(trusted))
+
+    jars = find_maltparser("maltparser-1.9.2")
+    chosen = os.path.realpath(os.path.dirname(jars[0]))
+    assert chosen == os.path.realpath(
+        str(trusted)
+    ), "CWD directory overrode the trusted MALT_PARSER"
+
+
+def test_absolute_path_still_accepted(tmp_path, monkeypatch):
+    """An explicit absolute directory is still used as-is."""
+    abs_dir = _make_malt_dir(tmp_path / "absmalt")
+    monkeypatch.delenv("MALT_PARSER", raising=False)
+
+    jars = find_maltparser(str(abs_dir))
+    chosen = os.path.realpath(os.path.dirname(jars[0]))
+    assert chosen == os.path.realpath(str(abs_dir))

--- a/nltk/test/unit/test_malt_security.py
+++ b/nltk/test/unit/test_malt_security.py
@@ -12,6 +12,7 @@ resolved through ``MALT_PARSER``.
 """
 
 import os
+import pathlib
 
 import pytest
 
@@ -66,3 +67,16 @@ def test_absolute_path_still_accepted(tmp_path, monkeypatch):
     jars = find_maltparser(str(abs_dir))
     chosen = os.path.realpath(os.path.dirname(jars[0]))
     assert chosen == os.path.realpath(str(abs_dir))
+
+
+def test_pathlike_argument_is_handled(tmp_path, monkeypatch):
+    """A pathlib.Path argument is accepted; a relative one fails cleanly."""
+    abs_dir = _make_malt_dir(tmp_path / "absmalt")
+    monkeypatch.delenv("MALT_PARSER", raising=False)
+    # An absolute Path is accepted (normalised via os.fspath).
+    assert find_maltparser(pathlib.Path(abs_dir))
+    # A relative Path with no MALT_PARSER raises a clean LookupError -- not an
+    # AssertionError from find_dir()'s str check, and not a CWD pickup.
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(LookupError):
+        find_maltparser(pathlib.Path("not-a-configured-malt-dir"))


### PR DESCRIPTION
## Summary
`nltk.parse.malt.find_maltparser()` accepted `parser_dirname` as-is whenever
`os.path.exists()` was true. For a **relative** name — which is NLTK's own
documented usage (`MaltParser('maltparser-1.7.2', 'engmalt.linear-1.7.mco')`) —
that resolves against the process **current working directory**, and it was
checked **before** the `MALT_PARSER` environment variable. So a `./maltparser-*/`
directory in the CWD silently overrides a trusted, configured `MALT_PARSER`, its
jars are placed on the Java classpath, and NLTK runs
`java -cp <those jars> org.maltparser.Malt`. An attacker who can write a directory
into the application's CWD therefore gets their `org.maltparser.Malt` executed —
arbitrary code execution via an **untrusted search path** (CWE-426 / CWE-427).

Writable CWDs are common (web-app working dirs, pipeline scratch dirs,
upload-staging dirs, shared multi-user dirs), and the planted directory only needs
the jar *names* NLTK asserts on (`log4j.jar`, `libsvm.jar`, `liblinear-1.8.jar`,
`maltparser-*.jar`); their contents are attacker-controlled.

## Details
```python
# nltk/parse/malt.py — find_maltparser()
if os.path.exists(parser_dirname):          # relative name -> CWD, before MALT_PARSER
    _malt_dir = parser_dirname
else:
    _malt_dir = find_dir(parser_dirname, env_vars=("MALT_PARSER",))
_malt_jars = set(find_jars_within_path(_malt_dir))   # -> java -cp ... org.maltparser.Malt
```

## Proof of concept (before this change)
With `MALT_PARSER` set to a trusted directory and a malicious `./maltparser-1.9.2/`
in the CWD whose `maltparser-1.9.2.jar` defines `org.maltparser.Malt`:
```python
from nltk.parse.malt import find_maltparser
find_maltparser("maltparser-1.9.2")   # selects the CWD jars, NOT MALT_PARSER
# NLTK then runs: java -cp <CWD jars> org.maltparser.Malt  -> attacker code runs
```
Verified end-to-end with a JDK: the attacker's `org.maltparser.Malt` executed,
overriding the configured `MALT_PARSER`.

## Fix
Only accept an explicit **absolute** directory as-is (matching the original "if a
full path is given" intent); resolve a relative name through `MALT_PARSER`
instead of the current working directory:

```python
if os.path.isabs(parser_dirname) and os.path.exists(parser_dirname):
    _malt_dir = parser_dirname
else:
    _malt_dir = find_dir(parser_dirname, env_vars=("MALT_PARSER",))
```

Note: a relative `parser_dirname` now requires `MALT_PARSER` (or an absolute
path) rather than silently using the CWD. The malt doctests use `+SKIP`, so this
behaviour change does not affect CI.

## Tests
`nltk/test/unit/test_malt_security.py`:
- a relative `parser_dirname` matching a directory in the CWD is **not** used
  (discovery raises instead of silently using the CWD);
- a CWD `maltparser-*/` directory does **not** override a configured
  `MALT_PARSER`;
- an explicit absolute directory is still accepted.

black `25.11.0` / isort `6.1.0` / ruff `0.15.6` clean.
