### PR TITLE
Clean up Stanford Java wrapper temp files

### DIFF
--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -60,7 +60,15 @@ def config_java(bin=None, options=None, verbose=False):
         _java_options = list(options)
 
 
-def java(cmd, classpath=None, stdin=None, stdout=None, stderr=None, blocking=True):
+def java(
+    cmd,
+    classpath=None,
+    stdin=None,
+    stdout=None,
+    stderr=None,
+    blocking=True,
+    options=None,
+):
     """
     Execute the given java command, by opening a subprocess that calls
     Java.  If java has not yet been configured, it will be configured
@@ -97,6 +105,8 @@ def java(cmd, classpath=None, stdin=None, stdout=None, stderr=None, blocking=Tru
     :param blocking: If ``false``, then return immediately after
         spawning the subprocess.  In this case, the return value is
         the ``Popen`` object, and not a ``(stdout, stderr)`` tuple.
+    :param options: Java options to use for this subprocess call. If not
+        specified, use the global options configured by ``config_java()``.
 
     :return: If ``blocking=True``, then return a tuple ``(stdout,
         stderr)``, containing the stdout and stderr outputs generated
@@ -134,7 +144,13 @@ def java(cmd, classpath=None, stdin=None, stdout=None, stderr=None, blocking=Tru
     # Construct the full command string.
     cmd = list(cmd)
     cmd = ["-cp", classpath] + cmd
-    cmd = [_java_bin] + _java_options + cmd
+    if options is None:
+        java_options = _java_options
+    else:
+        if isinstance(options, str):
+            options = options.split()
+        java_options = list(options)
+    cmd = [_java_bin] + java_options + cmd
 
     # Call java via a subprocess
     p = subprocess.Popen(cmd, stdin=stdin, stdout=stdout, stderr=stderr)

--- a/nltk/parse/corenlp.py
+++ b/nltk/parse/corenlp.py
@@ -13,7 +13,7 @@ import socket
 import time
 from typing import List, Tuple
 
-from nltk.internals import _java_options, config_java, find_jar_iter, java
+from nltk.internals import find_jar_iter, java
 from nltk.parse.api import ParserI
 from nltk.parse.dependencygraph import DependencyGraph
 from nltk.tag.api import TaggerI
@@ -120,21 +120,14 @@ class CoreNLPServer:
         if self.corenlp_options:
             cmd.extend(self.corenlp_options)
 
-        # Configure java.
-        default_options = " ".join(_java_options)
-        config_java(options=self.java_options, verbose=self.verbose)
-
-        try:
-            self.popen = java(
-                cmd,
-                classpath=self._classpath,
-                blocking=False,
-                stdout=stdout,
-                stderr=stderr,
-            )
-        finally:
-            # Return java configurations to their default values.
-            config_java(options=default_options, verbose=self.verbose)
+        self.popen = java(
+            cmd,
+            classpath=self._classpath,
+            blocking=False,
+            stdout=stdout,
+            stderr=stderr,
+            options=self.java_options,
+        )
 
         # Check that the server is istill running.
         returncode = self.popen.poll()

--- a/nltk/parse/stanford.py
+++ b/nltk/parse/stanford.py
@@ -11,13 +11,7 @@ import tempfile
 import warnings
 from subprocess import PIPE
 
-from nltk.internals import (
-    _java_options,
-    config_java,
-    find_jar_iter,
-    find_jars_within_path,
-    java,
-)
+from nltk.internals import find_jar_iter, find_jars_within_path, java
 from nltk.parse.api import ParserI
 from nltk.parse.dependencygraph import DependencyGraph
 from nltk.tree import Tree
@@ -229,43 +223,47 @@ class GenericStanfordParser(ParserI):
         if self.corenlp_options:
             cmd.extend(self.corenlp_options.split())
 
-        default_options = " ".join(_java_options)
-
-        # Configure java.
-        config_java(options=self.java_options, verbose=verbose)
-
         # Windows is incompatible with NamedTemporaryFile() without passing in delete=False.
-        with tempfile.NamedTemporaryFile(mode="wb", delete=False) as input_file:
-            # Write the actual sentences to the temporary input file
-            if isinstance(input_, str) and encoding:
-                input_ = input_.encode(encoding)
-            input_file.write(input_)
-            input_file.flush()
+        input_file_name = None
+        try:
+            with tempfile.NamedTemporaryFile(mode="wb", delete=False) as input_file:
+                input_file_name = input_file.name
+                # Write the actual sentences to the temporary input file
+                if isinstance(input_, str) and encoding:
+                    input_ = input_.encode(encoding)
+                input_file.write(input_)
+                input_file.flush()
 
-            # Run the tagger and get the output.
-            if self._USE_STDIN:
-                input_file.seek(0)
-                stdout, stderr = java(
-                    cmd,
-                    classpath=self._classpath,
-                    stdin=input_file,
-                    stdout=PIPE,
-                    stderr=PIPE,
-                )
-            else:
-                cmd.append(input_file.name)
-                stdout, stderr = java(
-                    cmd, classpath=self._classpath, stdout=PIPE, stderr=PIPE
-                )
+                # Run the tagger and get the output.
+                if self._USE_STDIN:
+                    input_file.seek(0)
+                    stdout, stderr = java(
+                        cmd,
+                        classpath=self._classpath,
+                        stdin=input_file,
+                        stdout=PIPE,
+                        stderr=PIPE,
+                        options=self.java_options,
+                    )
+                else:
+                    cmd.append(input_file_name)
+                    stdout, stderr = java(
+                        cmd,
+                        classpath=self._classpath,
+                        stdout=PIPE,
+                        stderr=PIPE,
+                        options=self.java_options,
+                    )
 
-            stdout = stdout.replace(b"\xc2\xa0", b" ")
-            stdout = stdout.replace(b"\x00\xa0", b" ")
-            stdout = stdout.decode(encoding)
-
-        os.unlink(input_file.name)
-
-        # Return java configurations to their default values.
-        config_java(options=default_options, verbose=False)
+                stdout = stdout.replace(b"\xc2\xa0", b" ")
+                stdout = stdout.replace(b"\x00\xa0", b" ")
+                stdout = stdout.decode(encoding)
+        finally:
+            if input_file_name:
+                try:
+                    os.unlink(input_file_name)
+                except OSError:
+                    pass
 
         return stdout
 

--- a/nltk/tag/stanford.py
+++ b/nltk/tag/stanford.py
@@ -22,7 +22,7 @@ import warnings
 from abc import abstractmethod
 from subprocess import PIPE
 
-from nltk.internals import _java_options, config_java, find_file, find_jar, java
+from nltk.internals import find_file, find_jar, java
 from nltk.tag.api import TaggerI
 
 _stanford_url = "https://nlp.stanford.edu/software"
@@ -91,34 +91,38 @@ class StanfordTagger(TaggerI):
 
     def tag_sents(self, sentences):
         encoding = self._encoding
-        default_options = " ".join(_java_options)
-        config_java(options=self.java_options, verbose=False)
 
-        # Create a temporary input file
-        _input_fh, self._input_file_path = tempfile.mkstemp(text=True)
+        input_file_path = None
+        try:
+            # Create a temporary input file
+            _input_fh, input_file_path = tempfile.mkstemp(text=True)
+            self._input_file_path = input_file_path
 
-        cmd = list(self._cmd)
-        cmd.extend(["-encoding", encoding])
+            cmd = list(self._cmd)
+            cmd.extend(["-encoding", encoding])
 
-        # Write the actual sentences to the temporary input file
-        _input_fh = os.fdopen(_input_fh, "wb")
-        _input = "\n".join(" ".join(x) for x in sentences)
-        if isinstance(_input, str) and encoding:
-            _input = _input.encode(encoding)
-        _input_fh.write(_input)
-        _input_fh.close()
+            # Write the actual sentences to the temporary input file
+            with os.fdopen(_input_fh, "wb") as input_fh:
+                _input = "\n".join(" ".join(x) for x in sentences)
+                if isinstance(_input, str) and encoding:
+                    _input = _input.encode(encoding)
+                input_fh.write(_input)
 
-        # Run the tagger and get the output
-        stanpos_output, _stderr = java(
-            cmd, classpath=self._stanford_jar, stdout=PIPE, stderr=PIPE
-        )
-        stanpos_output = stanpos_output.decode(encoding)
-
-        # Delete the temporary file
-        os.unlink(self._input_file_path)
-
-        # Return java configurations to their default values
-        config_java(options=default_options, verbose=False)
+            # Run the tagger and get the output
+            stanpos_output, _stderr = java(
+                cmd,
+                classpath=self._stanford_jar,
+                stdout=PIPE,
+                stderr=PIPE,
+                options=self.java_options,
+            )
+            stanpos_output = stanpos_output.decode(encoding)
+        finally:
+            if input_file_path:
+                try:
+                    os.unlink(input_file_path)
+                except OSError:
+                    pass
 
         return self.parse_output(stanpos_output, sentences)
 

--- a/nltk/test/unit/test_stanford_java_wrappers.py
+++ b/nltk/test/unit/test_stanford_java_wrappers.py
@@ -1,0 +1,209 @@
+from pathlib import Path
+
+import pytest
+
+import nltk.internals as internals
+import nltk.parse.corenlp as corenlp_mod
+import nltk.parse.stanford as stanford_parser_mod
+import nltk.tag.stanford as stanford_tagger_mod
+import nltk.tokenize.stanford as stanford_tokenizer_mod
+from nltk.parse.corenlp import CoreNLPServer
+from nltk.parse.stanford import GenericStanfordParser
+from nltk.tag.stanford import StanfordPOSTagger
+from nltk.tokenize.stanford import StanfordTokenizer
+from nltk.tokenize.stanford_segmenter import StanfordSegmenter
+
+
+def test_java_call_options_do_not_mutate_global_java_options(monkeypatch):
+    captured = {}
+
+    class FakePopen:
+        returncode = 0
+
+        def communicate(self):
+            return b"", b""
+
+    def fake_popen(cmd, stdin=None, stdout=None, stderr=None):
+        captured["cmd"] = cmd
+        return FakePopen()
+
+    monkeypatch.setattr(internals, "_java_bin", "java")
+    monkeypatch.setattr(internals, "_java_options", ["-XmxGLOBAL"])
+    monkeypatch.setattr(internals.subprocess, "Popen", fake_popen)
+
+    internals.java(
+        ["Main"],
+        classpath=("example.jar",),
+        stdout="pipe",
+        stderr="pipe",
+        options="-XmxLOCAL -Dexample=true",
+    )
+
+    assert captured["cmd"] == [
+        "java",
+        "-XmxLOCAL",
+        "-Dexample=true",
+        "-cp",
+        "example.jar",
+        "Main",
+    ]
+    assert internals._java_options == ["-XmxGLOBAL"]
+
+
+def test_stanford_tokenizer_cleans_temp_file_when_java_raises(monkeypatch):
+    captured = {}
+
+    tokenizer = StanfordTokenizer.__new__(StanfordTokenizer)
+    tokenizer._encoding = "utf-8"
+    tokenizer._options_cmd = None
+    tokenizer.java_options = "-XmxTOKENIZER"
+    tokenizer._stanford_jar = "stanford-tokenizer.jar"
+
+    monkeypatch.setattr(internals, "_java_options", ["-XmxGLOBAL"])
+
+    def fake_java(cmd, classpath=None, stdout=None, stderr=None, options=None):
+        temp_path = Path(cmd[-1])
+        captured["temp_path"] = temp_path
+        captured["input_text"] = temp_path.read_text(encoding="utf-8")
+        captured["options"] = options
+        raise OSError("forced java failure")
+
+    monkeypatch.setattr(stanford_tokenizer_mod, "java", fake_java)
+
+    with pytest.raises(OSError, match="forced java failure"):
+        tokenizer._execute(["edu.stanford.nlp.process.PTBTokenizer"], "secret text")
+
+    assert captured["input_text"] == "secret text"
+    assert captured["options"] == "-XmxTOKENIZER"
+    assert not captured["temp_path"].exists()
+    assert internals._java_options == ["-XmxGLOBAL"]
+
+
+def test_stanford_parser_cleans_temp_file_when_java_raises(monkeypatch):
+    captured = {}
+
+    parser = GenericStanfordParser.__new__(GenericStanfordParser)
+    parser._encoding = "utf-8"
+    parser.corenlp_options = ""
+    parser._classpath = ("stanford-parser.jar",)
+    parser.java_options = ["-XmxPARSER"]
+    parser._USE_STDIN = False
+
+    monkeypatch.setattr(internals, "_java_options", ["-XmxGLOBAL"])
+
+    def fake_java(cmd, classpath=None, stdout=None, stderr=None, options=None):
+        temp_path = Path(cmd[-1])
+        captured["temp_path"] = temp_path
+        captured["input_text"] = temp_path.read_text(encoding="utf-8")
+        captured["options"] = options
+        raise OSError("forced parser failure")
+
+    monkeypatch.setattr(stanford_parser_mod, "java", fake_java)
+
+    with pytest.raises(OSError, match="forced parser failure"):
+        parser._execute(
+            ["edu.stanford.nlp.parser.lexparser.LexicalizedParser"], "parse me"
+        )
+
+    assert captured["input_text"] == "parse me"
+    assert captured["options"] == ["-XmxPARSER"]
+    assert not captured["temp_path"].exists()
+    assert internals._java_options == ["-XmxGLOBAL"]
+
+
+def test_stanford_tagger_cleans_temp_file_when_java_raises(monkeypatch):
+    captured = {}
+
+    tagger = StanfordPOSTagger.__new__(StanfordPOSTagger)
+    tagger._encoding = "utf-8"
+    tagger._stanford_jar = "stanford-postagger.jar"
+    tagger._stanford_model = "english.tagger"
+    tagger.java_options = ["-XmxTAGGER"]
+
+    monkeypatch.setattr(internals, "_java_options", ["-XmxGLOBAL"])
+
+    def fake_java(cmd, classpath=None, stdout=None, stderr=None, options=None):
+        temp_path = Path(cmd[cmd.index("-textFile") + 1])
+        captured["temp_path"] = temp_path
+        captured["input_text"] = temp_path.read_text(encoding="utf-8")
+        captured["options"] = options
+        raise OSError("forced tagger failure")
+
+    monkeypatch.setattr(stanford_tagger_mod, "java", fake_java)
+
+    with pytest.raises(OSError, match="forced tagger failure"):
+        tagger.tag_sents([["secret", "tokens"]])
+
+    assert captured["input_text"] == "secret tokens"
+    assert captured["options"] == ["-XmxTAGGER"]
+    assert not captured["temp_path"].exists()
+    assert internals._java_options == ["-XmxGLOBAL"]
+
+
+def test_stanford_segmenter_cleans_temp_file_when_execute_raises():
+    captured = {}
+
+    segmenter = StanfordSegmenter.__new__(StanfordSegmenter)
+    segmenter._encoding = "UTF-8"
+    segmenter._java_class = "edu.stanford.nlp.ie.crf.CRFClassifier"
+    segmenter._model = "segmenter-model.ser.gz"
+    segmenter._keep_whitespaces = "false"
+    segmenter._sihan_corpora_dict = None
+
+    def fake_execute(cmd):
+        temp_path = Path(cmd[cmd.index("-textFile") + 1])
+        captured["temp_path"] = temp_path
+        captured["input_text"] = temp_path.read_text(encoding="utf-8")
+        raise RuntimeError("forced segmenter failure")
+
+    segmenter._execute = fake_execute
+
+    with pytest.raises(RuntimeError, match="forced segmenter failure"):
+        segmenter.segment_sents([["secret", "tokens"]])
+
+    assert captured["input_text"] == "secret tokens"
+    assert not captured["temp_path"].exists()
+
+
+def test_corenlp_server_start_uses_call_local_java_options(monkeypatch):
+    captured = {}
+
+    class FakePopen:
+        def poll(self):
+            return None
+
+    class FakeResponse:
+        ok = True
+
+    server = CoreNLPServer.__new__(CoreNLPServer)
+    server.verbose = False
+    server._classpath = ("stanford-corenlp.jar", "stanford-corenlp-models.jar")
+    server.corenlp_options = []
+    server.java_options = ["-XmxCORENLP"]
+    server.url = "http://localhost:9000"
+
+    monkeypatch.setattr(internals, "_java_options", ["-XmxGLOBAL"])
+
+    def fake_java(
+        cmd, classpath=None, blocking=True, stdout=None, stderr=None, options=None
+    ):
+        captured["options"] = options
+        captured["blocking"] = blocking
+        return FakePopen()
+
+    def fake_get(url):
+        captured.setdefault("health_urls", []).append(url)
+        return FakeResponse()
+
+    monkeypatch.setattr(corenlp_mod, "java", fake_java)
+    monkeypatch.setattr("requests.get", fake_get)
+
+    server.start()
+
+    assert captured["options"] == ["-XmxCORENLP"]
+    assert captured["blocking"] is False
+    assert captured["health_urls"] == [
+        "http://localhost:9000/live",
+        "http://localhost:9000/ready",
+    ]
+    assert internals._java_options == ["-XmxGLOBAL"]

--- a/nltk/tokenize/stanford.py
+++ b/nltk/tokenize/stanford.py
@@ -12,7 +12,7 @@ import tempfile
 import warnings
 from subprocess import PIPE
 
-from nltk.internals import _java_options, config_java, find_jar, java
+from nltk.internals import find_jar, java
 from nltk.parse.corenlp import CoreNLPParser
 from nltk.tokenize.api import TokenizerI
 
@@ -86,30 +86,33 @@ class StanfordTokenizer(TokenizerI):
         if _options_cmd:
             cmd.extend(["-options", self._options_cmd])
 
-        default_options = " ".join(_java_options)
-
-        # Configure java.
-        config_java(options=self.java_options, verbose=verbose)
-
         # Windows is incompatible with NamedTemporaryFile() without passing in delete=False.
-        with tempfile.NamedTemporaryFile(mode="wb", delete=False) as input_file:
-            # Write the actual sentences to the temporary input file
-            if isinstance(input_, str) and encoding:
-                input_ = input_.encode(encoding)
-            input_file.write(input_)
-            input_file.flush()
+        input_file_name = None
+        try:
+            with tempfile.NamedTemporaryFile(mode="wb", delete=False) as input_file:
+                input_file_name = input_file.name
+                # Write the actual sentences to the temporary input file
+                if isinstance(input_, str) and encoding:
+                    input_ = input_.encode(encoding)
+                input_file.write(input_)
+                input_file.flush()
 
-            cmd.append(input_file.name)
+                cmd.append(input_file_name)
 
-            # Run the tagger and get the output.
-            stdout, stderr = java(
-                cmd, classpath=self._stanford_jar, stdout=PIPE, stderr=PIPE
-            )
-            stdout = stdout.decode(encoding)
-
-        os.unlink(input_file.name)
-
-        # Return java configurations to their default values.
-        config_java(options=default_options, verbose=False)
+                # Run the tagger and get the output.
+                stdout, stderr = java(
+                    cmd,
+                    classpath=self._stanford_jar,
+                    stdout=PIPE,
+                    stderr=PIPE,
+                    options=self.java_options,
+                )
+                stdout = stdout.decode(encoding)
+        finally:
+            if input_file_name:
+                try:
+                    os.unlink(input_file_name)
+                except OSError:
+                    pass
 
         return stdout

--- a/nltk/tokenize/stanford_segmenter.py
+++ b/nltk/tokenize/stanford_segmenter.py
@@ -18,8 +18,6 @@ import warnings
 from subprocess import PIPE
 
 from nltk.internals import (
-    _java_options,
-    config_java,
     find_dir,
     find_file,
     find_jar,
@@ -232,44 +230,47 @@ class StanfordSegmenter(TokenizerI):
     def segment_sents(self, sentences):
         """ """
         encoding = self._encoding
-        # Create a temporary input file
-        _input_fh, self._input_file_path = tempfile.mkstemp(text=True)
+        input_file_path = None
+        try:
+            # Create a temporary input file
+            _input_fh, input_file_path = tempfile.mkstemp(text=True)
+            self._input_file_path = input_file_path
 
-        # Write the actural sentences to the temporary input file
-        _input_fh = os.fdopen(_input_fh, "wb")
-        _input = "\n".join(" ".join(x) for x in sentences)
-        if isinstance(_input, str) and encoding:
-            _input = _input.encode(encoding)
-        _input_fh.write(_input)
-        _input_fh.close()
+            # Write the actual sentences to the temporary input file
+            with os.fdopen(_input_fh, "wb") as input_fh:
+                _input = "\n".join(" ".join(x) for x in sentences)
+                if isinstance(_input, str) and encoding:
+                    _input = _input.encode(encoding)
+                input_fh.write(_input)
 
-        cmd = [
-            self._java_class,
-            "-loadClassifier",
-            self._model,
-            "-keepAllWhitespaces",
-            self._keep_whitespaces,
-            "-textFile",
-            self._input_file_path,
-        ]
-        if self._sihan_corpora_dict is not None:
-            cmd.extend(
-                [
-                    "-serDictionary",
-                    self._dict,
-                    "-sighanCorporaDict",
-                    self._sihan_corpora_dict,
-                    "-sighanPostProcessing",
-                    self._sihan_post_processing,
-                ]
-            )
+            cmd = [
+                self._java_class,
+                "-loadClassifier",
+                self._model,
+                "-keepAllWhitespaces",
+                self._keep_whitespaces,
+                "-textFile",
+                self._input_file_path,
+            ]
+            if self._sihan_corpora_dict is not None:
+                cmd.extend(
+                    [
+                        "-serDictionary",
+                        self._dict,
+                        "-sighanCorporaDict",
+                        self._sihan_corpora_dict,
+                        "-sighanPostProcessing",
+                        self._sihan_post_processing,
+                    ]
+                )
 
-        stdout = self._execute(cmd)
-
-        # Delete the temporary file
-        os.unlink(self._input_file_path)
-
-        return stdout
+            return self._execute(cmd)
+        finally:
+            if input_file_path:
+                try:
+                    os.unlink(input_file_path)
+                except OSError:
+                    pass
 
     def _sha256sum(self, file_path):
         stat = os.stat(file_path)
@@ -320,19 +321,15 @@ class StanfordSegmenter(TokenizerI):
         if _options_cmd:
             cmd.extend(["-options", self._options_cmd])
 
-        default_options = " ".join(_java_options)
-
         self._validate_classpath()
 
-        # Configure java.
-        config_java(options=self.java_options, verbose=verbose)
-
         stdout, _stderr = java(
-            cmd, classpath=self._stanford_jar, stdout=PIPE, stderr=PIPE
+            cmd,
+            classpath=self._stanford_jar,
+            stdout=PIPE,
+            stderr=PIPE,
+            options=self.java_options,
         )
         stdout = stdout.decode(encoding)
-
-        # Return java configurations to their default values.
-        config_java(options=default_options, verbose=False)
 
         return stdout


### PR DESCRIPTION
Summary:
- add call-local Java options to nltk.internals.java() so wrappers do not temporarily mutate global _java_options
- update Stanford/CoreNLP Java wrappers to pass java_options per subprocess call
- clean delete=False and mkstemp plaintext temp files in finally blocks when Java execution fails
- add regression coverage for temp cleanup and Java option state isolation

Tests:
- PYTHONPATH=. /tmp/nltk_audit_uv/bin/python -m pytest nltk/test/unit/test_stanford_java_wrappers.py -q
- PYTHONPATH=. /tmp/nltk_audit_uv/bin/python -m pytest nltk/test/unit/test_corenlp.py -q
- PYTHONPATH=. /tmp/nltk_audit_uv/bin/python -m compileall -q nltk/internals.py nltk/tokenize/stanford.py nltk/parse/stanford.py nltk/tag/stanford.py nltk/tokenize/stanford_segmenter.py nltk/parse/corenlp.py nltk/test/unit/test_stanford_java_wrappers.py