### PR TITLE
fix(security): close symlink escape in FramenetCorpusReader (CWE-59)

### DIFF
--- a/nltk/corpus/reader/framenet.py
+++ b/nltk/corpus/reader/framenet.py
@@ -779,6 +779,26 @@ def _reject_unsafe_path_component(value, kind):
         raise FramenetError(f"Invalid {kind}: {value!r}")
 
 
+def _validate_in_root(locpath, root, context):
+    """Reject a resolved path that escapes the corpus root through a symlink.
+
+    ``_reject_unsafe_path_component`` only rejects unsafe characters in the
+    caller-/corpus-supplied name itself; it never resolves symlinks. A
+    symlink planted inside the corpus subdirectory (``frame/``, ``lu/`` or
+    ``fulltext/``) can still point outside the corpus root even when the name
+    referencing it contains no separator or ``..`` at all.
+
+    This calls ``nltk.pathsec.validate_path`` with the corpus root as
+    ``required_root``, the same symlink-resolving containment guard used by
+    ``CorpusReader.open()`` and ``NKJPCorpusReader.add_root()``: both
+    ``locpath`` and ``root`` are resolved with ``Path.resolve()`` before the
+    containment check, so a symlink cannot escape undetected.
+    """
+    from nltk.pathsec import validate_path
+
+    validate_path(locpath, context=context, required_root=root)
+
+
 class AttrDict(dict):
     """A class that wraps a dict and allows accessing the keys of the
     dict as if they were attributes. Taken from here:
@@ -1385,15 +1405,21 @@ warnings(True) to display corpus consistency warnings when loading data
         except KeyError as e:  # probably means that fn_docid was not in the index
             raise FramenetError(f"Unknown document id: {fn_docid}") from e
 
-        # Security (CWE-22): defend against a malicious corpus index whose
-        # filename field contains path-traversal sequences.  Reject the unsafe
-        # name and resolve the path through self.abspath() so the file is read
-        # via the PathPointer / nltk.pathsec sandbox instead of the builtin
-        # open() that a bare string path would use in XMLCorpusView.
+        # Security (CWE-22 / CWE-59): defend against a malicious corpus index
+        # whose filename field contains path-traversal sequences or a symlink
+        # planted inside the fulltext directory.  Reject the unsafe name, then
+        # resolve through self.abspath() and validate_path() with the corpus
+        # root as required_root -- the same symlink-resolving containment
+        # guard CorpusReader.open() and NKJPCorpusReader use -- so the file is
+        # read via the PathPointer / nltk.pathsec sandbox instead of the
+        # builtin open() that a bare string path would use in XMLCorpusView,
+        # and a symlink cannot escape the corpus root even though its own name
+        # contains no separators or "..".
         _reject_unsafe_path_component(xmlfname, "document filename")
 
         # construct the path name for the xml file containing the document info
         locpath = self.abspath(os.path.join(self._fulltext_dir, xmlfname))
+        _validate_in_root(locpath, self.root, "FramenetCorpusReader")
 
         # Grab the top-level xml element containing the fulltext annotation
         with XMLCorpusView(locpath, "fullTextAnnotation") as view:
@@ -1482,16 +1508,22 @@ warnings(True) to display corpus consistency warnings when loading data
         elif not self._frame_idx:
             self._buildframeindex()
 
-        # Security (CWE-22): the frame name is interpolated into the XML file
-        # path.  Reject crafted names, then resolve through self.abspath() so the
-        # file is read via the PathPointer / nltk.pathsec sandbox rather than the
-        # builtin open() that a bare string path would use in XMLCorpusView.
+        # Security (CWE-22 / CWE-59): the frame name is interpolated into the
+        # XML file path.  Reject crafted names, then resolve through
+        # self.abspath() and validate_path() with the corpus root as
+        # required_root -- the same symlink-resolving containment guard
+        # CorpusReader.open() and NKJPCorpusReader use -- so the file is read
+        # via the PathPointer / nltk.pathsec sandbox rather than the builtin
+        # open() that a bare string path would use in XMLCorpusView, and a
+        # symlink planted inside the frame directory cannot escape the corpus
+        # root even though its own name contains no separators or "..".
         _reject_unsafe_path_component(fn_fname, "frame name")
 
         # construct the path name for the xml file containing the Frame info
         # Grab the xml for the frame
         try:
             locpath = self.abspath(os.path.join(self._frame_dir, fn_fname + ".xml"))
+            _validate_in_root(locpath, self.root, "FramenetCorpusReader")
             with XMLCorpusView(locpath, "frame") as view:
                 elt = view[0]
         except OSError as e:
@@ -1835,11 +1867,16 @@ warnings(True) to display corpus consistency warnings when loading data
         """
         fn_luid = lu.ID
 
