### PR TITLE
fix(security): route custom_distance through the pathsec sentinel (CWE-22)

### DIFF
--- a/nltk/metrics/distance.py
+++ b/nltk/metrics/distance.py
@@ -22,6 +22,8 @@ As metrics, they must satisfy the following three requirements:
 import operator
 import warnings
 
+from nltk.pathsec import open as _secure_open
+
 
 def _edit_dist_init(len1, len2):
     lev = []
@@ -294,7 +296,10 @@ def fractional_presence(label):
 
 def custom_distance(file):
     data = {}
-    with open(file) as infile:
+    # Route through the pathsec sentinel so the read honours the file-access
+    # sandbox (allowed data roots, symlink resolution) instead of the builtin
+    # open, which bypasses it and can read arbitrary local files (CWE-22).
+    with _secure_open(file) as infile:
         for l in infile:
             labelA, labelB, dist = l.strip().split("\t")
             labelA = frozenset([labelA])

--- a/nltk/test/unit/test_distance.py
+++ b/nltk/test/unit/test_distance.py
@@ -2,7 +2,9 @@ from typing import Tuple
 
 import pytest
 
+from nltk import pathsec
 from nltk.metrics.distance import (
+    custom_distance,
     edit_distance,
     edit_distance_align,
     jaro_similarity,
@@ -391,3 +393,29 @@ class TestEditDistanceAlign:
                 (1, 0),
                 (0, 1),
             ], f"Invalid step from {(i1,j1)} to {(i2,j2)}"
+
+
+class TestCustomDistanceSandbox:
+    def test_enforces_pathsec_sandbox(self, tmp_path, monkeypatch):
+        """``custom_distance`` must read through the pathsec sandbox (CWE-22).
+
+        Regression test ensuring it does not fall back to the builtin ``open``:
+        under ``ENFORCE`` a path outside the allowed roots is rejected, while an
+        in-root file still loads into a working distance callable.
+        """
+        allowed = tmp_path / "data"
+        allowed.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        monkeypatch.setattr(pathsec, "ENFORCE", True)
+        monkeypatch.setattr(pathsec, "_get_allowed_roots", lambda: {allowed.resolve()})
+
+        out_tsv = outside / "d.tsv"
+        out_tsv.write_text("a\tb\t0.5\n", encoding="utf-8")
+        with pytest.raises((PermissionError, ValueError)):
+            custom_distance(str(out_tsv))
+
+        in_tsv = allowed / "d.tsv"
+        in_tsv.write_text("a\tb\t0.5\n", encoding="utf-8")
+        dist = custom_distance(str(in_tsv))
+        assert dist(frozenset(["a"]), frozenset(["b"])) == 0.5


### PR DESCRIPTION
# Fix pathsec sandbox-bypass file read in `custom_distance` (CWE-22)

## Description

`nltk.metrics.distance.custom_distance(file)` opens a caller-supplied filename
with the builtin `open()` instead of routing through NLTK's centralized
file-access sentinel (`nltk.pathsec.open`):

```python
# nltk/metrics/distance.py  (before)
def custom_distance(file):
    data = {}
    with open(file) as infile:          # builtin open, no pathsec containment
        ...
```

Because it bypasses the library's centralized I/O boundary, it neutralizes the
file-access enforcement policy. Under `pathsec.ENFORCE = True` (the NLTK 3.10
default) every NLTK-mediated read is meant to stay inside the designated data
roots; `custom_distance` escapes that and reads arbitrary local files the process
can access. This is the same class as PR #3626 (`nltk.sem.util.read_sents`).

## The fix

Open through the sentinel, exactly like the rest of the resource layer
(`from nltk.pathsec import open as _secure_open`, the same idiom used in
`nltk/data.py`, `nltk/util.py`, `nltk/corpus/reader/util.py`):

```python
def custom_distance(file):
    data = {}
    with _secure_open(file) as infile:
        ...
```

`_secure_open` runs `validate_path` first — resolving symlinks and checking the
path against the allowed roots — and raises `PermissionError` under `ENFORCE`
before any bytes are read. The text-mode default (`mode="r"`) matches the
previous `open(file)`, so legitimate in-sandbox reads are unchanged.

## Behaviour (verified)

| Access | Before | After |
|--------|--------|-------|
| `custom_distance` on a file **outside** the allowed roots | **reads (bypass)** | **blocked** (`PermissionError`) |
| `pathsec.open` on the same out-of-root file | blocked | blocked |
| `custom_distance` on an **in-sandbox** `.tsv` | reads | reads (unchanged; `dist(a,b)=0.5`) |

## Testing

- `verify_custom_distance_fix.py` / `poc_custom_distance_pathsec_bypass.py` —
  the out-of-root read is now blocked; an in-sandbox file still parses and the
  returned distance callable works.
- `pytest nltk/test/unit/test_distance.py` — 70 passed;
  `python -m doctest nltk/metrics/distance.py` — pass.
- `black==25.11.0`, `ruff==0.15.6`, `isort==6.1.0` (repo-pinned) — clean.
