### PR TITLE
Fix pathsec.urlopen treating NO_PROXY as a configured proxy (#3748)

### DIFF
--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -561,6 +561,24 @@ def _reject_unpinnable_proxied_fetch(url_str):
     warnings.warn(msg, RuntimeWarning, stacklevel=3)
 
 
+def _env_proxy_carries(url_str):
+    """True if an http/https environment proxy would actually carry ``url_str``.
+
+    ``getproxies()`` reports a ``"no"`` key for ``NO_PROXY`` -- a host *exclusion*
+    list, not a proxy -- so keying on the real ``http``/``https`` schemes and
+    deferring the host decision to ``urllib.request.proxy_bypass`` mirrors what
+    urllib actually does. That fixes the false positive where ``NO_PROXY`` alone
+    made every fetch look proxied (issue #3748), while keeping the SSRF block
+    (GHSA-6ww7) for a genuinely proxied egress: if a proxy would carry the
+    request, NLTK cannot pin the validated IP, so it must still refuse.
+    """
+    proxies = urllib.request.getproxies()
+    if "http" not in proxies and "https" not in proxies:
+        return False
+    host = urlparse(url_str).hostname
+    return bool(host) and not urllib.request.proxy_bypass(host)
+
+
 def urlopen(url, *args, **kwargs):
     """
     Secure wrapper for urllib.request.urlopen with redirect validation.
@@ -593,10 +611,12 @@ def urlopen(url, *args, **kwargs):
 
     # If the caller configured no ProxyHandler at all, environment proxies still
     # apply: build_opener() would install a default ProxyHandler from
-    # getproxies(). Treat that as proxied too, because the proxy -- not NLTK --
-    # is then the egress that resolves names and performs the CONNECT tunnel; the
-    # connect-time pinning handlers cannot tunnel and would break proxied HTTPS.
-    if not proxied and not has_proxy_handler and urllib.request.getproxies():
+    # getproxies(). Treat that as proxied too -- but only when a proxy would
+    # actually carry *this* URL, so NO_PROXY alone does not falsely block every
+    # fetch (issue #3748). When it is genuinely proxied, the proxy is the egress
+    # that resolves names and performs the CONNECT tunnel; the connect-time
+    # pinning handlers cannot tunnel and would break proxied HTTPS.
+    if not proxied and not has_proxy_handler and _env_proxy_carries(url_str):
         proxied = True
 
     if not proxied:

--- a/nltk/test/unit/test_pathsec.py
+++ b/nltk/test/unit/test_pathsec.py
@@ -477,6 +477,87 @@ def test_env_proxy_fails_closed_under_enforce(monkeypatch):
         pathsec.urlopen("http://safe.example.com/x")
 
 
+# --- issue #3748: NO_PROXY must not be mistaken for a configured proxy --------
+#
+# getproxies() reports a "no" key for NO_PROXY, an exclusion list. The old check
+# treated any non-empty getproxies() as a proxy and blocked every download. The
+# fix keys on real http/https schemes and defers the host decision to
+# proxy_bypass -- so NO_PROXY-only is direct+pinned (benign), while a genuine
+# proxy egress stays blocked (GHSA-6ww7). These pin both halves.
+
+
+def test_no_proxy_only_is_not_treated_as_proxied(monkeypatch):
+    """NO_PROXY alone (getproxies()=={'no': ...}) is a bypass list, not a proxy.
+
+    The fetch must go direct and pinned, exactly as if nothing were set --
+    otherwise every download fails in any environment that sets NO_PROXY.
+    """
+    monkeypatch.setattr(
+        urllib.request, "getproxies", lambda: {"no": "localhost,127.0.0.1"}
+    )
+    handlers = _capture_urlopen_handlers(monkeypatch)
+
+    assert any(isinstance(h, pathsec._SafeHTTPHandler) for h in handlers)
+    assert any(isinstance(h, pathsec._SafeHTTPSHandler) for h in handlers)
+    proxy_handlers = [h for h in handlers if isinstance(h, urllib.request.ProxyHandler)]
+    assert len(proxy_handlers) == 1 and proxy_handlers[0].proxies == {}
+
+
+def test_env_proxy_helper_maps_each_case():
+    """_env_proxy_carries mirrors urllib: proxied iff a real http/https proxy
+    would carry the host and it is not bypassed by NO_PROXY. Fails closed."""
+    url = "http://raw.githubusercontent.com/x"
+
+    def check(proxies, bypass, expected):
+        with patch.object(urllib.request, "getproxies", lambda: proxies), patch.object(
+            urllib.request, "proxy_bypass", lambda host: bypass
+        ):
+            assert pathsec._env_proxy_carries(url) is expected
+
+    check({}, False, False)  # nothing set
+    check({"no": "localhost"}, False, False)  # NO_PROXY only (the bug)
+    check({"http": "http://p:8080"}, False, True)  # real proxy -> block
+    check({"http": "http://p:8080"}, True, False)  # proxy but host bypassed -> direct
+    check({"all": "http://p:8080"}, False, False)  # urllib ignores 'all' for http/https
+
+
+def test_proxy_with_no_proxy_target_still_pins(monkeypatch):
+    """A proxy is configured but the target is in NO_PROXY: urllib fetches it
+    directly, so NLTK must pin (not block) -- and the SSRF filter still governs
+    the direct connection."""
+    monkeypatch.setattr(
+        urllib.request,
+        "getproxies",
+        lambda: {"http": "http://proxy.local:3128", "no": "raw.githubusercontent.com"},
+    )
+    monkeypatch.setattr(urllib.request, "proxy_bypass", lambda host: True)
+    handlers = _capture_urlopen_handlers(
+        monkeypatch, url="http://raw.githubusercontent.com/x"
+    )
+
+    assert any(isinstance(h, pathsec._SafeHTTPSHandler) for h in handlers)
+    proxy_handlers = [h for h in handlers if isinstance(h, urllib.request.ProxyHandler)]
+    assert len(proxy_handlers) == 1 and proxy_handlers[0].proxies == {}
+
+
+def test_proxy_with_unbypassed_target_still_fails_closed(monkeypatch):
+    """The attack the fix must NOT reopen: a real proxy carries the target (not
+    bypassed), so NLTK cannot pin the IP -- the fetch must still be refused even
+    though NO_PROXY is present for *other* hosts (GHSA-6ww7)."""
+    monkeypatch.setattr(
+        urllib.request,
+        "getproxies",
+        lambda: {"http": "http://proxy.local:3128", "no": "example.com"},
+    )
+    monkeypatch.setattr(urllib.request, "proxy_bypass", lambda host: False)
+    monkeypatch.setattr(urllib.request, "_opener", None)
+    monkeypatch.setattr(pathsec, "_resolve_hostname", lambda h: [])
+    monkeypatch.setattr(pathsec, "ALLOW_PROXIED_FETCH", False)
+
+    with pytest.raises(PermissionError, match="proxied fetch"):
+        pathsec.urlopen("http://raw.githubusercontent.com/x")
+
+
 def test_env_proxy_opt_in_skips_pinning_handlers(monkeypatch):
     """When the operator opts into trusting the proxy, the proxy is the egress:
     the pinning handlers must NOT be installed (they cannot do the CONNECT

--- a/nltk/test/unit/test_pathsec.py
+++ b/nltk/test/unit/test_pathsec.py
@@ -503,22 +503,95 @@ def test_no_proxy_only_is_not_treated_as_proxied(monkeypatch):
     assert len(proxy_handlers) == 1 and proxy_handlers[0].proxies == {}
 
 
-def test_env_proxy_helper_maps_each_case():
+@pytest.mark.parametrize(
+    "proxies, bypass, expected",
+    [
+        # --- benign: no real http/https proxy would carry the request ---------
+        ({}, False, False),  # nothing set
+        ({"no": "localhost"}, False, False),  # NO_PROXY only (the reported bug)
+        ({"no": "*"}, False, False),  # NO_PROXY wildcard
+        ({"all": "http://p:8080"}, False, False),  # urllib ignores 'all' for http/https
+        ({"ftp": "http://p:8080"}, False, False),  # only an ftp proxy
+        ({"http": "http://p:8080"}, True, False),  # http proxy but host bypassed
+        ({"https": "http://p:8080"}, True, False),  # https proxy but host bypassed
+        ({"http": "http://p:8080", "no": "raw.githubusercontent.com"}, True, False),
+        # --- must block: a real http/https proxy carries the host -------------
+        ({"http": "http://p:8080"}, False, True),
+        ({"https": "http://p:8080"}, False, True),
+        ({"http": "http://p:8080", "https": "http://p:8080"}, False, True),
+        ({"http": "http://p:8080", "no": "otherhost.example"}, False, True),
+    ],
+)
+def test_env_proxy_carries_truth_table(proxies, bypass, expected):
     """_env_proxy_carries mirrors urllib: proxied iff a real http/https proxy
     would carry the host and it is not bypassed by NO_PROXY. Fails closed."""
-    url = "http://raw.githubusercontent.com/x"
+    with patch.object(urllib.request, "getproxies", lambda: proxies), patch.object(
+        urllib.request, "proxy_bypass", lambda host: bypass
+    ):
+        assert (
+            pathsec._env_proxy_carries("http://raw.githubusercontent.com/x") is expected
+        )
 
-    def check(proxies, bypass, expected):
-        with patch.object(urllib.request, "getproxies", lambda: proxies), patch.object(
-            urllib.request, "proxy_bypass", lambda host: bypass
-        ):
-            assert pathsec._env_proxy_carries(url) is expected
 
-    check({}, False, False)  # nothing set
-    check({"no": "localhost"}, False, False)  # NO_PROXY only (the bug)
-    check({"http": "http://p:8080"}, False, True)  # real proxy -> block
-    check({"http": "http://p:8080"}, True, False)  # proxy but host bypassed -> direct
-    check({"all": "http://p:8080"}, False, False)  # urllib ignores 'all' for http/https
+def test_issue_3748_no_proxy_env_downloads_are_not_blocked(monkeypatch):
+    """The reporter's exact scenario, end to end through real getproxies().
+
+    Only NO_PROXY is set (no HTTP_PROXY/HTTPS_PROXY), so getproxies() returns
+    {'no': ...} from the environment and nothing is proxied -- the download must
+    install the pinning handlers and proceed, not raise 'proxied fetch'.
+    """
+    for var in (
+        "HTTP_PROXY",
+        "http_proxy",
+        "HTTPS_PROXY",
+        "https_proxy",
+        "ALL_PROXY",
+        "all_proxy",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("NO_PROXY", "localhost,127.0.0.1")
+
+    assert urllib.request.getproxies().get("no")  # sanity: the env is as reported
+    handlers = _capture_urlopen_handlers(monkeypatch)
+    assert any(isinstance(h, pathsec._SafeHTTPSHandler) for h in handlers)
+    proxy_handlers = [h for h in handlers if isinstance(h, urllib.request.ProxyHandler)]
+    assert len(proxy_handlers) == 1 and proxy_handlers[0].proxies == {}
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        "http://169.254.169.254/latest/meta-data/",  # cloud metadata
+        "http://127.0.0.1/admin",  # loopback
+        "http://[::1]/admin",  # loopback IPv6
+        "http://10.0.0.1/internal",  # RFC1918
+        "http://metadata.google.internal/computeMetadata/v1/",  # metadata by name
+        "http://example.com/x",  # even an innocuous host: proxy = unpinnable
+    ],
+)
+def test_proxied_fetch_refused_for_every_target_even_with_no_proxy_present(
+    target, monkeypatch
+):
+    """Exploit must not leak: when a real proxy carries the request, NLTK cannot
+    pin the IP, so every target is refused (GHSA-6ww7) -- including when NO_PROXY
+    is set for *other* hosts, so the fix cannot be turned into a bypass."""
+    monkeypatch.setattr(
+        urllib.request,
+        "getproxies",
+        lambda: {
+            "http": "http://proxy.local:3128",
+            "https": "http://proxy.local:3128",
+            "no": "trusted.internal",
+        },
+    )
+    monkeypatch.setattr(urllib.request, "proxy_bypass", lambda host: False)
+    monkeypatch.setattr(urllib.request, "_opener", None)
+    monkeypatch.setattr(pathsec, "_resolve_hostname", lambda h: [])
+    monkeypatch.setattr(pathsec, "ENFORCE", True)
+    monkeypatch.setattr(pathsec, "ALLOW_PROXIED_FETCH", False)
+
+    with pytest.raises(PermissionError, match="proxied fetch"):
+        pathsec.urlopen(target)
 
 
 def test_proxy_with_no_proxy_target_still_pins(monkeypatch):


### PR DESCRIPTION
Fixes #3748.

## Problem

`getproxies()` reports a `"no"` key for the `NO_PROXY` environment variable — a host **exclusion** list, not a proxy. The env-proxy guard treated *any* non-empty `getproxies()` as proxied:

```python
if not proxied and not has_proxy_handler and urllib.request.getproxies():
    proxied = True
```

so setting `NO_PROXY` (routine in Docker builds) made `pathsec.urlopen` refuse every download. Regression in 3.10.3; `nltk.download(...)` worked in 3.10.2.

## Fix

Key on the real `http`/`https` schemes and defer the host decision to `urllib.request.proxy_bypass()` — which is what urllib itself uses — so a fetch is treated as proxied only when a proxy would actually carry it:

| Environment | Decision |
|---|---|
| `NO_PROXY` only | direct + pinned ✅ (the reported bug) |
| proxy set, target in `NO_PROXY` | direct + pinned ✅ (urllib bypasses it) |
| proxy carries the target | **refused** 🔒 (GHSA-6ww7 stays closed) |
| `ALL_PROXY` only | direct + pinned ✅ (urllib ignores `all` for http/https) |

The logic lives in one small helper, `_env_proxy_carries()`, and fails closed on any doubt.

## SSRF unchanged (GHSA-6ww7 / CWE-918)

The block for a genuinely proxied egress is unchanged. Two adversarial tests confirm it, and I verified live that:
- a proxy-carried fetch of `169.254.169.254` is still **refused**, even with `NO_PROXY` present for other hosts;
- a `NO_PROXY`-only DNS-rebind to a link-local address is still caught by the connect-time IP pin.

## Tests

Added to `test_pathsec.py`: the `_env_proxy_carries` truth table, `NO_PROXY`-only installs pinning (not a block), proxy+bypassed-target pins, and proxy+unbypassed-target still fails closed. Full pathsec suite: 73 passed.

Credit to @nickodell for the report and @ekaf for the `proxy_bypass` approach.