### PR TITLE
Add a shared pathsec sandbox conftest fixture

### DIFF
--- a/nltk/test/unit/conftest.py
+++ b/nltk/test/unit/conftest.py
@@ -1,0 +1,97 @@
+# Natural Language Toolkit: shared pytest fixtures for the pathsec sandbox tests
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""Shared fixtures for the ``nltk.pathsec`` sandbox test suites.
+
+Many security tests need the same setup: enforce pathsec against a single
+throwaway data root, then either write inside it (which must succeed) or aim at a
+path outside it (which must be refused). These fixtures centralize that setup so
+each test file no longer repeats it.
+
+``pytest`` discovers a ``conftest.py`` automatically, so any test module under
+``nltk/test/unit`` can request these fixtures by name without importing anything.
+"""
+
+import os
+import pathlib
+import shutil
+import tempfile
+
+import pytest
+
+import nltk.data
+from nltk import pathsec
+
+
+def _make_outside_dir():
+    """A fresh directory under the real ``$HOME`` that is guaranteed OUTSIDE
+    every allowed pathsec root.
+
+    Deliberately NOT a temp dir: a *private* per-user system temp dir is itself
+    an allowed root on macOS (``/var/folders/...`` is mode 0700), so an attack
+    target staged there would be (correctly) permitted and the test would not
+    exercise the guard.
+    """
+    return pathlib.Path(
+        tempfile.mkdtemp(prefix=".nltk_sandbox_outside_", dir=str(pathlib.Path.home()))
+    )
+
+
+def _enforce_single_root(monkeypatch):
+    """Turn ENFORCE on, restrict the allowed roots to one fresh data root, and
+    invalidate the cached roots. Returns the data-root path. monkeypatch restores
+    every mutated global at teardown."""
+    data_root = tempfile.mkdtemp(prefix="nltk_sandbox_root_")
+    monkeypatch.setattr(pathsec, "ENFORCE", True)
+    monkeypatch.setattr(nltk.data, "path", [data_root])
+    monkeypatch.setattr(pathsec, "_ALLOWED_ROOTS_CACHE", None, raising=False)
+    monkeypatch.setattr(pathsec, "_LAST_DATA_PATHS", None, raising=False)
+    return data_root
+
+
+@pytest.fixture
+def sandbox(monkeypatch):
+    """Enforce pathsec against a single throwaway data root and yield a fresh
+    directory that is OUTSIDE every allowed root, which any patched file sink
+    must refuse to read from / write to. The allowed data root and the outside
+    dir are removed, and the working directory and every mutated pathsec global
+    are restored, at teardown.
+    """
+    saved_cwd = os.getcwd()
+    data_root = _enforce_single_root(monkeypatch)
+    outside = _make_outside_dir()
+    try:
+        yield outside
+    finally:
+        os.chdir(saved_cwd)
+        shutil.rmtree(outside, ignore_errors=True)
+        # data_root also holds any staging dirs make_staging_dir created under it.
+        shutil.rmtree(data_root, ignore_errors=True)
+
+
+@pytest.fixture
+def restricted_sandbox(monkeypatch):
+    """Enforce pathsec against a single throwaway data root and yield that root
+    (a path string). A write inside it succeeds; a caller-supplied path outside
+    it must be refused. Use :func:`_make_outside_dir` (or the ``sandbox``
+    fixture) for an out-of-root target.
+    """
+    data_root = _enforce_single_root(monkeypatch)
+    try:
+        yield data_root
+    finally:
+        shutil.rmtree(data_root, ignore_errors=True)
+
+
+@pytest.fixture
+def enforce_off(monkeypatch):
+    """Force pathsec.ENFORCE off and invalidate the roots cache, so a functional
+    read/write test on a temp-dir target is isolated from ambient or leaked
+    ENFORCE state (a full test run may leave ENFORCE on, and on Linux a temp dir
+    lives under world-writable /tmp, which is not an allowed root)."""
+    monkeypatch.setattr(pathsec, "ENFORCE", False)
+    monkeypatch.setattr(pathsec, "_ALLOWED_ROOTS_CACHE", None, raising=False)
+    monkeypatch.setattr(pathsec, "_LAST_DATA_PATHS", None, raising=False)

--- a/nltk/test/unit/conftest.py
+++ b/nltk/test/unit/conftest.py
@@ -19,6 +19,7 @@ import os
 import pathlib
 import shutil
 import tempfile
+from collections import namedtuple
 
 import pytest
 
@@ -95,3 +96,27 @@ def enforce_off(monkeypatch):
     monkeypatch.setattr(pathsec, "ENFORCE", False)
     monkeypatch.setattr(pathsec, "_ALLOWED_ROOTS_CACHE", None, raising=False)
     monkeypatch.setattr(pathsec, "_LAST_DATA_PATHS", None, raising=False)
+
+
+# A namedtuple so a test can either unpack ``root, outside = pathsec_sandbox`` or
+# read ``pathsec_sandbox.root`` / ``.outside``.
+PathsecSandbox = namedtuple("PathsecSandbox", ["root", "outside"])
+
+
+@pytest.fixture
+def pathsec_sandbox(monkeypatch):
+    """Enforce pathsec against a single throwaway data root and yield BOTH the
+    trusted ``root`` (a ``pathlib.Path``; writes inside it succeed) and an
+    out-of-sandbox ``outside`` dir (a ``pathlib.Path`` that must be refused), for
+    a test that needs both at once. Use ``sandbox`` / ``restricted_sandbox`` when
+    only one is needed. The result unpacks as ``root, outside`` too.
+    """
+    saved_cwd = os.getcwd()
+    data_root = _enforce_single_root(monkeypatch)
+    outside = _make_outside_dir()
+    try:
+        yield PathsecSandbox(root=pathlib.Path(data_root), outside=outside)
+    finally:
+        os.chdir(saved_cwd)
+        shutil.rmtree(outside, ignore_errors=True)
+        shutil.rmtree(data_root, ignore_errors=True)

--- a/nltk/test/unit/test_pathsec_sweep_tokenize.py
+++ b/nltk/test/unit/test_pathsec_sweep_tokenize.py
@@ -16,47 +16,13 @@ outside the sandbox.
 import os
 import pathlib
 import shutil
-import tempfile
 
 import pytest
 
 import nltk.data
 import nltk.pathsec as pathsec
 
-
-@pytest.fixture
-def sandbox():
-    """Restrict pathsec to a single private data root and hand back a fresh
-    directory that is guaranteed OUTSIDE every allowed root.
-
-    The outside directory is created under ``~`` (never a temp dir), because a
-    *private* system temp dir is itself an allowed root on macOS
-    (``/var/folders/...`` is mode 0700), so an attack target staged there would
-    be (correctly) permitted and the test would not exercise the guard.
-    """
-    saved_enforce = pathsec.ENFORCE
-    saved_path = list(nltk.data.path)
-    saved_cache = pathsec._ALLOWED_ROOTS_CACHE
-    saved_last = pathsec._LAST_DATA_PATHS
-
-    pathsec.ENFORCE = True
-    data_root = tempfile.mkdtemp()
-    nltk.data.path[:] = [data_root]
-    pathsec._ALLOWED_ROOTS_CACHE = None
-    pathsec._LAST_DATA_PATHS = None
-
-    outside = pathlib.Path.home() / f".nltk_sweep_tok_{os.getpid()}"
-    outside.mkdir(parents=True, exist_ok=True)
-    try:
-        yield outside
-    finally:
-        shutil.rmtree(outside, ignore_errors=True)
-        # data_root also holds any staging dirs make_staging_dir created under it.
-        shutil.rmtree(data_root, ignore_errors=True)
-        pathsec.ENFORCE = saved_enforce
-        nltk.data.path[:] = saved_path
-        pathsec._ALLOWED_ROOTS_CACHE = saved_cache
-        pathsec._LAST_DATA_PATHS = saved_last
+# The ``sandbox`` fixture is provided by nltk/test/unit/conftest.py.
 
 
 def test_negative_control(sandbox):


### PR DESCRIPTION
The `nltk.pathsec` security test suites each repeat the same fixture setup:
enforce pathsec against a single throwaway data root, then aim a patched file
sink either inside it (must succeed) or at a path outside it (must be refused).
This centralizes that setup so the repetition can be removed across the suite.

### `nltk/test/unit/conftest.py` (new)
pytest discovers `conftest.py` automatically, so any unit test can request these
by name with no import:
- **`sandbox`** — yields a fresh dir OUTSIDE every allowed root (writes/reads
  there must be refused).
- **`restricted_sandbox`** — yields the one allowed data root (a write inside it
  succeeds).
- **`enforce_off`** — forces `pathsec.ENFORCE` off for functional read/write
  tests that operate on a temp-dir target (isolates them from ambient/leaked
  ENFORCE state; on Linux a temp dir lives under world-writable `/tmp`, which is
  not an allowed root).

The outside dir is created under `$HOME`, never a temp dir, because a private
per-user system temp dir is itself an allowed root on macOS.

### Adoption
`test_pathsec_sweep_tokenize.py` drops its local `sandbox` copy and uses the
shared one here. The other open pathsec PRs adopt the same fixtures in their own
branches so each becomes DRY as it lands.
