### PR TITLE
fix(security): route read_sents through pathsec sentinel

### DIFF
--- a/nltk/sem/util.py
+++ b/nltk/sem/util.py
@@ -13,8 +13,6 @@ syntax tree, followed by evaluation of the semantic representation in
 a first-order model.
 """
 
-import codecs
-
 from nltk.pathsec import open as _secure_open
 from nltk.sem import evaluate
 
@@ -147,7 +145,11 @@ def read_sents(filename, encoding="utf8"):
     # Reroute to secure sentinel for path validation
     with _secure_open(filename, "r", encoding=encoding) as fp:
         sents = [l.rstrip() for l in fp]
-    # ... existing list comprehensions ...
+
+    # Filter out blank lines and comments
+    sents = [l for l in sents if len(l) > 0]
+    sents = [l for l in sents if not l[0] == "#"]
+
     return sents
 
 

--- a/nltk/sem/util.py
+++ b/nltk/sem/util.py
@@ -15,6 +15,7 @@ a first-order model.
 
 import codecs
 
+from nltk.pathsec import open as _secure_open
 from nltk.sem import evaluate
 
 ##############################################################
@@ -143,12 +144,10 @@ def demo_model0():
 
 
 def read_sents(filename, encoding="utf8"):
-    with codecs.open(filename, "r", encoding) as fp:
+    # Reroute to secure sentinel for path validation
+    with _secure_open(filename, "r", encoding=encoding) as fp:
         sents = [l.rstrip() for l in fp]
-
-    # get rid of blank lines
-    sents = [l for l in sents if len(l) > 0]
-    sents = [l for l in sents if not l[0] == "#"]
+    # ... existing list comprehensions ...
     return sents
 
 

--- a/nltk/test/unit/test_pathsec.py
+++ b/nltk/test/unit/test_pathsec.py
@@ -13,6 +13,7 @@ import nltk
 import nltk.downloader  # We will inspect this module directly
 from nltk import pathsec
 from nltk.downloader import Downloader
+from nltk.sem.util import read_sents
 
 
 @pytest.fixture(autouse=True)
@@ -418,3 +419,11 @@ def test_streambackedcorpusview_string_fileid_uses_pathsec(tmp_path, monkeypatch
 
     with pytest.raises((ValueError, PermissionError)):
         view._open()
+
+
+def test_read_sents_enforces_pathsec():
+    # Enable strict sandbox
+    pathsec.ENFORCE = True
+    # Attempt to access a file outside the data root
+    with pytest.raises(PermissionError):
+        read_sents("/etc/passwd")

--- a/nltk/test/unit/test_pathsec.py
+++ b/nltk/test/unit/test_pathsec.py
@@ -422,8 +422,16 @@ def test_streambackedcorpusview_string_fileid_uses_pathsec(tmp_path, monkeypatch
 
 
 def test_read_sents_enforces_pathsec():
-    # Enable strict sandbox
+    # 1. Enable strict sandbox
     pathsec.ENFORCE = True
-    # Attempt to access a file outside the data root
-    with pytest.raises(PermissionError):
-        read_sents("/etc/passwd")
+
+    # 2. Construct an absolute path that is structurally impossible to be a valid NLTK data root
+    # Using a root-level path like '/nonexistent_nltk_root/file.txt' ensures it
+    # cannot be in the allowed_roots list, avoiding the need for mocks.
+    forbidden_path = os.path.join(os.sep, "nonexistent_nltk_root_XYZ_123", "secret.txt")
+
+    # 3. Verify that attempting to read this file triggers a PermissionError
+    # We catch the exception to verify it's the right type.
+    # If the function succeeds (no exception), the test fails.
+    with pytest.raises(PermissionError, match="Security Violation"):
+        read_sents(forbidden_path)


### PR DESCRIPTION
This PR hardens `nltk.sem.util.read_sents()` against arbitrary local file read vulnerabilities by routing its file access through `nltk.pathsec`. Currently, this utility function uses `codecs.open()` to process caller-supplied filenames directly. Because it bypasses NLTK’s centralized security sentinel, it effectively neutralizes the `ENFORCE = True` security policy, allowing access to files outside of designated data roots when the function is used in multi-tenant or web-based pipelines.

#### Details
- **Vulnerability:** Unvalidated local file read (CWE-22).
- **Root Cause:** `read_sents()` uses the built-in `codecs` library for direct I/O. It fails to utilize the `nltk.pathsec` security sentinel, which is the documented, intended boundary for preventing unauthorized file system access in NLTK.
- **Impact:** In environments where `nltk.pathsec.ENFORCE = True` is expected to provide a hard sandbox, this function provides a bypass that allows unauthorized reads of local text files. This is particularly relevant for applications that programmatically use NLTK to process semantic data from user-supplied inputs.

#### Fix
The fix replaces the direct `codecs.open()` call with the `nltk.pathsec.open` sentinel. This ensures that every file path processed by `read_sents()` is subjected to the same containment checks, symlink resolution, and sandbox enforcement as other NLTK corpus readers.

#### Testing
- **New Regression Test:** Added `test_read_sents_enforces_pathsec` in `nltk/test/unit/test_pathsec.py`. 
- **Validation:** The test forces `nltk.pathsec.ENFORCE = True` and confirms that calling `read_sents()` with an out-of-root path (e.g., `/etc/passwd`) now correctly raises a `PermissionError` instead of succeeding.