### PR TITLE
Route _download_package() writes through pathsec.open

### DIFF
--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -176,7 +176,9 @@ from xml.etree import ElementTree
 from defusedxml.ElementTree import parse as safe_parse
 
 import nltk
-from nltk.pathsec import ZipFile, open as pathsec_open, urlopen, validate_path
+from nltk.pathsec import ZipFile
+from nltk.pathsec import open as pathsec_open
+from nltk.pathsec import urlopen, validate_path
 
 # urllib2 = nltk.internals.import_from_stdlib('urllib2')
 

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -176,7 +176,7 @@ from xml.etree import ElementTree
 from defusedxml.ElementTree import parse as safe_parse
 
 import nltk
-from nltk.pathsec import ZipFile, open, urlopen, validate_path
+from nltk.pathsec import ZipFile, open as pathsec_open, urlopen, validate_path
 
 # urllib2 = nltk.internals.import_from_stdlib('urllib2')
 
@@ -816,7 +816,7 @@ class Downloader:
 
                 try:
                     infile = urlopen(info.url)
-                    with open(
+                    with pathsec_open(
                         tmp_filepath,
                         "wb",
                         context="Downloader._download_package",

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -176,7 +176,7 @@ from xml.etree import ElementTree
 from defusedxml.ElementTree import parse as safe_parse
 
 import nltk
-from nltk.pathsec import ZipFile, urlopen
+from nltk.pathsec import ZipFile, open, urlopen, validate_path
 
 # urllib2 = nltk.internals.import_from_stdlib('urllib2')
 
@@ -816,7 +816,12 @@ class Downloader:
 
                 try:
                     infile = urlopen(info.url)
-                    with open(tmp_filepath, "wb") as outfile:
+                    with open(
+                        tmp_filepath,
+                        "wb",
+                        context="Downloader._download_package",
+                        required_root=download_dir,
+                    ) as outfile:
                         num_blocks = max(1, info.size / (1024 * 16))
                         for block in itertools.count():
                             s = infile.read(1024 * 16)
@@ -829,6 +834,11 @@ class Downloader:
                                     min(80, 5 + 75 * (block / num_blocks))
                                 )
                     infile.close()
+                    validate_path(
+                        filepath,
+                        context="Downloader._download_package",
+                        required_root=download_dir,
+                    )
                     os.replace(tmp_filepath, filepath)
                     self._status_cache.pop(info.id, None)
                 except OSError as e:

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -450,9 +450,9 @@ def urlopen(url, *args, **kwargs):
     return opener.open(url, *args, **kwargs)
 
 
-def open(file, mode="r", **kwargs):
+def open(file, mode="r", *, context="pathsec.open", required_root=None, **kwargs):
     """Secure wrapper for builtins.open."""
-    validate_path(file, context="pathsec.open")
+    validate_path(file, context=context, required_root=required_root)
     return builtins.open(file, mode=mode, **kwargs)
 
 

--- a/nltk/test/unit/test_downloader.py
+++ b/nltk/test/unit/test_downloader.py
@@ -3,7 +3,7 @@ import shutil
 import unittest.mock
 
 from nltk import download
-from nltk.downloader import build_index
+from nltk.downloader import Downloader, build_index
 
 
 def test_downloader_using_existing_parent_download_dir(tmp_path):
@@ -81,3 +81,82 @@ def test_build_index(tmp_path):
     sha256_checksum = package_element.get("sha256_checksum")
     assert isinstance(sha256_checksum, str)
     assert len(sha256_checksum) > 5
+
+
+def test_download_package_uses_scoped_pathsec_open(tmp_path):
+    """
+    Regression test for PR #3622.
+
+    Verify that _download_package() routes the package write through
+    pathsec.open with the downloader's download_dir as required_root, and that
+    the final destination is still validated before os.replace().
+    """
+    download_dir = str(tmp_path.joinpath("download"))
+    os.makedirs(download_dir, exist_ok=True)
+
+    downloader = Downloader(download_dir=download_dir)
+
+    class DummyInfo:
+        id = "dummy"
+        url = "https://example.com/dummy.txt"
+        size = 1
+        filename = os.path.join("corpora", "dummy.txt")
+        subdir = "corpora"
+        unzip = False
+
+    info = DummyInfo()
+    tmp_file = os.path.join(download_dir, info.filename) + ".tmp"
+    final_file = os.path.join(download_dir, info.filename)
+
+    with unittest.mock.patch(
+        "nltk.downloader.urlopen"
+    ) as urlopen_mock, unittest.mock.patch(
+        "nltk.downloader.pathsec_open"
+    ) as pathsec_open_mock, unittest.mock.patch(
+        "nltk.downloader.validate_path"
+    ) as validate_path_mock, unittest.mock.patch(
+        "nltk.downloader.os.replace"
+    ) as replace_mock, unittest.mock.patch(
+        "nltk.downloader.os.makedirs"
+    ), unittest.mock.patch(
+        "nltk.downloader.os.open", return_value=3
+    ), unittest.mock.patch(
+        "nltk.downloader.os.close"
+    ), unittest.mock.patch(
+        "nltk.downloader.os.path.exists", return_value=False
+    ), unittest.mock.patch(
+        "nltk.downloader.time.time", return_value=0
+    ), unittest.mock.patch(
+        "nltk.downloader.itertools.count", return_value=iter([0])
+    ), unittest.mock.patch.object(
+        Downloader, "status", return_value=Downloader.NOT_INSTALLED
+    ):
+
+        infile = unittest.mock.Mock()
+        infile.read.side_effect = [b"x", b""]
+        infile.close.return_value = None
+        urlopen_mock.return_value = infile
+
+        outfile = unittest.mock.Mock()
+        pathsec_open_mock.return_value.__enter__.return_value = outfile
+        pathsec_open_mock.return_value.__exit__.return_value = False
+
+        list(downloader._download_package(info, download_dir, force=True))
+
+        pathsec_open_mock.assert_called_once_with(
+            tmp_file,
+            "wb",
+            context="Downloader._download_package",
+            required_root=download_dir,
+        )
+
+        validate_path_mock.assert_any_call(
+            final_file,
+            context="Downloader._download_package",
+            required_root=download_dir,
+        )
+
+        replace_mock.assert_called_once_with(tmp_file, final_file)
+
+        # Sanity check: the PR-specific path scoping does not change builtins.open.
+        assert open is __builtins__["open"]


### PR DESCRIPTION
## Summary

This PR remedies regressions introduced by the rushed downloader hotfixes in #3594 and #3595, which were merged to address a Windows-only CI failure after #3593. Those patches moved _download_package() toward ad-hoc local path checks, but left the package write path using builtin open(), drifting away from the central sink-level protections introduced by #3522. This change restores that model by routing downloader writes through pathsec.open() with a downloader-scoped root, while preserving the Windows-compatible containment approach.

This PR complements the downloader containment fixes by making
`Downloader._download_package()` stop using builtin `open()` for package writes.

Instead, the temporary download target is opened through `nltk.pathsec.open()`,
and the final publish target is validated before `os.replace()`.

## Change

- extend `nltk.pathsec.open()` to accept:
  - `context`
  - `required_root`
- route `_download_package()` temporary file writes through:
  - `pathsec.open(tmp_filepath, "wb", context="Downloader._download_package", required_root=download_dir)`
- validate the final `filepath` with the same scoped root before `os.replace(...)`

## Why

The downloader already uses `pathsec.urlopen` and `pathsec.ZipFile`, but the
raw package write path still used builtin `open()`. That means this sink was
not participating in the central I/O security model introduced by `nltk.pathsec`.


This PR restores sink-level enforcement while keeping the downloader's
existing local containment logic in place.

## Relationship to #3619

This PR is intended to complement #3619, not replace it.

- #3619 restores symlink-aware containment logic for downloader targets.
- This PR restores central `pathsec` enforcement at the package write sink.

Together, they reduce the risk of further drift between downloader-specific
logic and the centralized path security model.