### PR TITLE
fix(security): bound DRT resolve_anaphora work to stop quadratic time+memory DoS (CVE-2026-12873)

### DIFF
--- a/nltk/sem/drt.py
+++ b/nltk/sem/drt.py
@@ -999,12 +999,56 @@ class AnaphoraResolutionException(Exception):
     pass
 
 
-def resolve_anaphora(expression, trail=[]):
+#: Upper bound on the number of (pronoun, discourse-referent) examinations a
+#: single ``resolve_anaphora`` call may perform. Each pronoun condition scans
+#: every referent on the trail and retains the compatible ones as candidate
+#: antecedents, so a DRS with N referents and N pronouns costs O(N**2) time and
+#: retained memory; a small crafted DRS string then pins the CPU and exhausts
+#: memory (CWE-770; CVE-2026-12873). Once this many examinations have been made,
+#: resolution raises ``AnaphoraResolutionException`` instead of running
+#: unbounded. Raise it if you legitimately need to resolve a larger discourse.
+MAX_ANAPHORA_OPERATIONS = 1_000_000
+
+
+class _AnaphoraBudget:
+    """Counts candidate-antecedent examinations and aborts runaway resolution.
+
+    The whole resolution shares one budget, so it bounds the total O(N**2) work
+    regardless of how the DRS is structured.
+    """
+
+    __slots__ = ("remaining", "limit")
+
+    def __init__(self, limit):
+        self.remaining = limit
+        self.limit = limit
+
+    def spend(self):
+        self.remaining -= 1
+        if self.remaining < 0:
+            raise AnaphoraResolutionException(
+                "Refusing to resolve anaphora: examining candidate antecedents "
+                "exceeded the limit of %d (pronoun, referent) steps, which a DRS "
+                "with many referents and pronouns reaches at O(n**2) time and "
+                "memory (CWE-770). Resolve a smaller discourse, or raise "
+                "nltk.sem.drt.MAX_ANAPHORA_OPERATIONS." % self.limit
+            )
+
+
+def resolve_anaphora(expression, trail=[], budget=None):
+    # A shared budget bounds the total (pronoun, referent) examinations across
+    # the whole resolution: each pronoun scans every referent on the trail and
+    # retains the compatible ones, so a DRS with many referents and pronouns is
+    # O(N**2) in time and retained memory and a small crafted string can exhaust
+    # the process (CWE-770; CVE-2026-12873).
+    if budget is None:
+        budget = _AnaphoraBudget(MAX_ANAPHORA_OPERATIONS)
     if isinstance(expression, ApplicationExpression):
         if expression.is_pronoun_function():
             possible_antecedents = PossibleAntecedents()
             for ancestor in trail:
                 for ref in ancestor.get_refs():
+                    budget.spend()
                     refex = expression.make_VariableExpression(ref)
 
                     # ==========================================================
@@ -1021,14 +1065,18 @@ def resolve_anaphora(expression, trail=[]):
                 resolution = possible_antecedents
             return expression.make_EqualityExpression(expression.argument, resolution)
         else:
-            r_function = resolve_anaphora(expression.function, trail + [expression])
-            r_argument = resolve_anaphora(expression.argument, trail + [expression])
+            r_function = resolve_anaphora(
+                expression.function, trail + [expression], budget
+            )
+            r_argument = resolve_anaphora(
+                expression.argument, trail + [expression], budget
+            )
             return expression.__class__(r_function, r_argument)
 
     elif isinstance(expression, DRS):
         r_conds = []
         for cond in expression.conds:
-            r_cond = resolve_anaphora(cond, trail + [expression])
+            r_cond = resolve_anaphora(cond, trail + [expression], budget)
 
             # if the condition is of the form '(x = [])' then raise exception
             if isinstance(r_cond, EqualityExpression):
@@ -1046,7 +1094,9 @@ def resolve_anaphora(expression, trail=[]):
 
             r_conds.append(r_cond)
         if expression.consequent:
-            consequent = resolve_anaphora(expression.consequent, trail + [expression])
+            consequent = resolve_anaphora(
+                expression.consequent, trail + [expression], budget
+            )
         else:
             consequent = None
         return expression.__class__(expression.refs, r_conds, consequent)
@@ -1056,29 +1106,32 @@ def resolve_anaphora(expression, trail=[]):
 
     elif isinstance(expression, NegatedExpression):
         return expression.__class__(
-            resolve_anaphora(expression.term, trail + [expression])
+            resolve_anaphora(expression.term, trail + [expression], budget)
         )
 
     elif isinstance(expression, DrtConcatenation):
         if expression.consequent:
