### PR TITLE
Fix CWE-88 JVM argument injection in java_options (CVE-2026-12841)

### DIFF
--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -32,14 +32,17 @@ _BLOCKED_JVM_FLAG_PREFIXES = (
     "-agentlib",
     "-agentpath",
     "-javaagent",
-    "-Xrunjdwp",
-    "-Xdebug",
-    "-Xnoagent",
+    "-xrunjdwp",
+    "-xdebug",
+    "-xnoagent",
 )
 
 
 def _validate_java_options(options):
-    """Raise ValueError if options contains flags that enable remote debugging or agent injection."""
+    """
+    Raise ValueError if options contains flags that enable remote
+    debugging or agent injection (CVE-2026-12841, CWE-88).
+    """
     for flag in options:
         if flag.lower().startswith(_BLOCKED_JVM_FLAG_PREFIXES):
             raise ValueError(
@@ -81,7 +84,7 @@ def config_java(bin=None, options=None, verbose=False):
             options = options.split()
         options = list(options)
         _validate_java_options(options)
-        _java_options = options
+        _java_options[:] = options
 
 
 def java(cmd, classpath=None, stdin=None, stdout=None, stderr=None, blocking=True):

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -26,30 +26,63 @@ from xml.etree import ElementTree
 _java_bin = None
 _java_options = []
 
-# Flags that load native or remote-debug agents — blocked to prevent
-# JVM argument injection (CVE-2026-12841, CWE-88).
-_BLOCKED_JVM_FLAG_PREFIXES = (
-    "-agentlib",
-    "-agentpath",
-    "-javaagent",
-    "-xrunjdwp",
-    "-xdebug",
-    "-xnoagent",
+# Allowlist of safe JVM tuning flags for NLTK's Java wrapper.
+# Anything not matching is rejected to prevent argument injection
+# (CVE-2026-12841, CWE-88).  An allowlist is used rather than a
+# denylist so that -jar, @argfile, and future dangerous flags are
+# blocked without needing to be enumerated explicitly.
+_SAFE_JVM_PREFIXES = (
+    "-xmx",      # max heap size:   -Xmx512m
+    "-xms",      # initial heap:    -Xms128m
+    "-xss",      # thread stack:    -Xss4m
+    "-xbatch",   # disable bg JIT
+    "-xint",     # interpret-only mode
+    "-xcomp",    # compile-only mode
+    "-xmixed",   # mixed mode (JVM default)
+    "-verbose",  # diagnostic output: -verbose:gc
+    "-xx:",      # advanced tuning:  -XX:+UseG1GC
 )
+
+_SAFE_JVM_EXACT = frozenset({"-server", "-client"})
 
 
 def _validate_java_options(options):
     """
-    Raise ValueError if options contains flags that enable remote
-    debugging or agent injection (CVE-2026-12841, CWE-88).
+    Raise ValueError if *options* contains JVM flags that can change
+    the executed program, load agents, or expand argument files.
+
+    Uses an allowlist of safe JVM memory/tuning flags that NLTK's Java
+    wrapper is known to need.  This is intentionally stricter than a
+    denylist so that -jar, @argfile, and future dangerous flags are
+    rejected without needing to be enumerated (CVE-2026-12841, CWE-88).
     """
     for flag in options:
-        if flag.lower().startswith(_BLOCKED_JVM_FLAG_PREFIXES):
+        n = flag.lower()
+
+        # @argfile references are expanded by the Java launcher before
+        # any other argument processing and can smuggle blocked flags.
+        if n.startswith("@"):
             raise ValueError(
-                f"java_options contains a disallowed JVM flag: {flag!r}. "
-                "Flags that load native agents or enable remote debugging are "
-                "not permitted (see CVE-2026-12841)."
+                f"java_options contains a disallowed Java argument file "
+                f"reference: {flag!r} (CVE-2026-12841, CWE-88)."
             )
+
+        # Allow -Dkey=value system properties. The prefix is always
+        # uppercase -D in valid usage; check the original flag.
+        if flag.startswith("-D") and "=" in flag:
+            continue
+
+        if n in _SAFE_JVM_EXACT:
+            continue
+
+        if n.startswith(_SAFE_JVM_PREFIXES):
+            continue
+
+        raise ValueError(
+            f"java_options contains a disallowed JVM/launcher flag: {flag!r}. "
+            "Only JVM memory-tuning and safe runtime flags are permitted "
+            "(CVE-2026-12841, CWE-88)."
+        )
 
 
 # [xx] add classpath option to config_java?

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -26,6 +26,28 @@ from xml.etree import ElementTree
 _java_bin = None
 _java_options = []
 
+# Flags that load native or remote-debug agents — blocked to prevent
+# JVM argument injection (CVE-2026-12841, CWE-88).
+_BLOCKED_JVM_FLAG_PREFIXES = (
+    "-agentlib",
+    "-agentpath",
+    "-javaagent",
+    "-Xrunjdwp",
+    "-Xdebug",
+    "-Xnoagent",
+)
+
+
+def _validate_java_options(options):
+    """Raise ValueError if options contains flags that enable remote debugging or agent injection."""
+    for flag in options:
+        if flag.lower().startswith(_BLOCKED_JVM_FLAG_PREFIXES):
+            raise ValueError(
+                f"java_options contains a disallowed JVM flag: {flag!r}. "
+                "Flags that load native agents or enable remote debugging are "
+                "not permitted (see CVE-2026-12841)."
+            )
+
 
 # [xx] add classpath option to config_java?
 def config_java(bin=None, options=None, verbose=False):
@@ -57,7 +79,9 @@ def config_java(bin=None, options=None, verbose=False):
     if options is not None:
         if isinstance(options, str):
             options = options.split()
-        _java_options = list(options)
+        options = list(options)
+        _validate_java_options(options)
+        _java_options = options
 
 
 def java(cmd, classpath=None, stdin=None, stdout=None, stderr=None, blocking=True):

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -33,8 +33,11 @@ _java_options = []
 # blocked without needing to be enumerated explicitly.
 _SAFE_JVM_PREFIXES = (
     "-xmx",  # max heap size:   -Xmx512m
+    "-mx",  # max heap (legacy alias of -Xmx, used by Stanford/CoreNLP): -mx2g
     "-xms",  # initial heap:    -Xms128m
+    "-ms",  # initial heap (legacy alias of -Xms): -ms128m
     "-xss",  # thread stack:    -Xss4m
+    "-ss",  # thread stack (legacy alias of -Xss): -ss4m
     "-xbatch",  # disable bg JIT
     "-xint",  # interpret-only mode
     "-xcomp",  # compile-only mode

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -32,15 +32,15 @@ _java_options = []
 # denylist so that -jar, @argfile, and future dangerous flags are
 # blocked without needing to be enumerated explicitly.
 _SAFE_JVM_PREFIXES = (
-    "-xmx",      # max heap size:   -Xmx512m
-    "-xms",      # initial heap:    -Xms128m
-    "-xss",      # thread stack:    -Xss4m
-    "-xbatch",   # disable bg JIT
-    "-xint",     # interpret-only mode
-    "-xcomp",    # compile-only mode
-    "-xmixed",   # mixed mode (JVM default)
+    "-xmx",  # max heap size:   -Xmx512m
+    "-xms",  # initial heap:    -Xms128m
+    "-xss",  # thread stack:    -Xss4m
+    "-xbatch",  # disable bg JIT
+    "-xint",  # interpret-only mode
+    "-xcomp",  # compile-only mode
+    "-xmixed",  # mixed mode (JVM default)
     "-verbose",  # diagnostic output: -verbose:gc
-    "-xx:",      # advanced tuning:  -XX:+UseG1GC
+    "-xx:",  # advanced tuning:  -XX:+UseG1GC
 )
 
 _SAFE_JVM_EXACT = frozenset({"-server", "-client"})
@@ -200,7 +200,7 @@ def java(cmd, classpath=None, stdin=None, stdout=None, stderr=None, blocking=Tru
     p = subprocess.Popen(cmd, stdin=stdin, stdout=stdout, stderr=stderr)
     if not blocking:
         return p
-    (stdout, stderr) = p.communicate()
+    stdout, stderr = p.communicate()
 
     # Check the return code.
     if p.returncode != 0:

--- a/nltk/test/internals.doctest
+++ b/nltk/test/internals.doctest
@@ -159,3 +159,62 @@ Now test invalid scenarios
     Traceback (most recent call last):
     ...
     nltk.internals.ReadError: Expected close quote at 1
+
+=====================================================
+ _validate_java_options (CVE-2026-12841, CWE-88)
+=====================================================
+
+>>> from nltk.internals import _validate_java_options
+
+Safe JVM tuning flags are permitted (no exception raised):
+
+>>> _validate_java_options(["-Xmx512m"])
+>>> _validate_java_options(["-Xms128m"])
+>>> _validate_java_options(["-Xss4m"])
+>>> _validate_java_options(["-XX:+UseG1GC"])
+>>> _validate_java_options(["-verbose:gc"])
+>>> _validate_java_options(["-server"])
+>>> _validate_java_options(["-client"])
+>>> _validate_java_options(["-Dsome.property=value"])
+>>> _validate_java_options(["-Xmx1g", "-Dsome.key=val", "-server"])
+
+Agent-loading and JDWP flags are blocked:
+
+>>> _validate_java_options(["-agentlib:jdwp=transport=dt_socket,server=y"])  # doctest: +ELLIPSIS
+Traceback (most recent call last):
+    ...
+ValueError: java_options contains a disallowed JVM/launcher flag: '-agentlib:jdwp=transport=dt_socket,server=y'...
+
+>>> _validate_java_options(["-agentpath:/tmp/agent.so"])  # doctest: +ELLIPSIS
+Traceback (most recent call last):
+    ...
+ValueError: java_options contains a disallowed JVM/launcher flag: '-agentpath:/tmp/agent.so'...
+
+>>> _validate_java_options(["-javaagent:/tmp/agent.jar"])  # doctest: +ELLIPSIS
+Traceback (most recent call last):
+    ...
+ValueError: java_options contains a disallowed JVM/launcher flag: '-javaagent:/tmp/agent.jar'...
+
+>>> _validate_java_options(["-Xrunjdwp:transport=dt_socket"])  # doctest: +ELLIPSIS
+Traceback (most recent call last):
+    ...
+ValueError: java_options contains a disallowed JVM/launcher flag: '-Xrunjdwp:transport=dt_socket'...
+
+-jar and @argfile bypasses are also blocked:
+
+>>> _validate_java_options(["-jar", "/tmp/evil.jar"])  # doctest: +ELLIPSIS
+Traceback (most recent call last):
+    ...
+ValueError: java_options contains a disallowed JVM/launcher flag: '-jar'...
+
+>>> _validate_java_options(["@evil.args"])  # doctest: +ELLIPSIS
+Traceback (most recent call last):
+    ...
+ValueError: java_options contains a disallowed Java argument file reference: '@evil.args'...
+
+Matching is case-insensitive:
+
+>>> _validate_java_options(["-AGENTLIB:jdwp=transport=dt_socket"])  # doctest: +ELLIPSIS
+Traceback (most recent call last):
+    ...
+ValueError: java_options contains a disallowed JVM/launcher flag: '-AGENTLIB:jdwp=transport=dt_socket'...

--- a/nltk/test/internals.doctest
+++ b/nltk/test/internals.doctest
@@ -171,6 +171,13 @@ Safe JVM tuning flags are permitted (no exception raised):
 >>> _validate_java_options(["-Xmx512m"])
 >>> _validate_java_options(["-Xms128m"])
 >>> _validate_java_options(["-Xss4m"])
+
+The legacy short aliases (-mx / -ms / -ss) that Stanford and CoreNLP
+wrappers pass are equivalent and also permitted:
+
+>>> _validate_java_options(["-mx2g"])
+>>> _validate_java_options(["-ms128m"])
+>>> _validate_java_options(["-ss4m"])
 >>> _validate_java_options(["-XX:+UseG1GC"])
 >>> _validate_java_options(["-verbose:gc"])
 >>> _validate_java_options(["-server"])


### PR DESCRIPTION
Add _validate_java_options() which blocks flags that load native agents or enable remote debugging (-agentlib, -agentpath, -javaagent, -Xrunjdwp, -Xdebug, -Xnoagent) from being passed to the JVM via the java_options parameter in config_java(), StanfordSegmenter, and GenericStanfordParser.

Reported by samrigby64 via huntr. CVE-2026-12841 assigned.