### PR TITLE
Enforce restrictive primitive type checking in pathsec wrappers

### DIFF
--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -520,17 +520,57 @@ def urlopen(url, *args, **kwargs):
 
 def open(file, mode="r", *, context="pathsec.open", required_root=None, **kwargs):
     """Secure wrapper for builtins.open."""
-    validate_path(file, context=context, required_root=required_root)
-    return builtins.open(file, mode=mode, **kwargs)
+    # 1. Allow file descriptors (integers) to pass through, matching original logic
+    if isinstance(file, int):
+        validate_path(file, context=context, required_root=required_root)
+        return builtins.open(file, mode=mode, **kwargs)
+
+    # 2. Force extraction of the real path from PathLike objects
+    try:
+        raw_path = os.fspath(file)
+    except TypeError:
+        raise TypeError("Path must be a string, bytes, or os.PathLike")
+
+    # 3. Strict primitive enforcement against type manipulation
+    if type(raw_path) not in (str, bytes):
+        raise TypeError(
+            f"Strict security policy: Path must resolve to exact str or bytes, not '{type(raw_path).__name__}'"
+        )
+
+    if type(raw_path) is bytes:
+        raw_path = os.fsdecode(raw_path)
+
+    # 4. Execution Substitution: validate and open the pure primitive, discarding the original object
+    validate_path(raw_path, context=context, required_root=required_root)
+    return builtins.open(raw_path, mode=mode, **kwargs)
 
 
 class ZipFile(zipfile.ZipFile):
     """Secure wrapper for zipfile.ZipFile."""
 
     def __init__(self, file, *args, **kwargs):
