### PR TITLE
ci: sandboxed-open guard + stabilize security tests across platforms/pythons (#3740)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,15 @@ repos:
     hooks:
     - id: ruff
       args: [--fix]
+  - repo: local
+    hooks:
+    - id: no-unsandboxed-open
+      name: no un-sandboxed open() in sandbox-sensitive modules
+      description: >-
+        Corpus readers and nltk.data resolve untrusted paths; they must open
+        files through the pathsec sandbox (CWE-22/59). Fails on a bare builtin
+        open() in the guarded modules (issue #3740).
+      entry: python tools/check_no_unsandboxed_open.py
+      language: system
+      pass_filenames: false
+      always_run: true

--- a/nltk/tag/perceptron.py
+++ b/nltk/tag/perceptron.py
@@ -332,14 +332,26 @@ class PerceptronTagger(TaggerI):
     def save_to_json(self, lang="xxx", loc=None):
         if not loc:
             loc = self.save_dir
-        # The default TRAINED_TAGGER_PATH is the system temp dir -- shared and
-        # world-writable on Linux -- and the save dir is a *guessable* name in
-        # it, so a local attacker can pre-plant or race a symlink at ``loc``. A
-        # plain ``islink`` pre-check is non-atomic (TOCTOU) and misses it once
-        # created; ``_open_private_model_dir`` instead creates/re-opens the leaf
-        # atomically with O_NOFOLLOW|O_DIRECTORY and verifies it is a real,
-        # user-owned, non-world-writable directory, returning a pinned fd
-        # (CWE-59/377/378).
+        # On POSIX the default TRAINED_TAGGER_PATH is a shared, world-writable
+        # temp dir (/tmp) and the save dir is a *guessable* name in it, so a
+        # local attacker can pre-plant or race a symlink at ``loc``. A plain
+        # ``islink`` pre-check is non-atomic (TOCTOU) and misses it once created;
+        # ``_open_private_model_dir`` instead creates/re-opens the leaf atomically
+        # with O_NOFOLLOW|O_DIRECTORY, verifies it is a real, user-owned,
+        # non-world-writable directory, and returns a pinned fd we write relative
+        # to (CWE-59/377/378).
+        #
+        # On Windows ``%TEMP%`` is per-user and ACL-protected (no such squat), and
+        # ``os.open`` cannot open a directory as a descriptor there, so use a
+        # plain create + write.
+        if os.name != "posix":
+            os.makedirs(loc, exist_ok=True)
+            _authorize_private_dir(loc)
+            for param, json_file in zip(self.encode_json_obj(), self.param_files(lang)):
+                with open(path_join(loc, json_file), "w") as fout:
+                    json.dump(param, fout)
+            return
+
         dir_fd = _open_private_model_dir(loc)
         try:
             _authorize_private_dir(loc)

--- a/nltk/test/unit/test_path_traversal_security.py
+++ b/nltk/test/unit/test_path_traversal_security.py
@@ -149,7 +149,10 @@ def test_no_payload_reads_a_sentinel_outside_the_data_root():
         for p in payloads:
             try:
                 ptr = D.find(p)
-            except (ValueError, LookupError):
+            except Exception:
+                # Any exception (ValueError guard, LookupError not-found, or a
+                # UnicodeDecodeError from decoding overlong %c0%af on Python 3.14+)
+                # means the payload did not resolve to a readable file -- no leak.
                 continue
             try:
                 content = ptr.open().read()
@@ -175,13 +178,16 @@ def test_double_encoded_stays_literal_in_root():
     saved = list(D.path)
     D.path.insert(0, dataroot)
     try:
-        for p in (
-            "..%252fsecret.txt",
-            "..%c0%afsecret.txt",
-            "..%252f..%252fsecret.txt",
-        ):
+        # Valid percent-encoding: url2pathname single-decodes -> literal in-root
+        # name that does not exist -> LookupError (never a separator/traversal).
+        for p in ("..%252fsecret.txt", "..%252f..%252fsecret.txt"):
             with pytest.raises(LookupError):
-                D.find(p)  # literal in-root name that does not exist -> not found
+                D.find(p)
+        # Overlong-UTF-8 ``%c0%af`` never decodes to "/". On Python <3.14 unquote
+        # replaces the bytes (-> literal in-root -> LookupError); on 3.14+ unquote
+        # raises UnicodeDecodeError. Either way it is rejected, never a leak.
+        with pytest.raises((LookupError, UnicodeDecodeError)):
+            D.find("..%c0%afsecret.txt")
     finally:
         D.path[:] = saved
 

--- a/nltk/test/unit/test_path_traversal_security.py
+++ b/nltk/test/unit/test_path_traversal_security.py
@@ -40,7 +40,6 @@ _MUST_REJECT = [
     "%2e%2e/%2e%2e/etc/passwd",
     "%2e%2e%2f%2e%2e%2fetc%2fpasswd",
     "%2fetc%2fpasswd",
-    "/etc/passwd",
     "corpora/../../../etc/passwd",
     "corpora/%2e%2e%2f%2e%2e%2fetc%2fpasswd",
     "nltk:../secret.txt",
@@ -71,10 +70,30 @@ _MUST_ALLOW = [
 ]
 
 
+# POSIX-only: a bare leading-slash path is absolute only on POSIX. On Windows it
+# has no drive letter, so it normalizes to a relative resource name and is a
+# not-found LookupError (not a traversal). Windows absolute forms (drive-letter /
+# UNC, in _MUST_REJECT) are rejected on every platform.
+_MUST_REJECT_POSIX_ABS = ["/etc/passwd"]
+
+
 @pytest.mark.parametrize("payload", _MUST_REJECT)
 def test_find_rejects_traversal(payload):
     with pytest.raises(ValueError):
         D.find(payload)
+
+
+@pytest.mark.skipif(
+    os.name != "posix", reason="a bare leading-slash is absolute only on POSIX"
+)
+@pytest.mark.parametrize("payload", _MUST_REJECT_POSIX_ABS)
+def test_posix_absolute_path_is_rejected(payload):
+    with pytest.raises(ValueError):
+        D.find(payload)
+    with pytest.raises(ValueError):
+        D.load(payload, format="raw")
+    with pytest.raises(ValueError):
+        D.normalize_resource_url(payload)
 
 
 @pytest.mark.parametrize("payload", _MUST_REJECT)
@@ -167,16 +186,41 @@ def test_double_encoded_stays_literal_in_root():
         D.path[:] = saved
 
 
-def test_file_scheme_absolute_is_by_design_not_traversal():
-    """The ``file:`` scheme is an explicit, documented absolute-path reference --
-    it is *meant* to read the named file. The traversal boundary applies to
-    no-protocol / nltk: resource names (relative to the data root), which cannot
-    reach an absolute path. This test pins that contract so file:// handling is
-    not "fixed" into rejecting legitimate absolute loads."""
+def test_file_scheme_is_not_rejected_as_a_traversal():
+    """The security-relevant, platform-independent half: the ``file:`` scheme is
+    an explicit reference, NOT a data-root-relative name -- so the traversal
+    guard must not reject a plain file: URL as "unsafe" (it is by-design, unlike
+    a no-protocol ``..`` name). (file: URL *path* resolution -- drive letters,
+    leading slashes -- differs on Windows and is exercised by nltk.data's own
+    tests; the actual read is checked POSIX-only below.)"""
+    for url in ("file:///data/corpus/x.txt", "file://localhost/data/x.txt"):
+        # Must not raise ValueError ("unsafe resource path"); a LookupError later
+        # (resource absent) would be fine, but normalization itself must accept.
+        D.normalize_resource_url(url)
+
+
+@pytest.mark.skipif(
+    os.name != "posix", reason="file: URL path resolution is POSIX-specific here"
+)
+def test_file_scheme_reads_an_in_root_file(monkeypatch):
+    """A legitimate file: load of a file inside an allowed root works -- pinning
+    that file:// handling is by-design and not "fixed" into rejecting it."""
+    import pathlib
+
+    import nltk.data
+    import nltk.pathsec as P
+
     base = tempfile.mkdtemp()
-    target = os.path.join(base, "explicit.txt")
-    open(target, "w").write("EXPLICIT-CONTENT")
-    obj = D.load("file://" + target, format="raw")
+    allowed = os.path.join(base, "allowed")
+    os.makedirs(allowed)
+    monkeypatch.setattr(P, "ENFORCE", True)
+    monkeypatch.setattr(nltk.data, "path", list(nltk.data.path) + [allowed])
+    monkeypatch.setattr(P, "_ALLOWED_ROOTS_CACHE", None)
+
+    target = os.path.join(allowed, "explicit.txt")
+    with open(target, "w") as fh:
+        fh.write("EXPLICIT-CONTENT")
+    obj = D.load(pathlib.Path(target).as_uri(), format="raw")
     data = obj.decode() if isinstance(obj, bytes) else obj
     assert "EXPLICIT-CONTENT" in data
 
@@ -188,7 +232,8 @@ def test_file_scheme_absolute_is_by_design_not_traversal():
 
 @pytest.mark.skipif(os.name != "posix", reason="O_NOFOLLOW hardening is POSIX-only")
 class TestPathsecSymlinkHardening:
-    def _roots(self):
+    def _roots(self, monkeypatch):
+        import nltk.data
         import nltk.pathsec as P
 
         base = tempfile.mkdtemp()
@@ -196,11 +241,18 @@ class TestPathsecSymlinkHardening:
         os.makedirs(root)
         outside = os.path.join(base, "outside")
         os.makedirs(outside)
-        P.ENFORCE = True
+        monkeypatch.setattr(P, "ENFORCE", True)
+        # Register ``root`` (not ``base``) as an allowed data root so pathsec
+        # permits access on every platform: Linux ``/tmp`` is world-writable and
+        # is deliberately NOT auto-trusted, unlike a private macOS ``$TMPDIR``.
+        # ``outside`` stays a sibling of ``root`` -- outside every allowed root --
+        # so an escape to it is still a genuine violation.
+        monkeypatch.setattr(nltk.data, "path", list(nltk.data.path) + [root])
+        monkeypatch.setattr(P, "_ALLOWED_ROOTS_CACHE", None)
         return P, base, root, outside
 
-    def test_benign_write_read_roundtrip_and_private_perms(self):
-        P, base, root, outside = self._roots()
+    def test_benign_write_read_roundtrip_and_private_perms(self, monkeypatch):
+        P, base, root, outside = self._roots(monkeypatch)
         p = os.path.join(root, "model.json")
         with P.open(p, "w", required_root=root) as fh:
             fh.write("HELLO")
@@ -208,8 +260,8 @@ class TestPathsecSymlinkHardening:
         # created file must not be group/world readable (CWE-377/378)
         assert (os.stat(p).st_mode & 0o077) == 0
 
-    def test_static_symlink_to_outside_is_refused_read_and_write(self):
-        P, base, root, outside = self._roots()
+    def test_static_symlink_to_outside_is_refused_read_and_write(self, monkeypatch):
+        P, base, root, outside = self._roots(monkeypatch)
         victim = os.path.join(outside, "victim")
         open(victim, "w").write("ORIG")
         link = os.path.join(root, "pkg")
@@ -223,7 +275,7 @@ class TestPathsecSymlinkHardening:
     def test_write_toctou_symlink_swap_is_blocked(self, monkeypatch):
         # Simulate the race the O_NOFOLLOW hardening closes: validate_path passed
         # on stale state, then a symlink appears at the destination before open.
-        P, base, root, outside = self._roots()
+        P, base, root, outside = self._roots(monkeypatch)
         victim = os.path.join(outside, "victim")
         open(victim, "w").write("ORIG")
         link = os.path.join(root, "evil")
@@ -234,7 +286,7 @@ class TestPathsecSymlinkHardening:
         assert open(victim).read() == "ORIG", "write followed the symlink (TOCTOU leak)"
 
     def test_read_toctou_symlink_swap_is_blocked(self, monkeypatch):
-        P, base, root, outside = self._roots()
+        P, base, root, outside = self._roots(monkeypatch)
         secret = os.path.join(outside, "secret")
         open(secret, "w").write("TOP-SECRET")
         link = os.path.join(root, "data")
@@ -244,7 +296,7 @@ class TestPathsecSymlinkHardening:
             P.open(link, "r", required_root=root).read()
 
     def test_hardlink_to_outside_inode_is_refused(self, monkeypatch):
-        P, base, root, outside = self._roots()
+        P, base, root, outside = self._roots(monkeypatch)
         secret = os.path.join(outside, "secret")
         open(secret, "w").write("TOP-SECRET")
         hard = os.path.join(root, "hard")
@@ -256,11 +308,11 @@ class TestPathsecSymlinkHardening:
         with pytest.raises(PermissionError):
             P.open(hard, "r", required_root=root).read()
 
-    def test_malformed_mode_does_not_leak_fd(self):
+    def test_malformed_mode_does_not_leak_fd(self, monkeypatch):
         # os.open() accepts some mode strings os.fdopen() rejects (e.g. ""). The
         # fdopen must be inside the fd-closing guard or repeated calls exhaust
         # the fd table (DoS).
-        P, base, root, outside = self._roots()
+        P, base, root, outside = self._roots(monkeypatch)
         f = os.path.join(root, "x")
         with open(f, "w") as fh:
             fh.write("hi")

--- a/nltk/test/unit/test_quadratic_dos.py
+++ b/nltk/test/unit/test_quadratic_dos.py
@@ -231,15 +231,30 @@ class TestSyllableTokenizerDoS:  # SyllableTokenizer -- has MULTIPLE directions
     def test_direction1_vowelless_syllables_are_linear(self, monkeypatch):
         # Pre-patch: `validate_syllables` rebuilt the whole list
         # (`valid_syllables[:-1] + [...]`) for every vowelless syllable, so a
-        # token like 'aebcd'*n cost O(n^2) (8000 rep = 0.77s, quadratic curve).
-        # In-place merge makes it linear. Guard is lifted so the loop actually
-        # runs on the large input. A 4x-input ratio test tolerates the constant.
+        # token like 'aebcd'*n cost O(n^2). In-place merge makes it linear.
+        #
+        # This is a wall-clock ratio test, so it must be robust to CI timing
+        # noise: (1) a base size large enough that a single tokenize is well
+        # above timer resolution (a 4000-rep base measured ~0.01s -- noise
+        # dominated -- and made the ratio explode on a free-threaded runner); and
+        # (2) the MEDIAN of a few runs, robust to both a fast and a slow outlier.
+        # Linear -> t4 ~ 4*t1; the pre-fix O(n^2) -> t4 ~ 16*t1, so an 8x
+        # threshold separates them with wide margin.
+        import statistics
+
         from nltk.tokenize import SyllableTokenizer
 
         monkeypatch.setattr(SyllableTokenizer, "MAX_TOKEN_LEN", 10**9)
-        t1 = _elapsed(lambda: SyllableTokenizer().tokenize("aebcd" * 4000))
-        t4 = _elapsed(lambda: SyllableTokenizer().tokenize("aebcd" * 16000))
-        assert t4 < 10 * t1 + 0.5
+
+        def _median(n):
+            return statistics.median(
+                _elapsed(lambda: SyllableTokenizer().tokenize("aebcd" * n))
+                for _ in range(3)
+            )
+
+        t1 = _median(8000)
+        t4 = _median(32000)  # 4x the input
+        assert t4 < 8 * t1 + 0.5
 
     def test_direction2_giant_multivowel_token_is_bounded(self):
         # A multi-vowel token passes the early return and reaches the O(n)

--- a/tools/check_no_unsandboxed_open.py
+++ b/tools/check_no_unsandboxed_open.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# Natural Language Toolkit: sandboxed-open CI guard
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+"""Fail if a bare builtin ``open(`` is used in a sandbox-sensitive module.
+
+Modules that resolve *untrusted* paths (corpus readers reading corpus files,
+``nltk.data`` resolving resource names) must open files through the pathsec
+sandbox -- ``from nltk.pathsec import open as pathsec_open`` -- so path
+traversal / symlink-TOCTOU protections apply (CWE-22/59). The two historical
+aliases (``pathsec_open`` / ``_secure_open``) both point at ``nltk.pathsec.open``;
+this guard makes the *policy* enforceable regardless of the alias, which is the
+security intent behind issue #3740 (superseding a one-off alias rename that could
+silently drift again).
+
+An AST check is used rather than a regex so that only the *builtin* ``open(...)``
+(``ast.Name`` ``open``) is flagged -- ``pathsec_open(...)``, ``self.open(...)``,
+``fp.open()``, ``os.open(...)``, ``gzip.open(...)`` etc. (all ``ast.Attribute``
+or differently-named) are correctly ignored.
+
+A deliberate, reviewed exception may be annotated with a trailing
+``# sandboxed-open ok: <reason>`` comment on the same line.
+
+Usage: ``python tools/check_no_unsandboxed_open.py`` (exit 1 on any violation).
+"""
+
+import ast
+import os
+import sys
+
+# Sandbox-sensitive modules that must never open a file with the builtin. These
+# are currently clean; the guard keeps them that way.
+GUARDED_PATHS = [
+    "nltk/corpus/reader",
+    "nltk/corpus/util.py",
+    "nltk/data.py",
+]
+
+SUPPRESS_MARKER = "# sandboxed-open ok"
+
+
+def _iter_py_files(path):
+    if os.path.isfile(path):
+        yield path
+        return
+    for dirpath, _dirs, files in os.walk(path):
+        for name in files:
+            if name.endswith(".py"):
+                yield os.path.join(dirpath, name)
+
+
+def find_violations(paths):
+    violations = []
+    for base in paths:
+        for py in _iter_py_files(base):
+            with open(
+                py, encoding="utf-8"
+            ) as fh:  # sandboxed-open ok: the guard itself
+                source = fh.read()
+            try:
+                tree = ast.parse(source, py)
+            except SyntaxError:
+                continue
+            lines = source.splitlines()
+            for node in ast.walk(tree):
+                if (
+                    isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Name)
+                    and node.func.id == "open"
+                ):
+                    # Scan every physical line of the call so a suppression
+                    # marker still counts if the formatter wrapped the call.
+                    end = getattr(node, "end_lineno", node.lineno) or node.lineno
+                    span = lines[node.lineno - 1 : end]
+                    if any(SUPPRESS_MARKER in ln for ln in span):
+                        continue
+                    line = span[0].strip() if span else ""
+                    violations.append((py, node.lineno, line.strip()))
+    return violations
+
+
+def main():
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    os.chdir(root)
+    violations = find_violations(GUARDED_PATHS)
+    if not violations:
+        print("sandboxed-open guard: OK (no un-sandboxed open() in guarded modules)")
+        return 0
+    print(
+        "sandboxed-open guard: FAILED -- builtin open() in a sandbox-sensitive module."
+    )
+    print("Use `from nltk.pathsec import open as pathsec_open` (or annotate a reviewed")
+    print(f"exception with `{SUPPRESS_MARKER}: <reason>`). Offenders:\n")
+    for path, lineno, text in violations:
+        print(f"  {path}:{lineno}: {text}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Full CI matrix green (3.10–3.14 + 3.14t × ubuntu/macOS/windows). Four commits, two concerns:

## 1. Sandboxed-open guard (#3740)
`tools/check_no_unsandboxed_open.py` — an AST check that **fails if a bare builtin `open(` appears in a sandbox-sensitive module** (`nltk/corpus/reader/`, `nltk/corpus/util.py`, `nltk/data.py` — all clean) — wired as a **pre-commit local hook**. Corpus readers and `nltk.data` resolve untrusted paths, so they must open through the pathsec sandbox (CWE-22/59). A durable answer to #3740: makes the policy enforceable regardless of import alias, instead of a one-off rename that can drift. AST-based (only builtin `open` is flagged; `pathsec_open()`, `os.open()`, `self.open()` ignored); reviewed exceptions via `# sandboxed-open ok: <reason>`.

## 2. Stabilize the merged security tests across platforms / Python versions
The GHSA-8mgp path-traversal suite and the earlier quadratic-DoS suite were validated on macOS/local only (advisory forks had Actions disabled), so several **platform/version-fragile tests** were red once they hit the real matrix. Fixed with **no weakening of any security assertion** — each either broadens *accepted rejection outcomes* (a real leak returns no exception, so it's still caught) or makes timing measurement robust:

| Failure | Type | Fix |
|---|---|---|
| Linux: temp dirs aren't a pathsec allowed root (`/tmp` is world-writable) | test | register the sandbox root into `nltk.data.path` (existing `test_pathsec.py` idiom) |
| Windows: `file://` URL path semantics (drive letters/slashes) | test | split into a cross-platform "normalize doesn't reject `file:`" check + a POSIX-only read |
| Windows: bare leading-slash `/etc/passwd` isn't absolute (no drive letter) | test | gate that one payload POSIX-only; Windows absolute forms (`C:\…`, `\\…`) stay cross-platform |
| **Windows: `PerceptronTagger.save_to_json` crashed** — `os.open()` can't fd-open a directory | **production** | POSIX-gate the O_NOFOLLOW dir-fd hardening; plain `makedirs`+write on Windows (`%TEMP%` is per-user ACL-protected, no shared-temp squat there) |
| Python 3.14: `url2pathname` raises `UnicodeDecodeError` on overlong-UTF-8 `%c0%af` | test | accept `(LookupError, UnicodeDecodeError)` — both mean rejected/no-leak |
| Python 3.14t: SyllableTokenizer linearity ratio flaked (noisy sub-timer-resolution baseline on the free-threaded build) | test | larger base + median-of-3; 8x threshold still separates linear (~4×) from O(n²) (~16×) |

The one **production** fix (perceptron on Windows) is a real bug on develop from the 8mgp merge, corrected here.

Verified locally: macOS, simulated-Linux (`is_private_dir(tmp)` forced False), Windows-like (POSIX classes skipped), real-3.14 `unquote` behavior, and timing stability across repeated runs. Full CI: **22/22 green**.