### PR TITLE
fix(security): prevent pickle RCE in TransitionParser model loading (CWE-502)

### DIFF
--- a/nltk/parse/transitionparser.py
+++ b/nltk/parse/transitionparser.py
@@ -21,7 +21,13 @@ except ImportError:
     pass
 
 from nltk.parse import DependencyEvaluator, DependencyGraph, ParserI
-from nltk.picklesec import pickle_load
+from nltk.picklesec import allowlisted_pickle_load
+
+# Modules whose globals a saved TransitionParser model legitimately needs. The
+# model is a trained scikit-learn classifier backed by numpy/scipy arrays, so
+# allowing only these scientific-stack modules lets a genuine model load while
+# blocking arbitrary-code gadgets (os, posix, subprocess, builtins, ...).
+_MODEL_ALLOWED_MODULES = ("numpy", "scipy", "sklearn")
 
 
 class Configuration:
@@ -555,9 +561,14 @@ class TransitionParser(ParserI):
         :return: list (DependencyGraph) with the 'head' and 'rel' information
         """
         result = []
-        # First load the model
+        # First load the model. The model is a trained scikit-learn classifier,
+        # so it is loaded through an allowlisting unpickler (CWE-502): only
+        # numpy/scipy/sklearn globals may be reconstructed, and anything else --
+        # e.g. os.system -- raises UnpicklingError instead of executing. See
+        # nltk/picklesec.py and huntr report
+        # https://huntr.com/bounties/38abc191-0525-42a1-96fd-262c1c187012
         with open(modelFile, "rb") as f:
-            model = pickle_load(f)
+            model = allowlisted_pickle_load(f, allowed_modules=_MODEL_ALLOWED_MODULES)
         operation = Transition(self._algorithm)
 
         for depgraph in depgraphs:

--- a/nltk/picklesec.py
+++ b/nltk/picklesec.py
@@ -139,3 +139,20 @@ def allowlisted_pickle_load(
     return AllowlistUnpickler(
         file, allowed_globals=allowed_globals, allowed_modules=allowed_modules
     ).load()
+
+
+_PUNKT_ALLOWED_MODULES = ("nltk.tokenize.punkt", "nltk.tokenize")
+
+
+def punkt_pickle_load(file: BinaryIO) -> Any:
+    """
+    Safely load a legacy Punkt pickle file.
+
+    Old NLTK Punkt models were distributed as pickle files containing
+    ``PunktParameters``, ``PunktLanguageVars``, and related classes.
+    This helper loads them through :class:`AllowlistUnpickler` restricted to
+    the ``nltk.tokenize.punkt`` and ``nltk.tokenize`` modules, so arbitrary
+    code gadgets (``os.system``, ``subprocess``, etc.) are blocked while
+    legitimate Punkt objects reconstruct normally.
+    """
+    return allowlisted_pickle_load(file, allowed_modules=_PUNKT_ALLOWED_MODULES)

--- a/nltk/picklesec.py
+++ b/nltk/picklesec.py
@@ -141,20 +141,3 @@ def allowlisted_pickle_load(
     return AllowlistUnpickler(
         file, allowed_globals=allowed_globals, allowed_modules=allowed_modules
     ).load()
-
-
-_PUNKT_ALLOWED_MODULES = ("nltk.tokenize.punkt", "nltk.tokenize")
-
-
-def punkt_pickle_load(file: BinaryIO) -> Any:
-    """
-    Safely load a legacy Punkt pickle file.
-
-    Old NLTK Punkt models were distributed as pickle files containing
-    ``PunktParameters``, ``PunktLanguageVars``, and related classes.
-    This helper loads them through :class:`AllowlistUnpickler` restricted to
-    the ``nltk.tokenize.punkt`` and ``nltk.tokenize`` modules, so arbitrary
-    code gadgets (``os.system``, ``subprocess``, etc.) are blocked while
-    legitimate Punkt objects reconstruct normally.
-    """
-    return allowlisted_pickle_load(file, allowed_modules=_PUNKT_ALLOWED_MODULES)

--- a/nltk/picklesec.py
+++ b/nltk/picklesec.py
@@ -105,6 +105,8 @@ class AllowlistUnpickler(pickle.Unpickler):
         **kwargs: Any,
     ):
         super().__init__(file, **kwargs)
+        if isinstance(allowed_modules, str):
+            allowed_modules = (allowed_modules,)
         self._allowed_globals = set(allowed_globals)
         self._allowed_modules = tuple(allowed_modules)
 

--- a/nltk/picklesec.py
+++ b/nltk/picklesec.py
@@ -13,12 +13,17 @@ Helpers for safer and/or more explicit pickle usage in NLTK.
   Intended for loading NLTK data packages where we control the serialization.
 - WarningUnpickler: emits a security warning before unpickling (does not make
   unpickling safe).
+- AllowlistUnpickler: only reconstructs an explicit, audited allowlist of
+  globals. Use it for loading objects whose set of legitimate classes is known
+  (e.g. a trained model) so that arbitrary-code gadgets such as ``os.system``
+  can never be reconstructed from an untrusted file.
 """
 
 from __future__ import annotations
 
 import pickle
 import warnings
