### PR TITLE
Harden maxent / named-entity model-artifact saves against shared-tmp planting

### DIFF
--- a/nltk/chunk/named_entity.py
+++ b/nltk/chunk/named_entity.py
@@ -14,17 +14,19 @@ import os
 import re
 
 from nltk.pathsec import open as pathsec_open
+from nltk.pathsec import validate_path
 from nltk.tag import ClassifierBasedTagger, pos_tag
 from nltk.xmlsec import parse as safe_parse
 
 try:
     from nltk.classify import MaxentClassifier
+    from nltk.classify.maxent import save_maxent_params
 except ImportError:
     pass
 
 from nltk.chunk.api import ChunkParserI
 from nltk.chunk.util import ChunkScore
-from nltk.data import find
+from nltk.data import find, make_staging_dir
 from nltk.tokenize import word_tokenize
 from nltk.tree import Tree
 
@@ -169,7 +171,7 @@ class NEChunkParser(ChunkParserI):
         for child in sent:
             if isinstance(child, Tree):
                 if len(child) == 0:
-                    print("Warning -- empty chunk in sentence")
+                    print("Warning; empty chunk in sentence")
                     continue
                 toks.append((child[0], f"B-{child.label()}"))
                 for tok in child[1:]:
@@ -232,7 +234,7 @@ def load_ace_file(textfile, fmt):
     annfile = textfile + ".tmx.rdc.xml"
 
     # Read the xml file, and get a list of entities. These ACE paths are walked
-    # from a corpus root, so keep them inside the allowed data roots -- a
+    # from a corpus root, so keep them inside the allowed data roots; a
     # symlinked .sgm/.xml must not resolve outside (CWE-59, GHSA-7qj2).
     entities = []
     with pathsec_open(annfile, context="load_ace_file") as infile:
@@ -328,6 +330,7 @@ class Maxent_NE_Chunker(NEChunkParser):
     def __init__(self, fmt="multiclass"):
 
         self._fmt = fmt
+        self._save_dir = None
         self._tab_dir = find(f"chunkers/maxent_ne_chunker_tab/english_ace_{fmt}/")
         self.load_params()
 
@@ -340,17 +343,51 @@ class Maxent_NE_Chunker(NEChunkParser):
         )
         self._tagger = NEChunkParserTagger(classifier=mc)
 
-    def save_params(self):
-        from nltk.classify.maxent import save_maxent_params
+    @property
+    def save_dir(self) -> str:
+        """This chunker's private directory for saved model artifacts.
 
+        Created lazily on first use with an unpredictable name and mode 0700, so
+        (unlike the old guessable ``/tmp/...``) another local user cannot
+        pre-create or symlink it to redirect or read the write (CWE-377/378).
+        The same directory is reused across calls, so a chunker's saved
+        artifacts share one known, private location.
+        """
+        if self._save_dir is None:
+            self._save_dir = make_staging_dir(prefix=f"nltk_ne_chunker_{self._fmt}_")
+        return self._save_dir
+
+    def save_params(self, tab_dir: str | None = None) -> str:
+        """Write the trained maxent parameters as tab files.
+
+        The old default was a *guessable* name in the shared, world-writable
+        system temp (``/tmp/english_ace_<fmt>/``). That is a threat by itself: on
+        a multi-user host another user can pre-create or symlink that exact path
+        to redirect or read the write (CWE-377/378), and pathsec refuses a
+        shared-temp destination anyway (so it would not even work). Default
+        instead to this chunker's :attr:`save_dir`; a private (mode 0700),
+        unpredictably-named directory that no other user can pre-plant. A caller
+        may still pass an explicit ``tab_dir``; it is validated against the NLTK
+        data sandbox before the parameter files are written, so an outside path
+        is refused (GHSA-8mgp-746c-j5xp).
+
+        :param tab_dir: destination directory; defaults to :attr:`save_dir`.
+        :type tab_dir: str or None
+        :return: the directory the parameter files were written to.
+        :rtype: str
+        """
         classif = self._tagger._classifier
         ecg = classif._encoding
         wgt = classif._weights
         mpg = ecg._mapping
         lab = ecg._labels
         aon = ecg._alwayson
-        fmt = self._fmt
-        save_maxent_params(wgt, mpg, lab, aon, tab_dir=f"/tmp/english_ace_{fmt}/")
+        if tab_dir is None:
+            tab_dir = self.save_dir
+        validate_path(tab_dir, context="Maxent_NE_Chunker.save_params")
+
+        save_maxent_params(wgt, mpg, lab, aon, tab_dir=tab_dir)
+        return tab_dir
 
 
 def build_model(fmt="multiclass"):
@@ -394,10 +431,11 @@ def build_model(fmt="binary"):
             cmp_chunks(correct, guess)
     print(chunkscore)
 
-    outfilename = f"/tmp/ne_chunker_{fmt}.pickle"
+    outdir = make_staging_dir(prefix=f"nltk_ne_chunker_{fmt}_")
+    outfilename = f"{outdir}/ne_chunker_{fmt}.pickle"
     print(f"Saving chunker to {outfilename}...")
 
-    with open(outfilename, "wb") as outfile:
+    with pathsec_open(outfilename, "wb", context="build_model") as outfile:
         pickle.dump(cp, outfile, -1)
 
     return cp

--- a/nltk/classify/maxent.py
+++ b/nltk/classify/maxent.py
@@ -51,6 +51,7 @@ For all values of ``feat_val`` and ``some_label``.  This mapping is
 performed by classes that implement the ``MaxentFeatureEncodingI``
 interface.
 """
+
 try:
     import numpy
 except ImportError:
@@ -64,8 +65,11 @@ from nltk.classify.api import ClassifierI
 from nltk.classify.megam import call_megam, parse_megam_weights, write_megam_file
 from nltk.classify.tadm import call_tadm, parse_tadm_weights, write_tadm_file
 from nltk.classify.util import CutoffChecker, accuracy, log_likelihood
-from nltk.data import gzip_open_unicode
+from nltk.data import gzip_open_unicode, make_staging_dir
+from nltk.pathsec import open as pathsec_open
+from nltk.pathsec import validate_path
 from nltk.probability import DictionaryProbDist
+from nltk.tabdata import MaxentEncoder
 from nltk.util import OrderedDict
 
 __docformat__ = "epytext en"
@@ -398,7 +402,7 @@ class MaxentFeatureEncodingI:
 
     def labels(self):
         """
-        :return: A list of the \"known labels\" -- i.e., all labels
+        :return: A list of the \"known labels\"; i.e., all labels
             ``l`` such that ``self.encode(fs,l)`` can be a nonzero
             joint-feature vector for some value of ``fs``.
         :rtype: list
