### PR TITLE
Fix typos in classify, tokenize, and parse modules

### DIFF
--- a/nltk/classify/naivebayes.py
+++ b/nltk/classify/naivebayes.py
@@ -43,7 +43,7 @@ from nltk.probability import DictionaryProbDist, ELEProbDist, FreqDist, sum_logs
 class NaiveBayesClassifier(ClassifierI):
     """
     A Naive Bayes classifier.  Naive Bayes classifiers are
-    paramaterized by two probability distributions:
+    parameterized by two probability distributions:
 
       - P(label) gives the probability that an input will receive each
         label, given no information about the input's features.

--- a/nltk/classify/positivenaivebayes.py
+++ b/nltk/classify/positivenaivebayes.py
@@ -38,7 +38,7 @@ Some sentences about sports:
     >>> sports_sentences = [ 'The team dominated the game',
     ...                      'They lost the ball',
     ...                      'The game was intense',
-    ...                      'The goalkeeper catched the ball',
+    ...                      'The goalkeeper caught the ball',
     ...                      'The other team controlled the ball' ]
 
 Mixed topics, including sports:

--- a/nltk/classify/weka.py
+++ b/nltk/classify/weka.py
@@ -1,4 +1,4 @@
-# Natural Language Toolkit: Interface to Weka Classsifiers
+# Natural Language Toolkit: Interface to Weka Classifiers
 #
 # Copyright (C) 2001-2026 NLTK Project
 # Author: Edward Loper <edloper@gmail.com>

--- a/nltk/parse/shiftreduce.py
+++ b/nltk/parse/shiftreduce.py
@@ -210,7 +210,7 @@ class ShiftReduceParser(ParserI):
         """
         # 1: just show shifts.
         # 2: show shifts & reduces
-        # 3: display which tokens & productions are shifed/reduced
+        # 3: display which tokens & productions are shifted/reduced
         self._trace = trace
 
     def _trace_stack(self, stack, remaining_text, marker=" "):

--- a/nltk/tokenize/nist.py
+++ b/nltk/tokenize/nist.py
@@ -125,7 +125,7 @@ class NISTTokenizer(TokenizerI):
     INTERNATIONAL_REGEXES = [NONASCII, PUNCT_1, PUNCT_2, SYMBOLS]
 
     def lang_independent_sub(self, text):
-        """Performs the language independent string substituitions."""
+        """Performs the language independent string substitutions."""
         # It's a strange order of regexes.
         # It'll be better to unescape after STRIP_EOL_HYPHEN
         # but let's keep it close to the original NIST implementation.

--- a/nltk/tokenize/stanford_segmenter.py
+++ b/nltk/tokenize/stanford_segmenter.py
@@ -32,7 +32,7 @@ class StanfordSegmenter(TokenizerI):
     """Interface to the Stanford Segmenter
 
     If stanford-segmenter version is older than 2016-10-31, then path_to_slf4j
-    should be provieded, for example::
+    should be provided, for example::
 
         seg = StanfordSegmenter(path_to_slf4j='/YOUR_PATH/slf4j-api.jar')
 


### PR DESCRIPTION
Fix several spelling mistakes found by codespell across three submodules.

## Changes

- `nltk/classify/naivebayes.py`: `paramaterized` -> `parameterized`
- `nltk/classify/weka.py`: `Classsifiers` -> `Classifiers` (triple-s in comment)
- `nltk/classify/positivenaivebayes.py`: `catched` -> `caught`
- `nltk/tokenize/nist.py`: `substituitions` -> `substitutions`
- `nltk/tokenize/stanford_segmenter.py`: `provieded` -> `provided`
- `nltk/parse/shiftreduce.py`: `shifed` -> `shifted`

All fixes are in docstrings and comments only — no logic changes.