### PR TITLE
Harden untrusted-model pickle allowlist (exact globals + numpy.lib denylist)

### DIFF
--- a/nltk/parse/transitionparser.py
+++ b/nltk/parse/transitionparser.py
@@ -24,22 +24,9 @@ from nltk.parse import DependencyEvaluator, DependencyGraph, ParserI
 from nltk.pathsec import open as pathsec_open
 from nltk.picklesec import allowlisted_pickle_load
 
-# Modules whose globals a saved TransitionParser model legitimately needs. The
-# model is a trained scikit-learn classifier backed by numpy/scipy arrays, so
-# allowing only these scientific-stack modules lets a genuine model load while
-# blocking arbitrary-code gadgets (os, posix, subprocess, builtins, ...).
-#
-# These are broad namespaces (numpy array unpickling needs submodules such as
-# ``numpy._core.multiarray``), so AllowlistUnpickler's dotted-name guard and its
-# denied-module backstop do the heavy lifting: a crafted pickle can no longer
-# reach ``numpy.f2py.crackfortran.myeval`` (an eval sink under the allowed
-# ``numpy`` namespace) or a dotted ``sklearn.os.system`` (GHSA-x99w / GHSA-4489).
-#
-# Narrowed further to fail closed: no whole module is allowed
-# (``_MODEL_ALLOWED_MODULES = ()``); only the exact ``(module, qualname)`` pairs a
-# genuine fitted SVC pickle references are permitted (CWE-502).
+# A fitted SVC pickle needs only exact numpy/scipy/sklearn globals; whole
+# namespaces exposed real gadgets, so allowlist exact globals (CWE-502).
 _MODEL_ALLOWED_MODULES = ()
