### PR TITLE
Prevent infinite loop from cyclic collection indices

### DIFF
--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -178,6 +178,7 @@ from nltk.data import _check_decompression_bomb
 from nltk.pathsec import ZipFile
 from nltk.pathsec import open as pathsec_open
 from nltk.pathsec import urlopen, validate_path
+from nltk.util import acyclic_breadth_first
 from nltk.xmlsec import parse as safe_parse
 
 # urllib2 = nltk.internals.import_from_stdlib('urllib2')
@@ -1251,9 +1252,10 @@ class Downloader:
     # /////////////////////////////////////////////////////////////////
 
     def _update_index(self, url=None):
-        """A helper function that ensures that self._index is
-        up-to-date.  If the index is older than self.INDEX_TIMEOUT,
-        then download it again."""
+        """
+        A helper function that ensures that self._index is up-to-date.
+        If the index is older than self.INDEX_TIMEOUT, then download it again.
+        """
         # Check if the index is already up-to-date.  If so, do nothing.
         if not (
             self._index is None
@@ -1297,16 +1299,19 @@ class Downloader:
                     del collection.children[i]
 
         # Fill in collection.packages for each collection.
+        # Use acyclic_breadth_first to safely traverse the collection graph,
+        # avoiding infinite loops from self-referential or mutually-referential cycles.
         for collection in self._collections.values():
             packages = {}
-            queue = [collection]
-            for child in queue:
-                if isinstance(child, Collection):
-                    queue.extend(child.children)
-                elif isinstance(child, Package):
+            for child in acyclic_breadth_first(
+                collection,
+                children=lambda node: (
+                    node.children if isinstance(node, Collection) else ()
+                ),
+                verbose=False,
+            ):
+                if isinstance(child, Package):
                     packages[child.id] = child
-                else:
-                    pass
             collection.packages = packages.values()
 
         # Flush the status cache

--- a/nltk/test/unit/security_probes/ghsa_pcm8_fqjx_rvx8.py
+++ b/nltk/test/unit/security_probes/ghsa_pcm8_fqjx_rvx8.py
@@ -6,6 +6,8 @@ import sys
 import tempfile
 from pathlib import Path
 
+import nltk
+
 from ._base import FIXED, VULNERABLE, probe
 
 
@@ -31,21 +33,30 @@ def _cyclic_collection_index():
 
     try:
         uri = Path(path).as_uri()
-        script = f"""
-import sys
-import nltk
-from nltk.downloader import Downloader
-nltk.pathsec.ENFORCE = False
-dl = Downloader(server_index_url={repr(uri)})
-packages = dl.packages()
-print(','.join(p.id for p in packages))
-"""
+        script_lines = [
+            "import sys",
+            "import nltk",
+            "from nltk.downloader import Downloader",
+            "nltk.pathsec.ENFORCE = False",
+            f"dl = Downloader(server_index_url={repr(uri)})",
+            "packages = dl.packages()",
+            "print(','.join(p.id for p in packages))",
+        ]
+        script = "\n".join(script_lines)
+
+        env = os.environ.copy()
+        # Derive import root from nltk.__file__
+        nltk_root = os.path.dirname(os.path.dirname(os.path.dirname(nltk.__file__)))
+        env["PYTHONPATH"] = nltk_root + os.pathsep + env.get("PYTHONPATH", "")
+
         result = subprocess.run(
             [sys.executable, "-c", script],
             capture_output=True,
             text=True,
             timeout=10,
+            env=env,
         )
+
         if result.returncode != 0:
             return VULNERABLE, f"Subprocess failed: {result.stderr.strip()}"
         output = result.stdout.strip()

--- a/nltk/test/unit/security_probes/ghsa_pcm8_fqjx_rvx8.py
+++ b/nltk/test/unit/security_probes/ghsa_pcm8_fqjx_rvx8.py
@@ -1,0 +1,75 @@
+"""GHSA-pcm8-fqjx-rvx8 [moderate] -- Cyclic collection index causes infinite loop in nltk.downloader"""
+
+import os
+import tempfile
+import threading
+import time
+
+from nltk.downloader import Downloader
+
+from ._base import FIXED, VULNERABLE, probe
+
+
+@probe("GHSA-pcm8-fqjx-rvx8")
+def _cyclic_collection_index():
+    # Create a self-referential index
+    xml = """<?xml version="1.0"?>
+<index>
+  <packages>
+    <package id="p1" name="Sample" subdir="corpora/p1"
+             url="http://example.invalid/p1.zip" unzip="0" size="0" unzipped_size="0"/>
+  </packages>
+  <collections>
+    <collection id="a" name="Cyclic">
+      <item ref="a"/>
+      <item ref="p1"/>
+    </collection>
+  </collections>
+</index>"""
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False) as f:
+        f.write(xml)
+        path = f.name
+
+    try:
+        # Disable pathsec for file:// access in the probe
+        import nltk
+
+        original_enforce = nltk.pathsec.ENFORCE
+        nltk.pathsec.ENFORCE = False
+
+        dl = Downloader(server_index_url="file://" + path)
+
+        # Run packages() with a timeout to detect hangs
+        result = []
+        exception = []
+        done = threading.Event()
+
+        def target():
+            try:
+                result.append(dl.packages())
+            except Exception as e:
+                exception.append(e)
+            finally:
+                done.set()
+
+        t = threading.Thread(target=target)
+        t.daemon = True
+        t.start()
+        completed = done.wait(timeout=10)
+
+        nltk.pathsec.ENFORCE = original_enforce
+
+        if not completed:
+            return VULNERABLE, "Downloader.packages() hung (infinite loop)"
+        elif exception:
+            return VULNERABLE, f"Downloader.packages() raised: {exception[0]}"
+        else:
+            # Verify we got the expected package
+            packages = result[0] if result else []
+            if any(p.id == "p1" for p in packages):
+                return FIXED, "Cyclic index handled correctly, packages returned"
+            else:
+                return VULNERABLE, "Expected package 'p1' not found"
+    finally:
+        os.unlink(path)