@@ -452,7 +456,7 @@ class FunctionBackedMaxentFeatureEncoding(MaxentFeatureEncodingI):
 
         :type labels: list
         :param labels: A list of the \"known labels\" for this
-            encoding -- i.e., all labels ``l`` such that
+            encoding; i.e., all labels ``l`` such that
             ``self.encode(fs,l)`` can be a nonzero joint-feature vector
             for some value of ``fs``.
         """
@@ -579,7 +583,7 @@ class BinaryMaxentFeatureEncoding(MaxentFeatureEncodingI):
                 for label2 in self._labels:
                     if (fname, fval, label2) in self._mapping:
                         break  # we've seen this fname/fval combo
-                # We haven't -- fire the unseen-value feature
+                # We haven't; fire the unseen-value feature
                 else:
                     if fname in self._unseen:
                         encoding.append((self._unseen[fname], 1))
@@ -602,7 +606,7 @@ class BinaryMaxentFeatureEncoding(MaxentFeatureEncodingI):
                 self._inv_mapping[i] = info
 
         if f_id < len(self._mapping):
-            (fname, fval, label) = self._inv_mapping[f_id]
+            fname, fval, label = self._inv_mapping[f_id]
             return f"{fname}=={fval!r} and label is {label!r}"
         elif self._alwayson and f_id in self._alwayson.values():
             for label, f_id2 in self._alwayson.items():
@@ -919,7 +923,7 @@ class TypedMaxentFeatureEncoding(MaxentFeatureEncodingI):
                     for label2 in self._labels:
                         if (fname, fval, label2) in self._mapping:
                             break  # we've seen this fname/fval combo
-                    # We haven't -- fire the unseen-value feature
+                    # We haven't; fire the unseen-value feature
                     else:
                         if fname in self._unseen:
                             encoding.append((self._unseen[fname], 1))
@@ -942,7 +946,7 @@ class TypedMaxentFeatureEncoding(MaxentFeatureEncodingI):
                 self._inv_mapping[i] = info
 
         if f_id < len(self._mapping):
-            (fname, fval, label) = self._inv_mapping[f_id]
+            fname, fval, label = self._inv_mapping[f_id]
             return f"{fname}=={fval!r} and label is {label!r}"
         elif self._alwayson and f_id in self._alwayson.values():
             for label, f_id2 in self._alwayson.items():
@@ -1580,27 +1584,52 @@ def load_maxent_params(tab_dir):
     return wgt, mpg, lab, aon
 
 
-def save_maxent_params(wgt, mpg, lab, aon, tab_dir="/tmp"):
+def save_maxent_params(wgt, mpg, lab, aon, tab_dir: str | None = None) -> str:
+    """Write maxent classifier parameters as tab files; return the directory.
 
-    from os import mkdir
-    from os.path import isdir
+    The old default was the shared, world-writable system temp (``/tmp``); a
+    guessable destination another local user could pre-create or symlink
+    (CWE-377/378), and one pathsec refuses anyway. Default instead to a fresh
+    private (mode 0700), unpredictably-named directory. A caller-supplied
+    ``tab_dir`` is validated against the NLTK data sandbox before the directory
+    is created or any file is written (GHSA-8mgp-746c-j5xp).
 
-    from nltk.tabdata import MaxentEncoder
-
+    :param tab_dir: destination directory; defaults to a fresh private one.
+    :type tab_dir: str or None
+    :return: the directory the parameter files were written to.
+    :rtype: str
+    """
     menc = MaxentEncoder()
-    if not isdir(tab_dir):
-        mkdir(tab_dir)
+    if tab_dir is None:
+        tab_dir = make_staging_dir(prefix="nltk_maxent_params_")
+    validate_path(tab_dir, context="save_maxent_params")
+    if not os.path.isdir(tab_dir):
+        # 0700 so a caller-supplied output dir is private regardless of umask,
+        # matching the private default staging dir.
+        os.mkdir(tab_dir, 0o700)
 
     print(f"Saving Maxent parameters in {tab_dir}")
 
-    with open(f"{tab_dir}/weights.txt", "w") as f:
+    # newline="" writes LF, not the platform default, so the tab files reload
+    # cleanly on Windows (a default text write there emits CRLF, leaving a stray
+    # \r on every reloaded token).
+    with pathsec_open(
+        f"{tab_dir}/weights.txt", "w", context="save_maxent_params", newline=""
+    ) as f:
         f.write(f"{menc.list2txt(map(repr, wgt.tolist()))}")
-    with open(f"{tab_dir}/mapping.tab", "w") as f:
+    with pathsec_open(
+        f"{tab_dir}/mapping.tab", "w", context="save_maxent_params", newline=""
+    ) as f:
         f.write(f"{menc.tupdict2tab(mpg)}")
-    with open(f"{tab_dir}/labels.txt", "w") as f:
+    with pathsec_open(
+        f"{tab_dir}/labels.txt", "w", context="save_maxent_params", newline=""
+    ) as f:
         f.write(f"{menc.list2txt(lab)}")
-    with open(f"{tab_dir}/alwayson.tab", "w") as f:
+    with pathsec_open(
+        f"{tab_dir}/alwayson.tab", "w", context="save_maxent_params", newline=""
+    ) as f:
         f.write(f"{menc.ivdict2tab(aon)}")
+    return tab_dir
 
 
 def maxent_pos_tagger():

--- a/nltk/sentiment/sentiment_analyzer.py
+++ b/nltk/sentiment/sentiment_analyzer.py
@@ -22,6 +22,7 @@ from nltk.metrics import BigramAssocMeasures
 from nltk.metrics import f_measure as eval_f_measure
 from nltk.metrics import precision as eval_precision
 from nltk.metrics import recall as eval_recall
+from nltk.pathsec import open as pathsec_open
 from nltk.probability import FreqDist
 
 
@@ -187,7 +188,12 @@ class SentimentAnalyzer:
         Store `content` in `filename`. Can be used to store a SentimentAnalyzer.
         """
         print("Saving", filename, file=sys.stderr)
-        with open(filename, "wb") as storage_file:
+        # ``filename`` is caller-controlled; route the write through the pathsec
+        # sandbox so a classifier cannot be pickled to an arbitrary path outside
+        # the allowed NLTK data roots (GHSA-8mgp-746c-j5xp).
+        with pathsec_open(
+            filename, "wb", context="SentimentAnalyzer.save_file"
+        ) as storage_file:
             import pickle
 
             # The protocol=2 parameter is for python2 compatibility

