### PR TITLE
fix(security): validate types after wordnet_app pickle deserialization

### DIFF
--- a/nltk/app/wordnet_app.py
+++ b/nltk/app/wordnet_app.py
@@ -726,15 +726,27 @@ class Reference:
         """
         Decode a reference encoded with Reference.encode
 
-        :raises ValueError: if the decoded data isn't shaped like a
-            genuine Reference (word: str, synset_relations: dict).
+        :raises ValueError: if the input isn't valid base64/pickle data, or
+            if the decoded data isn't shaped like a genuine Reference
+            (word: str, synset_relations: dict[str, set]).
             RestrictedUnpickler only blocks class/function reconstruction;
-            it does not guarantee the *type* of the objects it returns, so
-            the shape must still be checked before use.
+            it does not guarantee the *type* or *shape* of what it returns,
+            so that must still be checked before use. Any failure while
+            decoding, unpickling, or unpacking the payload is normalized to
+            ValueError so callers only need to guard against one exception
+            type.
         """
-        string = base64.urlsafe_b64decode(string.encode())
-        word, synset_relations = RestrictedUnpickler(io.BytesIO(string)).load()
+        try:
+            raw = base64.urlsafe_b64decode(string.encode())
+            word, synset_relations = RestrictedUnpickler(io.BytesIO(raw)).load()
+        except Exception as e:
+            raise ValueError("Malformed wordnet_app reference") from e
         if not isinstance(word, str) or not isinstance(synset_relations, dict):
+            raise ValueError("Malformed wordnet_app reference")
+        if not all(
+            isinstance(key, str) and isinstance(value, (set, frozenset))
+            for key, value in synset_relations.items()
+        ):
             raise ValueError("Malformed wordnet_app reference")
         return Reference(word, synset_relations)
 

--- a/nltk/app/wordnet_app.py
+++ b/nltk/app/wordnet_app.py
@@ -743,8 +743,10 @@ class Reference:
             raise ValueError("Malformed wordnet_app reference") from e
         if not isinstance(word, str) or not isinstance(synset_relations, dict):
             raise ValueError("Malformed wordnet_app reference")
+        # Must be plain, mutable sets: toggle_synset_relation() calls .add()
+        # and .remove() on these values, which frozenset doesn't support.
         if not all(
-            isinstance(key, str) and isinstance(value, (set, frozenset))
+            isinstance(key, str) and isinstance(value, set)
             for key, value in synset_relations.items()
         ):
             raise ValueError("Malformed wordnet_app reference")

--- a/nltk/app/wordnet_app.py
+++ b/nltk/app/wordnet_app.py
@@ -173,7 +173,12 @@ class MyServerHandler(BaseHTTPRequestHandler):
             # TODO add a variation of this that takes a non ecoded word or MWE.
             type = "text/html"
             sp = sp[len("lookup_") :]
-            page, word = page_from_href(sp)
+            try:
+                page, word = page_from_href(sp)
+            except ValueError:
+                type = "text/plain"
+                page = "Could not parse lookup reference."
+                word = "* Error *"
         elif sp == "start_page":
             # if this is the first request we should display help
             # information, and possibly set a default word.
@@ -720,9 +725,17 @@ class Reference:
     def decode(string):
         """
         Decode a reference encoded with Reference.encode
+
+        :raises ValueError: if the decoded data isn't shaped like a
+            genuine Reference (word: str, synset_relations: dict).
+            RestrictedUnpickler only blocks class/function reconstruction;
+            it does not guarantee the *type* of the objects it returns, so
+            the shape must still be checked before use.
         """
         string = base64.urlsafe_b64decode(string.encode())
         word, synset_relations = RestrictedUnpickler(io.BytesIO(string)).load()
+        if not isinstance(word, str) or not isinstance(synset_relations, dict):
+            raise ValueError("Malformed wordnet_app reference")
         return Reference(word, synset_relations)
 
     def toggle_synset_relation(self, synset, relation):

