### PR TITLE
fix(security): bound LogicParser recursion depth to prevent uncaught RecursionError (CWE-674)

### DIFF
--- a/nltk/sem/logic.py
+++ b/nltk/sem/logic.py
@@ -99,6 +99,13 @@ def binding_ops():
 class LogicParser:
     """A lambda calculus expression parser."""
 
+    #: Maximum expression-nesting depth the recursive-descent parser will
+    #: descend to. Deeply nested input would otherwise recurse until Python
+    #: raises an uncaught ``RecursionError`` and crashes the caller
+    #: (uncontrolled recursion, CWE-674); past this depth a normal
+    #: ``LogicalExpressionException`` is raised instead. Configurable.
+    MAX_PARSE_DEPTH = 200
+
     def __init__(self, type_check=False):
         """
         :param type_check: should type checking be performed
@@ -109,6 +116,7 @@ class LogicParser:
 
         self._currentIndex = 0
         self._buffer = []
+        self._parse_depth = 0
         self.type_check = type_check
 
         """A list of tuples of quote characters.  The 4-tuple is comprised
@@ -148,6 +156,7 @@ class LogicParser:
         data = data.rstrip()
 
         self._currentIndex = 0
+        self._parse_depth = 0
         self._buffer, mapping = self.process(data)
 
         try:
@@ -280,21 +289,32 @@ class LogicParser:
 
     def process_next_expression(self, context):
         """Parse the next complete expression from the stream and return it."""
+        self._parse_depth += 1
         try:
-            tok = self.token()
-        except ExpectedMoreTokensException as e:
-            raise ExpectedMoreTokensException(
-                self._currentIndex + 1, message="Expression expected."
-            ) from e
+            if self._parse_depth > self.MAX_PARSE_DEPTH:
+                raise LogicalExpressionException(
+                    self._currentIndex,
+                    "Expression nesting exceeds the maximum depth (%d)."
+                    % self.MAX_PARSE_DEPTH,
+                )
 
-        accum = self.handle(tok, context)
+            try:
+                tok = self.token()
+            except ExpectedMoreTokensException as e:
+                raise ExpectedMoreTokensException(
+                    self._currentIndex + 1, message="Expression expected."
+                ) from e
 
-        if not accum:
-            raise UnexpectedTokenException(
-                self._currentIndex, tok, message="Expression expected."
-            )
+            accum = self.handle(tok, context)
 
