### PR TITLE
fix(security): require a session token for WordNet Browser shutdown (CWE-352)

### DIFF
--- a/nltk/app/wordnet_app.py
+++ b/nltk/app/wordnet_app.py
@@ -48,10 +48,12 @@ Options::
 import base64
 import copy
 import getopt
+import hmac
 import html
 import io
 import os
 import pickle
+import secrets
 import sys
 import threading
 import time
@@ -61,13 +63,19 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 
 # Allow this program to run inside the NLTK source tree.
 from sys import argv
-from urllib.parse import unquote_plus
+from urllib.parse import parse_qs, unquote_plus
 
 from nltk.corpus import wordnet as wn
 from nltk.corpus.reader.wordnet import Lemma, Synset
 from nltk.picklesec import RestrictedUnpickler
 
 firstClient = True
+
+# Per-process secret token. It is embedded only in the browser's own "Shutdown"
+# link and required by the shutdown route, so a cross-site page (which cannot
+# read the link under the Same-Origin Policy) cannot forge a shutdown request
+# (CWE-352). The loopback bind already blocks remote access (CWE-306).
+_shutdown_token = secrets.token_urlsafe(32)
 
 # True if we're not also running a web browser.  The value f server_mode
 # gets set by demo().
@@ -81,16 +89,36 @@ class MyServerHandler(BaseHTTPRequestHandler):
     def do_HEAD(self):
         self.send_head()
 
+    def _shutdown_authorized(self):
+        """True only for a same-session shutdown carrying the secret token.
+
+        The token is generated per process and embedded only in the browser's
+        own Shutdown link, so a cross-site page cannot supply it; this blocks
+        CSRF-driven shutdown (CWE-352).
+        """
+        token = parse_qs(self.path.partition("?")[2]).get("token", [""])[0]
+        return bool(_shutdown_token) and hmac.compare_digest(token, _shutdown_token)
+
     def do_GET(self):
         global firstClient
         sp = self.path[1:]
-        if unquote_plus(sp) == "SHUTDOWN THE SERVER":
+        if unquote_plus(sp.partition("?")[0]) == "SHUTDOWN THE SERVER":
             if server_mode:
                 page = "Server must be killed with SIGTERM."
                 type = "text/plain"
-            else:
+            elif self._shutdown_authorized():
                 print("Server shutting down!")
                 os._exit(0)
+            else:
+                # Refuse a token-less / cross-site shutdown request (CWE-352).
+                self.send_response(403)
+                self.send_header("Content-type", "text/plain")
+                self.end_headers()
+                self.wfile.write(
+                    b"Forbidden: shutdown requires the session token "
+                    b"from the browser's Shutdown link."
+                )
+                return
 
         elif sp == "":  # First request.
             type = "text/html"
@@ -958,7 +986,11 @@ def get_static_upper_page(with_shutdown):
 </html>
 """
     if with_shutdown:
-        shutdown_link = '<a href="SHUTDOWN THE SERVER">Shutdown</a>'
+        # Carry the per-process token so the shutdown route can tell this
+        # in-app click apart from a forged cross-site request (CWE-352).
+        shutdown_link = (
+            '<a href="SHUTDOWN THE SERVER?token=%s">Shutdown</a>' % _shutdown_token
+        )
     else:
         shutdown_link = ""
 

--- a/nltk/app/wordnet_app.py
+++ b/nltk/app/wordnet_app.py
@@ -90,11 +90,11 @@ class MyServerHandler(BaseHTTPRequestHandler):
         self.send_head()
 
     def _shutdown_authorized(self):
-        """True only for a same-session shutdown carrying the secret token.
+        """True only for a shutdown request carrying the per-process token.
 
-        The token is generated per process and embedded only in the browser's
-        own Shutdown link, so a cross-site page cannot supply it; this blocks
-        CSRF-driven shutdown (CWE-352).
+        The token is generated once per server process and embedded only in the
+        browser's own Shutdown link, so a cross-site page cannot supply it; this
+        blocks CSRF-driven shutdown (CWE-352).
         """
         token = parse_qs(self.path.partition("?")[2]).get("token", [""])[0]
         return bool(_shutdown_token) and hmac.compare_digest(token, _shutdown_token)
