### PR TITLE
fix(security): block IPv6 transition-embedded internal IPv4 in SSRF filter (NAT64 bypass, CWE-918)

### DIFF
--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -207,6 +207,40 @@ def _resolve_hostname(hostname):
         return []
 
 
+# IPv6->IPv4 transition prefixes that have no dedicated stdlib accessor.
+_NAT64_WELL_KNOWN = ipaddress.ip_network("64:ff9b::/96")
+_IPV4_COMPATIBLE = ipaddress.ip_network("::/96")
+
+
+def _embedded_ipv4(ip):
+    """The embedded IPv4 for IPv6 forms that *are* an IPv4 address, else None.
+
+    Covers IPv4-mapped (``::ffff:0:0/96``), IPv4-compatible (``::/96``) and the
+    NAT64 well-known prefix (``64:ff9b::/96``). For these the IPv6 wrapper has no
+    independent routable meaning, so the embedded IPv4 is what gets reached.
+    """
+    if not isinstance(ip, ipaddress.IPv6Address):
+        return None
+    mapped = ip.ipv4_mapped
+    if mapped is not None:
+        return mapped
+    if ip in _NAT64_WELL_KNOWN or ip in _IPV4_COMPATIBLE:
+        return ipaddress.IPv4Address(ip.packed[-4:])
+    return None
+
+
+def _tunneled_ipv4s(ip):
+    """IPv4 addresses tunneled by routable IPv6 wrappers (6to4 / Teredo)."""
+    if not isinstance(ip, ipaddress.IPv6Address):
+        return
+    sixtofour = ip.sixtofour
+    if sixtofour is not None:
+        yield sixtofour
+    teredo = ip.teredo
+    if teredo is not None:
+        yield from teredo  # (Teredo server, Teredo client)
+
+
 def _ip_is_forbidden(ip):
     """Return True if the SSRF filter must refuse to connect to ``ip``.
 
@@ -218,15 +252,20 @@ def _ip_is_forbidden(ip):
     superset of it. Multicast is still rejected explicitly because some CPython
     versions classify multicast addresses as ``is_global``.
 
-    IPv4-mapped IPv6 addresses (e.g. ``::ffff:127.0.0.1``) are evaluated as their
-    embedded IPv4 address: the stdlib's ``is_*`` classification of mapped
-    addresses is version dependent and has not always reflected the embedded
-    address, so the mapped form could otherwise smuggle a forbidden IPv4 past the
-    check.
+    IPv6 addresses that embed an IPv4 address are evaluated by that embedded IPv4,
+    not by the wrapper: the stdlib classifies the wrappers (IPv4-mapped,
+    IPv4-compatible, NAT64 ``64:ff9b::/96``, 6to4 ``2002::/16``, Teredo
+    ``2001::/32``) as globally routable, so a forbidden internal IPv4 (loopback,
+    the link-local cloud-metadata address, ...) could otherwise be smuggled past
+    the check and then routed to that IPv4 by a NAT64/6to4/Teredo gateway
+    (CWE-918). This extends the previous IPv4-mapped-only unwrap.
     """
-    mapped = getattr(ip, "ipv4_mapped", None)
-    if mapped is not None:
-        ip = mapped
+    embedded = _embedded_ipv4(ip)
+    if embedded is not None:
+        ip = embedded
+    for tunneled in _tunneled_ipv4s(ip):
+        if tunneled.is_multicast or not tunneled.is_global:
+            return True
     return ip.is_multicast or not ip.is_global
 
 

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -255,7 +255,7 @@ def _ip_is_forbidden(ip):
     IPv6 addresses that embed an IPv4 address are evaluated by that embedded IPv4,
     not by the wrapper: the stdlib classifies the wrappers (IPv4-mapped,
     IPv4-compatible, NAT64 ``64:ff9b::/96``, 6to4 ``2002::/16``, Teredo
-    ``2001::/32``) as globally routable, so a forbidden internal IPv4 (loopback,
+    ``2001:0::/32``) as globally routable, so a forbidden internal IPv4 (loopback,
     the link-local cloud-metadata address, ...) could otherwise be smuggled past
     the check and then routed to that IPv4 by a NAT64/6to4/Teredo gateway
     (CWE-918). This extends the previous IPv4-mapped-only unwrap.

