### PR TITLE
Fix EOF handling in IEERCorpusReader to prevent empty document yields

### DIFF
--- a/nltk/corpus/reader/ieer.py
+++ b/nltk/corpus/reader/ieer.py
@@ -22,7 +22,7 @@ APW_19980429, NYT_19980315, NYT_19980403, and NYT_19980407.
 """
 
 import nltk
-from nltk.corpus.reader.api import *
+from nltk.corpus.reader.api import CorpusReader, StreamBackedCorpusView, concat
 
 #: A dictionary whose keys are the names of documents in this corpus;
 #: and whose values are descriptions of those documents' contents.
@@ -40,6 +40,12 @@ documents = sorted(titles)
 
 
 class IEERDocument:
+    """
+    A class to represent a single document from the IEER corpus.
+    Attributes include the document text, document number, document type,
+    date/time, and headline.
+    """
+
     def __init__(self, text, docno=None, doctype=None, date_time=None, headline=""):
         self.text = text
         self.docno = docno
@@ -61,7 +67,9 @@ class IEERDocument:
 
 
 class IEERCorpusReader(CorpusReader):
-    """ """
+    """
+    Corpus reader for the Information Extraction and Entity Recognition (IEER) Corpus.
+    """
 
     def docs(self, fileids=None):
         return concat(
@@ -80,12 +88,7 @@ class IEERCorpusReader(CorpusReader):
         )
 
     def _read_parsed_block(self, stream):
-        # TODO: figure out while empty documents are being returned
-        return [
-            self._parse(doc)
-            for doc in self._read_block(stream)
-            if self._parse(doc).docno is not None
-        ]
+        return [self._parse(doc) for doc in self._read_block(stream)]
 
     def _parse(self, doc):
         val = nltk.chunk.ieerstr2tree(doc, root_label="DOCUMENT")
@@ -100,7 +103,7 @@ class IEERCorpusReader(CorpusReader):
         while True:
             line = stream.readline()
             if not line:
-                break
+                return []
             if line.strip() == "<DOC>":
                 break
         out.append(line)

--- a/nltk/test/unit/test_ieer.py
+++ b/nltk/test/unit/test_ieer.py
@@ -1,0 +1,17 @@
+import unittest
+
+from nltk.corpus import ieer
+
+
+class TestIEER(unittest.TestCase):
+    def test_parsed_docs(self):
+        docs = ieer.parsed_docs("APW_19980314")
+        self.assertEqual(len(docs), 23)
+        self.assertEqual(docs[0].docno, "APW19980314.0391")
+
+    def test_docs_does_not_contain_empty_strings(self):
+        docs = list(ieer.docs())
+        # The corpus has 94 valid documents in total
+        self.assertEqual(len(docs), 94)
+        # Ensure there are no trailing empty documents/strings resulting from EOF misbehavior
+        self.assertTrue(all(bool(doc.strip()) for doc in docs))


### PR DESCRIPTION
Resolves the TODO: `# TODO: figure out while empty documents are being returned` in `ieer.py`.

* **Bug:** Hitting EOF in `_read_block()` returned `[""]` instead of `[]`, resulting in `ieer.docs()` returning 6 empty documents (one at the end of each file).
* **Fix:** Updated `_read_block()` to return `[]` at EOF and simplified `_read_parsed_block()` to remove the redundant filter and duplicate parsing calls.
* **Testing:** Added a new unit test suite (`test_ieer.py`) to verify correct document counts (94) and check that no empty strings are returned.