### PR TITLE
fix(ci): resolve isort block (#3615) and restore CCG lexicon syntax (#3641)

### DIFF
--- a/nltk/ccg/lexicon.py
+++ b/nltk/ccg/lexicon.py
@@ -32,16 +32,15 @@ NEXTPRIM_RE = re.compile(r"""([A-Za-z]+(?:\[[A-Za-z,]+\])?)(.*)""")
 APP_RE = re.compile(r"""([\\/])([.,_]?)([.,]?)(.*)""")
 
 # Parses the definition of the right-hand side (rhs) of either a word or a family.
-# Requiring whitespace (``\s+``) between the identifier and the separator fixes
-# the identifier/separator boundary *before* the ``-``/``=`` run: ``[\S_]+`` and the
-# arrow alternative ``[-=]+>`` both match ``-``/``=``, so without that anchor a line
-# with a long ``-``/``=`` run and no closing ``>`` makes the engine slide the boundary
-# across the whole run and re-scan for the absent arrow from every position --
-# quadratic in the line length (CWE-1333). This requires the standard, whitespace-
-# separated ``ident <sep> rhs`` form; the compact ``ident<sep>rhs`` syntax the old
-# pattern accepted via that backtracking is no longer matched (no in-tree lexicon
-# uses it).
-LEX_RE = re.compile(r"""([\S_]+)\s+(::|[-=]+>)\s*(.+)""", re.UNICODE)
+# The identifier and the arrow alternative ``[-=]+>`` both match ``-``/``=``, so the
+# original ``([\S_]+)`` let the engine slide the identifier/arrow boundary across a
+# long ``-``/``=`` run while re-scanning for the absent ``>`` from every position --
+# quadratic in the line length (CWE-1333). Anchoring the identifier's last character
+# to be neither ``-`` nor ``=`` (``[^\s=-]``) fixes the boundary before any such run,
+# so the arrow is tried once: the parse is linear, the usual whitespace-separated
+# ``ident <sep> rhs`` form is unchanged, and the compact ``ident<sep>rhs`` form is
+# still accepted (and now splits sensibly, e.g. ``a-->b`` -> ``a``/``-->``/``b``).
+LEX_RE = re.compile(r"""([\S_]*?[^\s=-])\s*(::|[-=]+>)\s*(.+)""", re.UNICODE)
 
 # Parses the right hand side that contains category and maybe semantic predicate
 RHS_RE = re.compile(r"""([^{}]*[^ {}])\s*(\{[^}]+\})?""", re.UNICODE)

--- a/nltk/corpus/reader/senseval.py
+++ b/nltk/corpus/reader/senseval.py
@@ -24,9 +24,8 @@ is tagged with a sense identifier, and supplied with context.
 
 import re
 
-from defusedxml.ElementTree import fromstring as safe_fromstring
-
 import regex
+from defusedxml.ElementTree import fromstring as safe_fromstring
 
 from nltk.corpus.reader.api import *
 from nltk.corpus.reader.util import *

--- a/nltk/test/unit/test_ccg_lexicon_security.py
+++ b/nltk/test/unit/test_ccg_lexicon_security.py
@@ -71,3 +71,13 @@ def test_fromstring_does_not_hang():
     finished, status, value = _run_in_process(_fromstring_worker)
     assert finished, "fromstring() hung on a crafted lexicon line (ReDoS)"
     assert status == "ok", f"worker raised unexpectedly: {value}"
+
+
+def test_lex_re_parses_spaced_and_compact_entries():
+    """The ReDoS fix keeps both the whitespace-separated and the compact
+    ``ident<sep>rhs`` forms working, and the identifier no longer absorbs part of
+    the arrow (e.g. ``a-->b`` splits as ``a``/``-->``/``b``, not ``a-``/``->``)."""
+    assert LEX_RE.match("the => Det").groups() == ("the", "=>", "Det")
+    assert LEX_RE.match("Det :: NP/N").groups() == ("Det", "::", "NP/N")
+    assert LEX_RE.match("a-->b").groups() == ("a", "-->", "b")
+    assert LEX_RE.match("Det::NP/N").groups() == ("Det", "::", "NP/N")


### PR DESCRIPTION
## Summary

Follow-up to two recently-merged security PRs (#3615, #3641) that left `develop`
with a red CI and a syntax regression. This resolves both.

### 1. `#3615` — unblock CI (pre-commit `isort` on `senseval.py`)

After #3615 merged, `nltk/corpus/reader/senseval.py` had its two third-party
imports in separate blocks (a merge artifact — the PR's CI ran on an older base):

```python
import re

from defusedxml.ElementTree import fromstring as safe_fromstring

import regex
```

isort (`profile=black`) requires them in **one sorted group** (plain `import`
before `from`), so the `pre-commit` hook failed. Because `pre-commit` gates the
whole job matrix, **every Python×OS test job was skipped on every `develop` push
and every open PR** — that is the actual CI block. Fixed by reordering:

```python
import re

import regex
from defusedxml.ElementTree import fromstring as safe_fromstring
```

`isort --check-only nltk/` is now clean repo-wide.

### 2. `#3641` — restore CCG lexicon compact syntax (keeping the ReDoS fix)

#3641 fixed the `LEX_RE` ReDoS by requiring whitespace (`\s+`) between the
identifier and the separator, which silently dropped the compact `ident<sep>rhs`
form. The root cause of the ReDoS is that the identifier and the arrow
alternative `[-=]+>` both match `-`/`=`, so `([\S_]+)` let the engine slide the
boundary across a long `-`/`=` run while re-scanning for an absent `>` from every
position.

Anchor the identifier's **last character** to be neither `-` nor `=` instead:

```python
LEX_RE = re.compile(r"""([\S_]*?[^\s=-])\s*(::|[-=]+>)\s*(.+)""", re.UNICODE)
```

This fixes the boundary *before* any `-`/`=` run, so the arrow is tried once —
the parse is **linear** (no ReDoS) — while:
- the usual whitespace-separated `ident <sep> rhs` form is **unchanged**, and
- the compact `ident<sep>rhs` form is **accepted again**, and now splits
  sensibly (`a-->b` → `a`/`-->`/`b`, where the old pattern produced `a-`/`->`).

Verified linear on `"a" + "="*200000` (and `-`-run / leading-space variants).

## Testing

- `pre-commit` hooks (`pyupgrade`/`black`/`isort`/`ruff`) clean on the changed
  files and `isort` clean across `nltk/`.
- `ccg.doctest`, `ccg_semantics.doctest`, and the `ccg/lexicon.py` + `ccg/chart.py`
  module doctests pass.
- `nltk/test/unit/test_ccg_lexicon_security.py`: the two ReDoS guards still pass,
  plus a new test asserting both the spaced and compact lexicon forms parse
  correctly.
