### PR TITLE
allow escaped brackets in Tree.fromstring

### DIFF
--- a/nltk/test/unit/test_tree.py
+++ b/nltk/test/unit/test_tree.py
@@ -13,6 +13,15 @@ def test_fromstring_escaped_bracket_leaf_and_label():
     assert tree.leaves() == ["x"]
 
 
+def test_fromstring_roundtrips_escaped_bracket_leaf():
+    # a real-world case: a leaf holding a smiley whose close paren is escaped
+    source = r"(EMOJI :\))"
+    tree = Tree.fromstring(source)
+    assert tree.label() == "EMOJI"
+    assert tree.leaves() == [r":\)"]
+    assert str(tree) == source
+
+
 def test_fromstring_normal_parsing_unaffected():
     tree = Tree.fromstring("(S (NP the cat) (VP sat))")
     assert tree.label() == "S"

--- a/nltk/test/unit/test_tree.py
+++ b/nltk/test/unit/test_tree.py
@@ -1,0 +1,19 @@
+from nltk.tree import Tree
+
+
+def test_fromstring_allows_escaped_brackets():
+    for source in (r"(S \))", r"(S \()", r"(S (NP \)) (VP ok))"):
+        tree = Tree.fromstring(source)
+        assert str(tree) == source
+
+
+def test_fromstring_escaped_bracket_leaf_and_label():
+    tree = Tree.fromstring(r"(S (\( x))")
+    assert tree[0].label() == r"\("
+    assert tree.leaves() == ["x"]
+
+
+def test_fromstring_normal_parsing_unaffected():
+    tree = Tree.fromstring("(S (NP the cat) (VP sat))")
+    assert tree.label() == "S"
+    assert tree.leaves() == ["the", "cat", "sat"]

--- a/nltk/tree/tree.py
+++ b/nltk/tree/tree.py
@@ -647,7 +647,9 @@ class Tree(list):
         open_pattern, close_pattern = (re.escape(open_b), re.escape(close_b))
         # A token char is either a backslash-escaped bracket (kept verbatim) or
         # any character that is not whitespace or an unescaped bracket.
-        token_char = rf"(?:\\[{open_pattern}{close_pattern}]|[^\s{open_pattern}{close_pattern}])"
+        token_char = (
+            rf"(?:\\[{open_pattern}{close_pattern}]|[^\s{open_pattern}{close_pattern}])"
+        )
         if node_pattern is None:
             node_pattern = rf"{token_char}+"
         if leaf_pattern is None:

--- a/nltk/tree/tree.py
+++ b/nltk/tree/tree.py
@@ -645,10 +645,13 @@ class Tree(list):
         # Construct a regexp that will tokenize the string.
         open_b, close_b = brackets
         open_pattern, close_pattern = (re.escape(open_b), re.escape(close_b))
+        # A token char is either a backslash-escaped bracket (kept verbatim) or
+        # any character that is not whitespace or an unescaped bracket.
+        token_char = rf"(?:\\[{open_pattern}{close_pattern}]|[^\s{open_pattern}{close_pattern}])"
         if node_pattern is None:
-            node_pattern = rf"[^\s{open_pattern}{close_pattern}]+"
+            node_pattern = rf"{token_char}+"
         if leaf_pattern is None:
-            leaf_pattern = rf"[^\s{open_pattern}{close_pattern}]+"
+            leaf_pattern = rf"{token_char}+"
         token_re = re.compile(
             r"%s\s*(%s)?|%s|(%s)"
             % (open_pattern, node_pattern, close_pattern, leaf_pattern)


### PR DESCRIPTION
Fixes #1706.

`Tree.fromstring()` couldn't handle a leaf or label containing an escaped bracket, because the tokenizer split on every `(`/`)`:

```python
Tree.fromstring(r"(S \))")  # used to raise ValueError
```

The default node/leaf pattern now also matches a backslash-escaped bracket (`\(` or `\)`) as a normal token character. The escape is kept verbatim, so it round-trips: `(S \))` parses to a leaf `\)` and prints back as `(S \))` — no `-RRB-`-style placeholder, matching @tomaarsen's suggestion on the issue. Normal parsing is unaffected.

Added unit tests (there wasn't a dedicated `fromstring` test module before).