### PR TITLE
Prevent module hijacking in inline imports

### DIFF
--- a/nltk/__init__.py
+++ b/nltk/__init__.py
@@ -37,8 +37,14 @@ def _postpone(path):
 
 
 # Deprioritize dynamic and explicit current working directories
-for p in ["", os.getcwd()]:
+for p in ["", "."]:
     _postpone(p)
+
+try:
+    _postpone(os.getcwd())
+except OSError:
+    # Occurs if the current working directory was deleted after the Python process started
+    pass
 
 # //////////////////////////////////////////////////////
 # Metadata

--- a/nltk/__init__.py
+++ b/nltk/__init__.py
@@ -20,6 +20,25 @@ isort:skip_file
 
 import os
 import importlib
+import sys
+
+
+def _postpone(path):
+    """
+    Moves a path to the end of sys.path to enforce a restrictive module
+    search policy, preventing untrusted search path vulnerabilities (CWE-426).
+    """
+    if path in sys.path:
+        # Purge all instances of the path first
+        while path in sys.path:
+            sys.path.remove(path)
+        # Add a single instance back at the end
+        sys.path.append(path)
+
+
+# Deprioritize dynamic and explicit current working directories
+for p in ["", os.getcwd()]:
+    _postpone(p)
 
 # //////////////////////////////////////////////////////
 # Metadata

--- a/nltk/test/unit/test_security.py
+++ b/nltk/test/unit/test_security.py
@@ -1,51 +1,48 @@
-"""
-Unit tests for security-related patches and vulnerability regressions.
-"""
-
-import importlib
 import os
+import subprocess
 import sys
 import tempfile
 
 
 def test_module_hijacking_prevention():
-    """
-    Simulate a search path attack by dropping a malicious module in the CWD,
-    and ensure the system loads the safe installed module instead.
-    """
-    # Import nltk to ensure the sys.path mitigation is active
-    import nltk
+    """Ensure inline imports do not resolve from the current working directory."""
+    with tempfile.TemporaryDirectory() as d:
+        # 1. Attacker payload that prints a flag when imported
+        with open(os.path.join(d, "joblib.py"), "w") as f:
+            f.write("print('HIJACK_SUCCESS')\n")
 
-    with tempfile.TemporaryDirectory() as temp_dir:
-        # 1. Setup the attacker payload
-        malicious_module = os.path.join(temp_dir, "joblib.py")
-        with open(malicious_module, "w") as f:
-            f.write("hijacked = True\n")
+        # 2. Victim script explicitly importing the function to avoid NLTK namespace collisions
+        with open(os.path.join(d, "victim.py"), "w") as f:
+            f.write(
+                "from nltk.util import parallelize_preprocess\n"
+                "list(parallelize_preprocess(str.upper, ['a'], processes=1))\n"
+            )
 
-        # 2. Simulate an application changing to the attacker's directory
-        original_cwd = os.getcwd()
-        os.chdir(temp_dir)
+        # 3. Ensure subprocess uses the local, patched NLTK repository
+        env = os.environ.copy()
+        repo_root = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "..", "..", "..")
+        )
+        env["PYTHONPATH"] = repo_root + (
+            os.pathsep + env["PYTHONPATH"] if "PYTHONPATH" in env else ""
+        )
 
