### PR TITLE
fix(security): make jaro_similarity flagged-position lookup O(1) to stop cubic DoS (CVE-2026-12926)

### DIFF
--- a/nltk/metrics/distance.py
+++ b/nltk/metrics/distance.py
@@ -345,7 +345,13 @@ def jaro_similarity(s1, s2):
     matches = 0  # no.of matched characters in s1 and s2
     transpositions = 0  # no. of transpositions between s1 and s2
     flagged_1 = []  # positions in s1 which are matches to some character in s2
-    flagged_2 = []  # positions in s2 which are matches to some character in s1
+    # Positions in s2 which are matches to some character in s1. This is a set
+    # (not a list) so the ``j not in flagged_2`` membership test below is O(1):
+    # with a list it was O(len(flagged_2)) inside the O(n**2) double loop, which
+    # grows to O(n**3) on near-matching strings and lets two short inputs pin a
+    # CPU core (CWE-770; CVE-2026-12926). It is sorted into a list afterwards for
+    # the transposition pass, giving the same result.
+    flagged_2 = set()
 
     # Iterate through sequences, check for matches and compute transpositions.
     for i in range(len_s1):  # Iterate through each character.
@@ -355,9 +361,9 @@ def jaro_similarity(s1, s2):
             if s1[i] == s2[j] and j not in flagged_2:
                 matches += 1
                 flagged_1.append(i)
-                flagged_2.append(j)
+                flagged_2.add(j)
                 break
-    flagged_2.sort()
+    flagged_2 = sorted(flagged_2)
     for i, j in zip(flagged_1, flagged_2):
         if s1[i] != s2[j]:
             transpositions += 1

--- a/nltk/metrics/distance.py
+++ b/nltk/metrics/distance.py
@@ -345,25 +345,26 @@ def jaro_similarity(s1, s2):
     matches = 0  # no.of matched characters in s1 and s2
     transpositions = 0  # no. of transpositions between s1 and s2
     flagged_1 = []  # positions in s1 which are matches to some character in s2
-    # Positions in s2 which are matches to some character in s1. This is a set
-    # (not a list) so the ``j not in flagged_2`` membership test below is O(1):
-    # with a list it was O(len(flagged_2)) inside the O(n**2) double loop, which
-    # grows to O(n**3) on near-matching strings and lets two short inputs pin a
-    # CPU core (CWE-770; CVE-2026-12926). It is sorted into a list afterwards for
-    # the transposition pass, giving the same result.
-    flagged_2 = set()
+    # Positions in s2 which are matches to some character in s1, held as a set so
+    # the ``j not in matched_2`` membership test below is O(1): with a list it was
+    # O(len(matched_2)) inside the O(n**2) double loop, which grows to O(n**3) on
+    # near-matching strings and lets two short inputs pin a CPU core (CWE-770;
+    # CVE-2026-12926).
+    matched_2 = set()
 
     # Iterate through sequences, check for matches and compute transpositions.
     for i in range(len_s1):  # Iterate through each character.
         upperbound = min(i + match_bound, len_s2 - 1)
         lowerbound = max(0, i - match_bound)
         for j in range(lowerbound, upperbound + 1):
-            if s1[i] == s2[j] and j not in flagged_2:
+            if s1[i] == s2[j] and j not in matched_2:
                 matches += 1
                 flagged_1.append(i)
-                flagged_2.add(j)
+                matched_2.add(j)
                 break
-    flagged_2 = sorted(flagged_2)
+    # Ordered list of the matched s2 positions for the transposition pass, giving
+    # the same result as the original (which sorted the matched positions).
+    flagged_2 = sorted(matched_2)
     for i, j in zip(flagged_1, flagged_2):
         if s1[i] != s2[j]:
             transpositions += 1

--- a/nltk/test/unit/test_distance.py
+++ b/nltk/test/unit/test_distance.py
@@ -1,5 +1,5 @@
 import multiprocessing
-import os
+import queue
 from typing import Tuple
 
 import pytest
@@ -435,15 +435,24 @@ _JARO_TIMEOUT = 20
 _JARO_N = 8000
 
 