-            consequent = resolve_anaphora(expression.consequent, trail + [expression])
+            consequent = resolve_anaphora(
+                expression.consequent, trail + [expression], budget
+            )
         else:
             consequent = None
         return expression.__class__(
-            resolve_anaphora(expression.first, trail + [expression]),
-            resolve_anaphora(expression.second, trail + [expression]),
+            resolve_anaphora(expression.first, trail + [expression], budget),
+            resolve_anaphora(expression.second, trail + [expression], budget),
             consequent,
         )
 
     elif isinstance(expression, BinaryExpression):
         return expression.__class__(
-            resolve_anaphora(expression.first, trail + [expression]),
-            resolve_anaphora(expression.second, trail + [expression]),
+            resolve_anaphora(expression.first, trail + [expression], budget),
+            resolve_anaphora(expression.second, trail + [expression], budget),
         )
 
     elif isinstance(expression, LambdaExpression):
         return expression.__class__(
-            expression.variable, resolve_anaphora(expression.term, trail + [expression])
+            expression.variable,
+            resolve_anaphora(expression.term, trail + [expression], budget),
         )
 
 

--- a/nltk/sem/drt.py
+++ b/nltk/sem/drt.py
@@ -1020,6 +1020,13 @@ class _AnaphoraBudget:
     __slots__ = ("remaining", "limit")
 
     def __init__(self, limit):
+        # ``limit`` comes from the module-global ``MAX_ANAPHORA_OPERATIONS``,
+        # which callers may override; validate it so a bad value fails clearly
+        # here rather than as an obscure error mid-resolution.
+        if not isinstance(limit, int) or limit < 1:
+            raise ValueError(
+                f"MAX_ANAPHORA_OPERATIONS must be a positive int, got {limit!r}"
+            )
         self.remaining = limit
         self.limit = limit
 

