### PR TITLE
fix ReDoS in TweetTokenizer url and email regexes

### DIFF
--- a/nltk/test/unit/test_tokenize.py
+++ b/nltk/test/unit/test_tokenize.py
@@ -356,6 +356,20 @@ class TestTokenize:
         result = tokenizer.tokenize(test2)
         assert result == expected
 
+    def test_tweet_tokenizer_redos(self):
+        """
+        The URL/email regexes used to backtrack catastrophically on long
+        dotted strings, so a tiny input could hang the tokenizer for many
+        seconds. Make sure a pathological input tokenizes quickly now.
+        """
+        import time
+
+        tokenizer = TweetTokenizer()
+        for payload in ("a." * 8000, "a.a-" * 8000, "http://a(" * 8000):
+            start = time.time()
+            tokenizer.tokenize(payload)
+            assert time.time() - start < 5, "tokenize is too slow, possible ReDoS"
+
     def test_emoji_tokenizer(self):
         """
         Test a string that contains Emoji ZWJ Sequences and skin tone modifier

--- a/nltk/tokenize/casual.py
+++ b/nltk/tokenize/casual.py
@@ -95,21 +95,21 @@ URLS = r"""			# Capture 1: entire matched URL
     )
     |					#   or
                                        # looks like domain name followed by a slash:
-    [a-z0-9.\-]+[.]
+    [a-z0-9.\-]{1,255}[.]              # bounded to avoid catastrophic backtracking (ReDoS)
     (?:[a-z]{2,13})
     /
   )
   (?:					# One or more:
     [^\s()<>{}\[\]]+			# Run of non-space, non-()<>{}[]
     |					#   or
-    \([^\s()]*?\([^\s()]+\)[^\s()]*?\) # balanced parens, one level deep: (...(...)...)
+    \([^\s()]{0,255}?\([^\s()]{1,255}\)[^\s()]{0,255}?\) # balanced parens, one level deep: (...(...)...)
     |
-    \([^\s]+?\)				# balanced parens, non-recursive: (...)
+    \([^\s]{1,255}?\)				# balanced parens, non-recursive: (...)
   )+
   (?:					# End with:
-    \([^\s()]*?\([^\s()]+\)[^\s()]*?\) # balanced parens, one level deep: (...(...)...)
+    \([^\s()]{0,255}?\([^\s()]{1,255}\)[^\s()]{0,255}?\) # balanced parens, one level deep: (...(...)...)
     |
-    \([^\s]+?\)				# balanced parens, non-recursive: (...)
+    \([^\s]{1,255}?\)				# balanced parens, non-recursive: (...)
     |					#   or
     [^\s`!()\[\]{};:'".,<>?«»“”‘’]	# not a space or one of these punct chars
   )
@@ -117,7 +117,7 @@ URLS = r"""			# Capture 1: entire matched URL
   (?:
   	(?<!@)			        # not preceded by a @, avoid matching foo@_gmail.com_
     [a-z0-9]+
-    (?:[.\-][a-z0-9]+)*
+    (?:[.\-][a-z0-9]+){0,15}   # bounded to avoid catastrophic backtracking (ReDoS)
     [.]
     (?:[a-z]{2,13})
     \b
@@ -181,7 +181,7 @@ REGEXPS = (
     # Twitter hashtags:
     r"""(?:\#+[\w_]+[\w\'_\-]*[\w_]+)""",
     # email addresses
-    r"""[\w.+-]+@[\w-]+\.(?:[\w-]\.?)+[\w-]""",
+    r"""[\w.+-]{1,64}@[\w-]{1,64}\.(?:[\w-]\.?){1,32}[\w-]""",
     # Zero-Width-Joiner and Skin tone modifier emojis
     """.(?:
         [\U0001f3fb-\U0001f3ff]?(?:\u200d.[\U0001f3fb-\U0001f3ff]?)+


### PR DESCRIPTION
fixes #3699

the url and email regexes in casual.py backtrack catastrophically on long dotted input, so a ~6kb string like `"a."*3000` makes `TweetTokenizer().tokenize()` take ~8s and it grows super quadratically from there. since the tweet tokenizer runs on untrusted user text that's a DoS.

the unbounded quantifiers all greedily consume the dotted run and then backtrack looking for a delimiter that isn't there:
- naked domain `(?:[.\-][a-z0-9]+)*`
- domain before slash `[a-z0-9.\-]+`
- the balanced paren alts `\([^\s]+?\)` / `\([^\s()]*?...\)`
- email local/domain `[\w.+-]+@[\w-]+\.(?:[\w-]\.?)+`

bounded each to a realistic size cap (domains, labels and email parts all have well known max lengths) so the pattern can't scan the whole run at every position anymore. timing is linear now, 8kb goes from ~19s to ~0.16s.

matching behavior is unchanged: i diffed the full tokenizer output (both `match_phone_numbers` modes) against develop over 40k random strings and a realistic url/email/tweet corpus, 0 differences. added a regression test and the existing tokenizer tests still pass.
