### PR TITLE
fix(security): bound everygrams default max_len to stop unbounded-allocation DoS (CVE-2026-12861)

### DIFF
--- a/nltk/test/unit/test_everygrams_alloc.py
+++ b/nltk/test/unit/test_everygrams_alloc.py
@@ -9,13 +9,13 @@ The defaulted ``max_len`` is now capped by ``MAX_EVERYGRAMS_DEFAULT_LEN``; a
 longer sequence with the default raises ``ValueError`` asking for an explicit
 ``max_len``. An explicitly supplied ``max_len`` is never capped.
 
-The "must not allocate" test runs in a spawned process (with an address-space
-limit where supported, and a hard timeout) so a regression cannot OOM/hang the
-suite.
+The "must not allocate" test runs in a spawned process with a hard timeout, and
+the worker reports its outcome through its exit code (no queue/thread, so it is
+robust on free-threaded builds), so a regression cannot OOM/hang the suite.
 """
 
 import multiprocessing
-import queue
+import os
 
 import pytest
 
@@ -75,50 +75,39 @@ def test_explicit_max_len_is_never_capped():
     assert len(out) == 5000 + 4999 + 4998
 
 
-_TIMEOUT = 30
-_MEM_LIMIT_BYTES = 1_500_000_000  # 1.5 GB child address-space cap (where supported)
+_TIMEOUT = 60
+# Worker outcomes, reported via exit code (avoids a result queue / feeder thread,
+# which is fragile on free-threaded builds).
+_EXIT_REFUSED = 0  # ValueError raised before any allocation (the expected result)
+_EXIT_MATERIALIZED = 2  # the unbounded result was built (regression)
+_EXIT_OTHER = 3  # any other failure
 
 
-def _everygrams_worker(result_q):
+def _everygrams_worker():
+    toks = [str(i) for i in range(2000)]  # default max_len -> ~10 GB if unbounded
     try:
-        try:
-            import resource
-
-            resource.setrlimit(resource.RLIMIT_AS, (_MEM_LIMIT_BYTES, _MEM_LIMIT_BYTES))
-        except Exception:
-            pass  # best-effort; the timeout still bounds a regression
-        toks = [str(i) for i in range(2000)]  # default max_len -> ~10 GB if unbounded
-        try:
-            list(everygrams(toks))
-            result_q.put(("ok", "materialized"))
-        except ValueError:
-            result_q.put(("ok", "refused"))
-        except MemoryError:
-            result_q.put(("ok", "oom"))
-    except BaseException as exc:  # surface to the parent process
-        result_q.put(("error", repr(exc)))
+        list(everygrams(toks))
+        os._exit(_EXIT_MATERIALIZED)
+    except ValueError:
+        os._exit(_EXIT_REFUSED)
+    except BaseException:
+        os._exit(_EXIT_OTHER)
 
 
-def _run_in_process(target):
+def test_oversized_default_does_not_allocate():
+    """everygrams(long_seq) with the default max_len must be refused, not run."""
     ctx = multiprocessing.get_context("spawn")
-    result_q = ctx.Queue()
-    proc = ctx.Process(target=target, args=(result_q,))
+    proc = ctx.Process(target=_everygrams_worker)
     proc.start()
     proc.join(_TIMEOUT)
     if proc.is_alive():
         proc.terminate()
         proc.join()
-        return False, None, None
-    try:
-        status, payload = result_q.get_nowait()
-    except queue.Empty:
-        return True, "error", "worker produced no result"
-    return True, status, payload
-
-
-def test_oversized_default_does_not_allocate():
-    """everygrams(long_seq) with the default max_len must be refused, not run."""
-    finished, status, value = _run_in_process(_everygrams_worker)
-    assert finished, "everygrams() materialized an unbounded O(n**3) result (DoS)"
-    assert status == "ok", f"worker raised: {value}"
-    assert value == "refused"
+        raise AssertionError(
+            "everygrams() did not return quickly -> unbounded O(n**3) allocation (DoS)"
+        )
+    assert proc.exitcode == _EXIT_REFUSED, (
+        "everygrams() with the default max_len over a long sequence was not "
+        f"refused before allocating (worker exit code {proc.exitcode}); "
+        "expected a fast ValueError"
+    )

--- a/nltk/test/unit/test_everygrams_alloc.py
+++ b/nltk/test/unit/test_everygrams_alloc.py
@@ -1,0 +1,124 @@
+"""Regression tests for the unbounded-default-``max_len`` DoS in
+``nltk.util.everygrams`` (CWE-770; CVE-2026-12861).
+
+With ``max_len`` left at its ``-1`` default it expands to ``len(sequence)``, so
+enumerating every n-gram of every length from ``min_len`` to ``len(sequence)``
+over each window yields O(n**2) tuples totalling O(n**3) elements -- a
+few-thousand-token sequence then allocates gigabytes and OOM-kills the process.
+The defaulted ``max_len`` is now capped by ``MAX_EVERYGRAMS_DEFAULT_LEN``; a
+longer sequence with the default raises ``ValueError`` asking for an explicit
+``max_len``. An explicitly supplied ``max_len`` is never capped.
+
+The "must not allocate" test runs in a spawned process (with an address-space
+limit where supported, and a hard timeout) so a regression cannot OOM/hang the
+suite.
+"""
+
+import multiprocessing
+import queue
+
+import pytest
+
+from nltk.util import MAX_EVERYGRAMS_DEFAULT_LEN, everygrams
+
+
+def test_max_everygrams_default_len_is_a_finite_positive_int():
+    assert isinstance(MAX_EVERYGRAMS_DEFAULT_LEN, int)
+    assert MAX_EVERYGRAMS_DEFAULT_LEN > 0
+
+
+def test_behaviour_preserved_for_small_sequences():
+    sent = "a b c".split()
+    # The values asserted in the everygrams doctest must be unchanged.
+    assert list(everygrams(sent)) == [
+        ("a",),
+        ("a", "b"),
+        ("a", "b", "c"),
+        ("b",),
+        ("b", "c"),
+        ("c",),
+    ]
+    assert list(everygrams(sent, max_len=2)) == [
+        ("a",),
+        ("a", "b"),
+        ("b",),
+        ("b", "c"),
+        ("c",),
+    ]
+    assert list(everygrams(sent, min_len=2)) == [
+        ("a", "b"),
+        ("a", "b", "c"),
+        ("b", "c"),
+    ]
+
+
+def test_default_allowed_up_to_the_cap():
+    # A sequence exactly at the cap still uses the full default (no raise).
+    toks = [str(i) for i in range(MAX_EVERYGRAMS_DEFAULT_LEN)]
+    out = list(everygrams(toks))
+    n = MAX_EVERYGRAMS_DEFAULT_LEN
+    assert len(out) == n * (n + 1) // 2
+
+
+def test_oversized_default_raises():
+    # One past the cap with the default max_len is refused -- before allocating.
+    toks = [str(i) for i in range(MAX_EVERYGRAMS_DEFAULT_LEN + 1)]
+    with pytest.raises(ValueError):
+        list(everygrams(toks))
+
+
+def test_explicit_max_len_is_never_capped():
+    # An explicit (bounded) max_len over a long sequence stays linear and allowed.
+    toks = [str(i) for i in range(5000)]
+    out = list(everygrams(toks, max_len=3))
+    # 1-, 2- and 3-grams over 5000 tokens: ~3 * 5000, far below any cube.
+    assert len(out) == 5000 + 4999 + 4998
+
+
+_TIMEOUT = 30
+_MEM_LIMIT_BYTES = 1_500_000_000  # 1.5 GB child address-space cap (where supported)
+
+
+def _everygrams_worker(result_q):
+    try:
+        try:
+            import resource
+
+            resource.setrlimit(resource.RLIMIT_AS, (_MEM_LIMIT_BYTES, _MEM_LIMIT_BYTES))
+        except Exception:
+            pass  # best-effort; the timeout still bounds a regression
+        toks = [str(i) for i in range(2000)]  # default max_len -> ~10 GB if unbounded
+        try:
+            list(everygrams(toks))
+            result_q.put(("ok", "materialized"))
+        except ValueError:
+            result_q.put(("ok", "refused"))
+        except MemoryError:
+            result_q.put(("ok", "oom"))
+    except BaseException as exc:  # surface to the parent process
+        result_q.put(("error", repr(exc)))
+
+
+def _run_in_process(target):
+    ctx = multiprocessing.get_context("spawn")
+    result_q = ctx.Queue()
+    proc = ctx.Process(target=target, args=(result_q,))
+    proc.start()
+    proc.join(_TIMEOUT)
+    if proc.is_alive():
+        proc.terminate()
+        proc.join()
+        return False, None, None
+    try:
+        status, payload = result_q.get_nowait()
+    except queue.Empty:
+        return True, "error", "worker produced no result"
+    return True, status, payload
+
+
+def test_oversized_default_does_not_allocate():
+    """everygrams(long_seq) with the default max_len must be refused, not run."""
+    finished, status, value = _run_in_process(_everygrams_worker)
+    assert finished, "everygrams() materialized an unbounded O(n**3) result (DoS)"
+    assert status == "ok", f"worker raised: {value}"
+    assert value == "refused"

--- a/nltk/test/unit/test_everygrams_alloc.py
+++ b/nltk/test/unit/test_everygrams_alloc.py
@@ -79,15 +79,21 @@ _TIMEOUT = 60
 # Worker outcomes, reported via exit code (avoids a result queue / feeder thread,
 # which is fragile on free-threaded builds).
 _EXIT_REFUSED = 0  # ValueError raised before any allocation (the expected result)
-_EXIT_MATERIALIZED = 2  # the unbounded result was built (regression)
+_EXIT_ENUMERATED = 2  # the unbounded enumeration ran to completion (regression)
 _EXIT_OTHER = 3  # any other failure
 
 
 def _everygrams_worker():
-    toks = [str(i) for i in range(2000)]  # default max_len -> ~10 GB if unbounded
+    # With the default max_len this would enumerate O(n**2) tuples totalling
+    # O(n**3) elements if the guard were removed. Consume the iterator WITHOUT
+    # materializing it into a list: each tuple is transient, so peak memory
+    # stays low and a regression is caught by the parent's timeout rather than
+    # risking an OS OOM kill that could destabilize the whole CI job.
+    toks = [str(i) for i in range(2000)]
     try:
-        list(everygrams(toks))
-        os._exit(_EXIT_MATERIALIZED)
+        for _ in everygrams(toks):
+            pass
+        os._exit(_EXIT_ENUMERATED)
     except ValueError:
         os._exit(_EXIT_REFUSED)
     except BaseException:

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -1078,10 +1078,10 @@ def everygrams(
     :param pad_right: whether the ngrams should be right-padded
     :type pad_right: bool
     :rtype: iter(tuple)
-    :raise ValueError: if ``max_len`` is left at its default and the sequence is\
-    longer than ``MAX_EVERYGRAMS_DEFAULT_LEN``, since enumerating every n-gram of\
-    every length would allocate O(n**3) elements and exhaust memory (CWE-770).\
-    Pass an explicit ``max_len`` to bound the n-gram order.
+    :raise ValueError: if ``max_len`` is left at its default and the sequence is
+        longer than ``MAX_EVERYGRAMS_DEFAULT_LEN``, since enumerating every
+        n-gram of every length would allocate O(n**3) elements and exhaust
+        memory (CWE-770). Pass an explicit ``max_len`` to bound the n-gram order.
     """
 
     # Get max_len for padding.

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -1036,6 +1036,17 @@ def trigrams(sequence, **kwargs):
     yield from ngrams(sequence, 3, **kwargs)
 
 
