### PR TITLE
fix(security): stop symlink-following arbitrary deletion in Downloader stale-cleanup (CWE-59)

### DIFF
--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -723,6 +723,14 @@ class Downloader:
                 pass
 
         def _safe_rmtree(path):
+            # Never follow a symlinked directory while cleaning up: os.walk
+            # descends into a symlinked top regardless of ``followlinks``, so a
+            # pre-existing symlink at ``path`` (e.g. a planted unzip dir) would
+            # cause recursive deletion of the link's target *outside* the
+            # download directory (CWE-59 / CWE-22). Remove the link itself.
+            if os.path.islink(path):
+                _safe_remove(path)
+                return
             if not os.path.isdir(path):
                 return
             for root, dirs, files in os.walk(path, topdown=False):
@@ -732,8 +740,14 @@ class Downloader:
                     except OSError:
                         pass
                 for name in dirs:
+                    full = os.path.join(root, name)
+                    # os.walk (followlinks=False) lists but does not descend
+                    # symlinked subdirs; remove the link, never its target.
+                    if os.path.islink(full):
+                        _safe_remove(full)
+                        continue
                     try:
-                        os.rmdir(os.path.join(root, name))
+                        os.rmdir(full)
                     except OSError:
                         pass
             try:


### PR DESCRIPTION
# Fix symlink-following arbitrary deletion in Downloader stale-cleanup (CWE-59 / CWE-22)

## Description

This is a sibling of the validated NLTK Downloader arbitrary-file-write finding
(the lexical-check bypass, CVE-2026-12178): same root cause (the package-download
containment check is lexical and deliberately does not resolve symlinks), but a
different sink (a recursive deletion) on a different code path (stale cleanup),
which the write-path fix does not cover.

`_download_package` derives the unzip directory from the (lexically validated)
file path:

```python
filepath = os.path.join(download_dir, info.filename)   # lexically checked
unzipdir = filepath[:-4] if filepath.endswith(".zip") else None
```

`unzipdir` is `filepath` minus `.zip`, lexically inside `download_dir`, so it is
never separately validated or resolved against symlinks. When the package is
**stale**, the lock holder cleans up prior state and recursively removes the
unzip directory:

```python
if status == self.STALE:
    ...
    _safe_remove(filepath)
    if unzipdir:
        _safe_rmtree(unzipdir)
```

`_safe_rmtree` walks the directory with `os.walk(path, topdown=False)` and removes
everything. **`os.walk` follows a symlinked top** — the `followlinks=False`
default only governs sub-directories encountered during the walk, not the top,
which is always followed. So if `unzipdir` is a pre-existing **symlink pointing
outside `download_dir`**, the cleanup recursively deletes the symlink's *target*
— arbitrary file/directory deletion outside the download directory. (The sibling
single-file `_safe_remove` uses `os.remove`, which deletes the symlink itself, so
only the walk-based recursive remove is affected.)

The package becomes `STALE` when `filepath` exists with a size differing from the
index, so an attacker with write access to a shared download directory plants a
wrong-size `X.zip` and a symlink `X` → victim dir; the victim simply running the
normal `nltk.download('X')` then deletes the victim dir.

## The fix

Make `_safe_rmtree` never follow a symlink — remove the link itself rather than
recursing into its target:

```python
def _safe_rmtree(path):
    if os.path.islink(path):          # never follow a symlinked top (CWE-59)
        _safe_remove(path)            # os.remove deletes the link, not its target
        return
    if not os.path.isdir(path):
        return
    for root, dirs, files in os.walk(path, topdown=False):
        for name in files:
            ... os.remove ...
        for name in dirs:
            full = os.path.join(root, name)
            if os.path.islink(full):  # os.walk lists but doesn't descend these
                _safe_remove(full)    # remove the link, never its target
                continue
            ... os.rmdir ...
    ... os.rmdir(path) ...
```

- The top-level `os.path.islink` check closes the actual deletion primitive: a
  symlinked `unzipdir` is unlinked, never walked, so the target is untouched.
- The per-subdir `islink` branch is defence-in-depth (and makes cleanup
  complete): `os.walk` doesn't descend symlinked subdirs, and `os.rmdir` on a
  symlink fails anyway, so their targets were never at risk, but they are now
  removed as links instead of left behind.
- `os.remove`/`os.rmdir` on regular files/dirs are unchanged, so legitimate
  cleanup of a real prior extraction still fully removes it.

## Behaviour (verified)

| `unzipdir` | Before | After |
|------------|--------|-------|
| symlink → outside dir (planted) | **recursively deletes the target** | unlinks the symlink; target untouched |
| real directory with nested files (legit prior extraction) | removed | removed (unchanged) |
| nonexistent | no-op | no-op |

The report PoC, which deletes a victim directory through the planted symlink,
now reports `UNCONFIRMED` — the victim's files all survive and only the planted
symlink is removed.

## Testing

- `poc_downloader_rmtree_symlink_delete.py` (the report PoC) — victim data
  survives; only the symlink is removed.
- `verify_rmtree_fix.py` — a real stale `unzipdir` with nested files is still
  fully removed by the stale-cleanup path.
- `pytest nltk/test/unit/test_downloader_atomic.py` — passes.
- `black==25.11.0` and `ruff==0.15.6` (repo-pinned) — clean.
