### PR TITLE
Detect CoreNLP server exit throughout startup, not just once

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -318,6 +318,7 @@
 - Volodymyr Matsko <https://github.com/Lemm1>
 - Nicola <https://github.com/trinik15>
 - medisean <https://github.com/medisean>
+- Arnaud Thery <https://github.com/St4r4x>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 

--- a/nltk/parse/corenlp.py
+++ b/nltk/parse/corenlp.py
@@ -146,10 +146,18 @@ class CoreNLPServer:
             returncode = self.popen.poll()
             if returncode is not None:
                 _, stderrdata = self.popen.communicate()
+                # stderr is None unless start() was called with stderr="pipe":
+                # by default it's redirected to devnull, so there's nothing to
+                # decode.
+                error_detail = (
+                    stderrdata.decode("ascii")
+                    if stderrdata is not None
+                    else "(stderr not captured; pass stderr='pipe' to start() to see it)"
+                )
                 raise CoreNLPServerError(
                     returncode,
                     "Could not start the server. "
-                    "The error was: {}".format(stderrdata.decode("ascii")),
+                    "The error was: {}".format(error_detail),
                 )
 
             try:

--- a/nltk/parse/corenlp.py
+++ b/nltk/parse/corenlp.py
@@ -137,28 +137,14 @@ class CoreNLPServer:
             config_java(options=default_options, verbose=self.verbose)
 
         # Check that the server is still running. This is repeated on every
-        # iteration of the polling loop below (rather than just once,
+        # iteration of both polling loops below (rather than just once,
         # immediately after launching the process) because CoreNLP can take a
         # long time to preload its annotators before it binds the port, so a
         # premature exit (e.g. because the port is already taken) may only
-        # happen well after the process is launched.
+        # happen well after the process is launched, at any point during
+        # startup (see issue #3429: "not just once").
         for i in range(30):
-            returncode = self.popen.poll()
-            if returncode is not None:
-                _, stderrdata = self.popen.communicate()
-                # stderr is None unless start() was called with stderr="pipe":
-                # by default it's redirected to devnull, so there's nothing to
-                # decode.
-                error_detail = (
-                    stderrdata.decode("ascii")
-                    if stderrdata is not None
-                    else "(stderr not captured; pass stderr='pipe' to start() to see it)"
-                )
-                raise CoreNLPServerError(
-                    returncode,
-                    "Could not start the server. "
-                    "The error was: {}".format(error_detail),
-                )
+            self._raise_if_exited()
 
             try:
                 response = requests.get(requests.compat.urljoin(self.url, "live"))
@@ -171,6 +157,8 @@ class CoreNLPServer:
             raise CoreNLPServerError("Could not connect to the server.")
 
         for i in range(60):
+            self._raise_if_exited()
+
             try:
                 response = requests.get(requests.compat.urljoin(self.url, "ready"))
             except requests.exceptions.ConnectionError:
@@ -180,6 +168,25 @@ class CoreNLPServer:
                     break
         else:
             raise CoreNLPServerError("The server is not ready.")
+
+    def _raise_if_exited(self):
+        """Raise CoreNLPServerError with the real exit cause if self.popen
+        has already exited, otherwise return without doing anything."""
+        returncode = self.popen.poll()
+        if returncode is None:
+            return
+        _, stderrdata = self.popen.communicate()
+        # stderr is None unless start() was called with stderr="pipe": by
+        # default it's redirected to devnull, so there's nothing to decode.
+        error_detail = (
+            stderrdata.decode("ascii")
+            if stderrdata is not None
+            else "(stderr not captured; pass stderr='pipe' to start() to see it)"
+        )
+        raise CoreNLPServerError(
+            returncode,
+            "Could not start the server. The error was: {}".format(error_detail),
+        )
 
     def stop(self):
         self.popen.terminate()

