### PR TITLE
use exact thirds in masi_distance (fixes #3361)

### DIFF
--- a/nltk/metrics/distance.py
+++ b/nltk/metrics/distance.py
@@ -240,7 +240,7 @@ def masi_distance(label1, label2):
 
     >>> from nltk.metrics import masi_distance
     >>> masi_distance(set([1, 2]), set([1, 2, 3, 4]))
-    0.665
+    0.6666666666666667
 
     Passonneau 2006, Measuring Agreement on Set-Valued Items (MASI)
     for Semantic and Pragmatic Annotation.
@@ -253,9 +253,9 @@ def masi_distance(label1, label2):
     if len_label1 == len_label2 and len_label1 == len_intersection:
         m = 1
     elif len_intersection == min(len_label1, len_label2):
-        m = 0.67
+        m = 2 / 3
     elif len_intersection > 0:
-        m = 0.33
+        m = 1 / 3
     else:
         m = 0
 

--- a/nltk/test/metrics.doctest
+++ b/nltk/test/metrics.doctest
@@ -77,7 +77,7 @@ Other distance measures:
     >>> print(jaccard_distance(s1, s2))
     0.6
     >>> print(masi_distance(s1, s2))
-    0.868
+    0.8666666666666667
 
 ----------------------
 Miscellaneous Measures


### PR DESCRIPTION
Fixes #3361.

`masi_distance` used the rounded weights `0.67` and `0.33`, but the MASI metric (Passonneau 2006) is defined with exact monotonicity values of 1, 2/3, 1/3, 0. The rounding makes the distance slightly off, e.g. for `{1,2}` vs `{1,2,3,4}` it returned `0.665` instead of the correct `2/3 = 0.6666...`.

Switched the two weights to `2 / 3` and `1 / 3` and updated the doctest in distance.py and the one in metrics.doctest to the exact values.
