### PR TITLE
fix(security): route data.retrieve write through the pathsec sandbox (CVE-2026-12871)

### DIFF
--- a/nltk/data.py
+++ b/nltk/data.py
@@ -833,8 +833,13 @@ def retrieve(resource_url, filename=None, verbose=True):
     # Open the input & output streams.
     infile = _open(resource_url)
 
-    # Copy infile -> outfile, using 64k blocks.
-    with open(filename, "wb") as outfile:
+    # Copy infile -> outfile, using 64k blocks. Route the write through the
+    # pathsec sentinel so the destination honours the file-access sandbox
+    # (allowed data roots, symlink resolution) instead of the builtin open,
+    # which bypasses it and can write arbitrary local files -- an arbitrary
+    # file write that can escalate to code execution via a planted file
+    # (CWE-22).
+    with _secure_open(filename, "wb") as outfile:
         while True:
             s = infile.read(1024 * 64)  # 64k blocks.
             outfile.write(s)

--- a/nltk/test/unit/test_data_security.py
+++ b/nltk/test/unit/test_data_security.py
@@ -240,3 +240,57 @@ def test_gzip_pointer_open_enforces_sandbox(tmp_path, monkeypatch):
         fh.write(b"hello-gz")
     with data.GzipFileSystemPathPointer(str(good)).open() as fp:
         assert fp.read() == b"hello-gz"
+
+
+# ---------------------------------------------------------------------------
+# retrieve() write sink must honour the pathsec sandbox (CWE-22; CVE-2026-12871)
+# ---------------------------------------------------------------------------
+
+_RETRIEVE_PAYLOAD = b"ARBITRARY-FILE-WRITE-PAYLOAD"
+
+
+def test_retrieve_write_enforces_pathsec_sandbox(tmp_path, monkeypatch):
+    """Under ``ENFORCE``, an out-of-root write target is rejected; in-root works.
+
+    ``retrieve`` used the builtin ``open(..., "wb")`` for the destination, which
+    bypassed pathsec and allowed arbitrary local file writes outside the sandbox.
+    """
+    allowed = tmp_path / "data"
+    allowed.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    monkeypatch.setattr(pathsec, "ENFORCE", True)
+    monkeypatch.setattr(pathsec, "_get_allowed_roots", lambda: {allowed.resolve()})
+
+    # An in-root source whose bytes become the copied content.
+    src = allowed / "src.txt"
+    src.write_bytes(_RETRIEVE_PAYLOAD)
+    url = "file://" + str(src)
+
+    # Out-of-root target: the global sandbox (no required_root) raises
+    # PermissionError, and nothing must be written.
+    target = outside / "evil.txt"
+    with pytest.raises(PermissionError):
+        data.retrieve(url, filename=str(target), verbose=False)
+    assert not target.exists()
+
+    # In-root target still works and copies the bytes.
+    ok = allowed / "copy.txt"
+    data.retrieve(url, filename=str(ok), verbose=False)
+    assert ok.read_bytes() == _RETRIEVE_PAYLOAD
+
+
+def test_retrieve_write_unchanged_when_sandbox_disabled(tmp_path, monkeypatch):
+    """With the sandbox off, an out-of-root target still writes (only warns)."""
+    monkeypatch.setattr(pathsec, "ENFORCE", False)
+    # Force *no* allowed roots so the target is unambiguously out-of-root
+    # (tmp_path is usually inside tempfile.gettempdir(), which is allowed by
+    # default -- that would not exercise the disabled-sandbox path).
+    monkeypatch.setattr(pathsec, "_get_allowed_roots", set)
+    src = tmp_path / "src.txt"
+    src.write_bytes(_RETRIEVE_PAYLOAD)
+    target = tmp_path / "out.txt"
+    # Not enforcing: pathsec warns about the out-of-root path but still writes.
+    with pytest.warns(RuntimeWarning):
+        data.retrieve("file://" + str(src), filename=str(target), verbose=False)
+    assert target.read_bytes() == _RETRIEVE_PAYLOAD

--- a/nltk/test/unit/test_data_security.py
+++ b/nltk/test/unit/test_data_security.py
@@ -265,7 +265,7 @@ def test_retrieve_write_enforces_pathsec_sandbox(tmp_path, monkeypatch):
     # An in-root source whose bytes become the copied content.
     src = allowed / "src.txt"
     src.write_bytes(_RETRIEVE_PAYLOAD)
-    url = "file://" + str(src)
+    url = src.resolve().as_uri()  # RFC 8089 file URL (portable across platforms)
 
     # Out-of-root target: the global sandbox (no required_root) raises
     # PermissionError, and nothing must be written.
