### PR TITLE
Expand ~ in env-var paths (NLTK_DATA, find_file_iter)

### DIFF
--- a/nltk/data.py
+++ b/nltk/data.py
@@ -150,7 +150,7 @@ path = []
 
 # User-specified locations:
 _paths_from_env = os.environ.get("NLTK_DATA", "").split(os.pathsep)
-path += [d for d in _paths_from_env if d]
+path += [os.path.expanduser(d) for d in _paths_from_env if d]
 if "APPENGINE_RUNTIME" not in os.environ and os.path.expanduser("~/") != "~/":
     path.append(os.path.expanduser("~/nltk_data"))
 

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -628,6 +628,7 @@ def find_file_iter(
                 yield os.environ[env_var]
 
             for env_dir in os.environ[env_var].split(os.pathsep):
+                env_dir = os.path.expanduser(env_dir)
                 # Check if the environment variable contains a direct path to the bin
                 if os.path.isfile(env_dir):
                     if verbose:

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -623,9 +623,12 @@ def find_file_iter(
     # Check environment variables
     for env_var in env_vars:
         if env_var in os.environ:
-            if finding_dir:  # This is to file a directory instead of file
-                yielded = True
-                yield os.environ[env_var]
+            if finding_dir:  # This is to find a directory instead of file
+                for env_dir in os.environ[env_var].split(os.pathsep):
+                    env_dir = os.path.expanduser(env_dir)
+                    if env_dir:
+                        yielded = True
+                        yield env_dir
 
             for env_dir in os.environ[env_var].split(os.pathsep):
                 env_dir = os.path.expanduser(env_dir)

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -50,7 +50,7 @@ def _get_allowed_roots():
             try:
                 # Handle both string paths and PathPointer objects
                 raw_p = p.path if hasattr(p, "path") else p
-                roots.add(Path(str(raw_p)).resolve())
+                roots.add(Path(str(raw_p)).expanduser().resolve())
             except (OSError, ValueError, RuntimeError):
                 continue
 


### PR DESCRIPTION
Fixes #2825

Apply \os.path.expanduser\ to environment-variable path entries so
that paths containing \~\ resolve to the user's home directory:

- \data.py\: expand \~\ in each \NLTK_DATA\ path entry
- \pathsec.py\: use \Path.expanduser()\ before \esolve()\ on each
  \NLTK_DATA\ entry
- \internals.py\ \ind_file_iter\: expand \~\ in each env-var path
  component (already done in \ind_jar_iter\; this makes the other
  search functions consistent)

\ind_binary_iter\ is covered because it delegates to \ind_file_iter\.