### PR TITLE
fix(security): sparse Alignment index to stop unbounded-allocation DoS (CVE-2026-12837)

### DIFF
--- a/nltk/test/unit/translate/test_alignment.py
+++ b/nltk/test/unit/translate/test_alignment.py
@@ -13,6 +13,8 @@ to the dense allocation cannot OOM or hang the rest of the suite.
 import multiprocessing
 import queue
 
+import pytest
+
 from nltk.translate.api import Alignment
 
 
@@ -35,7 +37,20 @@ def test_getitem_and_range_preserved():
     assert sorted(a.invert()[2]) == [(2, 1), (2, 2)]
 
 
-_HUGE = 100_000_000
+def test_getitem_rejects_non_integer_keys():
+    # The sparse index has no contiguous range to slice; non-integer keys must
+    # raise rather than silently return [] (which would mask caller bugs).
+    a = Alignment([(0, 0), (0, 1), (1, 2)])
+    for bad in (slice(0, 2), "0", 1.0, (0, 1)):
+        with pytest.raises(TypeError):
+            a[bad]
+
+
+# A left index large enough to make a dense ``[[] for _ in range(_HUGE + 1)]``
+# regression unmistakable (the index would hold _HUGE + 1 keys instead of 2),
+# yet small enough that even if such a dense list were built it stays ~128 MB --
+# detected by the key-count assertion below without risking an OOM of the host.
+_HUGE = 2_000_000
 _TIMEOUT = 15
 
 

--- a/nltk/test/unit/translate/test_alignment.py
+++ b/nltk/test/unit/translate/test_alignment.py
@@ -1,0 +1,74 @@
+"""Regression tests for nltk.translate.Alignment.
+
+Covers the unbounded-allocation DoS (CWE-770; CVE-2026-12837): a tiny pair with a
+huge left index used to force a dense per-left-index list allocation, because the
+index was ``[[] for _ in range(self._len + 1)]``. The index is now sparse (a dict
+keyed by the left indices that occur). These tests confirm the index is sparse and
+that the public indexing / range behaviour is preserved.
+
+The allocation test runs in a spawned process with a hard timeout so a regression
+to the dense allocation cannot OOM or hang the rest of the suite.
+"""
+
+import multiprocessing
+import queue
+
+from nltk.translate.api import Alignment
+
+
+def test_index_is_sparse_not_dense():
+    a = Alignment([(0, 0), (0, 1), (1, 2), (2, 2)])
+    a.range()  # builds the index
+    assert isinstance(a._index, dict)
+    # keyed only by the left indices that occur, not range(_len + 1)
+    assert set(a._index) == {0, 1, 2}
+
+
+def test_getitem_and_range_preserved():
+    a = Alignment([(0, 0), (0, 1), (1, 2), (2, 2)])
+    assert sorted(a[0]) == [(0, 0), (0, 1)]
+    assert sorted(a[2]) == [(2, 2)]
+    assert a[5] == []  # a left index with no alignments
+    assert a.range() == [0, 1, 2]
+    assert a.range([0]) == [0, 1]
+    assert a.range([1, 2]) == [2]
+    assert sorted(a.invert()[2]) == [(2, 1), (2, 2)]
+
+
+_HUGE = 100_000_000
+_TIMEOUT = 15
+
+
+def _alloc_worker(result_q):
+    try:
+        a = Alignment.fromstring(f"0-0 {_HUGE}-1")
+        a.range()  # triggers _build_index
+        _ = a[0]
+        result_q.put(("ok", len(a._index)))
+    except BaseException as exc:  # surface to the parent process
+        result_q.put(("error", repr(exc)))
+
+
+def _run_in_process(target):
+    ctx = multiprocessing.get_context("spawn")
+    result_q = ctx.Queue()
+    proc = ctx.Process(target=target, args=(result_q,))
+    proc.start()
+    proc.join(_TIMEOUT)
+    if proc.is_alive():
+        proc.terminate()
+        proc.join()
+        return False, None, None
+    try:
+        status, payload = result_q.get_nowait()
+    except queue.Empty:
+        return True, "error", "worker produced no result"
+    return True, status, payload
+
+
+def test_huge_left_index_does_not_allocate():
+    """A tiny pair with a huge left index must not allocate a dense index."""
+    finished, status, value = _run_in_process(_alloc_worker)
+    assert finished, "Alignment allocated a dense index for a huge left index (DoS)"
+    assert status == "ok", f"worker raised: {value}"
+    assert value == 2, f"index must be sparse (2 keys), got {value}"

