### PR TITLE
fix(security): Quadratic-time DoS in NLTK GDFA

### DIFF
--- a/nltk/test/unit/translate/test_gdfa.py
+++ b/nltk/test/unit/translate/test_gdfa.py
@@ -2,6 +2,9 @@
 Tests GDFA alignments
 """
 
+import multiprocessing
+import os
+import traceback
 import unittest
 
 from nltk.translate.gdfa import grow_diag_final_and
@@ -152,3 +155,40 @@ class TestGDFA(unittest.TestCase):
             forwards, backwards, source_lens, target_lens, expected
         ):
             self.assertListEqual(expect, grow_diag_final_and(src_len, trg_len, fw, bw))
+
+
+def _gdfa_worker(length):
+    """Symmetrize a trivial alignment with huge lengths; exit 0 ok, 3 on error.
+
+    On error the traceback is printed before exiting so a failure here is
+    diagnosable in CI -- the parent process only sees the numeric exit code.
+    """
+    try:
+        grow_diag_final_and(length, length, "0-0", "0-0")
+        os._exit(0)
+    except BaseException:
+        traceback.print_exc()
+        os._exit(3)
+
+
+def test_gdfa_cost_independent_of_lengths():
+    """Large srclen/trglen with a trivial alignment must not blow up.
+
+    grow_diag()/final_and() previously scanned the whole srclen x trglen grid, so
+    a 17-byte call ``grow_diag_final_and(L, L, "0-0", "0-0")`` forced an O(L*L)
+    iteration (CWE-407). Run in a spawned process with a hard deadline: the scans
+    now walk the alignment/union points and return instantly, while the old grid
+    scan needs minutes at this size, so a regression is terminated and fails the
+    test instead of pinning a core for the rest of the suite.
+    """
+    ctx = multiprocessing.get_context("spawn")
+    proc = ctx.Process(target=_gdfa_worker, args=(50_000,))
+    proc.start()
+    proc.join(30)
+    if proc.is_alive():
+        proc.terminate()
+        proc.join()
+        raise AssertionError(
+            "grow_diag_final_and did not finish in time: O(srclen*trglen) regressed"
+        )
+    assert proc.exitcode == 0, f"worker failed (exit {proc.exitcode})"

--- a/nltk/test/unit/translate/test_gdfa.py
+++ b/nltk/test/unit/translate/test_gdfa.py
@@ -4,6 +4,7 @@ Tests GDFA alignments
 
 import multiprocessing
 import os
+import sys
 import traceback
 import unittest
 
@@ -160,14 +161,16 @@ class TestGDFA(unittest.TestCase):
 def _gdfa_worker(length):
     """Symmetrize a trivial alignment with huge lengths; exit 0 ok, 3 on error.
 
-    On error the traceback is printed before exiting so a failure here is
-    diagnosable in CI -- the parent process only sees the numeric exit code.
+    On error the traceback is printed (and stderr flushed, since ``os._exit``
+    skips normal shutdown) before exiting so a failure here is diagnosable in CI
+    -- the parent process only sees the numeric exit code.
     """
     try:
         grow_diag_final_and(length, length, "0-0", "0-0")
         os._exit(0)
     except BaseException:
         traceback.print_exc()
+        sys.stderr.flush()
         os._exit(3)
 
 

--- a/nltk/translate/gdfa.py
+++ b/nltk/translate/gdfa.py
@@ -88,26 +88,27 @@ def grow_diag_final_and(srclen, trglen, e2f, f2e):
         # iterate until no new points added
         while prev_len < len(alignment):
             no_new_points = True
-            # for english word e = 0 ... en
-            for e in range(srclen):
-                # for foreign word f = 0 ... fn
-                for f in range(trglen):
-                    # if ( e aligned with f)
-                    if (e, f) in alignment:
-                        # for each neighboring point (e-new, f-new)
-                        for neighbor in neighbors:
-                            neighbor = tuple(i + j for i, j in zip((e, f), neighbor))
-                            e_new, f_new = neighbor
-                            # if ( ( e-new not aligned and f-new not aligned)
-                            # and (e-new, f-new in union(e2f, f2e) )
-                            if (
-                                e_new not in aligned and f_new not in aligned
-                            ) and neighbor in union:
-                                alignment.add(neighbor)
-                                aligned["e"].add(e_new)
-                                aligned["f"].add(f_new)
-                                prev_len += 1
-                                no_new_points = False
+            # Walk only the points that are actually aligned (within the
+            # src x trg grid) instead of rescanning the whole srclen x trglen
+            # grid every round: the grid scan made the cost O(srclen*trglen),
+            # decoupled from the (much smaller) alignment size (CWE-407).
+            for e, f in list(alignment):
+                if not (0 <= e < srclen and 0 <= f < trglen):
+                    continue
+                # for each neighboring point (e-new, f-new)
+                for neighbor in neighbors:
+                    neighbor = tuple(i + j for i, j in zip((e, f), neighbor))
+                    e_new, f_new = neighbor
+                    # if ( ( e-new not aligned and f-new not aligned)
+                    # and (e-new, f-new in union(e2f, f2e) )
+                    if (
+                        e_new not in aligned and f_new not in aligned
+                    ) and neighbor in union:
+                        alignment.add(neighbor)
+                        aligned["e"].add(e_new)
+                        aligned["f"].add(f_new)
+                        prev_len += 1
+                        no_new_points = False
             # iterate until no new points added
             if no_new_points:
                 break
@@ -117,20 +118,22 @@ def grow_diag_final_and(srclen, trglen, e2f, f2e):
         Adds remaining points that are not in the intersection, not in the
         neighboring alignments but in the original *e2f* and *f2e* alignments
         """
