### PR TITLE
fix(security): bound phrase_extraction default max_phrase_length to stop cubic DoS (CVE-2026-12870)

### DIFF
--- a/nltk/test/unit/translate/test_phrase_based_security.py
+++ b/nltk/test/unit/translate/test_phrase_based_security.py
@@ -61,9 +61,13 @@ def test_docstring_example_preserved():
 
 
 def test_default_allowed_up_to_the_cap():
-    # A sentence pair exactly at the cap still uses the full default (no raise).
-    src, trg, align = _diag(MAX_PHRASE_EXTRACTION_DEFAULT_LEN)
-    assert len(phrase_extraction(src, trg, align)) > 0
+    # A sentence pair exactly at the cap uses the full default without raising.
+    # Use an empty alignment so the default-length guard is exercised at the
+    # boundary without building the (near-cubic) phrase set -- the guard depends
+    # only on the sentence length, not the alignment, so this still covers the
+    # boundary while keeping the test cheap and CI-stable.
+    src, trg, _ = _diag(MAX_PHRASE_EXTRACTION_DEFAULT_LEN)
+    assert phrase_extraction(src, trg, []) == set()
 
 
 def test_oversized_default_raises():

--- a/nltk/test/unit/translate/test_phrase_based_security.py
+++ b/nltk/test/unit/translate/test_phrase_based_security.py
@@ -1,0 +1,123 @@
+"""Regression tests for the cubic-blowup DoS in
+``nltk.translate.phrase_based.phrase_extraction`` (CWE-770; CVE-2026-12870).
+
+With ``max_phrase_length`` left at its default (0) it expands to the full
+sentence length, so the function enumerates O(n**2) phrase pairs, each holding
+an O(n)-word string -- O(n**3) total work/memory. A few-hundred-word sentence
+pair then pins the CPU and exhausts memory. The defaulted length is now capped
+by ``MAX_PHRASE_EXTRACTION_DEFAULT_LEN``; a longer sentence with the default
+raises ``ValueError`` asking for an explicit ``max_phrase_length``. An
+explicitly supplied ``max_phrase_length`` is never capped.
+
+The "must not run" test runs in a spawned process with a hard timeout, and the
+worker reports its outcome through its exit code (no queue/thread, so it is
+robust on free-threaded builds), so a regression cannot hang the suite.
+"""
+
+import multiprocessing
+import os
+
+import pytest
+
+from nltk.translate.phrase_based import (
+    MAX_PHRASE_EXTRACTION_DEFAULT_LEN,
+    phrase_extraction,
+)
+
+# The worked example from the phrase_extraction docstring.
+_SRC = "michael assumes that he will stay in the house"
+_TRG = "michael geht davon aus , dass er im haus bleibt"
+_ALIGN = [
+    (0, 0),
+    (1, 1),
+    (1, 2),
+    (1, 3),
+    (2, 5),
+    (3, 6),
+    (4, 9),
+    (5, 9),
+    (6, 7),
+    (7, 7),
+    (8, 8),
+]
+
+
+def _diag(n):
+    """An n-word source/target pair with a diagonal alignment."""
+    src = " ".join("s%d" % i for i in range(n))
+    trg = " ".join("t%d" % i for i in range(n))
+    return src, trg, [(i, i) for i in range(n)]
+
+
+def test_max_phrase_extraction_default_len_is_a_finite_positive_int():
+    assert isinstance(MAX_PHRASE_EXTRACTION_DEFAULT_LEN, int)
+    assert MAX_PHRASE_EXTRACTION_DEFAULT_LEN > 0
+
+
+def test_docstring_example_preserved():
+    # The default expands to max(9, 10) = 10 (<= cap), so the documented
+    # 24-phrase result is unchanged.
+    assert len(phrase_extraction(_SRC, _TRG, _ALIGN)) == 24
+
+
+def test_default_allowed_up_to_the_cap():
+    # A sentence pair exactly at the cap still uses the full default (no raise).
+    src, trg, align = _diag(MAX_PHRASE_EXTRACTION_DEFAULT_LEN)
+    assert len(phrase_extraction(src, trg, align)) > 0
+
+
+def test_oversized_default_raises():
+    # One past the cap with the default max_phrase_length is refused.
+    src, trg, align = _diag(MAX_PHRASE_EXTRACTION_DEFAULT_LEN + 1)
+    with pytest.raises(ValueError):
+        phrase_extraction(src, trg, align)
+
+
+def test_explicit_max_phrase_length_is_never_capped():
+    # An explicit (bounded) max_phrase_length over a long sentence stays cheap
+    # and is allowed regardless of the cap.
+    src, trg, align = _diag(2 * MAX_PHRASE_EXTRACTION_DEFAULT_LEN)
+    phrases = phrase_extraction(src, trg, align, max_phrase_length=5)
+    assert len(phrases) > 0
+
+
+_TIMEOUT = 60
+# Worker outcomes, reported via exit code (avoids a result queue / feeder thread,
+# which is fragile on free-threaded builds).
+_EXIT_REFUSED = 0  # ValueError raised before running (the expected result)
+_EXIT_RAN = 2  # the cubic enumeration ran to completion (regression)
+_EXIT_OTHER = 3  # any other failure
+
+
+def _phrase_worker():
+    # A moderate sentence pair, just over the cap. If the guard were removed
+    # this runs the cubic path, but at this size it stays well under ~150 MB and
+    # ~2 s, so a regression is caught by the non-zero exit code (or the parent's
+    # timeout) without risking an OS OOM kill of the whole CI job.
+    src, trg, align = _diag(400)
+    try:
+        phrase_extraction(src, trg, align)
+        os._exit(_EXIT_RAN)
+    except ValueError:
+        os._exit(_EXIT_REFUSED)
+    except BaseException:
+        os._exit(_EXIT_OTHER)
+
+
+def test_oversized_default_is_refused_not_run():
+    """phrase_extraction(long_pair) with the default must be refused, not run."""
+    ctx = multiprocessing.get_context("spawn")
+    proc = ctx.Process(target=_phrase_worker)
+    proc.start()
+    proc.join(_TIMEOUT)
+    if proc.is_alive():
+        proc.terminate()
+        proc.join()
+        raise AssertionError(
+            "phrase_extraction() did not return quickly -> ran the cubic path (DoS)"
+        )
+    assert proc.exitcode == _EXIT_REFUSED, (
+        "phrase_extraction() with the default max_phrase_length over a long "
+        f"sentence pair was not refused (worker exit code {proc.exitcode}); "
+        "expected a fast ValueError"
+    )