--- a/nltk/test/unit/test_security.py
+++ b/nltk/test/unit/test_security.py
@@ -53,11 +53,15 @@ def test_wordnet_app_reference_decode_rejects_wrong_types():
     nltk.app.wordnet_app.Reference.decode() unpickles attacker-controlled,
     base64-encoded data straight from the wordnet browser's lookup_ URLs via
     RestrictedUnpickler. RestrictedUnpickler blocks class/function
-    reconstruction, but it does not guarantee the *type* of what it returns:
-    pickle's built-in list/dict/int/etc. opcodes never go through the
-    blocked path. Without a type check, a single crafted lookup_<pickle> URL
-    (e.g. decoding to an int instead of a str) crashed the server with an
-    uncaught AttributeError in page_from_reference()'s word.split(",").
+    reconstruction, but it does not guarantee the *type* or *shape* of what
+    it returns: pickle's built-in list/dict/int/etc. opcodes never go
+    through the blocked path. Without validation, a single crafted
+    lookup_<pickle> URL crashed the server, either directly (e.g. decoding
+    to an int instead of a str crashed word.split(",") in
+    page_from_reference()) or downstream (e.g. a synset_relations dict with
+    non-set values crashed toggle_synset_relation()'s .add()/.remove()).
+    Every such failure must surface as ValueError, since that's the only
+    exception type the lookup_ route in do_GET catches.
     """
     import base64
     import pickle
@@ -70,12 +74,35 @@ def test_wordnet_app_reference_decode_rejects_wrong_types():
     assert ref.word == "dog"
     assert ref.synset_relations == {}
 
-    # Malformed references (wrong type for word or synset_relations) must be
-    # rejected here, rather than accepted and left to crash downstream code.
-    for bad_payload in [(42, {}), ([[[1]]], {}), (None, {}), ("dog", [])]:
+    # Malformed references must be rejected here, rather than accepted and
+    # left to crash downstream code. Covers: wrong type for word; wrong type
+    # for synset_relations itself; a synset_relations dict whose keys or
+    # values are the wrong type; and payloads that don't even unpack to a
+    # (word, synset_relations) pair (a bare int isn't iterable at all; a
+    # 1-tuple/3-tuple is the wrong arity).
+    bad_payloads = [
+        (42, {}),
+        ([[[1]]], {}),
+        (None, {}),
+        ("dog", []),
+        ("dog", {"dog.n.01": ["not", "a", "set"]}),
+        ("dog", {42: {"hypernym"}}),
+        42,
+        ("dog",),
+        ("dog", {}, "extra"),
+    ]
+    for bad_payload in bad_payloads:
         bad = base64.urlsafe_b64encode(pickle.dumps(bad_payload, -1)).decode()
         try:
             Reference.decode(bad)
             raise AssertionError(f"Reference.decode should reject {bad_payload!r}")
+        except ValueError:
+            pass
+
+    # Also covers input that isn't valid base64/pickle data at all.
+    for bad_string in ["not valid base64!!!", "", "====", "aGVsbG8="]:
+        try:
+            Reference.decode(bad_string)
+            raise AssertionError(f"Reference.decode should reject {bad_string!r}")
         except ValueError:
             pass

--- a/nltk/test/unit/test_security.py
+++ b/nltk/test/unit/test_security.py
@@ -46,3 +46,36 @@ def test_module_hijacking_prevention():
             "HIJACK_SUCCESS" not in res.stdout
         ), "Security Failure: Loaded module from CWD."
         assert res.returncode == 0, "Victim script failed unexpectedly."
+
+
+def test_wordnet_app_reference_decode_rejects_wrong_types():
+    """
+    nltk.app.wordnet_app.Reference.decode() unpickles attacker-controlled,
+    base64-encoded data straight from the wordnet browser's lookup_ URLs via
+    RestrictedUnpickler. RestrictedUnpickler blocks class/function
+    reconstruction, but it does not guarantee the *type* of what it returns:
+    pickle's built-in list/dict/int/etc. opcodes never go through the
+    blocked path. Without a type check, a single crafted lookup_<pickle> URL
+    (e.g. decoding to an int instead of a str) crashed the server with an
+    uncaught AttributeError in page_from_reference()'s word.split(",").
+    """
+    import base64
+    import pickle
+
+    from nltk.app.wordnet_app import Reference
+
+    # A legitimate reference still round-trips correctly.
+    good = base64.urlsafe_b64encode(pickle.dumps(("dog", {}), -1)).decode()
+    ref = Reference.decode(good)
+    assert ref.word == "dog"
+    assert ref.synset_relations == {}
+
+    # Malformed references (wrong type for word or synset_relations) must be
+    # rejected here, rather than accepted and left to crash downstream code.
+    for bad_payload in [(42, {}), ([[[1]]], {}), (None, {}), ("dog", [])]:
+        bad = base64.urlsafe_b64encode(pickle.dumps(bad_payload, -1)).decode()
+        try:
+            Reference.decode(bad)
+            raise AssertionError(f"Reference.decode should reject {bad_payload!r}")
+        except ValueError:
+            pass

--- a/nltk/test/unit/test_security.py
+++ b/nltk/test/unit/test_security.py
@@ -77,15 +77,18 @@ def test_wordnet_app_reference_decode_rejects_wrong_types():
     # Malformed references must be rejected here, rather than accepted and
     # left to crash downstream code. Covers: wrong type for word; wrong type
     # for synset_relations itself; a synset_relations dict whose keys or
-    # values are the wrong type; and payloads that don't even unpack to a
-    # (word, synset_relations) pair (a bare int isn't iterable at all; a
-    # 1-tuple/3-tuple is the wrong arity).
+    # values are the wrong type (including frozenset, which looks like a
+    # valid set but lacks the .add()/.remove() that toggle_synset_relation()
+    # needs, so it must be rejected too, not just non-set types); and
+    # payloads that don't even unpack to a (word, synset_relations) pair (a
+    # bare int isn't iterable at all; a 1-tuple/3-tuple is the wrong arity).
     bad_payloads = [
         (42, {}),
         ([[[1]]], {}),
         (None, {}),
         ("dog", []),
         ("dog", {"dog.n.01": ["not", "a", "set"]}),
+        ("dog", {"dog.n.01": frozenset()}),
         ("dog", {42: {"hypernym"}}),
         42,
         ("dog",),


### PR DESCRIPTION
## Summary

Fixes the vulnerability described in [GHSA-7pvm-89gg-6c6h](https://github.com/nltk/nltk/security/advisories/GHSA-7pvm-89gg-6c6h): `nltk.app.wordnet_app`'s `lookup_<base64-pickle>` route unpickles attacker-controlled data via `RestrictedUnpickler`, which correctly blocks class/function reconstruction (so the RCE this replaced in #3100 stays fixed), but never checks the *type* of what it returns. Pickle's built-in `list`/`dict`/`int`/etc. opcodes don't go through the blocked path, so a single crafted request can return, say, an `int` where the code expects a `str`. `page_from_reference()` immediately calls `word.split(",")` assuming a `str`, so one unauthenticated GET request crashes the request handler with an uncaught `AttributeError` and drops the connection with no response.

## Changes

- `Reference.decode()` now validates that the unpickled `word` is a `str` and `synset_relations` is a `dict`, raising `ValueError` otherwise, instead of returning unchecked data.
- The `lookup_` route in `do_GET` catches that `ValueError` and returns a clean response instead of letting the exception propagate.
- Added `test_wordnet_app_reference_decode_rejects_wrong_types` to `nltk/test/unit/test_security.py`, covering the legitimate round-trip plus several malformed shapes (`int`, nested `list`, `None` for `word`; `list` for `synset_relations`).

## Test plan

- [x] Reproduced the crash pre-fix: a `lookup_<...>` request encoding `(42, {})` raised `AttributeError: 'int' object has no attribute 'split'` server-side and dropped the connection (`RemoteDisconnected`).
- [x] Post-fix: the same request returns a clean response; legitimate lookups (e.g. `word="dog"`) still work before and after the malformed request, confirming no regression.
- [x] `pytest nltk/test/unit/test_security.py` passes (both the existing test and the new one).
- [x] `pre-commit run --files nltk/app/wordnet_app.py nltk/test/unit/test_security.py` passes (black, isort, ruff, pyupgrade, pre-commit-hooks).