### PR TITLE
Use OMW-2.0 with all WordNet versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
         id: nltk-data-cache
         with:
           path: ${{ github.workspace }}/nltk_data
-          key: nltk_data_${{ runner.os }}_v1
+          key: nltk_data_${{ runner.os }}_v2
 
       - name: Download nltk data on cache miss
         if: steps.nltk-data-cache.outputs.cache-hit != 'true'

--- a/nltk/corpus/__init__.py
+++ b/nltk/corpus/__init__.py
@@ -393,7 +393,7 @@ webtext: PlaintextCorpusReader = LazyCorpusLoader(
 wordnet: WordNetCorpusReader = LazyCorpusLoader(
     "wordnet",
     WordNetCorpusReader,
-    LazyCorpusLoader("omw-1.4", CorpusReader, r".*/wn-data-.*\.tab", encoding="utf8"),
+    LazyCorpusLoader("omw-2.0", CorpusReader, r".*/wn-data-.*\.tab", encoding="utf8"),
 )
 ## Use the following template to add a custom Wordnet package.
 ## Just uncomment, and replace the identifier (my_wordnet) in two places:
@@ -401,30 +401,30 @@ wordnet: WordNetCorpusReader = LazyCorpusLoader(
 # my_wordnet: WordNetCorpusReader = LazyCorpusLoader(
 #    "my_wordnet",
 #    WordNetCorpusReader,
-#    LazyCorpusLoader("omw-1.4", CorpusReader, r".*/wn-data-.*\.tab", encoding="utf8"),
+#    LazyCorpusLoader("omw-2.0", CorpusReader, r".*/wn-data-.*\.tab", encoding="utf8"),
 # )
 wordnet31: WordNetCorpusReader = LazyCorpusLoader(
     "wordnet31",
     WordNetCorpusReader,
-    LazyCorpusLoader("omw-1.4", CorpusReader, r".*/wn-data-.*\.tab", encoding="utf8"),
+    LazyCorpusLoader("omw-2.0", CorpusReader, r".*/wn-data-.*\.tab", encoding="utf8"),
 )
 wordnet2021: WordNetCorpusReader = LazyCorpusLoader(
     # Obsolete, use english_wordnet instead.
     "wordnet2021",
     WordNetCorpusReader,
-    LazyCorpusLoader("omw-1.4", CorpusReader, r".*/wn-data-.*\.tab", encoding="utf8"),
+    LazyCorpusLoader("omw-2.0", CorpusReader, r".*/wn-data-.*\.tab", encoding="utf8"),
 )
 wordnet2022: WordNetCorpusReader = LazyCorpusLoader(
     # Obsolete, use english_wordnet instead.
     "wordnet2022",
     WordNetCorpusReader,
-    LazyCorpusLoader("omw-1.4", CorpusReader, r".*/wn-data-.*\.tab", encoding="utf8"),
+    LazyCorpusLoader("omw-2.0", CorpusReader, r".*/wn-data-.*\.tab", encoding="utf8"),
 )
 english_wordnet: WordNetCorpusReader = LazyCorpusLoader(
     # Latest Open English Wordnet
     "english_wordnet",
     WordNetCorpusReader,
-    LazyCorpusLoader("omw-1.4", CorpusReader, r".*/wn-data-.*\.tab", encoding="utf8"),
+    LazyCorpusLoader("omw-2.0", CorpusReader, r".*/wn-data-.*\.tab", encoding="utf8"),
 )
 wordnet_ic: WordNetICCorpusReader = LazyCorpusLoader(
     "wordnet_ic", WordNetICCorpusReader, r".*\.dat"

--- a/nltk/test/wordnet.doctest
+++ b/nltk/test/wordnet.doctest
@@ -879,7 +879,7 @@ of the existing Wordnet entries, and edit the name in two places:
 oewn2023: WordNetCorpusReader = LazyCorpusLoader(
     "oewn2023",
     WordNetCorpusReader,
-    LazyCorpusLoader("omw-1.4", CorpusReader, r".*/wn-data-.*\.tab", encoding="utf8"),
+    LazyCorpusLoader("omw-2.0", CorpusReader, r".*/wn-data-.*\.tab", encoding="utf8"),
 )
 
 4. Enjoy:


### PR DESCRIPTION
Updates the Open Multilingual Wordnet version to 2.0. This version adds increased coverage of the Hispanic wordnets.

Test:

```
from nltk.corpus import wordnet as wn
from nltk.corpus import english_wordnet as ewn

wn.add_omw()
ewn.add_omw()

wnset = set(wn.all_lemma_names(lang="spa"))
ewnset = set(ewn.all_lemma_names(lang="spa"))

print(f"{len(wnset)} Spanish lemma names in WN {wn.get_version()} with {ewn._omw_reader.__name__}")
print(f"{len(ewnset)} Spanish lemma names in EWN {ewn.get_version()} with {ewn._omw_reader.__name__}")
print(f"First 10 removed entries in EWN {ewn.get_version()}: {sorted(list(wnset-ewnset))[:10]}")

```

Without this PR:

> 36681 Spanish lemma names in WN 3.0 with omw-1.4
> 36259 Spanish lemma names in EWN 2025+ with omw-1.4
> First 10 removed entries in EWN 2025+: ['Al-hakim', 'Alta_Normandía', 'Antonino_Pío', 'Aram_Kachaturian', 'Armagedón', 'Baja_Normandía', 'Bromo-Seltzer', 'Chiang_Kai-shek', 'Chouen-Lai', "Coeur_d'Alene"]
> 

With this PR:

> 90899 Spanish lemma names in WN 3.0 with omw-2.0
> 89908 Spanish lemma names in EWN 2025+ with omw-2.0
> First 10 removed entries in EWN 2025+: ['11-plus', '20/20', 'Al-hakim', 'Alta_Normandia', 'Alta_Normandía', 'Antonino_Pío', 'Aram_Kachaturian', 'Armageddon', 'Armagedón', 'Austria-Hungría']
> 