### PR TITLE
Guard tempfile.gettempdir() when building pathsec allowed roots

### DIFF
--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -56,7 +56,13 @@ def _get_allowed_roots():
 
     import tempfile
 
-    for loc in ["~/nltk_data", "/usr/share/nltk_data", tempfile.gettempdir()]:
+    candidate_locs = ["~/nltk_data", "/usr/share/nltk_data"]
+    try:
+        candidate_locs.append(tempfile.gettempdir())
+    except (OSError, ValueError, RuntimeError):
+        pass
+
+    for loc in candidate_locs:
         try:
             p = Path(loc).expanduser().resolve()
             if p.exists():

--- a/nltk/test/unit/test_pathsec.py
+++ b/nltk/test/unit/test_pathsec.py
@@ -144,6 +144,39 @@ def test_path_traversal_absolute():
         pathsec.open(outside, "r")
 
 
+# --- ALLOWED-ROOTS / TEMP-DIR FALLBACK TESTS ---
+
+
+def test_get_allowed_roots_survives_missing_tempdir(tmp_path, monkeypatch):
+    """Regression test for issue #3716.
+
+    ``_get_allowed_roots()`` used to build its fallback-location list as a
+    literal ``[..., tempfile.gettempdir()]``, which evaluates
+    ``tempfile.gettempdir()`` while constructing the list -- *before* the
+    loop's ``try/except`` runs. On a system with no usable temp directory
+    (read-only root filesystem, nothing mounted at ``/tmp``), ``gettempdir()``
+    raises ``FileNotFoundError`` (an ``OSError`` subclass) that propagates out
+    of the whole function, discarding the roots already collected from
+    ``nltk.data.path``/``NLTK_DATA`` and breaking resource lookups (e.g.
+    ``sent_tokenize()``) even when the resource is already cached.
+    """
+    import nltk.data
+
+    known_root = tmp_path / "nltk_data_known_root"
+    known_root.mkdir()
+
+    monkeypatch.setattr(nltk.data, "path", nltk.data.path + [str(known_root)])
+
+    # Force a clean cache: _get_allowed_roots() memoizes on (data.path, NLTK_DATA).
+    pathsec._ALLOWED_ROOTS_CACHE = None
+    pathsec._LAST_DATA_PATHS = None
+
+    with patch("tempfile.gettempdir", side_effect=FileNotFoundError("no temp dir")):
+        roots = pathsec._get_allowed_roots()
+
+    assert known_root.resolve() in roots
+
+
 # --- ZIP-SLIP TESTS ---
 
 


### PR DESCRIPTION
Fixes #3716.

`pathsec._get_allowed_roots()` builds its fallback directory list as a literal:

```python
for loc in ["~/nltk_data", "/usr/share/nltk_data", tempfile.gettempdir()]:
    try:
        p = Path(loc).expanduser().resolve()
        if p.exists():
            roots.add(p)
    except (OSError, ValueError, RuntimeError):
        continue
```

`tempfile.gettempdir()` is evaluated while the list is being constructed, before the loop's `try`/`except` runs. On a host with no usable temporary directory it raises `FileNotFoundError` (a subclass of `OSError`), which escapes `_get_allowed_roots()` entirely and throws away the roots already collected from `nltk.data.path` / `NLTK_DATA` earlier in the function. The exception propagates up through `validate_path`, so `sent_tokenize()` and other resource lookups fail even when the resource is already cached and `find()` located it successfully.

This moves the `gettempdir()` call under its own guard, so a failure just skips the temp-dir candidate instead of aborting the whole lookup:

```python
candidate_locs = ["~/nltk_data", "/usr/share/nltk_data"]
try:
    candidate_locs.append(tempfile.gettempdir())
except (OSError, ValueError, RuntimeError):
    pass

for loc in candidate_locs:
    ...
```

Behavior is unchanged when a temporary directory exists (the candidate list is identical to before), and the guard uses the same exception tuple already used inside the loop. Adds a regression test that patches `tempfile.gettempdir` to raise `FileNotFoundError` and asserts the allowed-roots lookup still returns the configured data root.
