### PR TITLE
fix(security): close validate/extract path mismatch in pathsec Zip-Slip guard (CWE-22)

### DIFF
--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -156,6 +156,29 @@ def validate_path(path_input, context="NLTK", required_root=None):
             raise
 
 
+def _zip_member_is_unsafe(name_str):
+    """True if a ZIP member is written somewhere other than where it is validated.
+
+    ``zipfile.ZipFile.extract`` sanitises a member name by *dropping* the drive
+    and every empty / ``.`` / ``..`` component while keeping the rest, whereas
+    ``Path.resolve`` collapses a ``..`` against its *preceding* component.  For a
+    member such as ``a/../b/x`` the two disagree: it is validated as ``<root>/b/x``
+    but written to ``<root>/a/b/x``, which can escape through a pre-existing
+    symlink at ``<root>/a/b`` that the collapsed validation path never visits.
+
+    The mismatch only ever arises from absolute / drive-qualified / ``..`` members
+    -- exactly the shapes a legitimate archive never uses -- so rather than keep
+    two different normalizations in sync we reject them outright.  This both
+    closes the validate/extract gap and is the proactive block the hardened
+    extractor promises (CWE-22 / CWE-59).
+    """
+    # Normalize every separator zipfile treats as such on this platform to "/".
+    normalized = name_str.replace("\\", "/") if os.path.altsep else name_str
+    if os.path.splitdrive(name_str)[0] or normalized.startswith("/"):
+        return True
+    return os.path.pardir in normalized.split("/")
+
+
 def validate_zip_archive(
     zip_obj_or_path, target_root, specific_member=None, context="ZipAudit"
 ):
