### PR TITLE
fix(security): bound recursion in PorterStemmer._is_consonant (CWE-674)

### DIFF
--- a/nltk/stem/porter.py
+++ b/nltk/stem/porter.py
@@ -138,10 +138,17 @@ class PorterStemmer(StemmerI):
         if word[i] in self.vowels:
             return False
         if word[i] == "y":
-            if i == 0:
-                return True
-            else:
-                return not self._is_consonant(word, i - 1)
+            # A 'y' counts as a consonant when the letter before it is not
+            # one, and as a vowel otherwise.  Resolve a run of 'y's
+            # iteratively instead of recursively so that a token such as
+            # "yyyy..." cannot drive the recursion depth past the
+            # interpreter limit and raise an uncaught RecursionError
+            # (CWE-674).
+            negate = False
+            while i > 0 and word[i] == "y":
+                negate = not negate
+                i -= 1
+            return (word[i] not in self.vowels) != negate
         return True
 
     def _measure(self, stem):

--- a/nltk/test/unit/test_stem.py
+++ b/nltk/test/unit/test_stem.py
@@ -169,3 +169,15 @@ class PorterTest(unittest.TestCase):
         assert porter.stem("Howe", to_lowercase=False) == "How"
         assert porter.stem("Sky") == "sky"
         assert porter.stem("Sky", to_lowercase=False) == "Ski"
+
+    def test_long_run_of_y_no_recursionerror(self):
+        """Regression test for the unbounded-recursion DoS (CWE-674).
+
+        ``_is_consonant`` used to recurse once per preceding ``'y'``, so a token
+        made of a long run of ``'y'`` overflowed the interpreter's recursion
+        limit and raised an uncaught ``RecursionError``. The iterative
+        implementation must handle a run far longer than that limit.
+        """
+        token = "y" * 100000
+        result = PorterStemmer().stem(token)
+        assert isinstance(result, str)


### PR DESCRIPTION
# Fix unbounded-recursion DoS in `PorterStemmer._is_consonant` (CWE-674)

## Description

`PorterStemmer._is_consonant(word, i)` recurses with no depth bound whenever the
current letter is `y`: for a `y` it returns the negation of the consonant test on
the *preceding* index, walking backward one stack frame per character.

```python
# nltk/stem/porter.py (before)
def _is_consonant(self, word, i):
    if word[i] in self.vowels:
        return False
    if word[i] == "y":
        if i == 0:
            return True
        else:
            return not self._is_consonant(word, i - 1)   # unbounded recursion
    return True
```

A single token consisting of a run of consecutive `y` characters drives the
recursion depth to the length of the run. Once it exceeds the interpreter's
recursion limit (default 1000) it raises an **uncaught `RecursionError`** that
crashes the worker or process.

`PorterStemmer().stem()` is one of NLTK's most widely used functions and is
routinely applied to individual tokens of untrusted text (search / IR indexing,
NLP preprocessing pipelines). A single ~1 KB token of `y` is enough to take down
any service that Porter-stems attacker-supplied text. No authentication and no
user interaction are required.

## The fix

Resolve the run of `y`s **iteratively** instead of recursively, in O(run length)
time and O(1) stack:

```python
if word[i] == "y":
    # A 'y' counts as a consonant when the letter before it is not one, and
    # as a vowel otherwise.  Resolve a run of 'y's iteratively instead of
    # recursively so that a token such as "yyyy..." cannot drive the
    # recursion depth past the interpreter limit (CWE-674).
    negate = False
    while i > 0 and word[i] == "y":
        negate = not negate
        i -= 1
    return (word[i] not in self.vowels) != negate
return True
```

How it preserves the exact result: the recursion for a `y` at index `i` is
`not _is_consonant(word, i-1)`, so a run of `k` `y`s applies `not` `k` times to
the classification of the first non-`y` letter encountered (or to the base case
`_is_consonant(word, 0) == True` when the run reaches the start of the token —
which equals `("y" not in self.vowels)`). The loop counts those negations in
`negate` and applies them once via the XOR (`!= negate`). For a non-`y` letter
the loop body never runs and the expression reduces to `word[i] not in
self.vowels`, identical to the original non-recursive branches.

## Behaviour preservation

Verified by an exhaustive oracle test: the new `_is_consonant` matches the
original recursive implementation on **every index of 21,092 inputs** (all
strings up to length 6 over `{a,b,y}`, plus 20,000 random `y`-heavy tokens up to
length 60) — **0 mismatches**. Documented examples are unchanged:

| word | `stem()` |
|------|----------|
| `syzygy` | `syzygi` |
| `toy` | `toy` |
| `happy` | `happi` |
| `sky` | `sky` |
| `ponies` | `poni` |
| `caresses` | `caress` |

## Reproduction / verification

| Input | Before | After |
|-------|--------|-------|
| `PorterStemmer().stem("y" * 1000)` | `RecursionError` | returns normally |
| `PorterStemmer().stem("y" * 5000)` | `RecursionError` | returns normally |
| `PorterStemmer().stem("y" * 100000)` | `RecursionError` | returns normally |

## Testing

- Exhaustive equivalence vs. the original recursive logic — 0 mismatches (see
  `verify_porter_fix.py`).
- `python -m doctest nltk/stem/porter.py` — pass.
- `nltk/test/stem.doctest` Porter sections — pass (the only failures are a
  missing `stopwords` corpus download used by the unrelated Snowball stemmer).
- `black==25.11.0` and `ruff==0.15.6` (repo-pinned) — clean.
- `poc_porter_recursion_dos.py` — the original reproducer; raises before the fix,
  returns normally after.