-def _jaro_worker():
-    jaro_similarity("a" * _JARO_N, "a" * (_JARO_N - 1) + "b")
-    os._exit(0)
+def _jaro_worker(result_q):
+    try:
+        jaro_similarity("a" * _JARO_N, "a" * (_JARO_N - 1) + "b")
+        result_q.put(("ok", None))
+    except BaseException as exc:  # surface to the parent process
+        result_q.put(("error", repr(exc)))
 
 
 def test_jaro_similarity_not_cubic_on_near_matches():
-    """A near-matching pair must compute quickly, not in cubic time (ReDoS-style)."""
+    """A near-matching pair must compute quickly, not in cubic time (ReDoS-style).
+
+    Runs in a spawned process with a hard timeout and reports status back via a
+    queue, so a regression to the cubic version is terminated (no lingering CPU)
+    and any worker exception is surfaced to the assertion.
+    """
     ctx = multiprocessing.get_context("spawn")
-    proc = ctx.Process(target=_jaro_worker)
+    result_q = ctx.Queue()
+    proc = ctx.Process(target=_jaro_worker, args=(result_q,))
     proc.start()
     proc.join(_JARO_TIMEOUT)
     if proc.is_alive():
@@ -452,4 +461,8 @@ def test_jaro_similarity_not_cubic_on_near_matches():
         raise AssertionError(
             "jaro_similarity did not finish in time -> cubic-time DoS (CWE-770)"
         )
-    assert proc.exitcode == 0, f"worker failed (exit code {proc.exitcode})"
+    try:
+        status, detail = result_q.get_nowait()
+    except queue.Empty:
+        raise AssertionError("jaro_similarity worker produced no result")
+    assert status == "ok", f"worker raised: {detail}"

--- a/nltk/test/unit/test_distance.py
+++ b/nltk/test/unit/test_distance.py
@@ -1,3 +1,5 @@
+import multiprocessing
+import os
 from typing import Tuple
 
 import pytest
@@ -419,3 +421,35 @@ class TestCustomDistanceSandbox:
         in_tsv.write_text("a\tb\t0.5\n", encoding="utf-8")
         dist = custom_distance(str(in_tsv))
         assert dist(frozenset(["a"]), frozenset(["b"])) == 0.5
+
+
+# ---------------------------------------------------------------------------
+# jaro_similarity must not be cubic on near-matching strings (CWE-770; CVE-2026-12926)
+# ---------------------------------------------------------------------------
+
+_JARO_TIMEOUT = 20
+# Two near-identical strings: almost every character matches inside the window.
+# The pre-fix ``j not in flagged_2`` list membership made this O(n**3) (~tens of
+# seconds at this size); with a set it is the algorithm's natural O(n**2)
+# (sub-second). It is CPU-only (a few KB of input), so there is no OOM risk.
+_JARO_N = 8000
+
+
+def _jaro_worker():
+    jaro_similarity("a" * _JARO_N, "a" * (_JARO_N - 1) + "b")
+    os._exit(0)
+
+
+def test_jaro_similarity_not_cubic_on_near_matches():
+    """A near-matching pair must compute quickly, not in cubic time (ReDoS-style)."""
+    ctx = multiprocessing.get_context("spawn")
+    proc = ctx.Process(target=_jaro_worker)
+    proc.start()
+    proc.join(_JARO_TIMEOUT)
+    if proc.is_alive():
+        proc.terminate()
+        proc.join()
+        raise AssertionError(
+            "jaro_similarity did not finish in time -> cubic-time DoS (CWE-770)"
+        )
+    assert proc.exitcode == 0, f"worker failed (exit code {proc.exitcode})"


### PR DESCRIPTION
# Make `jaro_similarity` flagged-position lookup O(1) to stop cubic-time DoS (CWE-770 / CVE-2026-12926)

## Description

`nltk.metrics.distance.jaro_similarity` matches two strings within a window of
about half the longer length — an O(n²) double loop — and, inside that loop,
tests whether a position is already flagged against a **list**:

