### PR TITLE
fix(security): resolve symlinks in downloader containment check (CWE-59)

### DIFF
--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -682,27 +682,64 @@ class Downloader:
         tmp_filepath = filepath + ".tmp"
         lock_filepath = filepath + ".lock"
 
-        # Defense-in-depth: verify filepath stays within download_dir.
+        # Defense-in-depth: verify the write target stays within download_dir.
         #
-        # This check is intentionally lexical rather than realpath-based.  The
-        # target file may not exist yet, and on Windows some Python versions can
-        # produce inconsistent short-name vs long-name representations when
-        # resolving non-existent paths (for example RUNNER~1 vs runneradmin).
-        # A normalized absolute commonpath check is sufficient here to block
-        # path traversal through package metadata such as "../".
+        # Two layers are required:
+        #
+        #   (1) Lexical containment blocks "../" traversal coming from package
+        #       metadata.  It is intentionally lexical (normpath/abspath, not
+        #       realpath) because the target leaf may not exist yet and on
+        #       Windows realpath of a non-existent path can be unstable
+        #       (short-name vs long-name, e.g. RUNNER~1 vs runneradmin).
+        #
+        #   (2) Symlink containment (CWE-59, "link following").  A purely lexical
+        #       check is bypassed by a symlink that already exists *inside*
+        #       download_dir and points outside it: the target is lexically
+        #       contained, but open()/os.replace() follow the link and write
+        #       outside.  We therefore also resolve the deepest *existing*
+        #       ancestor of the real write targets (the ".tmp" file open()s, and
+        #       the final filepath os.replace()s onto) and require it to stay
+        #       within download_dir.  Only existing components are resolved, so
+        #       the not-yet-existing-leaf concern that motivates (1) does not
+        #       apply here.
+        def _within(child, root):
+            try:
+                return os.path.commonpath([root, child]) == root
+            except ValueError:
+                return False
+
+        def _symlink_contained(path):
+            # Walk up to the deepest *lexically* existing ancestor.  os.path.lexists
+            # (not os.path.exists) is required so a planted symlink -- including a
+            # dangling one -- stops the walk and gets resolved, rather than being
+            # treated as a non-existent leaf and skipped.
+            ancestor = os.path.abspath(path)
+            while not os.path.lexists(ancestor):
+                parent = os.path.dirname(ancestor)
+                if parent == ancestor:
+                    break
+                ancestor = parent
+            real_ancestor = os.path.normcase(os.path.realpath(ancestor))
+            real_download = os.path.normcase(os.path.realpath(download_dir))
+            # If the deepest existing ancestor is at or above download_dir (e.g.
+            # download_dir itself does not exist yet, so the walk climbed past
+            # it), then no symlink *inside* download_dir could have redirected
+            # the path -- lexical containment already governs that case.
+            # Otherwise the resolved ancestor lives below download_dir and must
+            # stay within it.
+            if _within(real_download, real_ancestor):
+                return True
+            return _within(real_ancestor, real_download)
+
         safe_download = os.path.normcase(
             os.path.abspath(os.path.normpath(download_dir))
         )
         safe_filepath = os.path.normcase(os.path.abspath(os.path.normpath(filepath)))