--- a/nltk/sentiment/util.py
+++ b/nltk/sentiment/util.py
@@ -361,10 +361,23 @@ def json2csv_preprocess(
         limit is reached the conversion will stop. It can be useful to create
         subsets of the original tweets json data.
     """
-    with pathsec_open(
-        json_file, encoding=encoding, context="json2csv_preprocess"
-    ) as fp:
-        (writer, outf) = _outf_writer(outfile, encoding, errors, gzip_compress)
+    with pathsec_open(json_file, "rt", encoding=encoding, context="json2csv_preprocess") as fp:
+        from nltk.twitter.common import extract_fields
+        import gzip
+
+        if gzip_compress:
+            outf = pathsec_open(outfile, "wb", context="json2csv_preprocess")
+            outf = gzip.open(outf, "wt", newline="", encoding=encoding, errors=errors)
+        else:
+            outf = pathsec_open(
+                outfile,
+                "w",
+                newline="",
+                encoding=encoding,
+                errors=errors,
+                context="json2csv_preprocess",
+            )
+        writer = csv.writer(outf)
         # write the list of fields as header
         writer.writerow(fields)
 

--- a/nltk/sentiment/util.py
+++ b/nltk/sentiment/util.py
@@ -361,9 +361,12 @@ def json2csv_preprocess(
         limit is reached the conversion will stop. It can be useful to create
         subsets of the original tweets json data.
     """
-    with pathsec_open(json_file, "rt", encoding=encoding, context="json2csv_preprocess") as fp:
-        from nltk.twitter.common import extract_fields
+    with pathsec_open(
+        json_file, "rt", encoding=encoding, context="json2csv_preprocess"
+    ) as fp:
         import gzip
+
+        from nltk.twitter.common import extract_fields
 
         if gzip_compress:
             outf = pathsec_open(outfile, "wb", context="json2csv_preprocess")
@@ -887,7 +890,6 @@ if __name__ == "__main__":
 
     from nltk.classify import MaxentClassifier, NaiveBayesClassifier
     from nltk.classify.scikitlearn import SklearnClassifier
-    from nltk.twitter.common import _outf_writer, extract_fields
 
     naive_bayes = NaiveBayesClassifier.train
     svm = SklearnClassifier(LinearSVC()).train

--- a/nltk/sentiment/util.py
+++ b/nltk/sentiment/util.py
@@ -10,7 +10,6 @@
 Utility methods for Sentiment Analysis.
 """
 
-import codecs
 import csv
 import json
 import random
@@ -22,6 +21,7 @@ from copy import deepcopy
 import nltk
 from nltk.corpus import CategorizedPlaintextCorpusReader
 from nltk.data import load
+from nltk.pathsec import open as pathsec_open
 from nltk.tokenize import PunktTokenizer
 from nltk.tokenize.casual import EMOTICON_RE
 
@@ -257,7 +257,7 @@ def output_markdown(filename, **kwargs):
     """
     Write the output of an analysis to a file.
     """
-    with codecs.open(filename, "at") as outfile:
+    with pathsec_open(filename, "at", context="output_markdown") as outfile:
         text = "\n*** \n\n"
         text += "{} \n\n".format(time.strftime("%d/%m/%Y, %H:%M"))
         for k in sorted(kwargs):
@@ -361,7 +361,9 @@ def json2csv_preprocess(
         limit is reached the conversion will stop. It can be useful to create
         subsets of the original tweets json data.
     """
-    with codecs.open(json_file, encoding=encoding) as fp:
+    with pathsec_open(
+        json_file, encoding=encoding, context="json2csv_preprocess"
+    ) as fp:
         (writer, outf) = _outf_writer(outfile, encoding, errors, gzip_compress)
         # write the list of fields as header
         writer.writerow(fields)
@@ -430,7 +432,7 @@ def parse_tweets_set(
     if not sent_tokenizer:
         sent_tokenizer = PunktTokenizer()
 
-    with codecs.open(filename, "rt") as csvfile:
+    with pathsec_open(filename, "rt", context="parse_tweets_set") as csvfile:
         reader = csv.reader(csvfile)
         if skip_header:
             next(reader, None)  # skip the header

--- a/nltk/test/unit/test_maxent_ne_save_security.py
+++ b/nltk/test/unit/test_maxent_ne_save_security.py
@@ -1,0 +1,208 @@
+"""
+Regression tests for the model-artifact save hardening in
+``nltk.classify.maxent`` and ``nltk.chunk.named_entity`` (GHSA-8mgp-746c-j5xp,
+CWE-377/378).
+
+``save_maxent_params`` and ``Maxent_NE_Chunker.save_params`` used to write to a
+guessable path in the shared, world-writable system temp
+(``/tmp/english_ace_<fmt>/`` / ``/tmp``): on a multi-user host another local user
+could pre-create or symlink that exact path to redirect or read the write. They
+now default to a fresh private (mode 0700), unpredictably-named staging directory
+under an allowed data root, validate any caller-supplied destination against the
+pathsec sandbox before writing, and emit LF line endings so the tab files reload
+cleanly on Windows.
+
+The "outside" target is a fresh directory under the real ``$HOME``; never a temp
+dir, because the private system temp directory is itself an allowed pathsec root
+on macOS, which would make a temp target a false "outside".
+"""
+
+import inspect
+import os
+import shutil
+import tempfile
+import types
+from pathlib import Path
+
+import pytest
+
+import nltk.data
+import nltk.pathsec as pathsec
+
+
+@pytest.fixture
+def restricted_sandbox():
+    """Restrict pathsec's allowed roots to one throwaway data dir with
+    ``ENFORCE`` on, restoring every mutated global afterwards."""
+    saved_enforce = pathsec.ENFORCE
+    saved_path = list(nltk.data.path)
+    saved_cache = pathsec._ALLOWED_ROOTS_CACHE
+    saved_last = pathsec._LAST_DATA_PATHS
+    data_root = tempfile.mkdtemp()
+    try:
+        pathsec.ENFORCE = True
+        nltk.data.path[:] = [data_root]
+        pathsec._ALLOWED_ROOTS_CACHE = None
+        pathsec._LAST_DATA_PATHS = None
+        yield data_root
+    finally:
+        pathsec.ENFORCE = saved_enforce
+        nltk.data.path[:] = saved_path
+        pathsec._ALLOWED_ROOTS_CACHE = saved_cache
+        pathsec._LAST_DATA_PATHS = saved_last
+        shutil.rmtree(data_root, ignore_errors=True)
+
+
+def _outside_dir():
+    """A fresh directory path under the real ``$HOME``; guaranteed outside every
+    allowed pathsec root. Deliberately NOT a temp dir: the private system temp is
+    itself an allowed root, so a temp target would be a false "outside"."""
+    return Path.home() / f".nltk_maxent_ne_{os.getpid()}"
+
+
+# --- nltk.classify.maxent.save_maxent_params --------------------------------
+
+
+def test_save_maxent_params_refuses_outside_tab_dir(restricted_sandbox):
+    """maxent.save_maxent_params: a caller-controlled ``tab_dir`` must not let the
+    4 ``{tab_dir}/*`` writes land outside the sandbox."""
+    numpy = pytest.importorskip("numpy")
+    from nltk.classify.maxent import save_maxent_params
+
+    outside = _outside_dir()
+    param_files = ("weights.txt", "mapping.tab", "labels.txt", "alwayson.tab")
+    try:
+        # NEGATIVE CONTROL: prove the target is genuinely outside every root.
+        with pytest.raises(PermissionError):
+            pathsec.open(str(outside / "weights.txt"), "w")
+
+        # ATTACK: point tab_dir at the outside directory.
+        wgt = numpy.array([0.1, 0.2])
+        with pytest.raises(PermissionError):
+            save_maxent_params(wgt, {}, [], {}, tab_dir=str(outside))
+
+        # Containment: no parameter file was written outside the sandbox.
+        for name in param_files:
+            assert not (outside / name).exists()
+    finally:
+        shutil.rmtree(outside, ignore_errors=True)
+
+
+def test_save_maxent_params_default_is_private_dir_not_shared_tmp(restricted_sandbox):
+    """The default destination must be a fresh *private* (0700),
+    unpredictably-named directory (returned by the call); never the historical
+    guessable shared ``/tmp`` (CWE-377/378)."""
+    numpy = pytest.importorskip("numpy")
+    from nltk.classify.maxent import save_maxent_params
+
+    out = save_maxent_params(numpy.array([0.1, 0.2]), {}, [], {})
+    try:
+        # is_private_dir (0700, user-owned) is the real "not shared /tmp" check;
+        # a fresh mkdtemp lives under /tmp on Linux, so assert privacy plus the
+        # unpredictable mkdtemp name, not that the path avoids /tmp.
+        assert pathsec.is_private_dir(out), "default dir must be private (0700)"
+        assert os.path.basename(out).startswith("nltk_maxent_params_")
+        assert (Path(out) / "weights.txt").exists()
+    finally:
+        shutil.rmtree(out, ignore_errors=True)
+
+
+def test_save_maxent_params_round_trip(restricted_sandbox):
+    """Functional check: params written by save_maxent_params reload identically
+    via load_maxent_params (given a PathPointer, as the loaders use), and the tab
+    files are LF-only so a reload cannot pick up a stray CR on Windows."""
+    numpy = pytest.importorskip("numpy")
+    from nltk.classify.maxent import load_maxent_params, save_maxent_params
+    from nltk.data import FileSystemPathPointer
+
+    wgt = numpy.array([0.5, -1.25, 3.0])
+    mpg = {("word", "cat", "L1"): 5, ("shape", "upcase", "L2"): 7}
+    lab = ["L1", "L2"]
+    aon = {}
+    out = save_maxent_params(wgt, mpg, lab, aon)
+    try:
+        for name in ("weights.txt", "mapping.tab", "labels.txt", "alwayson.tab"):
+            assert b"\r" not in Path(out, name).read_bytes(), f"{name} has CR"
+        w2, m2, l2, a2 = load_maxent_params(FileSystemPathPointer(out))
+        assert numpy.allclose(w2, wgt)
+        assert l2 == lab
+        assert m2 == mpg
+        assert a2 == aon
+    finally:
+        shutil.rmtree(out, ignore_errors=True)
+
+
+# --- nltk.chunk.named_entity.Maxent_NE_Chunker.save_params -------------------
+
+
+def _stub_chunker(ne, fmt="multiclass"):
+    """A Maxent_NE_Chunker built without __init__ (which needs on-disk model
+    data) plus a stub tagger, so the in-memory parameter reads in save_params
+    succeed and the path guard is what decides the outcome."""
+    chunker = object.__new__(ne.Maxent_NE_Chunker)
+    chunker._fmt = fmt
+    chunker._save_dir = None
+    chunker._tagger = types.SimpleNamespace(
+        _classifier=types.SimpleNamespace(
+            _encoding=types.SimpleNamespace(_mapping={}, _labels=[], _alwayson={}),
+            _weights=[],
+        )
+    )
+    return chunker
+
+
+def test_ne_chunker_save_params_refuses_outside_path(restricted_sandbox):
+    """Maxent_NE_Chunker.save_params() must refuse an outside tab_dir before the
+    parameter files are written."""
+    ne = pytest.importorskip("nltk.chunk.named_entity")
+    target_dir = _outside_dir() / "english_ace_multiclass"
+    chunker = _stub_chunker(ne)
+    try:
+        with pytest.raises((PermissionError, ValueError)):
+            chunker.save_params(tab_dir=str(target_dir))
+        assert not target_dir.exists() or not any(target_dir.iterdir())
+    finally:
+        shutil.rmtree(_outside_dir(), ignore_errors=True)
+
+
+def test_ne_chunker_save_params_default_is_private_dir(restricted_sandbox, monkeypatch):
+    """The default destination must be a fresh *private* (0700),
+    unpredictably-named directory, reused across calls; never the historical
+    guessable ``/tmp/english_ace_<fmt>/`` (CWE-377/378)."""
+    ne = pytest.importorskip("nltk.chunk.named_entity")
+
+    captured = {}
+
+    def fake_save(wgt, mpg, lab, aon, tab_dir="/tmp"):
+        captured["tab_dir"] = tab_dir
+
+    # save_params uses the name imported into named_entity's namespace, so patch
+    # it there (not on nltk.classify.maxent).
+    monkeypatch.setattr(ne, "save_maxent_params", fake_save)
+
+    chunker = _stub_chunker(ne)
+    out = chunker.save_params()
+    try:
+        assert out == captured["tab_dir"], "save_params must return its dir"
+        assert "english_ace" not in out, "must not use the guessable historic name"
+        assert os.path.basename(out).startswith("nltk_ne_chunker_")
+        assert pathsec.is_private_dir(out), "default dir must be private (0700)"
+        assert chunker.save_dir == out
+        assert chunker.save_params() == out, "repeated save must reuse save_dir"
+    finally:
+        shutil.rmtree(out, ignore_errors=True)
+
+
+def test_maxent_and_ne_sinks_route_through_pathsec():
+    """Grep-style guard: the patched sinks must reference the pathsec sentinels,
+    so a future refactor that reverts to a bare open()/``/tmp`` is caught here."""
+    ne = pytest.importorskip("nltk.chunk.named_entity")
+    from nltk.classify import maxent
+
+    ne_src = inspect.getsource(ne.Maxent_NE_Chunker.save_params)
+    assert "validate_path(" in ne_src
+
+    mx_src = inspect.getsource(maxent.save_maxent_params)
+    assert "pathsec_open(" in mx_src
+    assert "validate_path(" in mx_src
+    assert '"/tmp' not in mx_src and "'/tmp" not in mx_src

--- a/nltk/test/unit/test_maxent_save_security.py
+++ b/nltk/test/unit/test_maxent_save_security.py
@@ -21,36 +21,13 @@ on macOS, which would make a temp target a false "outside".
 import inspect
 import os
 import shutil
-import tempfile
 from pathlib import Path
 
 import pytest
 
-import nltk.data
 import nltk.pathsec as pathsec
 
-
-@pytest.fixture
-def restricted_sandbox():
-    """Restrict pathsec's allowed roots to one throwaway data dir with
-    ``ENFORCE`` on, restoring every mutated global afterwards."""
-    saved_enforce = pathsec.ENFORCE
-    saved_path = list(nltk.data.path)
-    saved_cache = pathsec._ALLOWED_ROOTS_CACHE
-    saved_last = pathsec._LAST_DATA_PATHS
-    data_root = tempfile.mkdtemp()
-    try:
-        pathsec.ENFORCE = True
-        nltk.data.path[:] = [data_root]
-        pathsec._ALLOWED_ROOTS_CACHE = None
-        pathsec._LAST_DATA_PATHS = None
-        yield data_root
-    finally:
-        pathsec.ENFORCE = saved_enforce
-        nltk.data.path[:] = saved_path
-        pathsec._ALLOWED_ROOTS_CACHE = saved_cache
-        pathsec._LAST_DATA_PATHS = saved_last
-        shutil.rmtree(data_root, ignore_errors=True)
+# The ``restricted_sandbox`` fixture is provided by nltk/test/unit/conftest.py.
 
 
 def _outside_dir():

--- a/nltk/test/unit/test_maxent_save_security.py
+++ b/nltk/test/unit/test_maxent_save_security.py
@@ -1,16 +1,17 @@
 """
-Regression tests for the model-artifact save hardening in
-``nltk.classify.maxent`` and ``nltk.chunk.named_entity`` (GHSA-8mgp-746c-j5xp,
-CWE-377/378).
+Regression tests for the model-parameter save hardening in
+``nltk.classify.maxent`` (GHSA-8mgp-746c-j5xp, CWE-377/378).
 
-``save_maxent_params`` and ``Maxent_NE_Chunker.save_params`` used to write to a
-guessable path in the shared, world-writable system temp
-(``/tmp/english_ace_<fmt>/`` / ``/tmp``): on a multi-user host another local user
-could pre-create or symlink that exact path to redirect or read the write. They
-now default to a fresh private (mode 0700), unpredictably-named staging directory
-under an allowed data root, validate any caller-supplied destination against the
-pathsec sandbox before writing, and emit LF line endings so the tab files reload
-cleanly on Windows.
+``save_maxent_params`` used to write the classifier parameter files to the
+shared, world-writable system temp (``/tmp``): a guessable destination another
+local user could pre-create or symlink to redirect or read the write, and one
+pathsec refuses anyway. It now defaults to a fresh private (mode 0700),
+unpredictably-named staging directory under an allowed data root, validates any
+caller-supplied ``tab_dir`` against the pathsec sandbox before writing, and emits
+LF line endings so the tab files reload cleanly on Windows.
+
+(The named-entity chunker that calls this is exercised by
+``test_pathsec_sweep_chunk.py``.)
 
 The "outside" target is a fresh directory under the real ``$HOME``; never a temp
 dir, because the private system temp directory is itself an allowed pathsec root
@@ -21,7 +22,6 @@ import inspect
 import os
 import shutil
 import tempfile
-import types
 from pathlib import Path
 
 import pytest
@@ -57,10 +57,7 @@ def _outside_dir():
     """A fresh directory path under the real ``$HOME``; guaranteed outside every
     allowed pathsec root. Deliberately NOT a temp dir: the private system temp is
     itself an allowed root, so a temp target would be a false "outside"."""
-    return Path.home() / f".nltk_maxent_ne_{os.getpid()}"
-
-
-# --- nltk.classify.maxent.save_maxent_params --------------------------------
+    return Path.home() / f".nltk_maxent_{os.getpid()}"
 
 
 def test_save_maxent_params_refuses_outside_tab_dir(restricted_sandbox):
@@ -132,75 +129,10 @@ def test_save_maxent_params_round_trip(restricted_sandbox):
         shutil.rmtree(out, ignore_errors=True)
 
 
-# --- nltk.chunk.named_entity.Maxent_NE_Chunker.save_params -------------------
-
-
-def _stub_chunker(ne, fmt="multiclass"):
-    """A Maxent_NE_Chunker built without __init__ (which needs on-disk model
-    data) plus a stub tagger, so the in-memory parameter reads in save_params
-    succeed and the path guard is what decides the outcome."""
-    chunker = object.__new__(ne.Maxent_NE_Chunker)
-    chunker._fmt = fmt
-    chunker._save_dir = None
-    chunker._tagger = types.SimpleNamespace(
-        _classifier=types.SimpleNamespace(
-            _encoding=types.SimpleNamespace(_mapping={}, _labels=[], _alwayson={}),
-            _weights=[],
-        )
-    )
-    return chunker
-
-
-def test_ne_chunker_save_params_refuses_outside_path(restricted_sandbox):
-    """Maxent_NE_Chunker.save_params() must refuse an outside tab_dir before the
-    parameter files are written."""
-    ne = pytest.importorskip("nltk.chunk.named_entity")
-    target_dir = _outside_dir() / "english_ace_multiclass"
-    chunker = _stub_chunker(ne)
-    try:
-        with pytest.raises((PermissionError, ValueError)):
-            chunker.save_params(tab_dir=str(target_dir))
-        assert not target_dir.exists() or not any(target_dir.iterdir())
-    finally:
-        shutil.rmtree(_outside_dir(), ignore_errors=True)
-
-
-def test_ne_chunker_save_params_default_is_private_dir(restricted_sandbox, monkeypatch):
-    """The default destination must be a fresh *private* (0700),
-    unpredictably-named directory, reused across calls; never the historical
-    guessable ``/tmp/english_ace_<fmt>/`` (CWE-377/378)."""
-    ne = pytest.importorskip("nltk.chunk.named_entity")
-
-    captured = {}
-
-    def fake_save(wgt, mpg, lab, aon, tab_dir="/tmp"):
-        captured["tab_dir"] = tab_dir
-
-    # save_params uses the name imported into named_entity's namespace, so patch
-    # it there (not on nltk.classify.maxent).
-    monkeypatch.setattr(ne, "save_maxent_params", fake_save)
-
-    chunker = _stub_chunker(ne)
-    out = chunker.save_params()
-    try:
-        assert out == captured["tab_dir"], "save_params must return its dir"
-        assert "english_ace" not in out, "must not use the guessable historic name"
-        assert os.path.basename(out).startswith("nltk_ne_chunker_")
-        assert pathsec.is_private_dir(out), "default dir must be private (0700)"
-        assert chunker.save_dir == out
-        assert chunker.save_params() == out, "repeated save must reuse save_dir"
-    finally:
-        shutil.rmtree(out, ignore_errors=True)
-
-
-def test_maxent_and_ne_sinks_route_through_pathsec():
-    """Grep-style guard: the patched sinks must reference the pathsec sentinels,
-    so a future refactor that reverts to a bare open()/``/tmp`` is caught here."""
-    ne = pytest.importorskip("nltk.chunk.named_entity")
+def test_maxent_save_sink_routes_through_pathsec():
+    """Grep-style guard: the patched sink must reference the pathsec sentinels, so
+    a future refactor that reverts to a bare open()/``/tmp`` is caught here."""
     from nltk.classify import maxent
-
-    ne_src = inspect.getsource(ne.Maxent_NE_Chunker.save_params)
-    assert "validate_path(" in ne_src
 
     mx_src = inspect.getsource(maxent.save_maxent_params)
     assert "pathsec_open(" in mx_src

--- a/nltk/test/unit/test_pathsec_sweep_chunk.py
+++ b/nltk/test/unit/test_pathsec_sweep_chunk.py
@@ -27,35 +27,8 @@ import nltk.data
 import nltk.pathsec as pathsec
 
 
-@pytest.fixture
-def sandbox():
-    """Force ENFORCE on, point the sandbox at a throwaway data root, and yield a
-    fresh *outside* directory under ``~`` that is guaranteed unauthorized."""
-    old_paths = list(nltk.data.path)
-    old_enforce = pathsec.ENFORCE
-    old_cache = pathsec._ALLOWED_ROOTS_CACHE
-    old_last = pathsec._LAST_DATA_PATHS
-
-    data_root = tempfile.mkdtemp(prefix="nltk_sweep_data_")
-    outside = Path.home() / f".nltk_sweep_chunk_{os.getpid()}"
-
-    pathsec.ENFORCE = True
-    nltk.data.path[:] = [data_root]
-    pathsec._ALLOWED_ROOTS_CACHE = None
-    pathsec._LAST_DATA_PATHS = None
-
-    if outside.exists():
-        shutil.rmtree(outside, ignore_errors=True)
-    outside.mkdir(parents=True, exist_ok=True)
-    try:
-        yield outside
-    finally:
-        pathsec.ENFORCE = old_enforce
-        nltk.data.path[:] = old_paths
-        pathsec._ALLOWED_ROOTS_CACHE = old_cache
-        pathsec._LAST_DATA_PATHS = old_last
-        shutil.rmtree(outside, ignore_errors=True)
-        shutil.rmtree(data_root, ignore_errors=True)
+# The pathsec sandbox fixtures (sandbox / restricted_sandbox / enforce_off)
+# are provided by nltk/test/unit/conftest.py.
 
 
 def test_negative_control_pathsec_open_refuses_outside(sandbox):

--- a/nltk/test/unit/test_pathsec_sweep_chunk.py
+++ b/nltk/test/unit/test_pathsec_sweep_chunk.py
@@ -17,13 +17,10 @@ Linux ``tempfile.mkdtemp()`` lives under the shared ``/tmp``).
 import inspect
 import os
 import shutil
-import tempfile
 import types
-from pathlib import Path
 
 import pytest
 
-import nltk.data
 import nltk.pathsec as pathsec
 
 # The pathsec sandbox fixtures (sandbox / restricted_sandbox / enforce_off)

--- a/nltk/test/unit/test_pathsec_sweep_chunk.py
+++ b/nltk/test/unit/test_pathsec_sweep_chunk.py
@@ -1,0 +1,156 @@
+# Natural Language Toolkit: pathsec sweep tests (chunk / sentiment sinks)
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+#
+"""Attack tests for the bare-``open()`` sinks hardened under GHSA-8mgp-746c-j5xp
+in :mod:`nltk.chunk.named_entity` and :mod:`nltk.sentiment.sentiment_analyzer`.
+
+Each patched file-write API is driven with a path *outside* the NLTK data
+sandbox and must raise ``PermissionError`` and write nothing outside. The
+outside target is a fresh directory under the real home directory; never a
+temp dir, because the system temp dir can itself be an allowed root (and on
+Linux ``tempfile.mkdtemp()`` lives under the shared ``/tmp``).
+"""
+
+import inspect
+import os
+import shutil
+import tempfile
+import types
+from pathlib import Path
+
+import pytest
+
+import nltk.data
+import nltk.pathsec as pathsec
+
+
+@pytest.fixture
+def sandbox():
+    """Force ENFORCE on, point the sandbox at a throwaway data root, and yield a
+    fresh *outside* directory under ``~`` that is guaranteed unauthorized."""
+    old_paths = list(nltk.data.path)
+    old_enforce = pathsec.ENFORCE
+    old_cache = pathsec._ALLOWED_ROOTS_CACHE
+    old_last = pathsec._LAST_DATA_PATHS
+
+    data_root = tempfile.mkdtemp(prefix="nltk_sweep_data_")
+    outside = Path.home() / f".nltk_sweep_chunk_{os.getpid()}"
+
+    pathsec.ENFORCE = True
+    nltk.data.path[:] = [data_root]
+    pathsec._ALLOWED_ROOTS_CACHE = None
+    pathsec._LAST_DATA_PATHS = None
+
+    if outside.exists():
+        shutil.rmtree(outside, ignore_errors=True)
+    outside.mkdir(parents=True, exist_ok=True)
+    try:
+        yield outside
+    finally:
+        pathsec.ENFORCE = old_enforce
+        nltk.data.path[:] = old_paths
+        pathsec._ALLOWED_ROOTS_CACHE = old_cache
+        pathsec._LAST_DATA_PATHS = old_last
+        shutil.rmtree(outside, ignore_errors=True)
+        shutil.rmtree(data_root, ignore_errors=True)
+
+
+def test_negative_control_pathsec_open_refuses_outside(sandbox):
+    """Baseline: pathsec.open() itself refuses a write outside the sandbox."""
+    target = sandbox / "pwned.txt"
+    with pytest.raises(PermissionError):
+        pathsec.open(str(target), "w")
+    assert not target.exists()
+
+
+def test_sentiment_save_file_refuses_outside_path(sandbox):
+    """SentimentAnalyzer.save_file() must not pickle to an outside path."""
+    sa = pytest.importorskip("nltk.sentiment.sentiment_analyzer")
+    target = sandbox / "clf.pickle"
+    analyzer = sa.SentimentAnalyzer()
+    with pytest.raises(PermissionError):
+        analyzer.save_file({"weights": [1, 2, 3]}, str(target))
+    assert not target.exists()
+
+
+def test_ne_chunker_save_params_refuses_outside_path(sandbox):
+    """Maxent_NE_Chunker.save_params() must refuse an outside tab_dir before the
+    parameter files are written."""
+    ne = pytest.importorskip("nltk.chunk.named_entity")
+    target_dir = sandbox / "english_ace_multiclass"
+
+    # Build the object without __init__ (which needs on-disk model data) and give
+    # it a stub tagger so the in-memory param reads succeed; validate_path then
+    # refuses the outside tab_dir before save_maxent_params writes anything.
+    chunker = object.__new__(ne.Maxent_NE_Chunker)
+    chunker._fmt = "multiclass"
+    chunker._tagger = types.SimpleNamespace(
+        _classifier=types.SimpleNamespace(
+            _encoding=types.SimpleNamespace(_mapping={}, _labels=[], _alwayson={}),
+            _weights=[],
+        )
+    )
+    with pytest.raises(PermissionError):
+        chunker.save_params(tab_dir=str(target_dir))
+    assert not target_dir.exists() or not any(target_dir.iterdir())
+
+
+def test_ne_chunker_save_params_default_is_private_dir_not_shared_tmp(
+    sandbox, monkeypatch
+):
+    """The default destination must be a fresh *private* (0700),
+    unpredictably-named directory; never the historical guessable
+    ``/tmp/english_ace_<fmt>/`` in the shared, world-writable system temp, which
+    another local user could pre-create or symlink (CWE-377/378)."""
+    import nltk.pathsec as pathsec
+
+    ne = pytest.importorskip("nltk.chunk.named_entity")
+
+    captured = {}
+
+    def fake_save(wgt, mpg, lab, aon, tab_dir="/tmp"):
+        captured["tab_dir"] = tab_dir
+
+    # save_params uses the name imported into named_entity's namespace, so patch
+    # it there (not on nltk.classify.maxent).
+    monkeypatch.setattr(ne, "save_maxent_params", fake_save)
+
+    chunker = object.__new__(ne.Maxent_NE_Chunker)
+    chunker._fmt = "multiclass"
+    chunker._save_dir = None
+    chunker._tagger = types.SimpleNamespace(
+        _classifier=types.SimpleNamespace(
+            _encoding=types.SimpleNamespace(_mapping={}, _labels=[], _alwayson={}),
+            _weights=[],
+        )
+    )
+    out = chunker.save_params()
+    try:
+        assert out == captured["tab_dir"], "save_params must return its dir"
+        assert "english_ace" not in out, "must not use the guessable historic name"
+        assert os.path.basename(out).startswith("nltk_ne_chunker_")
+        assert os.path.isdir(out)
+        # Private (0700, user-owned) -> pathsec accepts it as a data root.
+        assert pathsec.is_private_dir(out)
+        # The private dir is created once (save_dir) and reused across calls.
+        assert chunker.save_dir == out
+        assert chunker.save_params() == out, "repeated save must reuse save_dir"
+    finally:
+        shutil.rmtree(out, ignore_errors=True)
+
+
+def test_sources_route_through_pathsec():
+    """Grep-style guard: the patched sinks must reference the pathsec sentinel,
+    so a future refactor that reverts to a bare open() is caught here."""
+    ne = pytest.importorskip("nltk.chunk.named_entity")
+    sa = pytest.importorskip("nltk.sentiment.sentiment_analyzer")
+
+    save_file_src = inspect.getsource(sa.SentimentAnalyzer.save_file)
+    assert "pathsec_open(" in save_file_src
+    assert "with open(" not in save_file_src
+
+    save_params_src = inspect.getsource(ne.Maxent_NE_Chunker.save_params)
+    assert "validate_path(" in save_params_src

--- a/nltk/test/unit/test_pathsec_sweep_chunk.py
+++ b/nltk/test/unit/test_pathsec_sweep_chunk.py
@@ -26,7 +26,6 @@ import pytest
 import nltk.data
 import nltk.pathsec as pathsec
 
-
 # The pathsec sandbox fixtures (sandbox / restricted_sandbox / enforce_off)
 # are provided by nltk/test/unit/conftest.py.
 

--- a/nltk/test/unit/test_pathsec_sweep_sentiment_util.py
+++ b/nltk/test/unit/test_pathsec_sweep_sentiment_util.py
@@ -4,18 +4,12 @@ output_markdown / json2csv_preprocess / parse_tweets_set used codecs.open on a
 caller-supplied path, bypassing pathsec. They now go through pathsec_open.
 """
 
-import os
-import pathlib
-import shutil
-import tempfile
-
 import pytest
 
-import nltk
 import nltk.pathsec as pathsec
 
-# The pathsec sandbox fixtures (sandbox / restricted_sandbox / enforce_off)
-# are provided by nltk/test/unit/conftest.py.
+# The pathsec sandbox fixtures (sandbox / restricted_sandbox / enforce_off /
+# pathsec_sandbox) are provided by nltk/test/unit/conftest.py.
 
 
 def test_negative_control(sandbox):
@@ -49,3 +43,16 @@ def test_parse_tweets_set_refuses_outside_path(sandbox):
             word_tokenizer=object(),
             sent_tokenizer=object(),
         )
+
+
+def test_json2csv_preprocess_refuses_outside_outfile(pathsec_sandbox):
+    """json2csv_preprocess reads a legitimate in-sandbox input but must refuse an
+    out-of-sandbox ``outfile`` (its CSV/GZIP output is a caller-supplied path)."""
+    from nltk.sentiment.util import json2csv_preprocess
+
+    src = pathsec_sandbox.root / "in.json"  # in-sandbox input, allowed to read
+    src.write_text('{"id": 1, "text": "hi"}\n', encoding="utf-8")
+    outfile = pathsec_sandbox.outside / "evil.csv"  # out-of-sandbox output
+    with pytest.raises(PermissionError):
+        json2csv_preprocess(str(src), str(outfile), fields=["id", "text"])
+    assert not outfile.exists(), "refused write must not have created the file"

--- a/nltk/test/unit/test_pathsec_sweep_sentiment_util.py
+++ b/nltk/test/unit/test_pathsec_sweep_sentiment_util.py
@@ -1,0 +1,71 @@
+"""GHSA-8mgp-746c-j5xp sweep: nltk.sentiment.util file I/O stays in the sandbox.
+
+output_markdown / json2csv_preprocess / parse_tweets_set used codecs.open on a
+caller-supplied path, bypassing pathsec. They now go through pathsec_open.
+"""
+
+import os
+import pathlib
+import shutil
+import tempfile
+
+import pytest
+
+import nltk
+import nltk.pathsec as pathsec
+
+
+@pytest.fixture
+def sandbox():
+    saved_paths = nltk.data.path[:]
+    saved_enforce = pathsec.ENFORCE
+    pathsec.ENFORCE = True
+    nltk.data.path[:] = [tempfile.mkdtemp()]
+    pathsec._ALLOWED_ROOTS_CACHE = None
+    pathsec._LAST_DATA_PATHS = None
+    # A genuinely-outside target: a fresh $HOME dir, never a temp dir (the
+    # private system temp is an allowed pathsec root on macOS).
+    outside_dir = pathlib.Path.home() / (".nltk_sweep_sentutil_%d" % os.getpid())
+    shutil.rmtree(outside_dir, ignore_errors=True)
+    outside_dir.mkdir(exist_ok=True)
+    try:
+        yield outside_dir
+    finally:
+        nltk.data.path[:] = saved_paths
+        pathsec.ENFORCE = saved_enforce
+        pathsec._ALLOWED_ROOTS_CACHE = None
+        pathsec._LAST_DATA_PATHS = None
+        shutil.rmtree(outside_dir, ignore_errors=True)
+
+
+def test_negative_control(sandbox):
+    target = str(sandbox / "x.txt")
+    with pytest.raises(PermissionError):
+        with pathsec.open(target, "w"):
+            pass
+
+
+def test_output_markdown_refuses_outside_path(sandbox):
+    from nltk.sentiment.util import output_markdown
+
+    target = sandbox / "report.md"
+    with pytest.raises(PermissionError):
+        output_markdown(str(target), model="x", accuracy=1.0)
+    assert not target.exists(), "refused write must not have created the file"
+
+
+def test_parse_tweets_set_refuses_outside_path(sandbox):
+    from nltk.sentiment.util import parse_tweets_set
+
+    outside = sandbox / "tweets.csv"
+    outside.write_text("1,hello\n", encoding="utf-8")  # a real file, so the
+    # refusal is the sandbox check, not FileNotFound.
+    # Pass tokenizers so the function reaches the file open without needing punkt
+    # data (unavailable in the sandboxed data path); the open raises first.
+    with pytest.raises(PermissionError):
+        parse_tweets_set(
+            str(outside),
+            label="pos",
+            word_tokenizer=object(),
+            sent_tokenizer=object(),
+        )

--- a/nltk/test/unit/test_pathsec_sweep_sentiment_util.py
+++ b/nltk/test/unit/test_pathsec_sweep_sentiment_util.py
@@ -14,7 +14,6 @@ import pytest
 import nltk
 import nltk.pathsec as pathsec
 
-
 # The pathsec sandbox fixtures (sandbox / restricted_sandbox / enforce_off)
 # are provided by nltk/test/unit/conftest.py.
 

--- a/nltk/test/unit/test_pathsec_sweep_sentiment_util.py
+++ b/nltk/test/unit/test_pathsec_sweep_sentiment_util.py
@@ -15,27 +15,8 @@ import nltk
 import nltk.pathsec as pathsec
 
 
-@pytest.fixture
-def sandbox():
-    saved_paths = nltk.data.path[:]
-    saved_enforce = pathsec.ENFORCE
-    pathsec.ENFORCE = True
-    nltk.data.path[:] = [tempfile.mkdtemp()]
-    pathsec._ALLOWED_ROOTS_CACHE = None
-    pathsec._LAST_DATA_PATHS = None
-    # A genuinely-outside target: a fresh $HOME dir, never a temp dir (the
-    # private system temp is an allowed pathsec root on macOS).
-    outside_dir = pathlib.Path.home() / (".nltk_sweep_sentutil_%d" % os.getpid())
-    shutil.rmtree(outside_dir, ignore_errors=True)
-    outside_dir.mkdir(exist_ok=True)
-    try:
-        yield outside_dir
-    finally:
-        nltk.data.path[:] = saved_paths
-        pathsec.ENFORCE = saved_enforce
-        pathsec._ALLOWED_ROOTS_CACHE = None
-        pathsec._LAST_DATA_PATHS = None
-        shutil.rmtree(outside_dir, ignore_errors=True)
+# The pathsec sandbox fixtures (sandbox / restricted_sandbox / enforce_off)
+# are provided by nltk/test/unit/conftest.py.
 
 
 def test_negative_control(sandbox):


### PR DESCRIPTION
Split out of #3753 so the classify/chunk/sentiment model- and data-save hardening
can be reviewed and merged on its own. Depends only on `nltk.pathsec` and
`nltk.data.make_staging_dir`, which are already on `develop`.

### Problem
Several sinks wrote or read a **caller-controlled / guessable path** with a bare
`open()` / `codecs.open()`, with no containment:
- `nltk.classify.maxent.save_maxent_params` and
  `nltk.chunk.named_entity.Maxent_NE_Chunker.save_params` wrote the trained model
  parameter files to the shared, world-writable system temp
  (`/tmp/english_ace_<fmt>/` and `/tmp`) — a path another local user can
  pre-create or symlink to redirect or read the write (CWE-377/378).
- `nltk.sentiment.sentiment_analyzer.SentimentAnalyzer.save_file` pickled a
  classifier to a caller-supplied path.
- `nltk.sentiment.util.output_markdown` / `json2csv_preprocess` /
  `parse_tweets_set` opened a caller-supplied markdown / JSON / CSV path.

### Fix
- The maxent / NE parameter saves default to a fresh **private (mode 0700),
  unpredictably-named** staging directory under an allowed data root
  (`make_staging_dir`), **validate** any caller-supplied destination against the
  pathsec sandbox before writing, route the writes through `pathsec.open`, return
  the directory used, and write **LF** line endings (clean reload on Windows).
  `Maxent_NE_Chunker` gains a reusable `save_dir`; `build_model` writes its pickle
  through the sandbox too.
- `SentimentAnalyzer.save_file` and the three `nltk.sentiment.util` sinks route
  their reads/writes through `pathsec.open`, refusing an out-of-sandbox path
  before any bytes move.

### Tests
- `test_pathsec_sweep_chunk.py` — `Maxent_NE_Chunker.save_params` /
  `SentimentAnalyzer.save_file` refuse an outside path (nothing written), the
  chunker default is a private 0700 dir, plus a source guard.
- `test_pathsec_sweep_sentiment_util.py` — `output_markdown` / `parse_tweets_set`
  refuse an outside path, with a negative control.
- `test_maxent_save_security.py` — `save_maxent_params`: outside-`tab_dir`
  refusal, private-default-dir guarantee, an LF-only round-trip, and a source
  guard.
