### PR TITLE
Harden tokenize file I/O against path traversal (punkt, stanford_segmenter)

### DIFF
--- a/nltk/data.py
+++ b/nltk/data.py
@@ -38,6 +38,7 @@ import os
 import pickle
 import re
 import sys
+import tempfile
 import textwrap
 import urllib.request
 import zipfile
@@ -173,6 +174,35 @@ else:
 ######################################################################
 # Util Functions
 ######################################################################
+
+
+def make_staging_dir(prefix="nltk_"):
+    """Create a fresh private directory for NLTK's own output, inside a data root.
+
+    NLTK's save helpers default here so their output lands within the security
+    sandbox (every ``nltk.data.path`` entry is an allowed root) on all platforms,
+    including Linux where the shared ``/tmp`` is deliberately not a root. The
+    directory is created with ``tempfile.mkdtemp`` (mode 0700, unpredictable name)
+    under the first ``nltk.data.path`` entry that can be written to.
+
+    :param prefix: filename prefix for the created directory.
+    :type prefix: str
+    :return: the absolute path of the created directory.
+    :rtype: str
+    :raises PermissionError: if no ``nltk.data.path`` entry is writable, in which
+        case the caller should pass an explicit destination directory.
+    """
+    for root in path:
+        base = os.path.expanduser(str(root.path if hasattr(root, "path") else root))
+        try:
+            os.makedirs(base, exist_ok=True)
+            return tempfile.mkdtemp(prefix=prefix, dir=base)
+        except OSError:
+            continue
+    raise PermissionError(
+        f"No writable NLTK data root to stage output in (tried {len(path)} "
+        "nltk.data.path entries); pass an explicit destination directory."
+    )
 
 
 def gzip_open_unicode(

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -52,6 +52,7 @@ from urllib.request import url2pathname
 from nltk.pathsec import ZipFile
 from nltk.pathsec import open as _secure_open
 from nltk.pathsec import urlopen as _secure_urlopen
+from nltk.pathsec import validate_path as _validate_path
 
 # Reject unsafe no-protocol paths: traversal segments, trailing '..', absolute paths,
 # backslashes, Windows drive letters. Use a raw-string pattern and do not anchor only
@@ -189,19 +190,27 @@ def make_staging_dir(prefix="nltk_"):
     :type prefix: str
     :return: the absolute path of the created directory.
     :rtype: str
-    :raises PermissionError: if no ``nltk.data.path`` entry is writable, in which
-        case the caller should pass an explicit destination directory.
+    :raises PermissionError: if no ``nltk.data.path`` entry is a writable allowed
+        root, in which case the caller should pass an explicit destination.
     """
     for root in path:
         base = os.path.expanduser(str(root.path if hasattr(root, "path") else root))
         try:
+            # Confirm base is inside the pathsec sandbox before creating anything,
+            # so a surprising ~ / $HOME / NLTK_DATA expansion cannot make
+            # os.makedirs build a directory chain, or mkdtemp stage output,
+            # outside the allowed roots. validate_path resolves symlinks the same
+            # way the allowed roots are computed, so this never trusts more than
+            # the sandbox does.
+            _validate_path(base, context="nltk.data.make_staging_dir")
             os.makedirs(base, exist_ok=True)
             return tempfile.mkdtemp(prefix=prefix, dir=base)
-        except OSError:
+        except (OSError, ValueError, PermissionError):
             continue
     raise PermissionError(
-        f"No writable NLTK data root to stage output in (tried {len(path)} "
-        "nltk.data.path entries); pass an explicit destination directory."
+        f"No writable in-sandbox NLTK data root to stage output in (tried "
+        f"{len(path)} nltk.data.path entries); pass an explicit destination "
+        "directory."
     )
 
 

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -82,6 +82,55 @@ def is_private_dir(path):
     return True
 
 
+# Directories NLTK itself created (via mkdtemp, mode 0700) to stage its OWN
+# output. A shared temp root (Linux /tmp, mode 1777) is never an allowed root,
+# but a private dir NLTK made under it is not attacker-writable, so its contents
+# are trusted once registered (CWE-377/378). This stays separate from
+# nltk.data.path so it never widens the corpus sandbox: only dirs NLTK created
+# are trusted, not every private temp dir, and a caller that seals the sandbox
+# (or monkeypatches the allowed roots) registers nothing and is unaffected.
+_NLTK_PRIVATE_STAGING_DIRS = set()
+
+
+def register_staging_dir(path):
+    """Trust *path*, a private (0700) directory NLTK just created for its output.
+
+    Returns *path* unchanged so a caller can wrap a ``mkdtemp`` call in place.
+    Only a currently private (0700, user-owned) directory is registered, and the
+    trust is re-verified at validation time, so a later deletion or takeover of
+    the name cannot be exploited.
+    """
+    try:
+        resolved = Path(path).resolve()
+    except (OSError, ValueError, RuntimeError):
+        return path
+    if is_private_dir(resolved):
+        _NLTK_PRIVATE_STAGING_DIRS.add(resolved)
+    return path
+
+
+def make_staging_dir(prefix="nltk_"):
+    """Create a private (0700) staging directory and register it as trusted.
+
+    A drop-in for ``tempfile.mkdtemp`` for NLTK's own output: on Linux, where the
+    shared ``/tmp`` root is untrusted, the returned directory is still writable
+    through the pathsec sandbox because it is registered here.
+    """
+    return register_staging_dir(tempfile.mkdtemp(prefix=prefix))
+
+
+def _is_registered_staging(target):
+    """True if *target* is within a registered staging dir that is STILL private.
+
+    Re-checking ``is_private_dir`` at call time means a stale registry entry whose
+    directory was deleted (and possibly recreated by another user) is not trusted.
+    """
+    for d in _NLTK_PRIVATE_STAGING_DIRS:
+        if (target == d or target.is_relative_to(d)) and is_private_dir(d):
+            return True
+    return False
+
+
 def _get_allowed_roots():
     """Dynamically determines allowed directories based on NLTK data paths."""
     global _ALLOWED_ROOTS_CACHE, _LAST_DATA_PATHS
@@ -205,6 +254,12 @@ def validate_path(path_input, context="NLTK", required_root=None):
         # LAYER 2: Global NLTK_DATA Sandbox
         allowed_roots = _get_allowed_roots()
         if any(target == root or target.is_relative_to(root) for root in allowed_roots):
+            return
+
+        # LAYER 3: NLTK's own private temp staging. A shared temp root stays
+        # untrusted, but a private (0700) dir NLTK created and registered for its
+        # own output is not attacker-writable, so staging into it is safe.
+        if _is_registered_staging(target):
             return
 
         # CWD Fallback (Explicit Opt-In for ENFORCE mode)
@@ -887,4 +942,6 @@ __all__ = [
     "urlopen",
     "ZipFile",
     "ENFORCE",
+    "make_staging_dir",
+    "register_staging_dir",
 ]

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -82,55 +82,6 @@ def is_private_dir(path):
     return True
 
 
-# Directories NLTK itself created (via mkdtemp, mode 0700) to stage its OWN
-# output. A shared temp root (Linux /tmp, mode 1777) is never an allowed root,
-# but a private dir NLTK made under it is not attacker-writable, so its contents
-# are trusted once registered (CWE-377/378). This stays separate from
-# nltk.data.path so it never widens the corpus sandbox: only dirs NLTK created
-# are trusted, not every private temp dir, and a caller that seals the sandbox
-# (or monkeypatches the allowed roots) registers nothing and is unaffected.
-_NLTK_PRIVATE_STAGING_DIRS = set()
-
-
-def register_staging_dir(path):
-    """Trust *path*, a private (0700) directory NLTK just created for its output.
-
-    Returns *path* unchanged so a caller can wrap a ``mkdtemp`` call in place.
-    Only a currently private (0700, user-owned) directory is registered, and the
-    trust is re-verified at validation time, so a later deletion or takeover of
-    the name cannot be exploited.
-    """
-    try:
-        resolved = Path(path).resolve()
-    except (OSError, ValueError, RuntimeError):
-        return path
-    if is_private_dir(resolved):
-        _NLTK_PRIVATE_STAGING_DIRS.add(resolved)
-    return path
-
-
-def make_staging_dir(prefix="nltk_"):
-    """Create a private (0700) staging directory and register it as trusted.
-
-    A drop-in for ``tempfile.mkdtemp`` for NLTK's own output: on Linux, where the
-    shared ``/tmp`` root is untrusted, the returned directory is still writable
-    through the pathsec sandbox because it is registered here.
-    """
-    return register_staging_dir(tempfile.mkdtemp(prefix=prefix))
-
-
-def _is_registered_staging(target):
-    """True if *target* is within a registered staging dir that is STILL private.
-
-    Re-checking ``is_private_dir`` at call time means a stale registry entry whose
-    directory was deleted (and possibly recreated by another user) is not trusted.
-    """
-    for d in _NLTK_PRIVATE_STAGING_DIRS:
-        if (target == d or target.is_relative_to(d)) and is_private_dir(d):
-            return True
-    return False
-
-
 def _get_allowed_roots():
     """Dynamically determines allowed directories based on NLTK data paths."""
     global _ALLOWED_ROOTS_CACHE, _LAST_DATA_PATHS
@@ -254,12 +205,6 @@ def validate_path(path_input, context="NLTK", required_root=None):
         # LAYER 2: Global NLTK_DATA Sandbox
         allowed_roots = _get_allowed_roots()
         if any(target == root or target.is_relative_to(root) for root in allowed_roots):
-            return
-
-        # LAYER 3: NLTK's own private temp staging. A shared temp root stays
-        # untrusted, but a private (0700) dir NLTK created and registered for its
-        # own output is not attacker-writable, so staging into it is safe.
-        if _is_registered_staging(target):
             return
 
         # CWD Fallback (Explicit Opt-In for ENFORCE mode)
@@ -942,6 +887,4 @@ __all__ = [
     "urlopen",
     "ZipFile",
     "ENFORCE",
-    "make_staging_dir",
-    "register_staging_dir",
 ]

--- a/nltk/test/unit/test_pathsec_sweep_tokenize.py
+++ b/nltk/test/unit/test_pathsec_sweep_tokenize.py
@@ -176,6 +176,9 @@ def test_load_lang_resets_save_dir(sandbox, monkeypatch):
         shutil.rmtree(d, ignore_errors=True)
 
 
+@pytest.mark.skipif(
+    os.name != "posix", reason="POSIX mode bits; Windows dirs use ACLs, not 0700"
+)
 def test_save_punkt_params_creates_caller_dir_private(sandbox):
     """A caller-supplied, in-sandbox destination that does not exist yet is
     created mode exactly 0700 regardless of umask (is_private_dir alone would

--- a/nltk/test/unit/test_pathsec_sweep_tokenize.py
+++ b/nltk/test/unit/test_pathsec_sweep_tokenize.py
@@ -1,0 +1,129 @@
+"""
+Attack tests for the bare-``open()`` path-traversal hardening
+(GHSA-8mgp-746c-j5xp) in the tokenize package:
+
+* ``nltk/tokenize/punkt.py`` -- ``save_punkt_params`` (4 param-file writes; its
+  ``dir`` defaults to a fresh private temp) and ``PunktSentenceTokenizer.dump``
+  (a debug write that now targets a fresh private temp, not a guessable /tmp).
+* ``nltk/tokenize/stanford_segmenter.py`` -- ``StanfordSegmenter._sha256sum``
+  (reads a caller-controlled classpath JAR).
+
+Each patched sink is driven with a path OUTSIDE every allowed NLTK data root
+and must raise ``PermissionError`` under pathsec ``ENFORCE``, writing nothing
+outside the sandbox.
+"""
+
+import os
+import pathlib
+import shutil
+import tempfile
+
+import pytest
+
+import nltk.data
+import nltk.pathsec as pathsec
+
+
+@pytest.fixture
+def sandbox():
+    """Restrict pathsec to a single private data root and hand back a fresh
+    directory that is guaranteed OUTSIDE every allowed root.
+
+    The outside directory is created under ``~`` -- never a temp dir, because a
+    *private* system temp dir is itself an allowed root on macOS
+    (``/var/folders/...`` is mode 0700), so an attack target staged there would
+    be (correctly) permitted and the test would not exercise the guard.
+    """
+    saved_enforce = pathsec.ENFORCE
+    saved_path = list(nltk.data.path)
+    saved_cache = pathsec._ALLOWED_ROOTS_CACHE
+    saved_last = pathsec._LAST_DATA_PATHS
+
+    pathsec.ENFORCE = True
+    nltk.data.path[:] = [tempfile.mkdtemp()]
+    pathsec._ALLOWED_ROOTS_CACHE = None
+    pathsec._LAST_DATA_PATHS = None
+
+    outside = pathlib.Path.home() / f".nltk_sweep_tok_{os.getpid()}"
+    outside.mkdir(parents=True, exist_ok=True)
+    try:
+        yield outside
+    finally:
+        shutil.rmtree(outside, ignore_errors=True)
+        pathsec.ENFORCE = saved_enforce
+        nltk.data.path[:] = saved_path
+        pathsec._ALLOWED_ROOTS_CACHE = saved_cache
+        pathsec._LAST_DATA_PATHS = saved_last
+
+
+def test_negative_control(sandbox):
+    """A plain write to a path outside all allowed roots must be refused -- proof
+    that the sandbox is genuinely enforcing in this process."""
+    target = sandbox / "control.txt"
+    with pytest.raises(PermissionError):
+        pathsec.open(str(target), "w")
+    assert not target.exists()
+
+
+def test_save_punkt_params_refuses_outside_dir(sandbox):
+    """``save_punkt_params(dir=<outside>)`` must refuse the caller-controlled
+    directory before creating it or writing any of its 4 param files."""
+    from nltk.tokenize.punkt import PunktParameters, save_punkt_params
+
+    outside_dir = sandbox / "punkt_tab"
+    params = PunktParameters()
+    with pytest.raises(PermissionError):
+        save_punkt_params(params, dir=str(outside_dir))
+    # validate_path rejects up front, so neither the dir nor any file is made.
+    assert not outside_dir.exists()
+    assert list(sandbox.iterdir()) == []
+
+
+def test_save_punkt_params_default_is_private_dir_not_tmp(sandbox):
+    """The default destination is a fresh private (0700), unpredictably-named
+    directory (returned by the call) -- never the old guessable ``/tmp``."""
+    from nltk.tokenize.punkt import PunktParameters, save_punkt_params
+
+    out = save_punkt_params(PunktParameters())
+    try:
+        assert not out.startswith("/tmp/"), "must not default into shared /tmp"
+        assert pathsec.is_private_dir(out)
+        assert (pathlib.Path(out) / "collocations.tab").exists()
+    finally:
+        shutil.rmtree(out, ignore_errors=True)
+
+
+def test_punkt_dump_writes_private_temp_not_hardcoded_tmp(sandbox):
+    """The ``dump`` debug scaffold must write to a fresh private (0700) temp file
+    and return its path -- never the old guessable ``/tmp/punkt.new``."""
+    from nltk.tokenize.punkt import PunktSentenceTokenizer, PunktToken
+
+    tok = PunktSentenceTokenizer()
+    out = tok.dump(iter([PunktToken("Hello"), PunktToken("world.")]))
+    try:
+        assert not out.startswith("/tmp/"), "must not write into shared /tmp"
+        assert os.path.basename(out) == "punkt.new"
+        assert pathsec.is_private_dir(os.path.dirname(out))
+        assert os.path.exists(out)
+    finally:
+        shutil.rmtree(os.path.dirname(out), ignore_errors=True)
+
+
+def test_stanford_sha256_refuses_outside_jar(sandbox):
+    """``StanfordSegmenter._sha256sum`` reads a caller-controlled classpath JAR;
+    a path outside all allowed roots must be refused."""
+    pytest.importorskip("nltk.tokenize.stanford_segmenter")
+    from nltk.tokenize.stanford_segmenter import StanfordSegmenter
+
+    # A real file must exist so os.stat() succeeds and control reaches the
+    # patched pathsec_open -- an absent file would raise FileNotFoundError first
+    # and mask the security check.
+    outside_jar = sandbox / "evil.jar"
+    outside_jar.write_bytes(b"PK\x03\x04 not really a jar")
+
+    # Bypass __init__ (which needs a real Stanford JAR on disk); _sha256sum only
+    # touches self._jar_sha256_cache.
+    seg = StanfordSegmenter.__new__(StanfordSegmenter)
+    seg._jar_sha256_cache = {}
+    with pytest.raises(PermissionError):
+        seg._sha256sum(str(outside_jar))

--- a/nltk/test/unit/test_pathsec_sweep_tokenize.py
+++ b/nltk/test/unit/test_pathsec_sweep_tokenize.py
@@ -40,7 +40,8 @@ def sandbox():
     saved_last = pathsec._LAST_DATA_PATHS
 
     pathsec.ENFORCE = True
-    nltk.data.path[:] = [tempfile.mkdtemp()]
+    data_root = tempfile.mkdtemp()
+    nltk.data.path[:] = [data_root]
     pathsec._ALLOWED_ROOTS_CACHE = None
     pathsec._LAST_DATA_PATHS = None
 
@@ -50,6 +51,8 @@ def sandbox():
         yield outside
     finally:
         shutil.rmtree(outside, ignore_errors=True)
+        # data_root also holds any staging dirs make_staging_dir created under it.
+        shutil.rmtree(data_root, ignore_errors=True)
         pathsec.ENFORCE = saved_enforce
         nltk.data.path[:] = saved_path
         pathsec._ALLOWED_ROOTS_CACHE = saved_cache
@@ -121,9 +124,9 @@ def test_stanford_sha256_refuses_outside_jar(sandbox):
     pytest.importorskip("nltk.tokenize.stanford_segmenter")
     from nltk.tokenize.stanford_segmenter import StanfordSegmenter
 
-    # A real file must exist so os.stat() succeeds and control reaches the
-    # patched pathsec_open; an absent file would raise FileNotFoundError first
-    # and mask the security check.
+    # A real file exercises the full chain (validate, then stat, then
+    # pathsec_open); a non-existent outside path is covered by the
+    # validate-before-stat test below.
     outside_jar = sandbox / "evil.jar"
     outside_jar.write_bytes(b"PK\x03\x04 not really a jar")
 
@@ -133,3 +136,61 @@ def test_stanford_sha256_refuses_outside_jar(sandbox):
     seg._jar_sha256_cache = {}
     with pytest.raises(PermissionError):
         seg._sha256sum(str(outside_jar))
+
+
+def test_stanford_sha256_validates_before_stat(sandbox):
+    """_sha256sum must validate the classpath entry BEFORE os.stat, so an
+    out-of-sandbox path is refused with no filesystem access (no metadata leak,
+    no symlink follow). A NON-EXISTENT outside path proves the order: before the
+    fix os.stat raised FileNotFoundError; the guard now raises PermissionError."""
+    pytest.importorskip("nltk.tokenize.stanford_segmenter")
+    from nltk.tokenize.stanford_segmenter import StanfordSegmenter
+
+    missing_outside = sandbox / "never_created.jar"  # deliberately absent
+    seg = StanfordSegmenter.__new__(StanfordSegmenter)
+    seg._jar_sha256_cache = {}
+    with pytest.raises(PermissionError):
+        seg._sha256sum(str(missing_outside))
+    assert not missing_outside.exists()
+
+
+def test_load_lang_resets_save_dir(sandbox, monkeypatch):
+    """Reusing a PunktTokenizer across languages must not keep writing into the
+    first language's staging dir; load_lang() invalidates the memoized save_dir
+    so each language gets its own directory."""
+    import nltk.tokenize.punkt as punkt_mod
+    from nltk.tokenize.punkt import PunktParameters, PunktTokenizer
+
+    # Avoid needing installed punkt_tab data: stub what load_lang loads.
+    monkeypatch.setattr("nltk.data.find", lambda p: "unused")
+    monkeypatch.setattr(punkt_mod, "load_punkt_params", lambda d: PunktParameters())
+
+    tok = PunktTokenizer("english")
+    first = tok.save_dir
+    assert os.path.basename(first).startswith("nltk_punkt_english_")
+    tok.load_lang("german")  # switching language must refresh the dir
+    second = tok.save_dir
+    assert second != first, "load_lang must invalidate the memoized save_dir"
+    assert os.path.basename(second).startswith("nltk_punkt_german_")
+    for d in (first, second):
+        shutil.rmtree(d, ignore_errors=True)
+
+
+def test_save_punkt_params_creates_caller_dir_private(sandbox):
+    """A caller-supplied, in-sandbox destination that does not exist yet is
+    created mode exactly 0700 regardless of umask (is_private_dir alone would
+    also accept 0755, so assert the exact mode)."""
+    from nltk.tokenize.punkt import PunktParameters, save_punkt_params
+
+    # An in-sandbox but not-yet-created directory (under the data root).
+    target = pathlib.Path(nltk.data.path[0]) / "caller_supplied_out"
+    assert not target.exists()
+    old_umask = os.umask(0o022)  # would leave g+rx,o+rx on a default os.mkdir
+    try:
+        out = save_punkt_params(PunktParameters(), dir=str(target))
+        mode = os.stat(out).st_mode & 0o777
+        assert mode == 0o700, f"caller dir must be created 0700, got {oct(mode)}"
+        assert (pathlib.Path(out) / "collocations.tab").exists()
+    finally:
+        os.umask(old_umask)
+        shutil.rmtree(target, ignore_errors=True)

--- a/nltk/test/unit/test_pathsec_sweep_tokenize.py
+++ b/nltk/test/unit/test_pathsec_sweep_tokenize.py
@@ -194,3 +194,32 @@ def test_save_punkt_params_creates_caller_dir_private(sandbox):
     finally:
         os.umask(old_umask)
         shutil.rmtree(target, ignore_errors=True)
+
+
+def test_save_punkt_params_round_trip(sandbox):
+    """Functional check: params written by save_punkt_params reload identically
+    via load_punkt_params (given a PathPointer, the API load_lang uses), so the
+    save/load pair still works end-to-end under enforcement after the hardening."""
+    from nltk.data import FileSystemPathPointer
+    from nltk.tokenize.punkt import (
+        PunktParameters,
+        load_punkt_params,
+        save_punkt_params,
+    )
+
+    params = PunktParameters()
+    params.abbrev_types = {"dr", "mr", "vs"}
+    params.collocations = {("new", "york"), ("los", "angeles")}
+    params.sent_starters = {"however", "the"}
+    params.ortho_context["foo"] = 5
+    params.ortho_context["bar"] = 12
+
+    out = save_punkt_params(params)
+    try:
+        reloaded = load_punkt_params(FileSystemPathPointer(out))
+        assert reloaded.abbrev_types == params.abbrev_types
+        assert reloaded.collocations == params.collocations
+        assert reloaded.sent_starters == params.sent_starters
+        assert dict(reloaded.ortho_context) == dict(params.ortho_context)
+    finally:
+        shutil.rmtree(out, ignore_errors=True)

--- a/nltk/test/unit/test_pathsec_sweep_tokenize.py
+++ b/nltk/test/unit/test_pathsec_sweep_tokenize.py
@@ -86,8 +86,11 @@ def test_save_punkt_params_default_is_private_dir_not_tmp(sandbox):
 
     out = save_punkt_params(PunktParameters())
     try:
-        assert not out.startswith("/tmp/"), "must not default into shared /tmp"
+        # is_private_dir (0700, user-owned) is the real "not shared /tmp" check;
+        # a fresh mkdtemp lives under /tmp on Linux, so assert privacy plus the
+        # unpredictable mkdtemp name, not that the path avoids /tmp.
         assert pathsec.is_private_dir(out)
+        assert os.path.basename(out).startswith("nltk_punkt_params_")
         assert (pathlib.Path(out) / "collocations.tab").exists()
     finally:
         shutil.rmtree(out, ignore_errors=True)
@@ -101,8 +104,11 @@ def test_punkt_dump_writes_private_temp_not_hardcoded_tmp(sandbox):
     tok = PunktSentenceTokenizer()
     out = tok.dump(iter([PunktToken("Hello"), PunktToken("world.")]))
     try:
-        assert not out.startswith("/tmp/"), "must not write into shared /tmp"
+        # is_private_dir on the parent is the real "not shared /tmp" check; a
+        # fresh mkdtemp lives under /tmp on Linux, so assert privacy plus the
+        # unpredictable mkdtemp name, not that the path avoids /tmp.
         assert os.path.basename(out) == "punkt.new"
+        assert os.path.basename(os.path.dirname(out)).startswith("nltk_punkt_dump_")
         assert pathsec.is_private_dir(os.path.dirname(out))
         assert os.path.exists(out)
     finally:

--- a/nltk/test/unit/test_pathsec_sweep_tokenize.py
+++ b/nltk/test/unit/test_pathsec_sweep_tokenize.py
@@ -2,10 +2,10 @@
 Attack tests for the bare-``open()`` path-traversal hardening
 (GHSA-8mgp-746c-j5xp) in the tokenize package:
 
-* ``nltk/tokenize/punkt.py`` -- ``save_punkt_params`` (4 param-file writes; its
+* ``nltk/tokenize/punkt.py``: ``save_punkt_params`` (4 param-file writes; its
   ``dir`` defaults to a fresh private temp) and ``PunktSentenceTokenizer.dump``
   (a debug write that now targets a fresh private temp, not a guessable /tmp).
-* ``nltk/tokenize/stanford_segmenter.py`` -- ``StanfordSegmenter._sha256sum``
+* ``nltk/tokenize/stanford_segmenter.py``: ``StanfordSegmenter._sha256sum``
   (reads a caller-controlled classpath JAR).
 
 Each patched sink is driven with a path OUTSIDE every allowed NLTK data root
@@ -29,7 +29,7 @@ def sandbox():
     """Restrict pathsec to a single private data root and hand back a fresh
     directory that is guaranteed OUTSIDE every allowed root.
 
-    The outside directory is created under ``~`` -- never a temp dir, because a
+    The outside directory is created under ``~`` (never a temp dir), because a
     *private* system temp dir is itself an allowed root on macOS
     (``/var/folders/...`` is mode 0700), so an attack target staged there would
     be (correctly) permitted and the test would not exercise the guard.
@@ -57,7 +57,7 @@ def sandbox():
 
 
 def test_negative_control(sandbox):
-    """A plain write to a path outside all allowed roots must be refused -- proof
+    """A plain write to a path outside all allowed roots must be refused; proof
     that the sandbox is genuinely enforcing in this process."""
     target = sandbox / "control.txt"
     with pytest.raises(PermissionError):
@@ -81,7 +81,7 @@ def test_save_punkt_params_refuses_outside_dir(sandbox):
 
 def test_save_punkt_params_default_is_private_dir_not_tmp(sandbox):
     """The default destination is a fresh private (0700), unpredictably-named
-    directory (returned by the call) -- never the old guessable ``/tmp``."""
+    directory (returned by the call), never the old guessable ``/tmp``."""
     from nltk.tokenize.punkt import PunktParameters, save_punkt_params
 
     out = save_punkt_params(PunktParameters())
@@ -95,7 +95,7 @@ def test_save_punkt_params_default_is_private_dir_not_tmp(sandbox):
 
 def test_punkt_dump_writes_private_temp_not_hardcoded_tmp(sandbox):
     """The ``dump`` debug scaffold must write to a fresh private (0700) temp file
-    and return its path -- never the old guessable ``/tmp/punkt.new``."""
+    and return its path, never the old guessable ``/tmp/punkt.new``."""
     from nltk.tokenize.punkt import PunktSentenceTokenizer, PunktToken
 
     tok = PunktSentenceTokenizer()
@@ -116,7 +116,7 @@ def test_stanford_sha256_refuses_outside_jar(sandbox):
     from nltk.tokenize.stanford_segmenter import StanfordSegmenter
 
     # A real file must exist so os.stat() succeeds and control reaches the
-    # patched pathsec_open -- an absent file would raise FileNotFoundError first
+    # patched pathsec_open; an absent file would raise FileNotFoundError first
     # and mask the security check.
     outside_jar = sandbox / "evil.jar"
     outside_jar.write_bytes(b"PK\x03\x04 not really a jar")

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -109,12 +109,12 @@ import math
 import os
 import re
 import string
-import tempfile
 from collections import defaultdict
 from collections.abc import Iterator
 from re import Match
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+from nltk.pathsec import make_staging_dir
 from nltk.pathsec import open as pathsec_open
 from nltk.pathsec import validate_path
 from nltk.picklesec import allowlisted_pickle_load
@@ -1646,7 +1646,7 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
         # Debug scaffold: write through pathsec to a fresh private (0700) temp
         # file, not a guessable /tmp path, and return it (CWE-377/378).
         outfilename = os.path.join(
-            tempfile.mkdtemp(prefix="nltk_punkt_dump_"), "punkt.new"
+            make_staging_dir(prefix="nltk_punkt_dump_"), "punkt.new"
         )
         print(f"writing to {outfilename}...")
         with pathsec_open(
@@ -1826,7 +1826,7 @@ class PunktTokenizer(PunktSentenceTokenizer):
         location.
         """
         if self._save_dir is None:
-            self._save_dir = tempfile.mkdtemp(prefix=f"nltk_punkt_{self._lang}_")
+            self._save_dir = make_staging_dir(prefix=f"nltk_punkt_{self._lang}_")
         return self._save_dir
 
     def save_params(self) -> str:
@@ -1872,7 +1872,7 @@ def save_punkt_params(params, dir: str | None = None) -> str:
     """
     tenc = TabEncoder()
     if dir is None:
-        dir = tempfile.mkdtemp(prefix="nltk_punkt_params_")
+        dir = make_staging_dir(prefix="nltk_punkt_params_")
     validate_path(dir, context="save_punkt_params")
     if not os.path.isdir(dir):
         os.mkdir(dir)

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -1815,6 +1815,10 @@ class PunktTokenizer(PunktSentenceTokenizer):
         lang_dir = find(f"tokenizers/punkt_tab/{lang}/")
         self._params = load_punkt_params(lang_dir)
         self._lang = lang
+        # A new language needs a new save dir; drop any memoized one so save_dir
+        # is recreated with the correct language prefix rather than reusing the
+        # previous language's directory.
+        self._save_dir = None
 
     @property
     def save_dir(self) -> str:
@@ -1881,7 +1885,9 @@ def save_punkt_params(params, dir: str | None = None) -> str:
         dir = make_staging_dir(prefix="nltk_punkt_params_")
     validate_path(dir, context="save_punkt_params")
     if not os.path.isdir(dir):
-        os.mkdir(dir)
+        # 0700 so a caller-supplied output dir is private regardless of umask,
+        # matching the private default staging dir.
+        os.mkdir(dir, 0o700)
     with pathsec_open(f"{dir}/collocations.tab", "w", context="save_punkt_params") as f:
         f.write(f"{tenc.tups2tab(params.collocations)}")
     with pathsec_open(

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -1643,10 +1643,8 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
 
     # [XX] TESTING
     def dump(self, tokens: Iterator[PunktToken]) -> str:
-        # Debug scaffold. Write to a fresh private (0700), unpredictably-named
-        # temp file -- not a hardcoded, guessable /tmp path another user could
-        # pre-create or symlink (CWE-377/378) -- through the pathsec sandbox, and
-        # return the path (GHSA-8mgp-746c-j5xp, CWE-22/CWE-59).
+        # Debug scaffold: write through pathsec to a fresh private (0700) temp
+        # file, not a guessable /tmp path, and return it (CWE-377/378).
         outfilename = os.path.join(
             tempfile.mkdtemp(prefix="nltk_punkt_dump_"), "punkt.new"
         )

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -1820,7 +1820,7 @@ class PunktTokenizer(PunktSentenceTokenizer):
         """This tokenizer's private directory for saved parameters.
 
         Created lazily on first use with an unpredictable name and mode 0700, so
-        -- unlike the old guessable ``/tmp/<lang>`` -- another local user cannot
+        (unlike the old guessable ``/tmp/<lang>``) another local user cannot
         pre-create or symlink it to redirect or read the write (CWE-377/378).
         Reused across calls, so the saved parameters share one known, private
         location.
@@ -1857,7 +1857,7 @@ def load_punkt_params(lang_dir):
 def save_punkt_params(params, dir: str | None = None) -> str:
     """Write Punkt parameters as tab files; return the directory.
 
-    The old default was the shared, guessable ``/tmp/punkt_tab`` -- a
+    The old default was the shared, guessable ``/tmp/punkt_tab``, a
     destination another local user could pre-create or symlink (CWE-377/378),
     and one pathsec refuses anyway. Default instead to a fresh private (mode
     0700), unpredictably-named directory. A caller-supplied ``dir`` is validated

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -106,15 +106,20 @@ The algorithm for this tokenizer is described in::
 # FIXME: Problem with ending string with e.g. '!!!' -> '!! !'
 
 import math
+import os
 import re
 import string
+import tempfile
 from collections import defaultdict
 from collections.abc import Iterator
 from re import Match
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+from nltk.pathsec import open as pathsec_open
+from nltk.pathsec import validate_path
 from nltk.picklesec import allowlisted_pickle_load
 from nltk.probability import FreqDist
+from nltk.tabdata import TabEncoder
 from nltk.tokenize.api import TokenizerI
 
 # Exact ``(module, qualname)`` allowlist -- no namespace prefix. A prefix allow
@@ -1637,9 +1642,18 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
             yield sentence
 
     # [XX] TESTING
-    def dump(self, tokens: Iterator[PunktToken]) -> None:
-        print("writing to /tmp/punkt.new...")
-        with open("/tmp/punkt.new", "w") as outfile:
+    def dump(self, tokens: Iterator[PunktToken]) -> str:
+        # Debug scaffold. Write to a fresh private (0700), unpredictably-named
+        # temp file -- not a hardcoded, guessable /tmp path another user could
+        # pre-create or symlink (CWE-377/378) -- through the pathsec sandbox, and
+        # return the path (GHSA-8mgp-746c-j5xp, CWE-22/CWE-59).
+        outfilename = os.path.join(
+            tempfile.mkdtemp(prefix="nltk_punkt_dump_"), "punkt.new"
+        )
+        print(f"writing to {outfilename}...")
+        with pathsec_open(
+            outfilename, "w", context="PunktSentenceTokenizer.dump"
+        ) as outfile:
             for aug_tok in tokens:
                 if aug_tok.parastart:
                     outfile.write("\n\n")
@@ -1649,6 +1663,7 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
                     outfile.write(" ")
 
                 outfile.write(str(aug_tok))
+        return outfilename
 
     # ////////////////////////////////////////////////////////////
     # { Customization Variables
@@ -1792,6 +1807,7 @@ class PunktTokenizer(PunktSentenceTokenizer):
 
     def __init__(self, lang="english"):
         PunktSentenceTokenizer.__init__(self)
+        self._save_dir = None
         self.load_lang(lang)
 
     def load_lang(self, lang="english"):
@@ -1801,8 +1817,23 @@ class PunktTokenizer(PunktSentenceTokenizer):
         self._params = load_punkt_params(lang_dir)
         self._lang = lang
 
-    def save_params(self):
-        save_punkt_params(self._params, dir=f"/tmp/{self._lang}")
+    @property
+    def save_dir(self) -> str:
+        """This tokenizer's private directory for saved parameters.
+
+        Created lazily on first use with an unpredictable name and mode 0700, so
+        -- unlike the old guessable ``/tmp/<lang>`` -- another local user cannot
+        pre-create or symlink it to redirect or read the write (CWE-377/378).
+        Reused across calls, so the saved parameters share one known, private
+        location.
+        """
+        if self._save_dir is None:
+            self._save_dir = tempfile.mkdtemp(prefix=f"nltk_punkt_{self._lang}_")
+        return self._save_dir
+
+    def save_params(self) -> str:
+        """Write this tokenizer's parameters to :attr:`save_dir`; return it."""
+        return save_punkt_params(self._params, dir=self.save_dir)
 
 
 def load_punkt_params(lang_dir):
@@ -1825,23 +1856,41 @@ def load_punkt_params(lang_dir):
     return params
 
 
-def save_punkt_params(params, dir="/tmp/punkt_tab"):
-    from os import mkdir
-    from os.path import isdir
+def save_punkt_params(params, dir: str | None = None) -> str:
+    """Write Punkt parameters as tab files; return the directory.
 
-    from nltk.tabdata import TabEncoder
+    The old default was the shared, guessable ``/tmp/punkt_tab`` -- a
+    destination another local user could pre-create or symlink (CWE-377/378),
+    and one pathsec refuses anyway. Default instead to a fresh private (mode
+    0700), unpredictably-named directory. A caller-supplied ``dir`` is validated
+    against the NLTK data sandbox before the directory is created or any file is
+    written; each file is then written through the pathsec sandbox, which also
+    closes the symlink-swap TOCTOU on write (GHSA-8mgp-746c-j5xp, CWE-22/CWE-59).
 
-    if not isdir(dir):
-        mkdir(dir)
+    :param dir: destination directory; defaults to a fresh private one.
+    :type dir: str or None
+    :return: the directory the parameter files were written to.
+    :rtype: str
+    """
     tenc = TabEncoder()
-    with open(f"{dir}/collocations.tab", "w") as f:
+    if dir is None:
+        dir = tempfile.mkdtemp(prefix="nltk_punkt_params_")
+    validate_path(dir, context="save_punkt_params")
+    if not os.path.isdir(dir):
+        os.mkdir(dir)
+    with pathsec_open(f"{dir}/collocations.tab", "w", context="save_punkt_params") as f:
         f.write(f"{tenc.tups2tab(params.collocations)}")
-    with open(f"{dir}/sent_starters.txt", "w") as f:
+    with pathsec_open(
+        f"{dir}/sent_starters.txt", "w", context="save_punkt_params"
+    ) as f:
         f.write(f"{tenc.set2txt(params.sent_starters)}")
-    with open(f"{dir}/abbrev_types.txt", "w") as f:
+    with pathsec_open(f"{dir}/abbrev_types.txt", "w", context="save_punkt_params") as f:
         f.write(f"{tenc.set2txt(params.abbrev_types)}")
-    with open(f"{dir}/ortho_context.tab", "w") as f:
+    with pathsec_open(
+        f"{dir}/ortho_context.tab", "w", context="save_punkt_params"
+    ) as f:
         f.write(f"{tenc.ivdict2tab(params.ortho_context)}")
+    return dir
 
 
 # def punkt_tokenizer(lang="english"):

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -114,7 +114,6 @@ from collections.abc import Iterator
 from re import Match
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from nltk.pathsec import make_staging_dir
 from nltk.pathsec import open as pathsec_open
 from nltk.pathsec import validate_path
 from nltk.picklesec import allowlisted_pickle_load
@@ -1643,8 +1642,10 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
 
     # [XX] TESTING
     def dump(self, tokens: Iterator[PunktToken]) -> str:
-        # Debug scaffold: write through pathsec to a fresh private (0700) temp
-        # file, not a guessable /tmp path, and return it (CWE-377/378).
+        from nltk.data import make_staging_dir
+
+        # Debug scaffold: write through pathsec to a fresh private (0700) dir under
+        # a data root, not a guessable /tmp path, and return it (CWE-377/378).
         outfilename = os.path.join(
             make_staging_dir(prefix="nltk_punkt_dump_"), "punkt.new"
         )
@@ -1819,12 +1820,14 @@ class PunktTokenizer(PunktSentenceTokenizer):
     def save_dir(self) -> str:
         """This tokenizer's private directory for saved parameters.
 
-        Created lazily on first use with an unpredictable name and mode 0700, so
-        (unlike the old guessable ``/tmp/<lang>``) another local user cannot
-        pre-create or symlink it to redirect or read the write (CWE-377/378).
-        Reused across calls, so the saved parameters share one known, private
-        location.
+        Created lazily on first use under a data root, with an unpredictable name
+        and mode 0700, so (unlike the old guessable ``/tmp/<lang>``) another local
+        user cannot pre-create or symlink it to redirect or read the write
+        (CWE-377/378). Reused across calls, so the saved parameters share one
+        known, private, in-sandbox location.
         """
+        from nltk.data import make_staging_dir
+
         if self._save_dir is None:
             self._save_dir = make_staging_dir(prefix=f"nltk_punkt_{self._lang}_")
         return self._save_dir
@@ -1860,7 +1863,8 @@ def save_punkt_params(params, dir: str | None = None) -> str:
     The old default was the shared, guessable ``/tmp/punkt_tab``, a
     destination another local user could pre-create or symlink (CWE-377/378),
     and one pathsec refuses anyway. Default instead to a fresh private (mode
-    0700), unpredictably-named directory. A caller-supplied ``dir`` is validated
+    0700), unpredictably-named directory under a data root, so the write lands
+    inside the sandbox on every platform. A caller-supplied ``dir`` is validated
     against the NLTK data sandbox before the directory is created or any file is
     written; each file is then written through the pathsec sandbox, which also
     closes the symlink-swap TOCTOU on write (GHSA-8mgp-746c-j5xp, CWE-22/CWE-59).
@@ -1872,6 +1876,8 @@ def save_punkt_params(params, dir: str | None = None) -> str:
     """
     tenc = TabEncoder()
     if dir is None:
+        from nltk.data import make_staging_dir
+
         dir = make_staging_dir(prefix="nltk_punkt_params_")
     validate_path(dir, context="save_punkt_params")
     if not os.path.isdir(dir):

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -1888,16 +1888,23 @@ def save_punkt_params(params, dir: str | None = None) -> str:
         # 0700 so a caller-supplied output dir is private regardless of umask,
         # matching the private default staging dir.
         os.mkdir(dir, 0o700)
-    with pathsec_open(f"{dir}/collocations.tab", "w", context="save_punkt_params") as f:
+    # newline="" writes LF, not the platform default, so the tab files match the
+    # installed punkt_tab format and reload cleanly on Windows (a default text
+    # write there emits CRLF, leaving a stray \r on every reloaded token).
+    with pathsec_open(
+        f"{dir}/collocations.tab", "w", context="save_punkt_params", newline=""
+    ) as f:
         f.write(f"{tenc.tups2tab(params.collocations)}")
     with pathsec_open(
-        f"{dir}/sent_starters.txt", "w", context="save_punkt_params"
+        f"{dir}/sent_starters.txt", "w", context="save_punkt_params", newline=""
     ) as f:
         f.write(f"{tenc.set2txt(params.sent_starters)}")
-    with pathsec_open(f"{dir}/abbrev_types.txt", "w", context="save_punkt_params") as f:
+    with pathsec_open(
+        f"{dir}/abbrev_types.txt", "w", context="save_punkt_params", newline=""
+    ) as f:
         f.write(f"{tenc.set2txt(params.abbrev_types)}")
     with pathsec_open(
-        f"{dir}/ortho_context.tab", "w", context="save_punkt_params"
+        f"{dir}/ortho_context.tab", "w", context="save_punkt_params", newline=""
     ) as f:
         f.write(f"{tenc.ivdict2tab(params.ortho_context)}")
     return dir

--- a/nltk/tokenize/stanford_segmenter.py
+++ b/nltk/tokenize/stanford_segmenter.py
@@ -289,11 +289,8 @@ class StanfordSegmenter(TokenizerI):
                 return cached_digest
 
         h = hashlib.sha256()
-        # ``file_path`` is a caller-controlled classpath entry (from the
-        # ``path_to_jar`` / ``path_to_slf4j`` constructor args or the
-        # STANFORD_SEGMENTER / SLF4J env vars). Route the read through the
-        # pathsec sandbox so a traversal path cannot be hashed/opened outside an
-        # allowed data root (GHSA-8mgp-746c-j5xp, CWE-22/CWE-59).
+        # file_path is a caller-controlled classpath entry; route the read
+        # through pathsec so a traversal path can't be opened outside a root.
         with pathsec_open(file_path, "rb", context="StanfordSegmenter._sha256sum") as f:
             for chunk in iter(lambda: f.read(4096), b""):
                 h.update(chunk)

--- a/nltk/tokenize/stanford_segmenter.py
+++ b/nltk/tokenize/stanford_segmenter.py
@@ -24,6 +24,7 @@ from nltk.internals import (
     java,
 )
 from nltk.pathsec import open as pathsec_open
+from nltk.pathsec import validate_path
 from nltk.tokenize.api import TokenizerI
 
 _stanford_url = "https://nlp.stanford.edu/software"
@@ -280,6 +281,10 @@ class StanfordSegmenter(TokenizerI):
                         raise
 
     def _sha256sum(self, file_path):
+        # file_path is a caller-controlled classpath entry; validate it before
+        # any filesystem access so an out-of-sandbox path fails without an
+        # os.stat metadata leak or symlink follow (CWE-22/CWE-59).
+        validate_path(file_path, context="StanfordSegmenter._sha256sum")
         stat = os.stat(file_path)
         cached = self._jar_sha256_cache.get(file_path)
         cache_key = (stat.st_mtime_ns, stat.st_size)
@@ -289,8 +294,8 @@ class StanfordSegmenter(TokenizerI):
                 return cached_digest
 
         h = hashlib.sha256()
-        # file_path is a caller-controlled classpath entry; route the read
-        # through pathsec so a traversal path can't be opened outside a root.
+        # Re-checked at open time by pathsec, whose O_NOFOLLOW closes the
+        # symlink-swap TOCTOU that a path-only validate_path cannot.
         with pathsec_open(file_path, "rb", context="StanfordSegmenter._sha256sum") as f:
             for chunk in iter(lambda: f.read(4096), b""):
                 h.update(chunk)

--- a/nltk/tokenize/stanford_segmenter.py
+++ b/nltk/tokenize/stanford_segmenter.py
@@ -23,6 +23,7 @@ from nltk.internals import (
     find_jar,
     java,
 )
+from nltk.pathsec import open as pathsec_open
 from nltk.tokenize.api import TokenizerI
 
 _stanford_url = "https://nlp.stanford.edu/software"
@@ -288,7 +289,12 @@ class StanfordSegmenter(TokenizerI):
                 return cached_digest
 
         h = hashlib.sha256()
-        with open(file_path, "rb") as f:
+        # ``file_path`` is a caller-controlled classpath entry (from the
+        # ``path_to_jar`` / ``path_to_slf4j`` constructor args or the
+        # STANFORD_SEGMENTER / SLF4J env vars). Route the read through the
+        # pathsec sandbox so a traversal path cannot be hashed/opened outside an
+        # allowed data root (GHSA-8mgp-746c-j5xp, CWE-22/CWE-59).
+        with pathsec_open(file_path, "rb", context="StanfordSegmenter._sha256sum") as f:
             for chunk in iter(lambda: f.read(4096), b""):
                 h.update(chunk)
         digest = h.hexdigest()


### PR DESCRIPTION
Path-traversal hardening for the tokenize package (GHSA-8mgp-746c-j5xp), split out of the umbrella PR for isolated review.

**`punkt.py`** — `save_punkt_params` now routes its four writes through pathsec and defaults `dir` to a fresh private `tempfile.mkdtemp` (validated before mkdir, returned, annotated `-> str`) instead of the guessable shared `/tmp/punkt_tab`; `PunktTokenizer` gains a private, lazily-created, reused `save_dir` property so `save_params()` no longer writes to `/tmp/<lang>`, and the `dump()` debug scaffold writes to a fresh private temp file (returned) rather than the hardcoded `/tmp/punkt.new`.

**`stanford_segmenter.py`** — `StanfordSegmenter._sha256sum` reads a caller-controlled classpath JAR through `pathsec.open`, so a path outside the allowed data roots is refused.

**`test_pathsec_sweep_tokenize.py`** — attack matrix proving each: the `save_punkt_params` default is a private in-sandbox dir (never `/tmp`) and an outside `dir` is refused; `dump` writes a private temp (never `/tmp`) and returns it; `_sha256sum` refuses an outside JAR.
