### PR TITLE
Contain CorpusReader / agreement / chat80 file I/O in the pathsec sandbox

### DIFF
--- a/nltk/corpus/reader/api.py
+++ b/nltk/corpus/reader/api.py
@@ -18,6 +18,7 @@ from itertools import chain
 from nltk import pathsec
 from nltk.corpus.reader.util import *
 from nltk.data import FileSystemPathPointer, PathPointer, ZipFilePathPointer
+from nltk.pathsec import validate_path
 
 
 class CorpusReader:
@@ -81,7 +82,7 @@ class CorpusReader:
         # The ``str`` test also covers ``FileSystemPathPointer`` (a ``str``
         # subclass), so a pointer root is validated too.
         if pathsec.ENFORCE and isinstance(root, str):
-            pathsec.validate_path(root, context="CorpusReader.__init__")
+            validate_path(root, context="CorpusReader.__init__")
 
         # Convert the root to a path pointer, if necessary.
         if isinstance(root, str) and not isinstance(root, PathPointer):
@@ -171,6 +172,21 @@ class CorpusReader:
         """
         return self._fileids
 
+    def _guard_fileid(self, fileid):
+        """Resolve a corpus-relative fileid to a path pointer with the scoped-root
+        guard, so view methods get the same containment as :meth:`open`.
+
+        View methods (``words``/``sents``/``parsed_sents``/...) open the pointers
+        returned by :meth:`abspaths` directly, bypassing :meth:`open`.
+        ``self._root.join`` already rejects a ``..`` traversal; the scoped
+        ``validate_path`` additionally resolves symlinks so an intermediate
+        directory symlink inside the corpus root that escapes it is refused too
+        (CWE-22/CWE-59).
+        """
+        path = self._root.join(fileid)
+        validate_path(path, context="CorpusReader", required_root=self._root)
+        return path
+
     def abspath(self, fileid):
         """
         Return the absolute path for the given file.
@@ -180,7 +196,7 @@ class CorpusReader:
             should be returned.
         :rtype: PathPointer
         """
-        return self._root.join(fileid)
+        return self._guard_fileid(fileid)
 
     def abspaths(self, fileids=None, include_encoding=False, include_fileid=False):
         """
@@ -205,7 +221,7 @@ class CorpusReader:
         elif isinstance(fileids, str):
             fileids = [fileids]
 
-        paths = [self._root.join(f) for f in fileids]
+        paths = [self._guard_fileid(f) for f in fileids]
 
         if include_encoding and include_fileid:
             return list(zip(paths, [self.encoding(f) for f in fileids], fileids))
@@ -244,8 +260,6 @@ class CorpusReader:
         path = self._root.join(file)
 
         # Layer 2: Scoped resolved guard (Fixes symlink escape test)
-        from nltk.pathsec import validate_path
-
         validate_path(path, context="CorpusReader", required_root=self._root)
 
         # --- FIX: Handle dict-based encodings (e.g., UDHR corpus) ---

--- a/nltk/metrics/agreement.py
+++ b/nltk/metrics/agreement.py
@@ -76,6 +76,7 @@ from operator import itemgetter
 
 from nltk.internals import deprecated
 from nltk.metrics.distance import binary_distance
+from nltk.pathsec import open as pathsec_open
 from nltk.probability import ConditionalFreqDist, FreqDist
 
 log = logging.getLogger(__name__)
@@ -476,7 +477,7 @@ if __name__ == "__main__":
 
     # read in data from the specified file
     data = []
