### PR TITLE
fix(security): close symlink escape in IPIPANCorpusReader (CWE-59)

### DIFF
--- a/nltk/corpus/reader/ipipan.py
+++ b/nltk/corpus/reader/ipipan.py
@@ -187,6 +187,24 @@ class IPIPANCorpusReader(CorpusReader):
         return list(ret_fileids)
 
     def _get_tag(self, f, tag):
+        # Security (CWE-22 / CWE-59): ``f`` reaches this point as a plain str,
+        # not a PathPointer -- ``_list_header_files`` / ``_list_morph_files_by``
+        # call ``.replace("morph.xml", "header.xml")`` on the result of
+        # ``self.abspath()``/``self.abspaths()``, and since
+        # ``FileSystemPathPointer`` subclasses ``str``, ``.replace()`` returns
+        # a plain string, silently discarding the PathPointer wrapper. That
+        # meant this ``open()`` call never went through nltk.pathsec at all,
+        # not even the global check that a PathPointer.open() would apply, so
+        # a symlink planted inside the corpus root (with a name containing no
+        # separators or "..", so it passes FileSystemPathPointer.join()
+        # cleanly) could point anywhere on the filesystem and still be
+        # opened. Validate the resolved path against the corpus root before
+        # opening, the same symlink-resolving containment guard
+        # CorpusReader.open() and NKJPCorpusReader use.
+        from nltk.pathsec import validate_path
+
+        validate_path(f, context="IPIPANCorpusReader", required_root=self.root)
+
         tags = []
         with open(f) as infile:
             header = infile.read()

--- a/nltk/test/unit/test_ipipan_security.py
+++ b/nltk/test/unit/test_ipipan_security.py
@@ -94,6 +94,24 @@ def test_ipipan_domains_rejects_symlink_escape(tmp_path):
         reader.domains(fileids=["evil_link2.xml"])
 
 
+def test_ipipan_categories_rejects_symlink_escape(tmp_path):
+    """categories() also shares _get_tag() with channels(); confirm it is
+    covered too. It post-processes _parse_header()'s result through
+    _map_category(), but the ValueError must fire before that ever runs."""
+    root = _make_corpus(tmp_path)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    secret = outside / "stolen.xml"
+    secret.write_text("<keyTerm>pwned</keyTerm>")
+
+    link = root / "evil_link4.xml"
+    _symlink_or_skip(secret, link)
+
+    reader = IPIPANCorpusReader(str(root), r".*\.xml")
+    with pytest.raises(ValueError, match="escapes root"):
+        reader.categories(fileids=["evil_link4.xml"])
+
+
 def test_ipipan_fileids_by_channel_rejects_symlink_escape(tmp_path):
     """_list_morph_files_by() (used by fileids(channels=...)) shares the same
     _get_tag() call and must be covered too."""

--- a/nltk/test/unit/test_ipipan_security.py
+++ b/nltk/test/unit/test_ipipan_security.py
@@ -1,0 +1,111 @@
+"""Regression tests for symlink-based path escape in IPIPANCorpusReader
+(CWE-22 / CWE-59).
+
+``channels()``, ``domains()``, ``categories()`` and ``fileids(channels=...)``
+route through ``_get_tag()``, which used to call the builtin ``open()`` on a
+plain string produced by ``.replace("morph.xml", "header.xml")`` on the
+result of ``self.abspath()``. Since ``FileSystemPathPointer`` subclasses
+``str``, that ``.replace()`` call silently discarded the ``PathPointer``
+wrapper, so the resulting ``open()`` never went through ``nltk.pathsec`` at
+all, not even the global, non-scoped check. A symlink planted inside the
+corpus root, with a name containing no separators or "..", passed the
+existing traversal guard cleanly and could point anywhere on the filesystem.
+
+Paths are built with ``os.path.join`` / ``os.pardir`` so the tests behave the
+same on POSIX and Windows.
+"""
+
+import os
+
+import pytest
+
+from nltk.corpus.reader.ipipan import IPIPANCorpusReader
+
+
+def _make_corpus(tmp_path):
+    root = tmp_path / "ipipan"
+    root.mkdir()
+    (root / "real_morph.xml").write_text("<tei>legit morph</tei>")
+    (root / "real_header.xml").write_text("<channel>legit-channel</channel>")
+    return root
+
+
+def _symlink_or_skip(target, link):
+    try:
+        os.symlink(target, link)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported in this environment")
+
+
+def test_ipipan_channels_reads_legitimate_file(tmp_path):
+    """A real in-root file must still work after adding the containment check."""
+    root = _make_corpus(tmp_path)
+    reader = IPIPANCorpusReader(str(root), r".*\.xml")
+    assert reader.channels(fileids=["real_morph.xml"]) == ["legit-channel"]
+
+
+def test_ipipan_channels_rejects_traversal_fileid(tmp_path):
+    """A ../ traversal fileid is rejected before any file is opened."""
+    root = _make_corpus(tmp_path)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "pwn_header.xml").write_text("<channel>pwned</channel>")
+
+    reader = IPIPANCorpusReader(str(root), r".*\.xml")
+    evil = os.path.join(os.pardir, "outside", "pwn_morph.xml")
+    with pytest.raises(ValueError, match="Traversal blocked"):
+        reader.channels(fileids=[evil])
+
+
+def test_ipipan_channels_rejects_symlink_escape(tmp_path):
+    """A symlink inside the corpus root passes the name guard but must still
+    be blocked, even though its own name has no separators or ".."."""
+    root = _make_corpus(tmp_path)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    secret = outside / "stolen.xml"
+    secret.write_text("<channel>TOP-SECRET-DATA-OUTSIDE-CORPUS-ROOT</channel>")
+
+    link = root / "evil_link.xml"
+    _symlink_or_skip(secret, link)
+
+    # Constructed the normal way: fileids is a regex, so the reader
+    # auto-discovers the symlink exactly as it would a real file.
+    reader = IPIPANCorpusReader(str(root), r".*\.xml")
+    assert "evil_link.xml" in reader.fileids()
+
+    with pytest.raises(ValueError, match="escapes root"):
+        reader.channels(fileids=["evil_link.xml"])
+
+
+def test_ipipan_domains_rejects_symlink_escape(tmp_path):
+    """domains() shares _get_tag() with channels(); confirm it is covered too."""
+    root = _make_corpus(tmp_path)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    secret = outside / "stolen.xml"
+    secret.write_text("<domain>pwned</domain>")
+
+    link = root / "evil_link2.xml"
+    _symlink_or_skip(secret, link)
+
+    reader = IPIPANCorpusReader(str(root), r".*\.xml")
+    with pytest.raises(ValueError, match="escapes root"):
+        reader.domains(fileids=["evil_link2.xml"])
+
+
+def test_ipipan_fileids_by_channel_rejects_symlink_escape(tmp_path):
+    """_list_morph_files_by() (used by fileids(channels=...)) shares the same
+    _get_tag() call and must be covered too."""
+    root = _make_corpus(tmp_path)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    secret = outside / "stolen.xml"
+    secret.write_text("<channel>pwned</channel>")
+
+    link = root / "evil_link3.xml"
+    _symlink_or_skip(secret, link)
+
+    reader = IPIPANCorpusReader(str(root), r".*\.xml")
+    with pytest.raises(ValueError, match="escapes root"):
+        reader.fileids(channels=["prasa"])


