### PR TITLE
Add feature structure constraints to CCG categories

### DIFF
--- a/nltk/ccg/api.py
+++ b/nltk/ccg/api.py
@@ -8,7 +8,28 @@
 from abc import ABCMeta, abstractmethod
 from functools import total_ordering
 
+from nltk.featstruct import FeatStruct, unify
 from nltk.internals import raise_unorderable_types
+from nltk.sem.logic import Variable
+
+
+def _freeze_features(features):
+    if features is None:
+        features = FeatStruct()
+    elif isinstance(features, FeatStruct):
+        features = features.copy()
+    else:
+        features = FeatStruct(features)
+    features.freeze()
+    return features
+
+
+def _feature_bindings(substitutions):
+    return {
+        variable: value
+        for variable, value in substitutions
+        if isinstance(variable, Variable)
+    }
 
 
 @total_ordering
@@ -254,12 +275,14 @@ class PrimitiveCategory(AbstractCCGCategory):
     Class representing primitive categories.
     Takes a string representation of the category, and a
     list of strings specifying the morphological subcategories.
+    Optional feature structures can also be used for key/value constraints.
     """
 
-    def __init__(self, categ, restrictions=[]):
+    def __init__(self, categ, restrictions=None, features=None):
         self._categ = categ
-        self._restrs = restrictions
-        self._comparison_key = (categ, tuple(restrictions))
+        self._restrs = list(restrictions or [])
+        self._features = _freeze_features(features)
+        self._comparison_key = (categ, tuple(self._restrs), repr(self._features))
 
     def is_primitive(self):
         return True
@@ -273,31 +296,54 @@ class PrimitiveCategory(AbstractCCGCategory):
     def restrs(self):
         return self._restrs
 
+    def features(self):
+        return self._features
+
     def categ(self):
         return self._categ
 
     # Substitution does nothing to a primitive category
     def substitute(self, subs):
-        return self
+        bindings = _feature_bindings(subs)
+        if not bindings or len(self._features) == 0:
+            return self
+        return PrimitiveCategory(
+            self._categ,
+            self._restrs,
+            self._features.substitute_bindings(bindings),
+        )
 
     # A primitive can be unified with a class of the same
     # base category, given that the other category shares all
-    # of its subclasses, or with a variable.
+    # of its subclasses and feature constraints, or with a variable.
     def can_unify(self, other):
-        if not other.is_primitive():
-            return None
         if other.is_var():
             return [(other, self)]
+        if not other.is_primitive():
+            return None
         if other.categ() == self.categ():
             for restr in self._restrs:
                 if restr not in other.restrs():
                     return None
-            return []
+            bindings = {}
+            if (
+                unify(
+                    self._features,
+                    other.features(),
+                    bindings,
+                    rename_vars=False,
+                )
+                is None
+            ):
+                return None
+            return list(bindings.items())
         return None
 
     def __str__(self):
-        if self._restrs == []:
+        if self._restrs == [] and len(self._features) == 0:
             return "%s" % self._categ
+        if len(self._features) > 0:
+            return f"{self._categ}{repr(self._features)}"
         restrictions = "[%s]" % ",".join(repr(r) for r in self._restrs)
         return f"{self._categ}{restrictions}"
 

--- a/nltk/ccg/lexicon.py
+++ b/nltk/ccg/lexicon.py
@@ -12,6 +12,7 @@ import re
 from collections import defaultdict
 
 from nltk.ccg.api import CCGVar, Direction, FunctionalCategory, PrimitiveCategory
+from nltk.featstruct import FeatStruct
 from nltk.internals import deprecated
 from nltk.sem.logic import Expression
 
@@ -19,12 +20,8 @@ from nltk.sem.logic import Expression
 # Regular expressions used for parsing components of the lexicon
 # ------------
 
-# Parses a primitive category and subscripts
-PRIM_RE = re.compile(r"""([A-Za-z]+)(\[[A-Za-z,]+\])?""")
-
-# Separates the next primitive category from the remainder of the
-# string
-NEXTPRIM_RE = re.compile(r"""([A-Za-z]+(?:\[[A-Za-z,]+\])?)(.*)""")
+# Parses a primitive category and any following annotation.
+PRIM_RE = re.compile(r"""([A-Za-z]+)(.*)""")
 
 # Separates the next application operator from the remainder.
 # The modifier slot also accepts `_`, marking a variable direction
@@ -150,7 +147,7 @@ def matchBrackets(string):
 
     while rest != "" and not rest.startswith(")"):
         if rest.startswith("("):
-            (part, rest) = matchBrackets(rest)
+            part, rest = matchBrackets(rest)
             inside = inside + part
         else:
             inside = inside + rest[0]
@@ -160,6 +157,28 @@ def matchBrackets(string):
     raise AssertionError("Unmatched bracket in string '" + string + "'")
 
 
+def matchSquareBrackets(string):
+    """
+    Separate a possibly nested square-bracket annotation from the rest of
+    the input.
+    """
+    rest = string[1:]
+    inside = "["
+    depth = 1
+
+    while rest != "":
+        char = rest[0]
+        inside = inside + char
+        rest = rest[1:]
+        if char == "[":
+            depth = depth + 1
+        elif char == "]":
+            depth = depth - 1
+            if depth == 0:
+                return (inside, rest)
+    raise AssertionError("Unmatched feature bracket in string '" + string + "'")
+
+
 def nextCategory(string):
     """
     Separate the string for the next portion of the category from the rest