```python
# nltk/metrics/distance.py (before)
flagged_2 = []                       # positions in s2 already matched
for i in range(len_s1):
    ...
    for j in range(lowerbound, upperbound + 1):
        if s1[i] == s2[j] and j not in flagged_2:   # O(len(flagged_2)) list scan
            matches += 1
            flagged_1.append(i)
            flagged_2.append(j)
            break
flagged_2.sort()
```

`j not in flagged_2` is an O(len(flagged_2)) linear scan of a list, and on
near-matching strings `flagged_2` grows toward `n` as matches accumulate — so the
membership test adds a third linear factor inside the O(n²) loop, making the
whole function **O(n³)**. The `if s1 == s2: return 1.0` fast path is trivially
bypassed by differing one character.

Measured on the current source (`jaro_similarity("a"*n, "a"*(n-1)+"b")`):

| n | time |
|--:|-----:|
| 1,000 | 0.40 s |
| 2,000 | 3.21 s |
| 4,000 | > 8 s |

(~8× per doubling → cubic.) A pair of small (a few KB) near-identical strings
ties up a worker core for tens of seconds; `jaro_winkler_similarity` inherits it
(it calls `jaro_similarity`). Any application that runs Jaro/Jaro-Winkler on
attacker-influenced strings (fuzzy matching, record linkage) is affected. No
authentication or non-default configuration is required. Validated as
**CVE-2026-12926** (CWE-770).

## The fix

Store the flagged `s2` positions in a **set** instead of a list, so the
`j not in flagged_2` membership test is **O(1)**. That removes the third factor
and restores the algorithm's natural O(n²) complexity. The flagged positions are
sorted into a list afterwards for the transposition pass, so the result is
unchanged:

```python
flagged_2 = set()
...
        if s1[i] == s2[j] and j not in flagged_2:
            matches += 1
            flagged_1.append(i)
            flagged_2.add(j)
            break
flagged_2 = sorted(flagged_2)        # was flagged_2.sort()
for i, j in zip(flagged_1, flagged_2):
    if s1[i] != s2[j]:
        transpositions += 1
```

Why this is exact: the `j not in flagged_2` guard means no position is ever
added twice, so the set holds exactly the same positions as the old list;
`sorted(set)` produces the same sorted positions the old `flagged_2.sort()` did,
so `matches`, `transpositions` and the returned score are identical. Only the
membership-test data structure changes.

## Behaviour preservation (verified)

- Reference values are unchanged: `jaro("MARTHA","MARHTA")` → `0.9444`,
  `jaro("DWAYNE","DUANE")` → `0.8222`, `jaro("DIXON","DICKSONX")` → `0.7667`,
  `jaro_winkler("MARTHA","MARHTA")` → `0.9611`; identical strings → `1.0`,
  disjoint → `0.0`.
- **Differential testing**: the set-based implementation was compared against the
  original on **200,000 random string pairs** — the returned float was
  **identical in every case** (0 mismatches).
- `python -m doctest nltk/metrics/distance.py` passes; `metrics.doctest`
  (**85 attempted, 0 failed**) and the existing `test_distance.py` (incl. the
  `TestJaroSimilarity` known-value/symmetry tests) pass — **matching `develop`**.

## Performance

| input | before | after |
|-------|--------|-------|
| `jaro_similarity("a"*8000, "a"*7999+"b")` | cubic (> 25 s) | ~0.44 s |
| `jaro_similarity("a"*4000, "a"*3999+"b")` | > 8 s | ~0.11 s |
| disjoint / benign pairs | unchanged | unchanged |

## Testing

- `nltk/test/unit/test_distance.py` (extended): a new test asserts that a
  near-matching pair computes in (quadratic) time rather than cubic — it runs in
  a spawned process with a hard timeout (exit-code IPC, robust on free-threaded
  builds; the payload is a few-KB string, so it is CPU-only with no OOM risk) so
  a regression to the list membership cannot hang the suite. It times out against
  the pre-fix `develop` version (> 25 s) and passes in well under a second against
  the fix. The existing `TestJaroSimilarity` tests already lock in the numeric
  results.
- `black==25.11.0`, `isort==6.1.0`, `ruff==0.15.6`, `pyupgrade --py310-plus`
  (repo-pinned hooks) — clean.