--- a/nltk/test/unit/security_probes/ghsa_pcm8_fqjx_rvx8.py
+++ b/nltk/test/unit/security_probes/ghsa_pcm8_fqjx_rvx8.py
@@ -3,8 +3,9 @@
 import os
 import tempfile
 import threading
-import time
+from pathlib import Path
 
+import nltk
 from nltk.downloader import Downloader
 
 from ._base import FIXED, VULNERABLE, probe
@@ -33,12 +34,12 @@ def _cyclic_collection_index():
 
     try:
         # Disable pathsec for file:// access in the probe
-        import nltk
-
         original_enforce = nltk.pathsec.ENFORCE
         nltk.pathsec.ENFORCE = False
 
-        dl = Downloader(server_index_url="file://" + path)
+        # Use pathlib to get a proper file:// URI (works on Windows)
+        uri = Path(path).as_uri()
+        dl = Downloader(server_index_url=uri)
 
         # Run packages() with a timeout to detect hangs
         result = []
@@ -65,7 +66,6 @@ def _cyclic_collection_index():
         elif exception:
             return VULNERABLE, f"Downloader.packages() raised: {exception[0]}"
         else:
-            # Verify we got the expected package
             packages = result[0] if result else []
             if any(p.id == "p1" for p in packages):
                 return FIXED, "Cyclic index handled correctly, packages returned"

--- a/nltk/test/unit/security_probes/ghsa_pcm8_fqjx_rvx8.py
+++ b/nltk/test/unit/security_probes/ghsa_pcm8_fqjx_rvx8.py
@@ -1,19 +1,16 @@
 """GHSA-pcm8-fqjx-rvx8 [moderate] -- Cyclic collection index causes infinite loop in nltk.downloader"""
 
 import os
+import subprocess
+import sys
 import tempfile
-import threading
 from pathlib import Path
-
-import nltk
-from nltk.downloader import Downloader
 
 from ._base import FIXED, VULNERABLE, probe
 
 
 @probe("GHSA-pcm8-fqjx-rvx8")
 def _cyclic_collection_index():
