### PR TITLE
fix(security): guard CHILDESCorpusReader.convert_age against malformed input (CWE-476)

### DIFF
--- a/nltk/corpus/reader/childes.py
+++ b/nltk/corpus/reader/childes.py
@@ -281,7 +281,7 @@ class CHILDESCorpusReader(XMLCorpusReader):
                 return None
 
     def convert_age(self, age_year):
-        "Caclculate age in months from a string in CHILDES format"
+        "Calculate age in months from a string in CHILDES format"
         m = re.match(r"P(\d+)Y(\d+)M?(\d?\d?)D?", age_year)
         if m is None:
             # A string that does not fit the CHILDES age shape would otherwise
@@ -289,8 +289,8 @@ class CHILDESCorpusReader(XMLCorpusReader):
             # public helper (CWE-476); fail with a clear, catchable error.
             raise ValueError(
                 f"Cannot convert age {age_year!r}: expected a CHILDES age string "
-                "of the form 'P<years>Y<months>M' (optionally with days), "
-                "e.g. 'P2Y10M' or 'P2Y1M15D'"
+                "of the form 'P<years>Y<months>' with an optional 'M' and "
+                "'<days>D', e.g. 'P2Y10M', 'P2Y10', or 'P2Y1M15D'"
             )
         age_month = int(m.group(1)) * 12 + int(m.group(2))
         try:

--- a/nltk/corpus/reader/childes.py
+++ b/nltk/corpus/reader/childes.py
@@ -275,13 +275,23 @@ class CHILDESCorpusReader(XMLCorpusReader):
                     if month:
                         age = self.convert_age(age)
                     return age
-            # some files don't have age data
-            except (TypeError, AttributeError) as e:
+            # some files have missing (TypeError) or malformed (ValueError) age
+            # data; AttributeError is kept for backward compatibility
+            except (TypeError, AttributeError, ValueError) as e:
                 return None
 
     def convert_age(self, age_year):
         "Caclculate age in months from a string in CHILDES format"
         m = re.match(r"P(\d+)Y(\d+)M?(\d?\d?)D?", age_year)
+        if m is None:
+            # A string that does not fit the CHILDES age shape would otherwise
+            # make ``m.group(1)`` raise a cryptic ``AttributeError`` out of this
+            # public helper (CWE-476); fail with a clear, catchable error.
+            raise ValueError(
+                f"Cannot convert age {age_year!r}: expected a CHILDES age string "
+                "of the form 'P<years>Y<months>M' (optionally with days), "
+                "e.g. 'P2Y10M' or 'P2Y1M15D'"
+            )
         age_month = int(m.group(1)) * 12 + int(m.group(2))
         try:
             if int(m.group(3)) > 15:

--- a/nltk/test/unit/test_childes_security.py
+++ b/nltk/test/unit/test_childes_security.py
@@ -15,9 +15,6 @@ import pytest
 
 from nltk.corpus.reader.childes import NS, CHILDESCorpusReader
 
