### PR TITLE
fix(security): route DependencyGraph.load through the pathsec sandbox (CVE-2026-12867)

### DIFF
--- a/nltk/parse/dependencygraph.py
+++ b/nltk/parse/dependencygraph.py
@@ -21,6 +21,7 @@ from itertools import chain
 from pprint import pformat
 
 from nltk.internals import find_binary
+from nltk.pathsec import open as _secure_open
 from nltk.tree import Tree
 
 #################################################################
@@ -222,7 +223,10 @@ class DependencyGraph:
         :return: a list of DependencyGraphs
 
         """
-        with open(filename) as infile:
+        # Route through the pathsec sentinel so the read honours the file-access
+        # sandbox (allowed data roots, symlink resolution) instead of the builtin
+        # open, which bypasses it and can read arbitrary local files (CWE-22).
+        with _secure_open(filename) as infile:
             return [
                 DependencyGraph(
                     tree_str,

--- a/nltk/test/unit/test_dependencygraph_security.py
+++ b/nltk/test/unit/test_dependencygraph_security.py
@@ -29,7 +29,10 @@ class TestDependencyGraphLoadSandbox:
 
         out_file = outside / "secret.conll"
         out_file.write_text(_RECORD, encoding="utf-8")
-        with pytest.raises((PermissionError, ValueError)):
+        # The global sandbox (no required_root) raises PermissionError for an
+        # out-of-root path; assert exactly that so the test can't pass on some
+        # unrelated error.
+        with pytest.raises(PermissionError):
             DependencyGraph.load(str(out_file))
 
         in_file = allowed / "ok.conll"
@@ -39,10 +42,16 @@ class TestDependencyGraphLoadSandbox:
         assert words == ["leaked-word"]
 
     def test_load_unchanged_when_sandbox_disabled(self, tmp_path, monkeypatch):
-        """With the sandbox off, behaviour is unchanged (reads any path)."""
+        """With the sandbox off, an out-of-root path still loads (only warns)."""
         monkeypatch.setattr(pathsec, "ENFORCE", False)
-        any_file = tmp_path / "anywhere.conll"
-        any_file.write_text(_RECORD, encoding="utf-8")
-        graphs = DependencyGraph.load(str(any_file))
+        # Force *no* allowed roots so the file is unambiguously out-of-root
+        # (tmp_path is usually inside tempfile.gettempdir(), which is allowed by
+        # default -- that would not exercise the disabled-sandbox path).
+        monkeypatch.setattr(pathsec, "_get_allowed_roots", set)
+        out_file = tmp_path / "anywhere.conll"
+        out_file.write_text(_RECORD, encoding="utf-8")
+        # Not enforcing: pathsec warns about the out-of-root path but still reads.
+        with pytest.warns(RuntimeWarning):
+            graphs = DependencyGraph.load(str(out_file))
         words = [n["word"] for n in graphs[0].nodes.values() if n.get("word")]
         assert words == ["leaked-word"]

--- a/nltk/test/unit/test_dependencygraph_security.py
+++ b/nltk/test/unit/test_dependencygraph_security.py
@@ -1,0 +1,48 @@
+"""Regression test for the pathsec sandbox bypass in
+``nltk.parse.dependencygraph.DependencyGraph.load`` (CWE-22; CVE-2026-12867).
+
+``load`` opened the caller-supplied filename with the builtin ``open``, which
+bypasses NLTK's centralized file-access sentinel (``nltk.pathsec``). Where an
+application enables the sandbox as a boundary and feeds it an attacker-influenced
+filename, that allowed arbitrary local files to be read and their parsed content
+returned via the graph's node words. ``load`` must instead route through
+``pathsec.open`` so the read honours the allowed data roots.
+"""
+
+import pytest
+
+from nltk import pathsec
+from nltk.parse.dependencygraph import DependencyGraph
+
+_RECORD = "1\tleaked-word\t_\tN\tN\t_\t0\troot\t_\t_\n\n"
+
+
+class TestDependencyGraphLoadSandbox:
+    def test_load_enforces_pathsec_sandbox(self, tmp_path, monkeypatch):
+        """Under ``ENFORCE``, an out-of-root path is rejected; in-root still loads."""
+        allowed = tmp_path / "data"
+        allowed.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        monkeypatch.setattr(pathsec, "ENFORCE", True)
+        monkeypatch.setattr(pathsec, "_get_allowed_roots", lambda: {allowed.resolve()})
+
+        out_file = outside / "secret.conll"
+        out_file.write_text(_RECORD, encoding="utf-8")
+        with pytest.raises((PermissionError, ValueError)):
+            DependencyGraph.load(str(out_file))
+
+        in_file = allowed / "ok.conll"
+        in_file.write_text(_RECORD, encoding="utf-8")
+        graphs = DependencyGraph.load(str(in_file))
+        words = [n["word"] for n in graphs[0].nodes.values() if n.get("word")]
+        assert words == ["leaked-word"]
+
+    def test_load_unchanged_when_sandbox_disabled(self, tmp_path, monkeypatch):
+        """With the sandbox off, behaviour is unchanged (reads any path)."""
+        monkeypatch.setattr(pathsec, "ENFORCE", False)
+        any_file = tmp_path / "anywhere.conll"
+        any_file.write_text(_RECORD, encoding="utf-8")
+        graphs = DependencyGraph.load(str(any_file))
+        words = [n["word"] for n in graphs[0].nodes.values() if n.get("word")]
+        assert words == ["leaked-word"]


### PR DESCRIPTION
# Route `DependencyGraph.load` through the pathsec sandbox (CWE-22 / CVE-2026-12867)

## Description

`nltk.parse.dependencygraph.DependencyGraph.load` opens a caller-supplied
filename with the builtin `open`, bypassing NLTK's centralized file-access
sentinel (`nltk.pathsec`):

```python
# nltk/parse/dependencygraph.py (before)
@staticmethod
def load(filename, zero_based=False, cell_separator=None, top_relation_label="ROOT"):
    ...
    with open(filename) as infile:                       # bypasses pathsec
        return [DependencyGraph(tree_str, ...) for tree_str in infile.read().split("\n\n")]
```

Because it bypasses the library's I/O boundary, it neutralizes the file-access
enforcement policy. In a multi-tenant or web pipeline where the sandbox
(`pathsec.ENFORCE`, on by default in NLTK 3.10) is expected to confine reads to
the designated data roots, an attacker-influenced filename lets `load` read
arbitrary local files and exposes their parsed content through the returned
graph's node words. The impact is a read-only path traversal, gated on an
application that both enables the sandbox and feeds `load` an untrusted filename.
Validated as **CVE-2026-12867** (CWE-22).

## The fix

Read through the pathsec sentinel (`pathsec.open`), exactly as the other
file-reading entry points in the tree already do (e.g. `metrics.distance`,
`corpus.reader`, `data.py`). `pathsec.open` runs `validate_path` — which enforces
the allowed data roots and resolves symlinks — before delegating to the builtin
`open`:

```python
from nltk.pathsec import open as _secure_open

    with _secure_open(filename) as infile:
        return [DependencyGraph(tree_str, ...) for tree_str in infile.read().split("\n\n")]
```

This is the minimal change that restores the boundary: a single import plus
swapping the `open` call. No signature, return type, or parsing behaviour
changes.

## Behaviour preservation (verified)

- When the sandbox is **disabled** (`pathsec.ENFORCE = False`), `pathsec.open`
  delegates straight to the builtin `open`, so `load` behaves exactly as before —
  any path still loads.
- When the sandbox is **enabled**, an **in-root** file still loads into the same
  list of `DependencyGraph`s (node words unchanged); only an **out-of-root** path
  is now rejected with `PermissionError` instead of being read.
- `python -m doctest nltk/parse/dependencygraph.py` passes.
- `dependency.doctest`: **34 attempted, 2 failed — identical to `develop`** (the
  2 failures are a pre-existing missing-corpus `LookupError`, unrelated to this
  change).

## Proof of concept (before → after)

With `ENFORCE = True` and a secret file outside every allowed root:

| call | before | after |
|------|--------|-------|
| `pathsec.open(secret)` | `PermissionError` (correctly blocked) | unchanged |
| `DependencyGraph.load(secret)` | **reads the file**, leaks its words | `PermissionError` (blocked) |
| `DependencyGraph.load(in_root_file)` | loads | loads (unchanged) |

## Testing

- `nltk/test/unit/test_dependencygraph_security.py` (new): with `ENFORCE` and the
  allowed roots monkeypatched to a temp dir, an out-of-root file is rejected
  (`PermissionError`/`ValueError`) while an in-root file still loads into a graph
  with the expected node word; and a separate test confirms behaviour is
  unchanged when the sandbox is disabled. The sandbox test fails against the
  pre-fix `develop` version (`DID NOT RAISE`) and passes against the fix.
- `black==25.11.0`, `isort==6.1.0`, `ruff==0.15.6` (repo-pinned) — clean.