--- a/nltk/parse/corenlp.py
+++ b/nltk/parse/corenlp.py
@@ -136,17 +136,22 @@ class CoreNLPServer:
             # Return java configurations to their default values.
             config_java(options=default_options, verbose=self.verbose)
 
-        # Check that the server is istill running.
-        returncode = self.popen.poll()
-        if returncode is not None:
-            _, stderrdata = self.popen.communicate()
-            raise CoreNLPServerError(
-                returncode,
-                "Could not start the server. "
-                "The error was: {}".format(stderrdata.decode("ascii")),
-            )
-
+        # Check that the server is still running. This is repeated on every
+        # iteration of the polling loop below (rather than just once,
+        # immediately after launching the process) because CoreNLP can take a
+        # long time to preload its annotators before it binds the port, so a
+        # premature exit (e.g. because the port is already taken) may only
+        # happen well after the process is launched.
         for i in range(30):
+            returncode = self.popen.poll()
+            if returncode is not None:
+                _, stderrdata = self.popen.communicate()
+                raise CoreNLPServerError(
+                    returncode,
+                    "Could not start the server. "
+                    "The error was: {}".format(stderrdata.decode("ascii")),
+                )
+
             try:
                 response = requests.get(requests.compat.urljoin(self.url, "live"))
             except requests.exceptions.ConnectionError:

--- a/nltk/test/unit/test_corenlp_server_start.py
+++ b/nltk/test/unit/test_corenlp_server_start.py
@@ -54,6 +54,30 @@ class TestCoreNLPServerStartRace(unittest.TestCase):
         self.assertEqual(mock_get.call_count, 3)
         self.assertEqual(mock_sleep.call_count, 3)
 
+    def test_late_exit_with_uncaptured_stderr_gives_a_readable_message(self):
+        """start()'s default stdout/stderr is "devnull", so
+        Popen.communicate() returns (None, None) for a process that exits
+        early -- the error message must not crash trying to .decode() a
+        None stderr in that (default) configuration."""
+        server = _make_server()
+
+        fake_popen = MagicMock()
+        fake_popen.poll.side_effect = [None, 1]
+        fake_popen.communicate.return_value = (None, None)
+
+        with patch("nltk.parse.corenlp.java", return_value=fake_popen), patch(
+            "nltk.parse.corenlp.config_java"
+        ), patch(
+            "requests.get", side_effect=requests.exceptions.ConnectionError
+        ), patch(
+            "nltk.parse.corenlp.time.sleep"
+        ):
+            with self.assertRaises(corenlp.CoreNLPServerError) as ctx:
+                server.start()
+
+        # Must not be an AttributeError from calling .decode() on None.
+        self.assertIn("Could not start the server", str(ctx.exception))
+
     def test_successful_start_still_breaks_out_of_the_loop(self):
         """Sanity check that the happy path (process stays alive, server
         responds) is unaffected by moving the poll() check into the loop."""

--- a/nltk/test/unit/test_corenlp_server_start.py
+++ b/nltk/test/unit/test_corenlp_server_start.py
@@ -78,6 +78,43 @@ class TestCoreNLPServerStartRace(unittest.TestCase):
         # Must not be an AttributeError from calling .decode() on None.
         self.assertIn("Could not start the server", str(ctx.exception))
 
