### PR TITLE
Skip draft step in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
 
   build-and-github-release:
     needs: gate-on-ci
-    name: Build and create GitHub draft release
+    name: Build and create GitHub release
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -108,5 +108,4 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           files: dist/*
-          draft: true
           generate_release_notes: true


### PR DESCRIPTION
The release workflow has always worked well, except that approving the draft turned out to be a little annoying.

So this PR modifies the release.yml workflow to publish the releases directly on Github, skipping the draft step.