-        # for english word e = 0 ... en
-        for e_new in range(srclen):
-            # for foreign word f = 0 ... fn
-            for f_new in range(trglen):
-                # if ( ( e-new not aligned and f-new not aligned)
-                # and (e-new, f-new in union(e2f, f2e) )
-                if (
-                    e_new not in aligned
-                    and f_new not in aligned
-                    and (e_new, f_new) in union
-                ):
-                    alignment.add((e_new, f_new))
-                    aligned["e"].add(e_new)
-                    aligned["f"].add(f_new)
+        # Iterate the union points directly (filtered to the src x trg grid)
+        # instead of scanning the whole srclen x trglen grid and testing each
+        # cell for membership -- the grid scan made this O(srclen*trglen),
+        # decoupled from the alignment size (CWE-407).
+        for e_new, f_new in union:
+            # if ( ( e-new not aligned and f-new not aligned)
+            # and (e-new, f-new in union(e2f, f2e) )
+            if (
+                e_new not in aligned
+                and f_new not in aligned
+                and 0 <= e_new < srclen
+                and 0 <= f_new < trglen
+            ):
+                alignment.add((e_new, f_new))
+                aligned["e"].add(e_new)
+                aligned["f"].add(f_new)
 
     grow_diag()
     final_and(e2f)


### PR DESCRIPTION
## Summary

`grow_diag_final_and` (`nltk/translate/gdfa.py`, exported as
`nltk.translate.grow_diag_final_and`) symmetrizes the forward/backward word
alignments of a sentence pair (the GDFA algorithm). Its `grow_diag()` helper
rescans the **entire `srclen` × `trglen` grid on every growth round**, and
`final_and()` does another full grid scan:

```python
for e in range(srclen):        # <-- FULL srclen x trglen grid,
    for f in range(trglen):     #     every pass, regardless of
        if (e, f) in alignment: #     how few points are aligned
            ...
```

`srclen` and `trglen` are independent integer parameters that are **never
validated against the alignment contents**, so the grid-scan cost
`O(srclen·trglen)` is completely decoupled from the size of the alignment data.
A 17-byte call `grow_diag_final_and(L, L, "0-0", "0-0")` forces an `L·L`
iteration — **O(n²) (CWE-407)**.

`grow_diag_final_and` is the standard symmetrization step for IBM-model /
fast_align word alignments; in a service that aligns user-submitted bitext,
`srclen`/`trglen` are the (untrusted) sentence token counts and `e2f`/`f2e` are
the alignment strings — all attacker-controlled. A tiny request can be driven
into tens of seconds of CPU. No authentication, corpus file, or non-default
configuration is required.

## The fix

Walk the **actual points** instead of the whole grid:

- `grow_diag()` iterates a snapshot of the currently aligned points
  (`for e, f in list(alignment)`) and checks each one's neighbours, filtered to
  the `src × trg` grid — the fixpoint (closure of union-neighbours) is reached in
  the same way, but the per-round cost is now `O(|alignment|·8)` instead of
  `O(srclen·trglen)`.
- `final_and()` iterates the union points directly (filtered to the grid)
  instead of testing every grid cell for union membership.

The grid bounds (`0 <= e < srclen` / `0 <= f < trglen`) are preserved so the set
of points considered — and therefore the result — is identical, including the
existing quirk that a point parsed outside the grid still survives if it was in
the intersection.

## Compatibility

Output is **unchanged**, verified against:
- the existing 10-example eflomal regression test
  (`test_gdfa.py::TestGDFA::test_from_eflomal_outputs`), which passes unmodified;
- the module doctest (8/8 pass);
- additional hand-checked cases (diagonal growth, empty intersection, and an
  out-of-grid intersection point) — all byte-identical before/after.

## Reproduction / measurements

`grow_diag_final_and(L, L, "0-0", "0-0")` (request stays ~17 bytes):

| L (= src/trg len) | before (current) | after (this PR) |
|---:|---:|---:|
| 1000 | 0.09s | ~0s |
| 2000 | 0.36s (×4) | ~0s |
| 4000 | 1.4s (×4) | ~0s |
| 8000 | 5.8s (×4) | ~0s |
| 256000 | minutes (projected) | ~0s |

Before: doubling `L` quadruples the time (O(L²)). After: the cost is independent
of `L` — it depends only on the alignment size.

## Tests

`nltk/test/unit/translate/test_gdfa.py`:
- the existing `test_from_eflomal_outputs` continues to pass (equivalence oracle);
- `test_gdfa_cost_independent_of_lengths` — spawned-process linearity guard with
  a hard deadline (a regression is terminated, not left to pin a core).