-        return self.attempt_adjuncts(accum, context)
+            if not accum:
+                raise UnexpectedTokenException(
+                    self._currentIndex, tok, message="Expression expected."
+                )
+
+            return self.attempt_adjuncts(accum, context)
+        finally:
+            self._parse_depth -= 1
 
     def handle(self, tok, context):
         """This method is intended to be overridden for logics that

--- a/nltk/sem/logic.py
+++ b/nltk/sem/logic.py
@@ -292,8 +292,11 @@ class LogicParser:
         self._parse_depth += 1
         try:
             if self._parse_depth > self.MAX_PARSE_DEPTH:
+                # Use 1-based index (consistent with ExpectedMoreTokensException);
+                # parse() formats the caret via mapping[index - 1], so index 0
+                # (limit hit before any token is consumed) must be avoided.
                 raise LogicalExpressionException(
-                    self._currentIndex,
+                    self._currentIndex + 1,
                     "Expression nesting exceeds the maximum depth (%d)."
                     % self.MAX_PARSE_DEPTH,
                 )

--- a/nltk/test/unit/test_logic_security.py
+++ b/nltk/test/unit/test_logic_security.py
@@ -13,17 +13,12 @@ from nltk.sem.logic import Expression, LogicalExpressionException, LogicParser
 
 
 def test_deeply_nested_expression_raises_clean_error():
-    """A pathologically deep expression must not raise RecursionError."""
-    payload = "-" * 5000 + "p"  # 5000 nested negations
+    """A pathologically deep expression raises a clean parse error, not an
+    uncaught RecursionError (uncontrolled recursion, CWE-674)."""
+    # If an uncaught RecursionError were raised instead, pytest.raises would not
+    # catch it and the test would fail with the unexpected exception.
     with pytest.raises(LogicalExpressionException):
-        Expression.fromstring(payload)
-    # And specifically NOT an uncaught RecursionError:
-    try:
-        Expression.fromstring(payload)
-    except RecursionError:  # pragma: no cover
-        pytest.fail("LogicParser raised an uncaught RecursionError (ReDoS-class DoS)")
-    except LogicalExpressionException:
-        pass
+        Expression.fromstring("-" * 5000 + "p")  # 5000 nested negations
 
 
 def test_normal_expressions_still_parse():
@@ -39,7 +34,7 @@ def test_normal_expressions_still_parse():
 
 
 def test_depth_cap_is_configurable_and_enforced():
-    """Below the cap parses; at/above the cap raises a clean parse error."""
+    """Nesting up to the cap parses; nesting beyond it raises a clean error."""
     saved = LogicParser.MAX_PARSE_DEPTH
     LogicParser.MAX_PARSE_DEPTH = 20
     try:

--- a/nltk/test/unit/test_logic_security.py
+++ b/nltk/test/unit/test_logic_security.py
@@ -1,0 +1,52 @@
+"""Regression tests for unbounded recursion in the logic parser (CWE-674).
+
+`LogicParser` is a recursive-descent parser: each nested sub-expression recurses
+through `process_next_expression`. Deeply nested input would otherwise recurse
+until Python raised an uncaught `RecursionError`, crashing the caller. The parser
+now caps the nesting depth at `LogicParser.MAX_PARSE_DEPTH` and raises a normal
+`LogicalExpressionException` instead.
+"""
+
+import pytest
+
+from nltk.sem.logic import Expression, LogicalExpressionException, LogicParser
+
+
+def test_deeply_nested_expression_raises_clean_error():
+    """A pathologically deep expression must not raise RecursionError."""
+    payload = "-" * 5000 + "p"  # 5000 nested negations
+    with pytest.raises(LogicalExpressionException):
+        Expression.fromstring(payload)
+    # And specifically NOT an uncaught RecursionError:
+    try:
+        Expression.fromstring(payload)
+    except RecursionError:  # pragma: no cover
+        pytest.fail("LogicParser raised an uncaught RecursionError (ReDoS-class DoS)")
+    except LogicalExpressionException:
+        pass
+
+
+def test_normal_expressions_still_parse():
+    """Ordinary expressions are unaffected by the depth cap."""
+    for s in [
+        "exists x.(P(x) & Q(x))",
+        "all x.(man(x) -> mortal(x))",
+        "\\x.(P(x))(a)",
+        "-(p & q)",
+        "P(a,b,c)",
+    ]:
+        assert str(Expression.fromstring(s))  # parses without error
+
+
+def test_depth_cap_is_configurable_and_enforced():
+    """Below the cap parses; at/above the cap raises a clean parse error."""
+    saved = LogicParser.MAX_PARSE_DEPTH
+    LogicParser.MAX_PARSE_DEPTH = 20
+    try:
+        # 19 nested negations: under the cap, parses fine.
+        assert str(Expression.fromstring("-" * 19 + "p"))
+        # 21 nested negations: over the cap, clean LogicalExpressionException.
+        with pytest.raises(LogicalExpressionException):
+            Expression.fromstring("-" * 21 + "p")
+    finally:
+        LogicParser.MAX_PARSE_DEPTH = saved


### PR DESCRIPTION
## Summary
`nltk.sem.logic.LogicParser` is a recursive-descent parser: every nested
sub-expression recurses through `process_next_expression`. Deeply nested input
recurses until Python raises an **uncaught `RecursionError`**, crashing the
caller — a denial of service from a few hundred bytes of input (uncontrolled
recursion, CWE-674). This is the same class as **GHSA-rf74-v2fm-23pw**, which the
project fixed for `JSONTaggedDecoder` by adding a depth cap.

## Details
```python
def process_next_expression(self, context):   # recursion point
    ...
    accum = self.handle(tok, context)          # -> handle_* -> process_next_expression
    return self.attempt_adjuncts(accum, context)
```
Reachable via the public `Expression.fromstring` / `LogicParser().parse` (and the
`DrtParser` subclass).

## Proof of concept (before this change)
```python
from nltk.sem.logic import Expression
Expression.fromstring("-" * 5000 + "p")   # uncaught RecursionError (crashes the request)
```
Measured at CPython's default recursion limit: ~330 nested operators already
raise `RecursionError`; a few hundred bytes suffice.

## Fix
Cap the expression-nesting depth at `LogicParser.MAX_PARSE_DEPTH` (default `200`,
well below the ~330 at which the default recursion limit is reached) and raise a
normal `LogicalExpressionException` past it — the parser's own error type, which
`parse()` already handles — instead of recursing into a crash. The cap is a
configurable class attribute. Ordinary expressions (which nest only a handful of
levels) are unaffected.

```python
class LogicParser:
    MAX_PARSE_DEPTH = 200
    def process_next_expression(self, context):
        self._parse_depth += 1
        try:
            if self._parse_depth > self.MAX_PARSE_DEPTH:
                raise LogicalExpressionException(self._currentIndex, "... maximum depth ...")
            ...
        finally:
            self._parse_depth -= 1
```

## Tests
`nltk/test/unit/test_logic_security.py`:
- a 5000-deep expression raises `LogicalExpressionException`, **not**
  `RecursionError`;
- ordinary expressions (`exists`, `all`, lambda, application, negation) still
  parse;
- with a lowered `MAX_PARSE_DEPTH`, input below the cap parses and input above it
  raises a clean error.

`nltk/test/logic.doctest` still passes; black `25.11.0` / isort `6.1.0` /
ruff `0.15.6` clean.

## Note
The same uncontrolled-recursion class exists in other NLTK recursive-descent
parsers (`FeatStructReader` / `FeatureGrammar.fromstring`, `DependencyGraph.tree()`,
and `Tree` `str`/`repr`/`__eq__` on a deeply nested tree). This PR fixes the logic
parser (the smallest-payload, cleanest case); the others can follow the same
pattern if desired.
