### PR TITLE
docs: add missing docstrings to 5 utility functions in compat and decorators

### DIFF
--- a/nltk/compat.py
+++ b/nltk/compat.py
@@ -18,6 +18,20 @@ _PY3_DATA_UPDATES = [os.path.join(*path_list) for path_list in DATA_UPDATES]
 
 
 def add_py3_data(path):
+    """Rewrite a corpus data path to use the ``/PY3`` subdirectory when available.
+
+    Some NLTK corpora ship a ``/PY3`` subdirectory that contains data
+    re-encoded or re-pickled for Python 3.  This function checks whether
+    *path* refers to one of those corpora (via ``_PY3_DATA_UPDATES``) and, if
+    so, inserts ``/PY3`` at the appropriate position in the path string.
+
+    Args:
+        path (str): The original corpus file path.
+
+    Returns:
+        str: The (possibly rewritten) path pointing to the ``/PY3`` variant,
+        or the original *path* unchanged if no rewrite is needed.
+    """
     for item in _PY3_DATA_UPDATES:
         if item in str(path) and "/PY3" not in str(path):
             pos = path.index(item) + len(item)
@@ -31,6 +45,21 @@ def add_py3_data(path):
 # for use in adding /PY3 to the second (filename) argument
 # of the file pointers in data.py
 def py3_data(init_func):
+    """Decorator that rewrites the filename argument of a file-pointer initialiser to use ``/PY3`` data.
+
+    Wraps *init_func* so that its second positional argument (the filename) is
+    passed through :func:`add_py3_data` before the original function is called.
+    This is used in ``nltk/data.py`` to transparently redirect corpus readers
+    to the Python-3-compatible copy of a dataset.
+
+    Args:
+        init_func (Callable): The ``__init__`` (or similar) method to wrap.
+
+    Returns:
+        Callable: A wrapped version of *init_func* with the same signature,
+        where the second positional argument is automatically rewritten.
+    """
+
     def _decorator(*args, **kwargs):
         args = (args[0], add_py3_data(args[1])) + args[2:]
         return init_func(*args, **kwargs)

--- a/nltk/decorators.py
+++ b/nltk/decorators.py
@@ -106,7 +106,22 @@ def getinfo(func):
 
 
 def update_wrapper(wrapper, model, infodict=None):
-    "akin to functools.update_wrapper"
+    """Update a wrapper function to look like the wrapped function (akin to ``functools.update_wrapper``).
+
+    Copies ``__name__``, ``__doc__``, ``__module__``, ``__dict__``, and
+    ``__defaults__`` from *model* (or from a pre-computed *infodict*) onto
+    *wrapper*, and also stores the original function as ``wrapper.undecorated``.
+
+    Args:
+        wrapper (Callable): The wrapper function whose metadata will be updated.
+        model (Callable or dict): The original function to copy metadata from,
+            or an info-dict as returned by :func:`getinfo`.
+        infodict (dict, optional): A pre-computed info-dict.  If ``None``,
+            :func:`getinfo` is called on *model*.
+
+    Returns:
+        Callable: *wrapper* with its metadata updated in-place.
+    """
     infodict = infodict or getinfo(model)
     wrapper.__name__ = infodict["name"]
     wrapper.__doc__ = infodict["doc"]
@@ -208,7 +223,22 @@ def decorator(caller):
 
 
 def getattr_(obj, name, default_thunk):
-    "Similar to .setdefault in dictionaries."
+    """Get an attribute of *obj*, setting it to a default value if it does not exist.
+
+    Behaves like :meth:`dict.setdefault`: if *obj* already has an attribute
+    called *name* the existing value is returned unchanged; otherwise
+    *default_thunk* is called, its return value is stored on *obj* as *name*,
+    and then returned.
+
+    Args:
+        obj: The object on which to look up (or set) the attribute.
+        name (str): The attribute name.
+        default_thunk (Callable[[], Any]): A zero-argument callable whose
+            return value is used as the default when the attribute is absent.
+
+    Returns:
+        Any: The existing attribute value, or the newly-set default.
+    """
     try:
         return getattr(obj, name)
     except AttributeError:
@@ -219,6 +249,20 @@ def getattr_(obj, name, default_thunk):
 
 @decorator
 def memoize(func, *args):
+    """Cache the return value of *func* for each unique combination of positional arguments.
+
+    Uses a per-function dictionary (``func.memoize_dic``) to store previously
+    computed results.  Repeated calls with identical *args* return the cached
+    value without re-executing *func*.
+
+    Args:
+        func (Callable): The function whose results should be cached.
+        *args: Positional arguments forwarded to *func*.
+
+    Returns:
+        Any: The return value of ``func(*args)``, retrieved from the cache on
+        subsequent calls with the same arguments.
+    """
     dic = getattr_(func, "memoize_dic", dict)
     # memoize_dic is created at the first call
     if args in dic:


### PR DESCRIPTION
## What does this PR do?

Adds proper `Args`/`Returns` docstrings to five public utility functions across two files. Each function previously had either no docstring at all or only a terse one-liner string literal.

**`nltk/compat.py` — 2 functions:**

| Function | Before | After |
|---|---|---|
| `add_py3_data` | No docstring | Full Args/Returns docstring explaining the `/PY3` path rewriting logic |
| `py3_data` | No docstring | Full Args/Returns docstring explaining the decorator's purpose |

**`nltk/decorators.py` — 3 functions:**

| Function | Before | After |
|---|---|---|
| `update_wrapper` | `"akin to functools.update_wrapper"` (bare string, not a docstring) | Full Args/Returns docstring listing all copied attributes |
| `getattr_` | `"Similar to .setdefault in dictionaries."` (bare string) | Full Args/Returns docstring |
| `memoize` | No docstring | Full Args/Returns docstring explaining the per-function cache |

## Tests

No logic changed — documentation only.

`black --check`, `isort --check-only`, and `ruff check` all pass with no errors.