### PR TITLE
don't crash chomsky_normal_form on terminals with siblings

### DIFF
--- a/nltk/test/unit/test_treetransforms.py
+++ b/nltk/test/unit/test_treetransforms.py
@@ -53,6 +53,15 @@ def test_chomsky_normal_form_with_terminal_siblings():
         assert tree == expected
 
 
+def test_chomsky_normal_form_with_nonstring_terminal():
+    """A non-string terminal (e.g. an int) among siblings must not crash."""
+    for factor in ("right", "left"):
+        tree = Tree("S", [Tree("A", ["a"]), 7, Tree("B", ["b"]), Tree("C", ["c"])])
+        chomsky_normal_form(tree, factor=factor)
+        for subtree in tree.subtrees():
+            assert len(subtree) <= 2
+
+
 def _un_chomsky_worker(n):
     """Un-binarise a large right-branching CNF tree; exit 0 ok, 3 on error."""
     try:

--- a/nltk/test/unit/test_treetransforms.py
+++ b/nltk/test/unit/test_treetransforms.py
@@ -41,6 +41,18 @@ def test_un_chomsky_collapses_artificial_node():
     assert tree == Tree.fromstring("(S (A a) (B b) (C c))")
 
 
+def test_chomsky_normal_form_with_terminal_siblings():
+    """A terminal sitting beside subtrees must not crash chomsky_normal_form."""
+    for factor in ("right", "left"):
+        tree = Tree.fromstring("(S (S 1) + (S 2))")
+        expected = Tree.fromstring("(S (S 1) + (S 2))")
+        chomsky_normal_form(tree, factor=factor)
+        for subtree in tree.subtrees():
+            assert len(subtree) <= 2
+        un_chomsky_normal_form(tree)
+        assert tree == expected
+
+
 def _un_chomsky_worker(n):
     """Un-binarise a large right-branching CNF tree; exit 0 ok, 3 on error."""
     try:

--- a/nltk/tree/transforms.py
+++ b/nltk/tree/transforms.py
@@ -145,7 +145,10 @@ def chomsky_normal_form(
 
             # chomsky normal form factorization
             if len(node) > 2:
-                childNodes = [child.label() for child in node]
+                childNodes = [
+                    child.label() if isinstance(child, Tree) else child
+                    for child in node
+                ]
                 nodeCopy = node.copy()
                 node[0:] = []  # delete the children
 

--- a/nltk/tree/transforms.py
+++ b/nltk/tree/transforms.py
@@ -146,7 +146,7 @@ def chomsky_normal_form(
             # chomsky normal form factorization
             if len(node) > 2:
                 childNodes = [
-                    child.label() if isinstance(child, Tree) else child
+                    str(child.label()) if isinstance(child, Tree) else str(child)
                     for child in node
                 ]
                 nodeCopy = node.copy()


### PR DESCRIPTION
Fixes #1883.

`Tree.chomsky_normal_form()` raised `AttributeError: 'str' object has no attribute 'label'` whenever a node had more than two children and one of them was a terminal, e.g. a parse of a grammar like `S -> S '+' S`:

```python
tree = Tree.fromstring("(S (S 1) + (S 2))")
tree.chomsky_normal_form()  # used to raise
```

The binarisation built the intermediate node names with `child.label()` for every child, which fails on terminal strings. Now it uses the terminal string itself for those. Output stays valid CNF and `un_chomsky_normal_form` still round-trips back to the original.

Added a regression test covering both factors.