### PR TITLE
fix(security): MaltParser process-wide CWD pollution during parsing (CVE-2026-12614)

### DIFF
--- a/nltk/parse/malt.py
+++ b/nltk/parse/malt.py
@@ -175,15 +175,25 @@ class MaltParser(ParserI):
         if not self._trained:
             raise Exception("Parser has not been trained. Call train() first.")
 
-        with tempfile.NamedTemporaryFile(
-            prefix="malt_input.conll.", dir=self.working_dir, mode="w", delete=False
-        ) as input_file:
+        input_file_name = None
+        output_file_name = None
+        try:
             with tempfile.NamedTemporaryFile(
+                prefix="malt_input.conll.", dir=self.working_dir, mode="w", delete=False
+            ) as input_file, tempfile.NamedTemporaryFile(
                 prefix="malt_output.conll.",
                 dir=self.working_dir,
                 mode="w",
                 delete=False,
             ) as output_file:
+                input_file_name = input_file.name
+                output_file_name = output_file.name
+
+                model_dir = os.path.split(self.model)[0]
+                model_cwd = os.path.abspath(model_dir) if model_dir else None
+                if model_cwd and not os.path.isdir(model_cwd):
+                    model_cwd = None
+
                 # Convert list of sentences to CONLL format.
                 for line in taggedsents_to_conll(sentences):
                     input_file.write(str(line))
@@ -191,19 +201,12 @@ class MaltParser(ParserI):
 
                 # Generate command to run maltparser.
                 cmd = self.generate_malt_command(
-                    input_file.name, output_file.name, mode="parse"
+                    input_file_name, output_file_name, mode="parse"
                 )
 
-                # This is a maltparser quirk, it needs to be run
-                # where the model file is. otherwise it goes into an awkward
-                # missing .jars or strange -w working_dir problem.
-                _current_path = os.getcwd()  # Remembers the current path.
-                try:  # Change to modelfile path
-                    os.chdir(os.path.split(self.model)[0])
-                except OSError:
-                    pass
-                ret = self._execute(cmd, verbose)  # Run command.
-                os.chdir(_current_path)  # Change back to current path.
+                # MaltParser needs to run from the model directory; use
+                # subprocess cwd so other threads do not see a process-wide chdir.
+                ret = self._execute(cmd, verbose, cwd=model_cwd)  # Run command.
 
                 if ret != 0:
                     raise Exception(
@@ -212,20 +215,25 @@ class MaltParser(ParserI):
                     )
 
                 # Must return iter(iter(Tree))
-                with open(output_file.name) as infile:
+                with open(output_file_name) as infile:
                     for tree_str in infile.read().split("\n\n"):
                         yield (
                             iter(
                                 [
                                     DependencyGraph(
-                                        tree_str, top_relation_label=top_relation_label
+                                        tree_str,
+                                        top_relation_label=top_relation_label,
                                     )
                                 ]
                             )
                         )
