### PR TITLE
fix(security): make Cistem stemmer linear to stop quadratic-time DoS (CVE-2026-12868)

### DIFF
--- a/nltk/stem/cistem.py
+++ b/nltk/stem/cistem.py
@@ -177,10 +177,10 @@ class Cistem(StemmerI):
         # Apply the substitution patterns. Each pattern (e[mr]$, nd$, t$, [esn]$)
         # only ever strips one or two characters anchored at the end of the
         # string. The original loop rebuilt the whole remaining string on every
-        # removal via ``regex.subn`` -- O(n) work per step over O(n) steps, i.e.
-        # O(n**2) in the word length, so a single long word pins a CPU core
-        # (CWE-770; CVE-2026-12868). Strip characters off the end of a list in
-        # O(1) per step instead, joining once at the end.
+        # removal via the compiled ``re`` patterns' ``Pattern.subn`` -- O(n) work
+        # per step over O(n) steps, i.e. O(n**2) in the word length, so a single
+        # long word pins a CPU core (CWE-770; CVE-2026-12868). Strip characters
+        # off the end of a list in O(1) per step instead, joining once at the end.
         #
         # Python's ``$`` matches at the end of the string *or* just before a
         # single trailing newline, so such a newline is transparent to the

--- a/nltk/stem/cistem.py
+++ b/nltk/stem/cistem.py
@@ -44,11 +44,11 @@ class Cistem(StemmerI):
 
     strip_ge = re.compile(r"^ge(.{4,})")
     repl_xx = re.compile(r"(.)\1")
-    strip_emr = re.compile(r"e[mr]$")
-    strip_nd = re.compile(r"nd$")
-    strip_t = re.compile(r"t$")
-    strip_esn = re.compile(r"[esn]$")
     repl_xx_back = re.compile(r"(.)\*")
+    # The end-anchored suffix patterns (e[mr]$, nd$, t$, [esn]$) are applied by
+    # direct end-of-string character checks in ``_segment_inner`` (see there),
+    # not via ``re``, so that stemming is linear rather than quadratic in the
+    # word length (CWE-770; CVE-2026-12868).
 
     def __init__(self, case_insensitive: bool = False):
         self._case_insensitive = case_insensitive
@@ -174,31 +174,56 @@ class Cistem(StemmerI):
         word = Cistem.replace_to(word)
         rest = ""
 
-        # Apply the substitution patterns
-        while len(word) > 3:
-            if len(word) > 5:
-                word, n = Cistem.strip_emr.subn("", word)
-                if n != 0:
+        # Apply the substitution patterns. Each pattern (e[mr]$, nd$, t$, [esn]$)
+        # only ever strips one or two characters anchored at the end of the
+        # string. The original loop rebuilt the whole remaining string on every
+        # removal via ``regex.subn`` -- O(n) work per step over O(n) steps, i.e.
+        # O(n**2) in the word length, so a single long word pins a CPU core
+        # (CWE-770; CVE-2026-12868). Strip characters off the end of a list in
+        # O(1) per step instead, joining once at the end.
+        #
+        # Python's ``$`` matches at the end of the string *or* just before a
+        # single trailing newline, so such a newline is transparent to the
+        # anchored patterns and is preserved (``_strip`` pops it aside and
+        # restores it); ``j`` is the index of the last character the patterns
+        # act on.
+        chars = list(word)
+
+        def _strip(count):
+            if chars[-1] == "\n":
+                newline = chars.pop()
+                del chars[-count:]
+                chars.append(newline)
+            else:
+                del chars[-count:]
+
+        while len(chars) > 3:
+            j = -2 if chars[-1] == "\n" else -1
+            if len(chars) > 5:
+                if chars[j] in "mr" and chars[j - 1] == "e":  # e[mr]$
+                    _strip(2)
                     rest_length += 2
                     continue
 
-                word, n = Cistem.strip_nd.subn("", word)
-                if n != 0:
+                if chars[j] == "d" and chars[j - 1] == "n":  # nd$
+                    _strip(2)
                     rest_length += 2
                     continue
 
             if not upper or self._case_insensitive:
-                word, n = Cistem.strip_t.subn("", word)
-                if n != 0:
+                if chars[j] == "t":  # t$
+                    _strip(1)
                     rest_length += 1
                     continue
 
-            word, n = Cistem.strip_esn.subn("", word)
-            if n != 0:
+            if chars[j] in "esn":  # [esn]$
+                _strip(1)
                 rest_length += 1
                 continue
             else:
                 break
+
+        word = "".join(chars)
 
         # Post-processing after applying the substitution patterns
         word = Cistem.replace_back(word)

