### PR TITLE
fix(security): make valuation separator regex linear to stop quadratic ReDoS (CVE-2026-12890)

### DIFF
--- a/nltk/sem/evaluate.py
+++ b/nltk/sem/evaluate.py
@@ -178,7 +178,14 @@ class Valuation(dict):
 ##########################################
 # REs used by the _read_valuation function
 ##########################################
-_VAL_SPLIT_RE = re.compile(r"\s*=+>\s*")
+# The ``(?<!=)`` makes the greedy ``=+`` run fail fast: without it, splitting a
+# line that holds a long run of ``=`` not terminated by ``>`` re-scans the run
+# from every position (match ``=+``, miss ``>``, backtrack), which is quadratic
+# in the run length and lets a single valuation string pin a CPU core
+# (CWE-1333; CVE-2026-12890). The lookbehind only lets ``=+`` start at the
+# beginning of a run, so interior positions fail in O(1); the split result is
+# unchanged.
+_VAL_SPLIT_RE = re.compile(r"\s*(?<!=)=+>\s*")
 _ELEMENT_SPLIT_RE = re.compile(r"\s*,\s*")
 _TUPLES_RE = re.compile(
     r"""\s*

--- a/nltk/test/unit/test_valuation_redos.py
+++ b/nltk/test/unit/test_valuation_redos.py
@@ -1,0 +1,67 @@
+"""Regression tests for the quadratic ReDoS in valuation parsing
+(CWE-1333; CVE-2026-12890).
+
+``nltk.sem.evaluate`` splits each valuation line on a ``\\s*=+>\\s*`` separator.
+The greedy ``=+`` run made splitting a line that holds a long run of ``=`` not
+terminated by ``>`` re-scan the run from every position, which is quadratic in
+the run length -- so a single untrusted valuation string could pin a CPU core.
+A ``(?<!=)`` lookbehind now lets the run be matched only at its start, making the
+split linear while leaving the parse result unchanged.
+
+The "must stay linear" test runs in a spawned process with a hard timeout, and
+the worker reports via its exit code (no queue/thread, so it is robust on
+free-threaded builds), so a regression to the quadratic pattern cannot hang the
+suite.
+"""
+
+import multiprocessing
+import os
+
+from nltk.sem import Valuation
+from nltk.sem.evaluate import read_valuation
+
+
+def test_valuation_parsing_preserved():
+    val = Valuation.fromstring(
+        "noosa => n\n"
+        "girl => {g1, g2}\n"
+        "chase => {(b1, g1), (b2, g1)}\n"
+        "x ==> y"  # multiple '=' in the separator must still work
+    )
+    assert val["noosa"] == "n"
+    assert sorted(val["girl"]) == [("g1",), ("g2",)]
+    assert sorted(val["chase"]) == [("b1", "g1"), ("b2", "g1")]
+    assert val["x"] == "y"
+
+
+_TIMEOUT = 20
+# A line with a long run of the separator's leading character ('=') that is not
+# terminated by '>'. The pre-fix greedy '=+' made splitting this quadratic (~50 s
+# at this size); the fix makes it linear (~milliseconds). It is CPU-only (a ~0.5
+# MB string), so there is no OOM risk.
+_EVIL = "sym " + "=" * 500_000
+
+
+def _parse_worker():
+    try:
+        # We don't care about the result/exception (the line has no valid
+        # separator); only that parsing returns quickly rather than hanging.
+        read_valuation(_EVIL)
+    except Exception:
+        pass
+    os._exit(0)
+
+
+def test_long_separator_run_parses_in_linear_time():
+    """A long '=' run must split in linear time, not quadratic (ReDoS)."""
+    ctx = multiprocessing.get_context("spawn")
+    proc = ctx.Process(target=_parse_worker)
+    proc.start()
+    proc.join(_TIMEOUT)
+    if proc.is_alive():
+        proc.terminate()
+        proc.join()
+        raise AssertionError(
+            "valuation parsing did not finish in time -> quadratic ReDoS (CWE-1333)"
+        )
+    assert proc.exitcode == 0, f"worker failed (exit code {proc.exitcode})"


### PR DESCRIPTION
# Fix quadratic ReDoS in valuation parsing (CWE-1333 / CVE-2026-12890)

## Description

`nltk.sem.evaluate` parses a valuation (a first-order-model interpretation) from
a string, splitting each line on a separator with the standard-library `re`:

```python
# nltk/sem/evaluate.py (before)
_VAL_SPLIT_RE = re.compile(r"\s*=+>\s*")
...
def _read_valuation_line(s):
    pieces = _VAL_SPLIT_RE.split(s)   # split scans the whole line
    symbol = pieces[0]
    value = pieces[1]
```

The separator is optional whitespace, a **greedy** run of the leading separator
character (`=+`), the terminator (`>`), and optional whitespace. Because `=+` is
greedy and the split has no limit (it scans the whole line), a line that holds a
long run of `=` **not** immediately followed by `>` forces the engine to re-scan
the run from every position — match `=+`, fail to find `>`, backtrack — which is
**quadratic** in the length of the run.

`_read_valuation_line` is reached from the public `Valuation.fromstring` /
`read_valuation`, so loading an untrusted valuation runs in quadratic time. Both
the pattern (the backtracking `re` module) and the input shape are a textbook
ReDoS. Measured on the current source (`re.split` of `"="*n`):

| run length | time |
|------:|-----:|
| 20,000 | 0.09 s |
| 40,000 | 0.34 s |
| 80,000 | 1.33 s |

(~4× per doubling → quadratic.) A ~tens-of-KB valuation string pins a CPU core
for seconds; larger inputs for much longer. No authentication or non-default
configuration is required. Validated as **CVE-2026-12890** (CWE-1333).

## The fix

Make the greedy `=+` run **fail fast**: a `(?<!=)` lookbehind lets `=+` start
only at the *beginning* of a run, so interior run positions fail the match in
O(1) instead of re-scanning the whole run. The split then runs in linear time,
and the split result is unchanged.

```python
_VAL_SPLIT_RE = re.compile(r"\s*(?<!=)=+>\s*")
```

Why this is exact: in the original, `re.split` tries to match at every position;
inside a `=` run every position re-runs the greedy `=+` (O(run) each → O(run²)).
With `(?<!=)`, a position preceded by `=` (i.e. inside a run) is rejected
immediately, so the run is examined once → O(run). The lookbehind only changes
*where a match may start* to the natural run boundary the leftmost-match already
uses, so every split — including the first symbol/value boundary the parser
relies on — is identical.

This is a fixed-width lookbehind, supported on all currently-tested Python
versions (3.10+).

## Behaviour preservation (verified)

- `python -m doctest nltk/sem/evaluate.py` passes; `semantics.doctest`
  (**149 attempted, 20 failed**) is **identical to `develop`** (the 20 are
  pre-existing missing-corpus failures, unrelated).
- Valuations parse to the same values: `noosa => n` → `'n'`;
  `girl => {g1, g2}` → `{('g1',), ('g2',)}`;
  `chase => {(b1, g1), (b2, g1)}` → the same tuple set; and a multi-`=`
  separator (`x ==> y`) still works.
- **Differential fuzzing**: the new pattern's `split` output was compared against
  the original on **300,000 random strings** (mixing `=`, `>`, `=>`/`==>`/`===>`,
  whitespace, braces, parens and multiple separators per line) — **0 mismatches**.

## Performance

| input | before | after |
|-------|--------|-------|
| split a 500,000-char `=` run | quadratic (~tens of seconds) | ~0.006 s |
| `read_valuation` of an 80 KB `=`-run line | ~1.3 s | ~0.001 s |
| normal valuations | unchanged | unchanged |

## Testing

- `nltk/test/unit/test_valuation_redos.py` (new): confirms valuation parsing is
  preserved (including the multi-`=` separator), and that a line with a long `=`
  run parses in linear time — that check runs in a spawned process with a hard
  timeout (exit-code IPC, robust on free-threaded builds; the payload is a ~0.5 MB
  string, so it is CPU-only with no OOM risk) so a regression to the quadratic
  pattern cannot hang the suite. It times out against the pre-fix `develop`
  version (> 25 s) and passes in milliseconds against the fix.
- `black==25.11.0`, `isort==6.1.0`, `ruff==0.15.6`, `pyupgrade --py310-plus`
  (repo-pinned hooks) — clean.