### PR TITLE
don't collapse repeated non-Latin letters in TweetTokenizer

### DIFF
--- a/nltk/test/unit/test_tokenize.py
+++ b/nltk/test/unit/test_tokenize.py
@@ -383,6 +383,28 @@ class TestTokenize:
             )
         assert proc.exitcode == 0, f"worker failed (exit code {proc.exitcode})"
 
+    def test_tweet_tokenizer_reduce_len_preserves_non_latin(self):
+        """
+        With ``reduce_len=False`` (the default), the tokenizer must not shorten
+        runs of repeated non-Latin letters. Regression test for
+        https://github.com/nltk/nltk/issues/3157, where a run of Cyrillic
+        characters was collapsed even though Latin ones were left untouched.
+        """
+        keep = TweetTokenizer(reduce_len=False)
+        # A Latin run is preserved (control) ...
+        assert keep.tokenize("Loooool") == ["Loooool"]
+        # ... and a Cyrillic run must be preserved identically.
+        assert keep.tokenize("Лооооол") == ["Лооооол"]
+
+        # reduce_len=True must still collapse long runs in any script.
+        shorten = TweetTokenizer(reduce_len=True)
+        assert shorten.tokenize("Loooool") == ["Loool"]
+        assert shorten.tokenize("Лооооол") == ["Лооол"]
+
+        # Long runs of a single punctuation character are still shortened even
+        # when reduce_len=False, so the tokenizer stays safe against ReDoS.
+        assert keep.tokenize("!!!!!!!!") == ["!", "!", "!"]
+
     def test_emoji_tokenizer(self):
         """
         Test a string that contains Emoji ZWJ Sequences and skin tone modifier

--- a/nltk/tokenize/casual.py
+++ b/nltk/tokenize/casual.py
@@ -212,7 +212,7 @@ REGEXPS_PHONE = (REGEXPS[0], PHONE_REGEX, *REGEXPS[1:])
 # the core tokenizing regexes. They are compiled lazily.
 
 # WORD_RE performs poorly on these patterns:
-HANG_RE = regex.compile(r"([^a-zA-Z0-9])\1{3,}")
+HANG_RE = regex.compile(r"([^\p{L}\p{N}])\1{3,}")
 
 # The emoticon string gets its own regex so that we can preserve case for
 # them as needed:


### PR DESCRIPTION
Fixes #3157.

`TweetTokenizer.tokenize` always runs `HANG_RE` to collapse long runs of repeated characters before the main word regex, guarding against catastrophic backtracking. Its character class was `[^a-zA-Z0-9]`, which treats every non-ASCII character as "dangerous", so runs of repeated non-Latin letters (e.g. Cyrillic `Лооооол`) were shortened even with `reduce_len=False`, corrupting the text.

Widen the preserved set to all Unicode letters and numbers:

```
-HANG_RE = regex.compile(r"([^a-zA-Z0-9])\1{3,}")
+HANG_RE = regex.compile(r"([^\p{L}\p{N}])\1{3,}")
```

Letters and digits of any script are now preserved, while symbols, punctuation and combining marks (none of which are `\p{L}`/`\p{N}`) are still collapsed, so the guard against pathological repeated-symbol input is unchanged. `reduce_len=True` continues to shorten lengthening in every script. Added a regression test in `test_tokenize.py`.
