### PR TITLE
Fix word_tokenize: pad opening single quote before multi-letter words

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -316,6 +316,7 @@
 - John Winstead <https://github.com/jhnwnstd/>
 - Bradley Erickson <https://github.com/13rac1>
 - Volodymyr Matsko <https://github.com/Lemm1>
+- Nicola <https://github.com/trinik15>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 

--- a/nltk/test/unit/test_tokenize.py
+++ b/nltk/test/unit/test_tokenize.py
@@ -800,6 +800,19 @@ class TestTokenize:
         expected = ["'", "v", "'", "'re", "'"]
         assert word_tokenize(sentence) == expected
 
+    def test_word_tokenize_opening_single_quote_padding(self):
+        sentence = "'Hard' to tell"
+        expected = ["'", "Hard", "'", "to", "tell"]
+        assert word_tokenize(sentence) == expected
+
+        sentence = "He said 'hello' to me"
+        expected = ["He", "said", "'", "hello", "'", "to", "me"]
+        assert word_tokenize(sentence) == expected
+
+        sentence = "It's more'n enough."
+        expected = ["It", "'s", "more", "'n", "enough", "."]
+        assert word_tokenize(sentence) == expected
+
     def test_punkt_pair_iter(self):
         test_cases = [
             ("12", [("1", "2"), ("2", None)]),

--- a/nltk/test/unit/test_tokenize.py
+++ b/nltk/test/unit/test_tokenize.py
@@ -813,6 +813,14 @@ class TestTokenize:
         expected = ["It", "'s", "more", "'n", "enough", "."]
         assert word_tokenize(sentence) == expected
 
+        sentence = "It's o'clock already"
+        expected = ["It", "'s", "o'clock", "already"]
+        assert word_tokenize(sentence) == expected
+
+        sentence = "O'Connor went home"
+        expected = ["O'Connor", "went", "home"]
+        assert word_tokenize(sentence) == expected
+
     def test_punkt_pair_iter(self):
         test_cases = [
             ("12", [("1", "2"), ("2", None)]),

--- a/nltk/tokenize/destructive.py
+++ b/nltk/tokenize/destructive.py
@@ -55,7 +55,10 @@ class NLTKWordTokenizer(TokenizerI):
         (re.compile(r"^\""), r"``"),
         (re.compile(r"(``)"), r" \1 "),
         (re.compile(r"([ \(\[{<])(\"|\'{2})"), r"\1 `` "),
-        (re.compile(r"(?i)(?<!\w)(\')(?!(?:re|ve|ll|m|t|s|d|n)\b)(?=\w)", re.U), r"\1 "),
+        (
+            re.compile(r"(?i)(?<!\w)(\')(?!(?:re|ve|ll|m|t|s|d|n)\b)(?=\w)", re.U),
+            r"\1 ",
+        ),
     ]
 
     # Ending quotes.

--- a/nltk/tokenize/destructive.py
+++ b/nltk/tokenize/destructive.py
@@ -55,7 +55,7 @@ class NLTKWordTokenizer(TokenizerI):
         (re.compile(r"^\""), r"``"),
         (re.compile(r"(``)"), r" \1 "),
         (re.compile(r"([ \(\[{<])(\"|\'{2})"), r"\1 `` "),
-        (re.compile(r"(?i)(\')(?!re|ve|ll|m|t|s|d|n)(\w)\b", re.U), r"\1 \2"),
+        (re.compile(r"(?i)(\')(?!re|ve|ll|m|t|s|d|n)(?=\w)", re.U), r"\1 "),
     ]
 
     # Ending quotes.

--- a/nltk/tokenize/destructive.py
+++ b/nltk/tokenize/destructive.py
@@ -55,7 +55,7 @@ class NLTKWordTokenizer(TokenizerI):
         (re.compile(r"^\""), r"``"),
         (re.compile(r"(``)"), r" \1 "),
         (re.compile(r"([ \(\[{<])(\"|\'{2})"), r"\1 `` "),
-        (re.compile(r"(?i)(\')(?!re|ve|ll|m|t|s|d|n)(?=\w)", re.U), r"\1 "),
+        (re.compile(r"(?i)(?<!\w)(\')(?!(?:re|ve|ll|m|t|s|d|n)\b)(?=\w)", re.U), r"\1 "),
     ]
 
     # Ending quotes.


### PR DESCRIPTION
The opening-quote regex required the following word to be exactly one character long, so the padding rule never fired for ordinary quoted words like 'Hard' or 'hello'.

Replaced the (\w)\b capture with a (?=\w) lookahead so the rule applies regardless of word length, while leaving clitics ('re, 've, 'll, 'm, 't, 's, 'd, 'n) untouched.

Fixes #1995