### PR TITLE
docs: wrap Chat-80 HOWTO output

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -317,6 +317,7 @@
 - Bradley Erickson <https://github.com/13rac1>
 - Volodymyr Matsko <https://github.com/Lemm1>
 - Nicola <https://github.com/trinik15>
+- medisean <https://github.com/medisean>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 

--- a/nltk/test/chat80.doctest
+++ b/nltk/test/chat80.doctest
@@ -108,14 +108,22 @@ the extraction.
     >>> concepts = chat80.clause2concepts('cities.pl', 'city', schema)
     >>> concepts
     [Concept('city'), Concept('country_of'), Concept('population_of')]
+    >>> from pprint import pprint
     >>> for c in concepts:
-    ...     print("%s:\n\t%s" % (c.prefLabel, c.extension[:4]))
+    ...     print(f"{c.prefLabel}:")
+    ...     pprint(c.extension[:4], indent=4, width=80)
     city:
-        ['athens', 'bangkok', 'barcelona', 'berlin']
+    ['athens', 'bangkok', 'barcelona', 'berlin']
     country_of:
-        [('athens', 'greece'), ('bangkok', 'thailand'), ('barcelona', 'spain'), ('berlin', 'east_germany')]
+    [   ('athens', 'greece'),
+        ('bangkok', 'thailand'),
+        ('barcelona', 'spain'),
+        ('berlin', 'east_germany')]
     population_of:
-        [('athens', '1368'), ('bangkok', '1178'), ('barcelona', '1280'), ('berlin', '3481')]
+    [   ('athens', '1368'),
+        ('bangkok', '1178'),
+        ('barcelona', '1280'),
+        ('berlin', '3481')]
 
 In addition, the ``extension`` can be further
 processed: in the case of the ``'border'`` relation, we check that the


### PR DESCRIPTION
## Summary

Wraps the long `country_of` and `population_of` output in the Chat-80 HOWTO with `pprint`, so the rendered documentation remains readable without horizontal scrolling.

Also adds the contributor entry requested by the contribution guide.

## Testing

- `python -m doctest -o ELLIPSIS -o NORMALIZE_WHITESPACE nltk/test/chat80.doctest`
- verified `nltk/test/chat80.doctest` has no lines over 100 characters
- `git diff --check`

Contributes to #2858.