### PR TITLE
fix(security): do not run the candc/boxer binary from the CWD (CWE-426)

### DIFF
--- a/nltk/sem/boxer.py
+++ b/nltk/sem/boxer.py
@@ -36,7 +36,7 @@ import tempfile
 from functools import reduce
 from optparse import OptionParser
 
-from nltk.internals import find_binary
+from nltk.internals import find_binary_iter
 from nltk.sem.drt import (
     DRS,
     DrtApplicationExpression,
@@ -237,13 +237,32 @@ class Boxer:
         return stdout
 
     def _find_binary(self, name, bin_dir, verbose=False):
-        return find_binary(
+        # find_binary() also matches a binary relative to the current working
+        # directory: a relative bin_dir yields e.g. "./candc", and even the
+        # default bin_dir=None matches a "<name>/<name>" directory in the CWD
+        # (find_file_iter joins the name with itself). Such a result contains a
+        # path separator, so _call()'s subprocess.Popen() would execute it
+        # directly from the CWD without consulting $PATH -- an attacker who can
+        # plant a "candc"/"boxer" file there would get code execution (an
+        # untrusted search path, CWE-426/CWE-427). Skip any CWD-relative
+        # candidate and use the first absolute one (an absolute bin_dir, the
+        # CANDC environment variable, or a $PATH lookup), none of which resolve
+        # against the CWD.
+        for binary in find_binary_iter(
             name,
             path_to_bin=bin_dir,
             env_vars=["CANDC"],
             url="http://svn.ask.it.usyd.edu.au/trac/candc/",
             binary_names=[name, name + ".exe"],
             verbose=verbose,
+        ):
+            if os.path.isabs(binary):
+                return binary
+        raise LookupError(
+            "No absolute %r binary found. Pass an absolute bin_dir to Boxer(...) "
+            "or set the CANDC environment variable to an absolute directory that "
+            "contains the candc/boxer binaries (a binary found relative to the "
+            "current working directory is refused)." % name
         )
 
     def _call(self, input_str, binary, args=[], verbose=False):

--- a/nltk/test/unit/test_boxer_security.py
+++ b/nltk/test/unit/test_boxer_security.py
@@ -1,0 +1,91 @@
+"""Regression tests for the untrusted-search-path fix in the Boxer wrapper.
+
+``Boxer`` resolves its external ``candc`` / ``boxer`` executables with
+``nltk.internals.find_binary`` and then runs them with ``subprocess.Popen``.
+``find_binary`` also matches a binary relative to the current working directory:
+
+* a relative ``bin_dir`` (e.g. ".") yields ``./candc`` (a path with a separator),
+  and
+* even the default ``bin_dir=None`` matches a ``candc/candc`` directory in the
+  CWD (``find_file_iter`` joins the name with itself).
+
+Either way the resolved path contains a separator, so ``Popen`` runs it directly
+from the CWD without consulting ``$PATH`` -- an attacker who can plant a
+``candc``/``boxer`` file there gets code execution (CWE-426/CWE-427).
+
+The wrapper now requires the resolved binary to be an *absolute* path, so a
+CWD-relative result is refused. An absolute ``bin_dir`` (or ``CANDC`` env var, or
+a ``$PATH`` lookup) keeps working.
+"""
+
+import os
+
+import pytest
+
+from nltk.sem.boxer import Boxer
+
+_BIN_NAMES = ("candc", "boxer")
+
+
+def _plant_binaries(directory):
+    """Create an (executable) file for candc and boxer in *directory*."""
+    os.makedirs(directory, exist_ok=True)
+    for name in _BIN_NAMES:
+        target = os.path.join(directory, name)
+        with open(target, "wb"):
+            pass
+        os.chmod(target, 0o755)
+    return directory
+
+
+def test_relative_bin_dir_is_rejected(tmp_path, monkeypatch):
+    """A relative bin_dir resolving the binary in the CWD must be refused."""
+    _plant_binaries(str(tmp_path))  # ./candc, ./boxer attacker-planted
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("CANDC", raising=False)
+
+    with pytest.raises(LookupError):
+        Boxer(bin_dir=".")
+
+
+def test_cwd_nested_dir_with_default_bin_dir_is_rejected(tmp_path, monkeypatch):
+    """The default bin_dir=None must not pick up a ./<name>/<name> in the CWD."""
+    # find_binary("candc", path_to_bin=None) joins the name with itself, so a
+    # CWD directory "<name>" containing an executable "<name>" would be run.
+    # Plant both so an unfixed wrapper would resolve *both* binaries and succeed.
+    for name in _BIN_NAMES:
+        nested = os.path.join(str(tmp_path), name, name)
+        os.makedirs(os.path.dirname(nested), exist_ok=True)
+        with open(nested, "wb"):
+            pass
+        os.chmod(nested, 0o755)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("CANDC", raising=False)
+
+    with pytest.raises(LookupError):
+        Boxer()
+
+
+def test_cwd_does_not_override_configured_candc(tmp_path, monkeypatch):
+    """A CWD binary must not shadow an absolute CANDC environment variable."""
+    _plant_binaries(str(tmp_path / "cwd"))  # attacker-planted in the CWD
+    trusted = _plant_binaries(str(tmp_path / "trusted"))  # configured location
+    monkeypatch.chdir(tmp_path / "cwd")
+    monkeypatch.setenv("CANDC", trusted)
+
+    boxer = Boxer(bin_dir=".")
+    assert os.path.realpath(boxer._candc_bin) == os.path.realpath(
+        os.path.join(trusted, "candc")
+    ), "CWD binary overrode the trusted CANDC location"
+
+
+def test_absolute_bin_dir_is_accepted(tmp_path, monkeypatch):
+    """An explicit absolute bin_dir is still used as-is."""
+    abs_dir = _plant_binaries(str(tmp_path / "candc-1.00"))
+    monkeypatch.delenv("CANDC", raising=False)
+
+    boxer = Boxer(bin_dir=abs_dir)
+    assert os.path.isabs(boxer._candc_bin)
+    assert os.path.realpath(boxer._candc_bin) == os.path.realpath(
+        os.path.join(abs_dir, "candc")
+    )


### PR DESCRIPTION
## Summary
`nltk.sem.boxer.Boxer` resolves its external `candc` / `boxer` executables with
`nltk.internals.find_binary` and then runs them with `subprocess.Popen`:

```python
# nltk/sem/boxer.py
self._candc_bin = self._find_binary("candc", bin_dir, ...)   # find_binary(path_to_bin=bin_dir)
...
cmd = [binary] + args
p = subprocess.Popen(cmd, ...)                                # boxer.py:267 / 271
```

`find_binary` also matches a binary **relative to the current working
directory**, producing a path that **contains a separator**:

- a **relative** `bin_dir` (e.g. `"."`) yields `./candc`; and
- even the **default `bin_dir=None`** matches a `candc/candc` directory in the
  CWD — `find_file_iter` joins the binary name with itself
  (`os.path.join("candc", "candc")`).

Because the resulting program path contains a separator, `subprocess.Popen`
executes it **directly from the CWD** (it does not consult `$PATH`), and the CWD
match is tried **before** the `CANDC` environment variable. An attacker who can
write a `candc`/`boxer` file into the application's CWD therefore gets their
binary executed — an **untrusted search path** (CWE-426 / CWE-427) leading to
arbitrary code execution. Every public entry point (`Boxer`, and the
`boxer`/`interpret` API) reaches this resolver.

This is the same class as the MaltParser (#3616), ReppTokenizer (#3618), Weka
(#3620) and Senna (#3621) CWD hijacks and as CVE-2026-0848.

## Proof of concept (before this change)
With a malicious `./candc` (and `./boxer`) planted in the CWD:

```python
from nltk.sem.boxer import Boxer
Boxer(bin_dir=".").interpret("a man walks")   # runs ./candc  -> attacker code
```
or, with the default configuration, a `./candc/candc` directory:

```python
Boxer().interpret("a man walks")              # find_binary -> "candc/candc" -> CWD exec
```
Verified end-to-end: `find_binary("candc", path_to_bin="candcdir")` returns
`candcdir/candc`, `path_to_bin="."` returns `./candc`, and `path_to_bin=None`
with a planted `./candc/candc` returns `candc/candc`; `Popen([...])` executes the
attacker binary from the CWD.

## Fix
Resolve via `find_binary_iter` and use the first **absolute** candidate, skipping
any CWD-relative match. A relative result can only come from a CWD lookup, so
this rules out CWD execution while still honouring an absolute `bin_dir`, the
`CANDC` environment variable, and a `$PATH` lookup:

```python
for binary in find_binary_iter(name, path_to_bin=bin_dir, env_vars=["CANDC"], ...):
    if os.path.isabs(binary):
        return binary
raise LookupError("No absolute %r binary found. Pass an absolute bin_dir ... "
                  "or set the CANDC environment variable ..." % name)
```

A CWD plant is now skipped in favour of the trusted `CANDC`/`$PATH` location (or
refused if none exists); absolute `bin_dir` usage is unchanged.

## Tests
`nltk/test/unit/test_boxer_security.py`:
- a relative `bin_dir` resolving the binary in the CWD is refused;
- the default `bin_dir=None` does not pick up a `./<name>/<name>` in the CWD;
- a CWD binary does not override an absolute `CANDC` environment variable;
- an explicit absolute `bin_dir` is still used as-is.

black `25.11.0` / isort `6.1.0` / ruff `0.15.6` clean.