--- a/nltk/test/unit/test_pathsec.py
+++ b/nltk/test/unit/test_pathsec.py
@@ -1,5 +1,6 @@
 import builtins
 import io
+import ipaddress
 import os
 import socket
 import urllib.request
@@ -73,6 +74,57 @@ def test_ssrf_ip_obfuscation():
             pass
         else:
             pytest.fail(f"Unexpected network failure: {e}")
+
+
+@pytest.mark.parametrize(
+    "addr",
+    [
+        # direct internal IPv4
+        "169.254.169.254",
+        "127.0.0.1",
+        # IPv4-mapped IPv6
+        "::ffff:169.254.169.254",
+        "::ffff:127.0.0.1",
+        # NAT64 well-known prefix 64:ff9b::/96 embedding an internal IPv4
+        "64:ff9b::a9fe:a9fe",  # -> 169.254.169.254
+        "64:ff9b::7f00:1",  # -> 127.0.0.1
+        # IPv4-compatible ::/96
+        "::a9fe:a9fe",  # -> 169.254.169.254
+        "::7f00:1",  # -> 127.0.0.1
+        # 6to4 2002::/16 and Teredo 2001:0::/32 embedding an internal IPv4
+        "2002:a9fe:a9fe::",  # 6to4 of 169.254.169.254
+        "2001:0:0:0:0:0:a9fe:a9fe",  # Teredo with internal client
+        # plain non-global IPv6
+        "::1",
+        "fe80::1",
+        "fc00::1",
+        "::",
+    ],
+)
+def test_ip_filter_forbids_transition_embedded_internal(addr):
+    """Internal IPv4 embedded in any IPv6->IPv4 transition form must be refused.
+
+    Regression for the NAT64 / IPv4-compatible / 6to4 / Teredo SSRF bypass
+    (CWE-918): the stdlib marks these wrappers globally routable, so the embedded
+    IPv4 must be inspected.
+    """
+    assert pathsec._ip_is_forbidden(ipaddress.ip_address(addr)) is True
+
+
+@pytest.mark.parametrize(
+    "addr",
+    [
+        "8.8.8.8",
+        "1.1.1.1",
+        "::ffff:8.8.8.8",  # IPv4-mapped public
+        "64:ff9b::808:808",  # NAT64 of the public 8.8.8.8
+        "2606:4700:4700::1111",  # public IPv6 (Cloudflare)
+        "2001:4860:4860::8888",  # public IPv6 (Google)
+    ],
+)
+def test_ip_filter_allows_global(addr):
+    """Genuinely globally-routable addresses (incl. NAT64-of-public) must pass."""
+    assert pathsec._ip_is_forbidden(ipaddress.ip_address(addr)) is False
 
 
 # --- PATH TRAVERSAL TESTS ---


### PR DESCRIPTION
# Fix NAT64 / IPv4-transition SSRF filter bypass in `nltk.pathsec` (CWE-918)

## Description

This is an incomplete-fix sibling of the accepted DNS-rebinding SSRF finding.
That fix pinned the validated IP at connect time and, in the address predicate
`_ip_is_forbidden`, unwrapped IPv4-**mapped** IPv6 (`::ffff:a.b.c.d`) so the
embedded IPv4 is classified rather than the wrapper. But it unwraps **only** the
mapped form. Other IPv6→IPv4 transition embeddings are classified `is_global` by
the standard library, so they pass the predicate at both the pre-check and the
connect-time pin:

```python
64:ff9b::a9fe:a9fe   # NAT64 of 169.254.169.254 (cloud metadata!)
64:ff9b::7f00:1      # NAT64 of 127.0.0.1        (loopback)
::a9fe:a9fe          # IPv4-compatible 169.254.169.254
::7f00:1             # IPv4-compatible 127.0.0.1
```

