### PR TITLE
fix(security): Quadratic-time DoS in NLTK Tree.un_chomsky_normal_form

### DIFF
--- a/nltk/test/unit/test_treetransforms.py
+++ b/nltk/test/unit/test_treetransforms.py
@@ -1,0 +1,74 @@
+"""Regression tests for the quadratic-time DoS in
+``nltk.tree.Tree.un_chomsky_normal_form`` (CWE-407).
+
+The un-binarisation pass removed each artificial Chomsky-Normal-Form node from
+its parent with ``parent.index(node)`` / ``parent.remove(...)``. Because ``Tree``
+subclasses ``list``, those compare children by value via the recursive
+``Tree.__eq__``, rescanning a child list that grows wide as nodes are spliced
+out -- O(n^2) over the artificial nodes (worse with deep subtrees). The pass now
+rebuilds each parent's child list in a single left-to-right sweep (O(n)),
+producing identical output for any tree in Chomsky Normal Form.
+"""
+
+import multiprocessing
+import os
+
+from nltk.tree import Tree
+from nltk.tree.transforms import chomsky_normal_form, un_chomsky_normal_form
+
+_TREES = [
+    "(S (NP (D the) (N cat)) (VP (V sat)))",
+    "(S (A a) (B b) (C c) (D d))",
+    "(S (NP (D the) (Adj big) (N dog)) (VP (V ran) (PP (P to) (NP home))))",
+]
+
+
+def test_un_chomsky_roundtrips_chomsky_normal_form():
+    """un_chomsky_normal_form must invert chomsky_normal_form for both factors."""
+    for source in _TREES:
+        for factor in ("right", "left"):
+            tree = Tree.fromstring(source)
+            expected = Tree.fromstring(source)
+            chomsky_normal_form(tree, factor=factor)
+            un_chomsky_normal_form(tree)
+            assert tree == expected
+
+
+def test_un_chomsky_collapses_artificial_node():
+    """An artificial ``|`` node is spliced into its parent (children in order)."""
+    tree = Tree.fromstring("(S (A a) (S|<B-C> (B b) (C c)))")
+    un_chomsky_normal_form(tree)
+    assert tree == Tree.fromstring("(S (A a) (B b) (C c))")
+
+
+def _un_chomsky_worker(n):
+    """Un-binarise a large right-branching CNF tree; exit 0 ok, 3 on error."""
+    try:
+        payload = "(S (A a) " + "(S| (A a) " * n + "(A a)" + ")" * (n + 1)
+        Tree.fromstring(payload).un_chomsky_normal_form()
+        os._exit(0)
+    except BaseException:
+        os._exit(3)
+
+
+def test_un_chomsky_is_linear_not_quadratic():
+    """A large CNF tree must un-binarise quickly (linear), not tie up a core.
+
+    Run in a spawned process with a hard deadline: the single-sweep pass returns
+    in milliseconds, while the previous O(n^2) version needs over a minute at
+    this size, so a regression is terminated instead of burning CPU for the rest
+    of the suite.
+    """
+    n = 20_000
+    deadline = 30
+    ctx = multiprocessing.get_context("spawn")
+    proc = ctx.Process(target=_un_chomsky_worker, args=(n,))
+    proc.start()
+    proc.join(deadline)
+    if proc.is_alive():
+        proc.terminate()
+        proc.join()
+        raise AssertionError(
+            "un_chomsky_normal_form did not finish in time: quadratic blow-up regressed"
+        )
+    assert proc.exitcode == 0, f"worker failed (exit {proc.exitcode})"

