### PR TITLE
Fix uncontrolled search path in HunposTagger

### DIFF
--- a/nltk/tag/hunpos.py
+++ b/nltk/tag/hunpos.py
@@ -71,7 +71,6 @@ class HunposTagger(TaggerI):
         """
         self._closed = True
         hunpos_paths = [
-            ".",
             "/usr/bin",
             "/usr/local/bin",
             "/opt/local/bin",


### PR DESCRIPTION
### Description
This PR removes the current working directory (`"."`) from the default binary search path in `HunposTagger` to enforce a restrictive execution policy. 
### Security Motivation
This addresses a  (CWE-427: Uncontrolled Search Path Element). vulnerability in HunposTagger. Previously, `hunpos_paths` implicitly trusted the current working directory. If a user ran an NLTK script in a shared or attacker-influenced directory containing a malicious executable named `hunpos-tag`, `find_binary()` would resolve and execute it via `subprocess.Popen`.

### Impact
*   **Secures binary resolution:** `find_binary()` will no longer search the current working directory (`.`). It now strictly limits the search to system paths (e.g., `/usr/bin`) and user-owned home directories (e.g., `~/bin`), alongside explicit environment variables.
*   **Backwards compatibility:** Users who legitimately need to run a `hunpos-tag` binary located in their current working directory can still do so by explicitly declaring it during initialization: `HunposTagger(path_to_model='...', path_to_bin='./hunpos-tag')`.