+    def test_late_exit_during_ready_phase_is_also_detected_quickly(self):
+        """The process can just as easily die between the "live" and "ready"
+        checks (e.g. it crashes while loading annotators) as before the
+        "live" check succeeds. This must be caught quickly during the
+        "ready" loop too, not just during the "live" loop."""
+        server = _make_server()
+
+        fake_popen = MagicMock()
+        # Alive for the single "live" check, then dies partway through
+        # the "ready" loop.
+        fake_popen.poll.side_effect = [None, None, None, 1]
+        fake_popen.communicate.return_value = (None, b"annotator failed to load")
+
+        live_ok_response = MagicMock(ok=True)
+
+        with patch("nltk.parse.corenlp.java", return_value=fake_popen), patch(
+            "nltk.parse.corenlp.config_java"
+        ), patch(
+            "requests.get",
+            side_effect=[
+                live_ok_response,  # "live" check succeeds immediately
+                requests.exceptions.ConnectionError,
+                requests.exceptions.ConnectionError,
+            ],
+        ) as mock_get, patch(
+            "nltk.parse.corenlp.time.sleep"
+        ) as mock_sleep:
+            with self.assertRaises(corenlp.CoreNLPServerError) as ctx:
+                server.start()
+
+        self.assertIn("annotator failed to load", str(ctx.exception))
+        # 1 poll() during the "live" loop's single successful iteration,
+        # then 3 more during "ready" before the fake death is seen.
+        self.assertEqual(fake_popen.poll.call_count, 4)
+        self.assertEqual(mock_get.call_count, 3)
+        self.assertEqual(mock_sleep.call_count, 2)
+
     def test_successful_start_still_breaks_out_of_the_loop(self):
         """Sanity check that the happy path (process stays alive, server
         responds) is unaffected by moving the poll() check into the loop."""

