### PR TITLE
fix(security): DoS in NLTK PropBank

### DIFF
--- a/nltk/corpus/reader/propbank.py
+++ b/nltk/corpus/reader/propbank.py
@@ -285,31 +285,25 @@ class PropbankInstance:
         if parse_fileid_xform is not None:
             fileid = parse_fileid_xform(fileid)
 
-        # Convert sentence & word numbers to ints. A non-numeric field would
-        # otherwise raise a cryptic ValueError that aborts iteration over the
-        # whole corpus; fail with the same clear message as the checks above.
+        # Convert the numeric fields and parse the inflection, the predicate
+        # location, and the argument pointers. Any malformed field would
+        # otherwise leak a cryptic ValueError (e.g. "invalid literal for int()",
+        # "Bad propbank inflection string", "bad propbank pointer", or an
+        # unpacking error from an argument missing its "-" separator) that aborts
+        # iteration over the whole corpus; fail with the same clear message as
+        # the checks above, so callers can catch a single error for any
+        # malformed line.
         try:
             sentnum = int(sentnum)
             wordnum = int(wordnum)
+            inflection = PropbankInflection.parse(inflection)
+            predicate = PropbankTreePointer.parse(rel[0][:-4])
+            arguments = []
+            for arg in args:
+                argloc, argid = arg.split("-", 1)
+                arguments.append((PropbankTreePointer.parse(argloc), argid))
         except ValueError:
             raise ValueError("Badly formatted propbank line: %r" % s) from None
