### PR TITLE
Write parse demo/profile output to a private staging dir, not /tmp or the CWD

### DIFF
--- a/nltk/parse/dependencygraph.py
+++ b/nltk/parse/dependencygraph.py
@@ -20,6 +20,7 @@ from collections import defaultdict
 from itertools import chain
 from pprint import pformat
 
+from nltk.data import make_staging_dir
 from nltk.internals import find_binary
 from nltk.pathsec import open as _secure_open
 from nltk.tree import Tree
@@ -662,12 +663,10 @@ Nov.    NNP     9       VMOD
         networkx.draw_networkx_labels(g, pos, dg.nx_labels)
         pylab.xticks([])
         pylab.yticks([])
-        from os.path import join
-
-        from nltk.data import make_staging_dir
+        import os
 
         # A private staging dir under a data root, not "tree.png" in the CWD.
-        outfile = join(make_staging_dir(prefix="nltk_depgraph_"), "tree.png")
+        outfile = os.path.join(make_staging_dir(prefix="nltk_depgraph_"), "tree.png")
         pylab.savefig(outfile)
         print(f"saved dependency tree to {outfile}")
         pylab.show()

--- a/nltk/parse/dependencygraph.py
+++ b/nltk/parse/dependencygraph.py
@@ -14,6 +14,7 @@ The input is assumed to be in Malt-TAB format
 (https://stp.lingfil.uu.se/~nivre/research/MaltXML.html).
 """
 
+import os
 import subprocess
 import warnings
 from collections import defaultdict
@@ -663,8 +664,6 @@ Nov.    NNP     9       VMOD
         networkx.draw_networkx_labels(g, pos, dg.nx_labels)
         pylab.xticks([])
         pylab.yticks([])
-        import os
-
         # A private staging dir under a data root, not "tree.png" in the CWD.
         outfile = os.path.join(make_staging_dir(prefix="nltk_depgraph_"), "tree.png")
         pylab.savefig(outfile)

--- a/nltk/parse/dependencygraph.py
+++ b/nltk/parse/dependencygraph.py
@@ -662,7 +662,15 @@ Nov.    NNP     9       VMOD
         networkx.draw_networkx_labels(g, pos, dg.nx_labels)
         pylab.xticks([])
         pylab.yticks([])
-        pylab.savefig("tree.png")
+        from os.path import join
+
+        from nltk.data import make_staging_dir
+
+        # Write to a fresh private (0700) staging dir under an allowed data root,
+        # not a fixed "tree.png" in the CWD.
+        outfile = join(make_staging_dir(prefix="nltk_depgraph_"), "tree.png")
+        pylab.savefig(outfile)
+        print(f"saved dependency tree to {outfile}")
         pylab.show()
 
 

--- a/nltk/parse/dependencygraph.py
+++ b/nltk/parse/dependencygraph.py
@@ -666,8 +666,7 @@ Nov.    NNP     9       VMOD
 
         from nltk.data import make_staging_dir
 
-        # Write to a fresh private (0700) staging dir under an allowed data root,
-        # not a fixed "tree.png" in the CWD.
+        # A private staging dir under a data root, not "tree.png" in the CWD.
         outfile = join(make_staging_dir(prefix="nltk_depgraph_"), "tree.png")
         pylab.savefig(outfile)
         print(f"saved dependency tree to {outfile}")

--- a/nltk/parse/featurechart.py
+++ b/nltk/parse/featurechart.py
@@ -12,6 +12,7 @@ feature structures as nodes.
 """
 from time import perf_counter
 
+from nltk.data import make_staging_dir
 from nltk.featstruct import TYPE, FeatStruct, find_variables, unify
 from nltk.grammar import (
     CFG,
@@ -650,14 +651,12 @@ def demo(
 
 
 def run_profile():
+    import os
     import profile
     import pstats
-    from os.path import join
-
-    from nltk.data import make_staging_dir
 
     # A private staging dir under a data root, not a guessable /tmp path.
-    stats_file = join(make_staging_dir(prefix="nltk_profile_"), "profile.out")
+    stats_file = os.path.join(make_staging_dir(prefix="nltk_profile_"), "profile.out")
     profile.run("for i in range(1): demo()", stats_file)
     p = pstats.Stats(stats_file)
     p.strip_dirs().sort_stats("time", "cum").print_stats(60)

--- a/nltk/parse/featurechart.py
+++ b/nltk/parse/featurechart.py
@@ -656,9 +656,7 @@ def run_profile():
 
     from nltk.data import make_staging_dir
 
-    # A fresh private (0700) staging dir under an allowed data root (the same
-    # helper NLTK's save code uses), not a hardcoded, guessable /tmp path another
-    # local user could pre-create or symlink (CWE-377/378).
+    # A private staging dir under a data root, not a guessable /tmp path.
     stats_file = join(make_staging_dir(prefix="nltk_profile_"), "profile.out")
     profile.run("for i in range(1): demo()", stats_file)
     p = pstats.Stats(stats_file)

--- a/nltk/parse/featurechart.py
+++ b/nltk/parse/featurechart.py
@@ -10,6 +10,7 @@
 Extension of chart parsing implementation to handle grammars with
 feature structures as nodes.
 """
+import os
 from time import perf_counter
 
 from nltk.data import make_staging_dir
@@ -651,7 +652,6 @@ def demo(
 
 
 def run_profile():
-    import os
     import profile
     import pstats
 

--- a/nltk/parse/featurechart.py
+++ b/nltk/parse/featurechart.py
@@ -651,11 +651,17 @@ def demo(
 
 def run_profile():
     import profile
-
-    profile.run("for i in range(1): demo()", "/tmp/profile.out")
     import pstats
+    from os.path import join
 
-    p = pstats.Stats("/tmp/profile.out")
+    from nltk.data import make_staging_dir
+
+    # A fresh private (0700) staging dir under an allowed data root (the same
+    # helper NLTK's save code uses), not a hardcoded, guessable /tmp path another
+    # local user could pre-create or symlink (CWE-377/378).
+    stats_file = join(make_staging_dir(prefix="nltk_profile_"), "profile.out")
+    profile.run("for i in range(1): demo()", stats_file)
+    p = pstats.Stats(stats_file)
     p.strip_dirs().sort_stats("time", "cum").print_stats(60)
     p.strip_dirs().sort_stats("cum", "time").print_stats(60)
 


### PR DESCRIPTION
Split out of #3753 — the two `nltk.parse` demo/profile sinks that wrote to a
hardcoded path. Depends only on `nltk.data.make_staging_dir`, already on
`develop`.

### Problem
- `featurechart.run_profile()` wrote its profile stats to a hardcoded
  `/tmp/profile.out` — a guessable path another local user could pre-create or
  symlink (CWE-377/378).
- `dependencygraph`'s demo saved `tree.png` into the current working directory.

### Fix
Both now write into a fresh private (mode 0700), unpredictably-named staging
directory created under an allowed NLTK data root via
`nltk.data.make_staging_dir` — the same helper the maxent / named-entity / weka
save code uses, which lands inside the pathsec sandbox on every platform
(including Linux, where the shared `/tmp` is deliberately not a data root). The
dependency-graph demo also prints where it saved the image.

No tests: these are `__main__`/dev-only demo and profiling helpers.