-        try:
-            # Clear joblib from the cache if it was already loaded by other tests,
-            # forcing Python to search sys.path again.
-            if "joblib" in sys.modules:
-                del sys.modules["joblib"]
+        # 4. Execute in the isolated directory
+        res = subprocess.run(
+            [sys.executable, "victim.py"],
+            cwd=d,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
 
-            # Invalidate Python's directory cache so it registers the newly created file
-            importlib.invalidate_caches()
+        # 5. Print raw output on failure so pytest captures it fully without truncation
+        if "HIJACK_SUCCESS" in res.stdout or res.returncode != 0:
+            print("--- SUBPROCESS STDOUT ---\n", res.stdout)
+            print("--- SUBPROCESS STDERR ---\n", res.stderr)
 
-            # 3. Trigger the import (simulating parallelize_preprocess behavior)
-            import joblib
-
-            # 4. Verify the exploit failed
-            assert (
-                getattr(joblib, "hijacked", False) is False
-            ), "Vulnerability: Loaded attacker module from CWD!"
-
-        finally:
-            # Restore the environment so we don't break subsequent tests
-            os.chdir(original_cwd)
-            if "joblib" in sys.modules:
-                del sys.modules["joblib"]
-            importlib.invalidate_caches()
+        # 6. Verify the exploit failed and the script executed normally
+        assert (
+            "HIJACK_SUCCESS" not in res.stdout
+        ), "Security Failure: Loaded module from CWD."
+        assert res.returncode == 0, "Victim script failed unexpectedly."

--- a/nltk/test/unit/test_security.py
+++ b/nltk/test/unit/test_security.py
@@ -2,37 +2,15 @@
 Unit tests for security-related patches and vulnerability regressions.
 """
 
+import importlib
 import os
 import sys
 import tempfile
 
 
-def test_sys_path_restrictive_posture():
-    """
-    Verify CWE-427 mitigation: dynamic CWD ('') and explicit CWD should be deprioritized
-    to the end of sys.path to enforce a restrictive module search policy.
-    """
-    # Import nltk to ensure __init__.py logic has run
-    import nltk
-
-    cwd = os.getcwd()
-
-    # If the dynamic CWD is in the path, it must not be the first element
-    if "" in sys.path:
-        assert (
-            sys.path.index("") > 0
-        ), "Security Failure: Dynamic CWD ('') is at the front of sys.path"
-
-    # If the explicit CWD is in the path, it must not be the first element
-    if cwd in sys.path:
-        assert (
-            sys.path.index(cwd) > 0
-        ), f"Security Failure: Explicit CWD ({cwd}) is at the front of sys.path"
-
-
 def test_module_hijacking_prevention():
     """
-    Simulate a CWE-427 attack by dropping a malicious module in the CWD,
+    Simulate a search path attack by dropping a malicious module in the CWD,
     and ensure the system loads the safe installed module instead.
     """
     # Import nltk to ensure the sys.path mitigation is active
@@ -60,7 +38,7 @@ def test_module_hijacking_prevention():
             # 4. Verify the exploit failed
             assert (
                 getattr(joblib, "hijacked", False) is False
-            ), "CWE-427 Vulnerability: Loaded attacker module from CWD!"
+            ), "Vulnerability: Loaded attacker module from CWD!"
 
         finally:
             # Restore the environment so we don't break subsequent tests

--- a/nltk/test/unit/test_security.py
+++ b/nltk/test/unit/test_security.py
@@ -32,6 +32,9 @@ def test_module_hijacking_prevention():
             if "joblib" in sys.modules:
                 del sys.modules["joblib"]
 
+            # Invalidate Python's directory cache so it registers the newly created file
+            importlib.invalidate_caches()
+
             # 3. Trigger the import (simulating parallelize_preprocess behavior)
             import joblib
 
@@ -45,3 +48,4 @@ def test_module_hijacking_prevention():
             os.chdir(original_cwd)
             if "joblib" in sys.modules:
                 del sys.modules["joblib"]
+            importlib.invalidate_caches()

--- a/nltk/test/unit/test_security.py
+++ b/nltk/test/unit/test_security.py
@@ -1,0 +1,69 @@
+"""
+Unit tests for security-related patches and vulnerability regressions.
+"""
+
+import os
+import sys
+import tempfile
+
+
+def test_sys_path_restrictive_posture():
+    """
+    Verify CWE-427 mitigation: dynamic CWD ('') and explicit CWD should be deprioritized
+    to the end of sys.path to enforce a restrictive module search policy.
+    """
+    # Import nltk to ensure __init__.py logic has run
+    import nltk
+
+    cwd = os.getcwd()
+
+    # If the dynamic CWD is in the path, it must not be the first element
+    if "" in sys.path:
+        assert (
+            sys.path.index("") > 0
+        ), "Security Failure: Dynamic CWD ('') is at the front of sys.path"
+
+    # If the explicit CWD is in the path, it must not be the first element
+    if cwd in sys.path:
+        assert (
+            sys.path.index(cwd) > 0
+        ), f"Security Failure: Explicit CWD ({cwd}) is at the front of sys.path"
+
+
+def test_module_hijacking_prevention():
+    """
+    Simulate a CWE-427 attack by dropping a malicious module in the CWD,
+    and ensure the system loads the safe installed module instead.
+    """
+    # Import nltk to ensure the sys.path mitigation is active
+    import nltk
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # 1. Setup the attacker payload
+        malicious_module = os.path.join(temp_dir, "joblib.py")
+        with open(malicious_module, "w") as f:
+            f.write("hijacked = True\n")
+
+        # 2. Simulate an application changing to the attacker's directory
+        original_cwd = os.getcwd()
+        os.chdir(temp_dir)
+
+        try:
+            # Clear joblib from the cache if it was already loaded by other tests,
+            # forcing Python to search sys.path again.
+            if "joblib" in sys.modules:
+                del sys.modules["joblib"]
+
+            # 3. Trigger the import (simulating parallelize_preprocess behavior)
+            import joblib
+
+            # 4. Verify the exploit failed
+            assert (
+                getattr(joblib, "hijacked", False) is False
+            ), "CWE-427 Vulnerability: Loaded attacker module from CWD!"
+
+        finally:
+            # Restore the environment so we don't break subsequent tests
+            os.chdir(original_cwd)
+            if "joblib" in sys.modules:
+                del sys.modules["joblib"]


### PR DESCRIPTION
Fix #3709: this PR mitigates a vulnerability caused by inline imports (such as `joblib` and `tqdm`) resolving against attacker-controlled modules in the current working directory. 

It resolves the issue by safely deprioritizing the current working directory (`''` and `os.getcwd()`) in `sys.path` during NLTK's initialization, ensuring that standard libraries and globally installed packages are always searched first.

### A Note on Vulnerability Classification (CWE-426 vs. CWE-427)
This vulnerability is often classified as CWE-426 (Untrusted Search Path), but it may be more adequate to track it under CWE-427. CWE-426 applies when an attacker can actively modify the search path itself (e.g., hijacking environment variables). In this case, the attacker does not control the search path; rather, they are writing a malicious payload to a directory that Python's default permissive path already trusts (the current working directory). Classifying this as CWE-427 more accurately reflects the issue and justifies our fix of enforcing a restrictive path resolution policy.

### Why this approach over a `_secure_import` utility?
While introducing a centralized `_secure_import` wrapper function was considered, modifying `sys.path` directly in `__init__.py` is a more robust architectural choice for the following reasons:

* **Zero Refactoring:** It eliminates the vulnerability without requiring us to track down and rewrite every lazy import scattered across the repository. 
* **Future-Proof Security:** A custom wrapper function relies on developers remembering to use it. By shifting the entire package from a permissive to a restrictive module-loading policy at startup, we guarantee that any future inline imports added by contributors remain secure by default.
* **Maintains Performance:** We retain the startup speed and memory benefits of lazy-loading heavy dependencies, without introducing the runtime overhead of a wrapper function or context manager on every call.
* **Standard Idioms:** It keeps the codebase clean and standard. Contributors can continue using standard Python `import` statements natively inside functions when necessary.

### Custom Module Usage
For users who legitimately need to shadow an installed dependency with a customized local module, we recommend explicitly inserting the target directory at the front of the search path (e.g., `sys.path.insert(0, '/path/to/custom_module')`) before importing NLTK. Because this explicitly targets a specific directory rather than relying on the implicit current working directory, this security patch will safely ignore it and respect the explicitly declared resolution order.