@@ -167,7 +186,12 @@ def nextCategory(string):
     """
     if string.startswith("("):
         return matchBrackets(string)
-    return NEXTPRIM_RE.match(string).groups()
+
+    cat, rest = PRIM_RE.match(string).groups()
+    if rest.startswith("["):
+        annotation, rest = matchSquareBrackets(rest)
+        cat = cat + annotation
+    return (cat, rest)
 
 
 def parseApplication(app):
@@ -186,6 +210,18 @@ def parseSubscripts(subscr):
     return []
 
 
+def parsePrimitiveAnnotation(annotation):
+    """
+    Parse primitive category annotations as either legacy subscripts or
+    feature structures.
+    """
+    if not annotation:
+        return ([], None)
+    if "=" in annotation:
+        return ([], FeatStruct(annotation))
+    return (parseSubscripts(annotation), None)
+
+
 def parsePrimitiveCategory(chunks, primitives, families, var):
     """
     Parse a primitive category
@@ -194,14 +230,14 @@ def parsePrimitiveCategory(chunks, primitives, families, var):
     correct `CCGVar`.
     """
     if chunks[0] == "var":
-        if chunks[1] is None:
+        if not chunks[1]:
             if var is None:
                 var = CCGVar()
             return (var, var)
 
     catstr = chunks[0]
     if catstr in families:
-        (cat, cvar) = families[catstr]
+        cat, cvar = families[catstr]
         if var is None:
             var = cvar
         else:
@@ -209,8 +245,8 @@ def parsePrimitiveCategory(chunks, primitives, families, var):
         return (cat, var)
 
     if catstr in primitives:
-        subscrs = parseSubscripts(chunks[1])
-        return (PrimitiveCategory(catstr, subscrs), var)
+        subscrs, features = parsePrimitiveAnnotation(chunks[1])
+        return (PrimitiveCategory(catstr, subscrs, features), var)
     raise AssertionError(
         "String '" + catstr + "' is neither a family nor primitive category."
     )
@@ -221,13 +257,13 @@ def augParseCategory(line, primitives, families, var=None):
     Parse a string representing a category, and returns a tuple with
     (possibly) the CCG variable for the category
     """
-    (cat_string, rest) = nextCategory(line)
+    cat_string, rest = nextCategory(line)
 
     if cat_string.startswith("("):
-        (res, var) = augParseCategory(cat_string[1:-1], primitives, families, var)
+        res, var = augParseCategory(cat_string[1:-1], primitives, families, var)
 
     else:
