### PR TITLE
Harden core security modules: pathsec URL-scheme bypass, picklesec denylist, xmlsec parse()

### DIFF
--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -12,6 +12,7 @@ import builtins
 import http.client
 import ipaddress
 import os
+import re
 import socket
 import stat
 import sys
@@ -22,6 +23,15 @@ import zipfile
 from functools import lru_cache
 from pathlib import Path
 from urllib.parse import unquote, urlparse
+
+# A path check is a *filesystem* check. A URL is not a filesystem path, and to
+# the kernel "http://.." is the directory "http:" then ".." -- a traversal. The
+# old ``if "://" in raw: return`` waved every such string straight through
+# validation (GHSA-8mgp-746c-j5xp). Match is anchored (a real scheme is a
+# prefix, never a substring), tolerates leading whitespace, and is
+# case-insensitive so ``HTTP://`` cannot slip past.
+_URL_SCHEME_RE = re.compile(r"^\s*(?:https?|ftp)://", re.IGNORECASE)
+_FILE_SCHEME_RE = re.compile(r"^\s*file:", re.IGNORECASE)
 
 # Security Enforcement Toggle
 # ENFORCE = False
@@ -144,12 +154,35 @@ def validate_path(path_input, context="NLTK", required_root=None):
     try:
         raw = path_input.path if hasattr(path_input, "path") else str(path_input)
 
-        if "://" in raw:
+        # A URL is not a filesystem path. Reject http(s)/ftp outright: no in-tree
+        # caller validates a network URL here (they use pathsec.urlopen), and
+        # "http://../../etc/passwd" is a kernel-level traversal, not a host.
+        # Delegating to validate_network_url() was tried and still fails open --
+        # urlparse gives host ".." which resolves to [] and passes -- so reject
+        # at this layer (GHSA-8mgp-746c-j5xp).
+        if _URL_SCHEME_RE.match(raw):
+            msg = (
+                f"Security Violation [{context}]: a URL was passed to a "
+                f"filesystem path check: {raw!r}. Use nltk.pathsec.urlopen() "
+                "for network I/O."
+            )
+            if ENFORCE:
+                raise PermissionError(msg)
+            warnings.warn(msg, RuntimeWarning, stacklevel=3)
+            return
+        if _FILE_SCHEME_RE.match(raw):
             parsed = urlparse(raw)
-            if parsed.scheme in ("http", "https", "ftp"):
+            # urllib opens Request.selector, which keeps ?/#/; -- urlparse().path
+            # drops them, so validating .path would check a different file than
+            # gets opened. Refuse the ambiguous forms outright.
+            if parsed.query or parsed.fragment or ";" in parsed.path:
+                raise PermissionError(
+                    f"Security Violation [{context}]: ambiguous file URL "
+                    f"(query/fragment/params) not allowed: {raw!r}"
+                )
+            raw = unquote(parsed.path)
+            if not raw:
                 return
-            if parsed.scheme == "file":
-                raw = unquote(parsed.path)
 
         # Resolve path to catch symlink escapes
         try:

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -150,12 +150,8 @@ def validate_path(path_input, context="NLTK", required_root=None):
     try:
         raw = path_input.path if hasattr(path_input, "path") else str(path_input)
 
