### PR TITLE
fix(security): DoS in NLTK segmentation pk metric via Uncaught divide-by-zero

### DIFF
--- a/nltk/metrics/segmentation.py
+++ b/nltk/metrics/segmentation.py
@@ -239,7 +239,11 @@ def pk(ref, hyp, k=None, boundary="1"):
     if len(ref) != len(hyp):
         raise ValueError("Segmentations have unequal length")
     if k is None:
-        k = int(round(len(ref) / (ref.count(boundary) * 2.0)))
+        # Half the average reference segment length. A boundary-free reference
+        # has a count of 0, which would make this an uncaught ZeroDivisionError
+        # (CWE-369); treat it as a single segment (count >= 1) so the metric is
+        # still computed instead of crashing.
+        k = int(round(len(ref) / (max(ref.count(boundary), 1) * 2.0)))
     if k < 0:
         raise ValueError("Window width k should not be negative")
 

--- a/nltk/test/unit/test_segmentation.py
+++ b/nltk/test/unit/test_segmentation.py
@@ -203,3 +203,22 @@ def test_pk_is_linear_not_quadratic():
     finished, exitcode = _finishes_within(_pk_worker, 200_000)
     assert finished, "pk did not finish in time: quadratic blow-up regressed"
     assert exitcode == 0, f"pk worker failed (exit {exitcode})"
+
+
+def test_pk_boundary_free_reference_does_not_divide_by_zero():
+    """A boundary-free reference must not crash pk's default-window derivation.
+
+    With no window size and a reference that contains no boundary symbol,
+    ``ref.count(boundary)`` is 0; pk previously raised an uncaught
+    ``ZeroDivisionError`` (CWE-369). It now derives a window and computes a score.
+    """
+    # Identical boundary-free segmentations -> perfect agreement, no crash.
+    assert pk("0" * 100, "0" * 100) == 0.0
+    # A hyp that introduces a boundary still yields a valid score in [0, 1].
+    score = pk("0" * 100, "0" * 50 + "1" + "0" * 49)
+    assert 0.0 <= score <= 1.0
+
+
+def test_pk_default_window_unchanged_for_segmented_reference():
+    """The default-window derivation is unchanged when the reference has boundaries."""
+    assert pk("0100" * 100, "0100" * 100) == 0.0

--- a/nltk/test/unit/test_segmentation.py
+++ b/nltk/test/unit/test_segmentation.py
@@ -220,5 +220,17 @@ def test_pk_boundary_free_reference_does_not_divide_by_zero():
 
 
 def test_pk_default_window_unchanged_for_segmented_reference():
-    """The default-window derivation is unchanged when the reference has boundaries."""
-    assert pk("0100" * 100, "0100" * 100) == 0.0
+    """The derived default window matches the historical formula when the
+    reference has boundaries.
+
+    Uses a case where the score is not trivially 0 (ref != hyp), so the
+    assertion would fail if the default-``k`` derivation ever changed.
+    """
+    ref = "0100" * 100
+    hyp = "1" * 400
+    # Historical default: round(len(ref) / (ref.count(boundary) * 2)).
+    k = int(round(len(ref) / (ref.count("1") * 2.0)))
+    assert k == 2
+    default_score = pk(ref, hyp)
+    assert default_score != 0.0  # non-trivial case: a changed window would differ
+    assert default_score == pk(ref, hyp, k)


### PR DESCRIPTION
# fix(security): DoS in NLTK segmentation pk metric via uncaught divide-by-zero (CWE-369)

## Description

When the window size `k` is not supplied, `nltk.metrics.segmentation.pk` derives
it by dividing the reference length by **twice the count of the boundary symbol**:

```python
# nltk/metrics/segmentation.py (before)
if k is None:
    k = int(round(len(ref) / (ref.count(boundary) * 2.0)))   # L227
```

A reference that contains **no boundary symbol** makes `ref.count(boundary) == 0`,
so this divides by zero and `pk` raises an uncaught `ZeroDivisionError` out of the
public metric. A boundary-free segmentation is ordinary input — a sequence the
segmenter left unsegmented. Confirmed with the report's PoC:

```python
from nltk.metrics import pk
pk("0" * 100, "0" * 100)   # -> ZeroDivisionError: float division by zero
```

**Impact:** a boundary-free reference crashes the `pk` metric with an uncaught
divide-by-zero, denying service to the worker that computes it. The pre-condition
is an application computing `pk` (without supplying `k`) on segmentation output
derived from untrusted text. No authentication or user interaction is required.
Weakness: **CWE-369** (divide by zero).

## The fix

`k` is meant to be *half the average reference segment length*. A boundary-free
reference is a single segment of length `len(ref)`, so clamp the divisor's count
to at least 1 — yielding `k = round(len(ref) / 2)` instead of a crash:

```python
if k is None:
    k = int(round(len(ref) / (max(ref.count(boundary), 1) * 2.0)))
```

Properties:
- **No crash, metric still computed.** A boundary-free reference now derives a
  valid window and returns a score, rather than raising. `pk("0"*100, "0"*100)`
  is `0.0` (two identical unsegmented inputs perfectly agree), which is the
  semantically correct result.
- **No behaviour change for segmented references.** When the reference has at
  least one boundary, `max(count, 1) == count`, so the derived `k` — and every
  returned score — is exactly as before.
- **Minimal & local.** A single `max(..., 1)` guard; no signature change. (It
  also makes an empty reference, another `count == 0` case, return `0.0` instead
  of crashing.)

## Behaviour preservation (verified)

- The `nltk/metrics/segmentation.py` module doctests pass; default-window scores
  on segmented references are unchanged (e.g. `pk("0100"*100, "0100"*100) == 0.0`).

## Testing

- `nltk/test/unit/test_segmentation.py` (extended): a boundary-free reference
  with no window size now computes (`pk("0"*100, "0"*100) == 0.0`, and a hyp with
  a boundary yields a score in `[0, 1]`) instead of raising; and the default-
  window derivation is asserted unchanged for a segmented reference. The
  boundary-free test fails against the pre-fix `develop` (`ZeroDivisionError` at
  line 227) and passes against the fix.
- `black==25.11.0`, `isort==6.1.0`, `ruff==0.15.6`, `pyupgrade --py310-plus`
  (repo-pinned hooks) — clean.

## Note

This is a different defect from the open #3672 (quadratic-time DoS in the same
`pk`/`windowdiff` loop, CWE-407): that fix rewrites the per-position counting,
while this fixes the `k`-derivation divide-by-zero (CWE-369). They touch
different lines and are independent.