--- a/nltk/translate/phrase_based.py
+++ b/nltk/translate/phrase_based.py
@@ -5,6 +5,17 @@
 # URL: <https://www.nltk.org/>
 # For license information, see LICENSE.TXT
 
+#: Largest sentence length for which :func:`phrase_extraction` expands the
+#: default ``max_phrase_length`` to the full sentence length. The default
+#: enumerates every phrase pair up to that length, which is O(n**2) pairs each
+#: holding an O(n)-word string -- O(n**3) total work/memory -- so leaving
+#: ``max_phrase_length`` at its default over a few-hundred-word sentence pair
+#: pins the CPU and exhausts memory (CWE-770). When the defaulted length would
+#: exceed this, ``phrase_extraction`` raises ``ValueError`` asking for an
+#: explicit ``max_phrase_length``. This only affects the default; an explicitly
+#: supplied ``max_phrase_length`` is never capped.
+MAX_PHRASE_EXTRACTION_DEFAULT_LEN = 256
+
 
 def extract(
     f_start,
@@ -149,6 +160,11 @@ def phrase_extraction(srctext, trgtext, alignment, max_phrase_length=0):
     :type max_phrase_length: int
     :param max_phrase_length: maximal phrase length, if 0 or not specified
         it is set to a length of the longer sentence (srctext or trgtext).
+    :raise ValueError: if ``max_phrase_length`` is left at its default and the
+        longer sentence exceeds ``MAX_PHRASE_EXTRACTION_DEFAULT_LEN``, since
+        enumerating every phrase pair up to the full length is O(n**3) in work
+        and memory and can exhaust the process (CWE-770). Pass an explicit
+        ``max_phrase_length`` to bound the phrase length.
     """
 
     srctext = srctext.split()  # e
@@ -157,7 +173,25 @@ def phrase_extraction(srctext, trgtext, alignment, max_phrase_length=0):
     trglen = len(trgtext)  # len(f)
     # Keeps an index of which source/target words that are aligned.
     f_aligned = [j for _, j in alignment]
-    max_phrase_length = max_phrase_length or max(srclen, trglen)
+    if not max_phrase_length:
+        # The default expands to the full sentence length, which makes
+        # phrase_extraction enumerate O(n**2) phrase pairs each holding an
+        # O(n)-word string -- O(n**3) total -- so a few-hundred-word sentence
+        # pair pins the CPU and exhausts memory (CWE-770). Refuse the unbounded
+        # default for long sentences instead of running it; an explicit
+        # max_phrase_length (an informed choice) is never capped.
+        max_phrase_length = max(srclen, trglen)
+        if max_phrase_length > MAX_PHRASE_EXTRACTION_DEFAULT_LEN:
+            raise ValueError(
+                "phrase_extraction() called with the default max_phrase_length "
+                "on a sentence pair of length %d: enumerating every phrase pair "
+                "up to that length is O(n**2) pairs each holding an O(n)-word "
+                "string (O(n**3) total) and can exhaust memory/CPU (CWE-770). "
+                "Pass an explicit max_phrase_length (e.g. 7, the usual "
+                "phrase-based MT limit), or raise "
+                "nltk.translate.phrase_based.MAX_PHRASE_EXTRACTION_DEFAULT_LEN."
+                % max_phrase_length
+            )
 
     # set of phrase pairs BP
     bp = set()


### PR DESCRIPTION
# Bound `phrase_extraction` default `max_phrase_length` to stop cubic-blowup DoS (CWE-770 / CVE-2026-12870)

## Description

`nltk.translate.phrase_based.phrase_extraction` extracts all consistent phrase
pairs from a source/target sentence and a word alignment. Its
`max_phrase_length` defaults to **the full sentence length**, and there is no cap
on the number of phrase pairs:

```python
# nltk/translate/phrase_based.py (before)
def phrase_extraction(srctext, trgtext, alignment, max_phrase_length=0):
    ...
    max_phrase_length = max_phrase_length or max(srclen, trglen)   # default -> full length
    for e_start in range(srclen):
        max_idx = min(srclen, e_start + max_phrase_length)         # no real bound
        for e_end in range(e_start, max_idx):
            ...
            extract(..., max_phrase_length)   # emits O(n) phrases, each an O(n)-word string
```

For an `n`-word sentence pair with a (diagonal) alignment, the nested ranges emit
~`n²/2` phrase pairs, and each pair builds and stores a phrase string of up to
`n` words → **O(n²) tuples × O(n) bytes = O(n³)** total work and memory. The
default `max_phrase_length = 0` self-expands to the whole sentence, so **the
worst case is the default path**.

Measured cost of `phrase_extraction(src, trg, diagonal_align)` (current source):

| n words | #phrases | time | peak memory |
|------:|--------:|-----:|------------:|
| 64 | 2,080 | 0.01 s | 1 MB |
| 128 | 8,256 | 0.08 s | 5 MB |
| 256 | 32,896 | 0.53 s | 36 MB |
| 400 | 80,200 | 2.1 s | 134 MB |

(~6× per doubling → cubic.) A few-hundred-to-thousand-word pair pins the CPU for
seconds-to-minutes and allocates hundreds of MB to GB — all three arguments are
untrusted and no non-default configuration is required. Validated as
**CVE-2026-12870** (CWE-770).

## The fix

Following the same approach as the `everygrams` default-`max_len` fix, cap the
**defaulted** `max_phrase_length`: when the sentinel would expand beyond
`MAX_PHRASE_EXTRACTION_DEFAULT_LEN` (256), raise a clear `ValueError` asking for
an explicit `max_phrase_length`, instead of silently running the O(n³) path:

```python
MAX_PHRASE_EXTRACTION_DEFAULT_LEN = 256

    if not max_phrase_length:
        max_phrase_length = max(srclen, trglen)
        if max_phrase_length > MAX_PHRASE_EXTRACTION_DEFAULT_LEN:
            raise ValueError(
                "phrase_extraction() called with the default max_phrase_length "
                "on a sentence pair of length %d: ... (O(n**3) total) and can "
                "exhaust memory/CPU (CWE-770). Pass an explicit max_phrase_length "
                "(e.g. 7, the usual phrase-based MT limit), or raise "
                "nltk.translate.phrase_based.MAX_PHRASE_EXTRACTION_DEFAULT_LEN."
                % max_phrase_length
            )
```

Properties:
- **Targets exactly the reported flaw** (the unbounded *default*). An explicitly
  supplied `max_phrase_length` — an informed choice — is **never capped**, so no
  existing caller that passes a length changes behaviour.
- **Behaviour-preserving for normal input**: a sentence pair up to 256 words
  still uses the full default; the documented worked example
  (`max(9, 10) = 10 ≤ 256`) is unchanged.
- **Non-silent**: it raises an actionable `ValueError` (telling the caller to
  pass `max_phrase_length`, e.g. `7`, the standard phrase-based MT limit) rather
  than silently truncating phrases, so a caller can't mistake a capped run for a
  complete one.
- **Bounded worst case**: with the default the largest allocation is now at
  `n = 256` (~0.5 s / ~36 MB, measured), instead of unbounded.
- **Tunable**: `MAX_PHRASE_EXTRACTION_DEFAULT_LEN` is a module-level constant a
  caller can raise if they really want the full default over a longer sentence.
- The `not max_phrase_length` check preserves the original `or`-based
  default-selection semantics exactly (0/unspecified → default).

## Behaviour preservation (verified)

- `python -m doctest nltk/translate/phrase_based.py`: passes — the documented
  24-phrase example is unchanged (its default expands to `10 ≤ 256`).
- A sentence pair exactly at the cap (256 words) still uses the full default; an
  explicit `phrase_extraction(long_pair, max_phrase_length=7)` over a 1000-word
  pair stays linear (~0.2 s) and is allowed.

## Performance

| call | before | after |
|------|--------|-------|
| `phrase_extraction(src, trg, align)`, 1000-word pair (default) | minutes, GBs → OOM | `ValueError` in ~0 ms (before running) |
| `phrase_extraction(...)`, ≤256-word pair (default) | ≤~0.5 s / 36 MB | unchanged |
| `phrase_extraction(..., max_phrase_length=7)` | linear | unchanged |

## Testing

- `nltk/test/unit/translate/test_phrase_based_security.py` (new): confirms
  `MAX_PHRASE_EXTRACTION_DEFAULT_LEN` is a finite positive int; that the
  docstring's 24-phrase example and explicit-`max_phrase_length` (never-capped)
  behaviour are preserved; that the default is allowed up to the cap and refused
  one past it; and that the default over a long pair is **refused, not run** —
  that last test runs in a spawned process with a hard timeout (the worker
  reports via its exit code, so it stays robust on free-threaded builds) so a
  regression can't hang the suite. The behaviour/refusal tests fail against the
  pre-fix `develop` version (which runs the cubic path to completion).
- `black==25.11.0`, `isort==6.1.0`, `ruff==0.15.6` (repo-pinned) — clean.