### PR TITLE
fix(security): do not run the senna binary from the CWD (CWE-829)

### DIFF
--- a/nltk/classify/senna.py
+++ b/nltk/classify/senna.py
@@ -49,22 +49,39 @@ class Senna(TaggerI):
 
     def __init__(self, senna_path, operations, encoding="utf-8"):
         self._encoding = encoding
-        self._path = path.normpath(senna_path) + sep
+
+        # Only accept an explicit *absolute* senna_path as the location of the
+        # senna executable. A relative path (e.g. ".") must NOT be resolved
+        # against the current working directory: executable() returns a path
+        # that contains a separator (e.g. "./senna-osx"), and subprocess.Popen()
+        # runs such a path directly from the CWD without consulting $PATH, so an
+        # attacker who can write a "senna-<platform>" file there would have it
+        # executed -- running code loaded from an untrusted location (CWE-829;
+        # an untrusted search path, CWE-426/CWE-427). A relative path falls
+        # through to the trusted SENNA environment variable instead.
+        if path.isabs(senna_path):
+            self._path = path.normpath(senna_path) + sep
+        else:
+            self._path = None
 
         # Verifies the existence of the executable on the self._path first
-        # senna_binary_file_1 = self.executable(self._path)
-        exe_file_1 = self.executable(self._path)
-        if not path.isfile(exe_file_1):
-            # Check for the system environment
-            if "SENNA" in environ:
-                # self._path = path.join(environ['SENNA'],'')
-                self._path = path.normpath(environ["SENNA"]) + sep
-                exe_file_2 = self.executable(self._path)
-                if not path.isfile(exe_file_2):
+        if self._path is None or not path.isfile(self.executable(self._path)):
+            # Check for the system environment; the SENNA directory must also be
+            # absolute for the same reason.
+            senna_env = environ.get("SENNA")
+            if senna_env and path.isabs(senna_env):
+                self._path = path.normpath(senna_env) + sep
+                if not path.isfile(self.executable(self._path)):
                     raise LookupError(
-                        "Senna executable expected at %s or %s but not found"
-                        % (exe_file_1, exe_file_2)
+                        "Senna executable expected at %s but not found"
+                        % self.executable(self._path)
                     )
+            elif self._path is None:
+                raise LookupError(
+                    "Senna executable not found. Pass an absolute senna_path to "
+                    "Senna(...) or set the SENNA environment variable to the "
+                    "absolute directory that contains the senna binary."
+                )
 
         self.operations = operations
 

--- a/nltk/classify/senna.py
+++ b/nltk/classify/senna.py
@@ -59,29 +59,26 @@ class Senna(TaggerI):
         # executed -- running code loaded from an untrusted location (CWE-829;
         # an untrusted search path, CWE-426/CWE-427). A relative path falls
         # through to the trusted SENNA environment variable instead.
+        self._path = None
         if path.isabs(senna_path):
             self._path = path.normpath(senna_path) + sep
-        else:
-            self._path = None
 
-        # Verifies the existence of the executable on the self._path first
+        # If the explicit (absolute) senna_path does not contain the executable,
+        # fall back to the SENNA environment variable, which must also be
+        # absolute for the same reason.
         if self._path is None or not path.isfile(self.executable(self._path)):
-            # Check for the system environment; the SENNA directory must also be
-            # absolute for the same reason.
             senna_env = environ.get("SENNA")
             if senna_env and path.isabs(senna_env):
                 self._path = path.normpath(senna_env) + sep
-                if not path.isfile(self.executable(self._path)):
-                    raise LookupError(
-                        "Senna executable expected at %s but not found"
-                        % self.executable(self._path)
-                    )
-            elif self._path is None:
-                raise LookupError(
-                    "Senna executable not found. Pass an absolute senna_path to "
-                    "Senna(...) or set the SENNA environment variable to the "
-                    "absolute directory that contains the senna binary."
-                )
+
+        # The executable must exist at this point; fail fast so construction is
+        # consistent (the path is verified here, not deferred to tag_sents()).
+        if self._path is None or not path.isfile(self.executable(self._path)):
+            raise LookupError(
+                "Senna executable not found. Pass an absolute senna_path to "
+                "Senna(...) or set the SENNA environment variable to the "
+                "absolute directory that contains the senna binary."
+            )
 
         self.operations = operations
 