-    # Create a self-referential index
     xml = """<?xml version="1.0"?>
 <index>
   <packages>
@@ -33,43 +30,30 @@ def _cyclic_collection_index():
         path = f.name
 
     try:
-        # Disable pathsec for file:// access in the probe
-        original_enforce = nltk.pathsec.ENFORCE
-        nltk.pathsec.ENFORCE = False
-
-        # Use pathlib to get a proper file:// URI (works on Windows)
         uri = Path(path).as_uri()
-        dl = Downloader(server_index_url=uri)
-
-        # Run packages() with a timeout to detect hangs
-        result = []
-        exception = []
-        done = threading.Event()
-
-        def target():
-            try:
-                result.append(dl.packages())
-            except Exception as e:
-                exception.append(e)
-            finally:
-                done.set()
-
-        t = threading.Thread(target=target)
-        t.daemon = True
-        t.start()
-        completed = done.wait(timeout=10)
-
-        nltk.pathsec.ENFORCE = original_enforce
-
-        if not completed:
-            return VULNERABLE, "Downloader.packages() hung (infinite loop)"
-        elif exception:
-            return VULNERABLE, f"Downloader.packages() raised: {exception[0]}"
+        script = f"""
+import sys
+import nltk
+from nltk.downloader import Downloader
+nltk.pathsec.ENFORCE = False
+dl = Downloader(server_index_url={repr(uri)})
+packages = dl.packages()
+print(','.join(p.id for p in packages))
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return VULNERABLE, f"Subprocess failed: {result.stderr.strip()}"
+        output = result.stdout.strip()
+        if output == "p1":
+            return FIXED, "Cyclic index handled correctly"
         else:
-            packages = result[0] if result else []
-            if any(p.id == "p1" for p in packages):
-                return FIXED, "Cyclic index handled correctly, packages returned"
-            else:
-                return VULNERABLE, "Expected package 'p1' not found"
+            return VULNERABLE, f"Expected 'p1', got '{output}'"
+    except subprocess.TimeoutExpired:
+        return VULNERABLE, "Subprocess timed out (infinite loop)"
     finally:
         os.unlink(path)

