### PR TITLE
fix(security):  algorithmic-complexity DoS in DependencyGraph.contains_cycle

### DIFF
--- a/nltk/parse/dependencygraph.py
+++ b/nltk/parse/dependencygraph.py
@@ -468,10 +468,10 @@ class DependencyGraph:
         # O(V + E).  The previous implementation repeatedly recomputed a
         # transitive closure with a triple-nested loop over a ``distances``
         # set that grows quadratically in the number of nodes, so its running
-        # time was super-polynomial in the (attacker-controlled) number of
-        # tokens -- roughly cubic on a graph parsed from CoNLL data and
-        # quintic on a list-``deps`` graph -- which let a single oversized
-        # graph exhaust CPU (CWE-407).
+        # time grew as a high-degree polynomial in the (attacker-controlled)
+        # number of tokens -- roughly cubic on a graph parsed from CoNLL data
+        # and quintic on a list-``deps`` graph -- versus O(V + E) here, which
+        # let a single oversized graph exhaust CPU (CWE-407).
         #
         # ``deps`` may be a list of addresses or a relation->addresses
         # mapping; iterating it yields the same edge targets the old code

--- a/nltk/parse/dependencygraph.py
+++ b/nltk/parse/dependencygraph.py
@@ -464,29 +464,47 @@ class DependencyGraph:
         [1, 2, 4, 3]
 
         """
-        distances = {}
+        # Detect a directed cycle with an iterative depth-first search in
+        # O(V + E).  The previous implementation repeatedly recomputed a
+        # transitive closure with a triple-nested loop over a ``distances``
+        # set that grows quadratically in the number of nodes, so its running
+        # time was super-polynomial in the (attacker-controlled) number of
+        # tokens -- roughly cubic on a graph parsed from CoNLL data and
+        # quintic on a list-``deps`` graph -- which let a single oversized
+        # graph exhaust CPU (CWE-407).
+        #
+        # ``deps`` may be a list of addresses or a relation->addresses
+        # mapping; iterating it yields the same edge targets the old code
+        # used.  The membership guard skips targets that are not nodes and
+        # avoids materialising spurious ``defaultdict`` entries in
+        # ``self.nodes``.
+        WHITE, GRAY, BLACK = 0, 1, 2
+        color = defaultdict(int)  # int() == WHITE
 
-        for node in self.nodes.values():
-            for dep in node["deps"]:
-                key = tuple([node["address"], dep])
-                distances[key] = 1
+        for start in list(self.nodes):
+            if color[start] != WHITE:
+                continue
+            color[start] = GRAY
+            path = [start]
+            stack = [iter(self.nodes[start]["deps"])]
+            while stack:
+                for dep in stack[-1]:
+                    if dep not in self.nodes:
+                        continue
+                    if color[dep] == GRAY:
+                        # Back edge: the gray nodes from ``dep`` onward form
+                        # the cycle, in traversal order.
+                        return path[path.index(dep) :]
+                    if color[dep] == WHITE:
+                        color[dep] = GRAY
+                        path.append(dep)
+                        stack.append(iter(self.nodes[dep]["deps"]))
+                        break
+                else:
+                    color[path.pop()] = BLACK
+                    stack.pop()
 
-        for _ in self.nodes:
-            new_entries = {}
-
-            for pair1 in distances:
-                for pair2 in distances:
-                    if pair1[1] == pair2[0]:
-                        key = tuple([pair1[0], pair2[1]])
-                        new_entries[key] = distances[pair1] + distances[pair2]
-
-            for pair in new_entries:
-                distances[pair] = new_entries[pair]
-                if pair[0] == pair[1]:
-                    path = self.get_cycle_path(self.get_by_address(pair[0]), pair[0])
-                    return path
-
-        return False  # return []?
+        return False
 
     def get_cycle_path(self, curr_node, goal_node_index):
         for dep in curr_node["deps"]:


### PR DESCRIPTION
# Fix algorithmic-complexity DoS in `DependencyGraph.contains_cycle` (CWE-407 / CWE-834)

## Description

`nltk.parse.dependencygraph.DependencyGraph.contains_cycle()` detected cycles by
repeatedly recomputing a transitive closure with a triple-nested loop over a
`distances` set that grows quadratically in the number of graph nodes:

```python
# nltk/parse/dependencygraph.py (before)
for _ in self.nodes:                 # O(N) iterations
    for pair1 in distances:          # |distances| grows toward O(N^2)
        for pair2 in distances:      #   x |distances|
            if pair1[1] == pair2[0]:
                ...
```

The running time is super-polynomial in the number of nodes (tokens) `N`:

- on a graph parsed from CoNLL data (where `deps` is a `relation -> [addresses]`
  dict) it is roughly **O(N³)**;
- on a list-`deps` graph (the format the method is written for) it is roughly
  **O(N⁵)**.

`N` is attacker-controlled: it is the number of tokens in a single dependency
record (a malicious or oversized CoNLL record passed to
`DependencyGraph(untrusted_conll)`) or the length of an input sentence fed to the
non-projective dependency parser, which invokes `contains_cycle()` internally
(`nonprojectivedependencyparser.py:504`). A single moderate input drives the
process into seconds-to-minutes of CPU time on one core and ties up the worker
that processes it — a denial of service. No authentication and no special
configuration are required.

## The fix

Replace the transitive-closure approach with an **iterative depth-first search**
that finds a directed cycle in **O(V + E)**:

```python
WHITE, GRAY, BLACK = 0, 1, 2
color = defaultdict(int)  # int() == WHITE

for start in list(self.nodes):
    if color[start] != WHITE:
        continue
    color[start] = GRAY
    path = [start]
    stack = [iter(self.nodes[start]["deps"])]
    while stack:
        for dep in stack[-1]:
            if dep not in self.nodes:
                continue
            if color[dep] == GRAY:
                # Back edge: the gray nodes from `dep` onward form the cycle.
                return path[path.index(dep) :]
            if color[dep] == WHITE:
                color[dep] = GRAY
                path.append(dep)
                stack.append(iter(self.nodes[dep]["deps"]))
                break
        else:
            color[path.pop()] = BLACK
            stack.pop()

return False
```

Design notes:

- **The DFS is iterative**, not recursive, so a long attacker-supplied chain
  cannot trigger a secondary `RecursionError`-based DoS.
- **`deps` shape is preserved exactly.** `deps` may be a list of addresses or a
  `relation -> [addresses]` mapping. Iterating it yields the same edge targets
  the old code iterated, and the `if dep not in self.nodes` guard both skips
  non-node targets and avoids materialising spurious `defaultdict` entries in
  `self.nodes` (so the method remains side-effect-free, exactly like before).
- **The public contract is unchanged:** `contains_cycle()` returns `False` when
  there is no cycle, and the cycle path (in traversal order) otherwise. The DFS
  reproduces the documented output `[1, 2, 4, 3]` for the docstring example and
  preserves the prior "no cycle reported" behaviour for the relation-keyed
  graphs the non-projective parser builds, so existing parser results are
  unaffected.

## Behaviour preservation

| Input | Before | After |
|-------|--------|-------|
| `DependencyGraph(treebank_data).contains_cycle()` | `False` | `False` |
| docstring cyclic graph | `[1, 2, 4, 3]` | `[1, 2, 4, 3]` |
| self-loop `1 -> 1` | `[1]` | `[1]` |
| acyclic list-`deps` tree | `False` | `False` |
| `ProbabilisticNonprojectiveParser.parse(...)` doctest | passes | passes |

## Performance (chain graph)

| Shape | N | Before | After |
|-------|---|--------|-------|
| list-`deps` (~O(N⁵)) | 80 | ~12,100 ms | ~0.04 ms |
| list-`deps` | 3000 | (hours, extrapolated) | ~0.8 ms |
| CoNLL (~O(N³)) | 800 | ~9,780 ms | ~0.20 ms |
| CoNLL | 3000 | (minutes, extrapolated) | ~0.8 ms |

## Testing

- `python -m doctest nltk/parse/dependencygraph.py` — pass.
- `python -m doctest nltk/parse/nonprojectivedependencyparser.py` — pass
  (this exercises `parse()` → `contains_cycle()` on the dict-shaped `b_graph`).
- `nltk/test/dependency.doctest` parser sections — pass; the only failures are
  a missing `dependency_treebank` corpus download and a pre-existing
  tab-vs-whitespace rendering diff present on `develop` before this change.
- `black==25.11.0` and `ruff==0.15.6` (repo-pinned) — clean.
- See `poc_contains_cycle_dos.py` (the original reproducer) and
  `verify_contains_cycle_fix.py` (parity + timing harness).
