### PR TITLE
fix: enforce package ownership during ZIP extraction

### DIFF
--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -829,6 +829,34 @@ class Downloader:
                                     min(80, 5 + 75 * (block / num_blocks))
                                 )
                     infile.close()
+
+                    # --- CVE-2026-12261 fix (integrity before commit) ---
+                    # Validate size and sha256 on the temp file BEFORE
+                    # replacing the destination.  This closes the window
+                    # where a tampered archive could be extracted while the
+                    # integrity check was still deferred to status logic.
+                    tmp_size = os.path.getsize(tmp_filepath)
+                    if tmp_size != int(info.size):
+                        _safe_remove(tmp_filepath)
+                        yield ErrorMessage(
+                            info,
+                            f"Integrity check failed for {info.id!r}: "
+                            f"size mismatch (got {tmp_size}, expected {info.size})",
+                        )
+                        return
+
+                    sha256_checksum = getattr(info, "sha256_checksum", None)
+                    if sha256_checksum:
+                        if sha256_hexdigest(tmp_filepath) != sha256_checksum:
+                            _safe_remove(tmp_filepath)
+                            yield ErrorMessage(
+                                info,
+                                f"Integrity check failed for {info.id!r}: "
+                                f"sha256 mismatch",
+                            )
+                            return
+                    # ---------------------------------------------------
+
                     os.replace(tmp_filepath, filepath)
                     self._status_cache.pop(info.id, None)
                 except OSError as e:
@@ -848,7 +876,14 @@ class Downloader:
                 zipdir = os.path.join(download_dir, info.subdir)
                 if info.unzip or os.path.exists(os.path.join(zipdir, info.id)):
                     yield StartUnzipMessage(info)
-                    for msg in _unzip_iter(filepath, zipdir, verbose=False):
+                    # --- CVE-2026-12261 fix (member ownership enforcement) ---
+                    # Pass info.id so _unzip_iter can reject any archive member
+                    # whose top-level path component is not the owning package.
+                    # zipdir itself stays as download_dir/subdir/ to preserve
+                    # the layout expected by _pkg_status and NLTK data loaders.
+                    for msg in _unzip_iter(
+                        filepath, zipdir, verbose=False, expected_root=info.id
+                    ):
                         _touch_lock()
                         msg.package = info
                         yield msg
@@ -2469,6 +2504,11 @@ def _validate_member(member, root_abs):
     ----------
     member : str
         The archive entry name (forward-slash separated, as stored in the ZIP).
+    .. note::
+        This function enforces Zip-Slip and symlink-escape containment only.
+        Cross-package ownership (CVE-2026-12261) is enforced separately by
+        the ``expected_root`` parameter of ``_unzip_iter``.
+
     root_abs : str
         Absolute path of the extraction root (used to build candidate paths
         and derive comparison prefixes via ``os.path.normcase``).
@@ -2489,7 +2529,7 @@ def _validate_member(member, root_abs):
     return None
 
 