-        try:
-            if os.path.commonpath([safe_download, safe_filepath]) != safe_download:
-                yield ErrorMessage(
-                    info,
-                    f"Path traversal blocked: package '{info.id}' attempted to "
-                    f"write outside download directory (subdir='{info.subdir}')",
-                )
-                return
-        except ValueError:
+        if not (
+            _within(safe_filepath, safe_download)
+            and _symlink_contained(filepath)
+            and _symlink_contained(tmp_filepath)
+        ):
             yield ErrorMessage(
                 info,
                 f"Path traversal blocked: package '{info.id}' attempted to "

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -719,16 +719,25 @@ class Downloader:
                 if parent == ancestor:
                     break
                 ancestor = parent
+            # Decide from the *lexical* ancestor whether the walk stopped at or
+            # above download_dir (e.g. download_dir itself does not exist yet, so
+            # the walk climbed past it).  In that case no symlink *inside*
+            # download_dir could have redirected the path -- lexical containment
+            # already governs that case.  This must use the lexical ancestor, not
+            # the resolved one: a symlink that exists *inside* download_dir and
+            # points to a parent of download_dir would otherwise resolve to an
+            # ancestor of download_dir and wrongly take this early-return, even
+            # though following it escapes the download directory.
+            lex_ancestor = os.path.normcase(ancestor)
+            lex_download = os.path.normcase(
+                os.path.abspath(os.path.normpath(download_dir))
+            )
+            if _within(lex_download, lex_ancestor):
+                return True
+            # The deepest existing ancestor lives lexically below download_dir;
+            # resolve symlinks on it and require it to stay within download_dir.
             real_ancestor = os.path.normcase(os.path.realpath(ancestor))
             real_download = os.path.normcase(os.path.realpath(download_dir))
-            # If the deepest existing ancestor is at or above download_dir (e.g.
-            # download_dir itself does not exist yet, so the walk climbed past
-            # it), then no symlink *inside* download_dir could have redirected
-            # the path -- lexical containment already governs that case.
-            # Otherwise the resolved ancestor lives below download_dir and must
-            # stay within it.
-            if _within(real_download, real_ancestor):
-                return True
             return _within(real_ancestor, real_download)
 
         safe_download = os.path.normcase(

--- a/nltk/test/unit/test_downloader_symlink_security.py
+++ b/nltk/test/unit/test_downloader_symlink_security.py
@@ -1,0 +1,136 @@
+"""Regression tests for symlink-following arbitrary file write in the downloader (CWE-59).
+
+``Downloader._download_package`` writes the package body to
+``os.path.join(download_dir, info.filename)`` (``info.filename`` is taken from
+the package index and is attacker-controllable).  A containment check guards
+against ``../`` traversal, but a purely *lexical* check is bypassed by a symlink
+that already exists *inside* ``download_dir`` and points outside it: the target
+is lexically contained, yet ``open()`` / ``os.replace()`` follow the link and
+write outside the download directory.
+
+The check must therefore be symlink-aware: it resolves the deepest existing
+ancestor of the real write targets before comparing, so a planted symlink cannot
+redirect the write out of ``download_dir``.  These tests pin that behaviour and
+also assert that legitimate downloads (including into a download dir that is
+itself a symlink) keep working.
+"""
+
+import hashlib
+import io
+import os
+
+import pytest
+
+from nltk.downloader import Downloader, ErrorMessage, Package
+
+PAYLOAD = b"package-body-bytes\n"
+
+
+def _package(filename, **overrides):
+    attrib = dict(
+        id="p",
+        name="p",
+        subdir="corpora",
+        url="http://example.invalid/p",
+        size=str(len(PAYLOAD)),
+        unzipped_size="0",
+        checksum="0",
+        sha256_checksum=hashlib.sha256(PAYLOAD).hexdigest(),
+        unzip="0",
+        filename=filename,
+    )
+    attrib.update(overrides)
+    return Package(**attrib)
+
+
+class _FakeResp(io.BytesIO):
+    def close(self):  # urlopen handle is closed by the downloader
+        pass
+
+
+@pytest.fixture
+def fake_urlopen(monkeypatch):
+    monkeypatch.setattr(
+        "nltk.downloader.urlopen", lambda url, *a, **k: _FakeResp(PAYLOAD)
+    )
+
+
+def _run(pkg, download_dir):
+    dl = Downloader()
+    return list(dl.incr_download(pkg, str(download_dir), force=True))
+
+
+def test_symlink_inside_download_dir_cannot_redirect_write(tmp_path, fake_urlopen):
+    """A symlink planted inside download_dir must not let the write escape it."""
+    download_dir = tmp_path / "nltk_data"
+    (download_dir / "corpora").mkdir(parents=True)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    # Attacker pre-plants download_dir/corpora/evil -> outside.
+    os.symlink(outside, download_dir / "corpora" / "evil")
+
+    pkg = _package("corpora/evil/OWNED.txt")
+    msgs = _run(pkg, download_dir)
+
+    assert any(isinstance(m, ErrorMessage) for m in msgs)
+    # Nothing written through the symlink, outside the download dir.
+    assert not (outside / "OWNED.txt").exists()
+
+
+def test_symlink_via_subdir_component_is_blocked(tmp_path, fake_urlopen):
+    """subdir routing through a planted symlink is blocked too (no `..` needed)."""
+    download_dir = tmp_path / "nltk_data"
+    (download_dir / "corpora").mkdir(parents=True)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    os.symlink(outside, download_dir / "corpora" / "link")
+
+    # subdir validation only rejects `..`/absolute, not a symlink component.
+    pkg = _package(filename="corpora/link/x", subdir="corpora/link")
+    msgs = _run(pkg, download_dir)
+
+    assert any(isinstance(m, ErrorMessage) for m in msgs)
+    assert not (outside / "x").exists()
+
+
+def test_symlink_at_tmp_leaf_is_blocked(tmp_path, fake_urlopen):
+    """A symlink planted at the leaf `.tmp` target must not be followed."""
+    download_dir = tmp_path / "nltk_data"
+    (download_dir / "corpora").mkdir(parents=True)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    secret = outside / "secret"
+    # download writes filepath + ".tmp" first -> plant a symlink there.
+    os.symlink(secret, download_dir / "corpora" / "p.zip.tmp")
+
+    pkg = _package("corpora/p.zip")
+    msgs = _run(pkg, download_dir)
+
+    assert any(isinstance(m, ErrorMessage) for m in msgs)
+    assert not secret.exists()
+
+
+def test_legitimate_download_still_works(tmp_path, fake_urlopen):
+    """A normal, contained package is written inside download_dir."""
+    download_dir = tmp_path / "nltk_data"
+    download_dir.mkdir()
+
+    pkg = _package("corpora/p.txt")
+    msgs = _run(pkg, download_dir)
+
+    assert not any(isinstance(m, ErrorMessage) for m in msgs)
+    assert (download_dir / "corpora" / "p.txt").read_bytes() == PAYLOAD
+
+
+def test_legitimate_symlinked_download_dir_still_works(tmp_path, fake_urlopen):
+    """A download_dir that is itself a symlink is allowed (resolves to itself)."""
+    real = tmp_path / "real_data"
+    real.mkdir()
+    download_dir = tmp_path / "nltk_data"  # symlink -> real
+    os.symlink(real, download_dir)
+
+    pkg = _package("corpora/p.txt")
+    msgs = _run(pkg, download_dir)
+
+    assert not any(isinstance(m, ErrorMessage) for m in msgs)
+    assert (real / "corpora" / "p.txt").read_bytes() == PAYLOAD

--- a/nltk/test/unit/test_downloader_symlink_security.py
+++ b/nltk/test/unit/test_downloader_symlink_security.py
@@ -18,10 +18,30 @@ itself a symlink) keep working.
 import hashlib
 import io
 import os
+import tempfile
 
 import pytest
 
 from nltk.downloader import Downloader, ErrorMessage, Package
+
+
+def _can_symlink():
+    # os.symlink exists on Windows but raises OSError/NotImplementedError without
+    # Developer Mode/admin (or where symlinks are disabled); skip rather than fail.
+    with tempfile.TemporaryDirectory() as d:
+        src = os.path.join(d, "src")
+        dst = os.path.join(d, "dst")
+        open(src, "w").close()
+        try:
+            os.symlink(src, dst)
+            return True
+        except (OSError, NotImplementedError, AttributeError):
+            return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _can_symlink(), reason="symlinks not supported on this platform/environment"
+)
 
 PAYLOAD = b"package-body-bytes\n"
 
