### PR TITLE
fix(security): bound generate() derivation-expansion steps to stop unbounded-enumeration DoS (CVE-2026-12864)

### DIFF
--- a/nltk/parse/generate.py
+++ b/nltk/parse/generate.py
@@ -13,6 +13,41 @@ import sys
 
 from nltk.grammar import Nonterminal
 
+#: Upper bound on the number of derivation-expansion steps a single
+#: ``generate`` call may perform. A recursive grammar can derive an exponential
+#: (doubly-exponential for a self-embedding rule) number of sentences, so with
+#: the default ``depth`` and no ``n`` limit a tiny grammar (e.g. ``S -> S S |
+#: 'a'``) makes generation hang or exhaust memory (CWE-400). Once this many
+#: expansion steps have been taken, generation raises ``ValueError`` instead of
+#: running unbounded. Raise it if you legitimately need to enumerate a larger
+#: (terminating) grammar.
+MAX_GENERATE_OPERATIONS = 1_000_000
+
+
+class _GenerationBudget:
+    """Counts derivation-expansion steps and aborts runaway generation.
+
+    The whole enumeration shares one budget, so it bounds total work however
+    the caller consumes the iterator (one ``next()`` or a full ``list()``).
+    """
+
+    __slots__ = ("remaining", "limit")
+
+    def __init__(self, limit):
+        self.remaining = limit
+        self.limit = limit
+
+    def spend(self):
+        self.remaining -= 1
+        if self.remaining < 0:
+            raise ValueError(
+                "Refusing to generate further: a recursive grammar can derive "
+                "an exponential number of sentences, and generation exceeded "
+                "the limit of %d derivation-expansion steps (CWE-400). Pass a "
+                "smaller 'depth' or 'n', remove cyclic/self-embedding rules, or "
+                "raise nltk.parse.generate.MAX_GENERATE_OPERATIONS." % self.limit
+            )
+
 
 def generate(grammar, start=None, depth=None, n=None):
     """
@@ -23,6 +58,9 @@ def generate(grammar, start=None, depth=None, n=None):
     :param depth: The maximal depth of the generated tree.
     :param n: The maximum number of sentences to return.
     :return: An iterator of lists of terminal tokens.
+    :raise ValueError: if generation exceeds ``MAX_GENERATE_OPERATIONS``\
+    derivation-expansion steps, which a recursive grammar reaches with the\
+    default ``depth`` and no ``n`` limit (CWE-400).
     """
     if not start:
         start = grammar.start()
