### PR TITLE
fix(security): make feature-structure rename regex linear to stop quadratic ReDoS (CVE-2026-12919)

### DIFF
--- a/nltk/featstruct.py
+++ b/nltk/featstruct.py
@@ -1285,7 +1285,15 @@ def _rename_variables(fstruct, vars, used_vars, new_vars, fs_class, visited):
 
 
 def _rename_variable(var, used_vars):
-    name, n = re.sub(r"\d+$", "", var.name), 2
+    # Strip a trailing run of digits from the variable name. The ``(?<!\d)``
+    # makes the greedy ``\d+`` fail fast: without it, a name with a long run of
+    # digits that is not at the end (e.g. ``x000...0z``) is re-scanned from every
+    # position (match ``\d+``, miss ``$``, backtrack), which is quadratic in the
+    # run length and lets a single feature-structure string pin a CPU core
+    # (CWE-1333; CVE-2026-12919). The lookbehind only lets ``\d+`` start at the
+    # beginning of a run, so interior positions fail in O(1); the result is
+    # unchanged.
+    name, n = re.sub(r"(?<!\d)\d+$", "", var.name), 2
     if not name:
         name = "?"
     while Variable(f"{name}{n}") in used_vars:

--- a/nltk/test/unit/test_featstruct_redos.py
+++ b/nltk/test/unit/test_featstruct_redos.py
@@ -54,11 +54,15 @@ _EVIL = "[a=?x" + "0" * 200_000 + "z]"
 
 
 def _rename_worker():
+    # Renaming this (valid) feature structure must actually complete quickly.
+    # Exit non-zero on any failure so the parent assertion fails -- otherwise a
+    # swallowed exception (e.g. parsing breaking before the rename runs) would
+    # let the test pass without exercising the vulnerable rename path.
     try:
         FeatStruct(_EVIL).rename_variables()
-    except Exception:
-        pass  # we only care that it returns quickly, not about the result
-    os._exit(0)
+        os._exit(0)
+    except BaseException:
+        os._exit(3)
 
 
 def test_long_digit_run_renames_in_linear_time():

--- a/nltk/test/unit/test_featstruct_redos.py
+++ b/nltk/test/unit/test_featstruct_redos.py
@@ -1,0 +1,76 @@
+"""Regression tests for the quadratic ReDoS in feature-structure variable
+renaming (CWE-1333; CVE-2026-12919).
+
+``nltk.featstruct._rename_variable`` strips a trailing run of digits from a
+variable name with ``re.sub(r"\\d+$", "", var.name)``. The greedy ``\\d+`` made a
+name with a long run of digits not at the end (e.g. ``x000...0z``) re-scan the
+run from every position, which is quadratic in the run length -- so a single
+untrusted feature structure renamed (or unified, which renames by default) could
+pin a CPU core. A ``(?<!\\d)`` lookbehind now lets the run match only at its
+start, making the substitution linear while leaving the result unchanged.
+
+The "must stay linear" test runs in a spawned process with a hard timeout, and
+the worker reports via its exit code (no queue/thread, so it is robust on
+free-threaded builds), so a regression to the quadratic pattern cannot hang the
+suite.
+"""
+
+import multiprocessing
+import os
+
+from nltk.featstruct import FeatStruct, _rename_variable
+from nltk.sem.logic import Variable
+
+
+def test_rename_variable_strips_trailing_digits():
+    # The trailing-number stripping (and fresh-suffix) behaviour is unchanged.
+    assert _rename_variable(Variable("x12"), set()) == Variable("x2")
+    assert _rename_variable(Variable("foo3"), set()) == Variable("foo2")
+    assert _rename_variable(Variable("x"), set()) == Variable("x2")
+    # A digit run that is not at the end is not stripped (ends in 'z').
+    assert _rename_variable(Variable("x000z"), set()) == Variable("x000z2")
+    # Only the trailing run is stripped.
+    assert _rename_variable(Variable("x1y23"), set()) == Variable("x1y2")
+    # Fresh suffix avoids clashes with used_vars.
+    assert _rename_variable(Variable("x"), {Variable("x2")}) == Variable("x3")
+
+
+def test_rename_and_unify_preserved():
+    assert str(FeatStruct("[a=?x, b=?y]").rename_variables()) == str(
+        FeatStruct("[a=?x2, b=?y2]")
+    )
+    unified = FeatStruct("[a=?p]").unify(FeatStruct("[b=?q]"))
+    assert unified is not None
+    assert unified["a"] == Variable("?p")
+    assert unified["b"] == Variable("?q")
+
+
+_TIMEOUT = 20
+# A variable name with a long run of digits that is not at the end. The pre-fix
+# greedy ``\d+`` made renaming this quadratic (~tens of seconds at this size);
+# the fix makes it linear (~milliseconds). It is CPU-only (a ~0.2 MB string), so
+# there is no OOM risk.
+_EVIL = "[a=?x" + "0" * 200_000 + "z]"
+
+
+def _rename_worker():
+    try:
+        FeatStruct(_EVIL).rename_variables()
+    except Exception:
+        pass  # we only care that it returns quickly, not about the result
+    os._exit(0)
+
+
+def test_long_digit_run_renames_in_linear_time():
+    """A long digit-run variable name must rename in linear time (not ReDoS)."""
+    ctx = multiprocessing.get_context("spawn")
+    proc = ctx.Process(target=_rename_worker)
+    proc.start()
+    proc.join(_TIMEOUT)
+    if proc.is_alive():
+        proc.terminate()
+        proc.join()
+        raise AssertionError(
+            "feature-structure renaming did not finish in time -> quadratic ReDoS"
+        )
+    assert proc.exitcode == 0, f"worker failed (exit code {proc.exitcode})"