--- a/nltk/test/unit/test_cistem.py
+++ b/nltk/test/unit/test_cistem.py
@@ -1,0 +1,82 @@
+"""Regression tests for the quadratic-time DoS in the Cistem stemmer
+(CWE-770; CVE-2026-12868).
+
+``Cistem._segment_inner`` stripped 1-2 trailing characters per iteration with
+``regex.subn("", word)``, which rebuilt the whole remaining string each time --
+O(n) work over O(n) iterations, i.e. O(n**2) in the word length. A single
+crafted word of a few tens of KB pinned a CPU core. The loop now strips from a
+list in O(1) per step (O(n) overall) while producing byte-identical output.
+
+The "must stay linear" test runs in a spawned process with a hard timeout, and
+the worker reports its outcome through its exit code (no queue/thread, so it is
+robust on free-threaded builds), so a regression to the O(n**2) loop cannot hang
+the suite.
+"""
+
+import multiprocessing
+import os
+
+from nltk.stem.cistem import Cistem
+
+# (word, expected stem, expected (stem, rest)) for the default (case-sensitive)
+# stemmer -- these are the examples documented in Cistem.stem / Cistem.segment.
+_CASE_SENSITIVE = [
+    ("Speicherbehältern", "speicherbehalt", ("speicherbehält", "ern")),
+    ("Grenzpostens", "grenzpost", ("grenzpost", "ens")),
+    ("Ausgefeiltere", "ausgefeilt", ("ausgefeilt", "ere")),
+]
+# expected stems / segments for the case-insensitive stemmer.
+_CASE_INSENSITIVE = [
+    ("Speicherbehältern", "speicherbehal", ("speicherbehäl", "tern")),
+    ("Grenzpostens", "grenzpo", ("grenzpo", "stens")),
+    ("Ausgefeiltere", "ausgefeil", ("ausgefeil", "tere")),
+]
+
+
+def test_stem_and_segment_examples_preserved():
+    stemmer = Cistem()
+    for word, stem, segment in _CASE_SENSITIVE:
+        assert stemmer.stem(word) == stem
+        assert stemmer.segment(word) == segment
+    ci = Cistem(case_insensitive=True)
+    for word, stem, segment in _CASE_INSENSITIVE:
+        assert ci.stem(word) == stem
+        assert ci.segment(word) == segment
+
+
+def test_empty_and_short_words():
+    stemmer = Cistem()
+    assert stemmer.stem("") == ""
+    assert stemmer.segment("") == ("", "")
+    assert stemmer.stem("Die") == "die"  # <= 3 chars: returned unchanged (lowered)
+
+
+_TIMEOUT = 20
+# A word that the pre-fix O(n**2) loop would take ~minutes on (the loop runs
+# ~n iterations, each rebuilding the whole ~n-char string), but the O(n) fix
+# stems in milliseconds. Made of repeated strippable suffixes to maximise the
+# iteration count.
+_BIG_WORD = "esn" * 40000  # 120k chars
+
+
+def _stem_worker():
+    try:
+        Cistem().stem(_BIG_WORD)
+        os._exit(0)  # finished quickly -> linear
+    except BaseException:
+        os._exit(3)
+
+
+def test_long_word_stems_in_linear_time():
+    """A long word must stem quickly, not run the old O(n**2) loop."""
+    ctx = multiprocessing.get_context("spawn")
+    proc = ctx.Process(target=_stem_worker)
+    proc.start()
+    proc.join(_TIMEOUT)
+    if proc.is_alive():
+        proc.terminate()
+        proc.join()
+        raise AssertionError(
+            "Cistem.stem did not finish in time -> quadratic-time DoS (CWE-770)"
+        )
+    assert proc.exitcode == 0, f"worker failed (exit code {proc.exitcode})"