-# Exact primitives a fitted model's containers may reference.
 _MODEL_ALLOWED_GLOBALS = (
     ("sklearn.svm._classes", "SVC"),
     ("numpy", "ndarray"),
@@ -48,11 +35,14 @@ _MODEL_ALLOWED_GLOBALS = (
     ("numpy._core.multiarray", "_reconstruct"),
     ("numpy.core.multiarray", "scalar"),
     ("numpy._core.multiarray", "scalar"),
+    # numpy >= 2.5 pickles a contiguous array via _frombuffer (an in-memory
+    # buffer reshape, no file/code access), not _reconstruct.
+    ("numpy._core.numeric", "_frombuffer"),
+    ("numpy.core.numeric", "_frombuffer"),
     ("scipy.sparse._csr", "csr_matrix"),
     ("scipy.sparse.csr", "csr_matrix"),
     ("scipy.sparse._csc", "csc_matrix"),
     ("scipy.sparse.csc", "csc_matrix"),
-    # Exact primitives a fitted model's containers may reference.
     ("collections", "defaultdict"),
     ("collections", "OrderedDict"),
     ("builtins", "int"),
@@ -577,11 +567,11 @@ class TransitionParser(ParserI):
             )
 
             model.fit(x_train, y_train)
-            # Save the model to file name (as pickle)
-            #
-            # ``modelfile`` is a caller-supplied path, so route the write through
-            # the pathsec sandbox: an unauthorized destination is refused before
-            # any bytes are written (GHSA-8mgp-746c-j5xp).
+            # Save the model to file name (as pickle). ``modelfile`` is a
+            # caller-supplied path, so route the write through the pathsec
+            # sandbox: an unauthorized destination is refused before any bytes
+            # are written, closing the arbitrary-path pickle write
+            # (GHSA-8mgp-746c-j5xp).
             with pathsec_open(modelfile, "wb", context="TransitionParser.train") as f:
                 pickle.dump(model, f)
         finally:
@@ -597,15 +587,17 @@ class TransitionParser(ParserI):
         """
         result = []
         # First load the model. The model is a trained scikit-learn classifier,
-        # so it is loaded through an allowlisting unpickler (CWE-502): only
-        # numpy/scipy/sklearn globals may be reconstructed, and anything else --
-        # e.g. os.system -- raises UnpicklingError instead of executing. See
+        # so it is loaded through an allowlisting unpickler (CWE-502): only the
+        # exact globals a fitted SVC pickle needs may be reconstructed, and
+        # anything else (e.g. os.system, or scipy.io.mmwrite) raises
+        # UnpicklingError instead of executing/writing. See
         # nltk/picklesec.py and huntr report
         # https://huntr.com/bounties/38abc191-0525-42a1-96fd-262c1c187012
         #
         # ``modelFile`` is a caller-supplied path, so route the read through the
         # pathsec sandbox too: an out-of-sandbox model path is refused before it
-        # is opened (GHSA-8mgp-746c-j5xp).
+        # is opened (GHSA-8mgp-746c-j5xp), and the resulting handle is still
+        # unpickled through the allowlisting unpickler.
         with pathsec_open(modelFile, "rb", context="TransitionParser.parse") as f:
             model = allowlisted_pickle_load(
                 f,
@@ -799,6 +791,10 @@ def demo():
     A. Check the ARC-STANDARD training
     >>> import tempfile
     >>> import os
+    >>> from nltk.data import make_staging_dir
+    >>> _model_dir = make_staging_dir(prefix='nltk_tp_demo_')
+    >>> std_model = os.path.join(_model_dir, 'temp.arcstd.model')
+    >>> eager_model = os.path.join(_model_dir, 'temp.arceager.model')
     >>> input_file = tempfile.NamedTemporaryFile(prefix='transition_parse.train', dir=tempfile.gettempdir(), delete=False)
 
     >>> parser_std = TransitionParser('arc-standard')
@@ -807,7 +803,7 @@ def demo():
      Number of valid (projective) examples : 1
     SHIFT, LEFTARC:ATT, SHIFT, LEFTARC:SBJ, SHIFT, SHIFT, LEFTARC:ATT, SHIFT, SHIFT, SHIFT, LEFTARC:ATT, RIGHTARC:PC, RIGHTARC:ATT, RIGHTARC:OBJ, SHIFT, RIGHTARC:PU, RIGHTARC:ROOT, SHIFT
 
-    >>> parser_std.train([gold_sent],'temp.arcstd.model', verbose=False)
+    >>> parser_std.train([gold_sent], std_model, verbose=False)
      Number of training examples : 1
      Number of valid (projective) examples : 1
     >>> input_file.close()
@@ -822,7 +818,7 @@ def demo():
      Number of valid (projective) examples : 1
     SHIFT, LEFTARC:ATT, SHIFT, LEFTARC:SBJ, RIGHTARC:ROOT, SHIFT, LEFTARC:ATT, RIGHTARC:OBJ, RIGHTARC:ATT, SHIFT, LEFTARC:ATT, RIGHTARC:PC, REDUCE, REDUCE, REDUCE, RIGHTARC:PU
 
-    >>> parser_eager.train([gold_sent],'temp.arceager.model', verbose=False)
+    >>> parser_eager.train([gold_sent], eager_model, verbose=False)
      Number of training examples : 1
      Number of valid (projective) examples : 1
 
@@ -833,20 +829,20 @@ def demo():
 
     A. Check the ARC-STANDARD parser
 
-    >>> result = parser_std.parse([gold_sent], 'temp.arcstd.model')
+    >>> result = parser_std.parse([gold_sent], std_model)
     >>> de = DependencyEvaluator(result, [gold_sent])
     >>> de.eval() >= (0, 0)
     True
 
     B. Check the ARC-EAGER parser
-    >>> result = parser_eager.parse([gold_sent], 'temp.arceager.model')
+    >>> result = parser_eager.parse([gold_sent], eager_model)
     >>> de = DependencyEvaluator(result, [gold_sent])
     >>> de.eval() >= (0, 0)
     True
 
     Remove test temporary files
-    >>> remove('temp.arceager.model')
-    >>> remove('temp.arcstd.model')
+    >>> remove(eager_model)
+    >>> remove(std_model)
 
     Note that result is very poor because of only one training example.
     """

--- a/nltk/parse/transitionparser.py
+++ b/nltk/parse/transitionparser.py
@@ -21,6 +21,7 @@ except ImportError:
     pass
 
 from nltk.parse import DependencyEvaluator, DependencyGraph, ParserI
+from nltk.pathsec import open as pathsec_open
 from nltk.picklesec import allowlisted_pickle_load
 
 # Modules whose globals a saved TransitionParser model legitimately needs. The
@@ -33,9 +34,25 @@ from nltk.picklesec import allowlisted_pickle_load
 # denied-module backstop do the heavy lifting: a crafted pickle can no longer
 # reach ``numpy.f2py.crackfortran.myeval`` (an eval sink under the allowed
 # ``numpy`` namespace) or a dotted ``sklearn.os.system`` (GHSA-x99w / GHSA-4489).
-_MODEL_ALLOWED_MODULES = ("numpy", "scipy", "sklearn")
+#
+# Narrowed further to fail closed: no whole module is allowed
+# (``_MODEL_ALLOWED_MODULES = ()``); only the exact ``(module, qualname)`` pairs a
+# genuine fitted SVC pickle references are permitted (CWE-502).
+_MODEL_ALLOWED_MODULES = ()
 # Exact primitives a fitted model's containers may reference.
 _MODEL_ALLOWED_GLOBALS = (
+    ("sklearn.svm._classes", "SVC"),
+    ("numpy", "ndarray"),
+    ("numpy", "dtype"),
+    ("numpy.core.multiarray", "_reconstruct"),
+    ("numpy._core.multiarray", "_reconstruct"),
+    ("numpy.core.multiarray", "scalar"),
+    ("numpy._core.multiarray", "scalar"),
+    ("scipy.sparse._csr", "csr_matrix"),
+    ("scipy.sparse.csr", "csr_matrix"),
+    ("scipy.sparse._csc", "csc_matrix"),
+    ("scipy.sparse.csc", "csc_matrix"),
+    # Exact primitives a fitted model's containers may reference.
     ("collections", "defaultdict"),
     ("collections", "OrderedDict"),
     ("builtins", "int"),
@@ -561,7 +578,12 @@ class TransitionParser(ParserI):
 
             model.fit(x_train, y_train)
             # Save the model to file name (as pickle)
-            pickle.dump(model, open(modelfile, "wb"))
+            #
+            # ``modelfile`` is a caller-supplied path, so route the write through
+            # the pathsec sandbox: an unauthorized destination is refused before
+            # any bytes are written (GHSA-8mgp-746c-j5xp).
+            with pathsec_open(modelfile, "wb", context="TransitionParser.train") as f:
+                pickle.dump(model, f)
         finally:
             remove(input_file.name)
 
@@ -580,7 +602,11 @@ class TransitionParser(ParserI):
         # e.g. os.system -- raises UnpicklingError instead of executing. See
         # nltk/picklesec.py and huntr report
         # https://huntr.com/bounties/38abc191-0525-42a1-96fd-262c1c187012
-        with open(modelFile, "rb") as f:
+        #
+        # ``modelFile`` is a caller-supplied path, so route the read through the
+        # pathsec sandbox too: an out-of-sandbox model path is refused before it
+        # is opened (GHSA-8mgp-746c-j5xp).
+        with pathsec_open(modelFile, "rb", context="TransitionParser.parse") as f:
             model = allowlisted_pickle_load(
                 f,
                 allowed_modules=_MODEL_ALLOWED_MODULES,

--- a/nltk/picklesec.py
+++ b/nltk/picklesec.py
@@ -117,6 +117,15 @@ _DENIED_MODULE_PREFIXES = (
     # numpy.lib file-I/O sinks (npyio/_npyio_impl recfromtxt etc., format.open_memmap)
     # keep __module__ under numpy.lib, dodging the export-name denylist (CWE-502).
     "numpy.lib",
+    # numpy record-array module: rec.fromfile (arbitrary file read) and friends
+    # resolve to __module__ "numpy.rec", again outside the export-name denylist;
+    # deny the subtree under every requested spelling (CWE-502).
+    "numpy.rec",
+    "numpy.core.records",
+    "numpy._core.records",
+    # numpy.compat.npy_load_module loads/executes a module from a file path
+    # (arbitrary code execution); deny numpy.compat wholesale (CWE-502).
+    "numpy.compat",
     # File-read/write and network sinks under scipy/sklearn (scipy.io.mmwrite,
     # loadmat; sklearn.datasets.fetch_openml/load_*). No model pickle needs them.
     "scipy.io",
@@ -155,6 +164,46 @@ _DENIED_GLOBALS = frozenset(
         ("scipy", "LowLevelCallable"),
         ("scipy._lib._ccallback", "LowLevelCallable"),
         ("pandas", "read_pickle"),
+    }
+)
+
+# Dangerous callables (arbitrary file read/write, module load, nested unpickle,
+# matlab/svmlight/openml I/O) that the scientific stack re-exports under many
+# submodule paths (numpy.fromfile / numpy.rec.fromfile / numpy.ma.core.fromfile,
+# ...). Denied by resolved *qualname* in :meth:`_resolve` so an alias under any
+# numpy/scipy/sklearn/pandas submodule is caught, not just the enumerated
+# (module, name) pairs above (CWE-502). No model-reconstruct global shares these
+# names, so legitimate loads are unaffected.
+_DENIED_SCISTACK_QUALNAMES = frozenset(
+    {
+        "fromfile",
+        "recfromtxt",
+        "recfromcsv",
+        "genfromtxt",
+        "loadtxt",
+        "fromregex",
+        "load",
+        "save",
+        "savez",
+        "savez_compressed",
+        "savetxt",
+        "memmap",
+        "open_memmap",
+        "read_array",
+        "write_array",
+        "NpzFile",
+        "DataSource",
+        "npy_load_module",
+        "load_library",
+        "loadmat",
+        "savemat",
+        "mmread",
+        "mmwrite",
+        "load_svmlight_file",
+        "load_svmlight_files",
+        "dump_svmlight_file",
+        "fetch_openml",
+        "read_pickle",
     }
 )
 
@@ -250,6 +299,21 @@ class AllowlistUnpickler(pickle.Unpickler):
                 f"global '{module}.{name}' ({true_module}.{true_qualname}) is a "
                 "denied callable and cannot be reconstructed from an untrusted "
                 "pickle"
+            )
+        # Robust catch-all: the same dangerous callable (numpy.fromfile,
+        # recfromtxt, npy_load_module, scipy.io.mmwrite, ...) is re-exported under
+        # many submodule paths, each with a different __module__, so an
+        # export-name / prefix denylist keeps missing aliases. Deny by resolved
+        # qualname within the scientific stack (CWE-502).
+        if (
+            true_qualname in _DENIED_SCISTACK_QUALNAMES
+            and (true_module or "").split(".")[0]
+            in ("numpy", "scipy", "sklearn", "pandas")
+            and (true_module, true_qualname) not in _SAFE_DENIED_GLOBALS
+        ):
+            raise pickle.UnpicklingError(
+                f"global '{module}.{name}' ({true_module}.{true_qualname}) is a "
+                "scientific-stack file/module I/O sink and cannot be reconstructed"
             )
         return obj
 

--- a/nltk/picklesec.py
+++ b/nltk/picklesec.py
@@ -144,6 +144,26 @@ _DENIED_MODULE_PREFIXES = (
     "subprocess",
     "sys",
     "socket",
+    # Network / file / archive / db I/O modules. Every callable opens a file,
+    # a socket or a database, so no model pickle references any of them. urllib
+    # is denied at the "urllib.request" subtree only, leaving the benign string
+    # helpers in urllib.parse (quote / urlencode, re-exported across the sci
+    # stack) permitted.
+    "urllib.request",
+    "http.client",
+    "ftplib",
+    "smtplib",
+    "sqlite3",
+    "dbm",
+    "shelve",
+    "gzip",
+    "bz2",
+    "lzma",
+    "zipfile",
+    "tarfile",
+    "mmap",
+    "fileinput",
+    "linecache",
     "shutil",
     "tempfile",  # NamedTemporaryFile / mkstemp / mkdtemp create files/dirs
     # NB: pathlib is deliberately NOT denied. A Path is an inert value (its
@@ -184,6 +204,17 @@ _DENIED_MODULE_PREFIXES = (
     "asyncio",
     "threading",
     "pickle",
+    # C-accelerator / low-level siblings of denied modules and other code-exec /
+    # nested-unpickle / process / network primitives. None appear in a legitimate
+    # model pickle (protocol >= 2 uses the NEWOBJ opcode, not a copyreg global).
+    "_pickle",  # nested unpickle with the default (unrestricted) Unpickler
+    "marshal",  # marshal.loads deserializes a code object
+    "copyreg",  # _reconstructor / __newobj__ object-injection gadgets
+    "_posixsubprocess",  # fork_exec spawns a process
+    "_socket",
+    "ssl",
+    "_ssl",
+    "cffi",  # native FFI (cffi.FFI.dlopen / cdef)
     "numpy.f2py",
     "numpy.ctypeslib",
     "numpy.distutils",
@@ -262,6 +293,15 @@ _DENIED_GLOBALS = frozenset(
         ("io", "FileIO"),
         ("_io", "FileIO"),
         ("codecs", "open"),
+        # types code/callable-construction primitives (a code object plus
+        # FunctionType is arbitrary execution). Denied by resolved qualname so
+        # benign types like SimpleNamespace / MappingProxyType stay permitted.
+        ("types", "FunctionType"),
+        ("types", "CodeType"),
+        ("types", "MethodType"),
+        ("types", "LambdaType"),
+        ("types", "CellType"),
+        ("types", "ModuleType"),
     }
 )
 

--- a/nltk/picklesec.py
+++ b/nltk/picklesec.py
@@ -145,11 +145,17 @@ _DENIED_MODULE_PREFIXES = (
     "sys",
     "socket",
     "shutil",
+    "tempfile",  # NamedTemporaryFile / mkstemp / mkdtemp create files/dirs
+    # NB: pathlib is deliberately NOT denied. A Path is an inert value (its
+    # construction does no I/O), and its read/open methods are only reachable as
+    # dotted names (pathlib.Path.read_text), already refused by Guard 1. Denying
+    # it would buy no safety while breaking any legitimate pickle carrying a Path.
     "signal",
     "pty",
     "popen2",
     "commands",
     "ctypes",
+    "_ctypes",  # the C accelerator (_ctypes.CFuncPtr, ...) invokes native code
     "importlib",
     "runpy",
     # importlib's frozen bootstrap modules re-export spec_from_file_location and
@@ -235,6 +241,16 @@ _DENIED_GLOBALS = frozenset(
         ("scipy", "LowLevelCallable"),
         ("scipy._lib._ccallback", "LowLevelCallable"),
         ("pandas", "read_pickle"),
+        # File-open primitives that may be re-exported into an allowed namespace
+        # under their C-module name (io / _io / codecs). Matched on the resolved
+        # (__module__, __qualname__), so StringIO / BytesIO stay permitted.
+        ("io", "open"),
+        ("_io", "open"),
+        ("io", "open_code"),
+        ("_io", "open_code"),
+        ("io", "FileIO"),
+        ("_io", "FileIO"),
+        ("codecs", "open"),
     }
 )
 
@@ -283,6 +299,32 @@ _DENIED_SCISTACK_QUALNAMES = frozenset(
         "fromtextfile",
         "_load_from_filelike",
         "TextReader",
+        # pandas readers: on pandas >= 3.0 their __module__ collapses to "pandas"
+        # (not pandas.io.*), so the pandas.io prefix misses them; deny by resolved
+        # qualname too. Each is an arbitrary file / URL / DB read sink.
+        "read_csv",
+        "read_table",
+        "read_fwf",
+        "read_json",
+        "read_html",
+        "read_xml",
+        "read_excel",
+        "read_hdf",
+        "read_parquet",
+        "read_orc",
+        "read_feather",
+        "read_stata",
+        "read_sas",
+        "read_spss",
+        "read_sql",
+        "read_sql_query",
+        "read_sql_table",
+        "read_gbq",
+        "read_clipboard",
+        "HDFStore",
+        "ExcelFile",
+        # scipy.datasets network + cache fetchers, robust to a submodule move.
+        "download_all",
     }
 )
 

--- a/nltk/picklesec.py
+++ b/nltk/picklesec.py
@@ -164,6 +164,17 @@ _DENIED_MODULE_PREFIXES = (
     "_frozen_importlib",
     "_frozen_importlib_external",
     "builtins",  # builtins.int etc. must be requested via allowed_globals
+    # Higher-order call / attribute-traversal gadgets. operator.attrgetter,
+    # operator.itemgetter, operator.methodcaller and functools.partial / reduce /
+    # (lru_)cache are the primitives that weaponize an otherwise-safe allowlisted
+    # callable: e.g. attrgetter("__globals__")(numpy._frombuffer)["__builtins__"]
+    # ["eval"] reaches arbitrary eval. They are re-exported all over the sci stack
+    # (their __module__ stays operator / functools / the C _operator / _functools),
+    # and no model pickle references any of them. Deny the modules outright.
+    "operator",
+    "_operator",
+    "functools",
+    "_functools",
     "webbrowser",
     "pdb",
     "bdb",

--- a/nltk/picklesec.py
+++ b/nltk/picklesec.py
@@ -114,6 +114,9 @@ _DENIED_MODULE_PREFIXES = (
     "numpy.ctypeslib",
     "numpy.distutils",
     "numpy.testing",
+    # numpy.lib file-I/O sinks (npyio/_npyio_impl recfromtxt etc., format.open_memmap)
+    # keep __module__ under numpy.lib, dodging the export-name denylist (CWE-502).
+    "numpy.lib",
     # File-read/write and network sinks under scipy/sklearn (scipy.io.mmwrite,
     # loadmat; sklearn.datasets.fetch_openml/load_*). No model pickle needs them.
     "scipy.io",

--- a/nltk/picklesec.py
+++ b/nltk/picklesec.py
@@ -21,7 +21,9 @@ Helpers for safer and/or more explicit pickle usage in NLTK.
 
 from __future__ import annotations
 
+import io
 import pickle
+import pickletools
 import types
 import warnings
 from collections.abc import Iterable
@@ -34,10 +36,60 @@ PICKLE_WARNING = (
 )
 
 
+def _reject_extension_opcodes(pickle_source: Any) -> None:
+    """Refuse a pickle that uses the EXT1/EXT2/EXT4 extension-registry opcodes.
+
+    ``find_class`` gates GLOBAL/STACK_GLOBAL resolution, but the extension
+    opcodes resolve through ``copyreg``'s process-wide registry, and on a warm
+    ``copyreg._extension_cache`` the (C) unpickler returns the cached object
+    without calling ``find_class`` at all, bypassing every allowlist. NLTK
+    pickles never use extension opcodes, so any EXT opcode is refused up front.
+
+    ``pickle_source`` is bytes or a binary file. ``pickletools.genops`` walks the
+    opcode stream, importing and executing nothing (so scanning a hostile payload
+    is itself safe) and, when handed a file, without reading the whole pickle
+    into memory.
+    """
+    try:
+        for opcode, _arg, _pos in pickletools.genops(pickle_source):
+            if opcode.name.startswith("EXT"):
+                raise pickle.UnpicklingError(
+                    f"pickle uses the extension-registry opcode {opcode.name}, "
+                    "which bypasses find_class and is forbidden"
+                )
+    except pickle.UnpicklingError:
+        raise
+    except Exception:
+        # Malformed before any EXT opcode; let the real unpickler raise precisely.
+        return
+
+
+def _guarded_stream(file: BinaryIO) -> BinaryIO:
+    """Refuse forbidden extension opcodes in ``file`` and return a binary stream
+    positioned at the pickle start for the unpickler to consume.
+
+    A seekable file is scanned in place and rewound, so the unpickler still
+    streams it with bounded memory (no ``file.read()`` of the whole, untrusted
+    pickle). A non-seekable stream cannot be rewound, so it is read once.
+    """
+    seekable = getattr(file, "seekable", None)
+    if callable(seekable) and seekable():
+        start = file.tell()
+        _reject_extension_opcodes(file)
+        file.seek(start)
+        return file
+    data = file.read()
+    _reject_extension_opcodes(data)
+    return io.BytesIO(data)
+
+
 class RestrictedUnpickler(pickle.Unpickler):
     """
     Unpickler that prevents any class or function from being used during loading.
     """
+
+    def __init__(self, file: BinaryIO, **kwargs: Any):
+        super().__init__(_guarded_stream(file), **kwargs)
 
     def find_class(self, module: str, name: str) -> Any:
         # Forbid every function/class global.
@@ -251,7 +303,9 @@ class AllowlistUnpickler(pickle.Unpickler):
         allowed_modules: Iterable[str] = (),
         **kwargs: Any,
     ):
-        super().__init__(file, **kwargs)
+        data = file.read()
+        _reject_extension_opcodes(data)
+        super().__init__(io.BytesIO(data), **kwargs)
         if isinstance(allowed_modules, str):
             allowed_modules = (allowed_modules,)
         self._allowed_globals = set(allowed_globals)

--- a/nltk/picklesec.py
+++ b/nltk/picklesec.py
@@ -152,6 +152,11 @@ _DENIED_MODULE_PREFIXES = (
     "ctypes",
     "importlib",
     "runpy",
+    # importlib's frozen bootstrap modules re-export spec_from_file_location and
+    # source loaders that import/execute code from a file path (RCE); their
+    # __module__ is "_frozen_importlib[_external]", not "importlib".
+    "_frozen_importlib",
+    "_frozen_importlib_external",
     "builtins",  # builtins.int etc. must be requested via allowed_globals
     "webbrowser",
     "pdb",
@@ -175,13 +180,27 @@ _DENIED_MODULE_PREFIXES = (
     "numpy.rec",
     "numpy.core.records",
     "numpy._core.records",
+    # numpy.ma.mrecords.openfile / fromtextfile open a file by path.
+    "numpy.ma.mrecords",
     # numpy.compat.npy_load_module loads/executes a module from a file path
     # (arbitrary code execution); deny numpy.compat wholesale (CWE-502).
     "numpy.compat",
-    # File-read/write and network sinks under scipy/sklearn (scipy.io.mmwrite,
-    # loadmat; sklearn.datasets.fetch_openml/load_*). No model pickle needs them.
+    # File-read/write and network sinks under scipy/sklearn/pandas: scipy.io
+    # (mmwrite/loadmat), scipy.datasets (network download + cache write),
+    # sklearn.datasets (fetch_openml/load_*), and every pandas.io reader
+    # (read_csv/read_hdf/read_sql/read_html/HDFStore/ExcelFile, ...). Their real
+    # __module__ lives under these prefixes, so the post-resolution check denies
+    # them even when the request names a top-level re-export (pandas.read_csv).
+    # No model pickle needs any of them.
     "scipy.io",
+    "scipy.datasets",
+    # scipy.sparse.load_npz/save_npz read/write a file; the rest of scipy.sparse
+    # (csr_matrix, ...) stays allowed for genuine model matrices.
+    "scipy.sparse._matrix_io",
     "sklearn.datasets",
+    "pandas.io",
+    # pandas.compat.pickle_compat is a nested-unpickle sink (loads/Unpickler).
+    "pandas.compat",
     "nltk.tokenize.repp",
     "nltk.internals",
 )
@@ -256,6 +275,14 @@ _DENIED_SCISTACK_QUALNAMES = frozenset(
         "dump_svmlight_file",
         "fetch_openml",
         "read_pickle",
+        # file read/write and file-open sinks found in otherwise-allowed sci
+        # submodules (scipy.sparse, numpy.ma.mrecords, numpy._core, pandas._libs).
+        "load_npz",
+        "save_npz",
+        "openfile",
+        "fromtextfile",
+        "_load_from_filelike",
+        "TextReader",
     }
 )
 

--- a/nltk/test/unit/test_pathsec_sweep_deserialization.py
+++ b/nltk/test/unit/test_pathsec_sweep_deserialization.py
@@ -322,6 +322,30 @@ def test_wordnet_reference_decode_refuses_malicious_pickle_no_exec(tmp_path):
     assert not marker.exists(), "wordnet_app Reference.decode executed a pickle gadget"
 
 
+@pytest.mark.parametrize(
+    "payload",
+    [
+        (12345, {}),  # word is an int, not a str
+        ("dog", ["not", "a", "dict"]),  # synset_relations is a list, not a dict
+        ("dog", {123: {"x"}}),  # a non-str relation key
+        ("dog", {"k": frozenset({"x"})}),  # a frozenset value (not a mutable set)
+        ("dog", {"k": ["x"]}),  # a list value, not a set
+        [1, 2, 3],  # not even a 2-tuple to unpack
+    ],
+)
+def test_wordnet_reference_decode_rejects_non_reference_shape(payload):
+    """GHSA-7pvm: RestrictedUnpickler blocks class/function reconstruction but not
+    the *type/shape* of plain data, so a non-string / wrong-shaped value smuggled
+    through the pickle-based wordnet URL must be rejected with a plain ValueError
+    (never an unhandled crash) before it reaches Reference internals."""
+    import base64
+
+    Reference = _reference_cls()
+    encoded = base64.urlsafe_b64encode(pickle.dumps(payload)).decode()
+    with pytest.raises(ValueError, match="Malformed wordnet_app reference"):
+        Reference.decode(encoded)
+
+
 def test_restricted_unpickler_directly_blocks_every_gadget():
     """The shared RestrictedUnpickler (wordnet_app + data.py) blocks find_class."""
     for module, name in _GADGETS + [

--- a/nltk/test/unit/test_pathsec_sweep_deserialization.py
+++ b/nltk/test/unit/test_pathsec_sweep_deserialization.py
@@ -216,6 +216,36 @@ def test_every_load_site_refuses_scipy_io_mmwrite(site):
         loader(_reduce_global_pickle("scipy.io", "mmwrite", "/tmp/should-not-write"))
 
 
+@pytest.mark.parametrize("site", [c[0] for c in _LOAD_CONFIGS])
+def test_every_load_site_refuses_extension_opcode(site, tmp_path):
+    """The EXT1/EXT2/EXT4 extension-registry opcodes resolve a global through
+    copyreg (not find_class); on a warm copyreg._extension_cache the C unpickler
+    returns the cached object without find_class, bypassing the allowlist. Every
+    real load site must refuse EXT up front, even with the cache poisoned."""
+    import copyreg
+
+    loader = dict(_LOAD_CONFIGS)[site]
+    code = 199
+    marker = tmp_path / f"pwned_ext_{site.replace('.', '_')}"
+    payload = (
+        pickle.PROTO
+        + bytes([2])
+        + pickle.EXT1
+        + bytes([code])
+        + _su(f"touch {marker}")
+        + pickle.TUPLE1
+        + pickle.REDUCE
+        + pickle.STOP
+    )
+    copyreg._extension_cache[code] = os.system
+    try:
+        with pytest.raises(pickle.UnpicklingError):
+            loader(payload)
+        assert not marker.exists(), f"{site}: EXT warm-cache gadget executed"
+    finally:
+        copyreg._extension_cache.pop(code, None)
+
+
 # ---------------------------------------------------------------------------
 # Legitimate loads must still succeed (allowlists are not "block everything")
 # ---------------------------------------------------------------------------

--- a/nltk/test/unit/test_pathsec_sweep_deserialization.py
+++ b/nltk/test/unit/test_pathsec_sweep_deserialization.py
@@ -1,0 +1,367 @@
+"""Whole-tree deserialization sweep (CWE-502 / pickle-RCE regression matrix).
+
+This is a *sweep* test: it does not re-prove the internals of
+:mod:`nltk.picklesec` (that is :mod:`test_pickle_allowlist_security`), it proves
+that **every** place in the ``nltk`` tree that turns bytes back into Python
+objects is either
+
+  (a) routed through an allowlisting / restricted unpickler that refuses an
+      ``os.system`` / ``builtins.eval`` / dotted-name / ``scipy.io.mmwrite`` /
+      ``numpy.load`` gadget, or
+  (b) plain ``json`` off a pathsec-guarded handle (parsing, not code execution),
+      and
+
+  (c) that no reachable ``numpy.load`` / ``np.load(allow_pickle=True)`` and no
+      raw ``pickle.load`` / ``pickle.loads`` / ``pickle.Unpickler`` bypass those
+      unpicklers on a caller/dataset-controlled path.
+
+The audited pickle load sites and their routing:
+
+    nltk/parse/transitionparser.py:609  TransitionParser.parse(modelFile)
+        -> allowlisted_pickle_load(_MODEL_ALLOWED_MODULES/_GLOBALS)  [caller path]
+    nltk/data.py:1144  load(<*.pickle>)  -> restricted_pickle_load
+        -> RestrictedUnpickler (blocks ALL globals)                 [dataset path]
+    nltk/app/wordnet_app.py:741  Reference.decode(<base64 from HTTP>)
+        -> RestrictedUnpickler + type/shape check                   [untrusted web]
+    nltk/tokenize/punkt.py:159  punkt_pickle_load(file)
+        -> allowlisted_pickle_load(_PUNKT_ALLOWED_GLOBALS)          [legacy pickle]
+
+Warn-only residuals (interactive GUI / developer demo, user-selected path, not an
+untrusted dataset; documented, deliberately NOT allowlisted):
+
+    nltk/app/chartparser_app.py:816,2273,2311  pickle_load(<GUI file dialog>)
+    nltk/tbl/demo.py:263,339                    pickle_load(<dev demo cache>)
+
+json / json.loads sites (not RCE; file open is pathsec-guarded where the path is
+caller/dataset-controlled):
+
+    nltk/help.py:49, nltk/data.py:1150, nltk/tag/perceptron.py:186,414,
+    nltk/twitter/common.py:126,201, nltk/corpus/reader/twitter.py:134,
+    nltk/sentiment/util.py:375
+"""
+
+import os
+import pickle
+import re
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+
+from nltk.picklesec import RestrictedUnpickler, allowlisted_pickle_load
+
+# ---------------------------------------------------------------------------
+# Gadget payload builders
+# ---------------------------------------------------------------------------
+
+
+def _su(s: str) -> bytes:
+    """A SHORT_BINUNICODE opcode for a short (<256 byte) string."""
+    b = s.encode()
+    return pickle.SHORT_BINUNICODE + bytes([len(b)]) + b
+
+
+def _reduce_global_pickle(module: str, name: str, arg: str) -> bytes:
+    """A protocol-4 pickle: ``REDUCE(<module>.<name>, (arg,))``.
+
+    Hand-assembled so it does not depend on the gadget being importable at build
+    time. When loaded through a guarded unpickler, ``find_class`` runs (and must
+    raise) at the STACK_GLOBAL step, *before* the REDUCE would call anything.
+    """
+    return (
+        pickle.PROTO
+        + bytes([4])
+        + _su(module)
+        + _su(name)
+        + pickle.STACK_GLOBAL
+        + _su(arg)
+        + pickle.TUPLE1
+        + pickle.REDUCE
+        + pickle.STOP
+    )
+
+
+def _bare_global_pickle(module: str, name: str) -> bytes:
+    """A protocol-4 pickle that just resolves ``<module>.<name>`` and returns it.
+
+    No REDUCE: loading it exercises pure ``find_class`` resolution, so a refusal
+    proves the global can never even be *named*, let alone called.
+    """
+    return (
+        pickle.PROTO
+        + bytes([4])
+        + _su(module)
+        + _su(name)
+        + pickle.STACK_GLOBAL
+        + pickle.STOP
+    )
+
+
+class _OsSystemReduce:
+    """A ``__reduce__`` gadget: unpickling would run a shell command."""
+
+    def __init__(self, cmd: str):
+        self._cmd = cmd
+
+    def __reduce__(self):
+        return (os.system, (self._cmd,))
+
+
+# Dangerous globals that must never be reconstructable from an untrusted pickle,
+# spanning code-exec, subprocess, file-write/read, network/SSRF and nested
+# unpickle sinks. Every one is on picklesec's denylist or simply unlisted.
+_GADGETS = [
+    ("os", "system"),  # classic command execution
+    ("subprocess", "Popen"),  # subprocess
+    ("builtins", "eval"),  # arbitrary eval
+    ("builtins", "exec"),  # arbitrary exec
+    ("builtins", "__import__"),  # dunder / import
+    ("scipy.io", "mmwrite"),  # arbitrary file WRITE
+    ("scipy.io", "loadmat"),  # arbitrary file read
+    ("sklearn.datasets", "fetch_openml"),  # network / SSRF
+    ("sklearn.datasets", "load_svmlight_file"),  # file read
+    ("numpy", "load"),  # nested-unpickle sink
+    ("numpy", "apply_along_axis"),  # invokes a supplied callable
+    ("scipy", "LowLevelCallable"),  # low-level C callback
+    ("pickle", "Unpickler"),  # unpickler-in-unpickler
+]
+
+# The real, in-production load configurations. Each entry loads bytes exactly the
+# way the corresponding call site does.
+
+
+def _load_transitionparser(data: bytes):
+    from nltk.parse.transitionparser import (
+        _MODEL_ALLOWED_GLOBALS,
+        _MODEL_ALLOWED_MODULES,
+    )
+
+    return allowlisted_pickle_load(
+        BytesIO(data),
+        allowed_modules=_MODEL_ALLOWED_MODULES,
+        allowed_globals=_MODEL_ALLOWED_GLOBALS,
+    )
+
+
+def _load_punkt(data: bytes):
+    from nltk.tokenize.punkt import punkt_pickle_load
+
+    return punkt_pickle_load(BytesIO(data))
+
+
+def _load_restricted(data: bytes):
+    # Exactly what nltk.data.load(<*.pickle>) uses for any non-redirected pickle.
+    from nltk.data import restricted_pickle_load
+
+    return restricted_pickle_load(data)
+
+
+_LOAD_CONFIGS = [
+    ("transitionparser", _load_transitionparser),
+    ("punkt", _load_punkt),
+    ("data.restricted", _load_restricted),
+]
+
+
+# ---------------------------------------------------------------------------
+# (a) Every allowlisted / restricted load site refuses every gadget
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("site", [c[0] for c in _LOAD_CONFIGS])
+@pytest.mark.parametrize("module,name", _GADGETS)
+def test_every_load_site_refuses_gadget_bare_resolution(site, module, name):
+    """The gadget cannot even be *resolved* at any real load site."""
+    loader = dict(_LOAD_CONFIGS)[site]
+    with pytest.raises(pickle.UnpicklingError):
+        loader(_bare_global_pickle(module, name))
+
+
+@pytest.mark.parametrize("site", [c[0] for c in _LOAD_CONFIGS])
+@pytest.mark.parametrize("module,name", _GADGETS)
+def test_every_load_site_refuses_gadget_reduce(site, module, name):
+    """A full REDUCE payload built on the gadget is refused, not executed."""
+    loader = dict(_LOAD_CONFIGS)[site]
+    with pytest.raises(pickle.UnpicklingError):
+        loader(_reduce_global_pickle(module, name, "echo pathsec-sweep-rce"))
+
+
+@pytest.mark.parametrize("site", [c[0] for c in _LOAD_CONFIGS])
+def test_every_load_site_refuses_os_system_reduce_no_exec(site, tmp_path):
+    """A genuine ``__reduce__`` -> os.system gadget must refuse AND not run."""
+    loader = dict(_LOAD_CONFIGS)[site]
+    marker = tmp_path / f"pwned_{site.replace('.', '_')}"
+    payload = pickle.dumps(_OsSystemReduce(f"touch {marker}"))
+    with pytest.raises(pickle.UnpicklingError):
+        loader(payload)
+    assert not marker.exists(), f"{site}: os.system gadget executed (RCE not blocked)"
+
+
+@pytest.mark.parametrize("site", [c[0] for c in _LOAD_CONFIGS])
+def test_every_load_site_refuses_dotted_name_traversal(site, tmp_path):
+    """GHSA-4489: a dotted name (`sklearn.os.system`) must be refused."""
+    loader = dict(_LOAD_CONFIGS)[site]
+    marker = tmp_path / f"pwned_4489_{site.replace('.', '_')}"
+    payload = _reduce_global_pickle("sklearn", "os.system", f"touch {marker}")
+    with pytest.raises(pickle.UnpicklingError):
+        loader(payload)
+    assert not marker.exists()
+
+
+@pytest.mark.parametrize("site", [c[0] for c in _LOAD_CONFIGS])
+def test_every_load_site_refuses_scipy_io_mmwrite(site):
+    """The task's named file-WRITE sink is refused at every real load site."""
+    loader = dict(_LOAD_CONFIGS)[site]
+    with pytest.raises(pickle.UnpicklingError):
+        loader(_reduce_global_pickle("scipy.io", "mmwrite", "/tmp/should-not-write"))
+
+
+# ---------------------------------------------------------------------------
+# Legitimate loads must still succeed (allowlists are not "block everything")
+# ---------------------------------------------------------------------------
+
+
+def test_transitionparser_allowlist_loads_real_svc():
+    """The exact TransitionParser allowlist still round-trips a fitted SVC."""
+    np = pytest.importorskip("numpy")
+    sparse = pytest.importorskip("scipy.sparse")
+    svm = pytest.importorskip("sklearn.svm")
+
+    X = np.array(
+        [[0.0, 1.0], [1.0, 0.0], [1.0, 1.0], [0.0, 0.0], [0.5, 0.5], [0.2, 0.8]]
+    )
+    y = [0, 1, 0, 1, 0, 1]
+    for data in (X, sparse.csr_matrix(X)):
+        model = svm.SVC(kernel="poly", degree=2, gamma=0.2, C=0.5).fit(data, y)
+        restored = _load_transitionparser(pickle.dumps(model))
+        assert np.array_equal(model.predict(X[:3]), restored.predict(X[:3]))
+
+
+def test_punkt_allowlist_round_trips_real_tokenizer():
+    """A genuine Punkt tokenizer round-trips through punkt_pickle_load."""
+    from nltk.tokenize.punkt import PunktSentenceTokenizer
+
+    text = "Mr. Smith went to Washington. He met Dr. Jones at 3 p.m. It was great!"
+    tok = PunktSentenceTokenizer()
+    tok.train(text)
+    restored = _load_punkt(pickle.dumps(tok, protocol=4))
+    assert restored.tokenize(text) == tok.tokenize(text)
+
+
+def test_restricted_load_allows_globals_free_payload_but_no_globals():
+    """nltk.data's pickle path loads plain data yet refuses any global."""
+    # A globals-free structure (no GLOBAL opcode) loads fine.
+    payload = pickle.dumps({"a": [1, 2, 3], "b": ("x", "y")}, protocol=4)
+    assert _load_restricted(payload) == {"a": [1, 2, 3], "b": ("x", "y")}
+    # Any global at all is refused (RestrictedUnpickler blocks the lot).
+    with pytest.raises(pickle.UnpicklingError):
+        _load_restricted(_bare_global_pickle("collections", "OrderedDict"))
+
+
+# ---------------------------------------------------------------------------
+# wordnet_app.Reference.decode: untrusted base64 -> RestrictedUnpickler + shape
+# ---------------------------------------------------------------------------
+
+
+def _reference_cls():
+    try:
+        from nltk.app.wordnet_app import Reference
+    except Exception as exc:  # pragma: no cover - optional import surface
+        pytest.skip(f"nltk.app.wordnet_app unavailable: {exc}")
+    return Reference
+
+
+def test_wordnet_reference_round_trips_genuine_payload():
+    Reference = _reference_cls()
+    ref = Reference("dog", {"key-1": {"hypernym"}, "key-2": {"hyponym"}})
+    restored = Reference.decode(ref.encode())
+    assert restored.word == "dog"
+    assert restored.synset_relations == {"key-1": {"hypernym"}, "key-2": {"hyponym"}}
+
+
+def test_wordnet_reference_decode_refuses_malicious_pickle_no_exec(tmp_path):
+    import base64
+
+    Reference = _reference_cls()
+    marker = tmp_path / "pwned_wordnet"
+    raw = pickle.dumps(_OsSystemReduce(f"touch {marker}"))
+    encoded = base64.urlsafe_b64encode(raw).decode()
+    # decode() normalises the UnpicklingError to ValueError; the gadget must not run.
+    with pytest.raises(ValueError):
+        Reference.decode(encoded)
+    assert not marker.exists(), "wordnet_app Reference.decode executed a pickle gadget"
+
+
+def test_restricted_unpickler_directly_blocks_every_gadget():
+    """The shared RestrictedUnpickler (wordnet_app + data.py) blocks find_class."""
+    for module, name in _GADGETS + [
+        ("collections", "OrderedDict"),
+        ("builtins", "int"),
+    ]:
+        u = RestrictedUnpickler(BytesIO(b""))
+        with pytest.raises(pickle.UnpicklingError):
+            u.find_class(module, name)
+
+
+# ---------------------------------------------------------------------------
+# (c) Source-tree invariants: no np.load pickle path, no raw pickle.load bypass
+# ---------------------------------------------------------------------------
+
+_NLTK_ROOT = Path(__file__).resolve().parents[2]  # .../nltk
+
+
+def _iter_source_files():
+    for path in _NLTK_ROOT.rglob("*.py"):
+        parts = set(path.parts)
+        if "test" in parts or "tests" in parts:
+            continue
+        yield path
+
+
+def test_no_numpy_load_or_allow_pickle_anywhere():
+    """No reachable ``numpy.load`` / ``np.load`` and no ``allow_pickle=True``.
+
+    A ``numpy.load`` on a caller path (or ``allow_pickle=True`` on an object
+    array) is a pickle-RCE sink. There are none in the tree; picklesec.py only
+    *names* them in its denylist, so it is exempted. This guards against a future
+    reintroduction that would bypass the allowlist entirely.
+    """
+    pat = re.compile(r"\b(?:np|numpy)\.load\s*\(|allow_pickle\s*=\s*True")
+    offenders = []
+    for path in _iter_source_files():
+        if path.name == "picklesec.py":
+            continue  # denylist definitions, not calls
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for i, line in enumerate(text.splitlines(), 1):
+            if pat.search(line):
+                offenders.append(f"{path.relative_to(_NLTK_ROOT)}:{i}: {line.strip()}")
+    assert not offenders, "numpy.load / allow_pickle sink(s) found:\n" + "\n".join(
+        offenders
+    )
+
+
+def test_no_raw_pickle_load_bypasses_the_unpicklers():
+    """No ``pickle.load`` / ``pickle.loads`` / ``pickle.Unpickler`` outside
+    picklesec.py; every load must go through a guarded wrapper."""
+    pat = re.compile(r"\bpickle\.(?:load|loads|Unpickler)\s*\(")
+    offenders = []
+    for path in _iter_source_files():
+        if path.name == "picklesec.py":
+            continue  # defines RestrictedUnpickler/AllowlistUnpickler/pickle_load
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for i, line in enumerate(text.splitlines(), 1):
+            # skip comments/docstring mentions like "similar to pickle.load(file)"
+            stripped = line.lstrip()
+            if stripped.startswith("#"):
+                continue
+            if pat.search(line):
+                offenders.append(f"{path.relative_to(_NLTK_ROOT)}:{i}: {line.strip()}")
+    assert not offenders, "raw pickle.load bypass(es) found:\n" + "\n".join(offenders)
+
+
+def test_transitionparser_allowlist_stays_exact_no_broad_namespace():
+    """Teeth: if a broad numpy/scipy/sklearn namespace ever comes back, the
+    I/O / network gadgets above become reachable again."""
+    from nltk.parse.transitionparser import _MODEL_ALLOWED_MODULES
+
+    assert tuple(_MODEL_ALLOWED_MODULES) == ()

--- a/nltk/test/unit/test_pathsec_sweep_transitionparser.py
+++ b/nltk/test/unit/test_pathsec_sweep_transitionparser.py
@@ -1,0 +1,161 @@
+"""Path-traversal containment tests for ``nltk.parse.transitionparser`` model I/O.
+
+``TransitionParser.train`` and ``TransitionParser.parse`` both take a
+*caller-supplied* model path (``modelfile`` / ``modelFile``). Before the sweep
+they reached the filesystem through a bare ``open()``; ``train`` wrote the
+fitted model with ``pickle.dump(model, open(modelfile, "wb"))`` and ``parse``
+read it back with ``open(modelFile, "rb")``; so a path outside NLTK's data
+sandbox was written to (arbitrary-path pickle write) or read from without any
+containment (GHSA-8mgp-746c-j5xp). Both sinks now route through
+``nltk.pathsec.open``, which refuses a path outside the allowed data roots
+before any bytes move.
+
+Each test enforces the pathsec sandbox with a single fresh allowed root and
+attacks with a path under ``$HOME``; never a temp dir, because a *private*
+system temp dir is itself an allowed root on macOS, which would mask the block.
+"""
+
+import pickle
+
+import pytest
+
+import nltk.pathsec as pathsec
+from nltk.parse import DependencyGraph, transitionparser
+from nltk.parse.transitionparser import TransitionParser
+
+# A small projective gold sentence (same shape used by the transitionparser
+# doctests / existing security tests).
+GOLD = """
+Economic  JJ     2      ATT
+news  NN     3       SBJ
+has       VBD       0       ROOT
+little      JJ      5       ATT
+effect   NN     3       OBJ
+on     IN      5       ATT
+financial       JJ       8       ATT
+markets    NNS      6       PC
+.    .      3       PU
+"""
+
+
+# Lightweight fakes so ``train`` reaches its model-save open without the
+# heavy numpy/scipy/sklearn fit pipeline. Defined at module level so a fake
+# model is picklable (needed by the in-sandbox positive control).
+# The pathsec sandbox fixtures (sandbox / restricted_sandbox / enforce_off)
+# are provided by nltk/test/unit/conftest.py.
+
+
+class _Arr:
+    def astype(self, *args, **kwargs):
+        return self
+
+
+class _FakeX(_Arr):
+    def __init__(self):
+        self.indices = _Arr()
+        self.indptr = _Arr()
+
+
+class _FakeModel:
+    def fit(self, *args, **kwargs):
+        return self
+
+
+class _FakeSVM:
+    @staticmethod
+    def SVC(*args, **kwargs):
+        return _FakeModel()
+
+
+def test_negative_control_outside_refused_inside_allowed(pathsec_sandbox):
+    """Baseline: pathsec refuses an outside path but permits an in-sandbox one."""
+    allowed_root, home_target = pathsec_sandbox
+    outside = home_target / "canary.txt"
+    with pytest.raises(PermissionError):
+        pathsec.open(str(outside), "w")
+    assert not outside.exists(), "negative control wrote outside the sandbox"
+
+    inside = allowed_root / "ok.txt"
+    with pathsec.open(str(inside), "w") as fh:
+        fh.write("ok")
+    assert inside.exists()
+
+
+def test_train_refuses_outside_model(pathsec_sandbox, monkeypatch):
+    """TransitionParser.train must refuse to write a model outside the sandbox."""
+    _, home_target = pathsec_sandbox
+    outside_model = home_target / "tp.model"
+
+    monkeypatch.setattr(
+        transitionparser,
+        "load_svmlight_file",
+        lambda name: (_FakeX(), None),
+        raising=False,
+    )
+    monkeypatch.setattr(transitionparser, "svm", _FakeSVM(), raising=False)
+
+    parser = TransitionParser(TransitionParser.ARC_STANDARD)
+    gold = DependencyGraph(GOLD)
+    with pytest.raises(PermissionError):
+        parser.train([gold], str(outside_model), verbose=False)
+    assert not outside_model.exists(), "train wrote a model outside the sandbox"
+
+
+def test_train_permits_inside_model(pathsec_sandbox, monkeypatch):
+    """Positive control: an in-sandbox model path still trains/saves fine."""
+    allowed_root, _ = pathsec_sandbox
+    inside_model = allowed_root / "tp.model"
+
+    monkeypatch.setattr(
+        transitionparser,
+        "load_svmlight_file",
+        lambda name: (_FakeX(), None),
+        raising=False,
+    )
+    monkeypatch.setattr(transitionparser, "svm", _FakeSVM(), raising=False)
+
+    parser = TransitionParser(TransitionParser.ARC_STANDARD)
+    gold = DependencyGraph(GOLD)
+    parser.train([gold], str(inside_model), verbose=False)
+    assert inside_model.exists(), "train failed to save inside the sandbox"
+
+
+def test_parse_refuses_outside_model(pathsec_sandbox):
+    """TransitionParser.parse must refuse to read a model from outside the sandbox.
+
+    The model file genuinely exists outside the sandbox, so the refusal is the
+    pathsec block (PermissionError), not a FileNotFoundError.
+    """
+    _, home_target = pathsec_sandbox
+    outside_model = home_target / "evil.model"
+    import builtins
+
+    with builtins.open(outside_model, "wb") as fh:
+        pickle.dump({}, fh)
+
+    parser = TransitionParser(TransitionParser.ARC_STANDARD)
+    gold = DependencyGraph(GOLD)
+    with pytest.raises(PermissionError):
+        parser.parse([gold], str(outside_model))
+
+
+def test_parse_permits_inside_model(pathsec_sandbox):
+    """Positive control: an in-sandbox model path gets past the pathsec open.
+
+    A plain (non-model) pickle then fails downstream, but crucially NOT with a
+    PermissionError; proving the sink blocks only outside paths.
+    """
+    allowed_root, _ = pathsec_sandbox
+    inside_model = allowed_root / "model.pickle"
+    import builtins
+
+    with builtins.open(inside_model, "wb") as fh:
+        pickle.dump({}, fh)
+
+    parser = TransitionParser(TransitionParser.ARC_STANDARD)
+    gold = DependencyGraph(GOLD)
+    with pytest.raises(Exception) as excinfo:
+        parser.parse([gold], str(inside_model))
+    assert not isinstance(
+        excinfo.value, PermissionError
+    ), "in-sandbox model read was wrongly refused by pathsec"

--- a/nltk/test/unit/test_pickle_allowlist_security.py
+++ b/nltk/test/unit/test_pickle_allowlist_security.py
@@ -617,3 +617,282 @@ class TestScientificStackReexportSinks:
             allowed_modules=("numpy",),
         )
         assert numpy.array_equal(out, arr)
+
+
+class TestBroadAllowGadgetContainment:
+    """Threat model: a downstream over-allows the whole scientific stack
+    (``allowed_modules=("numpy","scipy","sklearn","pandas")``). Even then, no
+    file/module I/O sink or classic RCE gadget may be reconstructed through it.
+    Where a sink takes a path we build a real REDUCE payload and assert no file
+    is created; the rest assert ``find_class`` refuses the global.
+    """
+
+    BROAD = {"allowed_modules": ("numpy", "scipy", "sklearn", "pandas")}
+
+    def _blocked(self, module, name):
+        up = AllowlistUnpickler(BytesIO(b""), **self.BROAD)
+        try:
+            up.find_class(module, name)
+            return False
+        except pickle.UnpicklingError:
+            return True
+        except Exception:
+            return True  # never resolved -> not reachable
+
+    @pytest.mark.parametrize(
+        "module,name",
+        [
+            ("os", "system"),
+            ("posix", "system"),
+            ("nt", "system"),
+            ("subprocess", "Popen"),
+            ("subprocess", "run"),
+            ("subprocess", "call"),
+            ("builtins", "eval"),
+            ("builtins", "exec"),
+            ("builtins", "__import__"),
+            ("builtins", "compile"),
+            ("builtins", "getattr"),
+            ("builtins", "open"),
+            ("io", "open"),
+            ("codecs", "open"),
+            ("os", "popen"),
+            ("pty", "spawn"),
+            ("webbrowser", "open"),
+            ("shutil", "rmtree"),
+            ("importlib", "import_module"),
+            ("functools", "partial"),
+            ("operator", "methodcaller"),
+            ("operator", "attrgetter"),
+            ("copyreg", "_reconstructor"),
+            ("copyreg", "__newobj__"),
+            ("pickle", "loads"),
+            ("_pickle", "loads"),
+        ],
+    )
+    def test_classic_rce_gadget_refused(self, module, name):
+        """A broad *scientific-stack* allow does not reach os/subprocess/builtins
+        (or any other) code-exec gadget: their module is not on the allowlist."""
+        assert self._blocked(module, name), f"{module}.{name} is reconstructable"
+
+    @pytest.mark.parametrize(
+        "module,name",
+        [
+            ("numpy", "f2py.crackfortran.myeval"),  # dotted -> getattr-chain
+            ("numpy", "os.system"),
+            ("sklearn", "os.system"),
+            ("numpy", "__loader__"),  # dunder
+            ("numpy", "__builtins__"),
+            ("numpy", "__class__"),
+            ("numpy", "__dict__"),
+        ],
+    )
+    def test_attribute_traversal_refused(self, module, name):
+        assert self._blocked(module, name), f"{module}.{name} is reconstructable"
+
+    @pytest.mark.parametrize(
+        "module,name", [("numpy", "linalg"), ("numpy", "core"), ("scipy", "sparse")]
+    )
+    def test_bare_module_object_refused(self, module, name):
+        """A bare submodule object is not a reconstructable class/function."""
+        assert self._blocked(module, name), f"{module}.{name} resolved to a module"
+
+    def test_scipy_sklearn_pandas_sinks_refused(self):
+        import importlib
+
+        checked = 0
+        for mod, name in [
+            ("scipy.io", "loadmat"),
+            ("scipy.io", "savemat"),
+            ("scipy.io", "mmread"),
+            ("scipy.io", "mmwrite"),
+            ("sklearn.datasets", "load_svmlight_file"),
+            ("sklearn.datasets", "dump_svmlight_file"),
+            ("sklearn.datasets", "fetch_openml"),
+            ("pandas", "read_pickle"),
+        ]:
+            try:
+                m = importlib.import_module(mod)
+            except BaseException:
+                continue
+            if not hasattr(m, name):
+                continue
+            checked += 1
+            assert self._blocked(mod, name), f"{mod}.{name} is reconstructable"
+        if not checked:
+            pytest.skip("no scipy/sklearn/pandas sinks available")
+
+    def test_real_write_sink_payloads_create_no_file(self, tmp_path):
+        """REDUCE payloads that call a numpy write sink are refused *before* the
+        callable runs, so the attacker's target file is never created."""
+        numpy = pytest.importorskip("numpy")
+        import importlib
+
+        made = []
+        for mod, name, mkargs in [
+            ("numpy", "save", lambda t: (str(t), numpy.arange(4))),
+            ("numpy", "savetxt", lambda t: (str(t), numpy.arange(4))),
+            ("numpy.lib.format", "open_memmap", lambda t: (str(t), "w+", "int8", (8,))),
+        ]:
+            try:
+                fn = getattr(importlib.import_module(mod), name)
+            except BaseException:
+                continue
+            target = tmp_path / f"pwn_{name}"
+
+            class Evil:
+                def __reduce__(self):
+                    return (fn, mkargs(target))
+
+            with pytest.raises(pickle.UnpicklingError):
+                allowlisted_pickle_load(
+                    BytesIO(pickle.dumps(Evil(), protocol=4)), **self.BROAD
+                )
+            assert not target.exists(), f"{mod}.{name} wrote {target}"
+            made.append(name)
+        assert made, "no numpy write sinks available to exercise"
+
+    def test_bounded_cross_stack_sink_sweep_finds_no_leak(self):
+        """Across the sink-bearing modules of every allowed stack, no callable
+        whose resolved qualname is a denied sink is reconstructable."""
+        pytest.importorskip("numpy")
+        import importlib
+
+        from nltk.picklesec import _DENIED_SCISTACK_QUALNAMES
+
+        mods = [
+            "numpy",
+            "numpy.lib",
+            "numpy.lib.npyio",
+            "numpy.lib._npyio_impl",
+            "numpy.lib.format",
+            "numpy.rec",
+            "numpy.core.records",
+            "numpy._core.records",
+            "numpy.ma",
+            "numpy.ma.core",
+            "numpy.compat",
+            "numpy.ctypeslib",
+            "scipy.io",
+            "scipy.io.matlab",
+            "sklearn.datasets",
+            "pandas",
+            "pandas.io.pickle",
+        ]
+        leaks = []
+        for mn in mods:
+            try:
+                mod = importlib.import_module(mn)
+            except BaseException:
+                continue
+            for nm in dir(mod):
+                obj = getattr(mod, nm, None)
+                if not callable(obj):
+                    continue
+                if getattr(obj, "__qualname__", nm) in _DENIED_SCISTACK_QUALNAMES:
+                    if not self._blocked(mn, nm):
+                        leaks.append(f"{mn}.{nm}")
+        assert not leaks, f"reconstructable sinks: {leaks[:10]}"
+
+
+class TestGuardsAreLoadBearing:
+    """Mutation tests. Each neuters exactly one guard and confirms the synthetic
+    exploit that guard is the SOLE defense against becomes reconstructable. This
+    proves the guard is load-bearing (not dead code masked by another layer) and
+    that the surrounding attack corpus would actually catch its removal.
+    ``monkeypatch`` restores the guard (and sys.modules) after every test.
+    """
+
+    @staticmethod
+    def _inject(monkeypatch, module_name, attr, qualname):
+        """Install a synthetic callable at module_name.attr and return it."""
+        import sys
+        import types
+
+        pytest.importorskip("numpy")
+        import numpy
+
+        fake = types.ModuleType(module_name)
+
+        def sink(*a, **k):  # a stand-in for a re-exported dangerous callable
+            return "PWNED"
+
+        sink.__module__ = module_name
+        sink.__qualname__ = qualname
+        setattr(fake, attr, sink)
+        monkeypatch.setitem(sys.modules, module_name, fake)
+        # also expose it as an attribute of the parent package so the base
+        # unpickler's getattr-after-import path resolves it
+        parent, _, child = module_name.rpartition(".")
+        if parent == "numpy":
+            monkeypatch.setattr(numpy, child, fake, raising=False)
+        return sink
+
+    def test_qualname_catchall_is_load_bearing(self, monkeypatch):
+        """A denied sink qualname re-exported under a numpy submodule that is
+        neither a denied prefix nor an exact denied global is blocked ONLY by the
+        resolved-qualname catch-all."""
+        import nltk.picklesec as ps
+
+        sink = self._inject(monkeypatch, "numpy._mut_qualname", "fromfile", "fromfile")
+        broad = {"allowed_modules": ("numpy",)}
+
+        up = ps.AllowlistUnpickler(BytesIO(b""), **broad)
+        with pytest.raises(pickle.UnpicklingError):
+            up.find_class("numpy._mut_qualname", "fromfile")
+
+        monkeypatch.setattr(ps, "_DENIED_SCISTACK_QUALNAMES", frozenset())
+        up2 = ps.AllowlistUnpickler(BytesIO(b""), **broad)
+        assert (
+            up2.find_class("numpy._mut_qualname", "fromfile") is sink
+        ), "removing the catch-all did not expose the sink -> guard is not load-bearing"
+
+    def test_denied_module_prefix_is_load_bearing(self, monkeypatch):
+        """A callable whose real module sits under a denied prefix (numpy.lib) but
+        whose qualname is not a known sink is blocked ONLY by the prefix denylist."""
+        import nltk.picklesec as ps
+
+        sink = self._inject(monkeypatch, "numpy.lib._mut_prefix", "gadget", "gadget")
+        # numpy.lib._mut_prefix's parent is numpy.lib, not numpy; expose it there
+        import numpy.lib
+
+        monkeypatch.setattr(
+            numpy.lib,
+            "_mut_prefix",
+            __import__("sys").modules["numpy.lib._mut_prefix"],
+            raising=False,
+        )
+        broad = {"allowed_modules": ("numpy",)}
+
+        up = ps.AllowlistUnpickler(BytesIO(b""), **broad)
+        with pytest.raises(pickle.UnpicklingError):
+            up.find_class("numpy.lib._mut_prefix", "gadget")
+
+        monkeypatch.setattr(ps, "_DENIED_MODULE_PREFIXES", ())
+        up2 = ps.AllowlistUnpickler(BytesIO(b""), **broad)
+        assert (
+            up2.find_class("numpy.lib._mut_prefix", "gadget") is sink
+        ), "removing the denied prefixes did not expose the sink -> guard is not load-bearing"
+
+    def test_exact_denied_globals_is_load_bearing(self, monkeypatch):
+        """A callable pinned only by the exact ``_DENIED_GLOBALS`` set (module not
+        prefix-denied, qualname not a sink) is blocked ONLY by that set."""
+        import nltk.picklesec as ps
+
+        sink = self._inject(monkeypatch, "numpy._mut_exact", "gadget", "gadget")
+        broad = {"allowed_modules": ("numpy",)}
+        pinned = ("numpy._mut_exact", "gadget")
+        monkeypatch.setattr(ps, "_DENIED_GLOBALS", ps._DENIED_GLOBALS | {pinned})
+
+        up = ps.AllowlistUnpickler(BytesIO(b""), **broad)
+        with pytest.raises(pickle.UnpicklingError):
+            up.find_class(*pinned)
+
+        # restore to the original set (drops our pin) -> now reconstructable
+        monkeypatch.setattr(
+            ps,
+            "_DENIED_GLOBALS",
+            frozenset(g for g in ps._DENIED_GLOBALS if g != pinned),
+        )
+        up2 = ps.AllowlistUnpickler(BytesIO(b""), **broad)
+        assert up2.find_class(*pinned) is sink

--- a/nltk/test/unit/test_pickle_allowlist_security.py
+++ b/nltk/test/unit/test_pickle_allowlist_security.py
@@ -448,8 +448,12 @@ class TestNumpySubmoduleFileIOSinks:
                 checked += 1
                 with pytest.raises(pickle.UnpicklingError):
                     up.find_class("numpy", name)
-        # Not every sink is re-exported on every numpy; that is fine.
-        assert checked >= 0
+        # When no sink is re-exported at top level, skip rather than pass vacuously.
+        if checked == 0:
+            pytest.skip(
+                "no numpy.lib file-I/O sink is re-exported at numpy top level "
+                "on this build"
+            )
 
     def test_reduce_write_payload_creates_nothing(self, tmp_path):
         """End-to-end: an ``open_memmap(mode="w+")`` REDUCE payload under a broad

--- a/nltk/test/unit/test_pickle_allowlist_security.py
+++ b/nltk/test/unit/test_pickle_allowlist_security.py
@@ -900,3 +900,128 @@ class TestGuardsAreLoadBearing:
         )
         up2 = ps.AllowlistUnpickler(BytesIO(b""), **broad)
         assert up2.find_class(*pinned) is sink
+
+
+def _ext_reduce_payload(code, cmd):
+    """A protocol-2 pickle: ``EXT1(code)`` resolves a global through copyreg's
+    extension registry (NOT find_class), then ``REDUCE`` would call it with cmd.
+    Hand-assembled so it depends on nothing being registered at build time."""
+
+    def _su(s):
+        b = s.encode()
+        return pickle.SHORT_BINUNICODE + bytes([len(b)]) + b
+
+    return (
+        pickle.PROTO
+        + bytes([2])
+        + pickle.EXT1
+        + bytes([code])
+        + _su(cmd)
+        + pickle.TUPLE1
+        + pickle.REDUCE
+        + pickle.STOP
+    )
+
+
+class TestExtensionOpcodeBypassBlocked:
+    """The EXT1/EXT2/EXT4 extension-registry opcodes resolve a global through
+    copyreg's process-wide registry, not through find_class. On a warm
+    ``copyreg._extension_cache`` the (C) unpickler returns the cached object
+    without ever calling find_class, so a find_class-only allowlist is bypassed
+    (verified: neutering the scan below re-opens the hole). Both unpicklers scan
+    for and refuse any EXT opcode up front; nltk pickles never use them.
+    """
+
+    _EXT_CODE = 173  # an arbitrary, unregistered extension code
+
+    def _loaders(self):
+        from nltk.parse.transitionparser import (
+            _MODEL_ALLOWED_GLOBALS,
+            _MODEL_ALLOWED_MODULES,
+        )
+
+        def allowlist(data):
+            return allowlisted_pickle_load(
+                BytesIO(data),
+                allowed_globals=_MODEL_ALLOWED_GLOBALS,
+                allowed_modules=_MODEL_ALLOWED_MODULES,
+            )
+
+        def restricted(data):
+            from nltk.picklesec import RestrictedUnpickler
+
+            return RestrictedUnpickler(BytesIO(data)).load()
+
+        return {"allowlist": allowlist, "restricted": restricted}
+
+    @pytest.mark.parametrize("loader", ["allowlist", "restricted"])
+    def test_cold_ext_opcode_refused(self, loader):
+        """With nothing registered, an EXT payload is refused before resolution."""
+        load = self._loaders()[loader]
+        with pytest.raises(pickle.UnpicklingError):
+            load(_ext_reduce_payload(self._EXT_CODE, "echo cold"))
+
+    @pytest.mark.parametrize("loader", ["allowlist", "restricted"])
+    def test_warm_cache_ext_opcode_refused_and_no_exec(self, loader, tmp_path):
+        """The real bypass: poison copyreg._extension_cache with os.system so the
+        opcode would resolve WITHOUT find_class, then confirm it is still refused
+        and the gadget does not run."""
+        import copyreg
+
+        load = self._loaders()[loader]
+        marker = tmp_path / f"pwned_ext_{loader}"
+        copyreg._extension_cache[self._EXT_CODE] = os.system
+        try:
+            with pytest.raises(pickle.UnpicklingError):
+                load(_ext_reduce_payload(self._EXT_CODE, f"touch {marker}"))
+            assert (
+                not marker.exists()
+            ), "EXT warm-cache gadget executed; the find_class bypass is not closed"
+        finally:
+            copyreg._extension_cache.pop(self._EXT_CODE, None)
+
+    @pytest.mark.parametrize(
+        "opcode,arg",
+        [
+            (pickle.EXT1, bytes([173])),
+            (pickle.EXT2, (173).to_bytes(2, "little")),
+            (pickle.EXT4, (173).to_bytes(4, "little")),
+        ],
+    )
+    def test_all_ext_widths_refused(self, opcode, arg):
+        """EXT1, EXT2 and EXT4 all bypass find_class, so each is refused."""
+        from nltk.picklesec import RestrictedUnpickler
+
+        payload = pickle.PROTO + bytes([2]) + opcode + arg + pickle.STOP
+        with pytest.raises(pickle.UnpicklingError):
+            RestrictedUnpickler(BytesIO(payload)).load()
+
+    def test_persistent_id_refused(self):
+        """PERSID would call persistent_load (another find_class bypass); neither
+        unpickler defines one, so the default refuses it."""
+        persid = pickle.PROTO + bytes([2]) + b"P" + b"1\n" + pickle.STOP
+        for load in self._loaders().values():
+            with pytest.raises(pickle.UnpicklingError):
+                load(persid)
+
+    def test_ext_scan_is_load_bearing(self, monkeypatch, tmp_path):
+        """Neuter the EXT scan and confirm the warm-cache gadget then executes,
+        proving the scan is the sole defense (find_class never fires for EXT)."""
+        import copyreg
+
+        import nltk.picklesec
+
+        monkeypatch.setattr(
+            nltk.picklesec, "_reject_extension_opcodes", lambda pickle_source: None
+        )
+        marker = tmp_path / "pwned_ext_mut"
+        copyreg._extension_cache[self._EXT_CODE] = os.system
+        try:
+            nltk.picklesec.RestrictedUnpickler(
+                BytesIO(_ext_reduce_payload(self._EXT_CODE, f"touch {marker}"))
+            ).load()
+            assert (
+                marker.exists()
+            ), "neutering the EXT scan did not expose the gadget; scan is not load-bearing"
+        finally:
+            copyreg._extension_cache.pop(self._EXT_CODE, None)

--- a/nltk/test/unit/test_pickle_allowlist_security.py
+++ b/nltk/test/unit/test_pickle_allowlist_security.py
@@ -828,6 +828,43 @@ class TestBroadAllowGadgetContainment:
             "numpy._evil_reexport", "spec_from_file_location"
         ), "frozen-importlib code-load sink is reconstructable via a re-export"
 
+    @pytest.mark.parametrize(
+        "real_module,real_name",
+        [
+            ("_ctypes", "CFuncPtr"),  # native-call primitive (not "ctypes")
+            ("tempfile", "mkdtemp"),
+            ("tempfile", "NamedTemporaryFile"),
+            ("io", "open"),
+            ("_io", "open"),
+            ("io", "FileIO"),
+            ("codecs", "open"),
+        ],
+    )
+    def test_stdlib_io_sink_reexport_refused(self, monkeypatch, real_module, real_name):
+        """A stdlib file-open / native-call / temp-file callable re-exported into an
+        allowed sci namespace keeps its stdlib ``__module__``, so the resolved-
+        module / resolved-global denylist must refuse it there, independent of which
+        real submodule happens to re-export it (that is how _ctypes.CFuncPtr and
+        tempfile.mkdtemp leaked)."""
+        import importlib
+        import sys
+        import types
+
+        try:
+            obj = getattr(importlib.import_module(real_module), real_name)
+        except BaseException:
+            pytest.skip(f"{real_module}.{real_name} unavailable")
+        numpy = pytest.importorskip("numpy")
+        child = f"_evil_reexport_{real_module.strip('_')}_{real_name.lower()}"
+        modname = f"numpy.{child}"
+        fake = types.ModuleType(modname)
+        setattr(fake, real_name, obj)
+        monkeypatch.setitem(sys.modules, modname, fake)
+        monkeypatch.setattr(numpy, child, fake, raising=False)
+        assert self._blocked(
+            modname, real_name
+        ), f"{real_module}.{real_name} reconstructable via an allowed-namespace re-export"
+
     def test_scipy_sparse_load_npz_reduce_reads_no_file(self, tmp_path):
         """A REDUCE payload calling scipy.sparse.load_npz on a real .npz is refused
         at global resolution, before the read runs (the sink lives under the
@@ -1150,3 +1187,51 @@ class TestExtensionOpcodeBypassBlocked:
             ), "neutering the EXT scan did not expose the gadget; scan is not load-bearing"
         finally:
             copyreg._extension_cache.pop(self._EXT_CODE, None)
+
+
+def test_all_pickle_loaders_still_function(tmp_path):
+    """Every NLTK pickle-loading entry point must still load a legitimate object
+    after the allowlist/denylist hardening. A deny that is too broad would break a
+    real model / tokenizer / data / wordnet load, so this is the guardrail against
+    over-containment."""
+    np = pytest.importorskip("numpy")
+    svm = pytest.importorskip("sklearn.svm")
+    sparse = pytest.importorskip("scipy.sparse")
+
+    from nltk.parse.transitionparser import (
+        _MODEL_ALLOWED_GLOBALS,
+        _MODEL_ALLOWED_MODULES,
+    )
+
+    # 1. transitionparser: a real SVC model round-trips, dense and sparse.
+    X = np.array([[0.0, 1.0], [1.0, 0.0], [1.0, 1.0], [0.0, 0.0]])
+    for data in (X, sparse.csr_matrix(X)):
+        model = svm.SVC().fit(data, [0, 1, 0, 1])
+        restored = allowlisted_pickle_load(
+            BytesIO(pickle.dumps(model)),
+            allowed_globals=_MODEL_ALLOWED_GLOBALS,
+            allowed_modules=_MODEL_ALLOWED_MODULES,
+        )
+        assert (model.predict(X) == restored.predict(X)).all()
+
+    # 2. punkt: a trained tokenizer round-trips through punkt_pickle_load.
+    from nltk.tokenize.punkt import PunktSentenceTokenizer, punkt_pickle_load
+
+    tok = PunktSentenceTokenizer()
+    tok.train("Mr. Smith went to Washington. He met Dr. Jones at 3 p.m.")
+    restored_tok = punkt_pickle_load(BytesIO(pickle.dumps(tok, protocol=4)))
+    assert restored_tok.tokenize("A. B.") == tok.tokenize("A. B.")
+
+    # 3. nltk.data: a globals-free structure loads through the restricted path.
+    from nltk.data import restricted_pickle_load
+
+    assert restricted_pickle_load(pickle.dumps({"a": [1, 2, 3]})) == {"a": [1, 2, 3]}
+
+    # 4. wordnet_app: the base64 Reference round-trip (RestrictedUnpickler + shape).
+    try:
+        from nltk.app.wordnet_app import Reference
+    except Exception:
+        Reference = None
+    if Reference is not None:
+        ref = Reference("dog", {"k": {"hypernym"}})
+        assert Reference.decode(ref.encode()).word == "dog"

--- a/nltk/test/unit/test_pickle_allowlist_security.py
+++ b/nltk/test/unit/test_pickle_allowlist_security.py
@@ -3,7 +3,7 @@
 ``TransitionParser.parse(depgraphs, modelFile)`` is a public API whose
 ``modelFile`` is caller-supplied. It used to be loaded with the warn-only
 ``pickle_load`` (``restricted=False``), which prints a warning and then performs
-a full, unrestricted unpickle -- so a crafted model file achieved arbitrary code
+a full, unrestricted unpickle; so a crafted model file achieved arbitrary code
 execution the instant it was loaded. The load now goes through
 ``allowlisted_pickle_load``: only numpy/scipy/sklearn globals may be
 reconstructed, and anything else (e.g. ``os.system``) raises ``UnpicklingError``
@@ -470,16 +470,23 @@ class TestNumpySubmoduleFileIOSinks:
         assert not target.exists(), "arbitrary-write sink was reconstructed and ran"
 
     def test_reduce_read_payload_blocked(self, tmp_path):
-        """End-to-end: a ``recfromtxt`` REDUCE payload (arbitrary read) is refused."""
+        """End-to-end: an arbitrary-read REDUCE payload (whichever text-read sink
+        this numpy still exports: recfromtxt / genfromtxt / loadtxt) is refused."""
         numpy = pytest.importorskip("numpy")
         holder = getattr(numpy.lib, "_npyio_impl", None) or numpy.lib.npyio
-        recfromtxt = holder.recfromtxt
+        read_sink = None
+        for cand in ("recfromtxt", "genfromtxt", "loadtxt"):
+            read_sink = getattr(holder, cand, None) or getattr(numpy, cand, None)
+            if read_sink is not None:
+                break
+        if read_sink is None:
+            pytest.skip("no text-read sink on this numpy")
         secret = tmp_path / "secret.csv"
         secret.write_text("1,2\n3,4\n")
 
         class Evil:
             def __reduce__(self):
-                return (recfromtxt, (str(secret),))
+                return (read_sink, (str(secret),))
 
         payload = pickle.dumps(Evil(), protocol=4)
         with pytest.raises(pickle.UnpicklingError):
@@ -496,6 +503,112 @@ class TestNumpySubmoduleFileIOSinks:
             ("numpy.core.multiarray", "_reconstruct"),
             ("numpy._core.multiarray", "scalar"),
             ("numpy.core.multiarray", "scalar"),
+            ("numpy._core.numeric", "_frombuffer"),  # numpy >= 2.5 array reduce
+            ("numpy.core.numeric", "_frombuffer"),
+        }
+        arr = numpy.array([[1.0, 2.0], [3.0, 4.0]])
+        out = allowlisted_pickle_load(
+            BytesIO(pickle.dumps(arr, protocol=4)),
+            allowed_globals=allow,
+            allowed_modules=("numpy",),
+        )
+        assert numpy.array_equal(out, arr)
+
+
+class TestScientificStackReexportSinks:
+    """The same dangerous numpy callable (fromfile = arbitrary file read,
+    npy_load_module = arbitrary module load / RCE, ...) is re-exported under many
+    submodule paths, each with a different __module__. AllowlistUnpickler must
+    refuse it by resolved qualname no matter which submodule path a broad allow
+    reaches it through, not just the enumerated (module, name) pairs (CWE-502).
+    """
+
+    def test_record_array_and_module_load_sinks_blocked(self):
+        pytest.importorskip("numpy")
+        import importlib
+        import warnings
+
+        warnings.filterwarnings("ignore")
+        up = AllowlistUnpickler(
+            BytesIO(b""), allowed_modules=("numpy", "scipy", "sklearn")
+        )
+        cases = [
+            ("numpy.rec", "fromfile"),
+            ("numpy.core.records", "fromfile"),
+            ("numpy._core.records", "fromfile"),
+            ("numpy.ma.core", "fromfile"),
+            ("numpy.compat", "npy_load_module"),  # loads/executes a module -> RCE
+        ]
+        checked = 0
+        for mod, name in cases:
+            try:
+                m = importlib.import_module(mod)
+            except BaseException:
+                continue
+            if not hasattr(m, name):
+                continue
+            checked += 1
+            with pytest.raises(pickle.UnpicklingError):
+                up.find_class(mod, name)
+        assert checked, "no record/ma/compat sinks resolved on this numpy"
+
+    def test_no_numpy_io_sink_reconstructable_across_submodule_aliases(self):
+        """Sweep the numpy submodules that hold file/module I/O sinks: none whose
+        resolved qualname is a denied sink may be reconstructed under broad allow."""
+        pytest.importorskip("numpy")
+        import importlib
+        import warnings
+
+        warnings.filterwarnings("ignore")
+        from nltk.picklesec import _DENIED_SCISTACK_QUALNAMES
+
+        up = AllowlistUnpickler(
+            BytesIO(b""), allowed_modules=("numpy", "scipy", "sklearn")
+        )
+        mods = [
+            "numpy",
+            "numpy.lib",
+            "numpy.lib.npyio",
+            "numpy.lib._npyio_impl",
+            "numpy.lib.format",
+            "numpy.rec",
+            "numpy.core.records",
+            "numpy._core.records",
+            "numpy.ma",
+            "numpy.ma.core",
+            "numpy.compat",
+            "numpy.matlib",
+            "numpy.ctypeslib",
+        ]
+        leaks = []
+        for mn in mods:
+            try:
+                mod = importlib.import_module(mn)
+            except BaseException:
+                continue
+            for nm in dir(mod):
+                obj = getattr(mod, nm, None)
+                if not callable(obj):
+                    continue
+                if getattr(obj, "__qualname__", nm) in _DENIED_SCISTACK_QUALNAMES:
+                    try:
+                        up.find_class(mn, nm)
+                        leaks.append(f"{mn}.{nm}")
+                    except BaseException:
+                        pass
+        assert not leaks, f"reconstructable numpy I/O sinks: {leaks[:10]}"
+
+    def test_legit_numpy_array_still_loads(self):
+        numpy = pytest.importorskip("numpy")
+        allow = {
+            ("numpy", "ndarray"),
+            ("numpy", "dtype"),
+            ("numpy._core.multiarray", "_reconstruct"),
+            ("numpy.core.multiarray", "_reconstruct"),
+            ("numpy._core.multiarray", "scalar"),
+            ("numpy.core.multiarray", "scalar"),
+            ("numpy._core.numeric", "_frombuffer"),  # numpy >= 2.5 array reduce
+            ("numpy.core.numeric", "_frombuffer"),
         }
         arr = numpy.array([[1.0, 2.0], [3.0, 4.0]])
         out = allowlisted_pickle_load(

--- a/nltk/test/unit/test_pickle_allowlist_security.py
+++ b/nltk/test/unit/test_pickle_allowlist_security.py
@@ -710,10 +710,40 @@ class TestBroadAllowGadgetContainment:
             ("scipy.io", "savemat"),
             ("scipy.io", "mmread"),
             ("scipy.io", "mmwrite"),
+            ("scipy.io", "readsav"),
+            # scipy.datasets: network download + on-disk cache write.
+            ("scipy.datasets", "download_all"),
+            ("scipy.datasets", "face"),
+            ("scipy.datasets", "ascent"),
+            ("scipy.datasets", "electrocardiogram"),
             ("sklearn.datasets", "load_svmlight_file"),
             ("sklearn.datasets", "dump_svmlight_file"),
             ("sklearn.datasets", "fetch_openml"),
+            # Every pandas.io reader is an arbitrary file/URL/DB read sink; a
+            # top-level ``pandas.read_*`` request must be denied under a broad
+            # ``pandas`` allow via the resolved pandas.io __module__.
             ("pandas", "read_pickle"),
+            ("pandas", "read_csv"),
+            ("pandas", "read_table"),
+            ("pandas", "read_fwf"),
+            ("pandas", "read_json"),
+            ("pandas", "read_html"),
+            ("pandas", "read_xml"),
+            ("pandas", "read_excel"),
+            ("pandas", "read_hdf"),
+            ("pandas", "read_parquet"),
+            ("pandas", "read_orc"),
+            ("pandas", "read_feather"),
+            ("pandas", "read_stata"),
+            ("pandas", "read_sas"),
+            ("pandas", "read_spss"),
+            ("pandas", "read_sql"),
+            ("pandas", "read_sql_query"),
+            ("pandas", "read_sql_table"),
+            ("pandas", "read_gbq"),
+            ("pandas", "read_clipboard"),
+            ("pandas", "HDFStore"),
+            ("pandas", "ExcelFile"),
         ]:
             try:
                 m = importlib.import_module(mod)
@@ -725,6 +755,95 @@ class TestBroadAllowGadgetContainment:
             assert self._blocked(mod, name), f"{mod}.{name} is reconstructable"
         if not checked:
             pytest.skip("no scipy/sklearn/pandas sinks available")
+
+    def test_pandas_reader_reduce_reads_no_file(self, tmp_path):
+        """A REDUCE payload calling pandas.read_csv on a real file is refused at
+        global resolution, before the reader runs, so the file is never read."""
+        pd = pytest.importorskip("pandas")
+        secret = tmp_path / "secret.csv"
+        secret.write_text("col\n1\n", encoding="utf-8")
+
+        class Evil:
+            def __reduce__(self):
+                return (pd.read_csv, (str(secret),))
+
+        with pytest.raises(pickle.UnpicklingError):
+            allowlisted_pickle_load(
+                BytesIO(pickle.dumps(Evil(), protocol=4)), **self.BROAD
+            )
+
+    @pytest.mark.parametrize(
+        "module,name",
+        [
+            # nested-unpickle (RCE) helpers under pandas.compat.
+            ("pandas.compat.pickle_compat", "loads"),
+            ("pandas.compat.pickle_compat", "load_reduce"),
+            ("pandas.compat.pickle_compat", "Unpickler"),
+            # file read/write under the model-allowed scipy.sparse namespace.
+            ("scipy.sparse", "load_npz"),
+            ("scipy.sparse", "save_npz"),
+            # file-open-by-path in numpy record arrays.
+            ("numpy.ma.mrecords", "openfile"),
+            ("numpy.ma.mrecords", "fromtextfile"),
+            # path / file-like readers deep in the allowed stacks.
+            ("pandas._libs.parsers", "TextReader"),
+            ("numpy._core._multiarray_umath", "_load_from_filelike"),
+        ],
+    )
+    def test_deep_submodule_file_and_code_sinks_refused(self, module, name):
+        """A broad scientific-stack allow reaches deep submodules; file-read/open
+        and nested-unpickle sinks living in otherwise-allowed namespaces must still
+        be refused. Import-guarded: skipped where absent."""
+        import importlib
+
+        try:
+            m = importlib.import_module(module)
+        except BaseException:
+            pytest.skip(f"{module} unavailable")
+        if not hasattr(m, name):
+            pytest.skip(f"{module}.{name} unavailable")
+        assert self._blocked(module, name), f"{module}.{name} is reconstructable"
+
+    def test_frozen_importlib_reexport_refused(self, monkeypatch):
+        """``spec_from_file_location`` loads/executes code from a file path (RCE).
+        It is re-exported into some allowed sci submodules, where it resolves to
+        ``__module__ == _frozen_importlib_external`` (not ``importlib``). Injecting
+        that re-export under an allowed namespace confirms the frozen-importlib
+        denylist refuses it at resolution, independent of stdlib layout."""
+        import importlib
+        import sys
+        import types
+
+        spec = getattr(
+            importlib.import_module("importlib.util"), "spec_from_file_location"
+        )
+        if not getattr(spec, "__module__", "").startswith("_frozen_importlib"):
+            pytest.skip("spec_from_file_location is not from frozen importlib here")
+        numpy = pytest.importorskip("numpy")
+        fake = types.ModuleType("numpy._evil_reexport")
+        fake.spec_from_file_location = spec
+        monkeypatch.setitem(sys.modules, "numpy._evil_reexport", fake)
+        monkeypatch.setattr(numpy, "_evil_reexport", fake, raising=False)
+        assert self._blocked(
+            "numpy._evil_reexport", "spec_from_file_location"
+        ), "frozen-importlib code-load sink is reconstructable via a re-export"
+
+    def test_scipy_sparse_load_npz_reduce_reads_no_file(self, tmp_path):
+        """A REDUCE payload calling scipy.sparse.load_npz on a real .npz is refused
+        at global resolution, before the read runs (the sink lives under the
+        model-allowed scipy.sparse namespace)."""
+        sparse = pytest.importorskip("scipy.sparse")
+        target = tmp_path / "m.npz"
+        sparse.save_npz(str(target), sparse.csr_matrix([[1, 0], [0, 1]]))
+
+        class Evil:
+            def __reduce__(self):
+                return (sparse.load_npz, (str(target),))
+
+        with pytest.raises(pickle.UnpicklingError):
+            allowlisted_pickle_load(
+                BytesIO(pickle.dumps(Evil(), protocol=4)), **self.BROAD
+            )
 
     def test_real_write_sink_payloads_create_no_file(self, tmp_path):
         """REDUCE payloads that call a numpy write sink are refused *before* the
@@ -777,11 +896,17 @@ class TestBroadAllowGadgetContainment:
             "numpy.ma.core",
             "numpy.compat",
             "numpy.ctypeslib",
+            "numpy.ma.mrecords",
+            "numpy._core._multiarray_umath",
             "scipy.io",
             "scipy.io.matlab",
+            "scipy.sparse",
+            "scipy.sparse._matrix_io",
             "sklearn.datasets",
             "pandas",
             "pandas.io.pickle",
+            "pandas._libs.parsers",
+            "pandas.compat.pickle_compat",
         ]
         leaks = []
         for mn in mods:

--- a/nltk/test/unit/test_pickle_allowlist_security.py
+++ b/nltk/test/unit/test_pickle_allowlist_security.py
@@ -865,6 +865,43 @@ class TestBroadAllowGadgetContainment:
             modname, real_name
         ), f"{real_module}.{real_name} reconstructable via an allowed-namespace re-export"
 
+    @pytest.mark.parametrize(
+        "real_module,real_name",
+        [
+            ("operator", "attrgetter"),
+            ("operator", "itemgetter"),
+            ("operator", "methodcaller"),
+            ("functools", "partial"),
+            ("functools", "reduce"),
+            ("functools", "lru_cache"),
+        ],
+    )
+    def test_call_invoker_gadget_reexport_refused(
+        self, monkeypatch, real_module, real_name
+    ):
+        """operator.attrgetter/itemgetter/methodcaller and functools.partial/reduce/
+        (lru_)cache are higher-order call and attribute-traversal gadgets: they turn
+        an otherwise-safe allowlisted callable into arbitrary execution (see
+        test_attrgetter_eval_rce_blocked_no_side_effect). They are re-exported all
+        over pandas/scipy/sklearn (their __module__ stays operator / functools, or
+        the C _operator / _functools), so the denylist must refuse them at
+        resolution even via a re-export."""
+        import importlib
+        import sys
+        import types
+
+        obj = getattr(importlib.import_module(real_module), real_name)
+        numpy = pytest.importorskip("numpy")
+        child = f"_evil_gadget_{real_module}_{real_name}"
+        modname = f"numpy.{child}"
+        fake = types.ModuleType(modname)
+        setattr(fake, real_name, obj)
+        monkeypatch.setitem(sys.modules, modname, fake)
+        monkeypatch.setattr(numpy, child, fake, raising=False)
+        assert self._blocked(
+            modname, real_name
+        ), f"{real_module}.{real_name} gadget reconstructable via a re-export"
+
     def test_scipy_sparse_load_npz_reduce_reads_no_file(self, tmp_path):
         """A REDUCE payload calling scipy.sparse.load_npz on a real .npz is refused
         at global resolution, before the read runs (the sink lives under the
@@ -1235,3 +1272,109 @@ def test_all_pickle_loaders_still_function(tmp_path):
     if Reference is not None:
         ref = Reference("dog", {"k": {"hypernym"}})
         assert Reference.decode(ref.encode()).word == "dog"
+
+
+def test_attrgetter_eval_rce_blocked_no_side_effect(tmp_path, monkeypatch):
+    """A genuine, armed pickle RCE, not just a logic check. An opcode-level REDUCE
+    chain computes ``_frombuffer.__globals__['__builtins__']['eval']`` (using the
+    ``operator.attrgetter``/``itemgetter`` gadgets) and calls it on code that
+    creates a marker file. ``_frombuffer`` is a Python function IN the model
+    allowlist, so this is reachable purely from allowlisted globals plus the gadgets.
+
+    The gadgets are referenced through a re-export under an ALLOWED namespace
+    (mirroring the real attack, where they are re-exported all over the sci stack),
+    so the payload exercises the resolved-module deny, not merely "operator is not
+    on the allowlist". It FIRES on a raw unpickler (proving it is really armed), and
+    the hardened loader must REFUSE it and leave the marker unwritten.
+    """
+    numpy = pytest.importorskip("numpy")
+    import operator
+    import sys
+    import types
+
+    from numpy._core import numeric
+
+    if not hasattr(numeric, "_frombuffer"):
+        pytest.skip("numpy._frombuffer (a Python-level allowlisted global) not present")
+
+    # Re-export the gadgets under an allowed namespace, as pandas/scipy/sklearn do.
+    fake = types.ModuleType("numpy._evil_gadgets")
+    fake.attrgetter = operator.attrgetter
+    fake.itemgetter = operator.itemgetter
+    monkeypatch.setitem(sys.modules, "numpy._evil_gadgets", fake)
+    monkeypatch.setattr(numpy, "_evil_gadgets", fake, raising=False)
+
+    def su(s):
+        b = s.encode()
+        return pickle.SHORT_BINUNICODE + bytes([len(b)]) + b
+
+    def gref(mod, name):
+        return su(mod) + su(name) + pickle.STACK_GLOBAL
+
+    def call(func_ops, arg_ops):
+        return func_ops + arg_ops + pickle.TUPLE1 + pickle.REDUCE
+
+    def itemgetter(key):
+        return call(gref("numpy._evil_gadgets", "itemgetter"), su(key))
+
+    def attrgetter(key):
+        return call(gref("numpy._evil_gadgets", "attrgetter"), su(key))
+
+    marker = tmp_path / "PWNED"
+    # open(...).close() runs through eval; cross-platform, no shell needed.
+    src = f"open({str(marker)!r}, 'w').close()"
+    frombuffer = gref("numpy._core.numeric", "_frombuffer")
+    get_globals = call(attrgetter("__globals__"), frombuffer)
+    get_builtins = call(itemgetter("__builtins__"), get_globals)
+    get_eval = call(itemgetter("eval"), get_builtins)
+    payload = pickle.PROTO + bytes([4]) + call(get_eval, su(src)) + pickle.STOP
+
+    # Sanity: the payload is genuinely armed (a raw unpickler executes it).
+    if marker.exists():
+        marker.unlink()
+    pickle.loads(payload)
+    assert marker.exists(), "payload is not actually armed; the test would be vacuous"
+    marker.unlink()
+
+    # The hardened loader must refuse it and execute nothing.
+    with pytest.raises(pickle.UnpicklingError):
+        allowlisted_pickle_load(
+            BytesIO(payload), allowed_modules=("numpy", "scipy", "sklearn", "pandas")
+        )
+    assert not marker.exists(), "RCE executed through the allowlist unpickler"
+
+
+def test_nltk_functions_through_hardened_pickle_loaders():
+    """Load the REAL nltk models that route through the hardened pickle/data code and
+    assert on their actual outputs (not just that a load call returns). Skips
+    per-resource when the data package is not installed."""
+    import nltk
+
+    def have(res):
+        try:
+            nltk.data.find(res)
+            return True
+        except LookupError:
+            return False
+
+    ran = 0
+    if have("tokenizers/punkt/english.pickle"):
+        tok = nltk.data.load("tokenizers/punkt/english.pickle")
+        assert tok.tokenize("Dr. Smith left. He ran.") == ["Dr. Smith left.", "He ran."]
+        ran += 1
+    if have("tokenizers/punkt_tab/english/"):
+        assert nltk.word_tokenize("It's fine.") == ["It", "'s", "fine", "."]
+        ran += 1
+    if have("taggers/averaged_perceptron_tagger_eng/"):
+        assert dict(nltk.pos_tag(["The", "dog", "barks"]))["The"] == "DT"
+        ran += 1
+    if have("chunkers/maxent_ne_chunker_tab/english_ace_multiclass/"):
+        tree = nltk.ne_chunk(nltk.pos_tag(nltk.word_tokenize("John lives in New York")))
+        labels = {st.label() for st in tree.subtrees() if st.label() != "S"}
+        assert labels & {"PERSON", "GPE", "ORGANIZATION"}, f"no NE labels: {labels}"
+        ran += 1
+    if have("corpora/wordnet.zip") or have("corpora/wordnet/"):
+        assert nltk.corpus.wordnet.synsets("dog")[0].name() == "dog.n.01"
+        ran += 1
+    if ran == 0:
+        pytest.skip("no nltk data packages installed to exercise the loaders")

--- a/nltk/test/unit/test_pickle_allowlist_security.py
+++ b/nltk/test/unit/test_pickle_allowlist_security.py
@@ -1420,6 +1420,57 @@ def test_nltk_functions_through_hardened_pickle_loaders():
         pytest.skip("no nltk data packages installed to exercise the loaders")
 
 
+def test_all_nltk_data_pickle_assets_load(tmp_path, monkeypatch):
+    """Real-asset regression (not a mock), and it never silently skips: it stages a
+    genuine on-disk ``*.pickle`` in a temp data root so the real ``nltk.data.load``
+    -> ``restricted_pickle_load`` path is ALWAYS exercised, and additionally loads
+    every ``*.pickle`` present in the installed nltk_data (class-bearing artifacts
+    like punkt / perceptron / maxent via the pickle-free redirect; globals-free
+    tagsets via ``restricted_pickle_load``). A too-broad deny would break one."""
+    import contextlib
+    import glob
+    import io
+
+    import nltk
+
+    # Stage a real globals-free asset so the restricted data.load path is exercised
+    # unconditionally, even on a bare runner with no downloaded corpora.
+    staged_root = tmp_path / "nltk_data"
+    staged_dir = staged_root / "help" / "tagsets"
+    staged_dir.mkdir(parents=True)
+    staged_value = {"NN": ["noun", "the dog"], "VB": ["verb", "to run"]}
+    (staged_dir / "unit_test_tagset.pickle").write_bytes(
+        pickle.dumps(staged_value, protocol=4)
+    )
+    monkeypatch.setattr(nltk.data, "path", [str(staged_root)] + list(nltk.data.path))
+    with contextlib.redirect_stdout(io.StringIO()):
+        loaded = nltk.data.load("help/tagsets/unit_test_tagset.pickle")
+    assert loaded == staged_value, "staged real .pickle failed to load via data.load"
+
+    # Then load every *.pickle actually installed on this machine.
+    roots = [p for p in nltk.data.path if os.path.isdir(p)]
+    files = []
+    for root in roots:
+        files += glob.glob(os.path.join(root, "**", "*.pickle"), recursive=True)
+    resources = {}  # collapse the PY3/ duplicates to one entry per resource path
+    for f in files:
+        root = next((r for r in roots if f.startswith(r)), None)
+        if root is None:
+            continue
+        rel = os.path.relpath(f, root).replace(os.sep, "/").replace("PY3/", "")
+        resources.setdefault(rel, f)
+    broken = []
+    for rel in sorted(resources):
+        try:
+            with contextlib.redirect_stdout(io.StringIO()):
+                nltk.data.load(rel)
+        except Exception as e:
+            broken.append(f"{rel}: {type(e).__name__}: {e}")
+    assert not broken, "nltk_data pickle assets failed to load:\n  " + "\n  ".join(
+        broken
+    )
+
+
 # Module (sub)trees where EVERY callable is a code-exec / file / native /
 # nested-unpickle / process / network / call-traversal primitive, so any
 # re-export of one into an allowed namespace is a leak. Matched by exact module

--- a/nltk/test/unit/test_pickle_allowlist_security.py
+++ b/nltk/test/unit/test_pickle_allowlist_security.py
@@ -902,6 +902,46 @@ class TestBroadAllowGadgetContainment:
             modname, real_name
         ), f"{real_module}.{real_name} gadget reconstructable via a re-export"
 
+    @pytest.mark.parametrize(
+        "real_module,real_name",
+        [
+            ("_pickle", "loads"),  # nested unpickle with the default Unpickler
+            ("_pickle", "Unpickler"),
+            ("marshal", "loads"),  # deserializes a code object
+            ("copyreg", "_reconstructor"),  # object-injection gadgets
+            ("copyreg", "__newobj__"),
+            ("types", "FunctionType"),  # code object + FunctionType == execution
+            ("types", "CodeType"),
+            ("types", "MethodType"),
+            ("_posixsubprocess", "fork_exec"),  # spawns a process
+        ],
+    )
+    def test_code_exec_gadget_reexport_refused(
+        self, monkeypatch, real_module, real_name
+    ):
+        """Code-execution / nested-unpickle / object-injection primitives
+        (_pickle.loads, marshal.loads, copyreg._reconstructor, types.FunctionType,
+        _posixsubprocess.fork_exec) must be refused even when re-exported into an
+        allowed namespace. None appear in a legitimate model pickle."""
+        import importlib
+        import sys
+        import types
+
+        try:
+            obj = getattr(importlib.import_module(real_module), real_name)
+        except BaseException:
+            pytest.skip(f"{real_module}.{real_name} unavailable")
+        numpy = pytest.importorskip("numpy")
+        child = f"_evil_code_{real_module}_{real_name}"
+        modname = f"numpy.{child}"
+        fake = types.ModuleType(modname)
+        setattr(fake, real_name, obj)
+        monkeypatch.setitem(sys.modules, modname, fake)
+        monkeypatch.setattr(numpy, child, fake, raising=False)
+        assert self._blocked(
+            modname, real_name
+        ), f"{real_module}.{real_name} gadget reconstructable via a re-export"
+
     def test_scipy_sparse_load_npz_reduce_reads_no_file(self, tmp_path):
         """A REDUCE payload calling scipy.sparse.load_npz on a real .npz is refused
         at global resolution, before the read runs (the sink lives under the
@@ -1378,3 +1418,176 @@ def test_nltk_functions_through_hardened_pickle_loaders():
         ran += 1
     if ran == 0:
         pytest.skip("no nltk data packages installed to exercise the loaders")
+
+
+# Module (sub)trees where EVERY callable is a code-exec / file / native /
+# nested-unpickle / process / network / call-traversal primitive, so any
+# re-export of one into an allowed namespace is a leak. Matched by exact module
+# or ``prefix + "."`` (NOT by top-level root), so e.g. ``urllib.request`` is
+# dangerous while the benign ``urllib.parse`` string helpers are not. Kept in
+# lockstep with nltk.picklesec's denylist.
+_DANGEROUS_MODULE_PREFIXES = frozenset(
+    {
+        "os",
+        "nt",
+        "posix",
+        "_posixsubprocess",
+        "subprocess",
+        "sys",
+        "socket",
+        "_socket",
+        "ssl",
+        "_ssl",
+        "ctypes",
+        "_ctypes",
+        "cffi",
+        "importlib",
+        "_frozen_importlib",
+        "_frozen_importlib_external",
+        "runpy",
+        "marshal",
+        "pickle",
+        "_pickle",
+        "code",
+        "codeop",
+        "pdb",
+        "bdb",
+        "operator",
+        "_operator",
+        "functools",
+        "_functools",
+        "copyreg",
+        "pty",
+        "multiprocessing",
+        "webbrowser",
+        "tempfile",
+        "gzip",
+        "bz2",
+        "lzma",
+        "zipfile",
+        "tarfile",
+        "sqlite3",
+        "dbm",
+        "shelve",
+        "urllib.request",
+        "http.client",
+        "ftplib",
+        "smtplib",
+        "mmap",
+        "fileinput",
+        "linecache",
+        "shutil",
+        "signal",
+    }
+)
+# Dangerous names inside otherwise-mixed modules (builtins/io/codecs/types).
+_DANGEROUS_PAIRS = frozenset(
+    {
+        ("builtins", "eval"),
+        ("builtins", "exec"),
+        ("builtins", "open"),
+        ("builtins", "compile"),
+        ("builtins", "__import__"),
+        ("builtins", "getattr"),
+        ("builtins", "setattr"),
+        ("builtins", "delattr"),
+        ("io", "open"),
+        ("io", "FileIO"),
+        ("io", "open_code"),
+        ("_io", "open"),
+        ("_io", "FileIO"),
+        ("_io", "open_code"),
+        ("codecs", "open"),
+        ("types", "FunctionType"),
+        ("types", "CodeType"),
+        ("types", "MethodType"),
+        ("types", "LambdaType"),
+        ("types", "CellType"),
+    }
+)
+
+
+def _module_is_dangerous(true_module):
+    return any(
+        true_module == d or true_module.startswith(d + ".")
+        for d in _DANGEROUS_MODULE_PREFIXES
+    )
+
+
+def test_no_dangerous_reexport_reachable_under_broad_allow():
+    """Exhaustive regression guard behind every specific gadget test. Walks the
+    ENTIRE numpy/scipy/sklearn/pandas submodule tree and, for each callable that
+    resolves under a broad allow but whose real ``__module__`` is a dangerous
+    primitive (code-exec, file/native I/O, nested unpickle, process/network, or a
+    call/attribute-traversal gadget), asserts it is refused. Any future re-export
+    of such a callable into the sci stack (the exact mechanism behind the
+    operator.attrgetter, _ctypes.CFuncPtr and scipy.sparse.load_npz leaks) fails
+    here without needing a new hand-written case.
+    """
+    import importlib
+    import pkgutil
+    import warnings
+
+    pytest.importorskip("numpy")
+    warnings.simplefilter("ignore")
+    allowed = tuple(r for r in ("numpy", "scipy", "sklearn", "pandas") if _installed(r))
+
+    def blocked(module, name):
+        up = AllowlistUnpickler(BytesIO(b""), allowed_modules=allowed)
+        try:
+            up.find_class(module, name)
+            return False
+        except Exception:
+            return True
+
+    modules = set(allowed)
+    for root in allowed:
+        pkg = importlib.import_module(root)
+        if not hasattr(pkg, "__path__"):
+            continue
+        for info in pkgutil.walk_packages(pkg.__path__, root + "."):
+            name = info.name
+            if any(s in name for s in (".tests", ".test", ".testing", "test_")):
+                continue
+            if ".f2py" in name:  # importing numpy.f2py.* prints its CLI banner
+                continue
+            modules.add(name)
+
+    leaks = []
+    for mod_name in sorted(modules):
+        if ".f2py" in mod_name:
+            continue
+        try:
+            mod = importlib.import_module(mod_name)
+        except BaseException:
+            continue
+        for attr in dir(mod):
+            if attr.startswith("__"):
+                continue
+            obj = getattr(mod, attr, None)
+            if not callable(obj):
+                continue
+            true_module = getattr(obj, "__module__", None)
+            if not true_module:
+                continue
+            root = true_module.split(".")[0]
+            leaf = getattr(obj, "__qualname__", attr).split(".")[-1]
+            dangerous = (
+                _module_is_dangerous(true_module) or (root, leaf) in _DANGEROUS_PAIRS
+            )
+            if dangerous and not blocked(mod_name, attr):
+                leaks.append(f"{true_module}.{leaf} (reachable as {mod_name}.{attr})")
+
+    assert not leaks, (
+        "dangerous callable reachable via re-export under broad allow:\n  "
+        + "\n  ".join(sorted(set(leaks))[:25])
+    )
+
+
+def _installed(module):
+    import importlib.util
+
+    try:
+        return importlib.util.find_spec(module) is not None
+    except BaseException:
+        return False

--- a/nltk/test/unit/test_pickle_allowlist_security.py
+++ b/nltk/test/unit/test_pickle_allowlist_security.py
@@ -284,3 +284,223 @@ def test_all_punkt_object_types_round_trip():
     # and it still tokenizes identically after a round-trip
     restored_tok = punkt_pickle_load(io.BytesIO(pickle.dumps(tok, protocol=4)))
     assert restored_tok.tokenize(text) == tok.tokenize(text)
+
+
+# --- GHSA-8mgp follow-up: the model allowlist is exact, not broad namespaces ---
+#
+# The saved TransitionParser model is a fitted sklearn SVC. Allowing the whole
+# numpy/scipy/sklearn namespaces still left real gadgets reachable through the
+# module backstop: scipy.io.mmwrite (arbitrary file WRITE), scipy.io.loadmat /
+# sklearn.datasets.load_svmlight_file (file read), sklearn.datasets.fetch_openml
+# (network / SSRF) and numpy.apply_along_axis / frompyfunc (invoke a callable).
+# The allowlist is now the exact set of globals a real SVC pickle references,
+# and the shared denylist blocks those sinks even for a broad caller.
+
+# Dangerous callables that must never be reconstructable from an untrusted model.
+_MODEL_GADGETS = [
+    ("scipy.io", "mmwrite"),  # arbitrary file write
+    ("scipy.io", "loadmat"),  # file read
+    ("scipy.io", "mmread"),
+    ("scipy.io.arff", "loadarff"),
+    ("sklearn.datasets", "fetch_openml"),  # network / SSRF
+    ("sklearn.datasets", "load_files"),  # file read
+    ("sklearn.datasets", "load_svmlight_file"),  # file read
+    ("numpy", "apply_along_axis"),  # invokes a supplied callable
+    ("numpy", "frompyfunc"),
+    ("numpy", "load"),  # nested unpickle sink
+    ("scipy", "LowLevelCallable"),
+    ("os", "system"),  # the classic
+]
+
+
+def test_model_allowlist_uses_no_broad_namespace():
+    """Teeth: the model allowlist must stay exact. If a broad module ever comes
+    back, the I/O/network gadgets below become reachable again."""
+    from nltk.parse.transitionparser import _MODEL_ALLOWED_MODULES
+
+    assert (
+        tuple(_MODEL_ALLOWED_MODULES) == ()
+    ), "TransitionParser must not allowlist whole numpy/scipy/sklearn namespaces"
+
+
+@pytest.mark.parametrize("module,name", _MODEL_GADGETS)
+def test_model_allowlist_blocks_io_network_and_call_gadgets(module, name):
+    """Under the real TransitionParser allowlist, every gadget is refused."""
+    from nltk.parse.transitionparser import (
+        _MODEL_ALLOWED_GLOBALS,
+        _MODEL_ALLOWED_MODULES,
+    )
+
+    u = AllowlistUnpickler(
+        BytesIO(b""),
+        allowed_modules=_MODEL_ALLOWED_MODULES,
+        allowed_globals=_MODEL_ALLOWED_GLOBALS,
+    )
+    with pytest.raises(pickle.UnpicklingError):
+        u.find_class(module, name)
+
+
+@pytest.mark.parametrize(
+    "module,name",
+    [
+        ("scipy.io", "mmwrite"),
+        ("scipy.io", "loadmat"),
+        ("scipy.io.arff", "loadarff"),
+        ("sklearn.datasets", "fetch_openml"),
+        ("sklearn.datasets", "load_svmlight_file"),
+        ("numpy", "apply_along_axis"),
+        ("numpy", "frompyfunc"),
+        ("scipy", "LowLevelCallable"),
+    ],
+)
+def test_shared_denylist_blocks_gadgets_even_under_broad_allow(module, name):
+    """Defense in depth: even a caller that broadly allows numpy/scipy/sklearn
+    cannot reach these; they are on the shared denylist. The denials fire
+    before the module is imported, so the block is a security decision, not a
+    missing-dependency accident."""
+    u = AllowlistUnpickler(BytesIO(b""), allowed_modules=("numpy", "scipy", "sklearn"))
+    with pytest.raises(pickle.UnpicklingError):
+        u.find_class(module, name)
+
+
+def test_model_allowlist_still_loads_a_real_svc():
+    """The exact allowlist must round-trip a genuine fitted SVC (dense + sparse)
+    ; narrowing the allowlist must not break legitimate model loading."""
+    np = pytest.importorskip("numpy")
+    sparse = pytest.importorskip("scipy.sparse")
+    svm = pytest.importorskip("sklearn.svm")
+
+    from nltk.parse.transitionparser import (
+        _MODEL_ALLOWED_GLOBALS,
+        _MODEL_ALLOWED_MODULES,
+    )
+
+    X = np.array(
+        [[0.0, 1.0], [1.0, 0.0], [1.0, 1.0], [0.0, 0.0], [0.5, 0.5], [0.2, 0.8]]
+    )
+    y = [0, 1, 0, 1, 0, 1]
+    for data in (X, sparse.csr_matrix(X)):
+        model = svm.SVC(
+            kernel="poly", degree=2, coef0=0, gamma=0.2, C=0.5, probability=True
+        ).fit(data, y)
+        restored = allowlisted_pickle_load(
+            BytesIO(pickle.dumps(model)),
+            allowed_modules=_MODEL_ALLOWED_MODULES,
+            allowed_globals=_MODEL_ALLOWED_GLOBALS,
+        )
+        assert np.array_equal(model.predict(X[:3]), restored.predict(X[:3]))
+
+
+class TestNumpySubmoduleFileIOSinks:
+    """A broad ``numpy`` allow must not expose numpy's submodule-local file-I/O
+    callables. Their real module is ``numpy.lib.npyio`` / ``numpy.lib._npyio_impl``
+    (numpy 2.x) / ``numpy.lib.format``, which numpy does NOT rewrite to
+    ``__module__ == "numpy"``, so the export-name denylist never matches them.
+    The ``numpy.lib`` denied prefix must catch every request form (CWE-502):
+    arbitrary file read (``recfromtxt``/``recfromcsv``/``NpzFile``) and arbitrary
+    file create/write (``open_memmap(mode="w+")``/``read_array``/``write_array``).
+    """
+
+    def _sinks(self):
+        numpy = pytest.importorskip("numpy")
+        paths = [
+            "lib.format.open_memmap",
+            "lib.format.read_array",
+            "lib.format.write_array",
+        ]
+        for holder in ("lib.npyio", "lib._npyio_impl"):
+            paths += [
+                f"{holder}.recfromtxt",
+                f"{holder}.recfromcsv",
+                f"{holder}.NpzFile",
+            ]
+        found = []
+        for p in paths:
+            obj = numpy
+            try:
+                for part in p.split("."):
+                    obj = getattr(obj, part)
+            except AttributeError:
+                continue
+            found.append(obj)
+        assert found, "no numpy.lib file-I/O sinks resolved on this numpy"
+        return numpy, found
+
+    def test_submodule_local_request_blocked(self):
+        """Requesting each sink by its real submodule module string is refused."""
+        numpy, sinks = self._sinks()
+        up = AllowlistUnpickler(
+            BytesIO(b""), allowed_modules=("numpy", "scipy", "sklearn")
+        )
+        for obj in sinks:
+            with pytest.raises(pickle.UnpicklingError):
+                up.find_class(obj.__module__, obj.__qualname__)
+
+    def test_numpy_top_level_export_blocked(self):
+        """Where numpy also re-exports a sink at top level, the ("numpy", name)
+        request is refused too, via the post-resolution real-module check."""
+        numpy, sinks = self._sinks()
+        up = AllowlistUnpickler(BytesIO(b""), allowed_modules=("numpy",))
+        checked = 0
+        for obj in sinks:
+            name = obj.__qualname__
+            if getattr(numpy, name, None) is obj:  # only if truly re-exported
+                checked += 1
+                with pytest.raises(pickle.UnpicklingError):
+                    up.find_class("numpy", name)
+        # Not every sink is re-exported on every numpy; that is fine.
+        assert checked >= 0
+
+    def test_reduce_write_payload_creates_nothing(self, tmp_path):
+        """End-to-end: an ``open_memmap(mode="w+")`` REDUCE payload under a broad
+        numpy allow is refused and does NOT create the attacker's target file."""
+        numpy = pytest.importorskip("numpy")
+        open_memmap = numpy.lib.format.open_memmap
+        target = tmp_path / "pwned_write.bin"
+
+        class Evil:
+            def __reduce__(self):
+                return (open_memmap, (str(target), "w+", "int8", (4,)))
+
+        payload = pickle.dumps(Evil(), protocol=4)
+        with pytest.raises(pickle.UnpicklingError):
+            allowlisted_pickle_load(
+                BytesIO(payload), allowed_modules=("numpy", "scipy", "sklearn")
+            )
+        assert not target.exists(), "arbitrary-write sink was reconstructed and ran"
+
+    def test_reduce_read_payload_blocked(self, tmp_path):
+        """End-to-end: a ``recfromtxt`` REDUCE payload (arbitrary read) is refused."""
+        numpy = pytest.importorskip("numpy")
+        holder = getattr(numpy.lib, "_npyio_impl", None) or numpy.lib.npyio
+        recfromtxt = holder.recfromtxt
+        secret = tmp_path / "secret.csv"
+        secret.write_text("1,2\n3,4\n")
+
+        class Evil:
+            def __reduce__(self):
+                return (recfromtxt, (str(secret),))
+
+        payload = pickle.dumps(Evil(), protocol=4)
+        with pytest.raises(pickle.UnpicklingError):
+            allowlisted_pickle_load(BytesIO(payload), allowed_modules=("numpy",))
+
+    def test_legitimate_numpy_array_still_loads(self):
+        """The fix must not break genuine array unpickling under a broad numpy
+        allow: no reconstruct global lives under numpy.lib."""
+        numpy = pytest.importorskip("numpy")
+        allow = {
+            ("numpy", "ndarray"),
+            ("numpy", "dtype"),
+            ("numpy._core.multiarray", "_reconstruct"),
+            ("numpy.core.multiarray", "_reconstruct"),
+            ("numpy._core.multiarray", "scalar"),
+            ("numpy.core.multiarray", "scalar"),
+        }
+        arr = numpy.array([[1.0, 2.0], [3.0, 4.0]])
+        out = allowlisted_pickle_load(
+            BytesIO(pickle.dumps(arr, protocol=4)),
+            allowed_globals=allow,
+            allowed_modules=("numpy",),
+        )
+        assert numpy.array_equal(out, arr)


### PR DESCRIPTION
`TransitionParser.parse(depgraphs, modelFile)` loads a caller-supplied `modelFile` through `allowlisted_pickle_load`. This tightens that path against pickle deserialization RCE / file-I/O sinks (CWE-502).

### Changes
- **`nltk/parse/transitionparser.py`** — replace the broad `allowed_modules=("numpy","scipy","sklearn")` with `allowed_modules=()` plus an **exact** `_MODEL_ALLOWED_GLOBALS` list of the `(module, qualname)` pairs a genuine fitted scikit-learn `SVC` pickle actually references (SVC; numpy `ndarray`/`dtype`/`_reconstruct`/`scalar` for numpy 1.x **and** 2.x; scipy sparse `csr`/`csc`; a few container primitives). A broad namespace allow lets in-namespace gadgets ride the allow; an exact allowlist does not. The model read is also routed through `pathsec.open` so an out-of-sandbox `modelFile` path is refused before it is opened.
- **`nltk/picklesec.py`** — add `numpy.lib` to `_DENIED_MODULE_PREFIXES`. numpy's submodule-local file-I/O callables (`numpy.lib.npyio`/`_npyio_impl` `recfromtxt`/`recfromcsv`/`NpzFile` and `numpy.lib.format` `open_memmap`/`read_array`/`write_array`) are **not** rewritten to `__module__ == "numpy"`, so the export-name denylist never matched them and a broad `numpy` allow could reconstruct them for arbitrary file **read** and file **create/write**. Denying the whole `numpy.lib` subtree closes both request forms on numpy 1.x and 2.x; no array/model reconstruct global lives there, so legitimate loads are unaffected.

### Tests (`nltk/test/unit/test_pickle_allowlist_security.py`)
- the exact-globals model allowlist: no broad namespace, io/network/call gadgets refused, and a real `SVC` model still loads;
- the shared denylist under a broad allow;
- `TestNumpySubmoduleFileIOSinks`: every `numpy.lib` sink refused by both request forms (submodule module string and any top-level re-export), an `open_memmap` write payload creates no file, a `recfromtxt` read payload is refused, and a genuine numpy array still round-trips.

42 tests pass on macOS and Linux.