### PR TITLE
add tests for transitive_closure

### DIFF
--- a/nltk/test/unit/test_util.py
+++ b/nltk/test/unit/test_util.py
@@ -106,5 +106,12 @@ def test_transitive_closure_empty():
 
 def test_transitive_closure_does_not_mutate_input():
     graph = {"a": {"b"}, "b": set()}
+    original_sets = {k: v for k, v in graph.items()}
+    snapshot = {k: set(v) for k, v in graph.items()}
+
     transitive_closure(graph)
-    assert graph == {"a": {"b"}, "b": set()}
+
+    assert graph == snapshot
+    assert set(graph) == set(snapshot)
+    # the same set objects, not new-but-equal ones
+    assert all(graph[k] is original_sets[k] for k in snapshot)

--- a/nltk/test/unit/test_util.py
+++ b/nltk/test/unit/test_util.py
@@ -1,6 +1,6 @@
 import pytest
 
-from nltk.util import everygrams
+from nltk.util import everygrams, transitive_closure
 
 
 @pytest.fixture
@@ -80,3 +80,31 @@ def test_everygrams_pad_left(everygram_input):
     ]
     output = list(everygrams(everygram_input, max_len=3, pad_left=True))
     assert output == expected_output
+
+
+def test_transitive_closure_chain():
+    graph = {"a": {"b"}, "b": {"c"}, "c": set()}
+    expected = {"a": {"b", "c"}, "b": {"c"}, "c": set()}
+    assert transitive_closure(graph) == expected
+
+
+def test_transitive_closure_reflexive():
+    graph = {"a": {"b"}, "b": {"c"}, "c": set()}
+    expected = {"a": {"a", "b", "c"}, "b": {"b", "c"}, "c": {"c"}}
+    assert transitive_closure(graph, reflexive=True) == expected
+
+
+def test_transitive_closure_cycle():
+    graph = {"a": {"b"}, "b": {"a"}}
+    expected = {"a": {"a", "b"}, "b": {"a", "b"}}
+    assert transitive_closure(graph) == expected
+
+
+def test_transitive_closure_empty():
+    assert transitive_closure({}) == {}
+
+
+def test_transitive_closure_does_not_mutate_input():
+    graph = {"a": {"b"}, "b": set()}
+    transitive_closure(graph)
+    assert graph == {"a": {"b"}, "b": set()}


### PR DESCRIPTION
noticed `transitive_closure` in `nltk/util.py` has no unit tests, so added a few to `test_util.py` next to the existing everygrams ones.

covers the cases i cared about while reading it:
- plain closure over a chain a->b->c
- the `reflexive=True` path (each node includes itself)
- a cycle, to make sure it terminates and includes both nodes
- empty graph
- that it doesn't mutate the input dict (it copies the sets internally, worth pinning so a future refactor doesn't break it)

all green locally, pre-commit passes.