--- a/nltk/tree/transforms.py
+++ b/nltk/tree/transforms.py
@@ -183,47 +183,51 @@ def chomsky_normal_form(
 def un_chomsky_normal_form(
     tree, expandUnary=True, childChar="|", parentChar="^", unaryChar="+"
 ):
-    # Traverse the tree-depth first keeping a pointer to the parent for modification purposes.
-    nodeList = [(tree, [])]
-    while nodeList != []:
-        node, parent = nodeList.pop()
+    # Traverse the tree depth-first, collapsing artificial Chomsky-Normal-Form
+    # nodes (whose label contains ``childChar``) into their parent.
+    nodeList = [tree]
+    while nodeList:
+        node = nodeList.pop()
         if isinstance(node, Tree):
-            # if the node contains the 'childChar' character it means that
-            # it is an artificial node and can be removed, although we still need
-            # to move its children to its parent
-            childIndex = node.label().find(childChar)
-            if childIndex != -1:
-                nodeIndex = parent.index(node)
-                parent.remove(parent[nodeIndex])
-                # Generated node was on the left if the nodeIndex is 0 which
-                # means the grammar was left factored.  We must insert the children
-                # at the beginning of the parent's children
-                if nodeIndex == 0:
-                    parent.insert(0, node[0])
-                    parent.insert(1, node[1])
-                else:
-                    parent.extend([node[0], node[1]])
+            # Splice every artificial child up into ``node`` in a single
+            # left-to-right pass. Doing this incrementally with
+            # parent.index()/parent.remove() compared children by value via the
+            # recursive ``Tree.__eq__``, rescanning a child list that grows wide
+            # as nodes are spliced out -- quadratic over the artificial nodes,
+            # and worse with deep subtrees (CWE-407). Rebuilding the child list
+            # once, expanding artificial nodes in order, is linear.
+            if any(
+                isinstance(child, Tree) and child.label().find(childChar) != -1
+                for child in node
+            ):
+                newChildren = []
+                # Stack of pending children, kept in original left-to-right order
+                # by reversing before pushing.
+                stack = list(reversed(node))
+                while stack:
+                    child = stack.pop()
+                    if isinstance(child, Tree) and child.label().find(childChar) != -1:
+                        # Artificial node: replace it in place with its children.
+                        stack.extend(reversed(child))
+                    else:
+                        newChildren.append(child)
+                node[:] = newChildren
 
-                # parent is now the current node so the children of parent will be added to the agenda
-                node = parent
-            else:
-                parentIndex = node.label().find(parentChar)
-                if parentIndex != -1:
-                    # strip the node name of the parent annotation
-                    node.set_label(node.label()[:parentIndex])
+            parentIndex = node.label().find(parentChar)
+            if parentIndex != -1:
+                # strip the node name of the parent annotation
+                node.set_label(node.label()[:parentIndex])
 
-                # expand collapsed unary productions
-                if expandUnary:
-                    unaryIndex = node.label().find(unaryChar)
-                    if unaryIndex != -1:
-                        newNode = Tree(
-                            node.label()[unaryIndex + 1 :], [i for i in node]
-                        )
-                        node.set_label(node.label()[:unaryIndex])
-                        node[0:] = [newNode]
+            # expand collapsed unary productions
+            if expandUnary:
+                unaryIndex = node.label().find(unaryChar)
+                if unaryIndex != -1:
+                    newNode = Tree(node.label()[unaryIndex + 1 :], [i for i in node])
+                    node.set_label(node.label()[:unaryIndex])
+                    node[0:] = [newNode]
 
             for child in node:
-                nodeList.append((child, node))
+                nodeList.append(child)
 
 
 def collapse_unary(tree, collapsePOS=False, collapseRoot=False, joinChar="+"):


### PR DESCRIPTION
# fix(security): Quadratic-time DoS in NLTK Tree.un_chomsky_normal_form (CWE-407)

## Description

`Tree.un_chomsky_normal_form` (`nltk/tree/transforms.py`) walks the tree and, for
every artificial Chomsky-Normal-Form node (whose label contains the binarisation
marker `childChar`, `"|"`), removes it from its parent and splices its children
up. It finds and removes the node with **value-equality list operations**:

```python
# nltk/tree/transforms.py (before)
nodeIndex = parent.index(node)        # list.index  -> value-equality scan
parent.remove(parent[nodeIndex])      # list.remove -> value-equality scan
```

Because `Tree` subclasses `list`, `index`/`remove` compare elements with
`Tree.__eq__` (`nltk/tree/tree.py:110`), a **recursive structural comparison**,
not an identity check. As artificial nodes are spliced out, the parent's child
list grows wide, and each `index`/`remove` rescans that growing list with deep
`__eq__` comparisons — **O(n²)** over the artificial nodes, and worse with deep
subtrees (each comparison is itself O(subtree)). Confirmed with the report's PoC
(a right-branching CNF tree):

```
n=1000: 0.24s   n=2000: 0.98s (x4)   n=4000: 4.1s (x4)   n=8000: 16.5s (x4)
~x4 per doubling = O(n^2); a few-thousand-node CNF tree hangs for seconds,
scaling to minutes.
```

`un_chomsky_normal_form` is the standard post-processing step after CKY/chart
parsing (which requires CNF) and the natural representation of a treebank stored
in CNF. Reachable from the public API:
`Tree.fromstring(<CNF tree string>).un_chomsky_normal_form()`.

**Impact:** a small attacker-supplied normal-form tree makes the un-binarisation
pass consume quadratic CPU, pinning a worker core (seconds, scaling to minutes).
The pre-condition is an application un-binarising a parse tree / CNF treebank
entry derived from untrusted input. No authentication or user interaction is
required. Weakness: **CWE-407** (inefficient algorithmic complexity).

## The fix

Collapse the artificial nodes in a **single left-to-right pass** instead of
removing-and-rescanning. For each node, rebuild its child list once, replacing
each artificial child in place with its children (descending through nested
artificial nodes in order):

```python
if any(isinstance(c, Tree) and c.label().find(childChar) != -1 for c in node):
    newChildren = []
    stack = list(reversed(node))
    while stack:
        child = stack.pop()
        if isinstance(child, Tree) and child.label().find(childChar) != -1:
            stack.extend(reversed(child))   # splice artificial node's children in
        else:
            newChildren.append(child)
    node[:] = newChildren
```

This drops the whole pass from **O(n²) to O(n)**: each node and each artificial
splice is handled exactly once, with no value-equality scans of the growing
child list. (Identity-based removal alone would not suffice — the previous
left-factored path also used `parent.insert(0, ...)`, which shifts the whole
list and is itself O(n²); a single-sweep rebuild fixes both factoring
directions.)

Properties:
- **Identical output for any CNF tree.** For a valid Chomsky-Normal-Form tree —
  the only input `un_chomsky_normal_form` is defined for — the result is
  unchanged: artificial children are spliced into their parent in left-to-right
  document order, exactly as before. `parentChar` stripping and `expandUnary`
  are applied to the same (non-artificial) nodes as before.
- **O(n²) → O(n).** Linear in the number of tree nodes.
- **Local.** Only the traversal/splice loop changes; the signature and the
  `parentChar`/`unaryChar` handling are unchanged.

## Behaviour preservation (verified)

- **Round-trip:** `un_chomsky_normal_form(chomsky_normal_form(t))` reproduces `t`
  for both `factor="right"` and `factor="left"` on 14 000+ random trees (0
  failures).
- **Differential:** on the same 14 000+ trees binarised with both factors, the
  new `un_chomsky_normal_form` output is **identical** to the current `develop`
  output.
- `treetransforms.doctest` and the `nltk/tree/transforms.py` module doctests
  pass unchanged.

## Performance

| input (right-branching CNF) | before | after |
|------|--------|-------|
| n = 8 000 | 16.5 s | < 0.01 s |
| n = 128 000 | ~70 min (extrapolated O(n²)) | ~0.07 s |

## Testing

- `nltk/test/unit/test_treetransforms.py` (new, 3 tests): `un_chomsky_normal_form`
  round-trips `chomsky_normal_form` for both factoring directions; an artificial
  `|` node is collapsed into its parent with children in order; and a large CNF
  tree un-binarises within a hard deadline in a spawned process (linear), where
  the quadratic version does not. The linearity guard fails against the pre-fix
  `develop` (terminated after the deadline) and passes against the fix.
- `black==25.11.0`, `isort==6.1.0`, `ruff==0.15.6`, `pyupgrade --py310-plus`
  (repo-pinned hooks) — clean.