### PR DESCRIPTION
# Fix quadratic ReDoS in feature-structure variable renaming (CWE-1333 / CVE-2026-12919)

## Description

`nltk.featstruct._rename_variable` renames a feature-structure variable by
stripping a trailing run of digits from its name with the standard-library `re`:

```python
# nltk/featstruct.py (before)
def _rename_variable(var, used_vars):
    name, n = re.sub(r"\d+$", "", var.name), 2
    ...
```

The pattern `\d+$` requires a run of digits immediately before the end of the
string. When a variable name contains a long run of digits that is **not** at the
end (e.g. `x000...0z`), the match fails, but `re.sub` re-scans the digit run from
**every** position — `\d+` greedily matches the run, fails to find `$`, backtracks
one digit at a time — which is **quadratic** in the run length. (`$` also matches
just before a trailing newline, so the engine can't short-circuit on the final
character.)

`_rename_variable` is reached from the public `FeatStruct.rename_variables()` and
from `FeatStruct.unify()`, which renames by default (`rename_vars=True`). So
renaming — or simply unifying — an untrusted feature structure runs in quadratic
time. Measured on the current source (`re.sub(r"\d+$", "", "x" + "0"*n + "z")`):

| digit run | time |
|------:|-----:|
| 8,000 | 0.12 s |
| 16,000 | 0.45 s |
| 32,000 | 1.80 s |

(~4× per doubling → quadratic.) A ~tens-of-KB variable name pins a CPU core for
seconds; the PoC reaches it through `FeatStruct.fromstring(...).rename_variables()`.
No authentication or non-default configuration is required. Validated as
**CVE-2026-12919** (CWE-1333).

## The fix

Make the greedy `\d+` run **fail fast**: a `(?<!\d)` lookbehind lets `\d+` start
only at the *beginning* of a digit run, so interior run positions fail the match
in O(1) instead of re-scanning the whole run. The substitution then runs in
linear time, and the stripped result is unchanged.

```python
name, n = re.sub(r"(?<!\d)\d+$", "", var.name), 2
```

Why this is exact: `re.sub(r"\d+$", ...)` removes the maximal trailing digit run;
the quadratic cost is the *search* (every position inside a non-terminal digit
run re-runs the greedy `\d+`). With `(?<!\d)`, a position preceded by a digit
(i.e. inside a run) is rejected immediately, so the run is examined once → O(n).
The trailing run, by definition, starts where the preceding character is not a
digit, so the match set — including the `$`-before-trailing-newline behaviour — is
identical. This is a fixed-width lookbehind, supported on all currently-tested
Python versions (3.10+).

## Behaviour preservation (verified)

- `_rename_variable` strips trailing numbers exactly as before: `x12` → base `x`
  (→ `x2`), `foo3` → `foo` (→ `foo2`), `x1y23` → `x1y` (→ `x1y2`); a digit run not
  at the end is untouched (`x000z` → `x000z2`); the fresh-suffix logic is
  unchanged.
- `rename_variables()` and `unify()` produce the same results.
- `python -m doctest nltk/featstruct.py` passes; `featstruct.doctest`
  (**335 attempted, 0 failed**) and `featgram.doctest` (**83 attempted, 24
  failed** — pre-existing missing-corpus) are **identical to `develop`**.
- **Differential fuzzing**: the new pattern's `sub` output was compared against
  the original on **300,000 random names** (mixing letters, digits, `?`, `_` and
  newlines) — **0 mismatches**.

## Performance

| input | before | after |
|-------|--------|-------|
| `re.sub` a 200,000-digit non-terminal run | quadratic (~tens of seconds) | ~0.002 s |
| `rename_variables` of a 32 KB digit-run name | ~1.8 s | ~0.0007 s |
| benign feature structures | unchanged | unchanged |

## Testing

- `nltk/test/unit/test_featstruct_redos.py` (new): confirms `_rename_variable`'s
  trailing-digit stripping and fresh-suffix behaviour, and that
  `rename_variables`/`unify` are preserved; and that a variable name with a long
  digit run renames in linear time — that check runs in a spawned process with a
  hard timeout (exit-code IPC, robust on free-threaded builds; the payload is a
  ~0.2 MB string, so it is CPU-only with no OOM risk) so a regression to the
  quadratic pattern cannot hang the suite. It times out against the pre-fix
  `develop` version (> 25 s) and passes in milliseconds against the fix.
- `black==25.11.0`, `isort==6.1.0`, `ruff==0.15.6`, `pyupgrade --py310-plus`
  (repo-pinned hooks) — clean.