### PR TITLE
fix(security): bound chart parse-tree extraction to stop exponential DoS (CVE-2026-12886)

### DIFF
--- a/nltk/ccg/chart.py
+++ b/nltk/ccg/chart.py
@@ -47,7 +47,13 @@ from nltk.ccg.combinator import (
 from nltk.ccg.lexicon import Token, fromstring
 from nltk.ccg.logic import *
 from nltk.parse import ParserI
-from nltk.parse.chart import AbstractChartRule, Chart, EdgeI
+from nltk.parse.chart import (
+    MAX_PARSE_TREES,
+    AbstractChartRule,
+    Chart,
+    EdgeI,
+    _ParseTreeBudget,
+)
 from nltk.sem.logic import *
 from nltk.tree import Tree
 
@@ -313,13 +319,20 @@ class CCGChart(Chart):
     # Constructs the trees for a given parse. Unfortnunately, the parse trees need to be
     # constructed slightly differently to those in the default Chart class, so it has to
     # be reimplemented
-    def _trees(self, edge, complete, memo, tree_class):
+    def _trees(self, edge, complete, memo, tree_class, budget=None):
         assert complete, "CCGChart cannot build incomplete trees"
+
+        # Share the same node-construction budget as the base Chart so a
+        # highly-ambiguous CCG grammar cannot make tree extraction exponential
+        # either (CWE-770; CVE-2026-12886).
+        if budget is None:
+            budget = _ParseTreeBudget(MAX_PARSE_TREES)
 
         if edge in memo:
             return memo[edge]
 
         if isinstance(edge, CCGLeafEdge):
+            budget.spend()
             word = tree_class(edge.token(), [self._tokens[edge.start()]])
             leaf = tree_class((edge.token(), "Leaf"), [word])
             memo[edge] = [leaf]
@@ -329,8 +342,11 @@ class CCGChart(Chart):
         trees = []
 
         for cpl in self.child_pointer_lists(edge):
-            child_choices = [self._trees(cp, complete, memo, tree_class) for cp in cpl]
+            child_choices = [
+                self._trees(cp, complete, memo, tree_class, budget) for cp in cpl
+            ]
             for children in itertools.product(*child_choices):
+                budget.spend()
                 lhs = (
                     Token(
                         self._tokens[edge.start() : edge.end()],

--- a/nltk/parse/chart.py
+++ b/nltk/parse/chart.py
@@ -426,6 +426,43 @@ class LeafEdge(EdgeI):
 ##  Chart
 ########################################################################
 
+#: Upper bound on the number of parse-tree nodes a single tree extraction
+#: (:meth:`Chart.trees`) may build. A highly-ambiguous grammar (e.g. the
+#: 15-byte ``S -> S S | 'a'``) makes the number of parses exponential in the
+#: sentence length (the Catalan numbers), and the trees are materialised eagerly
+#: -- so a tiny grammar plus a short sentence pins the CPU and exhausts memory,
+#: and even obtaining the first parse does not return (CWE-770; CVE-2026-12886).
+#: Once this many tree nodes have been built, extraction raises ``ValueError``
+#: instead of running unbounded. Raise it if you legitimately need to enumerate
+#: a more ambiguous parse forest.
+MAX_PARSE_TREES = 1_000_000
+
+
+class _ParseTreeBudget:
+    """Counts constructed parse-tree nodes and aborts runaway tree extraction.
+
+    One budget is shared across a whole :meth:`Chart.trees` call (including the
+    recursive subtree builds and the memoised reuse), so it bounds the total
+    work of reading an exponential parse forest off the chart.
+    """
+
+    __slots__ = ("remaining", "limit")
+
+    def __init__(self, limit):
+        self.remaining = limit
+        self.limit = limit
+
+    def spend(self):
+        self.remaining -= 1
+        if self.remaining < 0:
+            raise ValueError(
+                "Refusing to extract parse trees: a highly-ambiguous grammar can "
+                "yield an exponential number of parses, and tree extraction "
+                "exceeded the limit of %d parse-tree nodes (CWE-770). Parse with "
+                "a less ambiguous grammar or a shorter sentence, or raise "
+                "nltk.parse.chart.MAX_PARSE_TREES." % self.limit
+            )
+
 
 class Chart:
     """
@@ -690,17 +727,28 @@ class Chart:
             Tree may be used to encode that subtree in
             both trees.  If you need to eliminate this subtree
             sharing, then create a deep copy of each tree.
+        :raise ValueError: if more than ``MAX_PARSE_TREES`` parse-tree nodes
+            would be built, which a highly-ambiguous grammar reaches at an
+            exponential rate (CWE-770).
         """
-        return iter(self._trees(edge, complete, memo={}, tree_class=tree_class))
+        budget = _ParseTreeBudget(MAX_PARSE_TREES)
+        return iter(
+            self._trees(edge, complete, memo={}, tree_class=tree_class, budget=budget)
+        )
 
-    def _trees(self, edge, complete, memo, tree_class):
+    def _trees(self, edge, complete, memo, tree_class, budget=None):
         """
         A helper function for ``trees``.
 
         :param memo: A dictionary used to record the trees that we've
             generated for each edge, so that when we see an edge more
             than once, we can reuse the same trees.
+        :param budget: A shared :class:`_ParseTreeBudget` that bounds the total
+            number of parse-tree nodes built, so an exponential parse forest
+            cannot exhaust time/memory (CWE-770).
         """
+        if budget is None:
+            budget = _ParseTreeBudget(MAX_PARSE_TREES)
         # If we've seen this edge before, then reuse our old answer.
         if edge in memo:
             return memo[edge]
@@ -729,10 +777,15 @@ class Chart:
             # Get the set of child choices for each child pointer.
             # child_choices[i] is the set of choices for the tree's
             # ith child.
-            child_choices = [self._trees(cp, complete, memo, tree_class) for cp in cpl]
+            child_choices = [
+                self._trees(cp, complete, memo, tree_class, budget) for cp in cpl
+            ]
 
             # For each combination of children, add a tree.
             for children in itertools.product(*child_choices):
+                # Count every node built; a highly-ambiguous grammar would
+                # otherwise materialise an exponential number of them (CWE-770).
+                budget.spend()
                 trees.append(tree_class(lhs, children))
 
         # If the edge is incomplete, then extend it with "partial trees":

--- a/nltk/parse/chart.py
+++ b/nltk/parse/chart.py
@@ -790,7 +790,13 @@ class Chart:
 
         # If the edge is incomplete, then extend it with "partial trees":
         if edge.is_incomplete():
-            unexpanded = [tree_class(elt, []) for elt in edge.rhs()[edge.dot() :]]
+            unexpanded = []
+            for elt in edge.rhs()[edge.dot() :]:
+                # Count these childless nodes too, so MAX_PARSE_TREES is an
+                # accurate bound on constructed tree nodes when trees() is used
+                # on incomplete edges (complete=False).
+                budget.spend()
+                unexpanded.append(tree_class(elt, []))
             for tree in trees:
                 tree.extend(unexpanded)
 

--- a/nltk/test/unit/test_chart_parser.py
+++ b/nltk/test/unit/test_chart_parser.py
@@ -1,0 +1,99 @@
+"""Regression tests for the exponential chart-parsing DoS (CWE-770; CVE-2026-12886).
+
+A highly-ambiguous grammar such as the 15-byte ``S -> S S | 'a'`` makes the
+number of parses exponential in the sentence length (the Catalan numbers), and
+``nltk.parse.chart`` materialises every parse tree eagerly while reading them off
+the chart -- so a tiny grammar plus a short sentence pins the CPU and exhausts
+memory, and even obtaining the first parse never returns. The number of parse-tree
+nodes built is now bounded by ``MAX_PARSE_TREES``; once exceeded, tree extraction
+raises ``ValueError``.
+
+The "must not run unbounded" test runs in a spawned process with a hard timeout,
+and the worker reports its outcome via its exit code (no queue/thread, so it is
+robust on free-threaded builds), so a regression cannot hang the suite.
+"""
+
+import multiprocessing
+import os
+
+import pytest
+
+from nltk import CFG
+from nltk.parse import BottomUpChartParser, ChartParser
+from nltk.parse import chart as chart_mod
+from nltk.parse.chart import MAX_PARSE_TREES
+
+_AMBIG = CFG.fromstring("S -> S S | 'a'")  # 15 bytes, Catalan-many parses
+
+
+def test_max_parse_trees_is_a_finite_positive_int():
+    assert isinstance(MAX_PARSE_TREES, int)
+    assert MAX_PARSE_TREES > 0
+
+
+def test_parses_preserved():
+    # An ordinarily-ambiguous sentence still yields all of its parses.
+    g = CFG.fromstring(
+        "S -> NP VP\n"
+        "NP -> 'I' | 'a' N | NP PP\n"
+        "VP -> V NP | VP PP\n"
+        "PP -> P NP\n"
+        "N -> 'dog' | 'park'\n"
+        "V -> 'saw'\n"
+        "P -> 'in'"
+    )
+    parses = list(ChartParser(g).parse("I saw a dog in a park".split()))
+    assert len(parses) == 2  # the two PP-attachment readings
+
+    # The Catalan parse forest is produced in full while it stays under the cap.
+    p = BottomUpChartParser(_AMBIG)
+    assert len(list(p.parse(["a"] * 6))) == 42  # Catalan(5)
+    assert len(list(p.parse(["a"] * 10))) == 4862  # Catalan(9)
+
+
+def test_over_cap_extraction_is_refused(monkeypatch):
+    # With a tiny cap, an ambiguous parse forest that exceeds it is refused.
+    # In process and safe: even without the guard this builds only a few hundred
+    # trees, so the missing exception is detected rather than exhausting memory.
+    monkeypatch.setattr(chart_mod, "MAX_PARSE_TREES", 100)
+    with pytest.raises(ValueError):
+        list(BottomUpChartParser(_AMBIG).parse(["a"] * 8))  # Catalan(7) = 429 > 100
+
+
+_TIMEOUT = 60
+_EXIT_REFUSED = 0  # ValueError raised before building the full forest (expected)
+_EXIT_BUILT = 2  # the exponential forest was materialised (regression)
+_EXIT_OTHER = 3
+
+
+def _parse_worker():
+    # 14 tokens of the ambiguous grammar: the default cap refuses this after
+    # ~the cap's worth of trees (bounded memory), but without the guard it builds
+    # the full forest. The size is chosen so even a guard-removed run stays well
+    # under ~1 GB, so a regression is caught by the exit code (or the timeout)
+    # without an OS OOM kill.
+    try:
+        list(BottomUpChartParser(_AMBIG).parse(["a"] * 14))
+        os._exit(_EXIT_BUILT)
+    except ValueError:
+        os._exit(_EXIT_REFUSED)
+    except BaseException:
+        os._exit(_EXIT_OTHER)
+
+
+def test_exponential_grammar_is_refused_not_run():
+    """The default cap must refuse an exponential parse forest, not build it."""
+    ctx = multiprocessing.get_context("spawn")
+    proc = ctx.Process(target=_parse_worker)
+    proc.start()
+    proc.join(_TIMEOUT)
+    if proc.is_alive():
+        proc.terminate()
+        proc.join()
+        raise AssertionError(
+            "chart tree extraction did not finish -> unbounded exponential DoS"
+        )
+    assert proc.exitcode == _EXIT_REFUSED, (
+        "an exponential parse forest was not refused "
+        f"(worker exit code {proc.exitcode})"
+    )


### PR DESCRIPTION
# Bound chart parse-tree extraction to stop exponential DoS (CWE-770 / CVE-2026-12886)

## Description

`nltk.parse.chart.ChartParser` and its subclasses parse a token sequence against
a CFG and yield parse trees. Building the chart is polynomial, but reading the
trees off it is not: `Chart._trees` **materialises every parse tree eagerly**:

```python
# nltk/parse/chart.py (before) -- Chart._trees
for cpl in self.child_pointer_lists(edge):
    child_choices = [self._trees(cp, complete, memo, tree_class) for cp in cpl]
    for children in itertools.product(*child_choices):   # combinatorial
        trees.append(tree_class(lhs, children))           # all trees built into a list
```

With a tiny, highly-ambiguous grammar such as the 15-byte `S -> S S | 'a'`, the
number of parses is the Catalan number — exponential in the sentence length — and
because the trees are built into a list, **even obtaining the first parse never
returns** (`ChartParser.parse` → `chart.parses()` → `Chart._trees` materialises
the whole forest on the first step). There is no bound on parses, work, or time.

Both inputs are untrusted: a ~15-byte grammar via `CFG.fromstring` plus a short
token list. Confirmed (chart build vs. extraction, measured):

| n tokens | chart build | extract all parses |
|------:|------:|------:|
| 16 | 0.006 s (320 edges) | **TIMEOUT (> 8 s)** |
| 22 (first parse only) | fast | **hangs** |

This affects any "parse a sentence with a grammar" surface (grammar editors,
teaching tools, parser-as-a-service). No authentication or non-default
configuration is required. Validated as **CVE-2026-12886** (CWE-770).

## The fix

The number of parses is inherently exponential, so it cannot be made polynomial
without changing semantics. Instead — as with the `generate()` derivation-budget
fix — bound the total work with a shared budget and refuse before it explodes:

```python
MAX_PARSE_TREES = 1_000_000

class _ParseTreeBudget:
    __slots__ = ("remaining", "limit")
    def __init__(self, limit): self.remaining = limit; self.limit = limit
    def spend(self):
        self.remaining -= 1
        if self.remaining < 0:
            raise ValueError("Refusing to extract parse trees: ... (CWE-770). ...")
```

`Chart.trees` creates one budget and threads it through the recursive
`Chart._trees`, which spends one unit per tree node built:

```python
def trees(self, edge, tree_class=Tree, complete=False):
    budget = _ParseTreeBudget(MAX_PARSE_TREES)
    return iter(self._trees(edge, complete, memo={}, tree_class=tree_class, budget=budget))

def _trees(self, edge, complete, memo, tree_class, budget=None):
    ...
        for children in itertools.product(*child_choices):
            budget.spend()                       # count every node built
            trees.append(tree_class(lhs, children))
```

Properties:
- **Single chokepoint covers all chart parsers.** `ChartParser`, `BottomUp`/
  `TopDown`, `FeatureChartParser`, Earley and the probabilistic charts all read
  trees through `Chart.parses` → `Chart.trees` → `Chart._trees`, so bounding
  `_trees` bounds "ChartParser and subclasses".
- **One budget per `trees()` call, shared across the recursion** (including the
  memoised subtree reuse), so it bounds the total exponential work.
- **Non-silent**: it raises `ValueError` (rather than silently truncating the
  parse forest), so a caller can't mistake a capped result for the complete set.
- **Backward-compatible**: `budget` is an optional last parameter of the internal
  `_trees`; the public `trees`/`parses` signatures are unchanged.
- **Generous & tunable**: at the cap the worst case is ~0.4 s / ~280 MB, while
  `1_000_000` tree nodes is far beyond any realistic parse forest (a Catalan-9
  forest is ~4.8 k parses). `MAX_PARSE_TREES` is a module-level constant a caller
  can raise.

## Behaviour preservation (verified)

- `python -m doctest nltk/parse/chart.py` passes; `parse.doctest`
  (**146 attempted, 48 failed**) and `featgram.doctest` (**83 attempted,
  24 failed**) are **identical to `develop`** (the failures are pre-existing
  missing-corpus `LookupError`s, unrelated).
- An ordinarily-ambiguous sentence is unchanged: `"I saw a dog in a park"` →
  2 parses (both PP attachments); `S -> S S | 'a'` yields the full Catalan forest
  while under the cap (n=6 → 42, n=10 → 4862).

## Performance

| input (`S -> S S | 'a'`) | before | after |
|------|--------|-------|
| count all parses, 16+ tokens | TIMEOUT / OOM | `ValueError` in ~0.4 s |
| first parse only, 22 tokens | hangs forever | `ValueError` in ~0.4 s |
| any forest under the cap | unchanged | unchanged |

## Testing

- `nltk/test/unit/test_chart_parser.py` (new): confirms `MAX_PARSE_TREES` is a
  finite positive int; that ordinary parses are preserved (the PP-attachment
  sentence → 2; small Catalan forests in full); that an over-cap forest is
  refused (with a monkeypatched-low cap, in process and safe); and — in a spawned
  process with a hard timeout (exit-code IPC, robust on free-threaded builds) —
  that the default cap refuses a genuinely exponential forest rather than
  building it. The spawned size is chosen so even a guard-removed run stays well
  under ~1 GB, so a regression is caught without an OS OOM kill. It fails against
  the pre-fix `develop` version (which builds the forest) and passes against the
  fix.
- `black==25.11.0`, `isort==6.1.0`, `ruff==0.15.6`, `pyupgrade --py310-plus`
  (repo-pinned hooks) — clean.