### PR TITLE
Krippendorff's alpha: treat placeholder labels as missing data (#2865, #2732)

### DIFF
--- a/nltk/metrics/agreement.py
+++ b/nltk/metrics/agreement.py
@@ -94,7 +94,7 @@ class AnnotationTask:
     is the MASI metric, which requires Python sets.
     """
 
-    def __init__(self, data=None, distance=binary_distance):
+    def __init__(self, data=None, distance=binary_distance, missing_values=None):
         """Initialize an annotation task.
 
         The data argument can be None (to create an empty annotation task) or a sequence of 3-tuples,
@@ -104,12 +104,26 @@ class AnnotationTask:
         The distance argument is a function taking two arguments (labels) and producing a numerical distance.
         The distance from a label to itself should be zero:
         ``distance(l,l) = 0``
+
+        Missing data (a coder not annotating an item) is represented by simply
+        omitting that ``(coder, item, label)`` triple: Krippendorff's ``alpha``
+        drops items annotated by fewer than two coders. As a convenience,
+        ``missing_values`` may be a collection of label values that stand for
+        "not annotated" (e.g. ``[None]`` or ``["", None]``); triples whose label
+        is one of them are dropped on load, so a placeholder is not counted as a
+        real category. Membership is tested with ``==``/hashing, so the values
+        must be hashable, like any label. Note the other coefficients
+        (``kappa``, ``pi``, ``S``, ``weighted_kappa``) assume every coder rated
+        every item; ``missing_values`` is meaningful only for ``alpha``.
         """
         self.distance = distance
         self.I = set()
         self.K = set()
         self.C = set()
         self.data = []
+        self.missing_values = (
+            frozenset(missing_values) if missing_values else frozenset()
+        )
         if data is not None:
             self.load_array(data)
 
@@ -129,6 +143,11 @@ class AnnotationTask:
             (coder,item,label)
         """
         for coder, item, labels in array:
+            # A missing-value placeholder means this coder did not annotate this
+            # item; drop the triple rather than treat the placeholder as a real
+            # label (issues #2865, #2732).
+            if labels in self.missing_values:
+                continue
             self.C.add(coder)
             self.K.add(labels)
             self.I.add(item)

--- a/nltk/test/unit/test_disagreement.py
+++ b/nltk/test/unit/test_disagreement.py
@@ -1,5 +1,6 @@
 import unittest
 
+from nltk.metrics import masi_distance
 from nltk.metrics.agreement import AnnotationTask
 
 
@@ -172,3 +173,90 @@ class TestDisagreement(unittest.TestCase):
         ]
         annotation_task = AnnotationTask(data)
         self.assertAlmostEqual(annotation_task.alpha(), 0.743421052632)
