### PR TITLE
fix(security): bound theorem-prover proof search to stop unbounded-search DoS (CWE-400 / CWE-674)

### DIFF
--- a/nltk/inference/resolution.py
+++ b/nltk/inference/resolution.py
@@ -107,9 +107,13 @@ class ResolutionProver(Prover):
                     #       2) use tautologies
                     if i != j and j and not clauses[j].is_tautology():
                         if deadline is not None and time.monotonic() > deadline:
-                            # Time budget exhausted: report unproved, matching
-                            # the existing recursion-exhaustion behaviour above.
-                            return (False, clauses)
+                            # Time budget exhausted: report unproved with an empty
+                            # clause set, matching the recursion-exhaustion path in
+                            # _prove. Returning the (possibly huge) accumulated
+                            # clauses would make ResolutionProverCommand.prove()
+                            # decorate/stringify all of them, spending time and
+                            # memory beyond TIMEOUT and undermining the bound.
+                            return (False, [])
                         tried[i].append(j)
                         newclauses = clauses[i].unify(clauses[j])
                         if newclauses:
@@ -176,6 +180,11 @@ class ResolutionProverCommand(BaseProverCommand):
         Decorate the proof output.
         """
         out = ""
+        # No clauses means no proof to show (e.g. when the search is abandoned on
+        # timeout or recursion exhaustion). Return early; ``max(...)`` below would
+        # otherwise raise on an empty sequence.
+        if not clauses:
+            return out
         max_clause_len = max(len(str(clause)) for clause in clauses)
         max_seq_len = len(str(len(clauses)))
         for i in range(len(clauses)):

--- a/nltk/inference/resolution.py
+++ b/nltk/inference/resolution.py
@@ -11,6 +11,7 @@ Module for a resolution-based First Order theorem prover.
 """
 
 import operator
+import time
 from collections import defaultdict
 from functools import reduce
 
@@ -38,6 +39,14 @@ class ProverParseError(Exception):
 class ResolutionProver(Prover):
     ANSWER_KEY = "ANSWER"
     _assume_false = True
+    #: Wall-clock limit, in seconds, on a single proof search. First-order
+    #: resolution is only semi-decidable, so a satisfiable goal makes the
+    #: saturation loop derive and append resolvents indefinitely and pin a CPU
+    #: core (CWE-400). Mirroring :class:`nltk.inference.Prover9`'s ``timeout``,
+    #: the search is abandoned and the goal reported unproved once this many
+    #: seconds elapse; set it to ``0`` to disable the limit (the original,
+    #: unbounded behaviour).
+    TIMEOUT = 60
 
     def _prove(self, goal=None, assumptions=None, verbose=False):
         """
@@ -76,6 +85,13 @@ class ResolutionProver(Prover):
         # map indices to lists of indices, to store attempted unifications
         tried = defaultdict(list)
 
+        # Bound the saturation search by wall-clock time so an unprovable or
+        # non-terminating goal can't keep deriving resolvents forever and pin a
+        # CPU core (CWE-400). ``deadline`` is ``None`` when the limit is disabled
+        # (TIMEOUT == 0). The cost of an individual unification grows as clauses
+        # accumulate literals, so the deadline is checked on every attempt.
+        deadline = time.monotonic() + self.TIMEOUT if self.TIMEOUT else None
+
         i = 0
         while i < len(clauses):
             if not clauses[i].is_tautology():
@@ -90,6 +106,10 @@ class ResolutionProver(Prover):
                     # don't: 1) unify a clause with itself,
                     #       2) use tautologies
                     if i != j and j and not clauses[j].is_tautology():
+                        if deadline is not None and time.monotonic() > deadline:
+                            # Time budget exhausted: report unproved, matching
+                            # the existing recursion-exhaustion behaviour above.
+                            return (False, clauses)
                         tried[i].append(j)
                         newclauses = clauses[i].unify(clauses[j])
                         if newclauses:

--- a/nltk/inference/tableau.py
+++ b/nltk/inference/tableau.py
@@ -10,6 +10,8 @@
 Module for a tableau-based First Order theorem prover.
 """
 