-    with open(options.file) as infile:
+    with pathsec_open(options.file, context="agreement.__main__") as infile:
         for l in infile:
             toks = l.split(options.columnsep)
             coder, object_, labels = (

--- a/nltk/sem/chat80.py
+++ b/nltk/sem/chat80.py
@@ -129,6 +129,8 @@ import shelve
 import sys
 
 import nltk.data
+from nltk.pathsec import open as pathsec_open
+from nltk.pathsec import validate_path
 
 ###########################################################################
 # Chat-80 relation metadata bundles needed to build the valuation
@@ -421,6 +423,10 @@ def cities2table(filename, rel_name, dbname, verbose=False, setup=False):
     """
     import sqlite3
 
+    # dbname is a caller-supplied path handed straight to sqlite3.connect(),
+    # which creates/opens it. Validate it before any file is created so an
+    # out-of-sandbox target is refused up front (GHSA-8mgp-746c-j5xp).
+    validate_path(dbname, context="chat80.cities2table")
     records = _str2records(filename, rel_name)
     connection = sqlite3.connect(dbname)
     cur = connection.cursor()
@@ -610,6 +616,10 @@ def val_dump(rels, db):
                The suffix '.db' will be automatically appended.
     :type db: str
     """
+    # db is a caller-supplied path handed to shelve.open(), which creates the
+    # backing files. Validate before any work so an out-of-sandbox target is
+    # refused up front (GHSA-8mgp-746c-j5xp).
+    validate_path(db, context="chat80.val_dump")
     concepts = process_bundle(rels).values()
     valuation = make_valuation(concepts, read=True)
     db_out = shelve.open(db, "n")
@@ -627,6 +637,10 @@ def val_load(db):
                The suffix '.db' should be omitted from the name.
     :type db: str
     """
+    # db is a caller-supplied path handed to shelve.open(), which opens the
+    # backing files. Validate before touching the filesystem so an
+    # out-of-sandbox target is refused up front (GHSA-8mgp-746c-j5xp).
+    validate_path(db, context="chat80.val_load")
     dbname = db + ".db"
 
     if not os.access(dbname, os.R_OK):
@@ -674,7 +688,9 @@ def label_indivs(valuation, lexicon=False):
     pairs = [(e, e) for e in domain]
     if lexicon:
         lex = make_lex(domain)
-        with open("chat_pnames.cfg", "w") as outfile:
+        with pathsec_open(
+            "chat_pnames.cfg", "w", context="chat80.label_indivs"
+        ) as outfile:
             outfile.writelines(lex)
     # read the pairs into the valuation
     valuation.update(pairs)
@@ -793,7 +809,7 @@ Valuation object for use in the NLTK semantics package.
         help="print out the vocabulary of concept labels and their arity, then exit",
     )
 
-    (options, args) = opts.parse_args()
+    options, args = opts.parse_args()
     if options.outdb and options.indb:
         opts.error("Options --store and --load are mutually exclusive")
 

--- a/nltk/test/unit/test_agreement_chat80_pathsec.py
+++ b/nltk/test/unit/test_agreement_chat80_pathsec.py
@@ -1,0 +1,128 @@
+# Natural Language Toolkit: pathsec sweep attack tests (agreement / chat80)
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""Path-traversal attack tests for the caller-controlled file sinks hardened in
+``nltk.metrics.agreement`` and ``nltk.sem.chat80`` (GHSA-8mgp-746c-j5xp).
+
+Each patched API must refuse to read from / write to a path outside the NLTK
+data sandbox and must leave nothing behind.
+"""
+
+import os
+import pathlib
+import runpy
+import shutil
+import sys
+import tempfile
+
+import pytest
+
+import nltk.data
+import nltk.pathsec as pathsec
+
+
+@pytest.fixture
+def sandbox():
+    """Enforce pathsec with a single throwaway data root and yield an *outside*
+    target directory the sandbox must refuse.
+
+    The outside directory is a fresh dir under the real home directory; NOT a
+    temp dir, because on macOS the private per-user system temp dir *is* an
+    allowed root (``pathsec._get_allowed_roots``), which would make a temp-dir
+    "attack" spuriously succeed.
+    """
+    saved_enforce = pathsec.ENFORCE
+    saved_paths = list(nltk.data.path)
+    saved_cwd = os.getcwd()
+
+    data_root = tempfile.mkdtemp(prefix="nltk_sweep_sandbox_")
+    outside = pathlib.Path.home() / f".nltk_sweep_agreement_chat80_{os.getpid()}"
+    outside.mkdir(parents=True, exist_ok=True)
+
+    pathsec.ENFORCE = True
+    nltk.data.path[:] = [data_root]
+    pathsec._ALLOWED_ROOTS_CACHE = None
+    pathsec._LAST_DATA_PATHS = None
+
+    try:
+        yield outside
+    finally:
+        pathsec.ENFORCE = saved_enforce
+        nltk.data.path[:] = saved_paths
+        pathsec._ALLOWED_ROOTS_CACHE = None
+        pathsec._LAST_DATA_PATHS = None
+        os.chdir(saved_cwd)
+        shutil.rmtree(outside, ignore_errors=True)
+        shutil.rmtree(data_root, ignore_errors=True)
+
+
+def test_negative_control_open_outside_raises(sandbox):
+    """The sandbox is wired correctly: a plain pathsec.open() of the outside
+    target must be refused and write nothing."""
+    target = sandbox / "neg_control.txt"
+    with pytest.raises(PermissionError):
+        pathsec.open(str(target), "w")
+    assert not target.exists()
+
+
+# --------------------------------------------------------------------------- #
+# nltk.sem.chat80
+# --------------------------------------------------------------------------- #
+def test_chat80_val_dump_refuses_outside(sandbox):
+    from nltk.sem import chat80
+
+    target = sandbox / "evil_valuation"
+    with pytest.raises(PermissionError):
+        chat80.val_dump([], str(target))
+    # shelve may append backend suffixes (.db/.dir/.dat/.bak); none may appear.
+    assert not list(sandbox.glob("evil_valuation*"))
+
+
+def test_chat80_val_load_refuses_outside(sandbox):
+    from nltk.sem import chat80
+
+    target = sandbox / "evil_db"
+    with pytest.raises(PermissionError):
+        chat80.val_load(str(target))
+
+
+def test_chat80_cities2table_refuses_outside(sandbox):
+    from nltk.sem import chat80
+
+    target = sandbox / "evil_city.db"
+    with pytest.raises(PermissionError):
+        chat80.cities2table("cities.pl", "city", str(target))
+    assert not target.exists()
+
+
+def test_chat80_label_indivs_refuses_outside_cwd(sandbox):
+    from nltk.sem import chat80
+    from nltk.sem.evaluate import Valuation
+
+    # label_indivs writes the fixed name "chat_pnames.cfg" relative to CWD; make
+    # CWD the outside dir so the write would land outside the sandbox.
+    os.chdir(sandbox)
+    with pytest.raises(PermissionError):
+        chat80.label_indivs(Valuation([]), lexicon=True)
+    assert not (sandbox / "chat_pnames.cfg").exists()
+
+
+# --------------------------------------------------------------------------- #
+# nltk.metrics.agreement (__main__ -f caller-file read)
+# --------------------------------------------------------------------------- #
+def test_agreement_main_file_read_refuses_outside(sandbox):
+    target = sandbox / "evil_annotations.txt"
+    target.write_text("a 1 x\n")  # content is irrelevant; read must be refused
+
+    saved_argv = list(sys.argv)
+    sys.argv = ["agreement", "-f", str(target)]
+    try:
+        with pytest.raises(PermissionError):
+            # Runs the module's __main__ block in-process so the fixture's
+            # ENFORCE / nltk.data.path settings apply to the patched open.
+            runpy.run_module("nltk.metrics.agreement", run_name="__main__")
+    finally:
+        sys.argv = saved_argv

--- a/nltk/test/unit/test_agreement_pathsec.py
+++ b/nltk/test/unit/test_agreement_pathsec.py
@@ -11,52 +11,14 @@ The ``__main__`` ``-f`` file read must refuse a path outside the NLTK data
 sandbox and read nothing from it.
 """
 
-import os
-import pathlib
 import runpy
-import shutil
 import sys
-import tempfile
 
 import pytest
 
-import nltk.data
 import nltk.pathsec as pathsec
 
-
-@pytest.fixture
-def sandbox():
-    """Enforce pathsec with a single throwaway data root and yield an *outside*
-    target directory the sandbox must refuse.
-
-    The outside directory is a fresh dir under the real home directory; NOT a
-    temp dir, because on macOS the private per-user system temp dir *is* an
-    allowed root (``pathsec._get_allowed_roots``), which would make a temp-dir
-    "attack" spuriously succeed.
-    """
-    saved_enforce = pathsec.ENFORCE
-    saved_paths = list(nltk.data.path)
-    saved_cwd = os.getcwd()
-
-    data_root = tempfile.mkdtemp(prefix="nltk_sweep_sandbox_")
-    outside = pathlib.Path.home() / f".nltk_sweep_agreement_{os.getpid()}"
-    outside.mkdir(parents=True, exist_ok=True)
-
-    pathsec.ENFORCE = True
-    nltk.data.path[:] = [data_root]
-    pathsec._ALLOWED_ROOTS_CACHE = None
-    pathsec._LAST_DATA_PATHS = None
-
-    try:
-        yield outside
-    finally:
-        pathsec.ENFORCE = saved_enforce
-        nltk.data.path[:] = saved_paths
-        pathsec._ALLOWED_ROOTS_CACHE = None
-        pathsec._LAST_DATA_PATHS = None
-        os.chdir(saved_cwd)
-        shutil.rmtree(outside, ignore_errors=True)
-        shutil.rmtree(data_root, ignore_errors=True)
+# The ``sandbox`` fixture is provided by nltk/test/unit/conftest.py.
 
 
 def test_negative_control_open_outside_raises(sandbox):

--- a/nltk/test/unit/test_agreement_pathsec.py
+++ b/nltk/test/unit/test_agreement_pathsec.py
@@ -1,14 +1,14 @@
-# Natural Language Toolkit: pathsec sweep attack tests (agreement / chat80)
+# Natural Language Toolkit: pathsec sweep attack tests (agreement)
 #
 # Copyright (C) 2001-2026 NLTK Project
 # URL: <https://www.nltk.org/>
 # For license information, see LICENSE.TXT
 
-"""Path-traversal attack tests for the caller-controlled file sinks hardened in
-``nltk.metrics.agreement`` and ``nltk.sem.chat80`` (GHSA-8mgp-746c-j5xp).
+"""Path-traversal attack tests for the caller-controlled file read hardened in
+``nltk.metrics.agreement`` (GHSA-8mgp-746c-j5xp).
 
-Each patched API must refuse to read from / write to a path outside the NLTK
-data sandbox and must leave nothing behind.
+The ``__main__`` ``-f`` file read must refuse a path outside the NLTK data
+sandbox and read nothing from it.
 """
 
 import os
@@ -39,7 +39,7 @@ def sandbox():
     saved_cwd = os.getcwd()
 
     data_root = tempfile.mkdtemp(prefix="nltk_sweep_sandbox_")
-    outside = pathlib.Path.home() / f".nltk_sweep_agreement_chat80_{os.getpid()}"
+    outside = pathlib.Path.home() / f".nltk_sweep_agreement_{os.getpid()}"
     outside.mkdir(parents=True, exist_ok=True)
 
     pathsec.ENFORCE = True
@@ -68,51 +68,6 @@ def test_negative_control_open_outside_raises(sandbox):
     assert not target.exists()
 
 
-# --------------------------------------------------------------------------- #
-# nltk.sem.chat80
-# --------------------------------------------------------------------------- #
-def test_chat80_val_dump_refuses_outside(sandbox):
-    from nltk.sem import chat80
-
-    target = sandbox / "evil_valuation"
-    with pytest.raises(PermissionError):
-        chat80.val_dump([], str(target))
-    # shelve may append backend suffixes (.db/.dir/.dat/.bak); none may appear.
-    assert not list(sandbox.glob("evil_valuation*"))
-
-
-def test_chat80_val_load_refuses_outside(sandbox):
-    from nltk.sem import chat80
-
-    target = sandbox / "evil_db"
-    with pytest.raises(PermissionError):
-        chat80.val_load(str(target))
-
-
-def test_chat80_cities2table_refuses_outside(sandbox):
-    from nltk.sem import chat80
-
-    target = sandbox / "evil_city.db"
-    with pytest.raises(PermissionError):
-        chat80.cities2table("cities.pl", "city", str(target))
-    assert not target.exists()
-
-
-def test_chat80_label_indivs_refuses_outside_cwd(sandbox):
-    from nltk.sem import chat80
-    from nltk.sem.evaluate import Valuation
-
-    # label_indivs writes the fixed name "chat_pnames.cfg" relative to CWD; make
-    # CWD the outside dir so the write would land outside the sandbox.
-    os.chdir(sandbox)
-    with pytest.raises(PermissionError):
-        chat80.label_indivs(Valuation([]), lexicon=True)
-    assert not (sandbox / "chat_pnames.cfg").exists()
-
-
-# --------------------------------------------------------------------------- #
-# nltk.metrics.agreement (__main__ -f caller-file read)
-# --------------------------------------------------------------------------- #
 def test_agreement_main_file_read_refuses_outside(sandbox):
     target = sandbox / "evil_annotations.txt"
     target.write_text("a 1 x\n")  # content is irrelevant; read must be refused

--- a/nltk/test/unit/test_chat80_pathsec.py
+++ b/nltk/test/unit/test_chat80_pathsec.py
@@ -12,49 +12,12 @@ data sandbox and must leave nothing behind.
 """
 
 import os
-import pathlib
-import shutil
-import tempfile
 
 import pytest
 
-import nltk.data
 import nltk.pathsec as pathsec
 
-
-@pytest.fixture
-def sandbox():
-    """Enforce pathsec with a single throwaway data root and yield an *outside*
-    target directory the sandbox must refuse.
-
-    The outside directory is a fresh dir under the real home directory; NOT a
-    temp dir, because on macOS the private per-user system temp dir *is* an
-    allowed root (``pathsec._get_allowed_roots``), which would make a temp-dir
-    "attack" spuriously succeed.
-    """
-    saved_enforce = pathsec.ENFORCE
-    saved_paths = list(nltk.data.path)
-    saved_cwd = os.getcwd()
-
-    data_root = tempfile.mkdtemp(prefix="nltk_sweep_sandbox_")
-    outside = pathlib.Path.home() / f".nltk_sweep_chat80_{os.getpid()}"
-    outside.mkdir(parents=True, exist_ok=True)
-
-    pathsec.ENFORCE = True
-    nltk.data.path[:] = [data_root]
-    pathsec._ALLOWED_ROOTS_CACHE = None
-    pathsec._LAST_DATA_PATHS = None
-
-    try:
-        yield outside
-    finally:
-        pathsec.ENFORCE = saved_enforce
-        nltk.data.path[:] = saved_paths
-        pathsec._ALLOWED_ROOTS_CACHE = None
-        pathsec._LAST_DATA_PATHS = None
-        os.chdir(saved_cwd)
-        shutil.rmtree(outside, ignore_errors=True)
-        shutil.rmtree(data_root, ignore_errors=True)
+# The ``sandbox`` fixture is provided by nltk/test/unit/conftest.py.
 
 
 def test_negative_control_open_outside_raises(sandbox):

--- a/nltk/test/unit/test_chat80_pathsec.py
+++ b/nltk/test/unit/test_chat80_pathsec.py
@@ -1,0 +1,105 @@
+# Natural Language Toolkit: pathsec sweep attack tests (chat80)
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""Path-traversal attack tests for the caller-controlled file sinks hardened in
+``nltk.sem.chat80`` (GHSA-8mgp-746c-j5xp).
+
+Each patched API must refuse to read from / write to a path outside the NLTK
+data sandbox and must leave nothing behind.
+"""
+
+import os
+import pathlib
+import shutil
+import tempfile
+
+import pytest
+
+import nltk.data
+import nltk.pathsec as pathsec
+
+
+@pytest.fixture
+def sandbox():
+    """Enforce pathsec with a single throwaway data root and yield an *outside*
+    target directory the sandbox must refuse.
+
+    The outside directory is a fresh dir under the real home directory; NOT a
+    temp dir, because on macOS the private per-user system temp dir *is* an
+    allowed root (``pathsec._get_allowed_roots``), which would make a temp-dir
+    "attack" spuriously succeed.
+    """
+    saved_enforce = pathsec.ENFORCE
+    saved_paths = list(nltk.data.path)
+    saved_cwd = os.getcwd()
+
+    data_root = tempfile.mkdtemp(prefix="nltk_sweep_sandbox_")
+    outside = pathlib.Path.home() / f".nltk_sweep_chat80_{os.getpid()}"
+    outside.mkdir(parents=True, exist_ok=True)
+
+    pathsec.ENFORCE = True
+    nltk.data.path[:] = [data_root]
+    pathsec._ALLOWED_ROOTS_CACHE = None
+    pathsec._LAST_DATA_PATHS = None
+
+    try:
+        yield outside
+    finally:
+        pathsec.ENFORCE = saved_enforce
+        nltk.data.path[:] = saved_paths
+        pathsec._ALLOWED_ROOTS_CACHE = None
+        pathsec._LAST_DATA_PATHS = None
+        os.chdir(saved_cwd)
+        shutil.rmtree(outside, ignore_errors=True)
+        shutil.rmtree(data_root, ignore_errors=True)
+
+
+def test_negative_control_open_outside_raises(sandbox):
+    """The sandbox is wired correctly: a plain pathsec.open() of the outside
+    target must be refused and write nothing."""
+    target = sandbox / "neg_control.txt"
+    with pytest.raises(PermissionError):
+        pathsec.open(str(target), "w")
+    assert not target.exists()
+
+
+def test_chat80_val_dump_refuses_outside(sandbox):
+    from nltk.sem import chat80
+
+    target = sandbox / "evil_valuation"
+    with pytest.raises(PermissionError):
+        chat80.val_dump([], str(target))
+    # shelve may append backend suffixes (.db/.dir/.dat/.bak); none may appear.
+    assert not list(sandbox.glob("evil_valuation*"))
+
+
+def test_chat80_val_load_refuses_outside(sandbox):
+    from nltk.sem import chat80
+
+    target = sandbox / "evil_db"
+    with pytest.raises(PermissionError):
+        chat80.val_load(str(target))
+
+
+def test_chat80_cities2table_refuses_outside(sandbox):
+    from nltk.sem import chat80
+
+    target = sandbox / "evil_city.db"
+    with pytest.raises(PermissionError):
+        chat80.cities2table("cities.pl", "city", str(target))
+    assert not target.exists()
+
+
+def test_chat80_label_indivs_refuses_outside_cwd(sandbox):
+    from nltk.sem import chat80
+    from nltk.sem.evaluate import Valuation
+
+    # label_indivs writes the fixed name "chat_pnames.cfg" relative to CWD; make
+    # CWD the outside dir so the write would land outside the sandbox.
+    os.chdir(sandbox)
+    with pytest.raises(PermissionError):
+        chat80.label_indivs(Valuation([]), lexicon=True)
+    assert not (sandbox / "chat_pnames.cfg").exists()

--- a/nltk/test/unit/test_corpus_reader_pathsec.py
+++ b/nltk/test/unit/test_corpus_reader_pathsec.py
@@ -518,3 +518,107 @@ def test_validate_path_not_root_join_is_the_containment_guard(corpus_root):
     with pytest.raises((PermissionError, ValueError)):
         reader.abspath("evil.txt")
     reader.abspath("legit.txt")
+
+
+# ---------------------------------------------------------------------------
+# Functional smoke tests. _guard_fileid runs for EVERY reader (abspath /
+# abspaths back words / sents / raw / tagged_words / ...), for filesystem and
+# zip-backed roots, so these confirm it does not break legitimate corpus reads;
+# it only refuses out-of-root escapes (covered by the tests above).
+# ---------------------------------------------------------------------------
+
+_CORPUS_TEXT_A = "The dog runs. A cat sleeps.\n"
+_CORPUS_TEXT_B = "Birds fly high.\n"
+
+
+def _fs_plaintext_corpus():
+    root = tempfile.mkdtemp(prefix="fscorp_")
+    with open(os.path.join(root, "a.txt"), "w") as fh:
+        fh.write(_CORPUS_TEXT_A)
+    with open(os.path.join(root, "b.txt"), "w") as fh:
+        fh.write(_CORPUS_TEXT_B)
+    return root
+
+
+def test_guard_fileid_plaintext_fs_reads():
+    """A filesystem PlaintextCorpusReader still returns words/sents/raw/abspaths
+    through the guarded abspath path."""
+    import shutil
+
+    from nltk.corpus.reader import PlaintextCorpusReader
+
+    root = _fs_plaintext_corpus()
+    try:
+        r = PlaintextCorpusReader(root, r".*\.txt")
+        assert r.fileids() == ["a.txt", "b.txt"]
+        assert list(r.words())[:4] == ["The", "dog", "runs", "."]
+        assert r.sents()[0] == ["The", "dog", "runs", "."]
+        assert r.raw("a.txt").startswith("The dog")
+        assert len(r.abspaths()) == 2
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def test_guard_fileid_zip_backed_reads():
+    """A ZIP-backed reader (root is a ZipFilePathPointer) still reads through the
+    guard: it must not reject or choke on zip member paths, which have no
+    filesystem realpath. Most distributed NLTK corpora load this way."""
+    import shutil
+    import zipfile
+
+    from nltk.corpus.reader import PlaintextCorpusReader
+    from nltk.data import ZipFilePathPointer
+
+    zd = tempfile.mkdtemp(prefix="zipcorp_")
+    try:
+        zpath = os.path.join(zd, "mini.zip")
+        with zipfile.ZipFile(zpath, "w") as zf:
+            zf.writestr("mini/a.txt", _CORPUS_TEXT_A)
+            zf.writestr("mini/b.txt", _CORPUS_TEXT_B)
+        r = PlaintextCorpusReader(ZipFilePathPointer(zpath, "mini/"), r".*\.txt")
+        assert r.fileids() == ["a.txt", "b.txt"]
+        assert list(r.words())[:4] == ["The", "dog", "runs", "."]
+        assert r.sents()[0] == ["The", "dog", "runs", "."]
+        assert r.raw("a.txt").startswith("The dog")
+        assert len(r.abspaths()) == 2
+    finally:
+        shutil.rmtree(zd, ignore_errors=True)
+
+
+def test_guard_fileid_reads_still_work_under_enforce(monkeypatch):
+    """With pathsec.ENFORCE on and the corpus root allowlisted, in-root reads
+    still succeed; the guard allows in-root files and only refuses escapes."""
+    import shutil
+
+    from nltk.corpus.reader import PlaintextCorpusReader
+
+    root = _fs_plaintext_corpus()
+    try:
+        monkeypatch.setattr(pathsec, "ENFORCE", True)
+        monkeypatch.setattr(nltk_data, "path", [root, *nltk_data.path])
+        monkeypatch.setattr(pathsec, "_ALLOWED_ROOTS_CACHE", None, raising=False)
+        monkeypatch.setattr(pathsec, "_LAST_DATA_PATHS", None, raising=False)
+        r = PlaintextCorpusReader(root, r".*\.txt")
+        assert list(r.words())[:4] == ["The", "dog", "runs", "."]
+        assert r.raw("a.txt").startswith("The dog")
+        assert len(r.abspaths()) == 2
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def test_guard_fileid_tagged_corpus_reads():
+    """A different reader type (TaggedCorpusReader) also reads through the guard,
+    confirming the base-class guard does not break reader-specific parsing."""
+    import shutil
+
+    from nltk.corpus.reader import TaggedCorpusReader
+
+    root = tempfile.mkdtemp(prefix="tagcorp_")
+    try:
+        with open(os.path.join(root, "t.pos"), "w") as fh:
+            fh.write("The/AT dog/NN runs/VBZ ./.\n")
+        r = TaggedCorpusReader(root, r".*\.pos")
+        assert list(r.words())[:2] == ["The", "dog"]
+        assert r.tagged_words()[:2] == [("The", "AT"), ("dog", "NN")]
+    finally:
+        shutil.rmtree(root, ignore_errors=True)

--- a/nltk/test/unit/test_corpus_reader_pathsec.py
+++ b/nltk/test/unit/test_corpus_reader_pathsec.py
@@ -461,3 +461,60 @@ def test_no_corpus_reader_leaks_out_of_sandbox(monkeypatch, tmp_path):
     # sanity: the sweep must actually have discovered and driven the readers,
     # otherwise a silent import/enumeration failure would make it pass vacuously.
     assert len(classes) > 40, f"only {len(classes)} readers discovered"
+
+
+def test_view_methods_block_intermediate_dir_symlink_escape(corpus_root):
+    """View methods (words/sents/abspaths) open the pointers from ``abspaths()``
+    directly, bypassing ``open()``. An intermediate-directory symlink inside the
+    corpus root that resolves to an out-of-root file (still inside the global data
+    sandbox) must be refused on that channel too, exactly as ``open()`` refuses it
+    (CWE-59)."""
+    from nltk.corpus.reader.api import CorpusReader
+    from nltk.corpus.reader.plaintext import PlaintextCorpusReader
+
+    root = corpus_root["root"]
+    secret = os.path.realpath(corpus_root["link"])  # an out-of-root file
+    outside_dir = os.path.dirname(secret)
+    # an intermediate-DIRECTORY symlink inside the corpus root -> the outside dir
+    os.symlink(outside_dir, os.path.join(root, "subdir"))
+
+    reader = PlaintextCorpusReader(root, ["legit.txt"])
+    escaping = "subdir/" + os.path.basename(secret)
+
+    # control: open() already refuses the scoped escape
+    with pytest.raises((PermissionError, ValueError)):
+        CorpusReader.open(reader, escaping)
+    # the view-method channel must refuse it identically
+    for label, call in [
+        ("abspath", lambda: reader.abspath(escaping)),
+        ("abspaths", lambda: reader.abspaths([escaping])),
+        ("words", lambda: list(reader.words(fileids=[escaping]))),
+        ("raw", lambda: reader.raw([escaping])),
+    ]:
+        with pytest.raises((PermissionError, ValueError)):
+            call()
+
+    # a genuine in-root file still works through the same channel
+    assert reader.abspaths(["legit.txt"])
+    assert list(reader.words(fileids=["legit.txt"])) == ["in", "-", "root"]
+
+
+def test_validate_path_not_root_join_is_the_containment_guard(corpus_root):
+    """validate_path, not self._root.join, is the load-bearing guard. join on the
+    in-root symlink fileid returns a pointer (it only rejects a '..' traversal),
+    yet abspath, which adds validate_path, refuses that same fileid while still
+    resolving a genuine in-root file (CWE-59). This is the same claim a
+    monkeypatch mutation would make, proven directly without neutering anything."""
+    from nltk.corpus.reader.api import CorpusReader
+
+    reader = CorpusReader(corpus_root["root"], ["legit.txt"])
+
+    # self._root.join alone does NOT contain the escape: it yields a pointer to
+    # the in-root symlink, because join only rejects a '..' traversal.
+    assert reader._root.join("evil.txt") is not None
+
+    # abspath adds validate_path, which resolves the symlink and refuses it,
+    # while a genuine in-root file still resolves.
+    with pytest.raises((PermissionError, ValueError)):
+        reader.abspath("evil.txt")
+    reader.abspath("legit.txt")

--- a/nltk/test/unit/test_corpus_reader_pathsec.py
+++ b/nltk/test/unit/test_corpus_reader_pathsec.py
@@ -531,21 +531,10 @@ _CORPUS_TEXT_A = "The dog runs. A cat sleeps.\n"
 _CORPUS_TEXT_B = "Birds fly high.\n"
 
 
-@pytest.fixture
-def enforce_off(monkeypatch):
-    """Isolate a functional read test from ambient / leaked pathsec.ENFORCE state.
-
-    With ENFORCE off, CorpusReader.__init__ skips the global-root check, so a
-    temp-dir corpus that is not an allowlisted data root still constructs (on a
-    full test run an earlier test may leave ENFORCE on, and on Linux the temp
-    dir lives under world-writable /tmp, which is not an allowed root). The
-    _guard_fileid required_root containment check still runs on every fileid, so
-    the guard itself is exercised; the ENFORCE-on path is covered separately by
-    test_guard_fileid_reads_still_work_under_enforce.
-    """
-    monkeypatch.setattr(pathsec, "ENFORCE", False)
-    monkeypatch.setattr(pathsec, "_ALLOWED_ROOTS_CACHE", None, raising=False)
-    monkeypatch.setattr(pathsec, "_LAST_DATA_PATHS", None, raising=False)
+# The ``enforce_off`` fixture is provided by nltk/test/unit/conftest.py; it forces
+# pathsec.ENFORCE off so a temp-dir corpus (not an allowlisted data root, and on
+# Linux under world-writable /tmp) still constructs, while _guard_fileid's
+# required_root containment check still runs on every fileid.
 
 
 def _fs_plaintext_corpus():

--- a/nltk/test/unit/test_corpus_reader_pathsec.py
+++ b/nltk/test/unit/test_corpus_reader_pathsec.py
@@ -531,6 +531,23 @@ _CORPUS_TEXT_A = "The dog runs. A cat sleeps.\n"
 _CORPUS_TEXT_B = "Birds fly high.\n"
 
 
+@pytest.fixture
+def enforce_off(monkeypatch):
+    """Isolate a functional read test from ambient / leaked pathsec.ENFORCE state.
+
+    With ENFORCE off, CorpusReader.__init__ skips the global-root check, so a
+    temp-dir corpus that is not an allowlisted data root still constructs (on a
+    full test run an earlier test may leave ENFORCE on, and on Linux the temp
+    dir lives under world-writable /tmp, which is not an allowed root). The
+    _guard_fileid required_root containment check still runs on every fileid, so
+    the guard itself is exercised; the ENFORCE-on path is covered separately by
+    test_guard_fileid_reads_still_work_under_enforce.
+    """
+    monkeypatch.setattr(pathsec, "ENFORCE", False)
+    monkeypatch.setattr(pathsec, "_ALLOWED_ROOTS_CACHE", None, raising=False)
+    monkeypatch.setattr(pathsec, "_LAST_DATA_PATHS", None, raising=False)
+
+
 def _fs_plaintext_corpus():
     root = tempfile.mkdtemp(prefix="fscorp_")
     with open(os.path.join(root, "a.txt"), "w") as fh:
@@ -540,7 +557,7 @@ def _fs_plaintext_corpus():
     return root
 
 
-def test_guard_fileid_plaintext_fs_reads():
+def test_guard_fileid_plaintext_fs_reads(enforce_off):
     """A filesystem PlaintextCorpusReader still returns words/sents/raw/abspaths
     through the guarded abspath path."""
     import shutil
@@ -559,7 +576,7 @@ def test_guard_fileid_plaintext_fs_reads():
         shutil.rmtree(root, ignore_errors=True)
 
 
-def test_guard_fileid_zip_backed_reads():
+def test_guard_fileid_zip_backed_reads(enforce_off):
     """A ZIP-backed reader (root is a ZipFilePathPointer) still reads through the
     guard: it must not reject or choke on zip member paths, which have no
     filesystem realpath. Most distributed NLTK corpora load this way."""
@@ -606,7 +623,7 @@ def test_guard_fileid_reads_still_work_under_enforce(monkeypatch):
         shutil.rmtree(root, ignore_errors=True)
 
 
-def test_guard_fileid_tagged_corpus_reads():
+def test_guard_fileid_tagged_corpus_reads(enforce_off):
     """A different reader type (TaggedCorpusReader) also reads through the guard,
     confirming the base-class guard does not break reader-specific parsing."""
     import shutil


### PR DESCRIPTION
Split out of #3753 so the corpus-reader / metrics / semantics file-I/O
containment can be reviewed on its own. Depends only on `nltk.pathsec`, already
on `develop`.

### `nltk/corpus/reader/api.py` (CWE-59)
Corpus-view methods (`words` / `sents` / `parsed_sents` / ...) open the pointers
returned by `abspaths()` directly, bypassing `open()`. `abspath()` / `abspaths()`
now resolve every corpus-relative fileid through a shared `_guard_fileid`, which
runs `validate_path` so an intermediate-directory symlink inside a trusted corpus
root that escapes it is refused — the same containment `open()` already had. The
guard lives in the base class, so every reader (MTE / XML / PanLex / Lin / ...)
inherits it. `validate_path` is imported at module top (pathsec is pure stdlib,
so there is no import cycle).

### `nltk/metrics/agreement.py`
The `__main__` `-f` caller-file read goes through `pathsec.open`.

### `nltk/sem/chat80.py`
`cities2table` (sqlite3), `val_dump` / `val_load` (shelve) validate the
caller-supplied db path before touching the filesystem, and `label_indivs`
writes `chat_pnames.cfg` through `pathsec.open`.

### Tests
- `test_corpus_reader_pathsec.py` — base-class root/symlink containment across
  readers, plus a direct check that `self._root.join` alone does not contain the
  escape while `abspath` (which adds `validate_path`) refuses it.
- `test_chat80_pathsec.py` — each chat80 sink (cities2table / val_dump /
  val_load / label_indivs) refuses an outside path and leaves nothing behind.
- `test_agreement_pathsec.py` — the agreement `__main__` `-f` read refuses an
  outside path, with a negative control.
