### PR TITLE
Add stopwords.words("english-extended")

### DIFF
--- a/nltk/corpus/__init__.py
+++ b/nltk/corpus/__init__.py
@@ -312,8 +312,8 @@ sinica_treebank: SinicaTreebankCorpusReader = LazyCorpusLoader(
 state_union: PlaintextCorpusReader = LazyCorpusLoader(
     "state_union", PlaintextCorpusReader, r"(?!\.).*\.txt", encoding="ISO-8859-2"
 )
-stopwords: WordListCorpusReader = LazyCorpusLoader(
-    "stopwords", WordListCorpusReader, r"(?!README|\.).*", encoding="utf8"
+stopwords: StopwordsCorpusReader = LazyCorpusLoader(
+    "stopwords", StopwordsCorpusReader, r"(?!README|\.).*", encoding="utf8"
 )
 subjectivity: CategorizedSentencesCorpusReader = LazyCorpusLoader(
     "subjectivity",

--- a/nltk/corpus/reader/__init__.py
+++ b/nltk/corpus/reader/__init__.py
@@ -61,6 +61,10 @@ from nltk.corpus.reader.tagged import *
 from nltk.corpus.reader.cmudict import *
 from nltk.corpus.reader.conll import *
 from nltk.corpus.reader.chunked import *
+from nltk.corpus.reader.stopwords_extended import (
+    StopwordsEnglishExtended,
+    StopwordsExtension,
+)
 from nltk.corpus.reader.wordlist import *
 from nltk.corpus.reader.xmldocs import *
 from nltk.corpus.reader.ppattach import *
@@ -120,6 +124,9 @@ __all__ = [
     "CMUDictCorpusReader",
     "ConllChunkCorpusReader",
     "WordListCorpusReader",
+    "StopwordsCorpusReader",
+    "StopwordsExtension",
+    "StopwordsEnglishExtended",
     "PPAttachmentCorpusReader",
     "SensevalCorpusReader",
     "IEERCorpusReader",

--- a/nltk/corpus/reader/stopwords_extended.py
+++ b/nltk/corpus/reader/stopwords_extended.py
@@ -1,0 +1,127 @@
+# Natural Language Toolkit: Code-defined additions to word list corpora
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+"""
+Stop word lists defined in code rather than read from ``nltk_data``.
+
+:class:`~nltk.corpus.reader.wordlist.StopwordsCorpusReader` serves each
+:class:`StopwordsExtension` listed in its ``EXTENSIONS`` as a virtual fileid
+(``english-extended``), built from the corpus file plus the words below. No
+corpus file is added or changed, so an extension works on existing installs with
+no data download.
+
+Additions are limited to closed-class function words that have no frequent
+content-word homonym -- the rule the Snowball English stop list states for
+omitting ``will``, ``can``, ``may``, ``must`` and ``might``. See nltk/nltk#3747
+for the full survey and the accept/reject rationale.
+
+To add ``<lang>-extended``, define the word groups here, name the extension, and
+list it in ``StopwordsCorpusReader.EXTENSIONS``::
+
+    StopwordsLangExtended = StopwordsExtension(
+        fileid="<lang>-extended", base="<lang>", additions=_GROUP_ONE | _GROUP_TWO
+    )
+
+The invariant tests in ``nltk/test/unit/test_stopwords_extended.py`` are
+parametrised over ``EXTENSIONS``, so a new entry is covered automatically.
+"""
+
+from dataclasses import dataclass
+
+
+def curly_variants(words):
+    """Return U+2019 spellings of every entry containing a straight apostrophe.
+
+    Word processors, browsers and phone keyboards emit ``don’t``, which never
+    matches a list holding only ``don't``. Not English-specific: Catalan has 14
+    apostrophe forms in its list.
+
+        >>> sorted(curly_variants(["don't", "the"]))
+        ['don’t']
+    """
+    return frozenset(word.replace("'", "’") for word in words if "'" in word)
+
+
+@dataclass(frozen=True)
+class StopwordsExtension:
+    """One code-defined stop word list, layered over a corpus fileid.
+
+    :param fileid: the virtual fileid it is served as, e.g. ``english-extended``.
+    :param base: the corpus fileid it builds on, e.g. ``english``.
+    :param additions: words to add that are not in the corpus file.
+    :param add_curly_variants: also add U+2019 spellings of every apostrophe
+        form in the combined list. See :func:`curly_variants`.
+    """
+
+    fileid: str
+    base: str
+    additions: frozenset
+    add_curly_variants: bool = True
+
+    def build(self, base_words):
+        """Return *base_words* first and unchanged, then this extension's words."""
+        words = list(base_words)
+        words += sorted(self.additions.difference(words))
+        if self.add_curly_variants:
+            words += sorted(curly_variants(words).difference(words))
+        return words
+
+
+# ---------------------------------------------------------------------------
+# English
+# ---------------------------------------------------------------------------
+
+#: In the Snowball list, absent from NLTK's.
+_SNOWBALL_ADDITIONS = frozenset(
+    {
+        # modals with no content homonym -- Snowball: "would, could, should,
+        # ought might however be included". NLTK has `should` but not these.
+        "could",
+        "would",
+        "ought",
+        # negated `can`. NLTK carries every other negated modal
+        # (`don't`, `won't`, `shouldn't`, `couldn't`, ...) but not this one.
+        "cannot",
+        "can't",
+        # Snowball "COMPOUND FORMS ... pronoun + verb": deictic/wh-word + `is`.
+        # NLTK carries `that'll` and `it's` but none of these.
+        "let's",
+        "that's",
+        "there's",
+        "here's",
+        "who's",
+        "what's",
+        "where's",
+        "when's",
+        "why's",
+        "how's",
+    }
+)
+
+#: Missing members of paradigms NLTK already carries in part -- the recurring
+#: complaint behind #1800, #2588, #3047, #3073 and #3358.
+_PARADIGM_ADDITIONS = frozenset(
+    {
+        # modal + reduced `have`. NLTK has `should've` only.
+        "could've",
+        "would've",
+        "might've",
+        "must've",
+        # negated modals. NLTK has `mightn't`, `mustn't`, `needn't`, `shan't`.
+        "daren't",
+        "oughtn't",
+        "mayn't",
+    }
+)
+
+#: Preposition and negative adverb; homonym-free, in 5 of the 8 lists surveyed.
+_CLOSED_CLASS_ADDITIONS = frozenset({"never", "without"})
+
+#: ``stopwords.words("english-extended")``.
+StopwordsEnglishExtended = StopwordsExtension(
+    fileid="english-extended",
+    base="english",
+    additions=_SNOWBALL_ADDITIONS | _PARADIGM_ADDITIONS | _CLOSED_CLASS_ADDITIONS,
+)

--- a/nltk/corpus/reader/wordlist.py
+++ b/nltk/corpus/reader/wordlist.py
@@ -6,8 +6,10 @@
 # URL: <https://www.nltk.org/>
 # For license information, see LICENSE.TXT
 import os
+from io import StringIO
 
 from nltk.corpus.reader.api import *
+from nltk.corpus.reader.stopwords_extended import StopwordsEnglishExtended
 from nltk.corpus.reader.util import *
 from nltk.tokenize import line_tokenize
 
@@ -37,6 +39,94 @@ class WordListCorpusReader(CorpusReader):
             for line in line_tokenize(self.raw(fileids))
             if not line.startswith(ignore_lines_startswith)
         ]
+
+
+class StopwordsCorpusReader(WordListCorpusReader):
+    """A word list reader that also serves code-defined stop word lists.
+
+    ``stopwords.words("english")`` reads the ``stopwords`` corpus from
+    ``nltk_data`` unchanged. ``english-extended`` is a *virtual* fileid: it is
+    not a file in ``nltk_data``, but is assembled from the ``english`` file plus
+    the additions registered for it, and the U+2019 variants of both. No
+    corpus file is added or modified, so the extension ships with the library
+    and needs no data download.
+
+        >>> from nltk.corpus import stopwords
+        >>> base = stopwords.words("english")
+        >>> extended = stopwords.words("english-extended")
+        >>> set(base).issubset(extended)
+        True
+        >>> "cannot" in base, "cannot" in extended
+        (False, True)
+
+    The word lists themselves, and the criterion used to choose them, live in
+    :mod:`nltk.corpus.reader.stopwords_extended`.
+    """
+
+    #: The code-defined lists this reader serves, as virtual fileids. Listing a
+    #: new :class:`~nltk.corpus.reader.stopwords_extended.StopwordsExtension`
+    #: here is all it takes to serve another ``<lang>-extended``.
+    EXTENSIONS = (StopwordsEnglishExtended,)
+
+    def _extension(self, fileid):
+        """The extension serving *fileid*, or ``None``."""
+        if isinstance(fileid, str):
+            for extension in self.EXTENSIONS:
+                if extension.fileid == fileid:
+                    return extension
+        return None
+
+    def fileids(self):
+        """The corpus fileids, plus any virtual fileid whose base is present."""
+        available = super().fileids()
+        virtual = [e.fileid for e in self.EXTENSIONS if e.base in available]
+        return sorted(available + virtual)
+
+    def words(self, fileids=None, ignore_lines_startswith="\n", hf=False):
+        """As :meth:`WordListCorpusReader.words`, honouring virtual fileids."""
+        extension = self._extension(fileids)
+        if extension is None:
+            return super().words(
+                fileids, ignore_lines_startswith=ignore_lines_startswith, hf=hf
+            )
+        return extension.build(
+            super().words(
+                extension.base,
+                ignore_lines_startswith=ignore_lines_startswith,
+                hf=hf,
+            )
+        )
+
+    def raw(self, fileids=None):
+        """As :meth:`CorpusReader.raw`, honouring virtual fileids.
+
+        A virtual fileid has no file behind it, so its raw form is generated
+        from the word list. Without this, ``raw()`` would fail for a fileid that
+        :meth:`fileids` advertises.
+        """
+        if self._extension(fileids) is not None:
+            return "\n".join(self.words(fileids)) + "\n"
+        return super().raw(fileids)
+
+    def open(self, file):
+        """As :meth:`CorpusReader.open`, honouring virtual fileids."""
+        if self._extension(file) is not None:
+            return StringIO(self.raw(file))
+        return super().open(file)
+
+    def abspath(self, fileid):
+        """As :meth:`CorpusReader.abspath`; virtual fileids have no path.
+
+        Raising here is deliberate: a code-defined list has no file on disk, and
+        a clear error beats the ``OSError`` about a missing corpus file that a
+        path lookup would otherwise produce.
+        """
+        if self._extension(fileid) is not None:
+            raise ValueError(
+                f"{fileid!r} is defined in code, not by a file in the corpus, "
+                "so it has no path; use words() or raw() instead"
+            )
+        return super().abspath(fileid)
 
 
 class SwadeshCorpusReader(WordListCorpusReader):

--- a/nltk/test/corpus.doctest
+++ b/nltk/test/corpus.doctest
@@ -386,9 +386,20 @@ examples illustrate the use of the wordlist corpora:
     ['A', 'a', 'aa', 'aal', 'aalii', 'aam', 'Aani', 'aardvark', 'aardwolf', ...]
 
     >>> stopwords.fileids() # doctest: +SKIP
-    ['arabic', 'azerbaijani', 'bengali', 'danish', 'dutch', 'english', 'finnish', 'french', ...]
+    ['arabic', 'azerbaijani', 'bengali', 'danish', 'dutch', 'english', 'english-extended', 'finnish', ...]
     >>> sorted(stopwords.words('portuguese'))
     ['a', 'ao', 'aos', 'aquela', 'aquelas', 'aquele', 'aqueles', ...]
+
+``english-extended`` is not a file in the corpus: it is the ``english`` list
+plus a set of function words defined in code (see
+``nltk.corpus.reader.wordlist.StopwordsCorpusReader``), so it is always
+available and never changes the ``english`` list itself:
+
+    >>> base, extended = stopwords.words('english'), stopwords.words('english-extended')
+    >>> set(base).issubset(extended)
+    True
+    >>> ('cannot' in base, 'cannot' in extended)
+    (False, True)
     >>> names.fileids()
     ['female.txt', 'male.txt']
     >>> names.words('male.txt')

--- a/nltk/test/unit/test_stopwords_extended.py
+++ b/nltk/test/unit/test_stopwords_extended.py
@@ -1,0 +1,178 @@
+"""
+Tests for the code-defined ``english-extended`` stop word list.
+
+Covers the invariants that make the extension safe to add: it never removes or
+reorders anything from the corpus, it never touches the other languages, and it
+contains exactly the categories documented in
+:mod:`nltk.corpus.reader.stopwords_extended` -- including the words deliberately
+left out.
+"""
+
+import pytest
+
+from nltk.corpus import stopwords
+from nltk.corpus.reader.stopwords_extended import StopwordsEnglishExtended
+from nltk.corpus.reader.wordlist import (
+    StopwordsCorpusReader,
+    WordListCorpusReader,
+)
+
+pytestmark = pytest.mark.skipif(
+    not stopwords.fileids(), reason="stopwords corpus not installed"
+)
+
+
+@pytest.fixture(scope="module")
+def base():
+    return stopwords.words("english")
+
+
+@pytest.fixture(scope="module")
+def extended():
+    return stopwords.words("english-extended")
+
+
+@pytest.mark.parametrize("fileid", [e.fileid for e in StopwordsCorpusReader.EXTENSIONS])
+class TestExtendedIsAdditive:
+    """Invariants every registered extension must satisfy.
+
+    Parametrised over ``StopwordsCorpusReader.EXTENSIONS``, so a new ``<lang>-extended``
+    entry is covered here automatically.
+    """
+
+    def test_is_a_superset_of_its_base(self, fileid):
+        extension = stopwords._extension(fileid)
+        base = stopwords.words(extension.base)
+        assert set(base).issubset(set(stopwords.words(fileid)))
+
+    def test_base_list_is_unchanged(self, fileid):
+        # The corpus file must not be modified or shadowed by the extension.
+        extension = stopwords._extension(fileid)
+        base = stopwords.words(extension.base)
+        assert not (extension.additions & set(base))
+        assert len(base) == len(set(base))
+
+    def test_no_duplicates(self, fileid):
+        extended = stopwords.words(fileid)
+        assert len(extended) == len(set(extended))
+
+    def test_base_entries_keep_their_order(self, fileid):
+        extension = stopwords._extension(fileid)
+        base = stopwords.words(extension.base)
+        assert stopwords.words(fileid)[: len(base)] == base
+
+    def test_exposed_as_a_fileid(self, fileid):
+        assert fileid in stopwords.fileids()
+
+    def test_every_addition_is_present(self, fileid):
+        extension = stopwords._extension(fileid)
+        assert extension.additions.issubset(set(stopwords.words(fileid)))
+
+    def test_every_advertised_fileid_can_be_read(self, fileid):
+        # fileids() advertises the virtual name, so raw()/open() must work on it
+        # too -- otherwise `for f in fileids(): reader.raw(f)` breaks.
+        assert stopwords.raw(fileid).split("\n")[:-1] == stopwords.words(fileid)
+        with stopwords.open(fileid) as stream:
+            assert stream.read() == stopwords.raw(fileid)
+
+    def test_abspath_reports_that_there_is_no_file(self, fileid):
+        # A code-defined list has no path; the error must say so rather than
+        # surface an OSError about a missing corpus file.
+        with pytest.raises(ValueError, match="defined in code"):
+            stopwords.abspath(fileid)
+
+    def test_real_fileids_are_served_unchanged(self, fileid):
+        # A non-virtual fileid must be passed straight through, so the reader
+        # returns exactly what the plain WordListCorpusReader would. Note this
+        # cannot be checked by asserting the additions are absent elsewhere:
+        # `hinglish` legitimately lists English words in its own corpus file.
+        for lang in stopwords.fileids():
+            if stopwords._extension(lang):
+                continue
+            assert stopwords.words(lang) == WordListCorpusReader.words(stopwords, lang)
+
+
+class TestAcceptedAdditions:
+    @pytest.mark.parametrize(
+        "word",
+        [
+            # in Snowball's list, absent from NLTK's
+            "cannot",
+            "can't",
+            "could",
+            "would",
+            "ought",
+            "let's",
+            "that's",
+            "there's",
+            "here's",
+            "who's",
+            "what's",
+            "where's",
+            "when's",
+            "why's",
+            "how's",
+            # paradigm completions (NLTK already has `should've`, `mustn't`, ...)
+            "could've",
+            "would've",
+            "might've",
+            "must've",
+            "daren't",
+            "oughtn't",
+            "mayn't",
+            # closed-class, pass the homonym rule
+            "never",
+            "without",
+        ],
+    )
+    def test_accepted_word_is_present(self, extended, word):
+        assert word in extended
+
+    @pytest.mark.parametrize("word", ["don’t", "i’m", "can’t", "you’re", "it’s"])
+    def test_curly_apostrophe_variants_present(self, extended, word):
+        # U+2019 is what word processors, browsers and phones emit.
+        assert word in extended
+
+    def test_every_straight_form_has_a_curly_twin(self, extended):
+        words = set(extended)
+        missing = {w.replace("'", "’") for w in words if "'" in w} - words
+        assert not missing, f"missing U+2019 variants: {sorted(missing)[:10]}"
+
+
+class TestRejectedAdditions:
+    @pytest.mark.parametrize("word", ["may", "must", "might", "shall"])
+    def test_homonym_risky_modals_excluded(self, extended, word):
+        # Snowball omits these because of "merry month of MAY", "a smell of
+        # MUST", "with all thy MIGHT".
+        assert word not in extended
+
+    @pytest.mark.parametrize(
+        "word", ["gonna", "wanna", "gotta", "lemme", "gimme", "coulda", "shoulda"]
+    )
+    def test_colloquial_reductions_excluded(self, extended, word):
+        # Register-specific, absent from every reference list consulted, and
+        # NLTK's own tokenizer splits them (`gonna` -> `gon`, `na`), so an entry
+        # could never match.
+        assert word not in extended
+
+    @pytest.mark.parametrize(
+        "word", ["system", "cry", "fill", "inc", "ltd", "etc", "eg", "five", "serious"]
+    )
+    def test_smart_list_content_words_excluded(self, extended, word):
+        # Present in SMART-derived lists (scikit-learn, Terrier, MALLET,
+        # stopwords-iso) but content-bearing, so out of scope here.
+        assert word not in extended
+
+
+class TestDeclaredExtensions:
+    def test_declared_additions_match_the_delta(self, base, extended):
+        # Everything gained beyond the U+2019 variants must be exactly what the
+        # extension declares -- no accidental extras from the reader.
+        additions = StopwordsEnglishExtended.additions
+        added = set(extended) - set(base)
+        plain = {w for w in added if "’" not in w}
+        assert plain == additions - set(base)
+
+    def test_declared_additions_are_immutable(self):
+        for extension in StopwordsCorpusReader.EXTENSIONS:
+            assert isinstance(extension.additions, frozenset)


### PR DESCRIPTION
Closes the recurring "word X is missing from the English stop word list" reports without changing the corpus file.

Refs #3047, #2588, #1800, #3073, #3358, and supersedes the testing approach in #3434.

## Problem

Five issues report the same class of defect — a form is present for one member of a paradigm but missing for another:

| Issue | Report | Status today |
|---|---|---|
| **#3073** | `she's` present, **`he's` missing** — "quite a fundamental omission" | since fixed; the clearest illustration |
| **#3358** | `i'm` missing | since fixed |
| **#3047** | `i'm/i've/i'll/i'd`, `cannot`, `could've`, `ought`, `dare` … missing | pronoun forms fixed; **`cannot`, `could've`, `ought`, `mayn't`, `daren't`, `oughtn't` still missing** |
| **#2588** | general additions proposal | open |
| **#1800** | `wouldn` looks like a typo for `wouldn't` | open (both are present; the bare forms are tokenizer artifacts) |

Fixing this by editing `stopwords/english` in `nltk_data` needs a data release and silently changes results for every existing user. This PR instead adds an **opt-in list defined as data in code**: `stopwords.words("english")` is byte-for-byte unchanged, and `stopwords.words("english-extended")` returns it plus the additions — no data file, no re-download, works on existing installs.

## What counts as a stop word

I took the rule from the Snowball English list, which states it explicitly: **a closed-class function word is a safe stop word unless it has a frequent content-word homonym.** Snowball omits `will` ("he made a WILL"), `can` ("old tin CAN"), `may` ("merry month of MAY"), `must` ("a smell of MUST"), `might` ("with all thy MIGHT") on those grounds, while noting *"would, could, should, ought might however be included."*

Rarity is deliberately **not** grounds for exclusion — Snowball keeps rare forms "for completeness" (its example is `yourselves`), and NLTK already carries `shan't` and `mightn't`.

## Survey of eight reference lists

| List | Size | ∩ NLTK | only-list |
|---|---|---|---|
| stopwords-iso | 1298 | 192 | 1106 |
| Terrier | 733 | 120 | 613 |
| MALLET | 523 | 131 | 392 |
| scikit-learn | 318 | 119 | 199 |
| spaCy | 305 | 123 | 182 |
| **Snowball** | **174** | **159** | **15** |
| PostgreSQL | 127 | 127 | 0 |
| Lucene | 33 | 33 | 0 |
| *NLTK* | *198* | — | — |

They form two families: a **conservative function-word family** (Snowball; PostgreSQL and Lucene are strict subsets of NLTK's list) and the **SMART/Fox-derived family** (scikit-learn, Terrier, MALLET, stopwords-iso), which adds content-bearing words (`system`, `cry`, `fill`, `inc`, `ltd`, `serious`, number words). Raw cross-list consensus over-weights the SMART family because its members are not independent, so **Snowball is used as the reference**: it is the closest relative, sharing 159 of its 174 entries with NLTK.

A finding worth noting: NLTK currently includes the homonym-risky `will` and `can`, but **omits** the unambiguous `could`, `would` and `ought` — the reverse of Snowball's own recommendation. It also has every negated modal (`don't`, `won't`, `shouldn't`, `couldn't`, …) **except `can't`**.

## Accepted — 24 words + 63 U+2019 variants (198 → 285)

| Group | Words | Rationale |
|---|---|---|
| In Snowball, absent from NLTK | `cannot`, `can't`, `could`, `would`, `ought`, `let's`, `that's`, `there's`, `here's`, `who's`, `what's`, `where's`, `when's`, `why's`, `how's` | Snowball's "COMPOUND FORMS — pronoun + verb" and its unambiguous modals; `cannot`/`could`/`would` also appear in the SMART family (5/8 lists) |
| Paradigm completion | `could've`, `would've`, `might've`, `must've` · `daren't`, `oughtn't`, `mayn't` | NLTK already has `should've`; and `mightn't`/`mustn't`/`needn't`/`shan't`. Requested in #3047 |
| Closed-class, homonym-free | `never`, `without` | Preposition and negative adverb; NLTK already carries `against`/`between`/`through` and `no`/`nor`/`not`. In 5/8 lists |
| Typographic | U+2019 variants of every apostrophe form, derived at call time | Word processors, browsers and phone keyboards emit `don’t`, which never matches a list holding only `don't`. Same words, different codepoint — no new ambiguity. Not English-specific: Catalan has 14 apostrophe forms in its list |

## Rejected

| Rejected | Why |
|---|---|
| `may`, `must`, `might`, `shall` | Homonyms — the exact forms Snowball omits by name |
| `gonna`, `wanna`, `gotta`, `lemme`, `gimme`, `coulda`, `shoulda`, `woulda` | Register-specific; in **none** of the eight lists; and NLTK's own tokenizer splits them — `word_tokenize("gonna") == ["gon", "na"]` — so an entry could never match. (#3047's author likewise excluded forms that are "dialectal or too informal") |
| `system`, `cry`, `fill`, `inc`, `ltd`, `etc`, `eg`, `five`/`eight`/`nine`, `serious`, `name`, `get`, `go`, `us`, `one` | Content-bearing SMART/Fox-list entries; these are the long-criticised scikit-learn list's known weak spots |

## Design

**No data file is added and no corpus file is touched.** The word groups live in the new `nltk/corpus/reader/stopwords_extended.py`, one `frozenset` per reason they were added, with the citation beside each group.

Each list is an explicit `StopwordsExtension` that records its own virtual fileid and the corpus fileid it builds on:

```python
#: ``stopwords.words("english-extended")``.
StopwordsEnglishExtended = StopwordsExtension(
    fileid="english-extended",
    base="english",
    additions=_SNOWBALL_ADDITIONS | _PARADIGM_ADDITIONS | _CLOSED_CLASS_ADDITIONS,
)
```

`StopwordsCorpusReader` (in `wordlist.py`, beside the other `WordListCorpusReader` subclasses) lists what it serves:

```python
EXTENSIONS = (StopwordsEnglishExtended,)
```

Adding `<lang>-extended` later is a new `StopwordsExtension` plus one entry in that tuple — no reader logic, no corpus change, no test-harness change.

```python
>>> from nltk.corpus import stopwords
>>> len(stopwords.words("english")), len(stopwords.words("english-extended"))
(198, 285)
>>> set(stopwords.words("english")).issubset(stopwords.words("english-extended"))
True
```

Because `fileids()` advertises the virtual name, `raw()` and `open()` serve it too (generated from the word list) so `for f in fileids(): reader.raw(f)` keeps working; `abspath()` raises a clear error explaining that a code-defined list has no path, rather than an `OSError` about a missing corpus file.

## Tests — `nltk/test/unit/test_stopwords_extended.py` (61 tests)

Parametrised over `StopwordsCorpusReader.EXTENSIONS`, so a future `<lang>-extended` is covered automatically. Asserts:

- **additive invariants** — superset of the base, base order preserved, no duplicates, exposed via `fileids()`, every declared addition present;
- **every advertised fileid is readable** — `raw()` round-trips to `words()`, `open()` matches `raw()`, `abspath()` reports there is no file;
- **non-virtual fileids are served unchanged** — identical to what the plain `WordListCorpusReader` returns. (This can't be checked by asserting the additions are absent elsewhere: `hinglish` legitimately lists English words in its own corpus file.)
- **every accepted word**, the U+2019 completeness property, **and every rejected word stays out** — so a future edit can't quietly pull in the SMART list or the slang.

Skips cleanly when the corpus isn't installed. The wordlist section of `corpus.doctest` documents the new fileid.

Verified: 61 new tests pass; corpus/data suites pass; doctests on touched modules pass; isort/black/ruff and pre-commit clean.

### Note on #3434
PR #3434 targets the same issue with a test file. It can't run in CI (it skips unless a local `english_modified` file exists) and it rewrites the installed `stopwords/english` corpus in place during the run, restoring it only in a `finally`. The word list it asserts is largely the slang rejected above. This PR addresses the underlying request instead; #3434 can be closed.