-
-        # Parse the inflection
-        inflection = PropbankInflection.parse(inflection)
-
-        # Parse the predicate location.
-        predicate = PropbankTreePointer.parse(rel[0][:-4])
-
-        # Parse the arguments.
-        arguments = []
-        for arg in args:
-            arg_pieces = arg.split("-", 1)
-            # An argument missing its "-" separator would otherwise raise a
-            # cryptic unpacking ValueError that aborts the whole-corpus iteration.
-            if len(arg_pieces) != 2:
-                raise ValueError("Badly formatted propbank line: %r" % s)
-            argloc, argid = arg_pieces
-            arguments.append((PropbankTreePointer.parse(argloc), argid))
 
         # Put it all together.
         return PropbankInstance(

--- a/nltk/corpus/reader/propbank.py
+++ b/nltk/corpus/reader/propbank.py
@@ -285,9 +285,14 @@ class PropbankInstance:
         if parse_fileid_xform is not None:
             fileid = parse_fileid_xform(fileid)
 
-        # Convert sentence & word numbers to ints.
-        sentnum = int(sentnum)
-        wordnum = int(wordnum)
+        # Convert sentence & word numbers to ints. A non-numeric field would
+        # otherwise raise a cryptic ValueError that aborts iteration over the
+        # whole corpus; fail with the same clear message as the checks above.
+        try:
+            sentnum = int(sentnum)
+            wordnum = int(wordnum)
+        except ValueError:
+            raise ValueError("Badly formatted propbank line: %r" % s) from None
 
         # Parse the inflection
         inflection = PropbankInflection.parse(inflection)
@@ -298,7 +303,12 @@ class PropbankInstance:
         # Parse the arguments.
         arguments = []
         for arg in args:
-            argloc, argid = arg.split("-", 1)
+            arg_pieces = arg.split("-", 1)
+            # An argument missing its "-" separator would otherwise raise a
+            # cryptic unpacking ValueError that aborts the whole-corpus iteration.
+            if len(arg_pieces) != 2:
+                raise ValueError("Badly formatted propbank line: %r" % s)
+            argloc, argid = arg_pieces
             arguments.append((PropbankTreePointer.parse(argloc), argid))
 
         # Put it all together.

--- a/nltk/test/unit/test_propbank.py
+++ b/nltk/test/unit/test_propbank.py
@@ -1,0 +1,51 @@
+"""Regression tests for uncaught crashes on a malformed line in the PropBank
+instance parser (CWE-248 uncaught exception).
+
+``PropbankInstance.parse`` converted the sentence/word-number fields with
+``int(...)`` and split each argument on ``-`` without validating them, so a
+malformed corpus line raised a cryptic, uncaught ``ValueError`` (``invalid
+literal for int()`` / ``not enough values to unpack``). ``parse`` is called by
+``PropbankCorpusReader.instances()`` via ``_read_instance_block`` with no
+surrounding handler, so one bad line aborted iteration over the whole corpus.
+It now fails with the same clear ``"Badly formatted propbank line"`` ``ValueError``
+the parser already raises for other malformed lines; valid lines are unchanged.
+"""
+
+import pytest
+
+from nltk.corpus.reader.propbank import PropbankInstance
+
+_VALID = "wsj.mrg 0 16 gold rise.01 vp--a 16:0-rel"
+
+
+def test_parse_rejects_non_numeric_sentnum():
+    with pytest.raises(ValueError, match="Badly formatted propbank line"):
+        PropbankInstance.parse("wsj.mrg X 16 gold rise.01 vp--a 16:0-rel")
+
+
+def test_parse_rejects_non_numeric_wordnum():
+    with pytest.raises(ValueError, match="Badly formatted propbank line"):
+        PropbankInstance.parse("wsj.mrg 0 XX gold rise.01 vp--a 16:0-rel")
+
+
+def test_parse_rejects_argument_without_separator():
+    with pytest.raises(ValueError, match="Badly formatted propbank line"):
+        PropbankInstance.parse("wsj.mrg 0 16 gold rise.01 vp--a 16:0-rel BADARG")
+
+
+def test_parse_valid_line_preserved():
+    """A well-formed line still parses to the same fields."""
+    inst = PropbankInstance.parse(_VALID)
+    assert inst.fileid == "wsj.mrg"
+    assert inst.sentnum == 0
+    assert inst.wordnum == 16
+    assert inst.tagger == "gold"
+    assert inst.roleset == "rise.01"
+    assert inst.arguments == ()
+
+
+def test_parse_valid_line_with_argument_preserved():
+    """A well-formed line with an argument still parses the argument id."""
+    inst = PropbankInstance.parse(_VALID + " 15:1-ARG0")
+    assert len(inst.arguments) == 1
+    assert inst.arguments[0][1] == "ARG0"

--- a/nltk/test/unit/test_propbank.py
+++ b/nltk/test/unit/test_propbank.py
@@ -2,13 +2,15 @@
 instance parser (CWE-248 uncaught exception).
 
 ``PropbankInstance.parse`` converted the sentence/word-number fields with
-``int(...)`` and split each argument on ``-`` without validating them, so a
-malformed corpus line raised a cryptic, uncaught ``ValueError`` (``invalid
-literal for int()`` / ``not enough values to unpack``). ``parse`` is called by
-``PropbankCorpusReader.instances()`` via ``_read_instance_block`` with no
-surrounding handler, so one bad line aborted iteration over the whole corpus.
-It now fails with the same clear ``"Badly formatted propbank line"`` ``ValueError``
-the parser already raises for other malformed lines; valid lines are unchanged.
+``int(...)``, split each argument on ``-``, and parsed the inflection and
+tree-pointer fields without catching their ``ValueError``s, so a malformed corpus
+line raised a cryptic, uncaught ``ValueError`` (``invalid literal for int()``,
+``not enough values to unpack``, ``Bad propbank inflection string``, or ``bad
+propbank pointer``). ``parse`` is called by ``PropbankCorpusReader.instances()``
+via ``_read_instance_block`` with no surrounding handler, so one bad line aborted
+iteration over the whole corpus. It now fails with the same clear ``"Badly
+formatted propbank line"`` ``ValueError`` the parser already raises for other
+malformed lines; valid lines are unchanged.
 """
 
 import pytest
@@ -31,6 +33,21 @@ def test_parse_rejects_non_numeric_wordnum():
 def test_parse_rejects_argument_without_separator():
     with pytest.raises(ValueError, match="Badly formatted propbank line"):
         PropbankInstance.parse("wsj.mrg 0 16 gold rise.01 vp--a 16:0-rel BADARG")
+
+
+def test_parse_rejects_malformed_inflection():
+    with pytest.raises(ValueError, match="Badly formatted propbank line"):
+        PropbankInstance.parse("wsj.mrg 0 16 gold rise.01 xxxxx 16:0-rel")
+
+
+def test_parse_rejects_malformed_rel_pointer():
+    with pytest.raises(ValueError, match="Badly formatted propbank line"):
+        PropbankInstance.parse("wsj.mrg 0 16 gold rise.01 vp--a 16-rel")
+
+
+def test_parse_rejects_malformed_argument_pointer():
+    with pytest.raises(ValueError, match="Badly formatted propbank line"):
+        PropbankInstance.parse("wsj.mrg 0 16 gold rise.01 vp--a 16:0-rel XX:0-ARG0")
 
 
 def test_parse_valid_line_preserved():


### PR DESCRIPTION
# fix(security): DoS in NLTK PropBank (CWE-248)

## Description

`PropbankInstance.parse` (reached from `PropbankCorpusReader.instances()` via
`_read_instance_block`, with no surrounding handler) converts the sentence- and
word-number fields with `int(...)` and splits each argument on `-` **without
validating them**:

```python
# nltk/corpus/reader/propbank.py (before)
sentnum = int(sentnum)              # L288 -> ValueError on a non-numeric field
wordnum = int(wordnum)             # L289 -> ValueError on a non-numeric field
...
for arg in args:
    argloc, argid = arg.split("-", 1)   # L300 -> ValueError when arg has no "-"
```

A malformed corpus line therefore raises a cryptic, uncaught exception that
propagates out of the parser. Because the standard public iteration
(`instances()` → `_read_instance_block` at L145) calls `parse` with no
try/except, **one bad line aborts iteration over the entire corpus**. Confirmed
with the report's PoC:

```
"wsj.mrg X 16 gold rise.01 vp--a 16:0-rel"          -> ValueError: invalid literal for int() with base 10: 'X'
"wsj.mrg 0 16 gold rise.01 vp--a 16:0-rel BADARG"   -> ValueError: not enough values to unpack (expected 2, got 1)
```

**Impact:** a single malformed line in a PropBank file crashes the worker that
reads it and aborts the whole-corpus iteration. The pre-condition is an
application reading user-supplied or third-party data in this format. No
authentication or user interaction is required. Weakness: **CWE-248** (uncaught
exception).

## The fix

Validate the fields and fail with the **same clear `ValueError` the parser
already raises** for other malformed lines (`"Badly formatted propbank line:
%r"`, used above for the field-count and `-rel` checks), instead of leaking a
cryptic `int()` / unpack error:

```python
try:
    sentnum = int(sentnum)
    wordnum = int(wordnum)
except ValueError:
    raise ValueError("Badly formatted propbank line: %r" % s) from None
...
for arg in args:
    arg_pieces = arg.split("-", 1)
    if len(arg_pieces) != 2:
        raise ValueError("Badly formatted propbank line: %r" % s)
    argloc, argid = arg_pieces
    arguments.append((PropbankTreePointer.parse(argloc), argid))
```

Properties:
- **Clear, catchable, uniform error.** All malformed-line cases in `parse` now
  raise the one documented `"Badly formatted propbank line"` `ValueError`, so an
  application can catch a single, meaningful exception (and `from None` drops the
  confusing chained `int()` traceback) instead of a cryptic `invalid literal for
  int()` / `not enough values to unpack`.
- **No behaviour change for well-formed data.** Valid lines parse to exactly the
  same instance (same `fileid`, `sentnum`, `wordnum`, `roleset`, arguments).
- **Minimal & local.** Two guarded conversions; no public signature change.

## Behaviour preservation (verified)

- `python -m doctest nltk/corpus/reader/propbank.py` passes.
- A valid line parses unchanged: `"wsj.mrg 0 16 gold rise.01 vp--a 16:0-rel"` →
  `fileid='wsj.mrg'`, `sentnum=0`, `wordnum=16`, `roleset='rise.01'`, no
  arguments; with `15:1-ARG0` the argument id is still `ARG0`.

## Testing

- `nltk/test/unit/test_propbank.py` (new, 5 tests): a non-numeric sentence
  number, a non-numeric word number, and an argument with no `-` separator each
  raise `ValueError` matching `"Badly formatted propbank line"`; valid lines
  (with and without an argument) parse to the same fields. The three malformed
  cases fail against the pre-fix `develop` (`invalid literal for int()` /
  `not enough values to unpack`) and pass against the fix.
- `black==25.11.0`, `isort==6.1.0`, `ruff==0.15.6`, `pyupgrade --py310-plus`
  (repo-pinned hooks) — clean.