--- a/nltk/translate/api.py
+++ b/nltk/translate/api.py
@@ -210,11 +210,12 @@ class Alignment(frozenset):
 
     def __getitem__(self, key):
         """
-        Look up the alignments that map from a given index or slice.
+        Look up the alignments that map from a given (left) index.
+        Returns an empty list for an index that has no alignments.
         """
-        if not self._index:
+        if self._index is None:
             self._build_index()
-        return self._index.__getitem__(key)
+        return self._index.get(key, [])
 
     def invert(self):
         """
@@ -228,12 +229,12 @@ class Alignment(frozenset):
         If no positions are specified, compute the range of the entire mapping.
         """
         image = set()
-        if not self._index:
+        if self._index is None:
             self._build_index()
         if not positions:
-            positions = list(range(len(self._index)))
+            positions = self._index.keys()
         for p in positions:
-            image.update(f for _, f in self._index[p])
+            image.update(f for _, f in self._index.get(p, []))
         return sorted(image)
 
     def __repr__(self):
@@ -250,12 +251,20 @@ class Alignment(frozenset):
 
     def _build_index(self):
         """
-        Build a list self._index such that self._index[i] is a list
-        of the alignments originating from word i.
+        Build a sparse index mapping each left index ``i`` to the list of
+        alignments originating from word ``i``.
+
+        The index is keyed only by the left indices that actually occur, so its
+        size is bounded by the number of pairs rather than by the largest left
+        index (which is attacker-controlled in giza-format input). A dense
+        ``[[] for _ in range(self._len + 1)]`` list would instead let a single
+        tiny pair with a huge left index (e.g. ``"0-0 100000000-1"``) allocate
+        ~100M empty lists -- gigabytes of memory -- an unbounded-allocation DoS
+        (CWE-770; CVE-2026-12837).
         """
-        self._index = [[] for _ in range(self._len + 1)]
+        self._index = {}
         for p in self:
-            self._index[p[0]].append(p)
+            self._index.setdefault(p[0], []).append(p)
 
 
 def _giza2pair(pair_string):

--- a/nltk/translate/api.py
+++ b/nltk/translate/api.py
@@ -212,7 +212,16 @@ class Alignment(frozenset):
         """
         Look up the alignments that map from a given (left) index.
         Returns an empty list for an index that has no alignments.
+
+        Only integer indices are supported. Slicing and other non-integer
+        keys are rejected with ``TypeError`` rather than silently returning
+        ``[]`` -- the sparse index has no contiguous range to slice, so a
+        mistaken lookup should fail loudly instead of masking the bug.
         """
+        if not isinstance(key, int):
+            raise TypeError(
+                "Alignment indices must be integers, not %s" % type(key).__name__
+            )
         if self._index is None:
             self._build_index()
         return self._index.get(key, [])


### PR DESCRIPTION
# Fix unbounded-memory-allocation DoS in `Alignment` (CWE-770 / CVE-2026-12837)

## Description

`nltk.translate.Alignment` parses word-alignment strings in GIZA format. Each
`"i-j"` pair's left index `i` is converted with an unbounded `int()`, and the
**largest** left index is stored as `self._len`. When the alignment is first
indexed (`__getitem__`) or its range is computed (`range()`), `_build_index`
allocated a **dense** list with one entry per left index:

```python
# nltk/translate/api.py (before)
def _build_index(self):
    self._index = [[] for _ in range(self._len + 1)]   # one list per left index!
    for p in self:
        self._index[p[0]].append(p)
```