--- a/nltk/test/unit/test_drt_anaphora.py
+++ b/nltk/test/unit/test_drt_anaphora.py
@@ -10,8 +10,11 @@ by ``MAX_ANAPHORA_OPERATIONS``; once exceeded, resolution raises
 ``AnaphoraResolutionException``.
 """
 
+import math
+
 import pytest
 
+from nltk.sem import drt
 from nltk.sem.drt import (
     MAX_ANAPHORA_OPERATIONS,
     AnaphoraResolutionException,
@@ -55,12 +58,15 @@ def test_small_discourse_resolves():
     assert resolved is not None
 
 
-def test_oversized_discourse_is_refused():
-    # N such that N**2 exceeds the cap: resolution is refused before it can run
-    # the full O(N**2) work. The budget trips at MAX_ANAPHORA_OPERATIONS, so this
-    # stays bounded (~the cap's worth of candidates) and never exhausts memory --
-    # even if the guard were removed, this N completes well within CI limits, so
-    # the missing exception is detected rather than hanging/OOM-ing the suite.
-    n = int(MAX_ANAPHORA_OPERATIONS**0.5) + 100
+def test_oversized_discourse_is_refused(monkeypatch):
+    # Drive the guard with a small cap so the test stays fast and low-memory
+    # (rather than running the real 1,000,000-step budget in process). A DRS with
+    # n referents and n pronouns performs n**2 candidate examinations, so n just
+    # above the integer square root of the cap exceeds it. The budget then trips
+    # at ~the (small) cap's worth of candidates; even without the guard this n
+    # completes immediately, so a regression is detected rather than hanging.
+    cap = 1000
+    monkeypatch.setattr(drt, "MAX_ANAPHORA_OPERATIONS", cap)
+    n = math.isqrt(cap) + 1
     with pytest.raises(AnaphoraResolutionException):
         dexpr(_flat_drs(n)).resolve_anaphora()

--- a/nltk/test/unit/test_drt_anaphora.py
+++ b/nltk/test/unit/test_drt_anaphora.py
@@ -1,0 +1,66 @@
+"""Regression tests for the quadratic time+memory DoS in DRT anaphora
+resolution (CWE-770; CVE-2026-12873).
+
+``nltk.sem.drt.resolve_anaphora`` resolves each pronoun condition by scanning
+every discourse referent on the trail and retaining the compatible ones as
+candidate antecedents. A DRS with N referents and N ``PRO`` conditions therefore
+costs O(N**2) time and retained memory, so a small crafted DRS string exhausts
+the process. The total number of (pronoun, referent) examinations is now bounded
+by ``MAX_ANAPHORA_OPERATIONS``; once exceeded, resolution raises
+``AnaphoraResolutionException``.
+"""
+
+import pytest
+
+from nltk.sem.drt import (
+    MAX_ANAPHORA_OPERATIONS,
+    AnaphoraResolutionException,
+    DrtExpression,
+    resolve_anaphora,
+)
+
+dexpr = DrtExpression.fromstring
+
+
+def _flat_drs(n):
+    """A flat DRS string with ``n`` referents and ``n`` PRO conditions."""
+    refs = ",".join("x%d" % i for i in range(n))
+    conds = ",".join("PRO(x%d)" % i for i in range(n))
+    return "([%s],[%s])" % (refs, conds)
+
+
+def test_max_anaphora_operations_is_a_finite_positive_int():
+    assert isinstance(MAX_ANAPHORA_OPERATIONS, int)
+    assert MAX_ANAPHORA_OPERATIONS > 0
+
+
+def test_resolution_examples_preserved():
+    # The documented resolve_anaphora outputs must be unchanged.
+    assert (
+        str(resolve_anaphora(dexpr(r"([x,y,z],[dog(x), cat(y), walks(z), PRO(z)])")))
+        == "([x,y,z],[dog(x), cat(y), walks(z), (z = [x,y])])"
+    )
+    assert (
+        str(resolve_anaphora(dexpr(r"(([x,y],[]) + ([],[PRO(x)]))")).simplify())
+        == "([x,y],[(x = y)])"
+    )
+    # A pronoun that resolves to nothing still raises the domain exception.
+    with pytest.raises(AnaphoraResolutionException):
+        resolve_anaphora(dexpr(r"([x],[walks(x), PRO(x)])"))
+
+
+def test_small_discourse_resolves():
+    # Well under the cap: resolves normally (every PRO gets its antecedents).
+    resolved = dexpr(_flat_drs(300)).resolve_anaphora()
+    assert resolved is not None
+
+
+def test_oversized_discourse_is_refused():
+    # N such that N**2 exceeds the cap: resolution is refused before it can run
+    # the full O(N**2) work. The budget trips at MAX_ANAPHORA_OPERATIONS, so this
+    # stays bounded (~the cap's worth of candidates) and never exhausts memory --
+    # even if the guard were removed, this N completes well within CI limits, so
+    # the missing exception is detected rather than hanging/OOM-ing the suite.
+    n = int(MAX_ANAPHORA_OPERATIONS**0.5) + 100
+    with pytest.raises(AnaphoraResolutionException):
+        dexpr(_flat_drs(n)).resolve_anaphora()

--- a/nltk/test/unit/test_drt_anaphora.py
+++ b/nltk/test/unit/test_drt_anaphora.py
@@ -24,9 +24,9 @@ dexpr = DrtExpression.fromstring
 
 def _flat_drs(n):
     """A flat DRS string with ``n`` referents and ``n`` PRO conditions."""
-    refs = ",".join("x%d" % i for i in range(n))
-    conds = ",".join("PRO(x%d)" % i for i in range(n))
-    return "([%s],[%s])" % (refs, conds)
+    refs = ",".join(f"x{i}" for i in range(n))
+    conds = ",".join(f"PRO(x{i})" for i in range(n))
+    return f"([{refs}],[{conds}])"
 
 
 def test_max_anaphora_operations_is_a_finite_positive_int():


### PR DESCRIPTION
# Bound DRT `resolve_anaphora` work to stop quadratic time+memory DoS (CWE-770 / CVE-2026-12873)

## Description

`nltk.sem.drt.resolve_anaphora` resolves each pronoun condition `PRO(x)` by
scanning **every** discourse referent on the trail and retaining the compatible
ones as a candidate-antecedent list that is kept in the result:

```python
# nltk/sem/drt.py (before)
def resolve_anaphora(expression, trail=[]):
    if ... is_pronoun_function():
        possible_antecedents = PossibleAntecedents()
        for ancestor in trail:
            for ref in ancestor.get_refs():          # scan ALL referents, per pronoun
                ...
                possible_antecedents.append(refex)   # retained in the returned DRS
```

A DRS with `N` referents and `N` `PRO` conditions therefore performs **O(N²)**
referent examinations and retains **O(N²)** candidate entries — quadratic time
*and* resident memory. The structure is flat (no recursion-depth limit), and the
memory channel is the more severe one. The input is the public, documented API
`DrtExpression.fromstring(<untrusted>).resolve_anaphora()`.

Measured (`([x0..xN],[PRO(x0)..PRO(xN)])`, current source):

| N | candidate ops (N²) | time | +RSS |
|--:|------:|-----:|-----:|
| 400 | 160,000 | 0.16 s | 14 MB |
| 800 | 640,000 | 0.65 s | 57 MB |
| 1500 | 2,250,000 | 1.0 s | 123 MB |

A ~tens-of-KB DRS string drives seconds of CPU and hundreds of MB to multiple GB
of memory → OOM-kills/pins the worker. No authentication or non-default
configuration is required. Validated as **CVE-2026-12873** (CWE-770).

## The fix

The O(N²) here is partly the *result* size (each pronoun genuinely resolves to
its list of possible antecedents), so it cannot be made O(N) without changing
the semantics. Instead, bound the total work with a shared budget — the same
shape as the `generate()` derivation-budget fix — and refuse before it explodes:

```python
MAX_ANAPHORA_OPERATIONS = 1_000_000

class _AnaphoraBudget:
    __slots__ = ("remaining", "limit")
    def __init__(self, limit): self.remaining = limit; self.limit = limit
    def spend(self):
        self.remaining -= 1
        if self.remaining < 0:
            raise AnaphoraResolutionException("Refusing to resolve anaphora: ... (CWE-770). ...")

def resolve_anaphora(expression, trail=[], budget=None):
    if budget is None:
        budget = _AnaphoraBudget(MAX_ANAPHORA_OPERATIONS)
    ...
        for ancestor in trail:
            for ref in ancestor.get_refs():
                budget.spend()          # meter every (pronoun, referent) examination
                ...
    ... resolve_anaphora(sub, trail + [expression], budget)   # threaded through all recursion
```

Properties:
- **One budget per resolution, shared across the recursion** (threaded through
  every recursive call), so it bounds the total O(N²) work however the DRS is
  structured. Since retained candidates ≤ examinations, bounding examinations
  bounds both the time and the memory channels.
- **Non-silent**: it raises `AnaphoraResolutionException` — the existing domain
  exception for "resolution couldn't complete", which the real caller
  (`nltk.inference.discourse.process_thread`) already catches — rather than
  silently truncating antecedent lists (which would corrupt the semantics).
- **Backward-compatible**: `budget` is an optional last parameter
  (default `None`), so existing callers (`DrtExpression.resolve_anaphora`,
  `discourse.py`) are unchanged.
- **Generous & tunable**: at the cap the worst case is ~0.5 s / ~70 MB, while
  `1_000_000` examinations is ~1000× larger than any real discourse (the
  doctests use 3-7 referents). `MAX_ANAPHORA_OPERATIONS` is a module-level
  constant a caller can raise for a genuinely large discourse.

## Behaviour preservation (verified)

- `python -m doctest nltk/sem/drt.py` passes; `drt.doctest`: **152 attempted,
  4 failed — identical to `develop`** (the 4 are pre-existing missing-corpus
  `LookupError`s, unrelated). The `resolve_anaphora` examples are unchanged, e.g.
  `([x,y,z],[dog(x), cat(y), walks(z), PRO(z)])` →
  `([x,y,z],[dog(x), cat(y), walks(z), (z = [x,y])])`, and a pronoun that
  resolves to nothing still raises `AnaphoraResolutionException`.

## Performance

| input | before | after |
|-------|--------|-------|
| `resolve_anaphora` over a 5000-referent/5000-pronoun DRS (the DoS) | minutes, multi-GB → OOM | `AnaphoraResolutionException` in ~0.5 s / ~70 MB |
| any real discourse (≤ ~1000 referent examinations) | unchanged | unchanged |

## Testing

- `nltk/test/unit/test_drt_anaphora.py` (new): confirms
  `MAX_ANAPHORA_OPERATIONS` is a finite positive int; that the documented
  resolution outputs (and the "resolves to nothing" exception) are preserved;
  that a small discourse resolves normally; and that an oversized
  (`> sqrt(cap)` referents/pronouns) DRS is **refused**. The oversized check runs
  in process and is safe even if the guard were removed — the budget caps the
  work at ~the cap's worth of candidates (~70 MB), and the chosen size completes
  well within CI limits without the guard, so the missing exception is detected
  rather than hanging/OOM-ing the suite. It fails against the pre-fix `develop`
  version (which resolves it without raising) and passes against the fix.
- `black==25.11.0`, `isort==6.1.0`, `ruff==0.15.6` (repo-pinned) — clean.