### PR TITLE
Prevent Arbitrary File Write via XML Attribute Injection in nltk.downloader

### DIFF
--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -264,10 +264,6 @@ class Package:
         """Author of this package."""
 
         ext = os.path.splitext(url.split("/")[-1])[1]
-        self.filename = os.path.join(subdir, id + ext)
-        """The filename that should be used for this package's file.  It
-           is formed by joining ``self.subdir`` with ``self.id``, and
-           using the same extension as ``url``."""
 
         self.unzip = bool(int(unzip))  # '0' or '1'
         """A flag indicating whether this corpus should be unzipped by
@@ -276,6 +272,9 @@ class Package:
         # Include any other attributes provided by the XML file.
         self.__dict__.update(kw)
         self.filename = os.path.join(subdir, id + ext)  # Neutralize kw attack
+        """The filename that should be used for this package's file.  It
+           is formed by joining ``self.subdir`` with ``self.id``, and
+           using the same extension as ``url``."""
 
     @staticmethod
     def fromxml(xml):

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -275,6 +275,7 @@ class Package:
 
         # Include any other attributes provided by the XML file.
         self.__dict__.update(kw)
+        self.filename = os.path.join(subdir, id + ext)  # Neutralize kw attack
 
     @staticmethod
     def fromxml(xml):

--- a/nltk/test/unit/test_downloader.py
+++ b/nltk/test/unit/test_downloader.py
@@ -1,9 +1,31 @@
 import os
 import shutil
+import unittest
 import unittest.mock
+import xml.etree.ElementTree as ET
 
 from nltk import download
-from nltk.downloader import build_index
+from nltk.downloader import Package, build_index
+
+
+class TestPackageFromXmlInjection(unittest.TestCase):
+    """Security tests for XML attribute injection via Package.fromxml."""
+
+    def test_fromxml_neutralises_injected_filename(self):
+        """Malicious filename attribute in XML must be ignored."""
+        mock_xml = """
+        <package id="test_pkg" name="Test Package" subdir="corpora"
+                 url="http://example.com/test_pkg.zip" size="100"
+                 unzipped_size="100" checksum="0" unzip="0"
+                 filename="../../../vulnerable_overwrite.txt" />
+        """
+        xml_element = ET.fromstring(mock_xml)
+        pkg = Package.fromxml(xml_element)
+
+        expected = os.path.join("corpora", "test_pkg.zip")
+        self.assertEqual(pkg.filename, expected)
+        self.assertNotIn("..", pkg.filename)
+        self.assertFalse(os.path.isabs(pkg.filename))
 
 
 def test_downloader_using_existing_parent_download_dir(tmp_path):

--- a/nltk/test/unit/test_downloader.py
+++ b/nltk/test/unit/test_downloader.py
@@ -6,7 +6,27 @@ import unittest.mock
 import xml.etree.ElementTree as ET
 
 from nltk import download
-from nltk.downloader import Downloader, build_index
+from nltk.downloader import Downloader, Package, build_index
+
+
+class TestPackageFromXmlInjection(unittest.TestCase):
+    """Security tests for XML attribute injection via Package.fromxml."""
+
+    def test_fromxml_neutralises_injected_filename(self):
+        """Malicious filename attribute in XML must be ignored."""
+        mock_xml = """
+        <package id="test_pkg" name="Test Package" subdir="corpora"
+                 url="http://example.com/test_pkg.zip" size="100"
+                 unzipped_size="100" checksum="0" unzip="0"
+                 filename="../../../vulnerable_overwrite.txt" />
+        """
+        xml_element = ET.fromstring(mock_xml)
+        pkg = Package.fromxml(xml_element)
+
+        expected = os.path.join("corpora", "test_pkg.zip")
+        self.assertEqual(pkg.filename, expected)
+        self.assertNotIn("..", pkg.filename)
+        self.assertFalse(os.path.isabs(pkg.filename))
 
 
 def test_downloader_using_existing_parent_download_dir(tmp_path):

--- a/nltk/test/unit/test_downloader_symlink_security.py
+++ b/nltk/test/unit/test_downloader_symlink_security.py
@@ -47,11 +47,14 @@ PAYLOAD = b"package-body-bytes\n"
 
 
 def _package(filename, **overrides):
+    # Extract extension from the intended filename to build a matching URL,
+    # ensuring Package.__init__ reconstructs the base filename correctly.
+    ext = os.path.splitext(filename)[1]
     attrib = dict(
         id="p",
         name="p",
         subdir="corpora",
-        url="http://example.invalid/p",
+        url=f"http://example.invalid/p{ext}",
         size=str(len(PAYLOAD)),
         unzipped_size="0",
         checksum="0",
@@ -89,7 +92,9 @@ def test_symlink_inside_download_dir_cannot_redirect_write(tmp_path, fake_urlope
     # Attacker pre-plants download_dir/corpora/evil -> outside.
     os.symlink(outside, download_dir / "corpora" / "evil")
 
-    pkg = _package("corpora/evil/OWNED.txt")
+    pkg = _package("corpora/p.txt")
+    # Manually re-inject the malicious path after initialization to test downloader containment
+    pkg.filename = "corpora/evil/OWNED.txt"
     msgs = _run(pkg, download_dir)
 
     assert any(isinstance(m, ErrorMessage) for m in msgs)
@@ -109,7 +114,9 @@ def test_symlink_to_parent_of_download_dir_is_blocked(tmp_path, fake_urlopen):
     # download_dir/corpora/up -> tmp_path  (an ancestor of download_dir)
     os.symlink(tmp_path, download_dir / "corpora" / "up")
 
-    pkg = _package("corpora/up/OWNED.txt")
+    pkg = _package("corpora/p.txt")
+    # Manually re-inject the malicious path after initialization
+    pkg.filename = "corpora/up/OWNED.txt"
     msgs = _run(pkg, download_dir)
 
     assert any(isinstance(m, ErrorMessage) for m in msgs)
@@ -125,7 +132,9 @@ def test_symlink_via_subdir_component_is_blocked(tmp_path, fake_urlopen):
     os.symlink(outside, download_dir / "corpora" / "link")
 
     # subdir validation only rejects `..`/absolute, not a symlink component.
-    pkg = _package(filename="corpora/link/x", subdir="corpora/link")
+    pkg = _package(filename="corpora/p.txt", subdir="corpora/link")
+    # Manually re-inject the malicious path after initialization
+    pkg.filename = "corpora/link/x"
     msgs = _run(pkg, download_dir)
 
     assert any(isinstance(m, ErrorMessage) for m in msgs)
@@ -142,6 +151,8 @@ def test_symlink_at_tmp_leaf_is_blocked(tmp_path, fake_urlopen):
     # download writes filepath + ".tmp" first -> plant a symlink there.
     os.symlink(secret, download_dir / "corpora" / "p.zip.tmp")
 
+    # This does not require manual injection since Package.__init__ correctly
+    # derives "corpora/p.zip" which the downloader uses to append ".tmp".
     pkg = _package("corpora/p.zip")
     msgs = _run(pkg, download_dir)
 


### PR DESCRIPTION
This PR addresses a path traversal vulnerability in `nltk.downloader.Package` where malicious XML metadata injected via the `kw` argument could overwrite critical object properties, specifically `self.filename`.

### Root Cause

The `Package.__init__` method uses `self.__dict__.update(kw)` to apply XML attributes to the instance. Because `Package` accepts arbitrary keyword arguments, an attacker crafting a malicious `index.xml` could inject a `filename` attribute. This injected value overrides the safely computed path used for file downloads, enabling arbitrary file write outside the intended `download_dir`.

### Proposed Fix

The order of operations in `Package.__init__` has been adjusted. By recalculating and explicitly assigning `self.filename` *after* the `self.__dict__.update(kw)` call, we ensure that any attempt to inject a malicious path via the XML metadata is immediately neutralized. The system-calculated path now takes precedence over any user-supplied metadata.

### Verification Plan

* **Regression Test:** A unit test has been added to `test/unit/test_downloader.py` that simulates an injected `filename` attribute.
* **Validation:** Confirmed the test fails without this patch (confirming the vulnerability) and passes once the `filename` assignment is moved after the dictionary update.

### Reference

* **CVE:** CVE-2026-12178