-        # Security (CWE-22): the LU id comes from corpus data (a <lexUnit ID="...">
-        # attribute) and is interpolated into the XML file path.  A non-numeric
-        # id can carry path-traversal sequences; reject it, then resolve through
-        # self.abspath() so the file is read via the PathPointer / nltk.pathsec
-        # sandbox rather than the builtin open() used for a bare string path.
+        # Security (CWE-22 / CWE-59): the LU id comes from corpus data (a
+        # <lexUnit ID="..."> attribute) and is interpolated into the XML file
+        # path.  A non-numeric id can carry path-traversal sequences; reject
+        # it, then resolve through self.abspath() and validate_path() with the
+        # corpus root as required_root -- the same symlink-resolving
+        # containment guard CorpusReader.open() and NKJPCorpusReader use --
+        # so the file is read via the PathPointer / nltk.pathsec sandbox
+        # rather than the builtin open() used for a bare string path, and a
+        # symlink planted inside the LU directory cannot escape the corpus
+        # root even though its own name contains no separators or "..".
         _reject_unsafe_path_component(fn_luid, "LU id")
 
         fname = f"lu{fn_luid}.xml"
@@ -1848,6 +1885,7 @@ warnings(True) to display corpus consistency warnings when loading data
 
         try:
             locpath = self.abspath(os.path.join(self._lu_dir, fname))
+            _validate_in_root(locpath, self.root, "FramenetCorpusReader")
             with XMLCorpusView(locpath, "lexUnit") as view:
                 elt = view[0]
         except OSError as e:

--- a/nltk/test/unit/test_framenet_security.py
+++ b/nltk/test/unit/test_framenet_security.py
@@ -1,4 +1,4 @@
-"""Regression tests for path traversal in FramenetCorpusReader (CWE-22).
+"""Regression tests for path traversal in FramenetCorpusReader (CWE-22 / CWE-59).
 
 ``doc()``, ``frame_by_name()`` and ``_lu_file()`` interpolate a caller- or
 corpus-supplied name into an XML file path that is then read via
@@ -9,6 +9,13 @@ legitimate name must still resolve and read correctly through ``self.abspath()``
 
 Paths are built with ``os.path.join`` / ``os.pardir`` so the tests behave the
 same on POSIX and Windows.
