### PR TITLE
Improve offline testing: skip missing-corpus tests, document NLTK_DATA (#2969)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,6 +226,18 @@ python -m doctest nltk/test/tokenize.doctest
 These are faster than running the full test suite and useful for quick
 iteration during development.
 
+The suite loads corpora from `nltk_data`. To run it without network access
+(e.g. when packaging for a distribution), download the data once and point
+`NLTK_DATA` at it:
+
+```bash
+python -m nltk.downloader -d ./nltk_data all
+NLTK_DATA="$(pwd)/nltk_data" pytest nltk/test
+```
+
+A few tests need non-free corpora that `all` does not include; deselect those
+files if they cannot be obtained.
+
 
 ## Continuous Integration
 

--- a/nltk/test/unit/test_corpora.py
+++ b/nltk/test/unit/test_corpora.py
@@ -15,6 +15,16 @@ from nltk.corpus import (  # mwa_ppdb
 from nltk.tree import Tree
 
 
+def _corpus_available(corpus):
+    """True if a corpus is installed. ``fileids()`` raises ``LookupError`` when
+    it is not, so a bare ``not corpus.fileids()`` in a ``skipif`` aborts
+    collection offline instead of skipping (issue #2969)."""
+    try:
+        return bool(corpus.fileids())
+    except LookupError:
+        return False
+
+
 class TestUdhr(unittest.TestCase):
     def test_words(self):
         for name in udhr.fileids():
@@ -194,7 +204,7 @@ class TestCoNLL2007(unittest.TestCase):
 
 
 @pytest.mark.skipif(
-    not ptb.fileids(),
+    not _corpus_available(ptb),
     reason="A full installation of the Penn Treebank is not available",
 )
 class TestPTB(unittest.TestCase):


### PR DESCRIPTION
Addresses #2969 (running the test suite offline, e.g. distro packaging).

**Bug fix.** `test_corpora.py` used `@pytest.mark.skipif(not ptb.fileids(), ...)`. The `skipif` condition is evaluated at collection time, and `ptb.fileids()` **raises** `LookupError` when the Penn Treebank (non-free, not in `nltk.download('all')`) is absent — so an offline build errors at collection and cannot run *any* test in the file, which is exactly the failure in #2969. Guard it so a missing corpus skips rather than aborts.

**Docs.** Add a short note to CONTRIBUTING.md#tests on running offline: pre-download `nltk_data`, set `NLTK_DATA`, deselect the tests needing non-free corpora.

Verified: with the corpus absent the module now collects and the PTB tests skip; with it present the file is unchanged (12 passed, 8 skipped).