+from collections.abc import Iterable
 from typing import Any, BinaryIO
 
 PICKLE_WARNING = (
@@ -70,3 +75,67 @@ def pickle_load(
     if restricted:
         return RestrictedUnpickler(file).load()
     return WarningUnpickler(file, context=context).load()
+
+
+class AllowlistUnpickler(pickle.Unpickler):
+    """
+    Unpickler that only reconstructs an explicit, audited allowlist of globals.
+
+    Two complementary allowlists are supported:
+
+    - ``allowed_globals``: a set of exact ``(module, qualname)`` pairs.
+    - ``allowed_modules``: a set of module names; a global is permitted when its
+      module equals an allowed name or is a submodule of one (i.e. ``module``
+      equals ``name`` or starts with ``name + "."``).
+
+    Anything not covered by either allowlist raises ``UnpicklingError`` before
+    the global is resolved, so dangerous callables such as ``os.system`` or
+    ``builtins.eval`` can never be reconstructed from an untrusted pickle. This
+    is stricter than :func:`pickle_load` (which only warns and then executes)
+    but, unlike :class:`RestrictedUnpickler` (which blocks *all* globals), it
+    still allows the known-good classes a saved object legitimately needs.
+    """
+
+    def __init__(
+        self,
+        file: BinaryIO,
+        *,
+        allowed_globals: Iterable[tuple[str, str]] = (),
+        allowed_modules: Iterable[str] = (),
+        **kwargs: Any,
+    ):
+        super().__init__(file, **kwargs)
+        self._allowed_globals = set(allowed_globals)
+        self._allowed_modules = tuple(allowed_modules)
+
+    def _module_allowed(self, module: str) -> bool:
+        return any(
+            module == name or module.startswith(name + ".")
+            for name in self._allowed_modules
+        )
+
+    def find_class(self, module: str, name: str) -> Any:
+        if (module, name) in self._allowed_globals or self._module_allowed(module):
+            return super().find_class(module, name)
+        raise pickle.UnpicklingError(
+            f"global '{module}.{name}' is not in the pickle allowlist"
+        )
+
+
+def allowlisted_pickle_load(
+    file: BinaryIO,
+    *,
+    allowed_globals: Iterable[tuple[str, str]] = (),
+    allowed_modules: Iterable[str] = (),
+) -> Any:
+    """
+    Load a pickle while only permitting an explicit allowlist of globals.
+
+    See :class:`AllowlistUnpickler` for the meaning of ``allowed_globals`` and
+    ``allowed_modules``. Prefer this over the warn-only :func:`pickle_load` when
+    the set of legitimate classes in the file is known (e.g. a trained model),
+    because :func:`pickle_load` still executes arbitrary code.
+    """
+    return AllowlistUnpickler(
+        file, allowed_globals=allowed_globals, allowed_modules=allowed_modules
+    ).load()

--- a/nltk/test/unit/test_pickle_allowlist_security.py
+++ b/nltk/test/unit/test_pickle_allowlist_security.py
@@ -13,6 +13,7 @@ https://huntr.com/bounties/38abc191-0525-42a1-96fd-262c1c187012.
 
 import os
 import pickle
+import sys
 from io import BytesIO
 
 import pytest
@@ -114,7 +115,9 @@ def test_transitionparser_rejects_malicious_model(tmp_path):
     model_path = tmp_path / "evil.model"
     marker = tmp_path / "pwned"
     # Payload writes a marker file if (and only if) the reduce callable runs.
-    payload_cmd = f"touch {marker}"
+    payload_cmd = (
+        f'"{sys.executable}" -c "import pathlib; pathlib.Path({str(marker)!r}).touch()"'
+    )
 
     class _MarkerExploit:
         def __reduce__(self):

--- a/nltk/test/unit/test_pickle_allowlist_security.py
+++ b/nltk/test/unit/test_pickle_allowlist_security.py
@@ -1,0 +1,131 @@
+"""Regression tests for pickle RCE in model loading (CWE-502).
+
+``TransitionParser.parse(depgraphs, modelFile)`` is a public API whose
+``modelFile`` is caller-supplied. It used to be loaded with the warn-only
+``pickle_load`` (``restricted=False``), which prints a warning and then performs
+a full, unrestricted unpickle -- so a crafted model file achieved arbitrary code
+execution the instant it was loaded. The load now goes through
+``allowlisted_pickle_load``: only numpy/scipy/sklearn globals may be
+reconstructed, and anything else (e.g. ``os.system``) raises ``UnpicklingError``
+instead of executing. See huntr report
+https://huntr.com/bounties/38abc191-0525-42a1-96fd-262c1c187012.
+"""
+
+import os
+import pickle
+from io import BytesIO
+
+import pytest
+
+from nltk.picklesec import AllowlistUnpickler, allowlisted_pickle_load
+
+
+class _Exploit:
+    """A malicious "model": unpickling it would run a shell command."""
+
+    def __reduce__(self):
+        # Marker side effect stands in for arbitrary code execution.
+        return (os.system, ("echo nltk-pickle-rce >&2",))
+
+
+def test_allowlist_blocks_unlisted_global():
+    """A payload reaching for os.system must be refused, not executed."""
+    payload = pickle.dumps(_Exploit())
+    with pytest.raises(pickle.UnpicklingError):
+        allowlisted_pickle_load(
+            BytesIO(payload), allowed_modules=("numpy", "scipy", "sklearn")
+        )
+
+
+def test_allowlist_allows_exact_pair():
+    """An explicitly allowlisted (module, qualname) pair loads normally."""
+    import collections
+
+    data = pickle.dumps(collections.OrderedDict(a=1, b=2))
+    out = allowlisted_pickle_load(
+        BytesIO(data), allowed_globals={("collections", "OrderedDict")}
+    )
+    assert dict(out) == {"a": 1, "b": 2}
+
+
+def test_allowlist_allows_listed_module_but_not_siblings():
+    """A submodule of an allowed module is permitted; an unrelated one is not."""
+    numpy = pytest.importorskip("numpy")
+
+    arr = numpy.array([1.0, 2.0, 3.0])
+    out = allowlisted_pickle_load(
+        BytesIO(pickle.dumps(arr)), allowed_modules=("numpy",)
+    )
+    assert list(out) == [1.0, 2.0, 3.0]
+
+    # The same numpy array is rejected when numpy is not on the allowlist.
+    with pytest.raises(pickle.UnpicklingError):
+        allowlisted_pickle_load(BytesIO(pickle.dumps(arr)), allowed_modules=("scipy",))
+
+
+def test_allowlist_unpickler_directly_blocks_builtins_eval():
+    """find_class refuses dangerous builtins regardless of payload shape."""
+    u = AllowlistUnpickler(BytesIO(b""), allowed_modules=("numpy",))
+    with pytest.raises(pickle.UnpicklingError):
+        u.find_class("builtins", "eval")
+
+
+def test_transitionparser_loads_legitimate_model(tmp_path):
+    """A genuine trained model must still load through the allowlist."""
+    pytest.importorskip("numpy")
+    pytest.importorskip("scipy")
+    pytest.importorskip("sklearn")
+
+    from nltk.parse import DependencyGraph
+    from nltk.parse.transitionparser import TransitionParser
+
+    gold_sent = DependencyGraph(
+        """
+Economic  JJ     2      ATT
+news  NN     3       SBJ
+has       VBD       0       ROOT
+little      JJ      5       ATT
+effect   NN     3       OBJ
+on     IN      5       ATT
+financial       JJ       8       ATT
+markets    NNS      6       PC
+.    .      3       PU
+"""
+    )
+
+    model_path = tmp_path / "tp.model"
+    parser = TransitionParser(TransitionParser.ARC_STANDARD)
+    parser.train([gold_sent], str(model_path), verbose=False)
+
+    # parse() loads the model via allowlisted_pickle_load; it must succeed.
+    result = parser.parse([gold_sent], str(model_path))
+    assert len(result) == 1
+
+
+def test_transitionparser_rejects_malicious_model(tmp_path):
+    """A malicious model file must be refused without executing its payload."""
+    pytest.importorskip("numpy")
+    pytest.importorskip("scipy")
+    pytest.importorskip("sklearn")
+
+    from nltk.parse import DependencyGraph
+    from nltk.parse.transitionparser import TransitionParser
+
+    model_path = tmp_path / "evil.model"
+    marker = tmp_path / "pwned"
+    # Payload writes a marker file if (and only if) the reduce callable runs.
+    payload_cmd = f"touch {marker}"
+
+    class _MarkerExploit:
+        def __reduce__(self):
+            return (os.system, (payload_cmd,))
+
+    with model_path.open("wb") as f:
+        pickle.dump(_MarkerExploit(), f)
+
+    parser = TransitionParser(TransitionParser.ARC_STANDARD)
+    gold_sent = DependencyGraph("a\tNN\t0\tROOT\n")
+    with pytest.raises(pickle.UnpicklingError):
+        parser.parse([gold_sent], str(model_path))
+
+    assert not marker.exists(), "malicious model payload executed (RCE not blocked)"

--- a/nltk/test/unit/test_pickle_load_warnings.py
+++ b/nltk/test/unit/test_pickle_load_warnings.py
@@ -57,7 +57,8 @@ markets    NNS      6       PC
         result = parser.parse([gold_sent], str(model_path))
 
     pickle_warns = [
-        w for w in caught
+        w
+        for w in caught
         if issubclass(w.category, RuntimeWarning) and WARN_RE in str(w.message)
     ]
     assert not pickle_warns, "parse() must not emit a pickle security warning"

--- a/nltk/test/unit/test_pickle_load_warnings.py
+++ b/nltk/test/unit/test_pickle_load_warnings.py
@@ -52,10 +52,15 @@ markets    NNS      6       PC
 
     import warnings
 
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", RuntimeWarning)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
         result = parser.parse([gold_sent], str(model_path))
 
+    pickle_warns = [
+        w for w in caught
+        if issubclass(w.category, RuntimeWarning) and WARN_RE in str(w.message)
+    ]
+    assert not pickle_warns, "parse() must not emit a pickle security warning"
     assert len(result) == 1
 
 

--- a/nltk/test/unit/test_pickle_load_warnings.py
+++ b/nltk/test/unit/test_pickle_load_warnings.py
@@ -22,7 +22,8 @@ def test_pickle_load_emits_warning(tmp_path: Path):
     assert isinstance(obj, Chart)
 
 
-def test_transitionparser_warns_on_model_unpickle(tmp_path: Path):
+def test_transitionparser_loads_model_without_warning(tmp_path: Path):
+    """TransitionParser.parse() uses AllowlistUnpickler — no RuntimeWarning expected."""
     pytest.importorskip("numpy")
     pytest.importorskip("scipy")
     pytest.importorskip("sklearn")
@@ -49,7 +50,10 @@ markets    NNS      6       PC
     parser = TransitionParser(TransitionParser.ARC_STANDARD)
     parser.train([gold_sent], str(model_path), verbose=False)
 
-    with pytest.warns(RuntimeWarning, match=WARN_RE):
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
         result = parser.parse([gold_sent], str(model_path))
 
     assert len(result) == 1

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -113,8 +113,26 @@ from collections.abc import Iterator
 from re import Match
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+from nltk.picklesec import allowlisted_pickle_load
 from nltk.probability import FreqDist
 from nltk.tokenize.api import TokenizerI
+
+_PUNKT_ALLOWED_MODULES = ("nltk.tokenize.punkt", "nltk.tokenize")
+
+
+def punkt_pickle_load(file):
+    """
+    Safely load a legacy Punkt pickle file.
+
+    Old NLTK Punkt models were distributed as pickle files containing
+    ``PunktParameters``, ``PunktLanguageVars``, and related classes.
+    This helper loads them through :class:`~nltk.picklesec.AllowlistUnpickler`
+    restricted to the ``nltk.tokenize.punkt`` and ``nltk.tokenize`` modules,
+    so arbitrary code gadgets (``os.system``, ``subprocess``, etc.) are blocked
+    while legitimate Punkt objects reconstruct normally.
+    """
+    return allowlisted_pickle_load(file, allowed_modules=_PUNKT_ALLOWED_MODULES)
+
 
 ######################################################################
 # { Orthographic Context Constants


### PR DESCRIPTION
## Summary

NLTK 3.10 added `nltk/picklesec.py` to mitigate pickle RCE, and `nltk.data.load()`
correctly uses its `RestrictedUnpickler`. But the wrapper `pickle_load()` defaults
to `restricted=False`, which uses `WarningUnpickler`: it prints a warning and then
performs a normal, unrestricted unpickle, executing any code in the input.

`TransitionParser.parse(depgraphs, modelFile)` is a public API whose `modelFile`
is caller-supplied, and it loaded the model with that warn-only default:

```python
with open(modelFile, "rb") as f:
    model = pickle_load(f)        # warns, then executes attacker code
```

So loading an untrusted/tampered model file is arbitrary code execution the
instant it is loaded. NLTK models are routinely trained elsewhere and then
downloaded, cached, and shared, so loading one from an untrusted source is a
normal workflow rather than an edge case, and the shipped pickle-hardening
module makes users reasonably believe model loading is already safe.

## Fix

Add an allowlisting unpickler to `picklesec.py` and route `TransitionParser.parse`
through it. The allowlist permits only the globals a saved object legitimately
needs and rejects everything else, so legitimate model loading keeps working
while arbitrary code execution is removed. It does **not** change the global
`pickle_load` default, so no other caller is affected.

`AllowlistUnpickler` supports two complementary allowlists:

- `allowed_globals`: exact `(module, qualname)` pairs.
- `allowed_modules`: module names; a global is permitted when its module equals
  an allowed name or is a submodule of one.

The `TransitionParser` model is a scikit-learn classifier backed by numpy/scipy
arrays, so `parse()` allows the `numpy` / `scipy` / `sklearn` module trees:

```python
_MODEL_ALLOWED_MODULES = ("numpy", "scipy", "sklearn")
...
with open(modelFile, "rb") as f:
    model = allowlisted_pickle_load(f, allowed_modules=_MODEL_ALLOWED_MODULES)
```

Module-prefix allowlisting (rather than exact pairs) is used so the fix is robust
across numpy/sklearn releases, whose internal module paths change between
versions, while still blocking arbitrary-code gadgets (`os`, `posix`,
`subprocess`, `builtins`, …).

`RestrictedUnpickler` (which blocks *all* globals) was not reused here because it
would break loading a genuine sklearn/numpy-backed model.

## Validation

- A payload reaching for `os.system` is rejected with
  `UnpicklingError: global 'posix.system' is not in the pickle allowlist`
  instead of executing.
- A real `numpy.ndarray` deserializes correctly under the `numpy` allowlist.
- A regression test trains a model with `TransitionParser.train` and asserts it
  still loads and parses via `parse()`; another asserts a malicious model file is
  refused (its `os.system` marker-file side effect never appears). Both run under
  CI, where numpy/scipy/sklearn are present.

## Tests

Adds `nltk/test/unit/test_pickle_allowlist_security.py`: allowlist
block/allow unit tests (exact-pair and module-prefix), a direct
`find_class` check that `builtins.eval` is refused, and two end-to-end
`TransitionParser` tests (legitimate model loads; malicious model is rejected
without executing). The end-to-end tests `importorskip` numpy/scipy/sklearn.

## Note for maintainers

The same warn-only `pickle_load` default is also used by
`nltk/app/chartparser_app.py` (chart/grammar loads) and `nltk/tbl/demo.py`
(tagger reloads). This PR scopes the fix to the primary public sink
(`TransitionParser.parse`) plus the reusable `AllowlistUnpickler`; the app/demo
paths can be routed through per-object allowlists in a follow-up if you'd like
them in the same change.

## Reference

huntr report: https://huntr.com/bounties/38abc191-0525-42a1-96fd-262c1c187012