### PR TITLE
fix(security): bound Model.satisfy quantifier-nesting cost to stop combinatorial DoS (CVE-2026-12840)

### DIFF
--- a/nltk/sem/evaluate.py
+++ b/nltk/sem/evaluate.py
@@ -377,6 +377,46 @@ class Assignment(dict):
         return self
 
 
+def _max_binder_depth(parsed):
+    """
+    Greatest number of nested domain-quantifying binders along any path of
+    ``parsed`` (``all``/``exists``/``iota`` quantifiers and ``\\`` lambdas).
+
+    ``Model.satisfy`` iterates the whole domain once per such binder, so a
+    formula with depth *k* costs O(|domain| ** k); *k* is what bounds the
+    blow-up, and it comes entirely from the (untrusted) formula. Used by
+    ``Model._check_satisfy_cost`` to refuse a formula before the recursion
+    explodes (CWE-770; CVE-2026-12840).
+    """
+    if isinstance(
+        parsed,
+        (AllExpression, ExistsExpression, IotaExpression, LambdaExpression),
+    ):
+        return 1 + _max_binder_depth(parsed.term)
+    if isinstance(parsed, ApplicationExpression):
+        return max(
+            _max_binder_depth(parsed.function),
+            _max_binder_depth(parsed.argument),
+        )
+    if isinstance(parsed, NegatedExpression):
+        return _max_binder_depth(parsed.term)
+    if isinstance(
+        parsed,
+        (
+            AndExpression,
+            OrExpression,
+            ImpExpression,
+            IffExpression,
+            EqualityExpression,
+        ),
+    ):
+        return max(
+            _max_binder_depth(parsed.first),
+            _max_binder_depth(parsed.second),
+        )
+    return 0
+
+
 class Model:
     """
     A first order model is a domain *D* of discourse and a valuation *V*.
@@ -394,6 +434,14 @@ class Model:
     :param prop: If this is set, then we are building a propositional\
     model and don't require the domain of *V* to be subset of *D*.
     """
+
+    #: Upper bound on the number of domain-iteration steps a single
+    #: ``satisfy`` call may require. ``satisfy`` iterates the domain once per
+    #: nested quantifier/lambda, so a formula with *k* nested binders costs
+    #: O(|domain| ** k); *k* is attacker-controlled. Evaluating a formula whose
+    #: worst-case cost exceeds this bound is refused up front instead of being
+    #: allowed to exhaust memory/CPU (CWE-770; CVE-2026-12840).
+    MAX_SATISFY_OPERATIONS = 1_000_000
 
     def __init__(self, domain, valuation):
         assert isinstance(domain, set)
@@ -447,58 +495,90 @@ class Model:
         :param parsed: An expression of ``logic``.
         :type g: Assignment
         :param g: an assignment to individual variables.