+
+A separate class of tests below covers a symlink planted inside the corpus
+subdirectory itself (``frame/``, ``lu/`` or ``fulltext/``). Its own name
+contains no separator or ``..``, so it passes ``_reject_unsafe_path_component``
+cleanly; only resolving the path with ``Path.resolve()`` and checking it
+against the corpus root (what ``_validate_in_root`` / ``validate_path`` do)
+catches this.
 """
 
 import builtins
@@ -158,3 +165,78 @@ def test_reject_unsafe_path_component_blocks(bad):
 @pytest.mark.parametrize("ok", ["TestFrame", "Apply_heat", "lu123", "a.b-c"])
 def test_reject_unsafe_path_component_allows_normal(ok):
     _reject_unsafe_path_component(ok, "frame name")  # must not raise
+
+
+# --- symlink escape: name has no separator or ".." but still leaves the root --
+
+
+def _symlink_or_skip(target, link):
+    try:
+        os.symlink(target, link)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported in this environment")
+
+
+def test_framenet_frame_rejects_symlink_escape(tmp_path, monkeypatch):
+    """A symlink inside frame/ passes the name guard but must still be blocked."""
+    root = _make_corpus(tmp_path)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    secret = outside / "pwn.xml"
+    secret.write_text(_FRAME_XML.format(name="pwned"))
+
+    link = root / "frame" / "evil_link.xml"
+    _symlink_or_skip(secret, link)
+
+    fn = FramenetCorpusReader(str(root), [])
+    opened = _record_opens(monkeypatch)
+    with pytest.raises(ValueError, match="escapes root"):
+        fn.frame("evil_link")
+    assert not any(
+        "outside" in p for p in opened
+    ), "symlink escape reached the filesystem"
+
+
+def test_framenet_lu_file_rejects_symlink_escape(tmp_path, monkeypatch):
+    """A symlink inside lu/ passes the id guard but must still be blocked."""
+    root = _make_corpus(tmp_path)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    secret = outside / "pwn.xml"
+    secret.write_text(
+        '<?xml version="1.0"?><lexUnit ID="1" name="pwned.n" status="Created"/>'
+    )
+
+    link = root / "lu" / "luevilLU.xml"
+    _symlink_or_skip(secret, link)
+
+    fn = FramenetCorpusReader(str(root), [])
+    fn._lu_idx = {"__dummy__": AttrDict({"name": "__dummy__"})}  # skip _buildluindex()
+    lu = AttrDict({"ID": "evilLU"})
+    opened = _record_opens(monkeypatch)
+    with pytest.raises(ValueError, match="escapes root"):
+        fn._lu_file(lu)
+    assert not any(
+        "outside" in p for p in opened
+    ), "symlink escape reached the filesystem"
+
+
+def test_framenet_doc_rejects_symlink_escape(tmp_path, monkeypatch):
+    """A symlink inside fulltext/ passes the filename guard but must still be blocked."""
+    root = _make_corpus(tmp_path)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    secret = outside / "pwn.xml"
+    secret.write_text('<?xml version="1.0"?><fullTextAnnotation></fullTextAnnotation>')
+
+    link = root / "fulltext" / "evilDoc.xml"
+    _symlink_or_skip(secret, link)
+
+    fn = FramenetCorpusReader(str(root), [])
+    fn._fulltext_idx = {7: AttrDict({"filename": "evilDoc.xml"})}
+    opened = _record_opens(monkeypatch)
+    with pytest.raises(ValueError, match="escapes root"):
+        fn.doc(7)
+    assert not any(
+        "outside" in p for p in opened
+    ), "symlink escape reached the filesystem"


### PR DESCRIPTION
## Summary

Reported as [GHSA-f833-7jw8-xwrv](https://github.com/nltk/nltk/security/advisories/GHSA-f833-7jw8-xwrv).

`frame_by_name()`, `_lu_file()` and `doc()` reject unsafe characters in the caller- or corpus-supplied name via `_reject_unsafe_path_component()`, then resolve the path through `self.abspath()`. That guard only inspects the name string; it never resolves symlinks. A symlink planted inside the corpus subdirectory (`frame/`, `lu/` or `fulltext/`), with a name containing no separators or `..`, passes the guard cleanly, and `self.abspath()` (a plain `self._root.join(fileid)`) does not catch it either, so the file is opened from outside the corpus root anyway.

## PoC (before this change)

```python
import os
from nltk.corpus.reader.framenet import FramenetCorpusReader

os.symlink("/anywhere/outside/the/corpus/root/stolen.xml",
           "<corpus_root>/frame/evil_link.xml")

reader = FramenetCorpusReader("<corpus_root>", [])
result = reader.frame_by_name("evil_link")   # normal, routine call, no ".." anywhere
print(result["definition"])                   # content read from outside the corpus root
```

The same pattern applies to `_lu_file()` (`lu<id>.xml` under `lu/`) and `doc()` (arbitrary filename under `fulltext/`).

## Fix

Add `_validate_in_root()`, which calls `nltk.pathsec.validate_path()` with the corpus root as `required_root` at all three call sites. This is the same symlink-resolving, root-scoped containment check already used by `CorpusReader.open()` and `NKJPCorpusReader.add_root()`: both the candidate path and the root are resolved with `Path.resolve()` before the containment comparison, so a symlink cannot escape undetected.

## Tests

Adds three regression tests to `test_framenet_security.py`, one per call site, each planting a symlink inside the relevant corpus subdirectory and asserting the escape is rejected with no file outside the corpus root ever opened. The existing traversal and drive-prefix tests are unchanged and still pass.

## Validation

- Verified end to end against unpatched `develop`, with `ENFORCE=True`: all three call sites open the file outside the corpus root and return its content to the caller.
- After the fix, the same PoC and the new regression tests are blocked with a clear `Security Violation ... escapes root` error.
- Ran the full `test_framenet_security.py`, `test_corpus_reader.py`, `test_data_security.py` and `test_pathsec.py` suites in two independent fresh virtual environments (Python 3.12 and 3.13): all pass, no regressions.
- Tried chained symlinks, a symlinked whole subdirectory, NUL byte injection, and Unicode normalization tricks against the fixed code; all still rejected. The one known limitation is a theoretical TOCTOU window between validation and the actual open, which is an existing architectural property shared by `CorpusReader.open()` itself, not something introduced by this change.
- Ran `pre-commit` on the changed files (black, isort, ruff, pyupgrade): clean.
