### PR TITLE
fix(security): validate path in GzipFileSystemPathPointer.open() (CWE-22)

### DIFF
--- a/nltk/data.py
+++ b/nltk/data.py
@@ -494,7 +494,11 @@ class GzipFileSystemPathPointer(FileSystemPathPointer):
     """
 
     def open(self, encoding=None):
-        stream = GzipFile(self._path, "rb")
+        # Route through the sentinel like FileSystemPathPointer.open() so the
+        # path is validated against the allowed NLTK data roots (with symlinks
+        # resolved) before reading; decompress the validated stream rather than
+        # re-opening the path directly (CWE-22 / CWE-73).
+        stream = GzipFile(self._path, fileobj=_secure_open(self._path, "rb"))
         if encoding:
             stream = SeekableUnicodeStreamReader(stream, encoding)
         return stream

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -499,7 +499,9 @@ class GzipFileSystemPathPointer(FileSystemPathPointer):
         # resolved) before reading; decompress the validated stream rather than
         # re-opening the path directly (CWE-22 / CWE-73).
         stream = GzipFile(self._path, fileobj=_secure_open(self._path, "rb"))
-        if encoding:
+        # ``encoding is not None`` (not truthiness) to match
+        # FileSystemPathPointer.open() / ZipFilePathPointer.open().
+        if encoding is not None:
             stream = SeekableUnicodeStreamReader(stream, encoding)
         return stream
 

--- a/nltk/test/unit/test_data_security.py
+++ b/nltk/test/unit/test_data_security.py
@@ -1,8 +1,11 @@
+import gzip
+import os
 import zipfile
 
 import pytest
 
 import nltk.data as data
+from nltk import pathsec
 
 
 def test_normalize_rejects_no_protocol_traversal():
@@ -198,3 +201,42 @@ def test_find_zip_split_is_non_greedy(tmp_path):
         if isinstance(got, bytes):
             got = got.decode("utf-8")
         assert got == "ok"
+
+
+def test_gzip_pointer_open_enforces_sandbox(tmp_path, monkeypatch):
+    """GzipFileSystemPathPointer.open() must honour the pathsec sandbox.
+
+    Regression test for the sandbox bypass where the gzip pointer opened its
+    path with GzipFile directly instead of routing through pathsec.open()
+    (CWE-22 / CWE-73): it must refuse a path outside the allowed roots and an
+    in-root symlink that escapes outside, while still reading in-root files.
+    """
+    allowed = tmp_path / "data"
+    allowed.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    monkeypatch.setattr(pathsec, "ENFORCE", True)
+    monkeypatch.setattr(pathsec, "_get_allowed_roots", lambda: {allowed.resolve()})
+
+    # gzip file OUTSIDE the allowed root -> blocked
+    secret = outside / "secret.gz"
+    with gzip.open(secret, "wb") as fh:
+        fh.write(b"secret")
+    with pytest.raises((PermissionError, ValueError)):
+        data.GzipFileSystemPathPointer(str(secret)).open().read()
+
+    # in-root symlink escaping outside the allowed root -> blocked
+    link = allowed / "link.gz"
+    try:
+        os.symlink(secret, link)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported in this environment")
+    with pytest.raises((PermissionError, ValueError)):
+        data.GzipFileSystemPathPointer(str(link)).open().read()
+
+    # legitimate gzip INSIDE the allowed root -> reads (decompressed)
+    good = allowed / "good.gz"
+    with gzip.open(good, "wb") as fh:
+        fh.write(b"hello-gz")
+    with data.GzipFileSystemPathPointer(str(good)).open() as fp:
+        assert fp.read() == b"hello-gz"


### PR DESCRIPTION
# Fix sandbox-bypass arbitrary file read in `GzipFileSystemPathPointer.open()` (CWE-22 / CWE-73)

## Description

NLTK enables a file-access sandbox by default (`nltk.pathsec.ENFORCE = True`):
filesystem reads through the resource layer must resolve inside the allowed NLTK
data directories, and the centralized sentinel resolves symlinks before allowing
access.

`FileSystemPathPointer.open()` honours this — it opens through the sentinel:

```python
# nltk/data.py  FileSystemPathPointer.open()
stream = _secure_open(self._path, "rb")     # -> pathsec.open -> validate_path
```

But its subclass `GzipFileSystemPathPointer` **overrides** `open()` and opens the
path with the gzip constructor directly, never invoking the sentinel:

```python
# nltk/data.py  GzipFileSystemPathPointer.open()  (before)
stream = GzipFile(self._path, "rb")         # NO validation
```

Consequently a gzip pointer whose path points outside the allowed data
directories reads that file regardless of the sandbox — an arbitrary file read of
gzip-format files (which the gzip constructor decompresses), and a symlink-escape
read (it follows symlinks the path validator would otherwise reject). No
authentication, user interaction, or non-default configuration is required.

## The fix

Route the gzip pointer through the same sentinel the base class uses, then
decompress the *validated* stream instead of re-opening the path:

```python
# nltk/data.py  GzipFileSystemPathPointer.open()  (after)
stream = GzipFile(self._path, fileobj=_secure_open(self._path, "rb"))
if encoding:
    stream = SeekableUnicodeStreamReader(stream, encoding)
return stream
```

- `_secure_open` (`pathsec.open`) runs `validate_path` first, so the path is
  checked against the allowed roots with symlinks resolved — raising
  `PermissionError` under `ENFORCE` before any bytes are read.
- `GzipFile(filename, fileobj=...)` decompresses the already-opened, validated
  file object; with `fileobj` provided it does **not** open `filename` itself, so
  no second unsandboxed `open` happens. The `filename` argument only supplies the
  member name metadata — this mirrors the existing
  `ZipFilePathPointer.open()` pattern (`GzipFile(self._entry, fileobj=stream)`).

## Behaviour

| Access | Before | After |
|--------|--------|-------|
| gzip pointer to a file **outside** allowed roots | **reads (bypass)** | **blocked** (`PermissionError`) |
| gzip pointer via an in-root **symlink → outside** | **reads (escape)** | **blocked** |
| base `FileSystemPathPointer` to the same outside file | blocked | blocked |
| gzip pointer to a file **inside** an allowed data root | reads | reads (unchanged) |

## Reproduction

`poc_gzip_pathpointer_afr.py` writes a gzip file outside every allowed root and
opens it through both pointers:

- **Before:** base pointer is blocked, but
  `GzipFileSystemPathPointer(secret).open().read()` returns
  `b"TOP-SECRET-OUTSIDE-THE-SANDBOX"` — and the symlink variant returns
  `b"ESCAPED-VIA-SYMLINK"`.
- **After:** both raise `PermissionError: Security Violation [pathsec.open]:
  Unauthorized path ...`.

## Testing

- `poc_gzip_pathpointer_afr.py` / `verify_gzip_fix.py` — outside read blocked,
  symlink-escape blocked, in-sandbox gzip still loads (decompressed content
  returned).
- `pytest nltk/test/unit/test_data.py nltk/test/unit/test_data_security.py
  nltk/test/unit/test_open_datafile.py nltk/test/unit/test_pathsec.py
  nltk/test/unit/test_corpus_reader.py nltk/test/unit/test_corpus_util.py
  nltk/test/unit/test_downloader_atomic.py` — all pass. (The only failures in the
  broader suite — `test_corpus_views` and some `data.py` doctests — are missing
  corpus-download `LookupError`s that fail identically on `develop`.)
- `black==25.11.0` and `ruff==0.15.6` (repo-pinned) — clean.
