### PR TITLE
Split sentences ending in a curly quote or guillemet in Punkt

### DIFF
--- a/nltk/test/unit/test_tokenize.py
+++ b/nltk/test/unit/test_tokenize.py
@@ -998,6 +998,47 @@ class TestTokenize:
     def test_sent_tokenize(self, sentences: str, expected: list[str]):
         assert sent_tokenize(sentences) == expected
 
+    def test_sent_tokenize_curly_quotes_and_guillemets_issue_2333(self):
+        # Regression test for https://github.com/nltk/nltk/issues/2333.
+        #
+        # A sentence-final Unicode curly closing quote or guillemet that
+        # directly abuts the period, with no intervening whitespace, used to
+        # hide the sentence boundary from Punkt entirely: the period matched
+        # neither the "non-word char" branch nor the "whitespace" branch of
+        # the period-context regex, so period_context_re() never even
+        # yielded a match at that position. NLTKWordTokenizer's
+        # STARTING_QUOTES / ENDING_QUOTES (see
+        # test_word_tokenize_opening_single_quote_padding above) already
+        # special-cased this character set; PunktLanguageVars did not.
+        assert sent_tokenize("“First sentence.” Next one.") == [
+            "“First sentence.”",
+            "Next one.",
+        ]
+        assert sent_tokenize("He said “this is great.” Then left.") == [
+            "He said “this is great.”",
+            "Then left.",
+        ]
+        assert sent_tokenize("She asked, “Are you coming?” He nodded.") == [
+            "She asked, “Are you coming?”",
+            "He nodded.",
+        ]
+        assert sent_tokenize("Il a dit «bonjour.» Puis il est parti.") == [
+            "Il a dit «bonjour.»",
+            "Puis il est parti.",
+        ]
+
+        # Regression guards: straight quotes and plain text (no quotes at
+        # all) must tokenize exactly as before, unaffected by the new
+        # boundary-realignment / non-word-char classes.
+        assert sent_tokenize('He said "hi." Then left.') == [
+            'He said "hi."',
+            "Then left.",
+        ]
+        assert sent_tokenize("This is one sentence. This is another.") == [
+            "This is one sentence.",
+            "This is another.",
+        ]
+
     def test_string_tokenizer(self) -> None:
         sentence = "Hello there"
         tokenizer = CharTokenizer()

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -234,13 +234,11 @@ class PunktLanguageVars:
     """sentence internal punctuation, which indicates an abbreviation if
     preceded by a period-final token."""
 
-    # Include the Unicode curly quotes (u'\u2018' u'\u2019'
-    # u'\u201c' u'\u201d') and guillemets (u'\xab' u'\xbb')
-    # alongside the ASCII closing punctuation, so a sentence-final curly or
-    # guillemet quote realigns onto the sentence that just ended instead of
-    # hiding the boundary from Punkt. NLTKWordTokenizer
-    # (nltk/tokenize/destructive.py) already treats this same character set
-    # specially (STARTING_QUOTES / ENDING_QUOTES), added in gh-1682.
+    # Treat the Unicode curly quotes (u'\u2018' u'\u2019' u'\u201c' u'\u201d')
+    # and guillemets (u'\xab' u'\xbb') as closing punctuation like the ASCII
+    # quotes, so a sentence-final curly/guillemet quote is realigned onto the
+    # sentence it follows. NLTKWordTokenizer (nltk/tokenize/destructive.py)
+    # already handles this same set (STARTING_QUOTES / ENDING_QUOTES, gh-1682).
     re_boundary_realignment = re.compile(
         r'["\')\]}\u2018\u2019\u201c\u201d\xab\xbb]+?(?:\s+|(?=--)|$)',
         re.MULTILINE,
@@ -253,6 +251,8 @@ class PunktLanguageVars:
 
     @property
     def _re_non_word_chars(self):
+        # Including the curly quotes/guillemets here makes a period that
+        # directly abuts one still register as a sentence boundary.
         return (
             r"(?:[)\";}\]\*:@\'\({\[\u2018\u2019\u201c\u201d\xab\xbb%s])"
             % re.escape("".join(set(self.sent_end_chars) - {"."}))

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -234,7 +234,17 @@ class PunktLanguageVars:
     """sentence internal punctuation, which indicates an abbreviation if
     preceded by a period-final token."""
 
-    re_boundary_realignment = re.compile(r'["\')\]}]+?(?:\s+|(?=--)|$)', re.MULTILINE)
+    # Include the Unicode curly quotes (u'\u2018' u'\u2019'
+    # u'\u201c' u'\u201d') and guillemets (u'\xab' u'\xbb')
+    # alongside the ASCII closing punctuation, so a sentence-final curly or
+    # guillemet quote realigns onto the sentence that just ended instead of
+    # hiding the boundary from Punkt. NLTKWordTokenizer
+    # (nltk/tokenize/destructive.py) already treats this same character set
+    # specially (STARTING_QUOTES / ENDING_QUOTES), added in gh-1682.
+    re_boundary_realignment = re.compile(
+        r'["\')\]}\u2018\u2019\u201c\u201d\xab\xbb]+?(?:\s+|(?=--)|$)',
+        re.MULTILINE,
+    )
     """Used to realign punctuation that should be included in a sentence
     although it follows the period (or ?, !)."""
 
@@ -243,8 +253,9 @@ class PunktLanguageVars:
 
     @property
     def _re_non_word_chars(self):
-        return r"(?:[)\";}\]\*:@\'\({\[%s])" % re.escape(
-            "".join(set(self.sent_end_chars) - {"."})
+        return (
+            r"(?:[)\";}\]\*:@\'\({\[\u2018\u2019\u201c\u201d\xab\xbb%s])"
+            % re.escape("".join(set(self.sent_end_chars) - {"."}))
         )
 
     """Characters that cannot appear within words"""


### PR DESCRIPTION
## Problem

`sent_tokenize` (and `word_tokenize`, which uses it) fail to split a sentence that ends with a Unicode curly closing quote (`”`) or a guillemet (`»`) when more text follows:

```python
sent_tokenize("“First sentence.” Next one.")
# ['“First sentence.” Next one.']   -> should be ['“First sentence.”', 'Next one.']
```

A period directly followed by `”` / `»` matches neither the "non-word character" branch nor the whitespace branch of Punkt's period-context regex, so no sentence boundary is found there. Straight quotes (`"..."`) already work.

## Fix

Add the curly quote and guillemet characters (`‘ ’ “ ” « »`) to Punkt's two boundary character classes in `nltk/tokenize/punkt.py` — `re_boundary_realignment` and `_re_non_word_chars` — using the same `‘’“”\xab\xbb` set that `nltk/tokenize/destructive.py` already documents and uses for the word tokenizer (added in #1682). The change only affects text containing those characters; straight-quote, no-quote, abbreviation, decimal, and ellipsis tokenization are byte-identical to before.

## Test

Adds a regression test covering curly double quotes, a mid-sentence embedded quote, a quote after `?`, and French guillemets, plus straight-quote and no-quote controls, using the trained `punkt_tab/english` model.

Fixes #2333.