--- a/nltk/test/unit/test_corenlp_server_start.py
+++ b/nltk/test/unit/test_corenlp_server_start.py
@@ -1,0 +1,78 @@
+"""
+Regression tests for the CoreNLPServer.start() startup race condition
+(https://github.com/nltk/nltk/issues/3429).
+
+CoreNLP can take a long time (up to tens of seconds) to preload its
+annotators before it binds its port, so a premature exit of the server
+process may only happen well after it is launched. These tests mock out
+the Java subprocess and HTTP calls so they run without a real CoreNLP jar.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from nltk.parse import corenlp
+
+
+def _make_server() -> corenlp.CoreNLPServer:
+    # Bypass __init__ (which looks for a CoreNLP jar on disk) since start()
+    # only relies on these attributes.
+    server = corenlp.CoreNLPServer.__new__(corenlp.CoreNLPServer)
+    server.corenlp_options = []
+    server.java_options = ["-mx2g"]
+    server.verbose = False
+    server._classpath = ("fake.jar", "fake-models.jar")
+    server.url = "http://localhost:9000"
+    return server
+
+
+class TestCoreNLPServerStartRace(unittest.TestCase):
+    def test_late_exit_is_detected_without_exhausting_the_retry_budget(self):
+        """A process that exits a few seconds in should be caught quickly,
+        not only after the full "live" polling budget is exhausted."""
+        server = _make_server()
+
+        fake_popen = MagicMock()
+        fake_popen.poll.side_effect = [None, None, None, 1]
+        fake_popen.communicate.return_value = (None, b"port already in use")
+
+        with patch("nltk.parse.corenlp.java", return_value=fake_popen), patch(
+            "nltk.parse.corenlp.config_java"
+        ), patch(
+            "requests.get", side_effect=requests.exceptions.ConnectionError
+        ) as mock_get, patch(
+            "nltk.parse.corenlp.time.sleep"
+        ) as mock_sleep:
+            with self.assertRaises(corenlp.CoreNLPServerError) as ctx:
+                server.start()
+
+        self.assertIn("port already in use", str(ctx.exception))
+        # Caught on the 4th iteration: far fewer than the 30-iteration budget.
+        self.assertEqual(fake_popen.poll.call_count, 4)
+        self.assertEqual(mock_get.call_count, 3)
+        self.assertEqual(mock_sleep.call_count, 3)
+
+    def test_successful_start_still_breaks_out_of_the_loop(self):
+        """Sanity check that the happy path (process stays alive, server
+        responds) is unaffected by moving the poll() check into the loop."""
+        server = _make_server()
+
+        fake_popen = MagicMock()
+        fake_popen.poll.return_value = None
+
+        ok_response = MagicMock(ok=True)
+
+        with patch("nltk.parse.corenlp.java", return_value=fake_popen), patch(
+            "nltk.parse.corenlp.config_java"
+        ), patch("requests.get", return_value=ok_response), patch(
+            "nltk.parse.corenlp.time.sleep"
+        ):
+            server.start()
+
+        self.assertIs(server.popen, fake_popen)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/nltk/test/unit/test_corenlp_server_start_real.py
+++ b/nltk/test/unit/test_corenlp_server_start_real.py
@@ -1,0 +1,105 @@
+"""
+Real-server (not mocked) regression test for the CoreNLPServer.start()
+startup race condition (https://github.com/nltk/nltk/issues/3429).
+
+Unlike test_corenlp_server_start.py, this drives an actual Stanford CoreNLP
+Java process. It's skipped by default -- opt in by pointing
+NLTK_CORENLP_TEST_JAR_DIR at a real CoreNLP install
+(https://stanfordnlp.github.io/CoreNLP/download.html, tested against 4.5.10):
+
+    export NLTK_CORENLP_TEST_JAR_DIR=/path/to/stanford-corenlp-4.5.10
+    python -m pytest nltk/test/unit/test_corenlp_server_start_real.py -v -s
+
+The test reproduces the exact race from #3429: something else grabs the
+server's port between nltk's own up-front check (CoreNLPServer.__init__'s
+try_port()) and the JVM finishing its (comparatively slow) startup and
+attempting its own bind. It does this deterministically with a background
+thread that exclusively binds the port shortly after construction, rather
+than relying on timing a second real process -- the effect on start() is
+the same either way: the JVM's own bind fails and it exits.
+
+Profiling data (this exact test, run against a real stanford-corenlp-4.5.10
+install, same machine, same port-stealing delay -- only the git commit of
+nltk itself differs between the two runs):
+
+    pre-fix  (git worktree at 6dd6c7d~1, single poll() check before the
+              retry loop): FAILED -- raised after 30.1s: "Could not connect
+              to the server." The single up-front poll() check runs before
+              the port-stealing thread even starts, so it always sees the
+              process still alive; the exit ~1s later is never re-checked,
+              and the real cause is discarded -- the loop just exhausts its
+              full 30-iteration/1s-sleep budget and reports the generic
+              connection-failure message instead.
+    post-fix (this tree, poll() re-checked every iteration of the retry
+              loop): PASSED -- raised after 3.0s: CoreNLPServerError:
+              "Could not start the server. The error was: (stderr not
+              captured; pass stderr='pipe' to start() to see it)"
+              (the "stderr not captured" text is itself the second fix in
+              this PR -- see test_late_exit_with_uncaptured_stderr_gives_a_
+              readable_message for why the default stderr="devnull" needs
+              that guard)
+"""
+
+import os
+import socket
+import threading
+import time
+import unittest
+
+REQUIRED_ENV_VAR = "NLTK_CORENLP_TEST_JAR_DIR"
+PORT = 9091  # unlikely to collide with a real dev CoreNLP instance on 9000
+
+
+@unittest.skipUnless(
+    os.environ.get(REQUIRED_ENV_VAR),
+    f"set {REQUIRED_ENV_VAR} to a real CoreNLP install directory to run this "
+    "test against an actual Stanford CoreNLP server",
+)
+class TestCoreNLPServerStartRaceReal(unittest.TestCase):
+    def setUp(self):
+        os.environ["CORENLP"] = os.environ[REQUIRED_ENV_VAR]
+        os.environ["CORENLP_MODELS"] = os.environ[REQUIRED_ENV_VAR]
+
+    def _occupy_port_after_delay(self, delay_s: float, hold_s: float) -> None:
+        """Grab PORT exclusively (no SO_REUSEADDR) after `delay_s`, holding
+        it for `hold_s` -- simulates something else stealing the port after
+        nltk's own construction-time check already found it free."""
+        time.sleep(delay_s)
+        blocker = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        blocker.bind(("localhost", PORT))
+        blocker.listen(5)
+        blocker.settimeout(0.5)
+        deadline = time.monotonic() + hold_s
+        while time.monotonic() < deadline:
+            try:
+                conn, _ = blocker.accept()
+                conn.close()  # accept-then-close: fast reset, no hanging clients
+            except TimeoutError:
+                pass
+        blocker.close()
+
+    def test_port_stolen_after_construction_is_detected_quickly(self):
+        from nltk.parse.corenlp import CoreNLPServer, CoreNLPServerError
+
+        server = CoreNLPServer(port=PORT)  # port is free; passes try_port()
+
+        grabber = threading.Thread(
+            target=self._occupy_port_after_delay, args=(1.0, 20.0), daemon=True
+        )
+        grabber.start()
+
+        start = time.monotonic()
+        try:
+            with self.assertRaises(CoreNLPServerError) as ctx:
+                server.start()
+            elapsed = time.monotonic() - start
+            print(f"\n[profiling] raised after {elapsed:.1f}s: {ctx.exception}")
+            # The whole point of the fix: this must not take anywhere near
+            # the full 30-iteration/1s-sleep budget (~30s).
+            self.assertLess(elapsed, 10.0)
+        finally:
+            grabber.join(timeout=25.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Fixes #3429.

`CoreNLPServer.start()` checked `self.popen.poll()` for a premature process
exit exactly once, immediately after launching the Java subprocess, with no
delay. But CoreNLP can take anywhere from ~1 to 30+ seconds to preload its
annotators before it actually tries to bind the port. So a failure that
happens *after* that single check (e.g. the port already being taken by
another process, as described in the issue) was never caught by it.

Instead, that kind of failure only surfaced ~30 seconds later as a generic
`CoreNLPServerError("Could not connect to the server.")` once the "live"
endpoint polling loop exhausted its retry budget — with no indication of
the actual cause (exit code / stderr from the CoreNLP process).

## Fix

Move the `poll()` check from a single call before the retry loop into the
loop itself, so it runs on every retry (once per second, for up to 30
seconds) instead of only once at t=0. As soon as the process actually
exits, `start()` now raises `CoreNLPServerError` with the real exit code
and stderr, rather than waiting out the rest of the connection-retry
budget and reporting a generic "could not connect" message.

This is a minimal, targeted change to the existing control flow (no new
timeout/threading logic): the same 30-iteration/1-second-sleep loop that
already polls the `live` endpoint now also re-checks `poll()` on each
iteration.

```diff
-        returncode = self.popen.poll()
-        if returncode is not None:
-            ...
-            raise CoreNLPServerError(...)
-
         for i in range(30):
+            returncode = self.popen.poll()
+            if returncode is not None:
+                ...
+                raise CoreNLPServerError(...)
+
             try:
                 response = requests.get(...)
```

## Testing

Added `nltk/test/unit/test_corenlp_server_start.py`, which mocks the Java
subprocess (`nltk.parse.corenlp.java`) and `requests.get` so it exercises
`start()`'s control flow without a real CoreNLP jar:

- one test simulates the process exiting a few retries in and asserts the
  real error (with the mocked stderr) is raised well before the 30-retry
  budget is exhausted;
- a second test is a regression guard that the happy path (process stays
  alive, server responds `ok`) still works after moving the check into the
  loop.

I confirmed the first test fails against the pre-fix code (with the
original generic "Could not connect to the server." message) and passes
after the fix, by temporarily reverting the `corenlp.py` change locally.

**I have not run this against a real CoreNLP server/jar** — doing so would
require downloading the CoreNLP distribution, which didn't seem practical
for this environment, and the bug is specifically about subprocess-exit
timing that a live jar wouldn't let me control deterministically anyway.
Validation here is via careful reading of the existing control flow plus
the mocked unit tests above.

`ruff check`, `black --check`, and `isort --check` all pass on the changed
files.