### PR TITLE
fix(security): do not load weka.jar from the CWD (CWE-494)

### DIFF
--- a/nltk/classify/weka.py
+++ b/nltk/classify/weka.py
@@ -22,8 +22,14 @@ from nltk.internals import config_java, java
 from nltk.probability import DictionaryProbDist
 
 _weka_classpath = None
+# NB: the current working directory (".") is deliberately NOT searched. Picking
+# up a ``weka.jar`` from the CWD would load and run Java classes from an
+# unverified jar -- ``java -cp ./weka.jar weka.classifiers.bayes.NaiveBayes ...``
+# -- with no integrity check, so an attacker who can write ``./weka.jar`` gets
+# code execution (CWE-494; reachable via an untrusted search path, CWE-426). Set
+# the WEKAHOME environment variable or pass ``config_weka(classpath=...)`` to
+# point at a trusted weka.jar.
 _weka_search = [
-    ".",
     "/usr/share/weka",
     "/usr/local/share/weka",
     "/usr/lib/weka",

--- a/nltk/classify/weka.py
+++ b/nltk/classify/weka.py
@@ -47,7 +47,7 @@ def config_weka(classpath=None):
         _weka_classpath = classpath
 
     if _weka_classpath is None:
-        searchpath = _weka_search
+        searchpath = list(_weka_search)  # copy; don't mutate the module global
         if "WEKAHOME" in os.environ:
             searchpath.insert(0, os.environ["WEKAHOME"])
 

--- a/nltk/test/unit/test_weka_security.py
+++ b/nltk/test/unit/test_weka_security.py
@@ -1,0 +1,41 @@
+"""Regression tests for the unverified-jar / search-path fix in the Weka wrapper.
+
+``config_weka`` searched for ``weka.jar`` with the current working directory (".")
+listed first in ``_weka_search``. A ``./weka.jar`` planted in the CWD by an
+attacker would be selected over a system install and run via
+``java -cp ./weka.jar weka.classifiers.bayes.NaiveBayes ...`` with no integrity
+check -- arbitrary code execution (CWE-494, reachable via an untrusted search
+path, CWE-426). The CWD is no longer searched; ``WEKAHOME`` or an explicit
+``config_weka(classpath=...)`` must be used.
+"""
+
+import pytest
+
+import nltk.classify.weka as weka
+
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch):
+    # config_weka() calls config_java() first; stub it so the search logic runs
+    # without a JVM, and reset the cached classpath around each test.
+    monkeypatch.setattr(weka, "config_java", lambda *a, **k: None)
+    monkeypatch.setattr(weka, "_weka_classpath", None)
+    monkeypatch.delenv("WEKAHOME", raising=False)
+
+
+def test_cwd_weka_jar_is_not_picked_up(tmp_path, monkeypatch):
+    """A ./weka.jar in the CWD must not be auto-selected."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "weka.jar").write_bytes(b"")  # attacker-planted in the CWD
+
+    with pytest.raises(LookupError):
+        weka.config_weka()
+    assert weka._weka_classpath is None
+
+
+def test_explicit_classpath_still_used(tmp_path):
+    """An explicit classpath argument is still honoured."""
+    jar = tmp_path / "weka.jar"
+    jar.write_bytes(b"")
+    weka.config_weka(classpath=str(jar))
+    assert weka._weka_classpath == str(jar)

--- a/nltk/test/unit/test_weka_security.py
+++ b/nltk/test/unit/test_weka_security.py
@@ -13,6 +13,10 @@ import pytest
 
 import nltk.classify.weka as weka
 
+# Capture the real default search path at import time, before the autouse
+# fixture neutralises it, so the regression assertion below can check it.
+_DEFAULT_WEKA_SEARCH = list(weka._weka_search)
+
 
 @pytest.fixture(autouse=True)
 def _isolate(monkeypatch):
@@ -20,7 +24,16 @@ def _isolate(monkeypatch):
     # without a JVM, and reset the cached classpath around each test.
     monkeypatch.setattr(weka, "config_java", lambda *a, **k: None)
     monkeypatch.setattr(weka, "_weka_classpath", None)
+    # Neutralise the system search path so the outcome can't depend on a
+    # host-installed weka.jar (e.g. /usr/share/weka) on the test runner.
+    monkeypatch.setattr(weka, "_weka_search", [])
     monkeypatch.delenv("WEKAHOME", raising=False)
+
+
+def test_cwd_not_in_default_search_path():
+    """The CWD must not be part of the default weka.jar search path."""
+    assert "." not in _DEFAULT_WEKA_SEARCH
+    assert "" not in _DEFAULT_WEKA_SEARCH
 
 
 def test_cwd_weka_jar_is_not_picked_up(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
`nltk.classify.weka.config_weka()` searched for `weka.jar` with the **current
working directory listed first** in `_weka_search`:

```python
# nltk/classify/weka.py
_weka_search = [".", "/usr/share/weka", "/usr/local/share/weka", ...]   # "." tried first

for path in searchpath:                       # "." (CWD) before WEKAHOME / system dirs
    if os.path.exists(os.path.join(path, "weka.jar")):
        _weka_classpath = os.path.join(path, "weka.jar")                 # -> ./weka.jar
```

A `./weka.jar` in the process CWD is therefore preferred over a system-installed
Weka, with **no integrity/signature check** and **without any environment
variable or non-default argument**. NLTK then loads and runs classes from that
jar:

```python
# nltk/classify/weka.py
cmd = ["weka.classifiers.bayes.NaiveBayes", "-l", self._model, "-T", test_filename] + options
java(cmd, classpath=_weka_classpath, ...)     # java -cp ./weka.jar weka.classifiers.bayes.NaiveBayes ...
```

`config_weka()` is invoked automatically the first time a `WekaClassifier`
classifies or trains, so simply *using* a Weka classifier in a directory
containing an attacker-planted `weka.jar` executes the attacker's Java code —
**use of code without an integrity check (CWE-494)**, reachable via an untrusted
search path (CWE-426). This is the same class as the StanfordSegmenter
unverified-jar load (**CVE-2026-0848**) and the MaltParser (#3616) / ReppTokenizer
(#3618) CWD hijacks.

## Proof of concept (before this change)
Plant a malicious `./weka.jar` whose `weka.classifiers.bayes.NaiveBayes` writes a
sentinel, then use a Weka classifier from that directory:

```python
import nltk.classify.weka as weka
weka.config_weka()                 # selects ./weka.jar (".") over the system install
print(weka._weka_classpath)        # -> './weka.jar'
# WekaClassifier.classify_many()/train() then run:
#   java -cp ./weka.jar weka.classifiers.bayes.NaiveBayes ...  -> attacker code
```
Verified end-to-end (Temurin JDK 21): the CWD `./weka.jar` is selected and the
attacker's `weka.classifiers.bayes.NaiveBayes` class is executed by NLTK's own
`java` command.

## Fix
Do not search the current working directory for `weka.jar` — drop `"."` from
`_weka_search`. A trusted jar must be supplied via the `WEKAHOME` environment
variable or an explicit `config_weka(classpath=...)`:

```python
_weka_search = [
    "/usr/share/weka",
    "/usr/local/share/weka",
    "/usr/lib/weka",
    "/usr/local/lib/weka",
]
```

## Tests
`nltk/test/unit/test_weka_security.py`:
- a `./weka.jar` planted in the CWD is **not** auto-selected (`config_weka()`
  raises `LookupError`, `_weka_classpath` stays `None`);
- an explicit `config_weka(classpath=...)` is still honoured.

black `25.11.0` / isort `6.1.0` / ruff `0.15.6` clean.