--- a/nltk/test/unit/test_advisory_coverage_ci.py
+++ b/nltk/test/unit/test_advisory_coverage_ci.py
@@ -51,7 +51,7 @@ _HEADERS = {
 #: Closed/withdrawn advisories deliberately kept as regression probes. The
 #: public API lists only published advisories, so these must be named here or
 #: the reverse check would flag them as unknown.
-_CLOSED_WITH_PROBE = {"GHSA-4489-j4f3-2g8q"}
+_CLOSED_WITH_PROBE = {"GHSA-4489-j4f3-2g8q", "GHSA-pcm8-fqjx-rvx8"}
 
 
 def _next_url(link_header):

--- a/nltk/test/unit/test_downloader_cycle.py
+++ b/nltk/test/unit/test_downloader_cycle.py
@@ -1,8 +1,8 @@
 # nltk/test/unit/test_downloader_cycle.py
 import os
+import subprocess
+import sys
 import tempfile
-import threading
-import time
 import unittest
 from pathlib import Path
 
@@ -11,42 +11,37 @@ from nltk.downloader import Downloader
 
 
 class TestDownloaderCycle(unittest.TestCase):
-    def setUp(self):
-        # Disable pathsec to avoid file:// permission issues
-        self.orig_enforce = nltk.pathsec.ENFORCE
-        nltk.pathsec.ENFORCE = False
+    """Test that Downloader._update_index handles cyclic collection references safely."""
 
-    def tearDown(self):
-        nltk.pathsec.ENFORCE = self.orig_enforce
-
-    def _run_with_timeout(self, func, timeout=2):
+    def _run_with_timeout(self, func, timeout=5):
         """
-        Run func in a thread; return (completed, result, exception).
-        If completed is False, the thread timed out.
-        If exception is not None, the thread raised that exception.
+        Run a function in a subprocess and kill it if it exceeds timeout.
+        Returns (completed, result, exception) or (False, None, None) on timeout.
         """
-        result = []
-        exc = []
+        # Simple approach: we can't easily pass a lambda to a subprocess,
+        # so we wrap the function call in a subprocess with a timeout.
+        # For this specific test, we know func is always dl.packages().
+        # We'll just run the test logic in a subprocess.
+        pass
 
-        def target():
-            try:
-                result.append(func())
-            except Exception as e:
-                exc.append(e)
+    def test_acyclic_index(self):
+        """Control: a normal index should complete normally."""
+        xml = """<?xml version="1.0"?>
+<index>
+  <packages>
+    <package id="p1" name="Sample" subdir="corpora/p1"
+             url="http://example.invalid/p1.zip" unzip="0" size="0" unzipped_size="0"/>
+  </packages>
+  <collections>
+    <collection id="a" name="Acyclic">
+      <item ref="p1"/>
+    </collection>
+  </collections>
+</index>"""
+        self._run_index_test(xml, expected_packages=["p1"], timeout=5)
 
-        t = threading.Thread(target=target)
-        t.daemon = True
-        t.start()
-        t.join(timeout)
-
-        if t.is_alive():
-            return False, None, None
-        if exc:
-            return True, None, exc[0]
-        return True, result[0] if result else None, None
-
-    def test_cyclic_index_does_not_hang(self):
-        # Create a temporary index with a self-referential collection
+    def test_self_referential_index(self):
+        """A self-referential collection should complete without hanging."""
         xml = """<?xml version="1.0"?>
 <index>
   <packages>
@@ -60,26 +55,79 @@ class TestDownloaderCycle(unittest.TestCase):
     </collection>
   </collections>
 </index>"""
+        self._run_index_test(xml, expected_packages=["p1"], timeout=5)
 
+    def test_mutual_referential_index(self):
+        """Two collections referencing each other should complete without hanging."""
+        xml = """<?xml version="1.0"?>
+<index>
+  <packages>
+    <package id="p1" name="Sample" subdir="corpora/p1"
+             url="http://example.invalid/p1.zip" unzip="0" size="0" unzipped_size="0"/>
+  </packages>
+  <collections>
+    <collection id="a" name="A">
+      <item ref="b"/>
+      <item ref="p1"/>
+    </collection>
+    <collection id="b" name="B">
+      <item ref="a"/>
+    </collection>
+  </collections>
+</index>"""
+        self._run_index_test(xml, expected_packages=["p1"], timeout=5)
+
+    def _run_index_test(self, xml, expected_packages, timeout=5):
+        """
+        Write xml to a temp file, run Downloader.packages() in a subprocess,
+        and assert it returns within timeout and collects the expected packages.
+        """
         with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False) as f:
             f.write(xml)
             path = f.name
 
         try:
-            # Use pathlib to get a proper file:// URI (works on Windows with drive letters)
             uri = Path(path).as_uri()
-            dl = Downloader(server_index_url=uri)
+            # Build a script that runs the test and prints results
+            script = f"""
+import sys
+sys.path.insert(0, {repr(os.path.dirname(__file__))})
+import nltk
+from nltk.downloader import Downloader
 
-            completed, packages, exc = self._run_with_timeout(
-                lambda: dl.packages(), timeout=5
+# Disable pathsec for file:// tests
+nltk.pathsec.ENFORCE = False
+
+dl = Downloader(server_index_url={repr(uri)})
+packages = dl.packages()
+# Print package IDs as a comma-separated list
+print(','.join(p.id for p in packages))
+"""
+            # Run the script in a subprocess with a timeout
+            result = subprocess.run(
+                [sys.executable, "-c", script],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
             )
-
-            self.assertTrue(completed, "Cyclic index caused a hang (timeout)")
-            self.assertIsNone(exc, f"Unexpected exception: {exc}")
-            self.assertIsNotNone(packages, "dl.packages() returned None")
+            # Check that it completed successfully
             self.assertEqual(
-                [p.id for p in packages], ["p1"], "Expected package p1 to be collected"
+                result.returncode,
+                0,
+                f"Subprocess failed with exit code {result.returncode}\n"
+                f"stdout: {result.stdout}\nstderr: {result.stderr}",
             )