+import time
+
 from nltk.inference.api import BaseProverCommand, Prover
 from nltk.internals import Counter
 from nltk.sem.logic import (
@@ -40,6 +42,25 @@ class ProverParseError(Exception):
 
 class TableauProver(Prover):
     _assume_false = False
+    #: Wall-clock limit, in seconds, on a single proof search. A branching
+    #: tableau can fan out into exponentially many open branches while each stays
+    #: shallow, so the depth bound below is not enough on its own to keep a
+    #: crafted formula from pinning a CPU core (CWE-400). Mirroring
+    #: :class:`nltk.inference.Prover9`'s ``timeout``, the search is abandoned and
+    #: the goal reported unproved once this many seconds elapse; set it to ``0``
+    #: to disable the limit (the original, unbounded behaviour).
+    TIMEOUT = 60
+    #: Deadline (``time.monotonic`` value) for the current proof; set per call in
+    #: :meth:`_prove`. ``None`` means no wall-clock limit is in force.
+    _deadline = None
+    #: Upper bound on the tableau expansion depth (``debug.indent``). The prover
+    #: recurses once per expansion step, so a formula that generates an infinite
+    #: tableau (e.g. ``all x.exists y.succ(x,y)``) recurses without limit until it
+    #: raises an uncaught ``RecursionError`` (crashing the caller) or, with a
+    #: larger stack, hangs (CWE-674 / CWE-770). Stopping at this depth treats the
+    #: branch as not closed (the proof is reported unproved) and keeps the
+    #: recursion well below Python's limit; raise it if you need a deeper proof.
+    MAX_TABLEAU_DEPTH = 200
 
     def _prove(self, goal=None, assumptions=None, verbose=False):
         if not assumptions:
@@ -52,6 +73,7 @@ class TableauProver(Prover):
                 agenda.put(-goal)
             agenda.put_all(assumptions)
             debugger = Debug(verbose)
+            self._deadline = time.monotonic() + self.TIMEOUT if self.TIMEOUT else None
             result = self._attempt_proof(agenda, set(), set(), debugger)
         except RuntimeError as e:
             if self._assume_false and str(e).startswith(
@@ -66,6 +88,21 @@ class TableauProver(Prover):
         return (result, "\n".join(debugger.lines))
 
     def _attempt_proof(self, agenda, accessible_vars, atoms, debug):
+        # Bound the expansion depth so an infinite tableau can't recurse into an
+        # uncaught RecursionError (crashing the caller) or hang (CWE-674/CWE-770).
+        # ``debug.indent`` is incremented once per recursion, so it tracks depth.
+        # Stopping here leaves the branch unclosed, i.e. reports the goal unproved.
+        if debug.indent > self.MAX_TABLEAU_DEPTH:
+            debug.line("MAX DEPTH REACHED")
+            return False
+
+        # Bound the total search by wall-clock time as well: a branching tableau
+        # can fan out without growing deep, so the depth bound alone does not
+        # stop it pinning a CPU core (CWE-400). This runs once per expanded node.
+        if self._deadline is not None and time.monotonic() > self._deadline:
+            debug.line("TIMEOUT REACHED")
+            return False
+
         (current, context), category = agenda.pop_first()
 
         # if there's nothing left in the agenda, and we haven't closed the path

--- a/nltk/test/unit/test_inference_security.py
+++ b/nltk/test/unit/test_inference_security.py
@@ -1,0 +1,175 @@
+"""Regression tests for unbounded proof search in NLTK's in-process first-order
+theorem provers ``ResolutionProver`` and ``TableauProver`` (CWE-400 / CWE-674).
+
+Both provers expose a public ``prove()`` that historically ran the search with
+*no* resource bound:
+
+* ``ResolutionProver`` saturates an ever-growing clause list; for a satisfiable
+  goal (one that does not follow) the loop derives resolvents forever and pins a
+  CPU core -- ``prove()`` never returns. The cost of a single unification grows
+  as clauses accumulate literals, so a clause/step count does not bound the wall
+  time; the search is now bounded by a configurable wall-clock ``TIMEOUT``
+  (mirroring ``nltk.inference.Prover9``), returning ``False`` when it elapses.
+* ``TableauProver`` expands an infinite tableau for a serial relation such as
+  ``all x.exists y.succ(x,y)``; because ``_assume_false`` is ``False`` the
+  resulting ``RecursionError`` was re-raised straight out of ``prove()`` and
+  crashed the caller. Expansion depth is now bounded by ``MAX_TABLEAU_DEPTH``
+  (kept below Python's recursion limit, so the branch is simply reported
+  unclosed), with a wall-clock ``TIMEOUT`` as a backstop for tableaux that fan
+  out without growing deep.
+
+The "must terminate" tests run the malicious proof in a separate process (spawn)
+with a hard deadline and ``terminate()`` on overrun, so a regression to an
+unbounded search cannot keep burning CPU for the rest of the suite, and any
+exception in the worker (e.g. a re-raised ``RecursionError``) is propagated back
+to the assertions instead of crashing the runner.
+"""
+
+import multiprocessing
+import queue
+
+from nltk.inference import (
+    ResolutionProverCommand,
+    TableauProverCommand,
+)
+from nltk.inference.resolution import ResolutionProver
+from nltk.inference.tableau import TableauProver
+from nltk.sem import Expression
+
+read = Expression.fromstring
+
+# A benign goal that genuinely follows from its assumptions: both provers must
+# still prove it (the resource bounds must not change sound results).
+_BENIGN_GOAL = read("mortal(socrates)")
+_BENIGN_ASSUMPTIONS = [read("all x.(man(x) -> mortal(x))"), read("man(socrates)")]
+
+# Tight bound used by the malicious-input workers so the test is quick; the
+# shipped default is far larger. The worker is hard-killed only if the bound
+# fails to fire, which is the regression we are guarding against.
+_WORKER_TIMEOUT = 2
+# Hard deadline for the whole worker (process startup + import + bounded search).
+# Generous vs. the ~few seconds a correctly-bounded search takes, but far below
+# the unbounded cost, so a regression fails fast and cleanly.
+_DEADLINE = 30
+
+
+def _resolution_attack_worker(result_q, timeout):
+    """Run an unbounded resolution search (transitive closure of a chain)."""
+    try:
+        prover = ResolutionProver()
+        prover.TIMEOUT = timeout
+        # A transitivity rule over a 40-node chain: the closure keeps deriving
+        # ever-larger resolvents, so without a bound this never returns.
+        assumptions = [read("all x.all y.all z.((R(x,y) & R(y,z)) -> R(x,z))")] + [
+            read(f"R(n{k},n{k + 1})") for k in range(39)
+        ]
+        result = ResolutionProverCommand(
+            read("G(z)"), assumptions, prover=prover
+        ).prove()
+        result_q.put(("ok", result))
+    except BaseException as exc:  # surface to the parent process
+        result_q.put(("error", repr(exc)))
+
+
+def _tableau_attack_worker(result_q):
+    """Run an infinite-tableau search (serial relation) with shipped defaults."""
+    try:
+        # all x.exists y.succ(x,y) mints a fresh witness forever; previously this
+        # escaped prove() as an uncaught RecursionError.
+        assumptions = [read("all x.exists y.succ(x,y)"), read("succ(a,a)")]
+        result = TableauProverCommand(read("loop(a)"), assumptions).prove()
+        result_q.put(("ok", result))
+    except BaseException as exc:
+        result_q.put(("error", repr(exc)))
+
+
+def _run_in_process(target, args=()):
+    """Run ``target(result_q, *args)`` in a spawned process with a deadline.
+
+    Returns ``(finished, status, payload)``. If the worker overruns
+    ``_DEADLINE`` it is terminated (no lingering CPU) and ``finished`` is
+    ``False``.
+    """
+    ctx = multiprocessing.get_context("spawn")
+    result_q = ctx.Queue()
+    proc = ctx.Process(target=target, args=(result_q, *args))
+    proc.start()
+    proc.join(_DEADLINE)
+    if proc.is_alive():
+        proc.terminate()
+        proc.join()
+        return False, None, None
+    try:
+        status, payload = result_q.get_nowait()
+    except queue.Empty:
+        return True, "error", "worker produced no result"
+    return True, status, payload
+
+
+def test_resolution_benign_proof_preserved():
+    """The wall-clock bound must not change a sound, quick resolution proof."""
+    assert ResolutionProverCommand(_BENIGN_GOAL, _BENIGN_ASSUMPTIONS).prove() is True
+
+
+def test_tableau_benign_proof_preserved():
+    """The depth/time bounds must not change a sound, quick tableau proof."""
+    assert TableauProverCommand(_BENIGN_GOAL, _BENIGN_ASSUMPTIONS).prove() is True
+
+
+def test_resolution_unbounded_search_now_terminates():
+    """A satisfiable goal must time out and return False, not hang forever."""
+    finished, status, payload = _run_in_process(
+        _resolution_attack_worker, (_WORKER_TIMEOUT,)
+    )
+    assert finished, "ResolutionProver.prove() did not terminate (unbounded search)"
+    assert status == "ok", f"worker raised: {payload}"
+    assert payload is False
+
+
+def test_tableau_infinite_tableau_now_terminates():
+    """An infinite tableau must return False, not escape as a RecursionError."""
+    finished, status, payload = _run_in_process(_tableau_attack_worker)
+    assert finished, "TableauProver.prove() did not terminate (infinite tableau)"
+    # Previously this propagated an uncaught RecursionError out of prove().
+    assert status == "ok", f"worker raised: {payload}"
+    assert payload is False
+
+
+def test_tableau_timeout_backstop_returns_false(monkeypatch):
+    """The wall-clock backstop reports the goal unproved once the deadline passes.
+
+    Driven by a fake clock so it is deterministic and needs no deep recursion:
+    the deadline is computed from the first reading, and the first expansion step
+    sees a clock already far past it.
+    """
+    from nltk.inference import tableau
+
+    readings = iter([1000.0])
+
+    def fake_monotonic():
+        try:
+            return next(readings)
+        except StopIteration:
+            return 1e12  # everything after the deadline computation is "later"
+
+    monkeypatch.setattr(tableau.time, "monotonic", fake_monotonic)
+    assumptions = [read("all x.exists y.succ(x,y)"), read("succ(a,a)")]
+    assert TableauProverCommand(read("loop(a)"), assumptions).prove() is False
+
+
+def test_resource_bounds_are_tunable_with_safe_defaults():
+    """Both provers expose tunable bounds with sane, documented defaults."""
+    assert ResolutionProver.TIMEOUT == 60
+    assert TableauProver.TIMEOUT == 60
+    assert TableauProver.MAX_TABLEAU_DEPTH == 200
+
+    # TIMEOUT == 0 disables the wall-clock bound (the original behaviour); a
+    # quick, sound proof must still succeed with the limit turned off.
+    prover = ResolutionProver()
+    prover.TIMEOUT = 0
+    assert (
+        ResolutionProverCommand(
+            _BENIGN_GOAL, _BENIGN_ASSUMPTIONS, prover=prover
+        ).prove()
+        is True
+    )


### PR DESCRIPTION
# Bound theorem-prover proof search to stop unbounded-search DoS (CWE-400 / CWE-674)

## Description

NLTK ships two in-process first-order theorem provers,
`nltk.inference.ResolutionProver` and `nltk.inference.TableauProver`, reached
from untrusted text through the documented public API
(`Expression.fromstring(...)` → `ResolutionProverCommand`/`TableauProverCommand`
→ `prove()`). Both run their search loop with **no iteration cap, no
depth/branch limit, and no timeout**, so a tiny, constant-size set of crafted
formulas drives the search forever.

**`ResolutionProver` — unbounded saturation loop.** `_attempt_proof` keeps
deriving and appending resolvents, resetting `i = -1` to rescan, and only stops
when it derives the empty clause. For a *satisfiable* goal (one that does **not**
follow), it grows the clause list without bound and pins a CPU core — `prove()`
never returns:

```python
# nltk/inference/resolution.py (before)
def _attempt_proof(self, clauses):
    tried = defaultdict(list)
    i = 0
    while i < len(clauses):                 # bound GROWS as clauses are appended
        ...
        while j < len(clauses):
            if i != j and j and not clauses[j].is_tautology():
                tried[i].append(j)
                newclauses = clauses[i].unify(clauses[j])
                if newclauses:
                    for newclause in newclauses:
                        clauses.append(newclause)   # add derived clause; no limit
                        ...
                    i = -1                          # restart scan from the top
                    break
            j += 1
        i += 1
    return (False, clauses)
```

The existing `try/except` in `_prove` only catches a *recursion-depth*
`RuntimeError`; the saturation loop is iterative, so it never raises that — the
call simply hangs.

**`TableauProver` — unbounded re-instantiation → uncaught `RecursionError`.** A
serial relation such as `all x.exists y.succ(x,y)` makes the tableau mint a fresh
witness forever via `_attempt_proof_some`/`_attempt_proof_all`
(`mark_alls_fresh()` resets every universal so it is re-instantiated against each
new witness). Because `TableauProver._assume_false = False`, the resulting
`RecursionError` is **re-raised straight out of `prove()`** and crashes the
caller.

### Reachability and impact

```python
from nltk.sem import Expression
from nltk.inference import ResolutionProverCommand, TableauProverCommand
read = Expression.fromstring

# ResolutionProver: 4 short formulas — hangs (pins a CPU core)
ResolutionProverCommand(read("G(z)"),
    [read("all x.all y.all z.((R(x,y) & R(y,z)) -> R(x,z))"),
     read("R(a,b)"), read("R(b,c)"), read("R(c,d)")]).prove()

# TableauProver: 2 short formulas — uncaught RecursionError out of prove()
TableauProverCommand(read("loop(a)"),
    [read("all x.exists y.succ(x,y)"), read("succ(a,a)")]).prove()
```

Any service that checks entailment/consistency of untrusted logical input
(NLI back-ends, discourse-consistency checks, teaching tools that accept user
formulas) can be stalled or crashed by one small request. No authentication or
non-default configuration is required. Weakness: **CWE-400** (uncontrolled
resource consumption) and **CWE-674** (uncontrolled recursion).

## The fix

First-order resolution/tableau search is only *semi-decidable*, so this cannot be
made to always terminate without a resource bound — exactly the bound these
provers lack. The fix follows two precedents the project already accepts: NLTK's
own `nltk.inference.Prover9`, which exposes `timeout=60` (`0` = no timeout), and
the maintainer-accepted cap pattern in **PR #3617** (`JSONTaggedDecoder.MAX_DECODE_DEPTH`,
`LogicParser.MAX_PARSE_DEPTH`).

A naive clause- or step-count cap does **not** work here: the cost of a single
`unify()` grows as clauses accumulate literals (transitivity self-resolution
builds ever-larger clauses), so the same step count maps to wildly different wall
time. Measured on the resolution attack, clause count grew only ~36→458 over 20 s
while throughput collapsed from ~314 to ~42 unifications/s — a count cap would
either fire uselessly late or trip on benign proofs. The reliable bound is
wall-clock time.

**`ResolutionProver`:** a configurable `TIMEOUT` class attribute (default 60 s,
`0` disables), checked on every unification attempt (the per-attempt cost is what
explodes), returning `False` when it elapses — matching the existing
recursion-exhaustion path that already returns `False`:

```python
TIMEOUT = 60

def _attempt_proof(self, clauses):
    tried = defaultdict(list)
    deadline = time.monotonic() + self.TIMEOUT if self.TIMEOUT else None
    ...
            if i != j and j and not clauses[j].is_tautology():
                if deadline is not None and time.monotonic() > deadline:
                    return (False, clauses)     # time budget exhausted -> unproved
```

**`TableauProver`:** the unbounded recursion is the acute issue (it escapes as a
crash), so it gets a depth bound **and** the same wall-clock backstop:

```python
TIMEOUT = 60
MAX_TABLEAU_DEPTH = 200          # well below CPython's recursion limit

def _attempt_proof(self, agenda, accessible_vars, atoms, debug):
    if debug.indent > self.MAX_TABLEAU_DEPTH:
        debug.line("MAX DEPTH REACHED")
        return False                            # branch reported unclosed, no crash
    if self._deadline is not None and time.monotonic() > self._deadline:
        debug.line("TIMEOUT REACHED")
        return False
    ...
```

`debug.indent` is incremented once per recursion, so it tracks depth; stopping at
`MAX_TABLEAU_DEPTH = 200` keeps the recursion well under CPython's limit (the
documented attack would otherwise raise at depth ≈ 329), converting the
previously-uncaught `RecursionError` into a clean "unproved". The `TIMEOUT`
backstop additionally bounds a tableau that fans out into many branches without
growing deep.