@@ -292,5 +292,5 @@ def test_retrieve_write_unchanged_when_sandbox_disabled(tmp_path, monkeypatch):
     target = tmp_path / "out.txt"
     # Not enforcing: pathsec warns about the out-of-root path but still writes.
     with pytest.warns(RuntimeWarning):
-        data.retrieve("file://" + str(src), filename=str(target), verbose=False)
+        data.retrieve(src.resolve().as_uri(), filename=str(target), verbose=False)
     assert target.read_bytes() == _RETRIEVE_PAYLOAD


### PR DESCRIPTION
# Route `data.retrieve`'s write through the pathsec sandbox (CWE-22 / CVE-2026-12871)

## Description

`nltk.data.retrieve` copies a resource to a caller-supplied `filename`, but it
opens the **output** path with the builtin `open(..., "wb")`, bypassing NLTK's
centralized file-access sentinel (`nltk.pathsec`):

```python
# nltk/data.py (before)
def retrieve(resource_url, filename=None, verbose=True):
    ...
    infile = _open(resource_url)              # read side IS pathsec-guarded
    with open(filename, "wb") as outfile:     # WRITE side bypasses pathsec
        ...copy resource bytes...
```

Because the **write sink** bypasses the I/O boundary, it neutralizes the
file-access enforcement policy. With the sandbox enabled (`pathsec.ENFORCE`, on
by default in NLTK 3.10) and an attacker-influenced `filename`, `retrieve` writes
**arbitrary local files outside the allowed data roots**. Since the attacker
controls both the destination path and the content, a shell-init / login-profile
/ `authorized_keys` / autostart target escalates to **code execution as the
victim** (the write plants the payload; a subsequent user action runs it).

This is the write-side counterpart of the already-fixed read-side pathsec drift
(e.g. `DependencyGraph.load`, the gzip pointer, the corpus readers) and of the
downloader write fix — `retrieve`'s write target was simply never routed through
the sentinel. Validated as **CVE-2026-12871** (CWE-22, CVSS 9.6).

## The fix

Write through the pathsec sentinel (`pathsec.open`, already imported in
`data.py` as `_secure_open` and used elsewhere in the module). `pathsec.open`
runs `validate_path` — which enforces the allowed data roots and resolves
symlinks — before delegating to the builtin `open`, here in write mode:

```python
from nltk.pathsec import open as _secure_open   # already present

    with _secure_open(filename, "wb") as outfile:
        ...copy resource bytes...
```

This is the minimal change that restores the boundary: a single call swap. No
signature, return type, or copy behaviour changes. The read side
(`_open(resource_url)`) was already guarded and is untouched.

## Behaviour preservation (verified)

- When the sandbox is **disabled** (`pathsec.ENFORCE = False`), `pathsec.open`
  delegates straight to the builtin `open`, so `retrieve` behaves exactly as
  before — any path still writes.
- When the sandbox is **enabled**, an **in-root** target still writes the copied
  bytes; only an **out-of-root** target is now rejected with `PermissionError`
  (before any bytes are written).
- `data.doctest`: **79 attempted, 38 failed — identical to `develop`** (the 38
  are pre-existing missing-corpus failures, unrelated to this change). The
  `retrieve` examples there write into a `tempfile.mkdtemp()` directory, which is
  under `tempfile.gettempdir()` — an allowed root — so they are unaffected.

## Proof of concept (before → after)

With `ENFORCE = True` and an out-of-root target (the home directory):

| call | before | after |
|------|--------|-------|
| `pathsec.open(target, "wb")` | `PermissionError` (correctly blocked) | unchanged |
| `retrieve(url, filename=target)` | **writes** the file (arbitrary file write → RCE) | `PermissionError` (blocked) |
| `retrieve(url, filename=in_root)` | writes | writes (unchanged) |

## Testing

- `nltk/test/unit/test_data_security.py` (extended): with `ENFORCE` and the
  allowed roots monkeypatched to a temp dir, an out-of-root target is rejected
  (`PermissionError`) and nothing is written, while an in-root target still
  copies the bytes; a second test forces empty allowed roots and confirms that
  with the sandbox disabled the out-of-root write still succeeds (with a
  `RuntimeWarning`). The sandbox test fails against the pre-fix `develop` version
  (`DID NOT RAISE PermissionError`) and passes against the fix.
- `black==25.11.0`, `isort==6.1.0`, `ruff==0.15.6` (repo-pinned) — clean.