### PR TITLE
Add missing 'ucion' suffix to the Spanish Snowball stemmer

### DIFF
--- a/nltk/stem/snowball.py
+++ b/nltk/stem/snowball.py
@@ -5383,6 +5383,7 @@ class SpanishStemmer(_StandardStemmer):
         "acion",
         "aciones",
         "uciones",
+        "ucion",
         "adoras",
         "adores",
         "ancias",
@@ -5639,7 +5640,7 @@ class SpanishStemmer(_StandardStemmer):
                     word = suffix_replace(word, suffix, "log")
                     rv = suffix_replace(rv, suffix, "log")
 
-                elif suffix in ("uci\xf3n", "uciones"):
+                elif suffix in ("uci\xf3n", "uciones", "ucion"):
                     word = suffix_replace(word, suffix, "u")
                     rv = suffix_replace(rv, suffix, "u")
 

--- a/nltk/test/unit/test_stem.py
+++ b/nltk/test/unit/test_stem.py
@@ -58,6 +58,12 @@ class SnowballTest(unittest.TestCase):
         # The word 'algue' was raising an IndexError
         assert stemmer.stem("algue") == "algu"
 
+        # Unaccented '-ucion' (a common misspelling of '-ución') was left
+        # unstemmed, unlike the accented 'ución', the plural 'uciones' and the
+        # parallel '-acion', all of which the algorithm already handles.
+        assert stemmer.stem("constitucion") == "constitu"
+        assert stemmer.stem("resolucion") == "resolu"
+
     def test_short_strings_bug(self):
         stemmer = SnowballStemmer("english")
         assert stemmer.stem("y's") == "y"


### PR DESCRIPTION
## Problem

The Spanish Snowball stemmer leaves the unaccented singular `-ucion` suffix unstemmed, even though it already handles the accented `-ución`, the plural `-uciones`, and the exactly parallel `-acion`:

```python
>>> from nltk.stem.snowball import SnowballStemmer
>>> s = SnowballStemmer("spanish")
>>> s.stem("constitucion")   # -> 'constitucion'   (should be 'constitu')
>>> s.stem("constitución")   # -> 'constitu'        accented form works
>>> s.stem("resoluciones")   # -> 'resolu'          plural works
>>> s.stem("informacion")    # -> 'inform'          parallel '-acion' works
```

`-acion` (the unaccented singular of `-ación`) was added in #2725, but the exactly parallel `-ucion` was never added, leaving this asymmetry.

## Why `constitu` is correct

The official Snowball Spanish algorithm (`algorithms/spanish.sbl`) lists `ucion` as a step-1 suffix, in the same `R2 <- 'u'` group as `ución`/`uciones`:

```
'uci{o'}n' 'uciones'
'ucion' // Misspelling of '-ución'.
```

## Fix

Add `"ucion"` to `SpanishStemmer.__step1_suffixes` and to the `("ución", "uciones")` replacement branch. Two lines.

## Verification

Ran the stemmer over the official 28,378-word Spanish vocabulary (`snowballstem/snowball-data`) before and after the change: **exactly two words change** — `constitucion → constitu` and `resolucion → resolu` — and **no other word is affected** (zero regressions). Added the two words as assertions in `SnowballTest::test_spanish`; the test fails without the change and passes with it. `ruff check` is clean.

---

This PR was authored by an AI coding agent (Claude Code) running on this account: the AI found the bug, verified it against the official Snowball algorithm and reference vocabulary, wrote the fix and the test, and wrote this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.