-        # A URL is not a filesystem path. Reject http(s)/ftp outright: no in-tree
-        # caller validates a network URL here (they use pathsec.urlopen), and
-        # "http://../../etc/passwd" is a kernel-level traversal, not a host.
-        # Delegating to validate_network_url() was tried and still fails open --
-        # urlparse gives host ".." which resolves to [] and passes -- so reject
-        # at this layer (GHSA-8mgp-746c-j5xp).
+        # Reject a URL outright: no caller validates a network URL here, and
+        # "http://../.." is a kernel traversal, not a host (GHSA-8mgp-746c-j5xp).
         if _URL_SCHEME_RE.match(raw):
             msg = (
                 f"Security Violation [{context}]: a URL was passed to a "
@@ -168,9 +164,8 @@ def validate_path(path_input, context="NLTK", required_root=None):
             return
         if _FILE_SCHEME_RE.match(raw):
             parsed = urlparse(raw)
-            # urllib opens Request.selector, which keeps ?/#/; -- urlparse().path
-            # drops them, so validating .path would check a different file than
-            # gets opened. Refuse the ambiguous forms outright.
+            # urllib opens Request.selector (keeps ?/#/;) but urlparse().path
+            # drops them -- that would validate a different file than opens.
             if parsed.query or parsed.fragment or ";" in parsed.path:
                 raise PermissionError(
                     f"Security Violation [{context}]: ambiguous file URL "

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -24,12 +24,8 @@ from functools import lru_cache
 from pathlib import Path
 from urllib.parse import unquote, urlparse
 
-# A path check is a *filesystem* check. A URL is not a filesystem path, and to
-# the kernel "http://.." is the directory "http:" then ".." -- a traversal. The
-# old ``if "://" in raw: return`` waved every such string straight through
-# validation (GHSA-8mgp-746c-j5xp). Match is anchored (a real scheme is a
-# prefix, never a substring), tolerates leading whitespace, and is
-# case-insensitive so ``HTTP://`` cannot slip past.
+# A URL is not a filesystem path: to the kernel "http://.." is the dir "http:"
+# then a ".." traversal. Anchored, whitespace-tolerant, case-insensitive match.
 _URL_SCHEME_RE = re.compile(r"^\s*(?:https?|ftp)://", re.IGNORECASE)
 _FILE_SCHEME_RE = re.compile(r"^\s*file:", re.IGNORECASE)
 

--- a/nltk/picklesec.py
+++ b/nltk/picklesec.py
@@ -114,6 +114,13 @@ _DENIED_MODULE_PREFIXES = (
     "numpy.ctypeslib",
     "numpy.distutils",
     "numpy.testing",
+    # scipy.io / sklearn.datasets are file-read, file-write and network (openml)
+    # sinks under the otherwise-legitimate scipy/sklearn namespaces: e.g.
+    # scipy.io.mmwrite (arbitrary file write), scipy.io.loadmat / arff.loadarff
+    # (file read), sklearn.datasets.fetch_openml (SSRF), load_files /
+    # load_svmlight_file (file read). No model pickle needs them.
+    "scipy.io",
+    "sklearn.datasets",
     "nltk.tokenize.repp",
     "nltk.internals",
 )
@@ -138,6 +145,15 @@ _DENIED_GLOBALS = frozenset(
         ("numpy", "memmap"),
         ("numpy", "DataSource"),
         ("numpy", "vectorize"),
+        # numpy callables that invoke a supplied function -- a REDUCE gadget can
+        # ride them to call another reconstructed callable.
+        ("numpy", "apply_along_axis"),
+        ("numpy", "apply_over_axes"),
+        ("numpy", "frompyfunc"),
+        ("numpy", "piecewise"),
+        # scipy low-level C callback wrapper.
+        ("scipy", "LowLevelCallable"),
+        ("scipy._lib._ccallback", "LowLevelCallable"),
         ("pandas", "read_pickle"),
     }
 )

--- a/nltk/picklesec.py
+++ b/nltk/picklesec.py
@@ -114,11 +114,8 @@ _DENIED_MODULE_PREFIXES = (
     "numpy.ctypeslib",
     "numpy.distutils",
     "numpy.testing",
-    # scipy.io / sklearn.datasets are file-read, file-write and network (openml)
-    # sinks under the otherwise-legitimate scipy/sklearn namespaces: e.g.
-    # scipy.io.mmwrite (arbitrary file write), scipy.io.loadmat / arff.loadarff
-    # (file read), sklearn.datasets.fetch_openml (SSRF), load_files /
-    # load_svmlight_file (file read). No model pickle needs them.
+    # File-read/write and network sinks under scipy/sklearn (scipy.io.mmwrite,
+    # loadmat; sklearn.datasets.fetch_openml/load_*). No model pickle needs them.
     "scipy.io",
     "sklearn.datasets",
     "nltk.tokenize.repp",

--- a/nltk/xmlsec.py
+++ b/nltk/xmlsec.py
@@ -127,13 +127,8 @@ def parse(source):
     object is read in full so it can be screened before parsing;
     ``ElementTree.parse`` reads it to the end regardless, so nothing is lost.
     """
-    # A filename ``source`` is caller-controlled data I/O: validate it against
-    # the NLTK data sandbox *before* either back end opens it, so a traversal
-    # path (e.g. ``../../etc/passwd``) is refused whether or not ``defusedxml``
-    # is installed -- the ``defusedxml`` back end opens the filename itself, so
-    # guarding only the fallback ``open`` below would leave a gap
-    # (path traversal, CWE-22 / GHSA-8mgp-746c-j5xp). A file object is already
-    # opened by the caller and carries no path to validate.
+    # A filename source is caller-controlled: validate it before either back end
+    # (defusedxml or fallback) opens it (CWE-22). A file object carries no path.
     if not hasattr(source, "read"):
         validate_path(source, context="nltk.xmlsec.parse")
 

--- a/nltk/xmlsec.py
+++ b/nltk/xmlsec.py
@@ -54,6 +54,8 @@ import io
 from xml.etree import ElementTree
 from xml.parsers import expat
 
+from nltk.pathsec import validate_path
+
 __all__ = ["HAVE_DEFUSEDXML", "EntitiesForbidden", "fromstring", "parse"]
 
 try:
@@ -125,6 +127,16 @@ def parse(source):
     object is read in full so it can be screened before parsing;
     ``ElementTree.parse`` reads it to the end regardless, so nothing is lost.
     """
+    # A filename ``source`` is caller-controlled data I/O: validate it against
+    # the NLTK data sandbox *before* either back end opens it, so a traversal
+    # path (e.g. ``../../etc/passwd``) is refused whether or not ``defusedxml``
+    # is installed -- the ``defusedxml`` back end opens the filename itself, so
+    # guarding only the fallback ``open`` below would leave a gap
+    # (path traversal, CWE-22 / GHSA-8mgp-746c-j5xp). A file object is already
+    # opened by the caller and carries no path to validate.
+    if not hasattr(source, "read"):
+        validate_path(source, context="nltk.xmlsec.parse")
+
     if HAVE_DEFUSEDXML:
         return _defused_parse(source)
 


### PR DESCRIPTION
Three focused hardening changes to NLTK's core security modules (GHSA-8mgp-746c-j5xp), reviewable in isolation.

**`pathsec.py`** — `validate_path`, the chokepoint every file access funnels through, returned "authorized" for any `http/https/ftp://` string (`if "://" in raw: return`), so a URL-shaped string carrying a `..` traversal skipped all filesystem checks and defeated the guard for any caller that normalizes it as a URL (e.g. `urlparse("http://host/../../../etc/passwd").path` → `/etc/passwd`). It now rejects URL-shaped strings with an anchored scheme regex — a real scheme is a prefix, never the substring `"://" in raw` that caused the bug — unquotes `file:` URLs, and refuses the ambiguous `?`/`#`/`;` selector forms.

**`picklesec.py`** — adds the gadgets that survive a broad numpy/scipy/sklearn allowlist (`scipy.io` mmwrite/loadmat, `sklearn.datasets` fetch_openml/load_*, the numpy function-invoking callables, `scipy.LowLevelCallable`) to the shared denylist, so even a broad caller can't reconstruct them from an untrusted pickle.

**`xmlsec.py`** — `parse()` validates a filename `source` against the sandbox before either back end (defusedxml or fallback) opens it (CWE-22); a file object carries no path.

