### PR TITLE
fix(security): resolve relative ReppTokenizer dir via REPP_TOKENIZER, not the CWD (CWE-427)

### DIFF
--- a/nltk/test/unit/test_repp_security.py
+++ b/nltk/test/unit/test_repp_security.py
@@ -1,0 +1,66 @@
+"""Regression tests for the untrusted-search-path fix in ReppTokenizer (CWE-426).
+
+``find_repptokenizer`` used ``os.path.exists(repp_dirname)`` to accept a directory
+as-is. For a *relative* ``repp_dirname`` that resolves against the current working
+directory and is checked *before* the ``REPP_TOKENIZER`` environment variable, so
+an attacker who can write a ``./<name>/src/repp`` executable into the CWD could
+have it run (the command path contains a separator, so ``subprocess`` executes it
+directly) -- overriding a trusted ``REPP_TOKENIZER``.
+
+Only an explicit *absolute* directory is now taken as-is; a relative name is
+resolved through ``REPP_TOKENIZER``.
+"""
+
+import os
+import pathlib
+
+import pytest
+
+from nltk.tokenize.repp import ReppTokenizer
+
+
+def _make_repp_dir(path):
+    (path / "src").mkdir(parents=True, exist_ok=True)
+    (path / "erg").mkdir(parents=True, exist_ok=True)
+    (path / "src" / "repp").write_bytes(b"")
+    (path / "erg" / "repp.set").write_bytes(b"")
+    return path
+
+
+def test_relative_dirname_not_resolved_against_cwd(tmp_path, monkeypatch):
+    """A relative repp_dirname matching a CWD directory must NOT be used."""
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    _make_repp_dir(cwd / "reppdir")  # attacker-planted in the CWD
+    monkeypatch.chdir(cwd)
+    monkeypatch.delenv("REPP_TOKENIZER", raising=False)
+
+    with pytest.raises(LookupError):
+        ReppTokenizer("reppdir")
+
+
+def test_cwd_does_not_override_configured_repp_tokenizer(tmp_path, monkeypatch):
+    """A CWD directory must not shadow a configured REPP_TOKENIZER."""
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    _make_repp_dir(cwd / "reppdir")  # attacker-planted in the CWD
+    trusted = _make_repp_dir(tmp_path / "trusted")  # the configured location
+    monkeypatch.chdir(cwd)
+    monkeypatch.setenv("REPP_TOKENIZER", str(trusted))
+
+    tok = ReppTokenizer("reppdir")
+    assert os.path.realpath(tok.repp_dir) == os.path.realpath(
+        str(trusted)
+    ), "CWD directory overrode the trusted REPP_TOKENIZER"
+
+
+def test_absolute_path_still_accepted(tmp_path, monkeypatch):
+    """An explicit absolute directory is still used as-is, incl. as a Path."""
+    abs_dir = _make_repp_dir(tmp_path / "absrepp")
+    monkeypatch.delenv("REPP_TOKENIZER", raising=False)
+
+    assert os.path.realpath(ReppTokenizer(str(abs_dir)).repp_dir) == os.path.realpath(
+        str(abs_dir)
+    )
+    # a pathlib.Path is accepted too (normalised via os.fspath)
+    assert ReppTokenizer(pathlib.Path(abs_dir)).repp_dir

--- a/nltk/test/unit/test_repp_security.py
+++ b/nltk/test/unit/test_repp_security.py
@@ -62,5 +62,8 @@ def test_absolute_path_still_accepted(tmp_path, monkeypatch):
     assert os.path.realpath(ReppTokenizer(str(abs_dir)).repp_dir) == os.path.realpath(
         str(abs_dir)
     )
-    # a pathlib.Path is accepted too (normalised via os.fspath)
-    assert ReppTokenizer(pathlib.Path(abs_dir)).repp_dir
+    # a pathlib.Path is accepted too (normalised via os.fspath) and resolves to
+    # the same directory.
+    assert os.path.realpath(
+        ReppTokenizer(pathlib.Path(abs_dir)).repp_dir
+    ) == os.path.realpath(str(abs_dir))

