### PR TITLE
fix(security): reject CWD-relative binaries in find_binary (CWE-426)

### DIFF
--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -660,9 +660,34 @@ def find_binary_iter(
     :param url: URL presented to user for download help.
     :param verbose: Whether or not to print path when a file is found.
     """
-    yield from find_file_iter(
+    safe_match = False
+    for path in find_file_iter(
         path_to_bin or name, env_vars, searchpath, binary_names, url, verbose
-    )
+    ):
+        # ``find_file_iter`` probes the current working directory (e.g.
+        # ``os.path.join(name, name)`` and the bare name) before the configured
+        # ``env_vars`` and ``searchpath``. Returning such a CWD-relative match
+        # for a bare binary name lets an attacker who can write into the working
+        # directory plant an executable that overrides the configured tool and
+        # the library's trusted install locations -- and, because the returned
+        # path contains a separator, it is then run relative to the CWD rather
+        # than looked up on PATH: arbitrary code execution (CWE-426 / CWE-427).
+        # When the caller did not supply an explicit ``path_to_bin``, only accept
+        # a binary resolved to a trusted absolute location (env var / searchpath
+        # / ``which``); all legitimate matches there are absolute.
+        if path_to_bin is None and not os.path.isabs(path):
+            continue
+        safe_match = True
+        yield path
+    if not safe_match:
+        # ``find_file_iter`` itself raises ``LookupError`` when nothing matches,
+        # so reaching here means it found only untrusted CWD-relative
+        # executables, which were rejected above.
+        raise LookupError(
+            f"NLTK found {name!r} only in the current working directory, which "
+            "is not a trusted location for executables. Install it on PATH or in "
+            "a configured location, or pass an explicit path_to_bin."
+        )
 
 
 def find_binary(

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -660,29 +660,29 @@ def find_binary_iter(
     :param url: URL presented to user for download help.
     :param verbose: Whether or not to print path when a file is found.
     """
+    # Searching by a *bare* tool name (no explicit ``path_to_bin`` and no
+    # directory component in ``name``) is the insecure case: ``find_file_iter``
+    # probes the current working directory for ``<name>/<name>`` and the bare
+    # name before the configured ``env_vars`` / ``searchpath``, so a planted
+    # ``./<name>/...`` could be returned and -- because it contains a separator
+    # -- run relative to the CWD rather than looked up on PATH: arbitrary code
+    # execution (CWE-426 / CWE-427). Only in that case do we refuse CWD-relative
+    # matches and accept solely a trusted absolute location (env var / searchpath
+    # / ``which``). An explicit path supplied via ``path_to_bin`` or via ``name``
+    # itself (e.g. ``tools/prover9``) is the caller's own choice and is honored
+    # as before. ``not path_to_bin`` (rather than ``is None``) so an empty-string
+    # path_to_bin -- which ``path_to_bin or name`` already falls back to ``name``
+    # for -- cannot bypass the check.
+    searching_bare_name = not path_to_bin and os.path.dirname(name) == ""
     safe_match = False
     for path in find_file_iter(
         path_to_bin or name, env_vars, searchpath, binary_names, url, verbose
     ):
-        # ``find_file_iter`` probes the current working directory (e.g.
-        # ``os.path.join(name, name)`` and the bare name) before the configured
-        # ``env_vars`` and ``searchpath``. Returning such a CWD-relative match
-        # for a bare binary name lets an attacker who can write into the working
-        # directory plant an executable that overrides the configured tool and
-        # the library's trusted install locations -- and, because the returned
-        # path contains a separator, it is then run relative to the CWD rather
-        # than looked up on PATH: arbitrary code execution (CWE-426 / CWE-427).
-        # When the caller did not supply an explicit ``path_to_bin``, only accept
-        # a binary resolved to a trusted absolute location (env var / searchpath
-        # / ``which``); all legitimate matches there are absolute. ``not
-        # path_to_bin`` (rather than ``is None``) so an empty-string path_to_bin
-        # -- which ``path_to_bin or name`` already falls back to ``name`` for --
-        # cannot bypass the gate.
-        if not path_to_bin and not os.path.isabs(path):
+        if searching_bare_name and not os.path.isabs(path):
             continue
         safe_match = True
         yield path
-    if not safe_match:
+    if searching_bare_name and not safe_match:
         # ``find_file_iter`` itself raises ``LookupError`` when nothing matches,
         # so reaching here means it found only untrusted CWD-relative
         # executables, which were rejected above.

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -674,8 +674,11 @@ def find_binary_iter(
         # than looked up on PATH: arbitrary code execution (CWE-426 / CWE-427).
         # When the caller did not supply an explicit ``path_to_bin``, only accept
         # a binary resolved to a trusted absolute location (env var / searchpath
-        # / ``which``); all legitimate matches there are absolute.
-        if path_to_bin is None and not os.path.isabs(path):
+        # / ``which``); all legitimate matches there are absolute. ``not
+        # path_to_bin`` (rather than ``is None``) so an empty-string path_to_bin
+        # -- which ``path_to_bin or name`` already falls back to ``name`` for --
+        # cannot bypass the gate.
+        if not path_to_bin and not os.path.isabs(path):
             continue
         safe_match = True
         yield path

--- a/nltk/test/unit/test_internals.py
+++ b/nltk/test/unit/test_internals.py
@@ -80,3 +80,16 @@ def test_find_binary_honors_explicit_relative_path_to_bin(tmp_path, monkeypatch)
         _NAME, path_to_bin=os.path.join("tools", _NAME), binary_names=[_NAME]
     )
     assert os.path.basename(result) == _NAME
+
+
+def test_find_binary_honors_explicit_relative_path_via_name(tmp_path, monkeypatch):
+    """A relative path with a directory component passed via ``name`` (the
+    documented "name or path" usage) is an explicit choice and is honored; only
+    a *bare* name triggers the CWD-relative refusal."""
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    _make_exec(cwd / "tools" / _NAME)
+    monkeypatch.chdir(cwd)
+
+    result = find_binary(os.path.join("tools", _NAME), binary_names=[_NAME])
+    assert os.path.basename(result) == _NAME

--- a/nltk/test/unit/test_internals.py
+++ b/nltk/test/unit/test_internals.py
@@ -1,0 +1,82 @@
+"""Tests for nltk.internals binary discovery (untrusted-search-path hardening).
+
+``find_binary`` must not return a current-working-directory-relative executable
+when the caller did not supply an explicit ``path_to_bin``: such a path would be
+run relative to the CWD, so a planted ``./<name>/<name>`` could hijack the tool
+(CWE-426 / CWE-427). A trusted absolute match (env var / searchpath / ``which``)
+or an explicit ``path_to_bin`` is still honored.
+"""
+
+import os
+import stat
+
+import pytest
+
+from nltk.internals import find_binary
+
+_NAME = "nltktestbin"  # unlikely to exist on PATH
+
+
+def _make_exec(path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("#!/bin/sh\ntrue\n")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC)
+
+
+def test_find_binary_ignores_cwd_relative_when_no_path_to_bin(tmp_path, monkeypatch):
+    """A planted ``./<name>/<name>`` must be ignored in favour of a trusted
+    (absolute) searchpath match when no ``path_to_bin`` is given."""
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    _make_exec(cwd / _NAME / _NAME)  # attacker-planted ./<name>/<name>
+    realdir = tmp_path / "realbin"
+    _make_exec(realdir / _NAME)  # trusted, absolute location
+    monkeypatch.chdir(cwd)
+
+    result = find_binary(_NAME, searchpath=[str(realdir)], binary_names=[_NAME])
+    assert os.path.isabs(result)
+    assert os.path.realpath(result) == os.path.realpath(str(realdir / _NAME))
+
+
+def test_find_binary_empty_path_to_bin_treated_as_none(tmp_path, monkeypatch):
+    """An empty-string ``path_to_bin`` must not bypass the CWD-relative refusal."""
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    _make_exec(cwd / _NAME / _NAME)
+    realdir = tmp_path / "realbin"
+    _make_exec(realdir / _NAME)
+    monkeypatch.chdir(cwd)
+
+    result = find_binary(
+        _NAME, path_to_bin="", searchpath=[str(realdir)], binary_names=[_NAME]
+    )
+    assert os.path.isabs(result)
+    assert os.path.realpath(result) == os.path.realpath(str(realdir / _NAME))
+
+
+def test_find_binary_refuses_cwd_only_executable(tmp_path, monkeypatch):
+    """If the only match is a CWD-relative executable, the tool is reported as
+    not found rather than executed."""
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    _make_exec(cwd / _NAME / _NAME)
+    monkeypatch.chdir(cwd)
+
+    with pytest.raises(LookupError):
+        find_binary(
+            _NAME, searchpath=[str(tmp_path / "nonexistent")], binary_names=[_NAME]
+        )
+
+
+def test_find_binary_honors_explicit_relative_path_to_bin(tmp_path, monkeypatch):
+    """An explicit ``path_to_bin`` (even relative) is the caller's own choice and
+    is still honored."""
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    _make_exec(cwd / "tools" / _NAME)
+    monkeypatch.chdir(cwd)
+
+    result = find_binary(
+        _NAME, path_to_bin=os.path.join("tools", _NAME), binary_names=[_NAME]
+    )
+    assert os.path.basename(result) == _NAME


### PR DESCRIPTION
# Fix untrusted-search-path RCE in Prover9/Mace binary discovery (CWE-426 / CWE-427)

## Description

The Prover9 and Mace interfaces locate their native executables (`prover9`,
`mace4`, `prooftrans`, `interpformat`) through the shared
`nltk.internals.find_binary` helper, with no explicit binary path in the default
flow:

```python
# nltk/inference/prover9.py  Prover9Parent._find_binary
return nltk.internals.find_binary(
    name,                              # bare relative tool name, e.g. "prover9"
    searchpath=binary_locations,       # /usr/bin/prover9, ... (trusted, absolute)
    env_vars=["PROVER9"],
    binary_names=[name, name + ".exe"],
)
```

`find_binary` → `find_file_iter` resolves each relative alternative against the
**current working directory first**, before the configured `env_vars` and the
trusted `searchpath`:

```python
# nltk/internals.py  find_file_iter (first block)
for alternative in file_names:                       # ["prover9", "prover9", ...]
    path_to_file = os.path.join(filename, alternative)   # "prover9/prover9" (CWD!)
    if os.path.isfile(path_to_file): yield path_to_file  # before env/searchpath
    if os.path.isfile(alternative):  yield alternative   # "prover9" (CWD!)
```

`find_binary` returns the **first** match, so an attacker who writes a directory
`./prover9/` containing an executable `./prover9/prover9` into the working
directory makes `os.path.join("prover9","prover9")` → `"prover9/prover9"` be
returned **in preference to both** the administrator-configured `PROVER9`
environment variable **and** the trusted absolute install locations the library
hard-codes. Because the returned path contains a separator, `subprocess.Popen`
runs it relative to the CWD (a name with a separator is not looked up on `PATH`),
so the attacker's executable runs in place of the real prover the next time the
application proves a goal or builds a model — arbitrary native code execution.

A writable working directory (web-app working dirs, pipeline scratch dirs,
upload-staging, shared multi-user dirs) is a far weaker precondition than
overwriting an installed binary, and this overrides correctly configured tooling
— which is what makes it a library search-path flaw rather than a deployment
mistake. It affects every `find_binary` caller (Prover9/Mace, Boxer/C&C, megam,
tadm, `dot`).

## The fix

`find_file_iter`'s current-working-directory probe is a legitimate convenience
for **data files** (`find_file`, e.g. a model in the working directory) but must
never select an **executable** by a bare name. So the fix is scoped to
`find_binary_iter`: in the default flow (no explicit `path_to_bin`), reject any
candidate that is not an absolute path.

```python
# nltk/internals.py  find_binary_iter
safe_match = False
for path in find_file_iter(path_to_bin or name, env_vars, searchpath, binary_names, url, verbose):
    if path_to_bin is None and not os.path.isabs(path):
        continue        # drop CWD-relative executables (CWE-426/427)
    safe_match = True
    yield path
if not safe_match:
    raise LookupError(... "found only in the current working directory ...")
```

Why this is correct and minimal:

- **Every legitimate binary match is already absolute**: the `env_vars`,
  `searchpath` (the prover's hard-coded `/usr/...` locations) and POSIX `which`
  blocks all yield absolute paths. Only the CWD "no-magic" block yields relative
  paths (`prover9/prover9`, `prover9`). Dropping non-absolute results in the
  default flow removes exactly the hijack and nothing else.
- **Explicit `path_to_bin` is untouched** — `config_prover9(binary_location)`
  passes `path_to_bin`, so an operator-supplied path (even relative) is still
  honoured.
- **`find_file` / `find_dir` are untouched**, so model/data-file discovery in the
  working directory keeps working (reading a data file is not code execution).
- If only a CWD-relative executable exists (nothing trusted), the tool is
  reported as not found rather than executed.

## Behaviour (verified)

| Scenario | Before | After |
|----------|--------|-------|
| `_find_binary("prover9")` with `PROVER9` set + planted `./prover9/prover9` | returns `prover9/prover9` (**hijacked, RCE**) | returns the trusted `$PROVER9/prover9` (absolute) |
| only `./prover9/prover9` planted, tool not installed | returns `prover9/prover9` (**RCE**) | `LookupError` (refused) |
| `config_prover9("/abs/path")` (explicit `path_to_bin`) | works | works (unchanged) |
| `find_binary("sh")` (on PATH via `which`) | `/bin/sh` | `/bin/sh` (unchanged) |
| `find_file("model.mco")` in CWD | found | found (unchanged) |

The report's PoC now selects the trusted location instead of the planted
`prover9/prover9`, so the end-to-end RCE no longer reproduces.

## Testing

- `verify_search_path_fix.py` — hijack defeated, CWD-only refused with
  `LookupError`, explicit `path_to_bin` honoured.
- `poc_prover9_cwd_search_path_rce.py` (the report PoC) — no longer reproduces.
- `find_binary("sh")` (PATH) and `find_file("model.mco")` (CWD) still resolve.
- `black==25.11.0` and `ruff==0.15.6` (repo-pinned) — clean.
