### PR TITLE
Show README.md as the PyPI long description

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For documentation, please visit [nltk.org](https://www.nltk.org/).
 ## Contributing
 
 Do you want to contribute to NLTK development? Great!
-Please read [CONTRIBUTING.md](CONTRIBUTING.md) for more details.
+Please read [CONTRIBUTING.md](https://github.com/nltk/nltk/blob/develop/CONTRIBUTING.md) for more details.
 
 See also [how to contribute to NLTK](https://www.nltk.org/contribute.html).
 
@@ -35,9 +35,9 @@ If you publish work that uses NLTK, please cite the NLTK book, as follows:
 
 Copyright (C) 2001-2026 NLTK Project
 
-For license information, see [LICENSE.txt](LICENSE.txt).
+For license information, see [LICENSE.txt](https://github.com/nltk/nltk/blob/develop/LICENSE.txt).
 
-[AUTHORS.md](AUTHORS.md) contains a list of everyone who has contributed to NLTK.
+[AUTHORS.md](https://github.com/nltk/nltk/blob/develop/AUTHORS.md) contains a list of everyone who has contributed to NLTK.
 
 
 ### Redistributing

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,21 @@ version_file = os.path.join(os.path.dirname(__file__), "nltk", "VERSION")
 with open(version_file) as fh:
     nltk_version = fh.read().strip()
 
+# Use README.md as the long description shown on PyPI. Fall back to a short
+# blurb if it is unavailable, so a build can never fail on a missing README.
+_short_description = (
+    "The Natural Language Toolkit (NLTK) is a Python package for "
+    "natural language processing."
+)
+readme_file = os.path.join(os.path.dirname(__file__), "README.md")
+try:
+    with open(readme_file, encoding="utf-8") as fh:
+        long_description = fh.read()
+    long_description_content_type = "text/markdown"
+except OSError:
+    long_description = _short_description
+    long_description_content_type = "text/plain"
+
 # setuptools
 from setuptools import find_packages, setup
 
@@ -65,9 +80,8 @@ setup(
         "Source Code": "https://github.com/nltk/nltk",
         "Issue Tracker": "https://github.com/nltk/nltk/issues",
     },
-    long_description="""\
-The Natural Language Toolkit (NLTK) is a Python package for
-natural language processing.  NLTK requires Python 3.10, 3.11, 3.12, 3.13, or 3.14.""",
+    long_description=long_description,
+    long_description_content_type=long_description_content_type,
     license="Apache License, Version 2.0",
     keywords=[
         "NLP",


### PR DESCRIPTION
## Problem

The [PyPI project page](https://pypi.org/project/nltk/) shows only two sentences:

> The Natural Language Toolkit (NLTK) is a Python package for natural language processing. NLTK requires Python 3.10, 3.11, 3.12, 3.13, or 3.14.

That is not a recent regression — **it has always been this way.** `setup.py` hardcodes `long_description` as a string literal and has **never** read `README.md`:

- `git log --all -S 'README' -- setup.py` → **no commits, ever**.
- The literal traces to 2011 (`e2adf2c04`), where it read *"NLTK requires Python 2.5 or higher."*
- Description length per release, from the PyPI API: `0.9.9` 130 · `2.0.4` 125 · `3.0.0` 129 · `3.2.5` 128 · `3.3–3.5` 133 · `3.7` 135 · `3.8.1` 141 · `3.9.4–3.10.3` **144** chars. Only the Python-version list ever changed.

So the page shows none of the project overview, Contributing / Donate / Citing / Copyright sections, or badges.

A second symptom: because no content type was declared, **every** release emitted a `twine check` warning — ``` `long_description_content_type` missing. defaulting to `text/x-rst` ``` — and PyPI reports `description_content_type: null` for all versions.

## Change

- `setup.py`: read `README.md` and set `long_description_content_type="text/markdown"`. Uses the same `os.path.join(os.path.dirname(__file__), ...)` idiom already used for `nltk/VERSION`. If `README.md` is unreadable it **falls back to the short blurb** rather than raising, so a build can never fail on a missing README.
- `README.md`: make the three relative links absolute (`CONTRIBUTING.md`, `LICENSE.txt`, `AUTHORS.md` → `github.com/nltk/nltk/blob/develop/…`). Relative links **404 on PyPI**, which renders the README outside the repo; they still work normally on GitHub.

## Verification

| Check | Result |
|---|---|
| `twine check dist/*` | **PASSED, no warnings** (previously 1 warning on every release) |
| Wheel metadata | `Description-Content-Type: text/markdown`; description **1868 chars** (was 144), starts `# Natural Language Toolkit (NLTK)` |
| sdist packaging | `README.md` ships via `MANIFEST.in`'s `include *.md`; **rebuilding a wheel from the sdist** reproduces identical metadata (source builds unaffected) |
| PyPI rendering | `readme_renderer[md]` (the renderer PyPI itself uses) renders successfully — 2719 chars HTML, 12 links, **0 relative/404-prone**, badges + headings intact |
| Fallback | exercised with `README.md` absent → no crash, falls back to the plain-text blurb |
| Lint | `pre-commit` clean (no hook modifications) |