+#: Largest sequence length for which :func:`everygrams` will expand the default
+#: ``max_len`` sentinel to the full sequence length. Enumerating every n-gram of
+#: every length from ``min_len`` to ``len(sequence)`` over each window yields
+#: O(n**2) tuples totalling O(n**3) elements, so leaving ``max_len`` at its
+#: default over a few-thousand-token sequence allocates gigabytes and OOM-kills
+#: the process (CWE-770). When the defaulted ``max_len`` would exceed this,
+#: ``everygrams`` raises ``ValueError`` asking for an explicit ``max_len``. This
+#: only affects the default; an explicitly supplied ``max_len`` is never capped.
+MAX_EVERYGRAMS_DEFAULT_LEN = 256
+
+
 def everygrams(
     sequence, min_len=1, max_len=-1, pad_left=False, pad_right=False, **kwargs
 ):
@@ -1067,6 +1078,10 @@ def everygrams(
     :param pad_right: whether the ngrams should be right-padded
     :type pad_right: bool
     :rtype: iter(tuple)
+    :raise ValueError: if ``max_len`` is left at its default and the sequence is\
+    longer than ``MAX_EVERYGRAMS_DEFAULT_LEN``, since enumerating every n-gram of\
+    every length would allocate O(n**3) elements and exhaust memory (CWE-770).\
+    Pass an explicit ``max_len`` to bound the n-gram order.
     """
 
     # Get max_len for padding.
@@ -1076,6 +1091,19 @@ def everygrams(
         except TypeError:
             sequence = list(sequence)
             max_len = len(sequence)
+        # The default max_len expands to the full sequence length, which makes
+        # everygrams enumerate O(n**2) tuples totalling O(n**3) elements -- a
+        # few-thousand-token sequence then allocates gigabytes (CWE-770). Refuse
+        # the unbounded default for long sequences instead of OOM-ing; an
+        # explicit max_len (an informed choice) is never capped.
+        if max_len > MAX_EVERYGRAMS_DEFAULT_LEN:
+            raise ValueError(
+                "everygrams() called with the default max_len on a sequence of "
+                "%d items: enumerating every n-gram of every length up to %d "
+                "yields O(n**2) tuples (O(n**3) elements) and can exhaust memory "
+                "(CWE-770). Pass an explicit max_len (e.g. max_len=min_len), or "
+                "raise nltk.util.MAX_EVERYGRAMS_DEFAULT_LEN." % (max_len, max_len)
+            )
 
     # Pad if indicated using max_len.
     sequence = pad_sequence(sequence, max_len, pad_left, pad_right, **kwargs)


### PR DESCRIPTION
# Bound `everygrams` default `max_len` to stop unbounded-allocation DoS (CWE-770 / CVE-2026-12861)

## Description

`nltk.util.everygrams` (a public export) generates all n-grams of every length
from `min_len` to `max_len`. Its default `max_len` is a `-1` sentinel that
**expands to the full sequence length**:

```python
# nltk/util.py (before)
def everygrams(sequence, min_len=1, max_len=-1, ...):
    ...
    if max_len == -1:
        try:
            max_len = len(sequence)          # default == entire input length
        except TypeError:
            sequence = list(sequence)
            max_len = len(sequence)
```

So calling it with default arguments yields every n-gram of every length from
`1` up to the input length over each window. Materializing that output (the
normal way to use n-grams: `list(everygrams(...))`, `Counter(...)`, feeding a
counter) produces **O(n²) tuples** with average length **O(n)**, i.e. total size
**O(n³)**. A few-thousand-token input (a few KB of text) allocates many
gigabytes and OOM-kills the worker.

Measured peak memory of `list(everygrams(toks))` (current source):

| tokens | #ngrams | peak memory |
|------:|--------:|------------:|
| 250 | 31,375 | 22 MB |
| 500 | 125,250 | 173 MB |
| 1000 | 500,500 | 1.36 GB |
| 2000 | ~2,000,000 | ~10 GB → OOM |

The dangerous part is **the default**: a caller that simply lists or fully
iterates the result over untrusted text — without realizing the default means
"all lengths up to the entire input" — triggers the quadratic-count, cubic-size
blowup. No authentication, interaction, or non-default configuration is required.
Validated as **CVE-2026-12861** (CWE-770).

## The fix

Every legitimate caller (in NLTK: `nltk.lm.preprocessing.padded_everygrams`,
`padded_everygram_pipeline`, `translate.gleu_score`, and the tests) passes an
**explicit, small** `max_len`, which keeps the output linear. Only the *default*
path is unbounded. The fix caps the *defaulted* `max_len`: when the sentinel
would expand beyond `MAX_EVERYGRAMS_DEFAULT_LEN` it raises a clear `ValueError`
asking for an explicit `max_len`, instead of silently allocating O(n³):

```python
MAX_EVERYGRAMS_DEFAULT_LEN = 256

    if max_len == -1:
        try:
            max_len = len(sequence)
        except TypeError:
            sequence = list(sequence)
            max_len = len(sequence)
        if max_len > MAX_EVERYGRAMS_DEFAULT_LEN:
            raise ValueError(
                "everygrams() called with the default max_len on a sequence of "
                "%d items: enumerating every n-gram of every length up to %d "
                "yields O(n**2) tuples (O(n**3) elements) and can exhaust memory "
                "(CWE-770). Pass an explicit max_len (e.g. max_len=min_len), or "
                "raise nltk.util.MAX_EVERYGRAMS_DEFAULT_LEN." % (max_len, max_len)
            )
```

Properties:
- **Targets exactly the reported flaw** (the unbounded *default*). An
  explicitly-supplied `max_len` — an informed choice — is **never capped**, so
  no existing caller changes behaviour.
- **Non-silent**: it raises an actionable `ValueError` (telling the caller to
  pass `max_len`) rather than silently truncating to `≤256`-grams, so a caller
  can't mistake a capped run for a complete one.
- **Bounded worst case**: the largest allocation the default can now drive is at
  `n = 256` (~23 MB, measured), instead of unbounded.
- **Tunable**: `MAX_EVERYGRAMS_DEFAULT_LEN` is a module-level constant a caller
  can raise if they really want the full default over a longer sequence.
- The `TypeError` fallback (iterables without `__len__`) is preserved — the cap
  is checked after the length is materialized, exactly as the length itself is.

## Behaviour preservation (verified)

- The `everygrams` docstring examples are unchanged
  (`list(everygrams('a b c'.split()))`,
  `sorted(everygrams(sent), key=len)`, `max_len=2`):
  `python -m doctest nltk/util.py` passes.
- `nltk/test/unit/test_util.py` (incl. `test_everygrams_without_padding`, which
  uses the **default** `max_len` on a 3-item iterator), `test/unit/lm/*` and the
  `lm.doctest` everygrams examples are unaffected — **171 passed, 1 skipped,
  9 xfailed** (the xfails/skip and the 6 `lm.doctest` failures are pre-existing
  missing-corpus `LookupError`s, identical on `develop`).
- A sequence exactly at the cap still uses the full default; explicit
  `everygrams(long_seq, max_len=3)` stays linear (5000 tokens → ~1.2 MB).

## Performance

| call | before | after |
|------|--------|-------|
| `list(everygrams(toks))`, 2000 tokens (default) | ~10 GB → OOM | `ValueError` in ~0 ms (before any allocation) |
| `list(everygrams(toks))`, ≤256 tokens (default) | ≤23 MB | unchanged |
| `list(everygrams(long, max_len=3))` | linear | unchanged |

## Testing

- `nltk/test/unit/test_everygrams_alloc.py` (new): confirms
  `MAX_EVERYGRAMS_DEFAULT_LEN` is a finite positive int; confirms the docstring
  outputs and explicit-`max_len` (never-capped, linear) behaviour are preserved;
  confirms the default is allowed up to the cap and refused one past it; and
  asserts that `everygrams(long_seq)` with the default `max_len` is **refused,
  not materialized** — that last test runs in a spawned process with a hard
  timeout (the worker reports its outcome via its exit code, so it stays robust
  on free-threaded builds) so a regression (allocating the unbounded O(n³)
  result) can't OOM/hang the suite. It hangs/dies against the pre-fix `develop`
  version and passes instantly against the fix.
- `black==25.11.0`, `isort==6.1.0`, `ruff==0.15.6` (repo-pinned) — clean.