### PR TITLE
fix(security): validate resource paths after decoding to stop percent-encoded path traversal (CVE-2026-54293, #3504)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -316,6 +316,7 @@
 - John Winstead <https://github.com/jhnwnstd/>
 - Bradley Erickson <https://github.com/13rac1>
 - Volodymyr Matsko <https://github.com/Lemm1>
+- Zach Flint <https://github.com/ZachFlint>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -110,6 +110,27 @@ def _reject_unsafe_no_protocol(resource_url):
     _assert_no_encoded_bypass(resource_url)
 
 
+def _within_directory(candidate, root):
+    """Return True iff ``candidate`` realpath-resolves to a path inside ``root``."""
+    try:
+        root_real = os.path.realpath(root)
+        candidate_real = os.path.realpath(candidate)
+    except (OSError, ValueError):
+        return False
+    if not root_real:
+        return False
+    try:
+        return os.path.commonpath([root_real, candidate_real]) == root_real
+    except ValueError:
+        return False
+
+
+def _ensure_within_root(candidate, root, resource_name):
+    """Reject ``candidate`` unless it stays within the search ``root``."""
+    if root and not _within_directory(candidate, root):
+        raise ValueError(f"Unsafe resource path: {resource_name!r}")
+
+
 try:
     from zlib import Z_SYNC_FLUSH as FLUSH
 except ImportError:
@@ -285,6 +306,8 @@ def normalize_resource_url(resource_url):
         # nltk: protocol. This prevents smuggling filesystem paths through
         # nltk: URLs.
         if re.match(r"^[A-Za-z]:[/\\]", name):
+            raise ValueError(f"Unsafe resource path: {resource_url!r}")
+        if "\\" in name or os.path.pardir in name.replace("\\", "/").split("/"):
             raise ValueError(f"Unsafe resource path: {resource_url!r}")
         # If "nltk:" is used with an absolute path, treat it as "file://"
         if os.path.isabs(name):
@@ -770,6 +793,7 @@ def find(resource_name, paths=None):
         elif not path_ or os.path.isdir(path_):
             if zipfile is None:
                 p = os.path.join(path_, url2pathname(resource_name))
+                _ensure_within_root(p, path_, resource_name)
                 if os.path.exists(p):
                     if p.endswith(".gz"):
                         return GzipFileSystemPathPointer(p)
@@ -787,12 +811,15 @@ def find(resource_name, paths=None):
                         pkg = "/".join(parts[:2])  # e.g. "corpora/stopwords"
                         pkg_dir = os.path.join(path_, url2pathname(pkg))
                         pkg_zip = os.path.join(path_, url2pathname(pkg + ".zip"))
-                        if os.path.isdir(pkg_dir):
+                        if _within_directory(pkg_dir, path_) and os.path.isdir(pkg_dir):
                             _note_near_miss(pkg_dir)
-                        elif os.path.isfile(pkg_zip):
+                        elif _within_directory(pkg_zip, path_) and os.path.isfile(
+                            pkg_zip
+                        ):
                             _note_near_miss(pkg_zip)
             else:
                 p = os.path.join(path_, url2pathname(zipfile))
+                _ensure_within_root(p, path_, resource_name)
                 if os.path.exists(p):
                     try:
                         return ZipFilePathPointer(p, zipentry)

--- a/nltk/test/unit/test_data_path_traversal.py
+++ b/nltk/test/unit/test_data_path_traversal.py
@@ -1,0 +1,231 @@
+"""
+Path-traversal regression tests for ``nltk.data`` resource resolution.
+
+Covers issue nltk/nltk#3504 / CVE-2026-54293: arbitrary file read via
+percent-encoded sequences that bypass the path-safety checks and are then
+decoded into a real traversal path by ``urllib.request.url2pathname()``.
+
+The committed payloads only ever target a synthetic sentinel file created
+inside the test's own temporary directory; no real system file is read.
+"""
+
+import os
+import pickle
+import types
+import zipfile
+from pathlib import Path
+
+import pytest
+
+import nltk.data as data
+from nltk import pathsec
+
+SENTINEL = b"OUTSIDE-ROOT-SENTINEL-DO-NOT-READ"
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    """A hermetic nltk_data root plus an out-of-root sentinel file."""
+    root = tmp_path / "nltk_data"
+    corp = root / "corpora" / "mycorp"
+    corp.mkdir(parents=True)
+    (corp / "data.txt").write_text("hello world", encoding="utf-8")
+    (corp / "a.b.c.txt").write_text("dotted", encoding="utf-8")
+    (corp / "obj.pickle").write_bytes(pickle.dumps({"a": 1}))
+
+    deep = corp.joinpath(*list("abcdefgh"))
+    deep.mkdir(parents=True)
+    (deep / "deep.txt").write_text("deep-ok", encoding="utf-8")
+
+    (root / "grammars").mkdir()
+    (root / "grammars" / "toy.cfg").write_text("S -> 'a'\n", encoding="utf-8")
+
+    with zipfile.ZipFile(root / "corpora" / "zc.zip", "w") as zf:
+        zf.writestr("zc/inside.txt", "zipped-bytes")
+
+    secret = tmp_path / "secret.txt"
+    secret.write_bytes(SENTINEL)
+
+    monkeypatch.setattr(data, "path", [str(root)])
+    monkeypatch.setattr(data, "_resource_cache", {})
+    monkeypatch.setattr(pathsec, "ENFORCE", True)
+    monkeypatch.setattr(pathsec, "_get_allowed_roots", lambda: {root.resolve()})
+    return types.SimpleNamespace(root=root, secret=secret, tmp=tmp_path)
+
+
+def _read_or_none(resource, paths):
+    """find()+open() the resource, returning its bytes or None if it is refused."""
+    try:
+        ptr = data.find(resource, paths=paths)
+        stream = ptr.open()
+    except (ValueError, LookupError, OSError, PermissionError):
+        return None
+    try:
+        return stream.read()
+    except (ValueError, LookupError, OSError, PermissionError):
+        return None
+    finally:
+        try:
+            stream.close()
+        except Exception:
+            pass
+
+
+_MUST_RAISE_VALUEERROR = [
+    "%2e%2e/secret",
+    "..%2f",
+    "..%2fsecret",
+    "%2E%2E",
+    ".%2e",
+    "%2E%2e",
+    "%2e%2E/secret",
+    "%2e%2e%2fsecret",
+    "corpora/..%2f..%2fsecret",
+    "corpora/%2e%2e/%2e%2e/secret",
+    "corpora/%2E%2E/%2E%2E/secret",
+    "%2fetc%2fpasswd",
+    "%2Fetc%2Fpasswd",
+    "%5c..%5csecret",
+    "%43%3a%5csecret",
+    r"..\..\secret",
+    r"corpora\..\..\secret",
+    "C:/secret",
+    r"C:\secret",
+]
+
+
+@pytest.mark.parametrize("payload", _MUST_RAISE_VALUEERROR)
+def test_find_rejects_traversal_variants(env, payload):
+    with pytest.raises(ValueError):
+        data.find(payload, paths=[str(env.root)])
+
+
+@pytest.mark.parametrize("payload", _MUST_RAISE_VALUEERROR)
+def test_normalize_rejects_traversal_variants(env, payload):
+    with pytest.raises(ValueError):
+        data.normalize_resource_url("nltk:" + payload)
+
+
+@pytest.mark.parametrize("payload", _MUST_RAISE_VALUEERROR)
+def test_load_rejects_traversal_variants(env, payload):
+    with pytest.raises(ValueError):
+        data.load("nltk:" + payload, format="raw")
+
+
+_SENTINEL_PAYLOADS = [
+    "%2e%2e/secret.txt",
+    "..%2fsecret.txt",
+    "%2e%2e%2fsecret.txt",
+    "corpora/%2e%2e/%2e%2e/secret.txt",
+    "corpora/..%2f..%2fsecret.txt",
+    "%252e%252e/secret.txt",
+    "%252e%252e%252fsecret.txt",
+    "%2e%2e/secret.txt%00",
+    "%2e%2e/secret.txt%00.txt",
+    r"..\secret.txt",
+    "%2e%2e%5csecret.txt",
+    "%2fsecret.txt",
+]
+
+
+@pytest.mark.parametrize("payload", _SENTINEL_PAYLOADS)
+def test_payload_never_reads_out_of_root_sentinel(env, payload):
+    """The /etc/passwd-equivalent read attempt, against a synthetic sentinel."""
+    assert _read_or_none(payload, [str(env.root)]) != SENTINEL
+
+
+def test_absolute_file_uri_to_sentinel_is_blocked(env):
+    """A ``file://`` URI to the out-of-root sentinel is denied by the sandbox."""
+    with pytest.raises((PermissionError, ValueError, LookupError)):
+        data.load(env.secret.resolve().as_uri(), format="raw")
+
+
+def test_double_encoded_resolves_in_root_not_host(env):
+    """Double-encoding decodes once: a literal in-root name, never the sentinel."""
+    with pytest.raises((LookupError, ValueError)):
+        data.load("nltk:%252e%252e/secret.txt", format="raw")
+    assert _read_or_none("%252e%252e/secret.txt", [str(env.root)]) != SENTINEL
+
+
+def test_symlink_escape_is_blocked(env):
+    """An in-root symlink pointing outside the root is refused (realpath guard).
+
+    This is the case a substring/regex blocklist cannot catch: the resource
+    name is a perfectly ordinary in-root name, and only realpath resolution
+    reveals that it escapes the data directory.
+    """
+    link = env.root / "corpora" / "escape.txt"
+    try:
+        os.symlink(env.secret, link)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported in this environment")
+
+    with pytest.raises(ValueError):
+        data.find("corpora/escape.txt", paths=[str(env.root)])
+    assert _read_or_none("corpora/escape.txt", [str(env.root)]) != SENTINEL
+
+
+def test_null_byte_payloads_never_read_sentinel(env):
+    for payload in ("corpora/%00/secret.txt", "corpora/secret%00.txt"):
+        assert _read_or_none(payload, [str(env.root)]) != SENTINEL
+
+
+def test_guard_is_independent_of_pathsec_enforce(env, monkeypatch):
+    """find()'s containment guard rejects traversal even with ENFORCE disabled."""
+    monkeypatch.setattr(pathsec, "ENFORCE", False)
+    with pytest.raises(ValueError):
+        data.find("%2e%2e/secret.txt", paths=[str(env.root)])
+
+
+def test_nltk_scheme_raw(env):
+    assert data.load("nltk:corpora/mycorp/data.txt", format="raw") == b"hello world"
+
+
+def test_no_scheme_text(env):
+    assert data.load("corpora/mycorp/data.txt", format="text") == "hello world"
+
+
+def test_file_scheme_raw(env):
+    uri = (env.root / "corpora" / "mycorp" / "data.txt").resolve().as_uri()
+    assert data.load(uri, format="raw") == b"hello world"
+
+
+def test_pickle_format(env):
+    assert data.load("corpora/mycorp/obj.pickle", format="pickle") == {"a": 1}
+
+
+def test_grammar_cfg_each_scheme(env):
+    for url in ("nltk:grammars/toy.cfg", "grammars/toy.cfg"):
+        grammar = data.load(url)
+        assert any(str(p.lhs()) == "S" for p in grammar.productions())
+
+
+def test_zip_entry_access(env):
+    ptr = data.find("corpora/zc.zip/zc/inside.txt", paths=[str(env.root)])
+    assert ptr.open().read() == b"zipped-bytes"
+
+
+def test_zip_second_pass_fallback(env):
+    ptr = data.find("corpora/zc/inside.txt", paths=[str(env.root)])
+    assert ptr.open().read() == b"zipped-bytes"
+
+
+def test_empty_resource_name_stays_in_root(env):
+    ptr = data.find("", paths=[str(env.root)])
+    resolved = Path(str(ptr.path)).resolve()
+    assert resolved == env.root.resolve() or resolved.is_relative_to(env.root.resolve())
+
+
+def test_legitimate_dotted_name(env):
+    assert data.load("corpora/mycorp/a.b.c.txt", format="raw") == b"dotted"
+
+
+def test_safe_percent_encoded_dot_is_allowed(env):
+    assert data.load("nltk:corpora/mycorp/data%2Etxt", format="raw") == b"hello world"
+
+
+def test_long_nested_legitimate_path(env):
+    nested = "corpora/mycorp/" + "/".join("abcdefgh") + "/deep.txt"
+    assert data.load(nested, format="raw") == b"deep-ok"
+    ptr = data.find(nested, paths=[str(env.root)])
+    assert Path(str(ptr.path)).resolve().is_relative_to(env.root.resolve())


### PR DESCRIPTION
Fixes #3504 (CVE-2026-54293).

The path-safety checks in `nltk.data` run against the raw resource string, but `url2pathname()` percent-decodes that string afterwards when it builds the actual filesystem path. So `%2e%2e` gets past the `..` check and only turns back into `..` once we're already opening the file. `%2f` behaves the same way. That's enough to read files outside the nltk_data directories.

The real problem is that we were checking one string and opening a different one. Instead of trying to keep a regex in sync with however `url2pathname` happens to decode things, I moved the check to after the path is built and resolved.

`_within_directory()` runs `realpath()` on both the candidate file and the data root it came from, then compares them with `commonpath()`. `find()` now calls this on every path it's about to return. If the resolved path isn't under the root it was looked up in, it's rejected. Since it operates on the resolved path, it doesn't matter how the traversal was spelled: percent-encoding, backslashes, an absolute path, or a symlink that points out of the tree all get caught the same way. The old regex blocklist couldn't see symlinks at all.

This guard always raises and doesn't look at `pathsec.ENFORCE`. A relative resource name that resolves outside its data root isn't something a caller ever legitimately wants, so there's no warn-only case to honor. pathsec still covers the `open()` layer as a second line of defense.

I also tightened `normalize_resource_url()` for the `nltk:` scheme. It used to quietly rewrite `nltk:..\..\secret` into `nltk:../../secret` and leave `find()` to reject it; now it rejects literal `..` segments and backslashes itself. Absolute `nltk:` paths still reroute to `file://` as before.

One thing I left alone on purpose: I only decode once. `url2pathname` does a single decode pass, so the filesystem only ever sees one level. A double-encoded payload like `%252e%252e` decodes to the literal name `%2e%2e`, which is just a directory that doesn't exist, so you get a `LookupError` instead of someone's file. Decoding repeatedly in the check would also break legitimate names, where `%2520` is meant to be a literal `%20`.

## Tests

`nltk/test/unit/test_data_path_traversal.py`. No downloads needed: each test builds a throwaway nltk_data dir plus a sentinel file just outside it.

* Every encoded and literal traversal variant from the report, exercised through `find()`, `normalize_resource_url()` and `load()`.
* The actual read attempt: a set of payloads aimed at the out-of-root sentinel, asserting its contents never come back. This is the `/etc/passwd` case, done against a temp file.
* An in-root symlink that points outside the root, which is the case the old regex can't catch by design.
* The normal paths still work: `nltk:`, `file:` and bare relative loads; raw/text/pickle formats; a `.cfg` grammar; direct zip access and the `corpus/file -> corpus.zip/...` fallback.
* Edge cases: empty name, names with real dots, and deep nested paths.

I ran the whole `nltk/test/unit` suite before and after the change and the pass count is identical, nothing regressed. (The failures that do show up are pre-existing: missing downloaded corpora and no matplotlib installed.) `data.doctest` passes as well.

No real system paths appear anywhere in the tests, only the temp sentinel, so this is safe to publish.