So a single tiny pair with a huge left index forces a multi-gigabyte allocation,
regardless of how few pairs the alignment actually contains — e.g.
`Alignment.fromstring("0-0 100000000-1")` (a ~12-byte field) followed by
`.range()` / `[0]` allocates ~100M empty lists. The amplification is tens of
millions of times the input size, so a single crafted pair from untrusted GIZA
input OOM-kills the worker. Validated as **CVE-2026-12837**.

## The fix

Make the index **sparse** — a dict keyed only by the left indices that actually
occur — so its size is bounded by the number of pairs, not by the (attacker-
controlled) largest index:

```python
def _build_index(self):
    self._index = {}
    for p in self:
        self._index.setdefault(p[0], []).append(p)
```

`__getitem__` and `range()` are updated to use the dict:

```python
def __getitem__(self, key):
    if self._index is None:
        self._build_index()
    return self._index.get(key, [])      # [] for a left index with no alignments

def range(self, positions=None):
    image = set()
    if self._index is None:
        self._build_index()
    if not positions:
        positions = self._index.keys()    # was range(len(self._index)) == 0..self._len
    for p in positions:
        image.update(f for _, f in self._index.get(p, []))
    return sorted(image)
```

Notes:
- The cache check is `self._index is None` (set in `__new__`) instead of `not
  self._index`, so an empty alignment's index is still built only once (the dense
  version was always truthy after building; an empty dict is not).
- `self._len` is still computed in `__new__` (it's O(pairs) and only stores an
  integer — it was never the source of the allocation), so it remains available
  for backward compatibility.
- `__getitem__` now returns `[]` for any absent left index (the dense list raised
  `IndexError` only beyond `self._len`); a sparse index has no fixed length, and
  "no alignments from this word → `[]`" is the natural, consistent behaviour.
  Slicing the index (`a[i:j]`) is no longer supported — re-introducing it would
  reintroduce the O(largest-index) allocation for a full slice — but no code,
  test or doctest in the tree uses it (the only `Alignment` access is integer
  indexing and `range()`).

## Behaviour preservation (verified)

| call | before | after |
|------|--------|-------|
| `a[0]` (docstring) | `[(0, 1), (0, 0)]` | `[(0, 1), (0, 0)]` |
| `a.invert()[2]` (docstring) | `[(2, 1), (2, 2)]` | `[(2, 1), (2, 2)]` |
| `a[5]` (left index with no alignments, `<= _len`) | `[]` | `[]` |
| `a.range()` | `[0, 1, 2]` | `[0, 1, 2]` |
| `a.range([0])`, `a.range([1, 2])` | `[0, 1]`, `[2]` | `[0, 1]`, `[2]` |
| `fromstring`, `invert`, `issubset`, `==` (frozenset ops) | unchanged | unchanged |

## Performance

| input | before | after |
|-------|--------|-------|
| `fromstring("0-0 100000000-1")` then `.range()`/`[0]` | ~100M lists, multi-GB RSS, OOM | 2-key dict, ~0 MB, <1 ms |

## Testing

- `nltk/test/unit/translate/test_alignment.py` (new): the index is sparse (dict
  keyed by occurring left indices); `__getitem__`/`range`/`invert` behaviour is
  preserved; and a huge left index does not allocate (the allocation test runs in
  a spawned process with a hard timeout so a regression can't OOM/hang the suite).
  The sparse-index and allocation tests fail against the pre-fix dense version.
- `python -m doctest nltk/translate/api.py` — the `Alignment` docstrings pass
  (the only failures are the `AlignedSent` examples that need the `comtrans`
  corpus download, which also fail on `develop`).
- `pytest nltk/test/unit/translate/` — passes (the 2 failures are missing-corpus
  `LookupError`s for BLEU/NIST, unrelated).
- `black==25.11.0` and `ruff==0.15.6` (repo-pinned) — clean.