@@ -75,6 +95,25 @@ def test_symlink_inside_download_dir_cannot_redirect_write(tmp_path, fake_urlope
     assert any(isinstance(m, ErrorMessage) for m in msgs)
     # Nothing written through the symlink, outside the download dir.
     assert not (outside / "OWNED.txt").exists()
+
+
+def test_symlink_to_parent_of_download_dir_is_blocked(tmp_path, fake_urlopen):
+    """A symlink inside download_dir pointing to an *ancestor* must be blocked.
+
+    Regression for an early-return that used the resolved (not lexical) ancestor:
+    a link resolving to a parent of download_dir would otherwise be treated as
+    "at/above download_dir" and wrongly allowed.
+    """
+    download_dir = tmp_path / "nltk_data"
+    (download_dir / "corpora").mkdir(parents=True)
+    # download_dir/corpora/up -> tmp_path  (an ancestor of download_dir)
+    os.symlink(tmp_path, download_dir / "corpora" / "up")
+
+    pkg = _package("corpora/up/OWNED.txt")
+    msgs = _run(pkg, download_dir)
+
+    assert any(isinstance(m, ErrorMessage) for m in msgs)
+    assert not (tmp_path / "OWNED.txt").exists()
 
 
 def test_symlink_via_subdir_component_is_blocked(tmp_path, fake_urlopen):


### PR DESCRIPTION
## Summary

The download-target containment check added in #3595 (`_download_package`) is
**lexical** — it uses `os.path.normpath` / `os.path.abspath` + `os.path.commonpath`
and deliberately not `os.path.realpath`. A lexical check does not resolve symbolic
links, so it can be bypassed by a symlink that already exists **inside**
`download_dir` and points outside it:

- the write target is lexically still inside `download_dir` (so `commonpath` passes), but
- `open(tmp_filepath, "wb")` and `os.replace(...)` follow the link at the OS level and write **outside** the download directory,

with content taken verbatim from the package `url`. This re-opens the arbitrary
file write that #3595 was meant to close (a planted symlink as a path component,
or as the `.tmp` leaf, reached via the `filename` package attribute or a
`subdir="corpora/<link>"` — `subdir` validation rejects `..`/absolute but not a
symlink component). Weakness: CWE-59 (link following).