--- a/nltk/tokenize/repp.py
+++ b/nltk/tokenize/repp.py
@@ -139,7 +139,15 @@ class ReppTokenizer(TokenizerI):
         """
         A module to find REPP tokenizer binary and its *repp.set* config file.
         """
-        if os.path.exists(repp_dirname):  # If a full path is given.
+        # Accept str or os.PathLike uniformly (find_dir() requires a str).
+        repp_dirname = os.fspath(repp_dirname)
+        # Only accept an explicit *absolute* directory as-is. A relative name must
+        # not be resolved against the current working directory: an attacker able
+        # to write there could plant a ``<name>/src/repp`` executable and have it
+        # run -- the command path contains a separator, so subprocess executes it
+        # directly -- overriding a trusted ``REPP_TOKENIZER`` (an untrusted search
+        # path, CWE-426). A relative name is resolved through ``REPP_TOKENIZER``.
+        if os.path.isabs(repp_dirname) and os.path.isdir(repp_dirname):
             _repp_dir = repp_dirname
         else:  # Try to find path to REPP directory in environment variables.
             _repp_dir = find_dir(repp_dirname, env_vars=("REPP_TOKENIZER",))


### PR DESCRIPTION
## Summary
`nltk.tokenize.repp.ReppTokenizer.find_repptokenizer()` accepted `repp_dirname`
as-is whenever `os.path.exists()` was true. For a **relative** name that resolves
against the process **current working directory**, and it was checked **before**
the `REPP_TOKENIZER` environment variable. So a `./<name>/` directory in the CWD
silently overrides a trusted, configured `REPP_TOKENIZER`, and the tokenizer then
runs the binary with a path that contains a separator:

```python
cmd = [self.repp_dir + "/src/repp", "-c", self.repp_dir + "/erg/repp.set", ...]
subprocess.Popen(cmd)                                  # repp.py:105 / 113
```

Because the program path contains a `/`, `subprocess.Popen` executes it relative
to the CWD (it does not search `$PATH`). An attacker who can write a
`./<name>/src/repp` executable into the application's CWD therefore gets arbitrary
native code executed — an **untrusted search path** (CWE-426 / CWE-427). This is
the same class as the MaltParser fix (#3616).

## Proof of concept (before this change)
With `REPP_TOKENIZER` set to a trusted directory and a malicious
`./reppdir/src/repp` (+ `./reppdir/erg/repp.set`) in the CWD:
```python
from nltk.tokenize.repp import ReppTokenizer
tok = ReppTokenizer("reppdir")          # picks the CWD dir, NOT REPP_TOKENIZER
tok.tokenize_sents([["hello"]])         # runs ./reppdir/src/repp  -> attacker code
```
Verified end-to-end: the attacker's `./reppdir/src/repp` executes, overriding the
configured `REPP_TOKENIZER`.

## Fix
Normalise the argument with `os.fspath()`, accept an explicit **absolute**
directory as-is (`os.path.isdir`), and resolve a relative name through
`REPP_TOKENIZER` instead of the current working directory:

```python
repp_dirname = os.fspath(repp_dirname)
if os.path.isabs(repp_dirname) and os.path.isdir(repp_dirname):
    _repp_dir = repp_dirname
else:
    _repp_dir = find_dir(repp_dirname, env_vars=("REPP_TOKENIZER",))
```

A relative `repp_dirname` now requires `REPP_TOKENIZER` (or an absolute path)
rather than silently using the CWD.

## Tests
`nltk/test/unit/test_repp_security.py`:
- a relative `repp_dirname` matching a directory in the CWD is **not** used;
- a CWD `./<name>/` directory does **not** override a configured `REPP_TOKENIZER`;
- an explicit absolute directory (str or `pathlib.Path`) is still accepted.

black `25.11.0` / isort `6.1.0` / ruff `0.15.6` clean.