+            # Check that the output matches expected packages
+            output_packages = (
+                result.stdout.strip().split(",") if result.stdout.strip() else []
+            )
+            self.assertEqual(
+                output_packages,
+                expected_packages,
+                f"Expected packages {expected_packages}, got {output_packages}",
+            )
+        except subprocess.TimeoutExpired:
+            self.fail(f"Index test timed out after {timeout} seconds (infinite loop?)")
         finally:
             os.unlink(path)
 

--- a/nltk/test/unit/test_downloader_cycle.py
+++ b/nltk/test/unit/test_downloader_cycle.py
@@ -7,22 +7,72 @@ import unittest
 from pathlib import Path
 
 import nltk
-from nltk.downloader import Downloader
 
 
 class TestDownloaderCycle(unittest.TestCase):
     """Test that Downloader._update_index handles cyclic collection references safely."""
 
-    def _run_with_timeout(self, func, timeout=5):
+    def _run_index_test(self, xml, expected_packages, timeout=5):
         """
-        Run a function in a subprocess and kill it if it exceeds timeout.
-        Returns (completed, result, exception) or (False, None, None) on timeout.
+        Write xml to a temp file, run Downloader.packages() in a subprocess,
+        and assert it returns within timeout and collects the expected packages.
         """
-        # Simple approach: we can't easily pass a lambda to a subprocess,
-        # so we wrap the function call in a subprocess with a timeout.
-        # For this specific test, we know func is always dl.packages().
-        # We'll just run the test logic in a subprocess.
-        pass
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False) as f:
+            f.write(xml)
+            path = f.name
+
+        try:
+            uri = Path(path).as_uri()
+
+            # Build a script that runs the test and prints results
+            script = f"""
+import sys
+import nltk
+from nltk.downloader import Downloader
+
+# Disable pathsec for file:// tests
+nltk.pathsec.ENFORCE = False
+
+dl = Downloader(server_index_url={repr(uri)})
+packages = dl.packages()
+# Print package IDs as a comma-separated list
+print(','.join(p.id for p in packages))
+"""
+            # Set PYTHONPATH so the subprocess can find nltk
+            env = os.environ.copy()
+            # Add the current working directory (root of nltk source) to PYTHONPATH
+            cwd = os.getcwd()
+            env["PYTHONPATH"] = cwd + os.pathsep + env.get("PYTHONPATH", "")
+
+            # Run the script in a subprocess with a timeout
+            result = subprocess.run(
+                [sys.executable, "-c", script],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                env=env,
+            )
+
+            self.assertEqual(
+                result.returncode,
+                0,
+                f"Subprocess failed with exit code {result.returncode}\n"
+                f"stdout: {result.stdout}\nstderr: {result.stderr}",
+            )
+
+            output_packages = (
+                result.stdout.strip().split(",") if result.stdout.strip() else []
+            )
+            self.assertEqual(
+                output_packages,
+                expected_packages,
+                f"Expected packages {expected_packages}, got {output_packages}",
+            )
+
+        except subprocess.TimeoutExpired:
+            self.fail(f"Index test timed out after {timeout} seconds (infinite loop?)")
+        finally:
+            os.unlink(path)
 
     def test_acyclic_index(self):
         """Control: a normal index should complete normally."""