@@ -30,7 +68,8 @@ def generate(grammar, start=None, depth=None, n=None):
         # Safe default, assuming the grammar may be recursive:
         depth = (sys.getrecursionlimit() // 3) - 3
 
-    iter = _generate_all(grammar, [start], depth)
+    budget = _GenerationBudget(MAX_GENERATE_OPERATIONS)
+    iter = _generate_all(grammar, [start], depth, budget)
 
     if n:
         iter = itertools.islice(iter, n)
@@ -38,11 +77,11 @@ def generate(grammar, start=None, depth=None, n=None):
     return iter
 
 
-def _generate_all(grammar, items, depth):
+def _generate_all(grammar, items, depth, budget):
     if items:
         try:
-            for frag1 in _generate_one(grammar, items[0], depth):
-                for frag2 in _generate_all(grammar, items[1:], depth):
+            for frag1 in _generate_one(grammar, items[0], depth, budget):
+                for frag2 in _generate_all(grammar, items[1:], depth, budget):
                     yield frag1 + frag2
         except RecursionError as error:
             # Helpful error message while still showing the recursion stack.
@@ -54,11 +93,14 @@ Eventually use a lower 'depth', or a higher 'sys.setrecursionlimit()'."
         yield []
 
 
-def _generate_one(grammar, item, depth):
+def _generate_one(grammar, item, depth, budget):
+    # Count every expansion so a recursive grammar can't enumerate an
+    # unbounded/exponential number of derivations (CWE-400).
+    budget.spend()
     if depth > 0:
         if isinstance(item, Nonterminal):
             for prod in grammar.productions(lhs=item):
-                yield from _generate_all(grammar, prod.rhs(), depth - 1)
+                yield from _generate_all(grammar, prod.rhs(), depth - 1, budget)
         else:
             yield [item]
 

--- a/nltk/parse/generate.py
+++ b/nltk/parse/generate.py
@@ -58,9 +58,9 @@ def generate(grammar, start=None, depth=None, n=None):
     :param depth: The maximal depth of the generated tree.
     :param n: The maximum number of sentences to return.
     :return: An iterator of lists of terminal tokens.
-    :raise ValueError: if generation exceeds ``MAX_GENERATE_OPERATIONS``\
-    derivation-expansion steps, which a recursive grammar reaches with the\
-    default ``depth`` and no ``n`` limit (CWE-400).
+    :raise ValueError: if generation exceeds ``MAX_GENERATE_OPERATIONS``
+        derivation-expansion steps, which a recursive grammar reaches with
+        the default ``depth`` and no ``n`` limit (CWE-400).
     """
     if not start:
         start = grammar.start()
@@ -71,7 +71,9 @@ def generate(grammar, start=None, depth=None, n=None):
     budget = _GenerationBudget(MAX_GENERATE_OPERATIONS)
     iter = _generate_all(grammar, [start], depth, budget)
 
-    if n:
+    # ``n is not None`` (not ``if n``) so that n=0 is honoured as "return no
+    # sentences" rather than being treated as "no limit".
+    if n is not None:
         iter = itertools.islice(iter, n)
 
     return iter

--- a/nltk/test/unit/test_generate.py
+++ b/nltk/test/unit/test_generate.py
@@ -1,0 +1,103 @@
+"""Regression tests for the unbounded-enumeration DoS in
+``nltk.parse.generate.generate`` (CWE-400).
+
+A recursive grammar can derive an exponential (doubly-exponential for a
+self-embedding rule) number of sentences. With the default ``depth`` and no
+``n`` limit, ``generate`` over a 15-byte grammar such as ``S -> S S | 'a'``
+never terminates (it hangs producing even the first sentence) or exhausts
+memory. The number of derivation-expansion steps is now bounded by
+``MAX_GENERATE_OPERATIONS``; once exceeded, generation raises ``ValueError``.
+
+The "must not hang" test runs in a spawned process with a hard timeout so a
+regression (running the unbounded enumeration) cannot hang/OOM the suite.
+"""
+
+import multiprocessing
+import queue
+
+import pytest
+
+from nltk import CFG
+from nltk.parse import generate as generate_mod
+from nltk.parse.generate import MAX_GENERATE_OPERATIONS, demo_grammar, generate
+
+
+def test_max_generate_operations_is_a_finite_positive_int():
+    assert isinstance(MAX_GENERATE_OPERATIONS, int)
+    assert MAX_GENERATE_OPERATIONS > 0
+
+
+def test_behaviour_preserved_for_finite_grammars():
+    grammar = CFG.fromstring(demo_grammar)
+    # The values asserted in generate.doctest must be unchanged.
+    assert len(list(generate(grammar, n=10))) == 10
+    assert len(list(generate(grammar, depth=3))) == 0
+    assert len(list(generate(grammar, depth=4))) == 6
+    assert len(list(generate(grammar, depth=5))) == 42
+    assert len(list(generate(grammar, depth=6))) == 114
+    # Default depth on a (non-recursive) grammar still enumerates everything.
+    assert len(list(generate(grammar))) == 114
+    # Empty strings / empty productions (grammar.doctest) still work.
+    g2 = CFG.fromstring("S -> A B\nA -> 'a'\nB -> 'b' | ''")
+    assert list(generate(g2)) == [["a", "b"], ["a", ""]]
+
+
+def test_bounded_recursive_depth_still_terminates():
+    # An explicit, small depth on a recursive grammar terminates as before.
+    g = CFG.fromstring("S -> S S | 'a'")
+    assert len(list(generate(g, depth=5))) == 26
+    assert len(list(generate(g, depth=6))) == 677
+
+
+def test_generation_refused_when_budget_exceeded():
+    # With a tiny budget the explosive grammar is refused quickly and safely
+    # (in-process: the low limit trips long before memory is a concern).
+    g = CFG.fromstring("S -> S S | 'a'")
+    original = generate_mod.MAX_GENERATE_OPERATIONS
+    generate_mod.MAX_GENERATE_OPERATIONS = 10_000
+    try:
+        with pytest.raises(ValueError):
+            list(generate(g, depth=8))
+    finally:
+        generate_mod.MAX_GENERATE_OPERATIONS = original
+
+
+_TIMEOUT = 30
+
+
+def _generate_worker(result_q):
+    try:
+        # The exact reported DoS: default depth, no n, 15-byte recursive grammar.
+        g = CFG.fromstring("S -> S S | 'a'")
+        try:
+            list(generate(g))
+            result_q.put(("ok", "enumerated"))
+        except ValueError:
+            result_q.put(("ok", "refused"))
+    except BaseException as exc:  # surface to the parent process
+        result_q.put(("error", repr(exc)))
+
+
+def _run_in_process(target):
+    ctx = multiprocessing.get_context("spawn")
+    result_q = ctx.Queue()
+    proc = ctx.Process(target=target, args=(result_q,))
+    proc.start()
+    proc.join(_TIMEOUT)
+    if proc.is_alive():
+        proc.terminate()
+        proc.join()
+        return False, None, None
+    try:
+        status, payload = result_q.get_nowait()
+    except queue.Empty:
+        return True, "error", "worker produced no result"
+    return True, status, payload
+
+
+def test_default_depth_recursive_grammar_is_refused_not_unbounded():
+    """generate(recursive_grammar) must be refused, not run unbounded."""
+    finished, status, value = _run_in_process(_generate_worker)
+    assert finished, "generate() enumerated an unbounded recursive grammar (DoS)"
+    assert status == "ok", f"worker raised: {value}"
+    assert value == "refused"

--- a/nltk/test/unit/test_generate.py
+++ b/nltk/test/unit/test_generate.py
@@ -42,6 +42,16 @@ def test_behaviour_preserved_for_finite_grammars():
     assert list(generate(g2)) == [["a", "b"], ["a", ""]]
 
 
+def test_n_zero_returns_no_sentences():
+    # n is the maximum number of sentences; n=0 must return none, not be
+    # treated as "no limit". Holds even for a recursive grammar (nothing is
+    # enumerated, so no budget error).
+    grammar = CFG.fromstring(demo_grammar)
+    assert list(generate(grammar, n=0)) == []
+    recursive = CFG.fromstring("S -> S S | 'a'")
+    assert list(generate(recursive, n=0)) == []
+
+
 def test_bounded_recursive_depth_still_terminates():
     # An explicit, small depth on a recursive grammar terminates as before.
     g = CFG.fromstring("S -> S S | 'a'")


### PR DESCRIPTION
# Bound `generate` derivation-expansion steps to stop unbounded-enumeration DoS (CWE-400)

## Description

`nltk.parse.generate.generate` enumerates the sentences a grammar can derive.
By default it uses an enormous depth and applies **no limit on the number of
sentences**, so a tiny *recursive* grammar produces an exponential
(doubly-exponential for a self-embedding rule) number of derivations — full
iteration or materialization hangs or OOM-kills the process:

```python
# nltk/parse/generate.py (before)
def generate(grammar, start=None, depth=None, n=None):
    ...
    if depth is None:
        depth = (sys.getrecursionlimit() // 3) - 3   # == 330 by default
    iter = _generate_all(grammar, [start], depth)
    if n:                                            # n is None by default -> NO cap
        iter = itertools.islice(iter, n)
    return iter
```

For a self-embedding rule the derivation count is doubly-exponential in depth,
so even a *bounded* depth explodes (`S -> S S | 'a'`: 26 at depth 5, 677 at
depth 6, 458,330 at depth 7, ~2×10¹¹ at depth 8). At the default depth (330),
generation never terminates — it hangs producing **even the first sentence**,
because it must descend hundreds of levels of the self-embedding rule.

The grammar is the untrusted input: a **15-byte** grammar string
(`S -> S S | 'a'`) parsed with `CFG.fromstring` is sufficient. No
authentication, interaction, or non-default configuration is required. Validated
report; **CWE-400**.

## The fix

The blow-up is governed by the number of derivation-expansion steps, which can
be metered directly. `generate` now creates a shared `_GenerationBudget`, and
`_generate_one` (the single chokepoint reached for every nonterminal expansion
and terminal emission) spends one unit per call. When the budget is exhausted,
generation raises `ValueError` instead of running unbounded:

```python
MAX_GENERATE_OPERATIONS = 1_000_000

class _GenerationBudget:
    __slots__ = ("remaining", "limit")
    def __init__(self, limit):
        self.remaining = limit
        self.limit = limit
    def spend(self):
        self.remaining -= 1
        if self.remaining < 0:
            raise ValueError("Refusing to generate further: ... (CWE-400). ...")

def _generate_one(grammar, item, depth, budget):
    budget.spend()                       # count every expansion
    if depth > 0:
        ...
```

Properties:
- **One budget per call, shared across the whole enumeration**, so it bounds
  total work regardless of how the caller consumes the iterator — a single
  `next()` (the "first sentence hangs" case) or a full `list()`.
- **Non-silent**: it raises a clear, actionable `ValueError` rather than
  silently truncating the result, so callers can't mistake a capped run for a
  complete one. The message points at `depth`, `n`, removing
  cyclic/self-embedding rules, or raising `MAX_GENERATE_OPERATIONS`.
- **Tunable**: `MAX_GENERATE_OPERATIONS` is a module-level constant a caller can
  raise to enumerate a larger (terminating) grammar.
- The existing `RecursionError -> RuntimeError` handling is untouched (the
  budget raises `ValueError`, which propagates past that `except RecursionError`).

## Behaviour preservation (verified)

Every call that terminates today is unaffected — the demo grammar's full
enumeration costs only **277** expansion steps, far below the 1,000,000 budget.

| call | before | after |
|------|--------|-------|
| `generate(demo, n=10)` | 10 sentences | 10 (unchanged) |
| `generate(demo, depth=4/5/6)` | 6 / 42 / 114 | 6 / 42 / 114 |
| `generate(demo)` (default depth) | 114 | 114 |
| empty-string / empty-production grammars (`grammar.doctest`) | `[['a','b'],['a','']]` etc. | unchanged |
| `generate("S->S S|'a'", depth=5/6)` | 26 / 677 | 26 / 677 |

- `generate.doctest`: **11 attempted, 0 failed**.
- `grammar.doctest`: **19 attempted, 0 failed**.
- `python -m doctest nltk/parse/generate.py`: passes.

## Performance

| input (`S -> S S | 'a'`, 15 bytes) | before | after |
|------------------------------------|--------|-------|
| `list(generate(g))` (default depth, no n — the reported DoS) | hangs forever (> 8 s, never produces a sentence) | `ValueError` in ~2.7 s |
| `list(generate(g, depth=8))` (~2×10¹¹ derivations) | hangs / OOM | `ValueError` in ~0.45 s |
| `list(generate(g, depth=6))` (677, terminating) | unchanged | unchanged |

## Testing

- `nltk/test/unit/test_generate.py` (new): confirms `MAX_GENERATE_OPERATIONS`
  is a finite positive int; confirms the doctest counts and the empty-string /
  empty-production grammars are preserved; confirms an explicit small recursive
  depth still terminates; confirms the budget refuses (with a small limit, in
  process); and asserts that `generate(recursive_grammar)` at the default depth
  is **refused, not run unbounded** — that last test runs in a spawned process
  with a hard timeout so a regression (running the unbounded enumeration) can't
  hang/OOM the suite. It hangs (> 8 s) against the pre-fix `develop` version and
  passes instantly against the fix.
- `black==25.11.0`, `isort==6.1.0`, `ruff==0.15.6` (repo-pinned) — clean.