@@ -115,7 +115,7 @@ class MyServerHandler(BaseHTTPRequestHandler):
                 self.send_header("Content-type", "text/plain")
                 self.end_headers()
                 self.wfile.write(
-                    b"Forbidden: shutdown requires the session token "
+                    b"Forbidden: shutdown requires the per-process token "
                     b"from the browser's Shutdown link."
                 )
                 return


### PR DESCRIPTION
# Fix CSRF shutdown of the WordNet Browser server (CWE-352 / CWE-306)

## Description

The WordNet Browser starts an HTTP server that, in its default mode, terminates
the whole process (`os._exit(0)`) when it receives a **GET** to the shutdown
route `/SHUTDOWN THE SERVER`. The handler validates no Origin, Referer, Host, or
CSRF token, and the shutdown is a state-changing action reachable with a *simple*
GET:

```python
# nltk/app/wordnet_app.py  (before)
if unquote_plus(sp) == "SHUTDOWN THE SERVER":
    if server_mode:
        ...
    else:
        print("Server shutting down!")
        os._exit(0)            # <- fired by any cross-site GET
```

As a result, **any web page the user visits while the WordNet Browser is running
can shut the server down** — a cross-site request forgery denial of service
(`<img src="http://localhost:8000/SHUTDOWN THE SERVER">` is enough).

This is the residual half of a previously reported unauthenticated remote
shutdown. That report was addressed by binding the socket to `127.0.0.1`, which
stops a *remote host* from connecting. But the loopback server is still reachable
from the victim's own browser, so the unauthenticated shutdown survives via CSRF.

## The fix

Gate the shutdown on a **per-process secret token** that is embedded only in the
browser's own "Shutdown" link, so a cross-site page — which cannot read that link
under the Same-Origin Policy — cannot forge a valid shutdown request:

```python
_shutdown_token = secrets.token_urlsafe(32)   # generated per process
```

```python
def _shutdown_authorized(self):
    token = parse_qs(self.path.partition("?")[2]).get("token", [""])[0]
    return bool(_shutdown_token) and hmac.compare_digest(token, _shutdown_token)
```

```python
if unquote_plus(sp.partition("?")[0]) == "SHUTDOWN THE SERVER":
    if server_mode:
        ...                                   # unchanged (SIGTERM message)
    elif self._shutdown_authorized():
        print("Server shutting down!")
        os._exit(0)
    else:
        self.send_response(403)               # refuse forged / token-less GET
        ...
        return
```

The legitimate in-app link now carries the token:

```python
shutdown_link = '<a href="SHUTDOWN THE SERVER?token=%s">Shutdown</a>' % _shutdown_token
```

Why this is the right defense:

- **Token, not header checks.** A simple `<img>`/`fetch(no-cors)` GET may carry
  no `Origin` and a suppressible `Referer`, so header inspection alone is
  unreliable. An unguessable per-process token (256 bits) is deterministic and
  cannot be supplied by an attacker who cannot read the in-app page.
- **Constant-time compare** (`hmac.compare_digest`) avoids a timing oracle on the
  token.
- **Fail-closed:** if the token is somehow unset the route returns 403 rather
  than shutting down.
- The loopback bind (prior fix) still blocks remote access (CWE-306); this closes
  the browser-driven CSRF vector (CWE-352).

## Behaviour (verified end to end)

| Request | Before | After |
|---------|--------|-------|
| forged GET `/SHUTDOWN THE SERVER` (no token, `Origin: evil`) | **kills server** | **403**, server survives |
| forged GET with a wrong/guessed token | **kills server** | **403**, server survives |
| in-app `Shutdown` link GET (`?token=<secret>`) | kills server | kills server (`exit 0`) |
| `server_mode` (headless `--server-mode`) | "killed with SIGTERM" msg | unchanged |

Confirmed with the reporter's PoC vector: a no-token cross-origin GET now returns
403 and the server keeps serving (`GET /` → 200), while the legitimate
token-bearing request still triggers a clean `os._exit(0)`.

## Testing

- `verify_csrf_fix.py` — forged no-token / wrong-token GETs → 403 and the server
  stays up; the in-app token link still shuts the process down with exit code 0.
- `import nltk.app.wordnet_app` — OK; no NLTK unit tests cover this module.
- `black==25.11.0`, `ruff==0.15.6`, `isort==6.1.0` (repo-pinned) — clean.