@@ -76,60 +126,6 @@ class TestDownloaderCycle(unittest.TestCase):
   </collections>
 </index>"""
         self._run_index_test(xml, expected_packages=["p1"], timeout=5)
-
-    def _run_index_test(self, xml, expected_packages, timeout=5):
-        """
-        Write xml to a temp file, run Downloader.packages() in a subprocess,
-        and assert it returns within timeout and collects the expected packages.
-        """
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False) as f:
-            f.write(xml)
-            path = f.name
-
-        try:
-            uri = Path(path).as_uri()
-            # Build a script that runs the test and prints results
-            script = f"""
-import sys
-sys.path.insert(0, {repr(os.path.dirname(__file__))})
-import nltk
-from nltk.downloader import Downloader
-
-# Disable pathsec for file:// tests
-nltk.pathsec.ENFORCE = False
-
-dl = Downloader(server_index_url={repr(uri)})
-packages = dl.packages()
-# Print package IDs as a comma-separated list
-print(','.join(p.id for p in packages))
-"""
-            # Run the script in a subprocess with a timeout
-            result = subprocess.run(
-                [sys.executable, "-c", script],
-                capture_output=True,
-                text=True,
-                timeout=timeout,
-            )
-            # Check that it completed successfully
-            self.assertEqual(
-                result.returncode,
-                0,
-                f"Subprocess failed with exit code {result.returncode}\n"
-                f"stdout: {result.stdout}\nstderr: {result.stderr}",
-            )
-            # Check that the output matches expected packages
-            output_packages = (
-                result.stdout.strip().split(",") if result.stdout.strip() else []
-            )
-            self.assertEqual(
-                output_packages,
-                expected_packages,
-                f"Expected packages {expected_packages}, got {output_packages}",
-            )
-        except subprocess.TimeoutExpired:
-            self.fail(f"Index test timed out after {timeout} seconds (infinite loop?)")
-        finally:
-            os.unlink(path)
 
 
 if __name__ == "__main__":

--- a/nltk/test/unit/test_downloader_cycle.py
+++ b/nltk/test/unit/test_downloader_cycle.py
@@ -1,4 +1,3 @@
-# nltk/test/unit/test_downloader_cycle.py
 import os
 import subprocess
 import sys
@@ -10,41 +9,27 @@ import nltk
 
 
 class TestDownloaderCycle(unittest.TestCase):
-    """Test that Downloader._update_index handles cyclic collection references safely."""
-
     def _run_index_test(self, xml, expected_packages, timeout=5):
-        """
-        Write xml to a temp file, run Downloader.packages() in a subprocess,
-        and assert it returns within timeout and collects the expected packages.
-        """
         with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False) as f:
             f.write(xml)
             path = f.name
-
         try:
             uri = Path(path).as_uri()
-
-            # Build a script that runs the test and prints results
-            script = f"""
-import sys
-import nltk
-from nltk.downloader import Downloader
-
-# Disable pathsec for file:// tests
-nltk.pathsec.ENFORCE = False
-
-dl = Downloader(server_index_url={repr(uri)})
-packages = dl.packages()
-# Print package IDs as a comma-separated list
-print(','.join(p.id for p in packages))
-"""
-            # Set PYTHONPATH so the subprocess can find nltk
+            # Build script without leading indentation
+            script_lines = [
+                "import sys",
+                "import nltk",
+                "from nltk.downloader import Downloader",
+                "nltk.pathsec.ENFORCE = False",
+                f"dl = Downloader(server_index_url={repr(uri)})",
+                "packages = dl.packages()",
+                "print(','.join(p.id for p in packages))",
+            ]
+            script = "\n".join(script_lines)
             env = os.environ.copy()
-            # Add the current working directory (root of nltk source) to PYTHONPATH
-            cwd = os.getcwd()
-            env["PYTHONPATH"] = cwd + os.pathsep + env.get("PYTHONPATH", "")
-
-            # Run the script in a subprocess with a timeout
+            # Derive import root from nltk.__file__
+            nltk_root = os.path.dirname(os.path.dirname(os.path.dirname(nltk.__file__)))
+            env["PYTHONPATH"] = nltk_root + os.pathsep + env.get("PYTHONPATH", "")
             result = subprocess.run(
                 [sys.executable, "-c", script],
                 capture_output=True,
@@ -52,30 +37,17 @@ print(','.join(p.id for p in packages))
                 timeout=timeout,
                 env=env,
             )
-
             self.assertEqual(
-                result.returncode,
-                0,
-                f"Subprocess failed with exit code {result.returncode}\n"
-                f"stdout: {result.stdout}\nstderr: {result.stderr}",
+                result.returncode, 0, f"Subprocess failed: {result.stderr}"
             )
-
-            output_packages = (
-                result.stdout.strip().split(",") if result.stdout.strip() else []
-            )
-            self.assertEqual(
-                output_packages,
-                expected_packages,
-                f"Expected packages {expected_packages}, got {output_packages}",
-            )
-
+            output = result.stdout.strip().split(",") if result.stdout.strip() else []
+            self.assertEqual(output, expected_packages)
         except subprocess.TimeoutExpired:
-            self.fail(f"Index test timed out after {timeout} seconds (infinite loop?)")
+            self.fail(f"Test timed out after {timeout}s")
         finally:
             os.unlink(path)
 
     def test_acyclic_index(self):
-        """Control: a normal index should complete normally."""
         xml = """<?xml version="1.0"?>
 <index>
   <packages>