-def _unzip_iter(filename, root, verbose=True):
+def _unzip_iter(filename, root, verbose=True, expected_root=None):
     """
     Secure ZIP extraction using validate-then-extract.
 
@@ -2536,6 +2576,24 @@ def _unzip_iter(filename, root, verbose=True):
         # Phase 1 -- validate every member before touching the filesystem.
         has_violations = False
         for member in members:
+            # --- CVE-2026-12261 fix (cross-package ownership check) ---
+            # Reject any member whose top-level path component differs from
+            # the owning package id.  This blocks cross-package overwrite
+            # without path traversal: a member like
+            #   averaged_perceptron_tagger_eng/file.json
+            # inside a package with id='evil-corpus' is rejected because
+            # 'averaged_perceptron_tagger_eng' != 'evil-corpus'.
+            if expected_root is not None:
+                top = member.replace("\\", "/").lstrip("/").split("/")[0]
+                if top != expected_root:
+                    yield ErrorMessage(
+                        filename,
+                        f"Cross-package overwrite blocked: member {member!r} "
+                        f"is outside the owning package directory {expected_root!r}",
+                    )
+                    has_violations = True
+                    continue
+            # -----------------------------------------------------------
             error = _validate_member(member, root_abs)
             if error is not None:
                 yield ErrorMessage(filename, error)
@@ -2553,6 +2611,15 @@ def _unzip_iter(filename, root, verbose=True):
             return
 
         for member in members:
+            if expected_root is not None:
+                top = member.replace("\\", "/").lstrip("/").split("/")[0]
+                if top != expected_root:
+                    yield ErrorMessage(
+                        filename,
+                        f"Cross-package overwrite blocked: member {member!r} "
+                        f"is outside the owning package directory {expected_root!r}",
+                    )
+                    return
             error = _validate_member(member, root_abs)
             if error is not None:
                 yield ErrorMessage(filename, f"{error} (during extraction)")
@@ -2678,8 +2745,7 @@ def _check_package(pkg_xml, zipfilename, zf):
     # Zip file must expand to a subdir whose name matches uid.
     if sum((name != uid and not name.startswith(uid + "/")) for name in zf.namelist()):
         raise ValueError(
-            "Zipfile %s.zip does not expand to a single "
-            "subdirectory %s/" % (uid, uid)
+            "Zipfile %s.zip does not expand to a single subdirectory %s/" % (uid, uid)
         )
 
 

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -2745,7 +2745,9 @@ def _check_package(pkg_xml, zipfilename, zf):
     # Zip file must expand to a subdir whose name matches uid.
     if sum((name != uid and not name.startswith(uid + "/")) for name in zf.namelist()):
         raise ValueError(
-            "Zipfile %s.zip does not expand to a single subdirectory %s/" % (uid, uid)
+            "Zipfile {}.zip does not expand to a single subdirectory {}/".format(
+                uid, uid
+            )
         )
 
 

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -846,13 +846,23 @@ class Downloader:
                         return
 
                     sha256_checksum = getattr(info, "sha256_checksum", None)
+
                     if sha256_checksum:
                         if sha256_hexdigest(tmp_filepath) != sha256_checksum:
                             _safe_remove(tmp_filepath)
                             yield ErrorMessage(
                                 info,
-                                f"Integrity check failed for {info.id!r}: "
-                                f"sha256 mismatch",
+                                f"Integrity check failed for {info.id!r}: sha256 mismatch",
+                            )
+                            return
+                    else:
+                        md5_checksum = getattr(info, "checksum", None)
+
+                        if md5_checksum and md5_hexdigest(tmp_filepath) != md5_checksum:
+                            _safe_remove(tmp_filepath)
+                            yield ErrorMessage(
+                                info,
+                                f"Integrity check failed for {info.id!r}: md5 mismatch",
                             )
                             return
                     # ---------------------------------------------------

--- a/nltk/test/unit/test_downloader_atomic.py
+++ b/nltk/test/unit/test_downloader_atomic.py
@@ -226,3 +226,120 @@ class TestDownloaderAtomic(unittest.TestCase):
 
         self.assertFalse(ok)
         self.assertFalse(os.path.exists(extracted_file))
+
+    def _make_zip_with_members(self, members):
+        """Build a ZIP in srv_dir with given {member_path: content} dict."""
+        srv_dir = tempfile.mkdtemp()
+        buf = __import__("io").BytesIO()
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_STORED) as zf:
+            for path, content in members.items():
+                zf.writestr(path, content)
+        zb = buf.getvalue()
+        zip_path = os.path.join(srv_dir, "evil.zip")
+        open(zip_path, "wb").write(zb)
+        return srv_dir, zip_path, zb
+
+    def _make_pkg(self, zip_path, zb, pkg_id, subdir, members):
+        import hashlib
+        from pathlib import Path
+
+        unzipped = sum(len(v.encode()) for v in members.values())
+        return Package(
+            id=pkg_id,
+            url=Path(zip_path).resolve().as_uri(),
+            subdir=subdir,
+            size=len(zb),
+            unzipped_size=unzipped,
+            checksum=hashlib.md5(zb).hexdigest(),
+            sha256_checksum=hashlib.sha256(zb).hexdigest(),
+            unzip=True,
+        )
+
+    def test_cross_package_overwrite_blocked(self):
+        """Direct cross-package overwrite (CVE-2026-12261 core case).
+
+        evil-corpus declares subdir=corpora but its ZIP contains
+        abc/dummy.txt — another package's file.  The install must
+        be rejected and the victim file must remain unchanged.
+        """
+        # Write a sentinel victim file
+        victim_dir = os.path.join(self.test_dir, "corpora", "abc")
+        os.makedirs(victim_dir, exist_ok=True)
+        victim_file = os.path.join(victim_dir, "dummy.txt")
+        open(victim_file, "wb").write(b"original")
+
+        members = {"abc/dummy.txt": "poisoned"}
+        srv_dir, zip_path, zb = self._make_zip_with_members(members)
+        try:
+            evil_pkg = self._make_pkg(zip_path, zb, "evil-corpus", "corpora", members)
+            dl = Downloader(download_dir=self.test_dir)
+            ok = dl.download(evil_pkg, quiet=True, force=True, raise_on_error=False)
+
+            with open(victim_file, "rb") as f:
+                content = f.read()
+
+            self.assertFalse(ok, "Download should have been rejected")
+            self.assertEqual(
+                content, b"original", "Victim file must not be overwritten"
+            )
+        finally:
+            __import__("shutil").rmtree(srv_dir, ignore_errors=True)
+
+    def test_traversal_member_cannot_escape_package_ownership(self):
+        """Traversal-like members must not overwrite sibling packages."""
+
+        victim_dir = os.path.join(self.test_dir, "corpora", "abc")
+        os.makedirs(victim_dir, exist_ok=True)
+
+        victim_file = os.path.join(victim_dir, "dummy.txt")
+        with open(victim_file, "wb") as f:
+            f.write(b"original")
+
+        members = {
+            "evil-corpus/../abc/dummy.txt": "poisoned",
+        }
+
+        srv_dir, zip_path, zb = self._make_zip_with_members(members)
+
+        try:
+            evil_pkg = self._make_pkg(
+                zip_path,
+                zb,
+                "evil-corpus",
+                "corpora",
+                members,
+            )
+
+            dl = Downloader(download_dir=self.test_dir)
+
+            ok = dl.download(
+                evil_pkg,
+                quiet=True,
+                force=True,
+                raise_on_error=False,
+            )
+
+            self.assertTrue(
+                ok,
+                "Traversal-style member should not cause installation failure",
+            )
+
+            with open(victim_file, "rb") as f:
+                self.assertEqual(
+                    f.read(),
+                    b"original",
+                    "Traversal member must not overwrite victim package",
+                )
+
+            extracted_file = os.path.join(
+                self.test_dir,
+                "corpora",
+                "evil-corpus",
+                "abc",
+                "dummy.txt",
+            )
+
+            self.assertTrue(os.path.exists(extracted_file))
+
+        finally:
+            shutil.rmtree(srv_dir, ignore_errors=True)

--- a/nltk/test/unit/test_downloader_atomic.py
+++ b/nltk/test/unit/test_downloader_atomic.py
@@ -194,3 +194,35 @@ class TestDownloaderAtomic(unittest.TestCase):
             self.assertEqual(
                 dl.status(self.pkg, self.test_dir), dl.INSTALLED, msg=f"debug={debug}"
             )
+
+    def test_md5_mismatch_rejected_before_install(self):
+        """Legacy MD5 metadata should be enforced before install/extraction."""
+
+        bad_pkg = Package(
+            id="abc",
+            url=Path(self.source_zip_path).resolve().as_uri(),
+            subdir="corpora",
+            size=self.pkg.size,
+            unzipped_size=self.pkg.unzipped_size,
+            checksum="deadbeefdeadbeefdeadbeefdeadbeef",
+            unzip=True,
+        )
+
+        dl = Downloader(download_dir=self.test_dir)
+
+        ok = dl.download(
+            bad_pkg,
+            quiet=True,
+            force=True,
+            raise_on_error=False,
+        )
+
+        extracted_file = os.path.join(
+            self.test_dir,
+            "corpora",
+            "abc",
+            "dummy.txt",
+        )
+
+        self.assertFalse(ok)
+        self.assertFalse(os.path.exists(extracted_file))


### PR DESCRIPTION
## Summary

Fixes : Cross-Package Resource and Model Poisoning in `nltk.downloader`.

Reported via huntr: https://huntr.com/bounties/8b8c381e-08a8-4e4f-bb46-a320c96a364f

---

## Root Cause

Two flaws combined to allow cross-package model and corpus poisoning without path traversal:

**1. No package ownership enforcement (CWE-284)**
`_unzip_iter` extracted archives into the shared `download_dir/subdir/` namespace. A package declaring `subdir="taggers"` could include members like `averaged_perceptron_tagger_eng/file.json` and overwrite a completely different package's files with no traversal sequences required.

**2. Deferred integrity validation (CWE-494)**
Size and `sha256_checksum` were checked by `_pkg_status()` after `os.replace()` and extraction had already made files live on disk.

---

## Why filesystem layout is preserved

`_pkg_status()` derives the unzip directory as `filepath[:-4]` (e.g. `taggers/averaged_perceptron_tagger_eng`). NLTK data loaders also expect files at `taggers/averaged_perceptron_tagger_eng/file.json`. Changing `zipdir` to a package-isolated root would break both. The fix enforces ownership at the member level instead, leaving the layout unchanged.

---

## Fix

**Member ownership enforcement** (`_unzip_iter`)
Added `expected_root` parameter. Both Phase 1 (pre-extraction) and Phase 2 (per-member re-validation) now reject any member whose top-level path component does not match the owning package id. An `evil-corpus` package cannot write `averaged_perceptron_tagger_eng/...` because `"averaged_perceptron_tagger_eng" != "evil-corpus"`.

**Pre-extraction integrity** (`_download_package`)
Size and `sha256_checksum` are verified against the `.tmp` file before `os.replace()`. On mismatch the temp file is removed and installation is aborted.

---

## Test results

Existing downloader tests: 5/5 passed (`test_downloader.py`, `test_downloader_atomic.py`)

| Security / Regression Test | Result |
|---|---|
| Cross-package overwrite blocked | ✓ PASS |
| Integrity rejected before extraction | ✓ PASS |
| Legitimate install + pos_tag works | ✓ PASS |
| Package status correct after install | ✓ PASS |
| Victim status unchanged after blocked attack | ✓ PASS |

---

**Affected:** nltk <= 3.9.4
**CWE:** CWE-284 (Improper Access Control), CWE-494 (Download Without Integrity Check)