### PR TITLE
fix(security): read XML corpora through the path-pointer sentinel (CWE-22)

### DIFF
--- a/nltk/test/unit/test_corpus_reader.py
+++ b/nltk/test/unit/test_corpus_reader.py
@@ -53,3 +53,38 @@ def test_find_corpus_fileids_skips_symlink_escape(tmp_path):
 
     assert "inside.txt" in fileids
     assert "outside_link/secret.txt" not in fileids
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="requires os.symlink")
+def test_xml_corpus_reader_blocks_symlink_escape(tmp_path, monkeypatch):
+    """XML readers (BNC/CHILDES/Semcor) parse through the validated path-pointer
+    open(), so an in-corpus symlink to an out-of-root XML file must be blocked
+    rather than parsed and returned (CWE-22 / CWE-59).
+    """
+    from nltk import pathsec
+    from nltk.corpus.reader.bnc import BNCCorpusReader
+
+    corpus_root = tmp_path / "corpus"
+    corpus_root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+
+    # Valid BNC XML so that, if the symlink were followed, the reader would
+    # return the secret token rather than fail to parse.
+    secret = outside / "secret.xml"
+    secret.write_text(
+        '<bncDoc><stext><s n="1">'
+        '<w c5="NN0" hw="x" pos="SUBST">SECRET-OUTSIDE-CORPUS-ROOT </w>'
+        "</s></stext></bncDoc>",
+        encoding="utf-8",
+    )
+    os.symlink(str(secret), str(corpus_root / "link.xml"))
+
+    # Confine the pathsec sandbox to the corpus root so the symlink target is
+    # genuinely out of root.
+    monkeypatch.setattr(pathsec, "ENFORCE", True)
+    monkeypatch.setattr(pathsec, "_get_allowed_roots", lambda: {corpus_root.resolve()})
+
+    reader = BNCCorpusReader(root=str(corpus_root), fileids=r"link\.xml", lazy=False)
+    with pytest.raises((PermissionError, ValueError, OSError)):
+        reader.words("link.xml")


### PR DESCRIPTION
# Fix symlink arbitrary file read in NLTK XML corpus readers (CWE-22 / CWE-59)

## Description

NLTK enables a file-access sandbox by default (`nltk.pathsec.ENFORCE = True`):
corpus files are meant to be read through the validated path-pointer `open()`,
which resolves symlinks and rejects paths that escape the allowed roots.

The **BNC**, **CHILDES**, and **Semcor** readers read their files by passing the
per-file path pointer straight to the stdlib XML parser:

```python
xmldoc = ElementTree.parse(fileid).getroot()
```

`fileid` is a `FileSystemPathPointer`, which is a `str` subclass, so
`ElementTree` treats it as a filename and opens it with the builtin file
`open` — bypassing the validated `PathPointer.open()` / `nltk.pathsec` sentinel
and its symlink-resolving containment check.

As a result, a symlink inside the corpus root that points outside it is followed:
the reader parses the symlink's target and returns its content. The readers
return the full parsed text (words/sentences/attributes), so the **entire
content** of the targeted XML file is disclosed. A victim who loads an
attacker-supplied corpus directory (corpora are routinely distributed and loaded
as directories/archives) that embeds such a symlink leaks files from outside the
corpus root. No authentication or non-default configuration is required.

Affected call sites: `bnc.py:116`, `childes.py:219/239/265/357`, `semcor.py:127`.

## The fix

Parse through the validated path pointer's `open()` — the same sentinel the rest
of the resource layer uses (cf. `XMLCorpusReader.xml()` and
`StreamBackedCorpusView._open()`) — instead of handing the `str` path to
`ElementTree`:

```python
with fileid.open() as fp:
    xmldoc = ElementTree.parse(fp).getroot()
```

`FileSystemPathPointer.open()` routes through `nltk.pathsec`, which resolves
symlinks and raises `PermissionError` under `ENFORCE` before any bytes are read.
This is also **fail-closed**: if `fileid` were ever a plain `str` (not a path
pointer) it has no `.open()` and raises `AttributeError` rather than silently
re-opening the path. The parsed tree is fully materialized by `ElementTree.parse`
inside the `with`, so closing the stream afterwards is safe.

## Behaviour (verified)

| Reader / call | Before | After |
|---------------|--------|-------|
| `BNCCorpusReader.words()` (non-lazy, `bnc.py:116`) | **leaks** out-of-root file | **blocked** (`PermissionError`) |
| `CHILDESCorpusReader.corpus()` (`childes.py`) | **leaks** out-of-root file | **blocked** |
| `SemcorCorpusReader._words()` (`semcor.py:127`) | **leaks** out-of-root file | **blocked** |
| legitimate in-root corpus read (all three) | reads | reads (no false positive) |

PoC output before the fix: `BNC → 'SECRET-OUTSIDE-CORPUS-ROOT'`,
`CHILDES → [{'secret': 'SECRET-OUTSIDE-CORPUS-ROOT'}]`,
`Semcor → ['SECRET-OUTSIDE-CORPUS-ROOT']`. After the fix each raises
`PermissionError: Security Violation [pathsec.open]: Unauthorized path ...`.

> Note: the lazy code paths of BNC/Semcor already go through the sandboxed
> `StreamBackedCorpusView._open()`; the leaking paths are the direct
> `ElementTree.parse(fileid)` calls listed above. (Semcor's non-lazy `_words` is
> currently only reachable by a direct call due to a separate, pre-existing
> argument-count mismatch in `_items`; the fix secures the line regardless.)

## Testing

- `poc_xml_reader_symlink_afr.py` / `verify_xml_readers.py` — out-of-root symlink
  reads now blocked for BNC / CHILDES / Semcor; in-sandbox corpora still read
  correctly (no false positives).
- `pytest nltk/test/unit/test_pathsec.py nltk/test/unit/test_data_security.py
  nltk/test/unit/test_corpus_reader.py` — **64 passed**.
- `black==25.11.0` and `ruff==0.15.6` (repo-pinned) — clean on all three files.