+        :raise Error: if interpreting ``parsed`` could require more than\
+        ``MAX_SATISFY_OPERATIONS`` domain-iteration steps (CWE-770).
         """
+        self._check_satisfy_cost(parsed)
+        return self._satisfy(parsed, g, trace)
 
+    def _check_satisfy_cost(self, parsed):
+        """
+        Refuse ``parsed`` if its worst-case interpretation cost,
+        O(|domain| ** max-binder-depth), would exceed
+        ``MAX_SATISFY_OPERATIONS``. This bounds the work *before* the
+        recursion runs, so a deeply-nested formula cannot exhaust
+        memory/CPU (CWE-770; CVE-2026-12840). The check itself is cheap
+        (linear in the size of ``parsed``) and uses no large integers.
+        """
+        size = len(self.domain)
+        if size < 2:
+            # 0 or 1 domain element: |domain| ** k can never exceed the bound.
+            return
+        ops = 1
+        for _ in range(_max_binder_depth(parsed)):
+            ops *= size
+            if ops > self.MAX_SATISFY_OPERATIONS:
+                raise Error(
+                    "Refusing to evaluate formula: interpreting it over a "
+                    "domain of %d element(s) could require more than %d "
+                    "domain-iteration steps (CWE-770). Reduce the formula's "
+                    "quantifier nesting or the domain size."
+                    % (size, self.MAX_SATISFY_OPERATIONS)
+                )
+
+    def _satisfy(self, parsed, g, trace=None):
         if isinstance(parsed, ApplicationExpression):
             function, arguments = parsed.uncurry()
             if isinstance(function, AbstractVariableExpression):
                 # It's a predicate expression ("P(x,y)"), so used uncurried arguments
-                funval = self.satisfy(function, g)
-                argvals = tuple(self.satisfy(arg, g) for arg in arguments)
+                funval = self._satisfy(function, g)
+                argvals = tuple(self._satisfy(arg, g) for arg in arguments)
                 return argvals in funval
             else:
                 # It must be a lambda expression, so use curried form
-                funval = self.satisfy(parsed.function, g)
-                argval = self.satisfy(parsed.argument, g)
+                funval = self._satisfy(parsed.function, g)
+                argval = self._satisfy(parsed.argument, g)
                 return funval[argval]
         elif isinstance(parsed, NegatedExpression):
-            return not self.satisfy(parsed.term, g)
+            return not self._satisfy(parsed.term, g)
         elif isinstance(parsed, AndExpression):
-            return self.satisfy(parsed.first, g) and self.satisfy(parsed.second, g)
+            return self._satisfy(parsed.first, g) and self._satisfy(parsed.second, g)
         elif isinstance(parsed, OrExpression):
-            return self.satisfy(parsed.first, g) or self.satisfy(parsed.second, g)
+            return self._satisfy(parsed.first, g) or self._satisfy(parsed.second, g)
         elif isinstance(parsed, ImpExpression):
-            return (not self.satisfy(parsed.first, g)) or self.satisfy(parsed.second, g)
+            return (not self._satisfy(parsed.first, g)) or self._satisfy(
+                parsed.second, g
+            )
         elif isinstance(parsed, IffExpression):
-            return self.satisfy(parsed.first, g) == self.satisfy(parsed.second, g)
+            return self._satisfy(parsed.first, g) == self._satisfy(parsed.second, g)
         elif isinstance(parsed, EqualityExpression):
-            return self.satisfy(parsed.first, g) == self.satisfy(parsed.second, g)
+            return self._satisfy(parsed.first, g) == self._satisfy(parsed.second, g)
         elif isinstance(parsed, AllExpression):
             new_g = g.copy()
             for u in self.domain:
                 new_g.add(parsed.variable.name, u)
-                if not self.satisfy(parsed.term, new_g):
+                if not self._satisfy(parsed.term, new_g):
                     return False
             return True
         elif isinstance(parsed, ExistsExpression):
             new_g = g.copy()
             for u in self.domain:
                 new_g.add(parsed.variable.name, u)
-                if self.satisfy(parsed.term, new_g):
+                if self._satisfy(parsed.term, new_g):
                     return True
             return False
         elif isinstance(parsed, IotaExpression):
             new_g = g.copy()
             for u in self.domain:
                 new_g.add(parsed.variable.name, u)
-                if self.satisfy(parsed.term, new_g):
+                if self._satisfy(parsed.term, new_g):
                     return True
             return False
         elif isinstance(parsed, LambdaExpression):
             cf = {}
             var = parsed.variable.name
             for u in self.domain:
-                val = self.satisfy(parsed.term, g.add(var, u))
+                val = self._satisfy(parsed.term, g.add(var, u))
                 # NB the dict would be a lot smaller if we do this:
                 # if val: cf[u] = val
                 # But then need to deal with cases where f(a) should yield

--- a/nltk/sem/evaluate.py
+++ b/nltk/sem/evaluate.py
@@ -383,10 +383,10 @@ def _max_binder_depth(parsed):
     ``parsed`` (``all``/``exists``/``iota`` quantifiers and ``\\`` lambdas).
 
     ``Model.satisfy`` iterates the whole domain once per such binder, so a
-    formula with depth *k* costs O(|domain| ** k); *k* is what bounds the
-    blow-up, and it comes entirely from the (untrusted) formula. Used by
-    ``Model._check_satisfy_cost`` to refuse a formula before the recursion
-    explodes (CWE-770; CVE-2026-12840).
+    nesting path of depth *k* explores O(|domain| ** k) domain-value
+    combinations; *k* is what bounds the blow-up, and it comes entirely from
+    the (untrusted) formula. Used by ``Model._check_satisfy_cost`` to refuse a
+    formula before the recursion explodes (CWE-770; CVE-2026-12840).
     """
     if isinstance(
         parsed,
@@ -435,12 +435,15 @@ class Model:
     model and don't require the domain of *V* to be subset of *D*.
     """
 
-    #: Upper bound on the number of domain-iteration steps a single
-    #: ``satisfy`` call may require. ``satisfy`` iterates the domain once per
-    #: nested quantifier/lambda, so a formula with *k* nested binders costs
-    #: O(|domain| ** k); *k* is attacker-controlled. Evaluating a formula whose
-    #: worst-case cost exceeds this bound is refused up front instead of being
-    #: allowed to exhaust memory/CPU (CWE-770; CVE-2026-12840).
+    #: Upper bound on the number of domain-value combinations a single nested
+    #: quantifier/lambda path may explore. ``satisfy`` iterates the whole domain
+    #: once per nested binder, so a path of *k* nested binders explores
+    #: |domain| ** k combinations; *k* is attacker-controlled, and this product
+    #: is the term that blows up (a formula's total work is at most this times a
+    #: factor linear in the formula's size -- independent sibling quantifiers
+    #: only add, they do not multiply). A formula whose deepest path would
+    #: exceed this bound is refused up front instead of being allowed to exhaust
+    #: memory/CPU (CWE-770; CVE-2026-12840).
     MAX_SATISFY_OPERATIONS = 1_000_000
 
     def __init__(self, domain, valuation):
@@ -495,20 +498,25 @@ class Model:
         :param parsed: An expression of ``logic``.
         :type g: Assignment
         :param g: an assignment to individual variables.
-        :raise Error: if interpreting ``parsed`` could require more than\
-        ``MAX_SATISFY_OPERATIONS`` domain-iteration steps (CWE-770).
+        :raise Error: if ``parsed`` has a nested quantifier/lambda path whose\
+        domain-value combinations (|domain| ** nesting depth) would exceed\
+        ``MAX_SATISFY_OPERATIONS`` (CWE-770).
         """
         self._check_satisfy_cost(parsed)
         return self._satisfy(parsed, g, trace)
 
     def _check_satisfy_cost(self, parsed):
         """
-        Refuse ``parsed`` if its worst-case interpretation cost,
-        O(|domain| ** max-binder-depth), would exceed
-        ``MAX_SATISFY_OPERATIONS``. This bounds the work *before* the
-        recursion runs, so a deeply-nested formula cannot exhaust
-        memory/CPU (CWE-770; CVE-2026-12840). The check itself is cheap
-        (linear in the size of ``parsed``) and uses no large integers.
+        Refuse ``parsed`` if its most deeply nested quantifier/lambda path
+        would explore more than ``MAX_SATISFY_OPERATIONS`` domain-value
+        combinations, i.e. |domain| ** (max binder nesting depth). That product
+        is the combinatorial factor that drives the blow-up; bounding it
+        *before* the recursion runs stops a deeply-nested formula from
+        exhausting memory/CPU (CWE-770; CVE-2026-12840). Independent sibling
+        quantifiers are not multiplied (they only add a factor linear in the
+        formula's size), so they are intentionally not counted here. The check
+        itself is cheap (linear in the size of ``parsed``) and, by bailing on
+        the first overflow, uses no large integers.
         """
         size = len(self.domain)
         if size < 2:
@@ -519,11 +527,11 @@ class Model:
             ops *= size
             if ops > self.MAX_SATISFY_OPERATIONS:
                 raise Error(
-                    "Refusing to evaluate formula: interpreting it over a "
-                    "domain of %d element(s) could require more than %d "
-                    "domain-iteration steps (CWE-770). Reduce the formula's "
-                    "quantifier nesting or the domain size."
-                    % (size, self.MAX_SATISFY_OPERATIONS)
+                    "Refusing to evaluate formula: over a domain of %d "
+                    "element(s) its nested quantifiers would explore more than "
+                    "%d domain-value combinations (|domain| ** nesting depth) "
+                    "(CWE-770). Reduce the formula's quantifier nesting or the "
+                    "domain size." % (size, self.MAX_SATISFY_OPERATIONS)
                 )
 
     def _satisfy(self, parsed, g, trace=None):

--- a/nltk/test/unit/test_sem_evaluate.py
+++ b/nltk/test/unit/test_sem_evaluate.py
@@ -1,0 +1,96 @@
+"""Regression tests for the combinatorial-blowup DoS in nltk.sem model
+evaluation (CWE-770; CVE-2026-12840).
+
+A formula with k nested quantifiers/lambdas makes ``Model.satisfy`` do
+O(|domain| ** k) work, and k comes entirely from the (untrusted) formula. The
+cost is now bounded by ``Model.MAX_SATISFY_OPERATIONS`` before the recursion can
+blow up. These tests confirm the bound refuses deeply-nested formulas while
+legitimate shallow ones still evaluate.
+
+The "must not hang" test runs in a spawned process with a hard timeout so a
+regression (running the unbounded O(|domain| ** k) loop) cannot hang the suite.
+"""
+
+import multiprocessing
+import queue
+
+from nltk.sem import Assignment, Model, Valuation
+from nltk.sem.evaluate import Error, _max_binder_depth
+from nltk.sem.logic import Expression
+
+
+def _model():
+    dom = {"a", "b"}
+    val = Valuation([("P", {("a",)}), ("R", {("a", "b")})])
+    return Model(dom, val), Assignment(dom)
+
+
+def test_max_binder_depth():
+    p = Expression.fromstring
+    assert _max_binder_depth(p("P(x)")) == 0
+    assert _max_binder_depth(p("all x.P(x)")) == 1
+    assert _max_binder_depth(p("all x.all y.R(x,y)")) == 2
+    assert _max_binder_depth(p("all x.(P(x) & exists y.R(x,y))")) == 2
+    assert _max_binder_depth(p("exists x.-all y.R(x,y)")) == 2
+
+
+def test_legitimate_formulas_still_evaluate():
+    m, g = _model()
+    assert m.evaluate("all x.(x = x)", g) is True
+    assert m.evaluate("exists x.P(x)", g) is True
+    assert m.evaluate("all x.exists y.R(x,y)", g) is False
+
+
+def test_shallow_formula_within_bound_allowed():
+    # depth 5 over a domain of 10 -> 1e5 < MAX_SATISFY_OPERATIONS (1e6): allowed.
+    dom = set("abcdefghij")
+    m = Model(dom, Valuation([("P", {("a",)})]))
+    g = Assignment(dom)
+    f = "all x0.all x1.all x2.all x3.all x4.(x0 = x0)"
+    assert m.evaluate(f, g) is True
+
+
+_TIMEOUT = 15
+
+
+def _eval_worker(result_q):
+    try:
+        dom = set("abcdefghij")  # |domain| = 10
+        m = Model(dom, Valuation([("P", {("a",)})]))
+        g = Assignment(dom)
+        # 9 nested quantifiers -> 10**9 satisfaction checks if unbounded.
+        f = "".join("all x%d." % i for i in range(9)) + "(x0 = x0)"
+        try:
+            m.evaluate(f, g)
+            result_q.put(("ok", "evaluated"))
+        except Error:
+            result_q.put(("ok", "refused"))
+    except BaseException as exc:  # surface to the parent process
+        result_q.put(("error", repr(exc)))
+
+
+def _run_in_process(target):
+    ctx = multiprocessing.get_context("spawn")
+    result_q = ctx.Queue()
+    proc = ctx.Process(target=target, args=(result_q,))
+    proc.start()
+    proc.join(_TIMEOUT)
+    if proc.is_alive():
+        proc.terminate()
+        proc.join()
+        return False, None, None
+    try:
+        status, payload = result_q.get_nowait()
+    except queue.Empty:
+        return True, "error", "worker produced no result"
+    return True, status, payload
+
+
+def test_deeply_nested_formula_is_refused_not_evaluated():
+    """A deeply-nested formula must be refused, not run as O(|domain| ** k)."""
+    finished, status, value = _run_in_process(_eval_worker)
+    assert (
+        finished
+    ), "Model.evaluate ran an unbounded O(|domain| ** k) computation (DoS)"
+    assert status == "ok", f"worker raised: {value}"
+    assert value == "refused"


### PR DESCRIPTION
# Bound `Model.satisfy` quantifier-nesting cost (CWE-770 / CVE-2026-12840)

## Description

`nltk.sem.evaluate.Model` interprets a logic formula against a domain by
recursive satisfaction checking. Each quantifier/lambda clause iterates over the
**entire domain** and recurses into the sub-formula, so a formula with `k`
**nested** binders performs `O(|domain| ** k)` work:

```python
# nltk/sem/evaluate.py (before)
def satisfy(self, parsed, g, trace=None):
    ...
    elif isinstance(parsed, AllExpression):
        for u in self.domain:                      # iterate the whole domain
            new_g.add(parsed.variable.name, u)
            if not self.satisfy(parsed.term, new_g):   # ...and recurse
                return False
        return True
    ...
```

`Model.evaluate` parses the raw (untrusted) formula string and feeds it straight
to `satisfy`. The nesting depth `k` comes entirely from the formula string, while
the domain stays small and fixed — so a *tiny* formula drives an unbounded amount
of computation. A tautological inner body such as `(x0 = x0)` defeats
short-circuiting (every combination is actually visited) and needs no predefined
predicate, so it is fully attacker-controlled:

```python
# domain of 10; 9 nested quantifiers -> 10**9 satisfaction checks
f = "all x0.all x1.all x2.all x3.all x4.all x5.all x6.all x7.all x8.(x0 = x0)"
Model(set("abcdefghij"), Valuation([])).evaluate(f, Assignment(...))   # hangs
```

A ~90-byte formula pins a CPU for many minutes (and at slightly larger depths,
effectively forever) — a single crafted string is enough to wedge a worker.
Validated as **CVE-2026-12840** (CWE-770).

## The fix

The blow-up is governed by `k = max nesting depth of domain-binders`, which can
be computed in time linear in the formula size *without running it*. `satisfy`
is now a thin wrapper that rejects a formula up front when its worst-case cost
`|domain| ** k` would exceed `Model.MAX_SATISFY_OPERATIONS` (default
`1_000_000`); the original recursion is preserved verbatim as `_satisfy`:

```python
MAX_SATISFY_OPERATIONS = 1_000_000

def satisfy(self, parsed, g, trace=None):
    self._check_satisfy_cost(parsed)      # cheap, runs before the recursion
    return self._satisfy(parsed, g, trace)

def _check_satisfy_cost(self, parsed):
    size = len(self.domain)
    if size < 2:                          # |domain| ** k can't exceed the bound
        return
    ops = 1
    for _ in range(_max_binder_depth(parsed)):
        ops *= size
        if ops > self.MAX_SATISFY_OPERATIONS:
            raise Error("Refusing to evaluate formula: ... (CWE-770). ...")
```

`_max_binder_depth` walks the parsed expression (`all`/`exists`/`iota`
quantifiers and `\` lambdas each add 1; boolean/equality/application nodes take
the max over their children) and returns the deepest binder nesting. The cost
check multiplies incrementally and bails the instant it crosses the bound, so it
never builds a large integer even for an absurd depth (`k = 50` is refused in
microseconds, no bignum, no deep recursion).

Notes:
- The throttle is a public, overridable class attribute
  (`Model.MAX_SATISFY_OPERATIONS`), so a caller who genuinely needs a deeper
  evaluation over a small domain can raise it explicitly.
- `satisfiers` already routes every check through `self.satisfy`, so it inherits
  the same guard with no change.
- For `|domain| <= 1`, `|domain| ** k` can never exceed the bound, so the check
  is skipped entirely (zero overhead for the degenerate case).

## Behaviour preservation (verified)

- `Model.satisfy` / `Model.evaluate` results are byte-for-byte unchanged for
  every formula whose cost is within the bound — `_satisfy` is the original body,
  renamed, with the recursive calls pointed at `_satisfy`.
- `all x.(x = x)` → `True`, `exists x.P(x)` → `True`,
  `all x.exists y.R(x,y)` → `False` (all evaluate exactly as before).
- A formula at a depth that fits the bound still evaluates: depth 5 over a domain
  of 10 (`10**5 < 10**6`) returns its normal result.
- `python -m doctest nltk/sem/evaluate.py` passes; `demo()` produces all expected
  satisfier sets.
- `semantics.doctest`: **149 attempted, 20 failed — identical to `develop`** (the
  20 are pre-existing: missing `sample_grammars`/`book_grammars` corpora and the
  old `set([...])` repr in the `is_rel` examples), so this change introduces no
  new failures.

## Performance

| input (domain = 10) | before | after |
|---------------------|--------|-------|
| `all x0…all x8.(x0 = x0)` (depth 9, `10**9`) | hangs (> 8 s, then minutes) | refused in ~0.1 ms |
| depth 50 | astronomically infeasible | refused in ~0.2 ms (no bignum) |
| depth 6 (`10**6`, at the bound) | ~2 s | ~2 s (still evaluated) |
| depth ≤ 5 / normal formulas | unchanged | unchanged |

## Testing

- `nltk/test/unit/test_sem_evaluate.py` (new): unit-tests `_max_binder_depth`;
  confirms legitimate shallow formulas still evaluate to the same truth values;
  confirms a within-bound formula is allowed; and asserts a deeply-nested formula
  is **refused, not run** — that last test runs in a spawned process with a hard
  timeout so a regression (running the unbounded `O(|domain| ** k)` loop) can't
  hang the suite. The deep-nesting test hangs (> 8 s) against the pre-fix
  `develop` version and passes instantly against the fix.
- `black==25.11.0`, `isort==6.1.0`, `ruff==0.15.6` (repo-pinned) — clean.