-
-        os.remove(input_file.name)
-        os.remove(output_file.name)
+        finally:
+            for filename in (input_file_name, output_file_name):
+                if filename:
+                    try:
+                        os.remove(filename)
+                    except OSError:
+                        pass
 
     def parse_sents(self, sentences, verbose=False, top_relation_label="null"):
         """
@@ -276,9 +284,9 @@ class MaltParser(ParserI):
         return cmd
 
     @staticmethod
-    def _execute(cmd, verbose=False):
+    def _execute(cmd, verbose=False, cwd=None):
         output = None if verbose else subprocess.PIPE
-        p = subprocess.Popen(cmd, stdout=output, stderr=output)
+        p = subprocess.Popen(cmd, stdout=output, stderr=output, cwd=cwd)
         return p.wait()
 
     def train(self, depgraphs, verbose=False):

--- a/nltk/test/unit/test_malt.py
+++ b/nltk/test/unit/test_malt.py
@@ -1,0 +1,99 @@
+import os
+from pathlib import Path
+
+import pytest
+
+import nltk.parse.malt as malt
+from nltk.parse.malt import MaltParser
+
+
+def _minimal_malt_parser(tmp_path):
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    model_file = model_dir / "model.mco"
+    model_file.write_text("dummy model\n", encoding="utf-8")
+
+    working_dir = tmp_path / "work"
+    working_dir.mkdir()
+
+    parser = MaltParser.__new__(MaltParser)
+    parser._trained = True
+    parser.model = str(model_file)
+    parser.working_dir = str(working_dir)
+    parser.malt_jars = ["dummy-malt.jar"]
+    parser.additional_java_args = []
+    return parser, model_dir
+
+
+def _write_minimal_parse(cmd):
+    output_path = Path(cmd[cmd.index("-o") + 1])
+    output_path.write_text(
+        "1\thello\t_\tNN\tNN\t_\t0\tnull\t_\t_\n",
+        encoding="utf-8",
+    )
+
+
+def test_malt_parse_uses_subprocess_cwd_without_changing_process_cwd(
+    monkeypatch, tmp_path
+):
+    parser, model_dir = _minimal_malt_parser(tmp_path)
+    service_dir = tmp_path / "service"
+    service_dir.mkdir()
+    monkeypatch.chdir(service_dir)
+
+    def forbidden_chdir(path):
+        raise AssertionError(f"os.chdir() should not be called with {path!r}")
+
+    monkeypatch.setattr(malt.os, "chdir", forbidden_chdir)
+
+    captured = {}
+
+    def fake_execute(cmd, verbose=False, cwd=None):
+        captured["cwd"] = cwd
+        captured["process_cwd"] = os.getcwd()
+        captured["input_file"] = Path(cmd[cmd.index("-i") + 1])
+        captured["output_file"] = Path(cmd[cmd.index("-o") + 1])
+        _write_minimal_parse(cmd)
+        return 0
+
+    parser._execute = fake_execute
+
+    graphs = list(parser.parse_tagged_sents([[("hello", "NN")]]))
+
+    assert len(graphs) == 1
+    assert captured["cwd"] == str(model_dir)
+    assert captured["process_cwd"] == str(service_dir)
+    assert os.getcwd() == str(service_dir)
+    assert not captured["input_file"].exists()
+    assert not captured["output_file"].exists()
+
+
+def test_malt_parse_cleans_temp_files_and_preserves_cwd_on_execute_exception(
+    monkeypatch, tmp_path
+):
+    parser, model_dir = _minimal_malt_parser(tmp_path)
+    service_dir = tmp_path / "service"
+    service_dir.mkdir()
+    monkeypatch.chdir(service_dir)
+
+    captured = {}
+
+    def fake_execute(cmd, verbose=False, cwd=None):
+        captured["cwd"] = cwd
+        captured["process_cwd"] = os.getcwd()
+        captured["input_file"] = Path(cmd[cmd.index("-i") + 1])
+        captured["output_file"] = Path(cmd[cmd.index("-o") + 1])
+        assert captured["input_file"].exists()
+        assert captured["output_file"].exists()
+        raise RuntimeError("forced parser failure")
+
+    parser._execute = fake_execute
+
+    with pytest.raises(RuntimeError, match="forced parser failure"):
+        list(parser.parse_tagged_sents([[("hello", "NN")]]))
+
+    assert captured["cwd"] == str(model_dir)
+    assert captured["process_cwd"] == str(service_dir)
+    assert os.getcwd() == str(service_dir)
+    assert not captured["input_file"].exists()
+    assert not captured["output_file"].exists()


### PR DESCRIPTION
## Description

`nltk.parse.malt.MaltParser.parse_tagged_sents()` changes the process-wide current working directory to the Malt model directory before running the external parser, then restores it only after `_execute()` returns:

```python
# nltk/parse/malt.py (before)
_current_path = os.getcwd()
try:
    os.chdir(os.path.split(self.model)[0])
except OSError:
    pass

ret = self._execute(cmd, verbose)
os.chdir(_current_path)
```

Because `os.chdir()` is process-wide, this temporarily changes the working directory for every thread in the Python process, not only the MaltParser operation. In a multi-threaded service that uses NLTK and performs relative-path I/O in other request handlers, those unrelated relative writes can be redirected into the model directory during this window.

The restoration is also not protected by `finally`. If `_execute()` raises, or if later parsing logic raises before the cleanup code runs, the process CWD can remain polluted for subsequent requests. The temporary parser input/output files are also cleaned only at the end of the success path.

Validated as CVE-2026-12614.

## The fix

Avoid changing the process-wide CWD. Instead, compute the model directory and pass it as the subprocess working directory for the MaltParser child process:

```python
model_dir = os.path.split(self.model)[0]
model_cwd = os.path.abspath(model_dir) if model_dir else None
ret = self._execute(cmd, verbose, cwd=model_cwd)
```

`_execute()` now accepts an optional `cwd` parameter and passes it to `subprocess.Popen()`:

```python
@staticmethod
def _execute(cmd, verbose=False, cwd=None):
    ...
    p = subprocess.Popen(cmd, stdout=output, stderr=output, cwd=cwd)
```

This preserves the MaltParser requirement that the Java process runs from the model directory, without changing the Python process CWD seen by other threads. If the model path has no directory component, or the derived model directory is not available, the subprocess inherits the current CWD, matching the old fallback behaviour after `os.chdir()` failed and was ignored.

The input and output temporary files are also removed from a `finally` block so they are cleaned up on both success and exception paths.

This is a minimal boundary fix:
- no public API change for `parse_tagged_sents()`, `parse_sents()`, or callers;
- no change to generated MaltParser command arguments;
- no change to returned `DependencyGraph` objects;
- only the child Java process receives the model-directory working directory.

## Behaviour preservation (verified)

- The MaltParser subprocess still runs with the model directory as its working directory, matching the previous parser requirement.
- The Python process CWD remains unchanged before, during, and after `parse_tagged_sents()`.
- If parser execution raises, the original process CWD is still unchanged.
- Temporary input/output files are removed on both normal and exceptional paths.
- Existing command generation behaviour is unchanged.

## Proof of concept (before -> after)

With a service thread currently in `/srv/app` and a Malt model under `/srv/models/malt/model.mco`:

| call | before | after |
|------|--------|-------|
| `MaltParser.parse_tagged_sents(...)` while parser runs | process CWD becomes `/srv/models/malt` | process CWD stays `/srv/app` |
| another thread writes `open("upload.tmp", "w")` during that window | writes `/srv/models/malt/upload.tmp` | writes `/srv/app/upload.tmp` |
| `_execute()` raises | CWD can remain `/srv/models/malt` | CWD remains unchanged |
| `_execute()` raises before cleanup | temp parser files can remain | temp parser files are removed |

## Testing

- `nltk/test/unit/test_malt.py` adds regression coverage for the CWD pollution: `parse_tagged_sents()` is exercised with a fake `_execute()` and asserts that the Python process CWD remains unchanged while the child process receives the model directory through `cwd`.
- The test monkeypatches `os.chdir` to fail if the implementation attempts a process-wide directory change, so it fails against the vulnerable implementation and passes with the fix.
- A separate exception-path test verifies `_execute()` failure does not change the process CWD and that temporary input/output files are removed.

Local verification:

```bash
PYTHONPATH=. python -m pytest nltk/test/unit/test_malt.py -q
PYTHONPATH=. python -m compileall -q nltk/parse/malt.py nltk/test/unit/test_malt.py
```

## Credit

Reported by KKfine via huntr. CVE-2026-12614 assigned.
