### PR TITLE
detokenize periods mid-string, not just the last one

### DIFF
--- a/nltk/test/unit/test_tokenize.py
+++ b/nltk/test/unit/test_tokenize.py
@@ -1240,3 +1240,44 @@ class TestTreebankWordDetokenizer:
         original_tokens = ["``", "Hello", ",", "''", "he", "said", "."]
         result = self.detok.detokenize(original_tokens)
         assert '"' in result
+
+    def test_issue_3210_mid_string_period(self):
+        """Standalone period tokens mid-string must not keep a leading space (#3210)."""
+        tokens = [
+            "Lorem",
+            "ipsum",
+            "dolor",
+            "sit",
+            "amet",
+            ".",
+            "consectetur",
+            "adipiscing",
+            "elit",
+            ".",
+        ]
+        assert (
+            self.detok.detokenize(tokens)
+            == "Lorem ipsum dolor sit amet. consectetur adipiscing elit."
+        )
+
+    def test_issue_3210_multiple_sentence_periods(self):
+        """Every sentence-final period is joined, not only the last one (#3210)."""
+        tokens = [
+            "I",
+            "called",
+            "Dr.",
+            "Jones",
+            ".",
+            "I",
+            "called",
+            "Dr.",
+            "Jones",
+            ".",
+        ]
+        assert (
+            self.detok.detokenize(tokens) == "I called Dr. Jones. I called Dr. Jones."
+        )
+
+    def test_issue_3210_ellipsis_preserved(self):
+        """The mid-string period fix must not disturb ellipsis tokens (#3210)."""
+        assert self.detok.detokenize(["wait", "...", "what"]) == "wait...what"

--- a/nltk/tokenize/treebank.py
+++ b/nltk/tokenize/treebank.py
@@ -328,7 +328,7 @@ class TreebankWordDetokenizer(TokenizerI):
         (re.compile(r"([^'])\s'\s"), r"\1' "),
         (re.compile(r"\s([?!])"), r"\g<1>"),  # Strip left pad for [?!]
         # (re.compile(r'\s([?!])\s'), r'\g<1>'),
-        (re.compile(r'([^\.])\s(\.)([\]\)}>"\']*)\s*$'), r"\1\2\3"),
+        (re.compile(r'([^\.])\s(\.)(?!\.)([\]\)}>"\']*)'), r"\1\2\3"),
         # When tokenizing, [;@#$%&] are padded with whitespace regardless of
         # whether there are spaces before or after them.
         # But during detokenization, we need to distinguish between left/right


### PR DESCRIPTION
`TreebankWordDetokenizer().detokenize()` left a space before standalone period tokens that appear mid-string. For example `detokenize(["...","amet",".","consectetur",...])` produced `"amet . consectetur"` instead of `"amet. consectetur"` — only the final period was joined.

Root cause: the period-joining rule in `PUNCTUATION` was anchored with `\s*$`, so it only matched a period at the very end of the string. Dropping the `$` anchor lets it join every standalone period.

To leave ellipsis tokens alone, the pattern gains a `(?!\.)` guard so it never matches the first dot of a `...` run (those are collapsed separately by the `\s\.\.\.\s` rule). The rule still requires a space before the period, so attached periods in decimals (3.14), money ($3.88), versions (2.0.) and abbreviations (Dr., p.) are untouched.

Adds regression tests for mid-string periods, multiple sentence-final periods, and the ellipsis guard.