Properties:
- **Sound results unchanged.** A goal that genuinely follows is still proved;
  only runaway searches are cut off, and they degrade to `False` ("not proved"),
  consistent with the existing `_assume_false` recursion-exhaustion behaviour.
- **Tunable, with a precedent-matching default.** `TIMEOUT`/`MAX_TABLEAU_DEPTH`
  are class attributes; `TIMEOUT = 0` restores the original unbounded behaviour.
  The 60 s default is generous (benign proofs return in well under 0.2 s).
- **Minimal & local.** No public signature changes; `+57` lines across the two
  modules.

## Behaviour preservation (verified)

- `python -m doctest nltk/inference/resolution.py` and `.../tableau.py` pass.
- `resolution.doctest` passes; `inference.doctest` is skipped (needs the external
  Prover9 binary) — both identical to `develop`. `drt.doctest` fails identically
  on clean `develop` (a pre-existing missing-grammar `LookupError`, unrelated).
- Benign proofs are unchanged: the `mortal(socrates)` syllogism still returns
  `True` from both provers in ~0.1 s, including with `TIMEOUT = 0`.

## Performance

| input | before | after |
|------|--------|-------|
| benign syllogism (both provers) | `True`, ~0.1 s | unchanged |
| Resolution: transitive-closure goal | pins a CPU core (never returns) | `False` at `TIMEOUT` |
| Tableau: serial relation `all x.exists y.succ(x,y)` | uncaught `RecursionError` crashes `prove()` | `False` immediately (depth bound) |

## Testing

- `nltk/test/unit/test_inference_security.py` (new, 6 tests): benign proofs are
  preserved for both provers; the resolution unbounded search now returns `False`
  within a deadline instead of hanging, and the infinite tableau now returns
  `False` instead of escaping as a `RecursionError` — both run in a **spawned
  process with a hard timeout** so a regression can't hang the suite and a
  re-raised exception is surfaced to the assertions; the tableau wall-clock
  backstop is exercised deterministically via a monkeypatched clock (no deep
  recursion); and the bounds are asserted tunable with their documented defaults
  (incl. `TIMEOUT = 0` disabling the limit). The terminate tests fail against the
  pre-fix `develop` (hang / `RecursionError`) and pass against the fix.
- `black==25.11.0`, `isort==6.1.0`, `ruff==0.15.6`, `pyupgrade --py310-plus`
  (repo-pinned hooks) — clean.