-        (res, var) = parsePrimitiveCategory(
+        res, var = parsePrimitiveCategory(
             PRIM_RE.match(cat_string).groups(), primitives, families, var
         )
 
@@ -236,11 +272,11 @@ def augParseCategory(line, primitives, families, var=None):
         direction = parseApplication(app[0:3])
         rest = app[3]
 
-        (cat_string, rest) = nextCategory(rest)
+        cat_string, rest = nextCategory(rest)
         if cat_string.startswith("("):
-            (arg, var) = augParseCategory(cat_string[1:-1], primitives, families, var)
+            arg, var = augParseCategory(cat_string[1:-1], primitives, families, var)
         else:
-            (arg, var) = parsePrimitiveCategory(
+            arg, var = parsePrimitiveCategory(
                 PRIM_RE.match(cat_string).groups(), primitives, families, var
             )
         res = FunctionalCategory(res, arg, direction)
@@ -271,9 +307,9 @@ def fromstring(lex_str, include_semantics=False):
             ]
         else:
             # Either a family definition, or a word definition
-            (ident, sep, rhs) = LEX_RE.match(line).groups()
-            (catstr, semantics_str) = RHS_RE.match(rhs).groups()
-            (cat, var) = augParseCategory(catstr, primitives, families)
+            ident, sep, rhs = LEX_RE.match(line).groups()
+            catstr, semantics_str = RHS_RE.match(rhs).groups()
+            cat, var = augParseCategory(catstr, primitives, families)
 
             if sep == "::":
                 # Family definition

--- a/nltk/test/unit/test_ccg_features.py
+++ b/nltk/test/unit/test_ccg_features.py
@@ -1,0 +1,72 @@
+import unittest
+
+from nltk.ccg import chart, lexicon
+
+
+class TestCCGFeatureStructures(unittest.TestCase):
+    def test_parse_feature_structure_category(self):
+        lex = lexicon.fromstring(
+            r"""
+            :- S, NP
+            he => NP[AGR=sg,CASE=nom]
+            """
+        )
+
+        category = lex.categories("he")[0].categ()
+
+        self.assertEqual(category.features()["AGR"], "sg")
+        self.assertEqual(category.features()["CASE"], "nom")
+
+    def test_feature_structure_unification_rejects_conflicting_values(self):
+        lex = lexicon.fromstring(
+            r"""
+            :- S, NP
+            he => NP[AGR=sg]
+            they => NP[AGR=pl]
+            eats => S\NP[AGR=sg]
+            """
+        )
+
+        subject = lex.categories("he")[0].categ()
+        plural_subject = lex.categories("they")[0].categ()
+        verb_argument = lex.categories("eats")[0].categ().arg()
+
+        self.assertEqual(verb_argument.can_unify(subject), [])
+        self.assertIsNone(verb_argument.can_unify(plural_subject))
+
+    def test_feature_variable_bindings_substitute_into_result(self):
+        lex = lexicon.fromstring(
+            r"""
+            :- S, NP
+            agreed => S[AGR=?a]\NP[AGR=?a]
+            he => NP[AGR=sg]
+            """
+        )
+
+        verb = lex.categories("agreed")[0].categ()
+        subject = lex.categories("he")[0].categ()
+
+        substitutions = verb.arg().can_unify(subject)
+        result = verb.res().substitute(substitutions)
+
+        self.assertEqual(result.features()["AGR"], "sg")
+
+    def test_parser_uses_feature_structures_for_agreement(self):
+        lex = lexicon.fromstring(
+            r"""
+            :- S, NP
+            he => NP[AGR=sg]
+            they => NP[AGR=pl]
+            eats => S\NP[AGR=sg]
+            eat => S\NP[AGR=pl]
+            """
+        )
+        parser = chart.CCGChartParser(lex, chart.ApplicationRuleSet)
+
+        self.assertEqual(len(list(parser.parse("he eats".split()))), 1)
+        self.assertEqual(len(list(parser.parse("they eat".split()))), 1)
+        self.assertEqual(list(parser.parse("they eats".split())), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This is a scoped first slice for #3412. It adds feature-structure constraints to primitive CCG categories while preserving the existing category API and legacy subscript syntax.

Changes:
- store optional frozen `FeatStruct` values on `PrimitiveCategory` so CCG chart edges remain hashable
- unify primitive category feature structures and propagate feature-variable bindings through substitution
- parse feature annotations such as `NP[AGR=sg,CASE=nom]`, while keeping legacy annotations such as `NP[sg]`
- add focused parser and unification tests for agreement-style constraints

## Validation

- `python -m pytest nltk/test/ccg.doctest nltk/test/ccg_semantics.doctest nltk/test/unit/test_ccg_features.py nltk/test/unit/test_ccg_dir.py -q`
- `python -m pre_commit run --all-files`
- `git diff --check`

Refs #3412