### PR DESCRIPTION
## Summary

Reported as [GHSA-3hhw-38pf-pxj6](https://github.com/nltk/nltk/security/advisories/GHSA-3hhw-38pf-pxj6).

`channels()`, `domains()`, `categories()` and `fileids(channels=...)` route through `_get_tag()`, which calls the builtin `open()` on a plain string produced by `.replace("morph.xml", "header.xml")` on the result of `self.abspath()`. Since `FileSystemPathPointer` subclasses `str`, that `.replace()` call silently discards the `PathPointer` wrapper, so the resulting `open()` never goes through `nltk.pathsec` at all, not even the global, non-scoped check. A symlink planted inside the corpus root, with a name containing no separators or `..`, passes the existing traversal guard cleanly and can point anywhere on the filesystem the process can read.

This is a more severe variant of the same CWE-59 class already fixed for `CorpusReader.open()`, `NKJPCorpusReader.add_root()`, and `FramenetCorpusReader` (#3726): those still route through the global `pathsec` check at minimum. Here `pathsec` is skipped entirely.

## PoC (before this change)

```python
import os
import tempfile

from nltk.corpus.reader.ipipan import IPIPANCorpusReader

root = tempfile.mkdtemp()
corpus_root = os.path.join(root, "ipipan")
os.makedirs(corpus_root)

with open(os.path.join(corpus_root, "real_morph.xml"), "w") as f:
    f.write("<channel>legit</channel>")

secret_dir = os.path.join(root, "outside_ipipan_root")
os.makedirs(secret_dir)
secret_path = os.path.join(secret_dir, "stolen.xml")
with open(secret_path, "w") as f:
    f.write("<channel>TOP-SECRET-CHANNEL-DATA-FROM-OUTSIDE-CORPUS-ROOT</channel>")

os.symlink(secret_path, os.path.join(corpus_root, "evil_link.xml"))

reader = IPIPANCorpusReader(corpus_root, r".*\.xml")  # normal regex auto-discovery
print(reader.channels(fileids=["evil_link.xml"]))
# ['TOP-SECRET-CHANNEL-DATA-FROM-OUTSIDE-CORPUS-ROOT']
```

Literal `../` traversal in the fileid is already rejected by `FileSystemPathPointer.join()`, so this is specifically the symlink variant.

## Fix

Call `nltk.pathsec.validate_path()` with the corpus root as `required_root` inside `_get_tag()` itself, the single choke point all four affected methods route through, before the `open()` call. Same symlink-resolving, root-scoped containment check already used by `CorpusReader.open()` and `NKJPCorpusReader.add_root()`.

## Tests

Adds `nltk/test/unit/test_ipipan_security.py`: a legitimate in-root read still works, literal `../` traversal is still rejected, and a symlink planted inside the corpus root, discovered via normal regex-based auto-discovery rather than hand-picked at construction time, is rejected for `channels()`, `domains()` and `fileids(channels=...)`.

## Validation

- Verified end to end against unpatched `develop`: `channels()` opens the file outside the corpus root and returns its content to the caller, with the reader constructed the normal way (regex auto-discovery), not a contrived setup.
- After the fix, the same PoC and the new regression tests are blocked with a clear `Security Violation ... escapes root` error.
- Ran the full `test_ipipan_security.py`, `test_corpus_reader.py`, `test_data_security.py`, `test_pathsec.py` and `test_framenet_security.py` suites in two independent fresh virtual environments (Python 3.12 and 3.13): all pass, no regressions.
- Tried chained symlinks, a symlinked subdirectory with a subpath fileid, NUL byte injection, a drive-qualified name, and an absolute path fileid against the fixed code; all rejected. Also confirmed a symlink that legitimately resolves inside the corpus root still works normally, so the fix does not break legitimate in-root symlinks.
- Ran `pre-commit` on the changed files (black, isort, ruff, pyupgrade): clean.