Note the asymmetry this fixes: the ZIP **extraction** path (`_unzip_iter` /
`_validate_member`) already resolves symlinks with `realpath`; only the raw
download write relied on the bypassable lexical check.

## Fix

Keep the lexical check (it still blocks `../` and avoids realpath-ing a
not-yet-existing leaf, which motivated #3595's Windows note) and add a
symlink-aware layer:

- resolve the deepest **existing** ancestor of each real write target (the
  `.tmp` file that `open()` creates and the final `filepath` that `os.replace`
  targets) with `realpath`, and require it to stay within `download_dir`;
- the walk uses `os.path.lexists` so a planted/dangling symlink stops the walk
  and is resolved rather than skipped;
- only existing components are resolved, so the not-yet-existing-leaf / Windows
  short-name property that motivated the lexical check is preserved (when
  `download_dir` itself doesn't exist yet, the walk climbs to/above it and the
  lexical check governs).

## Tests

Adds `nltk/test/unit/test_downloader_symlink_security.py`:

- a symlink directory planted inside `download_dir` cannot redirect the write outside it;
- routing via `subdir="corpora/<link>"` is blocked too (no `..` needed);
- a symlink planted at the `.tmp` leaf is not followed;
- a legitimate contained download still succeeds;
- a `download_dir` that is itself a symlink still works (resolves to itself).

`test_downloader_symlink_security.py` passes (5/5) and the existing downloader
suites (`test_downloader`, `test_downloader_atomic`, `test_downloader_unzip`,
`test_downloader_xxe`) remain green. Formatted with the repo-pinned
black 25.11.0 / isort 6.1.0 / ruff 0.15.6.