+
+
+class TestMissingValues(unittest.TestCase):
+    """Krippendorff's alpha with missing data (issues #2865, #2732).
+
+    Missing data is represented by omitting the (coder, item, label) triple, or
+    by declaring placeholder label values via ``missing_values``. A placeholder
+    must not be counted as a real category.
+    """
+
+    #: Three coders, three items; every present rating agrees, some are missing.
+    RATINGS = {"1": [1, 1, 2], "2": [1, 1, None], "3": [None, 1, 2]}
+
+    def _task(self, sentinel="drop", **kwargs):
+        data = [
+            [coder, str(item), rating]
+            for coder, ratings in self.RATINGS.items()
+            for item, rating in enumerate(ratings)
+            if not (sentinel == "drop" and rating is None)
+        ]
+        return AnnotationTask(data=data, **kwargs)
+
+    def test_placeholder_counted_as_category_without_missing_values(self):
+        # Backward compatible: None is a real label, so agreement drops.
+        self.assertAlmostEqual(self._task(sentinel=None).alpha(), 0.33333333333333)
+
+    def test_missing_values_recovers_full_agreement(self):
+        # Declaring the placeholder as missing gives the expected alpha of 1.
+        self.assertAlmostEqual(
+            self._task(sentinel=None, missing_values=[None]).alpha(), 1.0
+        )
+
+    def test_omitting_triples_is_equivalent(self):
+        # Omitting the missing triples entirely is the same as declaring them.
+        self.assertAlmostEqual(self._task(sentinel="drop").alpha(), 1.0)
+
+    def test_string_placeholder(self):
+        # A caller that stringifies labels turns None into "None"; that string
+        # can be declared missing too.
+        data = [
+            [coder, str(item), str(rating)]
+            for coder, ratings in self.RATINGS.items()
+            for item, rating in enumerate(ratings)
+        ]
+        self.assertAlmostEqual(
+            AnnotationTask(data=data, missing_values=["None"]).alpha(), 1.0
+        )
+
+    def test_masi_multilabel_with_missing(self):
+        # The #2732 use case: multi-label sets with the MASI distance.
+        ratings = {
+            "1": [frozenset(["a"]), frozenset(["a", "b"])],
+            "2": [frozenset(["a"]), None],
+            "3": [None, frozenset(["a", "b"])],
+        }
+        data = [
+            [coder, i, rating]
+            for coder, rs in ratings.items()
+            for i, rating in enumerate(rs)
+            if rating is not None
+        ]
+        task = AnnotationTask(data=data, distance=masi_distance)
+        self.assertAlmostEqual(task.alpha(), 1.0)
+
+    def test_missing_values_does_not_change_complete_data(self):
+        # A no-op when nothing matches the placeholder: identical to no arg.
+        data = [
+            ("coder1", "dress1", "YES"),
+            ("coder2", "dress1", "NO"),
+            ("coder3", "dress1", "NO"),
+            ("coder1", "dress2", "YES"),
+            ("coder2", "dress2", "NO"),
+            ("coder3", "dress3", "NO"),
+        ]
+        self.assertAlmostEqual(
+            AnnotationTask(data, missing_values=[None]).alpha(),
+            AnnotationTask(data).alpha(),
+        )
+
+    def test_all_missing_raises_cleanly(self):
+        data = [("c1", "i1", None), ("c2", "i1", None)]
+        with self.assertRaises(ValueError):
+            AnnotationTask(data, missing_values=[None]).alpha()
+
+    def test_unhashable_placeholder_rejected_at_construction(self):
+        with self.assertRaises(TypeError):
+            AnnotationTask(data=[], missing_values=[[1, 2]])


### PR DESCRIPTION
Fixes #2865 and answers #2732.

## Problem

`AnnotationTask` counts a placeholder label (e.g. `None`) as a real category. So a dataset where every *present* rating agrees but some ratings are missing scores `alpha = 0.33` instead of `1.0` (#2865):

```python
rater1, rater2, rater3 = [1,1,2], [1,1,None], [None,1,2]
# ... AnnotationTask(...).alpha()  -> 0.333
```

## What's actually going on

`alpha()` **already** implements Krippendorff's missing-data handling — it drops items rated by fewer than two coders — so if the missing triples are simply **omitted**, the same data gives `1.0`. The only gap was that a `None` placeholder was being counted as a category.

## Fix

An opt-in `missing_values` argument: a collection of label values that mean *"not annotated"* (e.g. `[None]` or `["", None]`). Matching triples are dropped on load, so the placeholder is never a category.

```python
AnnotationTask(data, missing_values=[None]).alpha()   # -> 1.0
```

- **Backward compatible**: default drops nothing, so existing results are unchanged.
- Meaningful only for `alpha()` — `kappa`/`pi`/`S`/`weighted_kappa` assume complete data (documented). Also fills the module's long-standing `TODO: Describe handling of ... missing data`.

## No new attack surface

Deliberately checked, since agreement labels are caller-supplied: the change is pure set-membership + skip — no `eval`/`exec`, no regex, no file/network I/O — and it can only *drop* data, never amplify work, so it adds no DoS vector. An unhashable placeholder raises `TypeError` at construction (caught immediately, not exploitable).

## Tests

`TestMissingValues` covers the reported `None` case, the string `"None"` a caller gets from stringifying labels, the **MASI multi-label** case from #2732, backward compatibility on complete data, all-missing (clean `ValueError`), and the unhashable-placeholder guard. Full `test_disagreement.py` 14 passed; `metrics.doctest` passes.