--- a/nltk/test/unit/test_senna_security.py
+++ b/nltk/test/unit/test_senna_security.py
@@ -1,0 +1,83 @@
+"""Regression tests for the untrusted-search-path fix in the Senna wrapper.
+
+``Senna.__init__`` accepted a *relative* ``senna_path`` (e.g. ".") and resolved
+the executable against the current working directory. Because ``executable()``
+returns a path that contains a separator (e.g. ``./senna-osx``),
+``subprocess.Popen`` runs it directly from the CWD without consulting ``$PATH``,
+so an attacker who can write a ``senna-<platform>`` file there would have it
+executed -- running code from an untrusted location (CWE-829, an untrusted
+search path, CWE-426/CWE-427).
+
+Only an explicit *absolute* directory (or an absolute ``SENNA`` environment
+variable) is now used; a relative ``senna_path`` no longer falls back to the CWD.
+"""
+
+import os
+
+import pytest
+
+from nltk.classify.senna import Senna
+
+# Every platform-specific binary name executable() may pick.
+_SENNA_BINARIES = (
+    "senna-linux64",
+    "senna-linux32",
+    "senna-win32.exe",
+    "senna-osx",
+    "senna",
+)
+
+
+def _plant_senna_binaries(directory):
+    """Create an (executable) file for every candidate senna binary name."""
+    os.makedirs(directory, exist_ok=True)
+    for name in _SENNA_BINARIES:
+        target = os.path.join(directory, name)
+        with open(target, "wb"):
+            pass
+        os.chmod(target, 0o755)
+    return directory
+
+
+def test_cwd_senna_binary_is_not_picked_up(tmp_path, monkeypatch):
+    """A senna-<platform> planted in the CWD must not be auto-selected."""
+    _plant_senna_binaries(str(tmp_path))  # attacker-planted in the CWD
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("SENNA", raising=False)
+
+    with pytest.raises(LookupError):
+        Senna(".", ["pos"])
+
+
+def test_cwd_does_not_override_configured_senna(tmp_path, monkeypatch):
+    """A CWD directory must not shadow an absolute SENNA environment variable."""
+    cwd = tmp_path / "cwd"
+    _plant_senna_binaries(str(cwd))  # attacker-planted in the CWD
+    trusted = tmp_path / "trusted"
+    _plant_senna_binaries(str(trusted))  # the configured (trusted) location
+    monkeypatch.chdir(cwd)
+    monkeypatch.setenv("SENNA", str(trusted))
+
+    senna = Senna(".", ["pos"])
+    assert os.path.realpath(senna._path) == os.path.realpath(
+        str(trusted)
+    ), "CWD directory overrode the trusted SENNA location"
+
+
+def test_relative_senna_env_is_rejected(tmp_path, monkeypatch):
+    """A relative SENNA environment variable must not be resolved against CWD."""
+    _plant_senna_binaries(str(tmp_path))  # attacker-planted in the CWD
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("SENNA", ".")
+
+    with pytest.raises(LookupError):
+        Senna(".", ["pos"])
+
+
+def test_absolute_path_still_accepted(tmp_path, monkeypatch):
+    """An explicit absolute directory is still used as-is."""
+    abs_dir = _plant_senna_binaries(str(tmp_path / "senna"))
+    monkeypatch.delenv("SENNA", raising=False)
+
+    senna = Senna(abs_dir, ["pos"])
+    assert os.path.realpath(senna._path) == os.path.realpath(abs_dir)

--- a/nltk/test/unit/test_senna_security.py
+++ b/nltk/test/unit/test_senna_security.py
@@ -81,3 +81,13 @@ def test_absolute_path_still_accepted(tmp_path, monkeypatch):
 
     senna = Senna(abs_dir, ["pos"])
     assert os.path.realpath(senna._path) == os.path.realpath(abs_dir)
+
+
+def test_absolute_path_without_executable_raises(tmp_path, monkeypatch):
+    """An absolute senna_path with no senna binary fails fast (not deferred)."""
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    monkeypatch.delenv("SENNA", raising=False)
+
+    with pytest.raises(LookupError):
+        Senna(str(empty), ["pos"])


### PR DESCRIPTION
## Summary
`nltk.classify.senna.Senna` built the path to the external `senna` executable by
joining a caller-supplied directory with a fixed binary name and then ran it with
`subprocess.Popen`. When `senna_path` was a **relative** directory (e.g. `"."`),
the resulting program path **contained a separator** (e.g. `./senna-osx`):

```python
# nltk/classify/senna.py
self._path = path.normpath(senna_path) + sep          # "." -> "./"
...
_senna_cmd = [self.executable(self._path), ...]       # -> "./senna-osx"
p = Popen(_senna_cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
```

`subprocess.Popen` executes a program path that contains a separator **relative
to the current working directory** — it does **not** consult `$PATH`. So an
attacker who can place a file named `senna-<platform>`
(`senna-linux64` / `senna-linux32` / `senna-osx` / `senna-win32.exe`) in the
application's CWD has that file executed as a native program — **arbitrary code
execution from an untrusted location (CWE-829)**, reachable via an untrusted
search path (CWE-426/CWE-427). No environment variable, `$PATH` control, or
specific jar/class is required. `Senna` is constructed with a directory argument
by every public entry point (`SennaTagger`, `SennaChunkTagger`, `SennaNERTagger`),
so a relative tools directory reaching this code is realistic.

This is the same class as the MaltParser (#3616), ReppTokenizer (#3618) and Weka
(#3620) CWD hijacks and as CVE-2026-0848.

## Proof of concept (before this change)
With a malicious `./senna-<platform>` planted in the CWD:

```python
from nltk.classify import Senna
pipeline = Senna(".", ["pos"])        # relative senna_path -> "./" base
pipeline.tag("hello world".split())   # runs ./senna-osx  -> attacker code
```
Verified end-to-end: `Senna(".").executable()` returns `./senna-osx` and
`Popen([...])` executes the attacker binary from the CWD (the subsequent
output-parsing `IndexError` is raised *after* the binary has already run).

## Fix
Only resolve the executable against an explicit **absolute** directory. A
relative `senna_path` (including `"."`) no longer falls back to the current
working directory; it falls through to the trusted `SENNA` environment variable
(which must also be absolute):

```python
if path.isabs(senna_path):
    self._path = path.normpath(senna_path) + sep
else:
    self._path = None

if self._path is None or not path.isfile(self.executable(self._path)):
    senna_env = environ.get("SENNA")
    if senna_env and path.isabs(senna_env):
        self._path = path.normpath(senna_env) + sep
        ...
    elif self._path is None:
        raise LookupError(...)
```

An absolute `senna_path` (the documented usage, e.g.
`Senna('/usr/share/senna-v3.0', ...)`) is unchanged.

## Tests
`nltk/test/unit/test_senna_security.py`:
- a `senna-<platform>` planted in the CWD is **not** auto-selected for a relative
  `senna_path` (`LookupError`);
- a CWD directory does **not** override an absolute `SENNA` environment variable;
- a relative `SENNA` environment variable is rejected;
- an explicit absolute directory is still accepted.

black `25.11.0` / isort `6.1.0` / ruff `0.15.6` clean.