-        if isinstance(file, (str, Path)):
-            validate_path(file, context="pathsec.ZipFile")
-        super().__init__(file, *args, **kwargs)
+        # zipfile.ZipFile also accepts file-like objects (e.g., io.BytesIO).
+        # We only strictly normalize and validate path-like objects.
+        if isinstance(file, (str, bytes, os.PathLike)):
+            try:
+                raw_path = os.fspath(file)
+            except TypeError:
+                raise TypeError("Path must be a string, bytes, or os.PathLike")
+
+            if type(raw_path) not in (str, bytes):
+                raise TypeError(
+                    f"Strict security policy: Path must resolve to exact str or bytes, not '{type(raw_path).__name__}'"
+                )
+
+            if type(raw_path) is bytes:
+                raw_path = os.fsdecode(raw_path)
+
+            validate_path(raw_path, context="pathsec.ZipFile")
+            file_to_open = raw_path
+        else:
+            file_to_open = file
+
+        super().__init__(file_to_open, *args, **kwargs)
 
     def extract(self, member, path=None, pwd=None):
         validate_zip_archive(self, path or os.getcwd(), specific_member=member)

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -529,7 +529,7 @@ def open(file, mode="r", *, context="pathsec.open", required_root=None, **kwargs
     try:
         raw_path = os.fspath(file)
     except TypeError:
-        raise TypeError("Path must be a string, bytes, or os.PathLike")
+        raise TypeError("Path must be a string, bytes, or os.PathLike") from None
 
     # 3. Strict primitive enforcement against type manipulation
     if type(raw_path) not in (str, bytes):
@@ -555,7 +555,9 @@ class ZipFile(zipfile.ZipFile):
             try:
                 raw_path = os.fspath(file)
             except TypeError:
-                raise TypeError("Path must be a string, bytes, or os.PathLike")
+                raise TypeError(
+                    "Path must be a string, bytes, or os.PathLike"
+                ) from None
 
             if type(raw_path) not in (str, bytes):
                 raise TypeError(

--- a/nltk/test/unit/test_pathsec.py
+++ b/nltk/test/unit/test_pathsec.py
@@ -5,6 +5,7 @@ import os
 import socket
 import urllib.request
 import zipfile
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 from urllib.error import HTTPError, URLError
 
@@ -529,3 +530,136 @@ def test_read_sents_enforces_pathsec():
     # If the function succeeds (no exception), the test fails.
     with pytest.raises(PermissionError, match="Security Violation"):
         read_sents(forbidden_path)
+
+
+# ----------------------------------------------------------------------
+# Malicious Subclasses for Type Confusion & Object Manipulation Tests
+# ----------------------------------------------------------------------
+
+
+class ZeroLengthStr(str):
+    """
+    Simulates a boolean discrepancy attack.
+    Overrides __len__ so that `if not path:` evaluates to True,
+    attempting to bypass permissive guards while tricking the C-API.
+    """
+
+    def __len__(self):
+        return 0
+
+
+class DualFacedPath(os.PathLike):
+    """
+    Simulates an interface discrepancy (desync) attack.
+    Presents a safe path to `str()` casting, but delivers a malicious
+    path when `os.fspath()` is invoked by low-level file operations.
+    """
+
+    def __init__(self, real_path, shown_path):
+        self.real_path = str(real_path)
+        self.shown = str(shown_path)
+
+    def __fspath__(self):
+        return self.real_path
+
+    def __str__(self):
+        return self.shown
+
+
+# ----------------------------------------------------------------------
+# Fixtures
+# ----------------------------------------------------------------------
+
+
+@pytest.fixture
+def sandbox_env(tmp_path):
+    """Sets up a mock allowed root and an outside unallowed directory."""
+    safe_dir = tmp_path / "nltk_safe_root"
+    safe_dir.mkdir()
+
+    unsafe_dir = tmp_path / "outside_root"
+    unsafe_dir.mkdir()
+
+    secret_file = unsafe_dir / "secret.txt"
+    secret_file.write_text("UNAUTHORIZED_DATA", encoding="utf-8")
+
+    allowed_file = safe_dir / "allowed.txt"
+    allowed_file.write_text("AUTHORIZED_DATA", encoding="utf-8")
+
+    archive_path = unsafe_dir / "unauthorized.zip"
+    archive_path.touch()
+
+    return safe_dir, unsafe_dir, secret_file, allowed_file, archive_path
+
+
+# ----------------------------------------------------------------------
+# Restrictive Guard Tests
+# ----------------------------------------------------------------------
+
+
+def test_restrictive_guard_blocks_boolean_discrepancy_open(sandbox_env):
+    """Ensures restrictive type enforcement blocks length-override bypasses in open()."""
+    safe_dir, _, secret_file, _, _ = sandbox_env
+
+    malicious_path = ZeroLengthStr(str(secret_file))
+
+    # The strict policy must reject the subclass completely
+    with pytest.raises(
+        TypeError,
+        match="Strict security policy: Path must resolve to exact str or bytes",
+    ):
+        pathsec.open(malicious_path, "r", required_root=safe_dir)
+
+
+def test_restrictive_guard_blocks_interface_desync_open(sandbox_env):
+    """Ensures the real path is extracted and evaluated, catching the root escape."""
+    safe_dir, _, secret_file, allowed_file, _ = sandbox_env
+
+    malicious_path = DualFacedPath(real_path=secret_file, shown_path=allowed_file)
+
+    # The guard extracts real_path via os.fspath(), bypassing the __str__ illusion.
+    # validate_path then correctly identifies it as a root escape and throws ValueError.
+    with pytest.raises(ValueError, match="Security Violation .* escapes root"):
+        pathsec.open(malicious_path, "r", required_root=safe_dir)
+
+
+def test_restrictive_guard_blocks_boolean_discrepancy_zipfile(sandbox_env):
+    """Ensures restrictive type enforcement blocks length-override bypasses in ZipFile()."""
+    _, _, _, _, archive_path = sandbox_env
+
+    malicious_path = ZeroLengthStr(str(archive_path))
+
+    # ZipFile path normalization must also catch and reject the subclass
+    with pytest.raises(
+        TypeError,
+        match="Strict security policy: Path must resolve to exact str or bytes",
+    ):
+        pathsec.ZipFile(malicious_path, "r")
+
+
+def test_restrictive_guard_blocks_interface_desync_zipfile(sandbox_env):
+    """Ensures the real path is extracted and evaluated by ZipFile."""
+    safe_dir, _, _, allowed_file, archive_path = sandbox_env
+
+    # To strictly prove the desync fails validation regardless of the /tmp/ environment,
+    # we point the underlying real_path to an explicitly forbidden global location.
+    forbidden_path = "/this_is_a_forbidden_path_12345/unauth.zip"
+    malicious_path = DualFacedPath(real_path=forbidden_path, shown_path=allowed_file)
+
+    # The pathsec guard extracts the forbidden path and validate_path correctly
+    # blocks it, raising a PermissionError before it ever reaches zipfile.ZipFile.
+    with pytest.raises(PermissionError, match="Security Violation"):
+        pathsec.ZipFile(malicious_path, "r")
+
+
+def test_restrictive_guard_allows_pure_primitives(sandbox_env):
+    """Ensures pure primitive strings and pathlib.Path objects still function normally."""
+    safe_dir, _, _, allowed_file, _ = sandbox_env
+
+    # pathlib.Path should be allowed (it resolves to a pure primitive internally)
+    with pathsec.open(allowed_file, "r", required_root=safe_dir) as f:
+        assert f.read() == "AUTHORIZED_DATA"
+
+    # Pure string should be allowed
+    with pathsec.open(str(allowed_file), "r", required_root=safe_dir) as f:
+        assert f.read() == "AUTHORIZED_DATA"

--- a/nltk/test/unit/test_pathsec.py
+++ b/nltk/test/unit/test_pathsec.py
@@ -5,7 +5,6 @@ import os
 import socket
 import urllib.request
 import zipfile
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 from urllib.error import HTTPError, URLError
 
@@ -653,13 +652,17 @@ def test_restrictive_guard_blocks_interface_desync_zipfile(sandbox_env):
 
 
 def test_restrictive_guard_allows_pure_primitives(sandbox_env):
-    """Ensures pure primitive strings and pathlib.Path objects still function normally."""
+    """Ensures pure primitive strings, pathlib.Path objects, and bytes still function normally."""
     safe_dir, _, _, allowed_file, _ = sandbox_env
 
-    # pathlib.Path should be allowed (it resolves to a pure primitive internally)
+    # pathlib.Path should be allowed
     with pathsec.open(allowed_file, "r", required_root=safe_dir) as f:
         assert f.read() == "AUTHORIZED_DATA"
 
     # Pure string should be allowed
     with pathsec.open(str(allowed_file), "r", required_root=safe_dir) as f:
+        assert f.read() == "AUTHORIZED_DATA"
+
+    # Bytes path should be allowed (decoded safely)
+    with pathsec.open(os.fsencode(str(allowed_file)), "r", required_root=safe_dir) as f:
         assert f.read() == "AUTHORIZED_DATA"


### PR DESCRIPTION
This PR hardens the `nltk.pathsec` module against Object Type Confusion and Validation Discrepancy attacks. By transitioning the I/O wrappers from a permissive validation model to a strictly restrictive one, we prevent malicious subclasses from bypassing path containment checks.

**The Vulnerability**
Dynamic languages like Python evaluate high-level logic (e.g., boolean truthiness or `__str__` casting) differently than the underlying C-API file execution layers. A malicious object subclassing `str` or `os.PathLike` can exploit this by presenting a safe or empty path to the Python-level security guard, while delivering a dangerous path to the low-level `open()` or `ZipFile()` execution sink.

**The Fix**

1. **Strict Type Normalization:** The exposed `pathsec.open` and `pathsec.ZipFile` wrappers now force the extraction of the real path via `os.fspath()` and explicitly enforce that the resulting type is exactly `str` or `bytes`.
2. **Execution Substitution:** Once the primitive path is validated, the original user-supplied object is discarded. Only the guaranteed-safe primitive is passed down to `builtins.open` and `zipfile.ZipFile`, closing the execution gap.
3. **Test Coverage:** Added comprehensive unit tests in `nltk/test/unit/test_pathsec.py` to verify the restrictive guards successfully block boolean discrepancy and interface desync objects.

**Testing**

* [x] Added unit tests for malicious subclassing vectors.
* [x] All local tests pass without regressions.