@@ -172,8 +195,14 @@ def validate_zip_archive(
                 if "\0" in name_str:
                     raise ValueError(f"Null byte in ZIP member: {name_str}")
 
+                # ``resolve()`` follows symlinks, catching escapes through a
+                # pre-existing symlinked subpath. The extra component check
+                # rejects absolute / ``..`` members, whose write target diverges
+                # from this resolved path (CWE-22 / CWE-59).
                 member_path = (target / name_str).resolve()
-                if not (member_path == target or member_path.is_relative_to(target)):
+                if _zip_member_is_unsafe(name_str) or not (
+                    member_path == target or member_path.is_relative_to(target)
+                ):
                     msg = f"Security Violation [{context}]: Traversal member '{name_str}' detected."
                     if ENFORCE:
                         raise PermissionError(msg)

--- a/nltk/test/unit/test_pathsec.py
+++ b/nltk/test/unit/test_pathsec.py
@@ -132,6 +132,48 @@ def test_zip_slip_absolute_path(tmp_path):
             zf.extractall(tmp_path)
 
 
+def test_zip_slip_interior_dotdot(tmp_path):
+    """Test an interior ``..`` member (validate/extract normalization mismatch).
+
+    ``Path.resolve`` collapses the ``..`` so the member ``a/../b/evil.txt``
+    validates as ``<root>/b/evil.txt`` (inside the root), but ``zipfile`` drops
+    the ``..`` and writes ``<root>/a/b/evil.txt``. The hardened extractor must
+    reject the interior-``..`` member outright rather than let the validated and
+    written paths diverge (CWE-22).
+    """
+    malicious_zip = create_malicious_zip("a/../b/evil.txt")
+    with pytest.raises((ValueError, PermissionError)):
+        with pathsec.ZipFile(malicious_zip, "r") as zf:
+            zf.extractall(tmp_path)
+
+
+def test_zip_slip_interior_dotdot_symlink_escape(tmp_path):
+    """An interior-``..`` member must not escape through an in-root symlink.
+
+    With a pre-existing symlink at the path the dropped-``..`` member resolves
+    to (``<root>/a/b`` -> outside), the old validator passed the member (it only
+    inspected the ``..``-collapsed ``<root>/b/...``) while ``zipfile`` followed
+    the symlink and wrote outside the root. The member must be rejected and
+    nothing written outside the extraction root (CWE-22 / CWE-59).
+    """
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    root = tmp_path / "extract"
+    (root / "a").mkdir(parents=True)
+    try:
+        os.symlink(outside, root / "a" / "b")  # <root>/a/b -> outside
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported in this environment")
+
+    malicious_zip = create_malicious_zip("a/../b/evil.txt")
+    with pytest.raises((ValueError, PermissionError)):
+        with pathsec.ZipFile(malicious_zip, "r") as zf:
+            zf.extractall(root)
+    assert not (
+        outside / "evil.txt"
+    ).exists(), "member escaped the extraction root via an in-root symlink"
+
+
 # --- PROXY & HANDLER TESTS ---
 
 


### PR DESCRIPTION
# Fix Zip-Slip via validate/extract path-normalization mismatch in `nltk.pathsec` (CWE-22 / CWE-59)

## Description

`nltk.pathsec.ZipFile` is the hardened ZIP extractor used across NLTK. For each
member it calls the centralized validator `validate_zip_archive()` to enforce
that the member stays within the extraction root, then calls the standard-library
extractor to write the file. **The two steps normalize a member path containing a
`..` component differently, so the path that is validated is not the path that is
written.**

- `validate_zip_archive` computes `member_path = (target / name_str).resolve()`,
  and `Path.resolve()` **collapses** a `..` against its *preceding* component:
  `a/../b/evil.txt` → `<root>/b/evil.txt`.
- `zipfile.ZipFile.extract` instead **drops** the empty / `.` / `..` components
  and keeps the rest: `a/../b/evil.txt` → `<root>/a/b/evil.txt`.

So the validator inspects `<root>/b/evil.txt` (not a symlink → "contained" →
allowed), while the extractor writes to `<root>/a/b/evil.txt`. If `<root>/a/b` is
a **pre-existing symlink pointing outside the extraction root**, the write
follows the symlink and lands outside the root with fully attacker-controlled
content, while the centralized Zip-Slip check raised nothing.

Because `validate_zip_archive` is the centralized Zip-Slip sentinel, the mismatch
affects **every** caller of `pathsec.ZipFile.extract` / `.extractall`, not a
single extraction site.

## The fix

The divergence only ever arises from **absolute**, **drive-qualified**, or
**`..`-bearing** member names — the exact shapes a legitimate archive never uses,
and the shapes the hardened extractor already promises to *proactively block*
(see `nltk/test/unit/test_pathsec.py::test_zip_slip_traversal` /
`::test_zip_slip_absolute_path`). Rather than try to keep two different
normalizations in lock-step, reject those members outright:

```python
def _zip_member_is_unsafe(name_str):
    normalized = name_str.replace("\\", "/") if os.path.altsep else name_str
    if os.path.splitdrive(name_str)[0] or normalized.startswith("/"):
        return True
    return os.path.pardir in normalized.split("/")
```

```python
member_path = (target / name_str).resolve()
if _zip_member_is_unsafe(name_str) or not (
    member_path == target or member_path.is_relative_to(target)
):
    # ... raise PermissionError (ENFORCE) / warn
```

This keeps the existing symlink-resolving containment check — which already
catches a pure-symlink escape such as `a/b/x` where `<root>/a/b` is a symlink
(no `..` needed) — and adds the component check that closes the `..` / absolute
gap. The two together guarantee the validated decision matches the written
location.

## Behaviour

| Member | Before | After |
|--------|--------|-------|
| `a/../b/evil.txt` (with `<root>/a/b` → outside symlink) | **escapes**, no alert | **blocked** (PermissionError) |
| `../../../evil.sh` | blocked | blocked |
| `/etc/cron.d/evil_cron` | blocked | blocked |
| `a/b/x` (with `<root>/a/b` symlink → outside) | blocked (resolve) | blocked (resolve) |
| `corpus/data/file.txt` (benign nested) | extracted | extracted (no false positive) |

## Reproduction

`poc_validate_zip_archive_mismatch.py` plants `<root>/a/b → outside`, builds an
archive whose member is `a/../b/evil.txt`, and calls
`pathsec.ZipFile.extract(...)`:

- **Before:** `validate_zip_archive` raises nothing and
  `<outside>/evil.txt` is created with `b"PWNED-OUTSIDE-EXTRACTION-ROOT"`.
- **After:** `PermissionError: Security Violation [ZipAudit]: Traversal member
  'a/../b/evil.txt' detected.` and nothing is written outside the root.

## Testing

- `poc_validate_zip_archive_mismatch.py` — escape now blocked, no out-of-root write.
- `verify_pathsec_fix.py` — escape blocked; classic `../` and absolute members
  still blocked; benign nested archives extract fully (no false positives).
- `pytest nltk/test/unit/test_pathsec.py nltk/test/unit/test_nkjp_security.py
  nltk/test/unit/test_framenet_security.py nltk/test/unit/test_downloader_atomic.py
  nltk/test/unit/test_corpus_reader.py` — **58 passed** (this includes the
  pre-existing `test_zip_slip_traversal` / `test_zip_slip_absolute_path`).
- `black==25.11.0` and `ruff==0.15.6` (repo-pinned) — clean.