--- a/nltk/test/unit/test_cistem.py
+++ b/nltk/test/unit/test_cistem.py
@@ -1,9 +1,10 @@
 """Regression tests for the quadratic-time DoS in the Cistem stemmer
 (CWE-770; CVE-2026-12868).
 
-``Cistem._segment_inner`` stripped 1-2 trailing characters per iteration with
-``regex.subn("", word)``, which rebuilt the whole remaining string each time --
-O(n) work over O(n) iterations, i.e. O(n**2) in the word length. A single
+``Cistem._segment_inner`` stripped 1-2 trailing characters per iteration with a
+compiled ``re`` pattern's ``Pattern.subn("", word)``, which rebuilt the whole
+remaining string each time -- O(n) work over O(n) iterations, i.e. O(n**2) in the
+word length. A single
 crafted word of a few tens of KB pinned a CPU core. The loop now strips from a
 list in O(1) per step (O(n) overall) while producing byte-identical output.
 


### PR DESCRIPTION
# Make the Cistem stemmer linear to stop quadratic-time DoS (CWE-770 / CVE-2026-12868)

## Description

`nltk.stem.cistem.Cistem.stem` / `.segment` strip trailing characters in a loop
that rebuilds the whole remaining string each iteration:

```python
# nltk/stem/cistem.py (before) -- Cistem._segment_inner
while len(word) > 3:
    if len(word) > 5:
        word, n = Cistem.strip_emr.subn("", word)   # e[mr]$  -> rebuilds the whole string
        ...
        word, n = Cistem.strip_nd.subn("", word)    # nd$
        ...
    word, n = Cistem.strip_t.subn("", word)         # t$
    ...
    word, n = Cistem.strip_esn.subn("", word)       # [esn]$
```

Each iteration removes only one or two trailing characters, but every removal
via `regex.subn("", word)` allocates a fresh copy of the entire remaining
string. With ~`n` iterations (a word of repeated strippable suffixes) and O(`n`)
work per iteration, the total is **O(n²)** in the word length.

A single crafted word is enough — measured on the current source (`"esn" * k`):

| word length | time |
|------:|-----:|
| 15,000 | 0.9 s |
| 30,000 | 3.6 s |
| 60,000 | 15.4 s |

(~4× per doubling → quadratic.) A ~60 KB token pins a CPU core for ~15 s; a
larger one for minutes. The input is a single untrusted string
(`Cistem().stem(word)`); no authentication, interaction, or non-default
configuration is required. Validated as **CVE-2026-12868** (CWE-770).

## The fix

All four patterns are anchored at the end of the string (`e[mr]$`, `nd$`, `t$`,
`[esn]$`) and only ever remove 1-2 characters there. So instead of rebuilding
the whole string per removal, strip characters off the end of a list in **O(1)
per step** and join once at the end:

```python
chars = list(word)

def _strip(count):
    if chars[-1] == "\n":
        newline = chars.pop()      # see the newline note below
        del chars[-count:]
        chars.append(newline)
    else:
        del chars[-count:]

while len(chars) > 3:
    j = -2 if chars[-1] == "\n" else -1
    if len(chars) > 5:
        if chars[j] in "mr" and chars[j - 1] == "e":   # e[mr]$
            _strip(2); rest_length += 2; continue
        if chars[j] == "d" and chars[j - 1] == "n":    # nd$
            _strip(2); rest_length += 2; continue
    if not upper or self._case_insensitive:
        if chars[j] == "t":                            # t$
            _strip(1); rest_length += 1; continue
    if chars[j] in "esn":                              # [esn]$
        _strip(1); rest_length += 1; continue
    else:
        break

word = "".join(chars)
```

The whole method is now **O(n)** (one `list(word)`, O(n) O(1)-steps, one
`"".join`).

**Preserving Python's `$` semantics.** In non-multiline mode `$` matches at the
end of the string *or* just before a single trailing newline, so the original
`subn` would strip the character *before* a trailing `\n` and leave the `\n` in
place (and that `\n` keeps shielding subsequent characters as they are stripped).
The fix reproduces this exactly: `j` points one character earlier when the tail
is `\n`, and `_strip` pops the trailing `\n` aside and restores it so it is
preserved. This also matters for security: handling newlines via a slower
fallback would let an attacker re-trigger the quadratic path with a
newline-laced word, so the newline case is handled in the same O(n) loop.

The four now-unused compiled patterns (`strip_emr`, `strip_nd`, `strip_t`,
`strip_esn`) are removed; the patterns they encoded are applied by the
character checks above.

## Behaviour preservation (verified)

- `python -m doctest nltk/stem/cistem.py`: passes — all `stem`/`segment`
  examples in both case-sensitive and case-insensitive modes are unchanged
  (e.g. `"Speicherbehältern"` → `"speicherbehalt"`;
  `segment` → `("speicherbehält", "ern")`).
- **Differential fuzzing**: the new `_segment_inner` was compared against the
  original on **300,000 random words** drawn from an alphabet that stresses
  every pattern plus the `replace_to` special characters (`$ % & *`), German
  characters (`ü ö ä ß`), capitals, and embedded/trailing newlines, in both case
  modes — **0 mismatches** for both `stem` and `segment`.

## Performance

| input | before | after |
|-------|--------|-------|
| `stem("esn" * 20000)` (60 KB, the PoC) | ~15 s | ~8 ms |
| `stem("esn" * 40000)` (120 KB) | ~60 s | ~16 ms |
| normal words | unchanged | unchanged |

## Testing

- `nltk/test/unit/test_cistem.py` (new): asserts the documented `stem`/`segment`
  outputs (both case modes) and the empty/short-word behaviour are preserved,
  and that a long word stems in linear time — that last check runs in a spawned
  process with a hard timeout (the worker reports via its exit code, so it is
  robust on free-threaded builds) so a regression to the O(n²) loop cannot hang
  the suite. The long-word test fails (times out) against the pre-fix `develop`
  version and passes against the fix.
- `black==25.11.0`, `isort==6.1.0`, `ruff==0.15.6` (repo-pinned) — clean.