-# A reader needs no corpus files for the pure string->int helper.
-_READER = CHILDESCorpusReader("/tmp", r"nonexistent\.xml")
-
 # CHILDES ages and their value in months (years * 12 + months, +1 when the
 # optional day field is > 15). These must be unchanged by the fix.
 _VALID_AGES = {
@@ -32,17 +29,25 @@ _VALID_AGES = {
 _MALFORMED_AGES = ["", "garbage", "P2Y", "2Y3M", "P10M", "P2YxM"]
 
 
+@pytest.fixture(scope="module")
+def reader(tmp_path_factory):
+    """A reader needs no corpus files for the pure string->int helper, but the
+    root must exist (a hard-coded ``/tmp`` is absent on Windows)."""
+    root = tmp_path_factory.mktemp("childes")
+    return CHILDESCorpusReader(str(root), r"nonexistent\.xml")
+
+
 @pytest.mark.parametrize("age_string,months", _VALID_AGES.items())
-def test_convert_age_valid_strings_preserved(age_string, months):
+def test_convert_age_valid_strings_preserved(reader, age_string, months):
     """Well-formed ages convert exactly as before."""
-    assert _READER.convert_age(age_string) == months
+    assert reader.convert_age(age_string) == months
 
 
 @pytest.mark.parametrize("payload", _MALFORMED_AGES)
-def test_convert_age_rejects_malformed_with_valueerror(payload):
+def test_convert_age_rejects_malformed_with_valueerror(reader, payload):
     """A malformed age raises a clear ValueError, not a cryptic AttributeError."""
     with pytest.raises(ValueError):
-        _READER.convert_age(payload)
+        reader.convert_age(payload)
 
 
 def _age_in_months(tmp_path, age_attr):

--- a/nltk/test/unit/test_childes_security.py
+++ b/nltk/test/unit/test_childes_security.py
@@ -1,0 +1,68 @@
+"""Regression test for the uncaught NoneType dereference in
+``nltk.corpus.reader.childes.CHILDESCorpusReader.convert_age`` (CWE-476).
+
+``convert_age`` matched its input against a rigid ``P<d>Y<d>M?...`` pattern and
+immediately did ``m.group(1)`` without checking that the match succeeded. Any
+string that does not fit the shape made ``re.match`` return ``None``, so the
+group access raised a cryptic ``AttributeError: 'NoneType' object has no
+attribute 'group'`` out of this public helper. It now fails with a clear,
+catchable ``ValueError`` instead, and the internal corpus walk
+(``age(..., month=True)`` -> ``_get_age``) still degrades to ``None`` on a
+malformed age rather than crashing.
+"""
+
+import pytest
+
+from nltk.corpus.reader.childes import NS, CHILDESCorpusReader
+
+# A reader needs no corpus files for the pure string->int helper.
+_READER = CHILDESCorpusReader("/tmp", r"nonexistent\.xml")
+
+# CHILDES ages and their value in months (years * 12 + months, +1 when the
+# optional day field is > 15). These must be unchanged by the fix.
+_VALID_AGES = {
+    "P2Y10M": 34,
+    "P0Y0M": 0,
+    "P2Y1M15D": 25,  # 15 days -> not rounded up
+    "P2Y1M20D": 26,  # 20 days -> rounded up
+    "P2Y10": 34,  # trailing month marker is optional
+}
+
+# Strings that do not fit the CHILDES age shape (from the report's PoC).
+_MALFORMED_AGES = ["", "garbage", "P2Y", "2Y3M", "P10M", "P2YxM"]
+
+
+@pytest.mark.parametrize("age_string,months", _VALID_AGES.items())
+def test_convert_age_valid_strings_preserved(age_string, months):
+    """Well-formed ages convert exactly as before."""
+    assert _READER.convert_age(age_string) == months
+
+
+@pytest.mark.parametrize("payload", _MALFORMED_AGES)
+def test_convert_age_rejects_malformed_with_valueerror(payload):
+    """A malformed age raises a clear ValueError, not a cryptic AttributeError."""
+    with pytest.raises(ValueError):
+        _READER.convert_age(payload)
+
+
+def _age_in_months(tmp_path, age_attr):
+    """Build a one-participant CHILDES file and read its child age in months."""
+    xml = (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        f'<CHAT xmlns="{NS}"><Participants>'
+        f'<participant id="CHI" role="Target_Child" age="{age_attr}"/>'
+        "</Participants></CHAT>"
+    )
+    (tmp_path / "f.xml").write_text(xml, encoding="utf-8")
+    reader = CHILDESCorpusReader(str(tmp_path), r"f\.xml", lazy=False)
+    return reader.age(month=True)
+
+
+def test_corpus_walk_degrades_gracefully_on_malformed_age(tmp_path):
+    """The internal walk still returns None for a malformed age (not a crash)."""
+    assert _age_in_months(tmp_path, "garbage") == [None]
+
+
+def test_corpus_walk_converts_valid_age(tmp_path):
+    """Sanity: a well-formed age still converts through the public walk."""
+    assert _age_in_months(tmp_path, "P2Y10M") == [34]


### PR DESCRIPTION
# Guard CHILDESCorpusReader.convert_age against malformed input (CWE-476)

## Description

`nltk.corpus.reader.childes.CHILDESCorpusReader.convert_age` parses a CHILDES
age string (e.g. `"P2Y10M"`) into months. It matches the input against a rigid
pattern and **immediately dereferences the match without checking it succeeded**:

```python
# nltk/corpus/reader/childes.py (before)
def convert_age(self, age_year):
    "Caclculate age in months from a string in CHILDES format"
    m = re.match(r"P(\d+)Y(\d+)M?(\d?\d?)D?", age_year)
    age_month = int(m.group(1)) * 12 + int(m.group(2))   # m is None for any
    ...                                                  # non-matching string
```

For any string that does not fit the `P<d>Y<d>M?...` shape, `re.match` returns
`None`, so `m.group(1)` raises a cryptic
`AttributeError: 'NoneType' object has no attribute 'group'` out of this public
method. Confirmed with the report's PoC inputs (`""`, `"garbage"`, `"P2Y"`,
`"2Y3M"`, `"P10M"`):

```
'P2Y10M' -> 34
'' -> AttributeError: 'NoneType' object has no attribute 'group'
'garbage' -> AttributeError: ...
'P2Y' -> AttributeError: ...
```

`convert_age` is a public helper (the constructor needs no corpus files). The
internal corpus walk `age(..., month=True)` → `_get_age` is already guarded — it
wraps the call in `except (TypeError, AttributeError)` and returns `None` — so
the narrow vector is an application calling `convert_age` directly on
attacker-influenced strings, where the dereference crashes the request. No
authentication or user interaction is required. Weakness: **CWE-476**
(NULL-pointer-dereference analog). A supplementary-severity robustness issue.

## The fix

Check the match and fail with a clear, **catchable, documented** `ValueError`
that names the bad input and the expected shape, instead of leaking a `NoneType`
`AttributeError`:

```python
m = re.match(r"P(\d+)Y(\d+)M?(\d?\d?)D?", age_year)
if m is None:
    raise ValueError(
        f"Cannot convert age {age_year!r}: expected a CHILDES age string "
        "of the form 'P<years>Y<months>M' (optionally with days), "
        "e.g. 'P2Y10M' or 'P2Y1M15D'"
    )
age_month = int(m.group(1)) * 12 + int(m.group(2))
```

So that the internal walk keeps **degrading gracefully** (it returned `None` for
a malformed age before, by catching the `AttributeError`), `ValueError` is added
to `_get_age`'s `except` — the only `ValueError` source in that `try` is this
call:

```python
# some files have missing (TypeError) or malformed (ValueError) age
# data; AttributeError is kept for backward compatibility
except (TypeError, AttributeError, ValueError) as e:
    return None
```

Properties:
- **No behaviour change for valid input.** Well-formed ages convert to the exact
  same months as before (`"P2Y10M"` → 34, `"P2Y1M15D"` → 25, `"P2Y1M20D"` → 26).
- **Same graceful walk.** `age(..., month=True)` over a file with a missing
  (`None`, still `TypeError` from `re.match`) or malformed age still returns
  `None` rather than crashing the walk — unchanged.
- **Clearer contract.** Direct callers can catch a documented `ValueError`
  instead of a `NoneType` `AttributeError` that hides the real cause.
- **Minimal & local.** A null-check plus one widened `except`; no public
  signature change.

## Behaviour preservation (verified)

- `python -m doctest nltk/corpus/reader/childes.py` passes.
- `childes.doctest` exercises `age(..., month=True)` on real corpus data and is
  unaffected (it is skipped unless the CHILDES corpus is installed, via
  `childes_fixt.py`); the fix only adds an error path for inputs that previously
  crashed, so all valid conversions are identical.

## Testing

- `nltk/test/unit/test_childes_security.py` (new): a parametrized matrix asserts
  that well-formed ages convert to the same months as before; that each malformed
  input from the PoC raises `ValueError` (not `AttributeError`); and that the
  public corpus walk (`age(month=True)` over a crafted one-participant CHILDES
  file) still returns `[None]` for a malformed age and `[34]` for a valid one.
  The malformed-input cases fail against the pre-fix `develop`
  (`AttributeError: 'NoneType' object has no attribute 'group'`) and pass against
  the fix.
- `black==25.11.0`, `isort==6.1.0`, `ruff==0.15.6`, `pyupgrade --py310-plus`
  (repo-pinned hooks) — clean.