The NAT64 well-known prefix (`64:ff9b::/96`) and the IPv4-compatible prefix
(`::/96`) embed an internal IPv4, but the stdlib marks those ranges global and
the predicate only unwrapped the mapped form, so the embedded internal IPv4 was
never examined and the address was allowed. In any network with a NAT64 gateway
(the standard deployment of IPv6-only networks, mobile carriers, cloud IPv6-only
subnets), a packet to `64:ff9b::a9fe:a9fe` is translated to `169.254.169.254`, so
allowing it is a full-response SSRF to the cloud instance metadata service
(credential theft) that defeats `pathsec.ENFORCE = True`. Unlike the original, no
DNS control is required — a literal IPv6 URL is enough.

## The fix

Generalise `_ip_is_forbidden` to evaluate the IPv4 embedded in **every** IPv6→IPv4
transition form, not just the mapped one:

- **Address-equivalent forms** (IPv4-mapped `::ffff:0:0/96`, IPv4-compatible
  `::/96`, NAT64 `64:ff9b::/96`) — the IPv6 wrapper has no independent routable
  meaning, so the address is classified **by its embedded IPv4** (extends the
  previous mapped-only unwrap).
- **Routable tunnelling wrappers** (6to4 `2002::/16`, Teredo `2001::/32`, via the
  stdlib `sixtofour` / `teredo` accessors) — these are real IPv6 addresses that
  also tunnel to an embedded IPv4, so the address is forbidden if **either** the
  wrapper or any embedded IPv4 is non-global. This makes the check independent of
  stdlib-version differences in how those wrappers are classified.

```python
def _ip_is_forbidden(ip):
    embedded = _embedded_ipv4(ip)          # mapped / compatible / NAT64
    if embedded is not None:
        ip = embedded
    for tunneled in _tunneled_ipv4s(ip):   # 6to4 / Teredo
        if tunneled.is_multicast or not tunneled.is_global:
            return True
    return ip.is_multicast or not ip.is_global
```

Because the check is centralized, this closes the bypass at both the
`validate_network_url` pre-check and the `_resolve_and_validate_host`
connect-time pin.

## Behaviour (verified)

| Address | Before | After |
|---------|--------|-------|
| `64:ff9b::a9fe:a9fe` (NAT64 → 169.254.169.254) | **allowed (SSRF)** | forbidden |
| `64:ff9b::7f00:1` (NAT64 → 127.0.0.1) | **allowed** | forbidden |
| `::a9fe:a9fe` / `::7f00:1` (IPv4-compatible) | **allowed** | forbidden |
| `2002:a9fe:a9fe::` / `2001::a9fe:a9fe` (6to4 / Teredo internal) | blocked* | forbidden |
| `64:ff9b::808:808` (NAT64 → 8.8.8.8, public embedded) | allowed | allowed |
| `8.8.8.8`, `::ffff:8.8.8.8`, `2606:4700:4700::1111`, `2001:4860:4860::8888` | allowed | allowed |
| `::ffff:127.0.0.1`, `::1`, `fe80::1`, `fc00::1`, `::`, `10.0.0.5` | forbidden | forbidden |

\* 6to4/Teredo wrappers are already `is_global == False` on the current stdlib, so
they were blocked there too; the added unwrap makes that version-independent and
catches a non-global IPv4 embedded under a wrapper a future stdlib might mark
global. No genuinely-global IPv4/IPv6 (including NAT64-of-public) is newly
blocked.

The PoC's NAT64-embedded metadata/loopback addresses are now rejected at both the
pre-check and the connect-time pin.

## Testing

- `verify_nat64_ssrf_fix.py` — all transition-embedded internal IPv4s forbidden;
  genuinely-global IPv4/IPv6 (incl. mapped-public and NAT64-of-public) allowed.
- `poc_nat64_ssrf_bypass.py` (the report PoC) — Part 1 now blocks at pre-check and
  connect-time.
- `pytest nltk/test/unit/test_pathsec.py` — 33 passed.
- `black==25.11.0` and `ruff==0.15.6` (repo-pinned) — clean.