@@ -88,10 +60,9 @@ print(','.join(p.id for p in packages))
     </collection>
   </collections>
 </index>"""
-        self._run_index_test(xml, expected_packages=["p1"], timeout=5)
+        self._run_index_test(xml, ["p1"])
 
     def test_self_referential_index(self):
-        """A self-referential collection should complete without hanging."""
         xml = """<?xml version="1.0"?>
 <index>
   <packages>
@@ -105,10 +76,9 @@ print(','.join(p.id for p in packages))
     </collection>
   </collections>
 </index>"""
-        self._run_index_test(xml, expected_packages=["p1"], timeout=5)
+        self._run_index_test(xml, ["p1"])
 
     def test_mutual_referential_index(self):
-        """Two collections referencing each other should complete without hanging."""
         xml = """<?xml version="1.0"?>
 <index>
   <packages>
@@ -125,8 +95,4 @@ print(','.join(p.id for p in packages))
     </collection>
   </collections>
 </index>"""
-        self._run_index_test(xml, expected_packages=["p1"], timeout=5)
-
-
-if __name__ == "__main__":
-    unittest.main()
+        self._run_index_test(xml, ["p1"])

--- a/nltk/test/unit/test_downloader_cycle.py
+++ b/nltk/test/unit/test_downloader_cycle.py
@@ -4,6 +4,7 @@ import tempfile
 import threading
 import time
 import unittest
+from pathlib import Path
 
 import nltk
 from nltk.downloader import Downloader
@@ -19,19 +20,30 @@ class TestDownloaderCycle(unittest.TestCase):
         nltk.pathsec.ENFORCE = self.orig_enforce
 
     def _run_with_timeout(self, func, timeout=2):
-        """Run func in a thread; return True if it completes within timeout."""
+        """
+        Run func in a thread; return (completed, result, exception).
+        If completed is False, the thread timed out.
+        If exception is not None, the thread raised that exception.
+        """
         result = []
+        exc = []
 
         def target():
-            result.append(func())
+            try:
+                result.append(func())
+            except Exception as e:
+                exc.append(e)
 
         t = threading.Thread(target=target)
         t.daemon = True
         t.start()
         t.join(timeout)
+
         if t.is_alive():
-            return False, None
-        return True, result[0] if result else None
+            return False, None, None
+        if exc:
+            return True, None, exc[0]
+        return True, result[0] if result else None, None
 
     def test_cyclic_index_does_not_hang(self):
         # Create a temporary index with a self-referential collection
@@ -48,16 +60,23 @@ class TestDownloaderCycle(unittest.TestCase):
     </collection>
   </collections>
 </index>"""
+
         with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False) as f:
             f.write(xml)
             path = f.name
 
         try:
-            dl = Downloader(server_index_url="file://" + path)
-            completed, packages = self._run_with_timeout(
+            # Use pathlib to get a proper file:// URI (works on Windows with drive letters)
+            uri = Path(path).as_uri()
+            dl = Downloader(server_index_url=uri)
+
+            completed, packages, exc = self._run_with_timeout(
                 lambda: dl.packages(), timeout=5
             )
+
             self.assertTrue(completed, "Cyclic index caused a hang (timeout)")
+            self.assertIsNone(exc, f"Unexpected exception: {exc}")
+            self.assertIsNotNone(packages, "dl.packages() returned None")
             self.assertEqual(
                 [p.id for p in packages], ["p1"], "Expected package p1 to be collected"
             )

--- a/nltk/test/unit/test_downloader_cycle.py
+++ b/nltk/test/unit/test_downloader_cycle.py
@@ -1,0 +1,69 @@
+# nltk/test/unit/test_downloader_cycle.py
+import os
+import tempfile
+import threading
+import time
+import unittest
+
+import nltk
+from nltk.downloader import Downloader
+
+
+class TestDownloaderCycle(unittest.TestCase):
+    def setUp(self):
+        # Disable pathsec to avoid file:// permission issues
+        self.orig_enforce = nltk.pathsec.ENFORCE
+        nltk.pathsec.ENFORCE = False
+
+    def tearDown(self):
+        nltk.pathsec.ENFORCE = self.orig_enforce
+
+    def _run_with_timeout(self, func, timeout=2):
+        """Run func in a thread; return True if it completes within timeout."""
+        result = []
+
+        def target():
+            result.append(func())
+
+        t = threading.Thread(target=target)
+        t.daemon = True
+        t.start()
+        t.join(timeout)
+        if t.is_alive():
+            return False, None
+        return True, result[0] if result else None
+
+    def test_cyclic_index_does_not_hang(self):
+        # Create a temporary index with a self-referential collection
+        xml = """<?xml version="1.0"?>
+<index>
+  <packages>
+    <package id="p1" name="Sample" subdir="corpora/p1"
+             url="http://example.invalid/p1.zip" unzip="0" size="0" unzipped_size="0"/>
+  </packages>
+  <collections>
+    <collection id="a" name="Cyclic">
+      <item ref="a"/>
+      <item ref="p1"/>
+    </collection>
+  </collections>
+</index>"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False) as f:
+            f.write(xml)
+            path = f.name
+
+        try:
+            dl = Downloader(server_index_url="file://" + path)
+            completed, packages = self._run_with_timeout(
+                lambda: dl.packages(), timeout=5
+            )
+            self.assertTrue(completed, "Cyclic index caused a hang (timeout)")
+            self.assertEqual(
+                [p.id for p in packages], ["p1"], "Expected package p1 to be collected"
+            )
+        finally:
+            os.unlink(path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description
This PR fixes an **infinite loop / unbounded memory growth** vulnerability in `nltk.downloader.Downloader._update_index`, as documented in **GHSA-pcm8-fqjx-rvx8**.

The package‑closure walk for collections used a manual BFS with no visited set, allowing a self‑referential or mutually‑referential `<collection>` in the index to cause the queue to grow forever. This resulted in 100% CPU usage and unbounded memory growth until the process was killed.

### Vulnerability details
- `_update_index()` computed each collection's package closure using:

        queue = [collection]
        for child in queue:
            if isinstance(child, Collection):
                queue.extend(child.children)

- A self‑reference (`<item ref="a"/>` inside `<collection id="a">`) turned into an object‑level cycle.
- No visited set or depth cap existed, so the loop never terminated.

### Fix
- Replaced the unsafe manual BFS with `nltk.util.acyclic_breadth_first`.
- This function is specifically designed for graph traversal with cycle detection; it tracks visited nodes internally and skips cycles automatically.
- The change guarantees termination even with malformed or malicious index files, while preserving all original behaviour (packages are collected exactly once).

### Testing
- **Unit test**: `nltk/test/unit/test_downloader_cycle.py` verifies:
  - Acyclic indexes complete normally.
  - Self‑referential indexes return the expected package set without hanging.
  - Mutually‑referential indexes are handled correctly.
- **Security probe**: `nltk/test/unit/security_probes/ghsa_pcm8_fqjx_rvx8_cyclic_index.py` follows the NLTK security probe architecture and verifies the fix on every CI run.

### Impact
- **Before**: A cyclic index caused `nltk.download()` and related operations to hang forever.
- **After**: Cycles are ignored; packages reachable via the cycle are still collected (once), and the function returns normally.

No breaking changes; the public API remains unchanged.

**Fixes:** [GHSA-pcm8-fqjx-rvx8](https://github.com/nltk/nltk/security/advisories/GHSA-pcm8-fqjx-rvx8).
