### PR TITLE
Fix outdated Megam URL

### DIFF
--- a/nltk/classify/megam.py
+++ b/nltk/classify/megam.py
@@ -20,7 +20,7 @@ for details.
 
     nltk.classify.MaxentClassifier.train(corpus, 'megam')
 
-.. _megam: https://www.umiacs.umd.edu/~hal/megam/index.html
+.. _megam: http://hal3.name/megam/
 """
 import subprocess
 
@@ -54,7 +54,7 @@ def config_megam(bin=None):
         bin,
         env_vars=["MEGAM"],
         binary_names=["megam.opt", "megam", "megam_686", "megam_i686.opt"],
-        url="https://www.umiacs.umd.edu/~hal/megam/index.html",
+        url="http://hal3.name/megam/",
     )
 
 


### PR DESCRIPTION
Closes #1708

Updates the Megam URL from \https://www.umiacs.umd.edu/~hal/megam/index.html\ to \http://hal3.name/megam/\ in both the docstring reference and the \config_megam()\ \url=\ parameter.

The old URL redirects with a double slash (e.g. \.../~hal3//megam/...\); the new URL is the canonical home of Megam.