### PR TITLE
fix(security): remove quadratic scan in VADER polarity_scores (CWE-407)

### DIFF
--- a/nltk/sentiment/vader.py
+++ b/nltk/sentiment/vader.py
@@ -368,9 +368,19 @@ class SentimentIntensityAnalyzer:
         )
         sentiments = []
         words_and_emoticons = sentitext.words_and_emoticons
+        # Precompute the first index of each token once, in O(n). The loop below
+        # previously called ``words_and_emoticons.index(item)`` on every
+        # iteration -- an O(n) scan per token, i.e. O(n^2) overall on text with
+        # many distinct tokens, a remote CPU DoS (CWE-407). ``list.index``
+        # returns the first matching position, so this mapping yields the exact
+        # same indices in linear time.
+        first_index = {}
+        for idx, token in enumerate(words_and_emoticons):
+            if token not in first_index:
+                first_index[token] = idx
         for item in words_and_emoticons:
             valence = 0
-            i = words_and_emoticons.index(item)
+            i = first_index[item]
             if (
                 i < len(words_and_emoticons) - 1
                 and item.lower() == "kind"


### PR DESCRIPTION
# Fix remote quadratic-time DoS in VADER sentiment scoring (CWE-407)

## Description

`SentimentIntensityAnalyzer.polarity_scores` is one of NLTK's most commonly
network-exposed functions — routinely applied to untrusted, user-supplied text
(comments, reviews, chat, tweets). Its core loop performed a linear index lookup
once per token over the token list, which is itself linear, giving **quadratic**
total time:

```python
# nltk/sentiment/vader.py (before)
words_and_emoticons = sentitext.words_and_emoticons
for item in words_and_emoticons:            # n iterations
    valence = 0
    i = words_and_emoticons.index(item)     # O(n) linear scan EVERY iteration
```

For the k-th distinct token, `list.index` scans k elements, so over n distinct
tokens the cost is `0 + 1 + ... + n = O(n²)`. The work is independent of the
lexicon, so it triggers on any text made of distinct tokens. A single request of
a few hundred kilobytes of distinct words pins a CPU core for many seconds; being
quadratic, slightly larger inputs run for minutes and wedge the worker — a fully
remote, unauthenticated denial of service.

## The fix

`list.index(item)` returns the **first** position equal to `item`. Precompute
that mapping once in O(n) and look it up in O(1), giving identical indices in
linear total time:

```python
first_index = {}
for idx, token in enumerate(words_and_emoticons):
    if token not in first_index:
        first_index[token] = idx
for item in words_and_emoticons:
    valence = 0
    i = first_index[item]
    ...
```

This is deliberately **behaviour-preserving**: `i` keeps the exact
first-occurrence semantics of `list.index`, so every score is byte-for-byte
identical to the previous implementation (it intentionally does **not** switch to
`enumerate`, which would change `i` to the current position and alter scores for
text containing repeated tokens — and would break the score-pinned
`sentiment.doctest`).

## Behaviour preservation (verified)

- Output equivalence vs. the original `.index`-based loop over 9 texts that
  include **repeated tokens** (where first-occurrence vs current-position would
  diverge): **0 mismatches**.
- The real `vader_lexicon` doctest scores match exactly, e.g.
  `"VADER is smart, handsome, and funny."` →
  `compound: 0.8316, neg: 0.0, neu: 0.254, pos: 0.746` (and every other sentence
  that runs offline).

## Performance (distinct-token text)

| n tokens | Before | After | speedup |
|----------|--------|-------|---------|
| 8,000  | 0.257 s | 0.045 s | ×6 |
| 16,000 | 0.954 s | 0.139 s | ×7 |
| 32,000 | 3.787 s | 0.230 s | ×16 |
| 64,000 | 14.094 s | 0.577 s | ×24 |

The before column quadruples per doubling (O(n²)); the speedup grows with input
size, confirming the quadratic term is removed.

## Testing

- `verify_vader_fix.py` — equivalence (0 mismatches incl. repeated tokens) and
  before/after scaling.
- `poc_vader_quadratic_dos.py` — the original reproducer.
- Real `vader_lexicon` doctest scores unchanged.
- `black==25.11.0` and `ruff==0.15.6` (repo-pinned) — clean.
