### PR TITLE
Harden internals.java() (CWE-88): options, classpath, env, discovery; route MaltParser through it

### DIFF
--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -239,7 +239,7 @@ def _verify_jar_sandbox(classpath_entries):
 
     for p in data_path:
         try:
-            trusted_roots.append(os.path.realpath(p))
+            trusted_roots.append(os.path.normcase(os.path.realpath(p)))
         except Exception:
             continue
 
@@ -250,7 +250,7 @@ def _verify_jar_sandbox(classpath_entries):
         repo_root = os.path.realpath(os.path.join(nltk_package_dir, ".."))
         git_marker = os.path.join(repo_root, ".git")
         if os.path.isdir(git_marker) or os.path.isfile(git_marker):
-            trusted_roots.append(repo_root)
+            trusted_roots.append(os.path.normcase(repo_root))
     except Exception:
         pass
 
@@ -264,19 +264,31 @@ def _verify_jar_sandbox(classpath_entries):
         try:
             abs_wp = os.path.realpath(wp)
             if os.path.isdir(abs_wp):
-                trusted_roots.append(abs_wp)
+                trusted_roots.append(os.path.normcase(abs_wp))
         except Exception:
             continue
 
     trusted_roots = list(dict.fromkeys(trusted_roots))
 
     for entry in entries:
-        if not isinstance(entry, str) or not entry:
+        if not isinstance(entry, str):
+            # A non-string is not a CWD element, just an unsupported type; report
+            # the expected type rather than the misleading current-directory text.
+            raise UntrustedJarError(
+                f"Classpath entry must be a string, got {type(entry).__name__}: {entry!r}"
+            )
+        if not entry:
             # An empty entry is the JVM's current-directory element (CWD class
             # injection); refuse it rather than skip it.
             raise UntrustedJarError(
-                f"Empty or non-string classpath entry is forbidden (the JVM would "
-                f"treat it as the current directory): {entry!r}"
+                f"Empty classpath entry is forbidden (the JVM would treat it as "
+                f"the current directory): {entry!r}"
+            )
+        if "\x00" in entry:
+            # A NUL truncates the path in native calls; reject with a clear error
+            # instead of letting os.path.realpath raise a bare ValueError.
+            raise UntrustedJarError(
+                f"Classpath entry may not contain a NUL byte: {entry!r}"
             )
         if os.pathsep in entry:
             # An entry embedding os.pathsep passes the per-entry check as one path

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -80,10 +80,17 @@ _MODULE_LIST_RE = re.compile(r"\A[A-Za-z0-9_.,-]+\Z")
 # token cannot ride through on the ``-xmx`` prefix.
 _UNSAFE_OPTION_CHARS = frozenset(" \t\r\n;|&$`<>(){}[]*?!'\"\\")
 
-# JVM env vars that inject extra flags (JAVA_TOOL_OPTIONS / _JAVA_OPTIONS /
-# JDK_JAVA_OPTIONS) or classpath (CLASSPATH); stripped from the child env (CWE-88).
+# JVM env vars that inject flags (JAVA_TOOL_OPTIONS / _JAVA_OPTIONS / JDK_JAVA_OPTIONS
+# / IBM_JAVA_OPTIONS / OPENJ9_JAVA_OPTIONS) or classpath (CLASSPATH); stripped (CWE-88).
 _JVM_INJECTING_ENV_VARS = frozenset(
-    {"JAVA_TOOL_OPTIONS", "_JAVA_OPTIONS", "JDK_JAVA_OPTIONS", "CLASSPATH"}
+    {
+        "JAVA_TOOL_OPTIONS",
+        "_JAVA_OPTIONS",
+        "JDK_JAVA_OPTIONS",
+        "IBM_JAVA_OPTIONS",
+        "OPENJ9_JAVA_OPTIONS",
+        "CLASSPATH",
+    }
 )
 
 

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -970,12 +970,13 @@ def find_binary_iter(
     # -- run relative to the CWD rather than looked up on PATH: arbitrary code
     # execution (CWE-426 / CWE-427). Only in that case do we refuse CWD-relative
     # matches and accept solely a trusted absolute location (env var / searchpath
-    # / ``which``). An explicit path supplied via ``path_to_bin`` or via ``name``
-    # itself (e.g. ``tools/prover9``) is the caller's own choice and is honored
-    # as before. ``not path_to_bin`` (rather than ``is None``) so an empty-string
-    # path_to_bin -- which ``path_to_bin or name`` already falls back to ``name``
-    # for -- cannot bypass the check.
-    searching_bare_name = not path_to_bin and os.path.dirname(name) == ""
+    # / ``which``). A path with a directory component (e.g. ``tools/prover9`` or
+    # ``/usr/bin/java``), via ``name`` or ``path_to_bin``, is the caller's explicit
+    # choice and is honored. A *bare* tool name is NOT an explicit path even when
+    # passed as ``path_to_bin`` (a bare ``bin="java"`` would otherwise let a planted
+    # ``./java/java`` hijack it), so it triggers the refusal too; an empty
+    # ``path_to_bin`` falls back to ``name`` through ``path_to_bin or name``.
+    searching_bare_name = os.path.dirname(path_to_bin or name) == ""
     safe_match = False
     for path in find_file_iter(
         path_to_bin or name, env_vars, searchpath, binary_names, url, verbose

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -49,21 +49,17 @@ _java_options = []
 #     its own ``-encoding`` *program* argument, not ``-Dfile.encoding``.
 # An application that genuinely needs one of these passes it through the explicit
 # ``trusted_raw_options`` escape hatch (see ``java()``), taking responsibility.
-_SAFE_JVM_PREFIXES = (
-    "-xmx",  # max heap size:   -Xmx512m
-    "-mx",  # max heap (legacy alias of -Xmx, used by Stanford/CoreNLP): -mx2g
-    "-xms",  # initial heap:    -Xms128m
-    "-ms",  # initial heap (legacy alias of -Xms): -ms128m
-    "-xss",  # thread stack:    -Xss4m
-    "-ss",  # thread stack (legacy alias of -Xss): -ss4m
-    "-xbatch",  # disable bg JIT
-    "-xint",  # interpret-only mode
-    "-xcomp",  # compile-only mode
-    "-xmixed",  # mixed mode (JVM default)
-    "-verbose",  # diagnostic output: -verbose:gc
-)
+# Heap/stack sizing (-Xmx512m / -mx2g / -Xms128m / -Xss4m; no-X aliases are what
+# Stanford/CoreNLP pass). Anchored to number+unit so no suffix rides a bare prefix.
+_SAFE_SIZING_RE = re.compile(r"\A-(xmx|mx|xms|ms|xss|ss)\d+[kmgt]?\Z", re.IGNORECASE)
 
-_SAFE_JVM_EXACT = frozenset({"-server", "-client"})
+# -verbose diagnostic output: bare or one standard category (-verbose:gc etc.).
+_SAFE_VERBOSE_RE = re.compile(r"\A-verbose(:(class|gc|jni|module))?\Z", re.IGNORECASE)
+
+# Exact no-argument flags (mode / VM selectors); no suffix may ride these.
+_SAFE_JVM_EXACT = frozenset(
+    {"-server", "-client", "-xbatch", "-xint", "-xcomp", "-xmixed"}
+)
 
 # ``--add-modules <module-list>`` is required by CoreNLP on JDK 9-11 (a CoreNLP
 # dependency uses the JAXB module dropped from the default set). The value is a
@@ -77,7 +73,7 @@ _MODULE_LIST_RE = re.compile(r"\A[A-Za-z0-9_.,-]+\Z")
 # metacharacter. Rejecting those characters is therefore a free, name-agnostic
 # defense-in-depth layer (it has no false positives now that -D, whose values may
 # legitimately contain them, is not accepted): e.g. a malformed ``-Xmx512m ; rm``
-# token cannot ride through on the ``-xmx`` prefix.
+# token cannot ride through as a sizing flag.
 _UNSAFE_OPTION_CHARS = frozenset(" \t\r\n;|&$`<>(){}[]*?!'\"\\")
 
 # JVM env vars that inject flags (JAVA_TOOL_OPTIONS / _JAVA_OPTIONS / JDK_JAVA_OPTIONS
@@ -92,6 +88,16 @@ _JVM_INJECTING_ENV_VARS = frozenset(
         "CLASSPATH",
     }
 )
+
+
+def _java_child_env():
+    """Return os.environ minus the JVM-injecting variables, so any child java
+    process (java() here, or a wrapper that builds its own command) cannot pick up
+    flags/classpath from JAVA_TOOL_OPTIONS et al. (CWE-88). Single source of truth
+    for every JVM launch in NLTK."""
+    return {
+        k: v for k, v in os.environ.items() if k.upper() not in _JVM_INJECTING_ENV_VARS
+    }
 
 
 def _validate_java_options(options):
@@ -165,7 +171,7 @@ def _validate_java_options(options):
             i += 1
             continue
 
-        if n.startswith(_SAFE_JVM_PREFIXES):
+        if _SAFE_SIZING_RE.match(flag) or _SAFE_VERBOSE_RE.match(flag):
             i += 1
             continue
 
@@ -417,9 +423,7 @@ def java(
         final_cmd.extend(["-cp", classpath_arg])
     final_cmd.extend(cmd_list)
 
-    child_env = {
-        k: v for k, v in os.environ.items() if k.upper() not in _JVM_INJECTING_ENV_VARS
-    }
+    child_env = _java_child_env()
     try:
         p = subprocess.Popen(
             final_cmd,

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -80,6 +80,12 @@ _MODULE_LIST_RE = re.compile(r"\A[A-Za-z0-9_.,-]+\Z")
 # token cannot ride through on the ``-xmx`` prefix.
 _UNSAFE_OPTION_CHARS = frozenset(" \t\r\n;|&$`<>(){}[]*?!'\"\\")
 
+# JVM env vars that inject extra flags (JAVA_TOOL_OPTIONS / _JAVA_OPTIONS /
+# JDK_JAVA_OPTIONS) or classpath (CLASSPATH); stripped from the child env (CWE-88).
+_JVM_INJECTING_ENV_VARS = frozenset(
+    {"JAVA_TOOL_OPTIONS", "_JAVA_OPTIONS", "JDK_JAVA_OPTIONS", "CLASSPATH"}
+)
+
 
 def _validate_java_options(options):
     """
@@ -258,8 +264,20 @@ def _verify_jar_sandbox(classpath_entries):
     trusted_roots = list(dict.fromkeys(trusted_roots))
 
     for entry in entries:
-        if not entry:
-            continue
+        if not isinstance(entry, str) or not entry:
+            # An empty entry is the JVM's current-directory element (CWD class
+            # injection); refuse it rather than skip it.
+            raise UntrustedJarError(
+                f"Empty or non-string classpath entry is forbidden (the JVM would "
+                f"treat it as the current directory): {entry!r}"
+            )
+        if os.pathsep in entry:
+            # An entry embedding os.pathsep passes the per-entry check as one path
+            # but the JVM re-splits it into unverified elements (sandbox bypass).
+            raise UntrustedJarError(
+                f"Classpath entry may not contain the path separator {os.pathsep!r} "
+                f"(it would expand into multiple unverified elements): {entry!r}"
+            )
         if not os.path.isabs(entry):
             raise UntrustedJarError(f"Relative paths are strictly forbidden: {entry}")
 
@@ -327,18 +345,16 @@ def java(
     classpath_arg = None
     if classpath is not None:
         if isinstance(classpath, str):
-            raw_entries = [p for p in classpath.split(os.pathsep) if p]
-            original_classpath_string = classpath
+            # Keep empty parts ("a.jar::" is the JVM's CWD element) so
+            # _verify_jar_sandbox can refuse them instead of silently dropping them.
+            raw_entries = classpath.split(os.pathsep)
         else:
             raw_entries = list(classpath)
-            original_classpath_string = None
         if not raw_entries:
             raise ValueError("Classpath is empty after splitting")
         _verify_jar_sandbox(raw_entries)
-        if original_classpath_string is not None:
-            classpath_arg = original_classpath_string
-        else:
-            classpath_arg = os.pathsep.join(raw_entries)
+        # Rebuild from the verified entries only; never pass the raw string to -cp.
+        classpath_arg = os.pathsep.join(raw_entries)
 
     # The Java launcher treats the first non-option token as the main class. A
     # caller-supplied cmd must therefore begin with a real main-class name, not a
@@ -382,6 +398,9 @@ def java(
         final_cmd.extend(["-cp", classpath_arg])
     final_cmd.extend(cmd_list)
 
+    child_env = {
+        k: v for k, v in os.environ.items() if k.upper() not in _JVM_INJECTING_ENV_VARS
+    }
     try:
         p = subprocess.Popen(
             final_cmd,
@@ -389,6 +408,7 @@ def java(
             stdout=stdout,
             stderr=stderr,
             universal_newlines=True,
+            env=child_env,
         )
         if blocking:
             stdout_data, stderr_data = p.communicate()

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -91,10 +91,10 @@ _JVM_INJECTING_ENV_VARS = frozenset(
 
 
 def _java_child_env():
-    """Return os.environ minus the JVM-injecting variables, so any child java
-    process (java() here, or a wrapper that builds its own command) cannot pick up
-    flags/classpath from JAVA_TOOL_OPTIONS et al. (CWE-88). Single source of truth
-    for every JVM launch in NLTK."""
+    """Return os.environ minus the JVM-injecting variables, so the child JVM that
+    java() launches cannot pick up flags/classpath from JAVA_TOOL_OPTIONS et al.
+    (CWE-88). Every NLTK JVM launch is routed through java(), so this is the single
+    place the child environment is sanitised."""
     return {
         k: v for k, v in os.environ.items() if k.upper() not in _JVM_INJECTING_ENV_VARS
     }

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -1122,12 +1122,14 @@ def find_jar_iter(
         if is_regex:
             for filename in os.listdir(directory):
                 path_to_jar = os.path.join(directory, filename)
-                if os.path.isfile(path_to_jar):
-                    if re.match(name_pattern, filename):
-                        if verbose:
-                            print(f"[Found {filename}: {path_to_jar}]")
-                yielded = True
-                yield path_to_jar
+                # Only yield an actual file whose name matches the pattern; the
+                # yield was previously outside both guards, returning every dir
+                # entry (subdirs / unrelated files) as if it were the jar.
+                if os.path.isfile(path_to_jar) and re.match(name_pattern, filename):
+                    if verbose:
+                        print(f"[Found {filename}: {path_to_jar}]")
+                    yielded = True
+                    yield path_to_jar
         else:
             path_to_jar = os.path.join(directory, name_pattern)
             if os.path.isfile(path_to_jar):

--- a/nltk/parse/malt.py
+++ b/nltk/parse/malt.py
@@ -15,6 +15,7 @@ import tempfile
 
 from nltk.data import ZipFilePathPointer
 from nltk.internals import (
+    _java_child_env,
     _validate_java_options,
     _verify_jar_sandbox,
     find_dir,
@@ -298,7 +299,11 @@ class MaltParser(ParserI):
     @staticmethod
     def _execute(cmd, verbose=False, cwd=None):
         output = None if verbose else subprocess.PIPE
-        p = subprocess.Popen(cmd, stdout=output, stderr=output, cwd=cwd)
+        # MaltParser runs its own JVM (not internals.java()), so strip the same
+        # JVM-injecting env vars or JAVA_TOOL_OPTIONS et al. inject past the allowlist.
+        p = subprocess.Popen(
+            cmd, stdout=output, stderr=output, cwd=cwd, env=_java_child_env()
+        )
         return p.wait()
 
     def train(self, depgraphs, verbose=False):

--- a/nltk/parse/malt.py
+++ b/nltk/parse/malt.py
@@ -9,18 +9,15 @@
 
 import inspect
 import os
-import subprocess
 import sys
 import tempfile
 
 from nltk.data import ZipFilePathPointer
 from nltk.internals import (
-    _java_child_env,
-    _validate_java_options,
-    _verify_jar_sandbox,
     find_dir,
     find_file,
     find_jars_within_path,
+    java,
 )
 from nltk.parse.api import ParserI
 from nltk.parse.dependencygraph import DependencyGraph
@@ -196,24 +193,19 @@ class MaltParser(ParserI):
                 input_file_name = input_file.name
                 output_file_name = output_file.name
 
-                model_dir = os.path.split(self.model)[0]
-                model_cwd = os.path.abspath(model_dir) if model_dir else None
-                if model_cwd and not os.path.isdir(model_cwd):
-                    model_cwd = None
-
                 # Convert list of sentences to CONLL format.
                 for line in taggedsents_to_conll(sentences):
                     input_file.write(str(line))
                 input_file.close()
 
-                # Generate command to run maltparser.
+                # Generate command to run maltparser. The model's directory is
+                # passed to MaltParser via its ``-w`` argument (inside
+                # generate_malt_command), so no JVM working-directory is needed.
                 cmd = self.generate_malt_command(
                     input_file_name, output_file_name, mode="parse"
                 )
 
-                # MaltParser needs to run from the model directory; use
-                # subprocess cwd so other threads do not see a process-wide chdir.
-                ret = self._execute(cmd, verbose, cwd=model_cwd)  # Run command.
+                ret = self._execute(cmd, verbose)  # Run command.
 
                 if ret != 0:
                     raise Exception(
@@ -268,27 +260,19 @@ class MaltParser(ParserI):
         :type outputfilename: str
         """
 
-        # MaltParser builds and runs its own ``java`` command instead of routing
-        # through nltk.internals.java(), so apply the same protections here:
-        # sandbox the classpath JARs to the trusted NLTK data dirs
-        # (CWE-94, CVE-2026-12252) and validate the JVM options
-        # (CWE-88, CVE-2026-12841) before the command reaches subprocess.Popen.
-        _verify_jar_sandbox(self.malt_jars)
-        _validate_java_options(self.additional_java_args)
+        # Build only MaltParser's own arguments (main class + program args). The
+        # JVM binary, classpath sandbox, JVM-option allowlist and env sanitisation
+        # are all applied by nltk.internals.java() in _execute; this wrapper no
+        # longer rolls its own subprocess, so those protections cannot drift.
+        cmd = ["org.maltparser.Malt"]
 
-        cmd = ["java"]
-        cmd += self.additional_java_args  # Adds additional java arguments
-        cmd += [
-            "-cp",
-            os.pathsep.join(self.malt_jars),
-        ]  # Adds classpaths for jars
-        cmd += ["org.maltparser.Malt"]  # Adds the main function.
-
-        # Adds the model file.
-        if os.path.exists(self.model):  # when parsing
-            cmd += ["-c", os.path.split(self.model)[-1]]
-        else:  # when learning
-            cmd += ["-c", self.model]
+        # MaltParser reads/writes the .mco model in its working directory. Pass that
+        # directory as the ``-w`` program argument rather than chdir-ing the JVM
+        # process: no cwd is handed to java(), so there is no working-directory
+        # class-injection surface (an empty/CWD -cp element, CWE-88).
+        model_dir, model_name = os.path.split(self.model)
+        workingdir = os.path.abspath(model_dir) if model_dir else os.getcwd()
+        cmd += ["-w", workingdir, "-c", model_name]
 
         cmd += ["-i", inputfilename]
         if mode == "parse":
@@ -296,15 +280,21 @@ class MaltParser(ParserI):
         cmd += ["-m", mode]  # mode use to generate parses.
         return cmd
 
-    @staticmethod
-    def _execute(cmd, verbose=False, cwd=None):
-        output = None if verbose else subprocess.PIPE
-        # MaltParser runs its own JVM (not internals.java()), so strip the same
-        # JVM-injecting env vars or JAVA_TOOL_OPTIONS et al. inject past the allowlist.
-        p = subprocess.Popen(
-            cmd, stdout=output, stderr=output, cwd=cwd, env=_java_child_env()
-        )
-        return p.wait()
+    def _execute(self, cmd, verbose=False):
+        # Route MaltParser's JVM through the single hardened entry point so the
+        # classpath sandbox, JVM-option allowlist and env sanitisation all apply.
+        stdout = None if verbose else "pipe"
+        try:
+            java(
+                cmd,
+                classpath=self.malt_jars,
+                options=self.additional_java_args,
+                stdout=stdout,
+                stderr=stdout,
+            )
+            return 0
+        except OSError:
+            return 1  # non-zero exit; the caller raises its descriptive error
 
     def train(self, depgraphs, verbose=False):
         """

--- a/nltk/test/unit/test_internals.py
+++ b/nltk/test/unit/test_internals.py
@@ -93,3 +93,21 @@ def test_find_binary_honors_explicit_relative_path_via_name(tmp_path, monkeypatc
 
     result = find_binary(os.path.join("tools", _NAME), binary_names=[_NAME])
     assert os.path.basename(result) == _NAME
+
+
+def test_find_binary_bare_path_to_bin_refuses_cwd_relative(tmp_path, monkeypatch):
+    """A *bare* ``path_to_bin`` (no directory component, e.g. ``bin="java"``) is not
+    an explicit path: a planted ``./<name>/<name>`` must not hijack it; only an
+    absolute match is accepted (CWE-426 / CWE-427)."""
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    _make_exec(cwd / _NAME / _NAME)  # attacker-planted ./<name>/<name>
+    realdir = tmp_path / "realbin"
+    _make_exec(realdir / _NAME)  # trusted, absolute location
+    monkeypatch.chdir(cwd)
+
+    result = find_binary(
+        _NAME, path_to_bin=_NAME, searchpath=[str(realdir)], binary_names=[_NAME]
+    )
+    assert os.path.isabs(result)
+    assert os.path.realpath(result) == os.path.realpath(str(realdir / _NAME))

--- a/nltk/test/unit/test_internals.py
+++ b/nltk/test/unit/test_internals.py
@@ -12,7 +12,7 @@ import stat
 
 import pytest
 
-from nltk.internals import find_binary
+from nltk.internals import find_binary, find_jar, find_jar_iter
 
 _NAME = "nltktestbin"  # unlikely to exist on PATH
 
@@ -111,3 +111,24 @@ def test_find_binary_bare_path_to_bin_refuses_cwd_relative(tmp_path, monkeypatch
     )
     assert os.path.isabs(result)
     assert os.path.realpath(result) == os.path.realpath(str(realdir / _NAME))
+
+
+def test_find_jar_regex_searchpath_only_yields_matching_files(tmp_path):
+    """find_jar_iter(is_regex=True) over a searchpath must yield only actual files
+    whose name matches the pattern, never a subdirectory or an unrelated file that
+    merely happens to sort first in os.listdir()."""
+    d = tmp_path / "jars"
+    d.mkdir()
+    (d / "stanford-postagger-4.2.0.jar").write_text("x")
+    (d / "unrelated.txt").write_text("x")
+    (d / "a_subdir").mkdir()
+    pat = r"stanford-postagger-\d+\.\d+\.\d+\.jar"
+
+    yielded = list(
+        find_jar_iter(pat, None, env_vars=(), searchpath=[str(d)], is_regex=True)
+    )
+    assert [os.path.basename(p) for p in yielded] == ["stanford-postagger-4.2.0.jar"]
+    # find_jar (first match) must return the jar, not the subdirectory
+    result = find_jar(pat, None, env_vars=(), searchpath=[str(d)], is_regex=True)
+    assert os.path.basename(result) == "stanford-postagger-4.2.0.jar"
+    assert os.path.isfile(result)

--- a/nltk/test/unit/test_java_injection_exploit.py
+++ b/nltk/test/unit/test_java_injection_exploit.py
@@ -163,9 +163,15 @@ def test_trusted_jar_reaches_popen(spy_popen, tmp_path, monkeypatch):
     assert "-cp" in spy_popen[0]
 
 
-# --- MaltParser: builds its own `java` command, must be sandboxed too --------
-# (MaltParser bypasses internals.java(), so both the classpath sandbox and the
-#  JVM-option validation are applied inside generate_malt_command().)
+# --- MaltParser now routes through internals.java() -------------------------
+# (MaltParser no longer builds its own subprocess: generate_malt_command() returns
+#  only the maltparser argv, and _execute() hands the classpath/options to
+#  internals.java(), which applies the sandbox and the JVM-option allowlist.)
+
+
+class _PopenIntercept(Exception):
+    """Raised by a fake Popen so the launcher command can be inspected without
+    ever executing a real process."""
 
 
 def _malt_stub(jars, args, tmp_path):
@@ -186,11 +192,14 @@ def test_malt_untrusted_jar_is_blocked(tmp_path, monkeypatch):
     data_dir = tmp_path / "nltk_data"
     data_dir.mkdir()
     monkeypatch.setattr("nltk.data.path", [str(data_dir)])
+    monkeypatch.setattr("nltk.internals._java_bin", "/usr/bin/java")
     evil = tmp_path / "evil" / "maltparser-1.9.2.jar"
     evil.parent.mkdir()
     evil.touch()
-    with pytest.raises(UntrustedJarError):
-        _malt_stub([str(evil)], [], tmp_path).generate_malt_command("in", mode="parse")
+    m = _malt_stub([str(evil)], [], tmp_path)
+    cmd = m.generate_malt_command("in", "out", mode="parse")
+    with pytest.raises(UntrustedJarError):  # java()'s classpath sandbox refuses it
+        m._execute(cmd)
 
 
 def test_malt_arg_injection_is_blocked(tmp_path, monkeypatch):
@@ -200,20 +209,42 @@ def test_malt_arg_injection_is_blocked(tmp_path, monkeypatch):
     good = data_dir / "maltparser-1.9.2.jar"
     good.touch()
     monkeypatch.setattr("nltk.data.path", [str(data_dir)])
-    with pytest.raises(ValueError):
-        _malt_stub(
-            [str(good)], ["-XX:OnOutOfMemoryError=touch /tmp/x"], tmp_path
-        ).generate_malt_command("in", mode="parse")
+    monkeypatch.setattr("nltk.internals._java_bin", "/usr/bin/java")
+    m = _malt_stub([str(good)], ["-XX:OnOutOfMemoryError=touch /tmp/x"], tmp_path)
+    cmd = m.generate_malt_command("in", "out", mode="parse")
+    with pytest.raises(ValueError):  # java()'s option allowlist refuses it
+        m._execute(cmd)
 
 
 def test_malt_trusted_jar_and_safe_args_build_command(tmp_path, monkeypatch):
-    """A trusted in-nltk_data JAR with safe args still builds the command."""
+    """A trusted in-nltk_data JAR with safe args reaches java() and builds the full
+    launcher command (java + -cp + safe option + main class), never running the CWD."""
+    import subprocess as _sp
+
+    from nltk import internals
+
     data_dir = tmp_path / "nltk_data"
     data_dir.mkdir()
     good = data_dir / "maltparser-1.9.2.jar"
     good.touch()
     monkeypatch.setattr("nltk.data.path", [str(data_dir)])
-    cmd = _malt_stub([str(good)], ["-Xmx1024m"], tmp_path).generate_malt_command(
-        "in", mode="parse"
-    )
-    assert cmd[0] == "java" and "-Xmx1024m" in cmd and "org.maltparser.Malt" in cmd
+    monkeypatch.setattr("nltk.internals._java_bin", "java")
+
+    m = _malt_stub([str(good)], ["-Xmx1024m"], tmp_path)
+    argv = m.generate_malt_command("in", "out", mode="parse")
+    # generate_malt_command now returns only the maltparser argv (no java/-cp/opts)
+    assert argv[0] == "org.maltparser.Malt" and "-w" in argv
+    assert "java" not in argv and "-Xmx1024m" not in argv
+
+    captured = {}
+
+    def _fake_popen(cmd, *a, **k):
+        captured["cmd"] = list(cmd)
+        raise _PopenIntercept
+
+    monkeypatch.setattr(_sp, "Popen", _fake_popen)
+    with pytest.raises(_PopenIntercept):
+        m._execute(argv)
+    cmd = captured["cmd"]
+    assert cmd[0] == "java" and "-cp" in cmd
+    assert "-Xmx1024m" in cmd and "org.maltparser.Malt" in cmd

--- a/nltk/test/unit/test_java_per_call_options_security.py
+++ b/nltk/test/unit/test_java_per_call_options_security.py
@@ -276,7 +276,8 @@ def trusted_jar(tmp_path, monkeypatch):
     root.mkdir()
     jar = root / "good.jar"
     jar.write_bytes(b"PK\x03\x04")
-    # Trusted roots = exactly this dir, so the sandbox checks are deterministic.
+    # Put this dir on nltk.data.path so it is one of the trusted roots (the sandbox
+    # also adds the repo root / Weka dirs); enough to make these checks deterministic.
     monkeypatch.setattr(nltk.data, "path", [str(root)])
     return str(jar)
 
@@ -316,6 +317,35 @@ class TestJavaClasspathSandbox:
     def test_relative_classpath_refused(self, stub_java_bin):
         with pytest.raises(internals.UntrustedJarError):
             internals.java(["Main"], classpath="relative.jar")
+
+    def test_dot_cwd_classpath_refused(self, stub_java_bin):
+        """ "." / ".." are the current/parent dir; relative, so refused."""
+        for bad in (".", "..", os.path.join(".", "x.jar")):
+            with pytest.raises(internals.UntrustedJarError):
+                internals.java(["Main"], classpath=bad)
+
+    def test_non_string_classpath_entry_refused(self, stub_java_bin, trusted_jar):
+        """A non-string list entry (Path / int / bytes) is an unsupported type, not
+        a CWD element: refused with a type message, never reaching Popen."""
+        from pathlib import Path
+
+        for bad in (Path(trusted_jar), 1234, b"/tmp/evil.jar"):
+            with pytest.raises(internals.UntrustedJarError) as exc:
+                internals.java(["Main"], classpath=[trusted_jar, bad])
+            assert "must be a string" in str(exc.value)
+
+    def test_bytes_classpath_refused(self, stub_java_bin):
+        """A bytes classpath is list()-ed into ints by java(); each is non-string
+        and refused (fail closed), never silently coerced."""
+        with pytest.raises(internals.UntrustedJarError):
+            internals.java(["Main"], classpath=b"/tmp/evil.jar")
+
+    def test_nul_byte_classpath_entry_refused(self, stub_java_bin, trusted_jar):
+        """A NUL byte truncates the path in native calls; refused with a clear
+        UntrustedJarError, not a bare ValueError from realpath."""
+        with pytest.raises(internals.UntrustedJarError) as exc:
+            internals.java(["Main"], classpath=trusted_jar + "\x00/etc/passwd")
+        assert "NUL" in str(exc.value)
 
     def test_outside_root_classpath_refused(self, stub_java_bin, trusted_jar):
         with pytest.raises(internals.UntrustedJarError):

--- a/nltk/test/unit/test_java_per_call_options_security.py
+++ b/nltk/test/unit/test_java_per_call_options_security.py
@@ -92,6 +92,27 @@ DANGEROUS = [
     ["-Xmx$(id)"],
     ["-verbose:gc\n-XX:OnError=x"],
     ["-Xmx512m\x00-XX:OnError=id"],
+    # tab / CR / NBSP / DEL smuggling on an allowed prefix: the shape guard must
+    # reject these the same way it rejects the newline and NUL variants above.
+    ["-Xmx512m\t-XX:OnError=x"],
+    ["-Xmx512m\r-XX:OnError=x"],
+    ["-Xmx512m\xa0-XX:OnError=x"],
+    ["-Xmx512m\x7f-XX:OnError=x"],
+    # -D classpath / security-config injection: set the classpath or swap the
+    # policy / JAAS config via a system property, bypassing the -cp sandbox.
+    ["-Djava.class.path=/tmp/evil"],
+    ["-Djava.security.policy=/tmp/evil"],
+    ["-Djava.security.auth.login.config=/tmp/evil"],
+    ["-Djdk.attach.allowAttachSelf=true"],  # enable self-attach agent injection
+    # disable bytecode verification -> load malformed / malicious classes
+    ["-Xverify:none"],
+    ["-noverify"],
+    # unlock experimental options / read compile commands from an attacker file
+    ["-XX:+UnlockExperimentalVMOptions"],
+    ["-XX:CompileCommandFile=/tmp/evil"],
+    ["-Xshare:dump"],  # dump a CDS archive to an attacker-chosen path
+    ["--enable-native-access=ALL-UNNAMED"],  # grant native (Panama) access
+    ["-xx:onerror=reboot"],  # fully-lowercase -XX: must still be rejected
 ]
 
 

--- a/nltk/test/unit/test_java_per_call_options_security.py
+++ b/nltk/test/unit/test_java_per_call_options_security.py
@@ -571,3 +571,47 @@ def test_sandbox_trust_boundary_is_nltk_data_path(stub_java_bin, tmp_path, monke
     internals._verify_jar_sandbox([str(inside)])  # trusted: no raise
     with pytest.raises(internals.UntrustedJarError):
         internals._verify_jar_sandbox([str(outside)])
+
+
+# --- non-blocking path (CoreNLP launches its server via java(blocking=False)): the
+# option/classpath/env guards must all fire BEFORE Popen, not only for blocking runs.
+
+
+class TestJavaNonBlocking:
+    def test_nonblocking_rejects_bad_option_before_popen(
+        self, stub_java_bin, monkeypatch
+    ):
+        called = {"popen": False}
+        monkeypatch.setattr(
+            internals.subprocess,
+            "Popen",
+            lambda *a, **k: called.__setitem__("popen", True),
+        )
+        with pytest.raises(ValueError):
+            internals.java(["Main"], options=["-XX:OnError=id"], blocking=False)
+        assert called["popen"] is False
+
+    def test_nonblocking_rejects_untrusted_classpath_before_popen(
+        self, stub_java_bin, monkeypatch
+    ):
+        called = {"popen": False}
+        monkeypatch.setattr(
+            internals.subprocess,
+            "Popen",
+            lambda *a, **k: called.__setitem__("popen", True),
+        )
+        with pytest.raises(internals.UntrustedJarError):
+            internals.java(["Main"], classpath="/etc/passwd", blocking=False)
+        assert called["popen"] is False
+
+    def test_nonblocking_strips_env(self, stub_java_bin, monkeypatch):
+        captured = {}
+
+        def _fake_popen(cmd, *a, **k):
+            captured["env"] = k.get("env")
+            return object()  # java() returns this Popen unchanged when non-blocking
+
+        monkeypatch.setenv("JAVA_TOOL_OPTIONS", "-XX:OnError=x")
+        monkeypatch.setattr(internals.subprocess, "Popen", _fake_popen)
+        internals.java(["Main"], blocking=False)
+        assert "JAVA_TOOL_OPTIONS" not in captured["env"]

--- a/nltk/test/unit/test_java_per_call_options_security.py
+++ b/nltk/test/unit/test_java_per_call_options_security.py
@@ -17,6 +17,8 @@ Two defects are covered:
    unlisted flag passes it via ``java(trusted_raw_options=...)``.
 """
 
+import os
+
 import pytest
 
 from nltk import internals
@@ -51,9 +53,23 @@ DANGEROUS = [
     ["-Djava.ext.dirs=/tmp/evil"],
     ["-Djava.rmi.server.codebase=http://evil/"],
     ["-Djava.system.class.loader=Evil"],
-    # module path could point at attacker code (only --add-modules is allowed)
+    # module path / module-system flags could point at or open attacker code
+    # (only --add-modules with a plain module list is allowed)
     ["--module-path=/tmp/evil"],
     ["-p", "/tmp/evil"],
+    ["--add-opens", "java.base/java.lang=ALL-UNNAMED"],
+    ["--add-exports", "java.base/sun.misc=ALL-UNNAMED"],
+    ["--patch-module", "java.base=/tmp/evil"],
+    # boot classpath override -> load attacker classes ahead of the JDK
+    ["-Xbootclasspath/a:/tmp/evil.jar"],
+    ["-Xbootclasspath:/tmp/evil"],
+    # -Xlog / -Xloggc write an attacker-chosen file
+    ["-Xlog:gc:file=/tmp/pwned"],
+    ["-Xloggc:/tmp/pwned"],
+    # case variants must not bypass the (case-insensitive) allowlist match
+    ["-JavaAgent:/tmp/evil.jar"],
+    ["-AGENTLIB:jdwp=transport=dt_socket"],
+    ["-XrunJDWP:x"],
     # --add-modules with a non-module-list value (shell metachars / path)
     ["--add-modules", "java.se.ee; rm -rf /"],
     ["--add-modules", "/etc/passwd"],
@@ -211,3 +227,160 @@ def test_java_cmd_channel_rejects_unicode_whitespace_prefix(stub_java_bin, cmd):
     launcher token cannot slip past the main-class guard."""
     with pytest.raises(ValueError):
         internals.java(cmd)
+
+
+# --- classpath channel: only absolute jars inside a trusted data root ----------
+
+
+@pytest.fixture
+def trusted_jar(tmp_path, monkeypatch):
+    """A real .jar inside a temporary trusted data root (on nltk.data.path), so
+    _verify_jar_sandbox accepts it and the per-entry checks can be exercised."""
+    import nltk.data
+
+    root = tmp_path / "nltk_data"
+    root.mkdir()
+    jar = root / "good.jar"
+    jar.write_bytes(b"PK\x03\x04")
+    # Trusted roots = exactly this dir, so the sandbox checks are deterministic.
+    monkeypatch.setattr(nltk.data, "path", [str(root)])
+    return str(jar)
+
+
+class TestJavaClasspathSandbox:
+    """A caller-supplied classpath reaches ``-cp``. An empty element (``a.jar::`` /
+    ``:a.jar`` / ``a.jar::b.jar`` / ``""`` in a list) is the JVM's spelling of the
+    current working directory, so it would inject classes from CWD past the jar
+    sandbox; it must be refused (CWE-88), as must relative, out-of-root, symlinked
+    and @argfile entries."""
+
+    def test_empty_classpath_entry_is_refused(self, stub_java_bin, trusted_jar):
+        sep = os.pathsep
+        for bad in (
+            trusted_jar + sep + sep,  # trailing ::
+            sep + trusted_jar,  # leading :
+            trusted_jar + sep + sep + trusted_jar,  # empty middle
+            [trusted_jar, ""],  # empty list entry
+            [trusted_jar, None],  # non-string list entry
+        ):
+            with pytest.raises((ValueError, internals.UntrustedJarError)):
+                internals.java(["Main"], classpath=bad)
+
+    def test_entry_embedding_path_separator_refused(self, stub_java_bin, trusted_jar):
+        """A single list entry that embeds os.pathsep would pass the per-entry root
+        check as one path but re-split in the JVM into extra unverified elements
+        (out-of-root jar or empty CWD element); it must be refused."""
+        sep = os.pathsep
+        for bad in (
+            [trusted_jar + sep],  # trailing separator -> empty CWD element
+            [trusted_jar + sep + os.path.realpath(os.sep + "etc")],  # out-of-root
+            [trusted_jar + sep + sep],  # smuggled empty CWD element
+        ):
+            with pytest.raises(internals.UntrustedJarError):
+                internals.java(["Main"], classpath=bad)
+
+    def test_relative_classpath_refused(self, stub_java_bin):
+        with pytest.raises(internals.UntrustedJarError):
+            internals.java(["Main"], classpath="relative.jar")
+
+    def test_outside_root_classpath_refused(self, stub_java_bin, trusted_jar):
+        with pytest.raises(internals.UntrustedJarError):
+            internals.java(["Main"], classpath=os.path.realpath(os.sep + "etc"))
+
+    def test_symlink_escape_refused(self, stub_java_bin, trusted_jar, tmp_path):
+        outside = tmp_path / "outside.jar"
+        outside.write_bytes(b"PK\x03\x04")
+        link = os.path.join(os.path.dirname(trusted_jar), "link.jar")
+        try:
+            os.symlink(str(outside), link)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks not supported here")
+        with pytest.raises(internals.UntrustedJarError):
+            internals.java(["Main"], classpath=link)
+
+    def test_argfile_classpath_refused(self, stub_java_bin):
+        with pytest.raises(internals.UntrustedJarError):
+            internals.java(["Main"], classpath="@/tmp/argfile")
+
+    def test_legit_trusted_jar_reaches_cp_without_empty(
+        self, stub_java_bin, trusted_jar, monkeypatch
+    ):
+        captured = {}
+
+        def _fake_popen(cmd, *a, **k):
+            captured["cmd"] = list(cmd)
+            raise _PopenIntercept
+
+        monkeypatch.setattr(internals.subprocess, "Popen", _fake_popen)
+        with pytest.raises(_PopenIntercept):
+            internals.java(["Main"], classpath=trusted_jar)
+        cp_value = captured["cmd"][captured["cmd"].index("-cp") + 1]
+        assert cp_value == trusted_jar
+        assert "" not in cp_value.split(os.pathsep), cp_value
+
+    def test_empty_entry_guard_is_load_bearing(
+        self, stub_java_bin, trusted_jar, monkeypatch
+    ):
+        """Mutation: neuter the sandbox and the empty CWD element flows into -cp."""
+        captured = {}
+
+        def _fake_popen(cmd, *a, **k):
+            captured["cmd"] = list(cmd)
+            raise _PopenIntercept
+
+        monkeypatch.setattr(internals.subprocess, "Popen", _fake_popen)
+        monkeypatch.setattr(internals, "_verify_jar_sandbox", lambda entries: None)
+        with pytest.raises(_PopenIntercept):
+            internals.java(["Main"], classpath=trusted_jar + os.pathsep + os.pathsep)
+        cp_value = captured["cmd"][captured["cmd"].index("-cp") + 1]
+        assert "" in cp_value.split(os.pathsep), cp_value
+
+
+# --- environment channel: JVM-injecting variables must be stripped -------------
+
+
+class TestJavaEnvironmentSanitization:
+    """The JVM reads JAVA_TOOL_OPTIONS / _JAVA_OPTIONS / JDK_JAVA_OPTIONS as extra
+    flags and CLASSPATH as extra code, none of which the allowlist/sandbox sees.
+    java() must strip them from the child environment (CWE-88 defense in depth)."""
+
+    INJECTING = ("JAVA_TOOL_OPTIONS", "_JAVA_OPTIONS", "JDK_JAVA_OPTIONS", "CLASSPATH")
+
+    @staticmethod
+    def _capture_env(monkeypatch):
+        captured = {}
+
+        def _fake_popen(cmd, *a, **k):
+            captured["env"] = k.get("env")
+            raise _PopenIntercept
+
+        monkeypatch.setattr(internals.subprocess, "Popen", _fake_popen)
+        return captured
+
+    def test_injecting_env_vars_stripped(self, stub_java_bin, monkeypatch):
+        for var in self.INJECTING:
+            monkeypatch.setenv(var, "-XX:OnError=touch /tmp/pwned")
+        captured = self._capture_env(monkeypatch)
+        with pytest.raises(_PopenIntercept):
+            internals.java(["Main"])
+        env = captured["env"]
+        assert env is not None, "java() must pass an explicit, sanitized env"
+        for var in self.INJECTING:
+            assert var not in env, f"{var} leaked into the child JVM environment"
+
+    def test_benign_env_preserved(self, stub_java_bin, monkeypatch):
+        monkeypatch.setenv("NLTK_TEST_MARKER", "keepme")
+        captured = self._capture_env(monkeypatch)
+        with pytest.raises(_PopenIntercept):
+            internals.java(["Main"])
+        assert captured["env"].get("NLTK_TEST_MARKER") == "keepme"
+        assert "PATH" in captured["env"]
+
+    def test_env_strip_is_load_bearing(self, stub_java_bin, monkeypatch):
+        """Mutation: empty the strip set and the injecting var reaches the child."""
+        monkeypatch.setenv("JAVA_TOOL_OPTIONS", "-XX:OnError=x")
+        monkeypatch.setattr(internals, "_JVM_INJECTING_ENV_VARS", frozenset())
+        captured = self._capture_env(monkeypatch)
+        with pytest.raises(_PopenIntercept):
+            internals.java(["Main"])
+        assert "JAVA_TOOL_OPTIONS" in captured["env"]

--- a/nltk/test/unit/test_java_per_call_options_security.py
+++ b/nltk/test/unit/test_java_per_call_options_security.py
@@ -113,6 +113,17 @@ DANGEROUS = [
     ["-Xshare:dump"],  # dump a CDS archive to an attacker-chosen path
     ["--enable-native-access=ALL-UNNAMED"],  # grant native (Panama) access
     ["-xx:onerror=reboot"],  # fully-lowercase -XX: must still be rejected
+    # suffix riding an allowed prefix: the anchored sizing/verbose shapes reject any
+    # trailing bytes (empirically inert on the JVM, but refused for defense in depth)
+    ["-Xmx512m@/tmp/argfile"],
+    ["-verbose:gc:file=/tmp/pwned"],
+    ["-verbose:foobar"],  # unknown -verbose category
+    ["-Xmxevil"],  # sizing flag without a numeric size
+    ["-Xmx"],  # sizing flag with no value at all
+    ["-mx512m/tmp"],  # trailing path on a sizing flag
+    ["-Xss128m-XX:OnError=x"],  # two flags concatenated, no metachar to catch it
+    ["-Xbatchevil"],  # suffix on a no-argument mode flag
+    ["-server_evil"],  # suffix on an exact-match flag
 ]
 
 
@@ -136,6 +147,17 @@ SAFE = [
     ["-server"],
     ["-client"],
     ["-verbose:gc"],
+    # anchored-shape positives: raw-byte heap, capital unit, other categories and
+    # no-argument mode flags all must keep passing after the tightening
+    ["-Xmx2147483648"],
+    ["-Xmx8G"],
+    ["-Xss512k"],
+    ["-verbose"],
+    ["-verbose:class"],
+    ["-Xint"],
+    ["-Xcomp"],
+    ["-Xbatch"],
+    ["-Xmixed"],
     # --add-modules java.se.ee is required by CoreNLP on JDK 9-11 (both forms)
     ["--add-modules", "java.se.ee"],
     ["--add-modules=java.se.ee,java.xml.bind"],
@@ -455,3 +477,53 @@ class TestJavaEnvironmentSanitization:
         with pytest.raises(_PopenIntercept):
             internals.java(["Main"])
         assert "JAVA_TOOL_OPTIONS" in captured["env"]
+
+    def test_helper_strips_and_preserves(self, monkeypatch):
+        """The shared _java_child_env() helper (used by java() and the MaltParser
+        wrapper) drops every injecting var and keeps the rest."""
+        monkeypatch.setenv("JAVA_TOOL_OPTIONS", "-Xmx1m")
+        monkeypatch.setenv("CLASSPATH", "/tmp/evil")
+        monkeypatch.setenv("NLTK_KEEP", "1")
+        env = internals._java_child_env()
+        assert "JAVA_TOOL_OPTIONS" not in env and "CLASSPATH" not in env
+        assert env.get("NLTK_KEEP") == "1"
+
+
+# --- MaltParser runs its OWN java subprocess, not internals.java(): it must apply
+# the same env sanitization or JAVA_TOOL_OPTIONS et al. inject past the allowlist.
+
+
+def test_maltparser_execute_strips_injecting_env(monkeypatch):
+    from nltk.parse import malt
+
+    captured = {}
+
+    def _fake_popen(cmd, *a, **k):
+        captured["env"] = k.get("env")
+
+        class _P:
+            def wait(self):
+                return 0
+
+        return _P()
+
+    monkeypatch.setenv("JAVA_TOOL_OPTIONS", "-XX:OnError=touch /tmp/pwned")
+    monkeypatch.setenv("_JAVA_OPTIONS", "-javaagent:/tmp/evil.jar")
+    monkeypatch.setenv("NLTK_KEEP", "1")
+    monkeypatch.setattr(malt.subprocess, "Popen", _fake_popen)
+    malt.MaltParser._execute(["java", "-version"])
+    env = captured["env"]
+    assert env is not None, "MaltParser._execute must pass an explicit sanitized env"
+    assert "JAVA_TOOL_OPTIONS" not in env and "_JAVA_OPTIONS" not in env
+    assert env.get("NLTK_KEEP") == "1"  # benign vars are preserved
+
+
+def test_config_java_validates_global_options(monkeypatch):
+    """config_java() stores global options used when java(options=None); a
+    dangerous global flag must be rejected there too, not just per-call."""
+    monkeypatch.setattr(internals, "_java_options", [])
+    with pytest.raises(ValueError):
+        internals.config_java(bin="/usr/bin/java", options=["-XX:OnError=id"])
+    # a safe global set is accepted and stored
+    internals.config_java(bin="/usr/bin/java", options=["-Xmx512m"])
+    assert internals._java_options == ["-Xmx512m"]

--- a/nltk/test/unit/test_java_per_call_options_security.py
+++ b/nltk/test/unit/test_java_per_call_options_security.py
@@ -489,33 +489,49 @@ class TestJavaEnvironmentSanitization:
         assert env.get("NLTK_KEEP") == "1"
 
 
-# --- MaltParser runs its OWN java subprocess, not internals.java(): it must apply
-# the same env sanitization or JAVA_TOOL_OPTIONS et al. inject past the allowlist.
+# --- MaltParser now routes its JVM through internals.java() (no own subprocess, no
+# cwd), so it inherits the classpath sandbox, option allowlist and env sanitization.
 
 
-def test_maltparser_execute_strips_injecting_env(monkeypatch):
+def test_maltparser_execute_routes_through_java_with_sanitized_env(
+    monkeypatch, tmp_path
+):
+    import nltk.data
     from nltk.parse import malt
+
+    root = tmp_path / "nltk_data"
+    root.mkdir()
+    jar = (
+        root / "maltparser-1.9.2.jar"
+    )  # trusted (on nltk.data.path) so sandbox admits it
+    jar.write_bytes(b"PK\x03\x04")
+    monkeypatch.setattr(nltk.data, "path", [str(root)])
+    monkeypatch.setattr(internals, "_java_bin", "/usr/bin/java")
 
     captured = {}
 
     def _fake_popen(cmd, *a, **k):
         captured["env"] = k.get("env")
-
-        class _P:
-            def wait(self):
-                return 0
-
-        return _P()
+        captured["cmd"] = list(cmd)
+        raise _PopenIntercept
 
     monkeypatch.setenv("JAVA_TOOL_OPTIONS", "-XX:OnError=touch /tmp/pwned")
     monkeypatch.setenv("_JAVA_OPTIONS", "-javaagent:/tmp/evil.jar")
     monkeypatch.setenv("NLTK_KEEP", "1")
-    monkeypatch.setattr(malt.subprocess, "Popen", _fake_popen)
-    malt.MaltParser._execute(["java", "-version"])
+    monkeypatch.setattr(internals.subprocess, "Popen", _fake_popen)
+
+    parser = malt.MaltParser.__new__(malt.MaltParser)
+    parser.malt_jars = [str(jar)]
+    parser.additional_java_args = []
+    with pytest.raises(_PopenIntercept):
+        parser._execute(["org.maltparser.Malt", "-m", "parse"])
+
     env = captured["env"]
-    assert env is not None, "MaltParser._execute must pass an explicit sanitized env"
+    assert env is not None, "MaltParser must reach java()'s sanitized-env Popen"
     assert "JAVA_TOOL_OPTIONS" not in env and "_JAVA_OPTIONS" not in env
-    assert env.get("NLTK_KEEP") == "1"  # benign vars are preserved
+    assert env.get("NLTK_KEEP") == "1"  # benign vars preserved
+    # confirm it truly went through java(): -cp built from malt_jars + the main class
+    assert "-cp" in captured["cmd"] and "org.maltparser.Malt" in captured["cmd"]
 
 
 def test_config_java_validates_global_options(monkeypatch):

--- a/nltk/test/unit/test_java_per_call_options_security.py
+++ b/nltk/test/unit/test_java_per_call_options_security.py
@@ -615,3 +615,34 @@ class TestJavaNonBlocking:
         monkeypatch.setattr(internals.subprocess, "Popen", _fake_popen)
         internals.java(["Main"], blocking=False)
         assert "JAVA_TOOL_OPTIONS" not in captured["env"]
+
+
+# --- the java wrappers write the user's input to temp files and pass those paths
+# to the JVM; they must use a secure temp API, never a predictable-name one (CWE-377).
+
+_JAVA_WRAPPER_MODULES = [
+    "nltk.tokenize.stanford",
+    "nltk.parse.stanford",
+    "nltk.tag.stanford",
+    "nltk.tokenize.stanford_segmenter",
+    "nltk.classify.weka",
+    "nltk.parse.malt",
+]
+
+_SECURE_TEMP = ("NamedTemporaryFile", "mkstemp", "mkdtemp")
+_INSECURE_TEMP = ("tempfile.mktemp", "os.tmpnam", "os.tempnam")
+
+
+@pytest.mark.parametrize("modname", _JAVA_WRAPPER_MODULES)
+def test_java_wrapper_uses_secure_tempfiles(modname):
+    """Each java wrapper must create temp files with a secure API and never a
+    predictable-name one, so a symlink/CWD race can't hijack the file (CWE-377)."""
+    import importlib
+    import inspect
+
+    src = inspect.getsource(importlib.import_module(modname))
+    for bad in _INSECURE_TEMP:
+        assert bad not in src, f"{modname} uses insecure temp API {bad!r}"
+    assert any(
+        good in src for good in _SECURE_TEMP
+    ), f"{modname} does not use a recognised secure temp API {_SECURE_TEMP}"

--- a/nltk/test/unit/test_java_per_call_options_security.py
+++ b/nltk/test/unit/test_java_per_call_options_security.py
@@ -47,6 +47,9 @@ DANGEROUS = [
     ["-XX:onerror=reboot"],
     ["-XX:+UnlockDiagnosticVMOptions"],
     ["-XX:ErrorFile=/tmp/e"],
+    ["-XX:Flags=/tmp/e"],  # read VM options from an attacker file
+    ["-XX:VMOptionsFile=/tmp/e"],
+    ["-XX:SharedArchiveFile=/tmp/e"],
     ["-XX:ParallelGCThreads=1"],  # even a benign -XX: is rejected (use escape hatch)
     # -D system properties: not needed by NLTK/CoreNLP and can load code.
     ["-Dfile.encoding=UTF-8"],
@@ -59,9 +62,19 @@ DANGEROUS = [
     ["-p", "/tmp/evil"],
     ["--add-opens", "java.base/java.lang=ALL-UNNAMED"],
     ["--add-exports", "java.base/sun.misc=ALL-UNNAMED"],
+    ["--add-reads", "java.base=ALL-UNNAMED"],
     ["--patch-module", "java.base=/tmp/evil"],
+    ["--upgrade-module-path=/tmp/evil"],
+    # -cp / -classpath in options would add an unverified classpath
+    ["-cp", "/tmp/evil"],
+    ["-classpath", "/tmp/evil"],
+    ["--class-path=/tmp/evil"],
+    # -D loaders / security-manager toggles
+    ["-Djava.library.path=/tmp/evil"],
+    ["-Djava.security.manager=Evil"],
     # boot classpath override -> load attacker classes ahead of the JDK
     ["-Xbootclasspath/a:/tmp/evil.jar"],
+    ["-Xbootclasspath/p:/tmp/evil.jar"],
     ["-Xbootclasspath:/tmp/evil"],
     # -Xlog / -Xloggc write an attacker-chosen file
     ["-Xlog:gc:file=/tmp/pwned"],
@@ -344,7 +357,14 @@ class TestJavaEnvironmentSanitization:
     flags and CLASSPATH as extra code, none of which the allowlist/sandbox sees.
     java() must strip them from the child environment (CWE-88 defense in depth)."""
 
-    INJECTING = ("JAVA_TOOL_OPTIONS", "_JAVA_OPTIONS", "JDK_JAVA_OPTIONS", "CLASSPATH")
+    INJECTING = (
+        "JAVA_TOOL_OPTIONS",
+        "_JAVA_OPTIONS",
+        "JDK_JAVA_OPTIONS",
+        "IBM_JAVA_OPTIONS",
+        "OPENJ9_JAVA_OPTIONS",
+        "CLASSPATH",
+    )
 
     @staticmethod
     def _capture_env(monkeypatch):

--- a/nltk/test/unit/test_java_per_call_options_security.py
+++ b/nltk/test/unit/test_java_per_call_options_security.py
@@ -534,6 +534,58 @@ def test_maltparser_execute_routes_through_java_with_sanitized_env(
     assert "-cp" in captured["cmd"] and "org.maltparser.Malt" in captured["cmd"]
 
 
+def _bare_malt_parser(jars, java_args):
+    from nltk.parse import malt
+
+    parser = malt.MaltParser.__new__(malt.MaltParser)
+    parser.malt_jars = list(jars)
+    parser.additional_java_args = list(java_args)
+    return parser
+
+
+def _should_not_run(*a, **k):
+    raise AssertionError("subprocess.Popen must not run: the call should be rejected")
+
+
+def test_maltparser_dangerous_java_option_rejected_by_java(tmp_path, monkeypatch):
+    """Now that MaltParser routes through java(), a dangerous additional_java_args
+    flag is refused by java()'s option allowlist; malt no longer has to (and does
+    not) validate options itself."""
+    import nltk.data
+
+    root = tmp_path / "nltk_data"
+    root.mkdir()
+    jar = root / "maltparser-1.9.2.jar"
+    jar.write_bytes(b"PK\x03\x04")
+    monkeypatch.setattr(nltk.data, "path", [str(root)])
+    monkeypatch.setattr(internals, "_java_bin", "/usr/bin/java")
+    monkeypatch.setattr(internals.subprocess, "Popen", _should_not_run)
+
+    parser = _bare_malt_parser([str(jar)], ["-XX:OnError=touch /tmp/pwned"])
+    with pytest.raises(ValueError):
+        parser._execute(["org.maltparser.Malt", "-m", "parse"])
+
+
+def test_maltparser_untrusted_classpath_rejected_by_java(tmp_path, monkeypatch):
+    """A malt jar outside every trusted root is refused by java()'s classpath
+    sandbox, inherited now that malt routes through java()."""
+    import nltk.data
+
+    root = tmp_path / "nltk_data"
+    root.mkdir()  # trusted root, but the jar lives OUTSIDE it
+    monkeypatch.setattr(nltk.data, "path", [str(root)])
+    monkeypatch.setattr(internals, "_java_bin", "/usr/bin/java")
+    monkeypatch.setattr(internals.subprocess, "Popen", _should_not_run)
+
+    evil_dir = tmp_path / "evil"
+    evil_dir.mkdir()
+    evil_jar = evil_dir / "maltparser-1.9.2.jar"
+    evil_jar.write_bytes(b"PK\x03\x04")
+    parser = _bare_malt_parser([str(evil_jar)], [])
+    with pytest.raises(internals.UntrustedJarError):
+        parser._execute(["org.maltparser.Malt", "-m", "parse"])
+
+
 def test_config_java_validates_global_options(monkeypatch):
     """config_java() stores global options used when java(options=None); a
     dangerous global flag must be rejected there too, not just per-call."""

--- a/nltk/test/unit/test_java_per_call_options_security.py
+++ b/nltk/test/unit/test_java_per_call_options_security.py
@@ -527,3 +527,47 @@ def test_config_java_validates_global_options(monkeypatch):
     # a safe global set is accepted and stored
     internals.config_java(bin="/usr/bin/java", options=["-Xmx512m"])
     assert internals._java_options == ["-Xmx512m"]
+
+
+# --- discovery layer: an attacker who poisons a jar-discovery env var must still
+# be caught by the classpath sandbox when the wrapper passes the jar to java().
+
+
+def test_poisoned_jar_discovery_env_is_rejected_by_sandbox(
+    stub_java_bin, tmp_path, monkeypatch
+):
+    """find_jar honors env vars (STANFORD_POSTAGGER etc.); a jar it returns from an
+    attacker-set env still hits _verify_jar_sandbox and is refused if out of root."""
+    import nltk.data
+
+    trusted = tmp_path / "nltk_data"
+    trusted.mkdir()
+    monkeypatch.setattr(nltk.data, "path", [str(trusted)])  # only this dir is trusted
+    attacker = tmp_path / "attacker"
+    attacker.mkdir()
+    evil = attacker / "stanford-postagger.jar"  # outside every trusted root
+    evil.write_bytes(b"PK\x03\x04")
+    monkeypatch.setenv("STANFORD_POSTAGGER", str(evil))
+    found = internals.find_jar(
+        "stanford-postagger.jar", None, env_vars=("STANFORD_POSTAGGER",), searchpath=()
+    )
+    assert found == str(evil)  # discovery layer trusts the (attacker-set) env var
+    with pytest.raises(internals.UntrustedJarError):
+        internals.java(["edu.stanford.nlp.tagger.maxent.MaxentTagger"], classpath=found)
+
+
+def test_sandbox_trust_boundary_is_nltk_data_path(stub_java_bin, tmp_path, monkeypatch):
+    """The sandbox trusts exactly nltk.data.path (+ repo/Weka): a jar inside a data
+    root is accepted, one outside every root is refused."""
+    import nltk.data
+
+    root = tmp_path / "nltk_data"
+    root.mkdir()
+    inside = root / "good.jar"
+    inside.write_bytes(b"PK\x03\x04")
+    outside = tmp_path / "bad.jar"
+    outside.write_bytes(b"PK\x03\x04")
+    monkeypatch.setattr(nltk.data, "path", [str(root)])
+    internals._verify_jar_sandbox([str(inside)])  # trusted: no raise
+    with pytest.raises(internals.UntrustedJarError):
+        internals._verify_jar_sandbox([str(outside)])

--- a/nltk/test/unit/test_malt.py
+++ b/nltk/test/unit/test_malt.py
@@ -43,7 +43,7 @@ def _write_minimal_parse(cmd):
     )
 
 
-def test_malt_parse_uses_subprocess_cwd_without_changing_process_cwd(
+def test_malt_parse_passes_model_dir_via_w_without_changing_process_cwd(
     monkeypatch, tmp_path
 ):
     parser, model_dir = _minimal_malt_parser(tmp_path, monkeypatch)
@@ -58,8 +58,8 @@ def test_malt_parse_uses_subprocess_cwd_without_changing_process_cwd(
 
     captured = {}
 
-    def fake_execute(cmd, verbose=False, cwd=None):
-        captured["cwd"] = cwd
+    def fake_execute(cmd, verbose=False):
+        captured["cmd"] = cmd
         captured["process_cwd"] = os.getcwd()
         captured["input_file"] = Path(cmd[cmd.index("-i") + 1])
         captured["output_file"] = Path(cmd[cmd.index("-o") + 1])
@@ -71,7 +71,9 @@ def test_malt_parse_uses_subprocess_cwd_without_changing_process_cwd(
     graphs = list(parser.parse_tagged_sents([[("hello", "NN")]]))
 
     assert len(graphs) == 1
-    assert captured["cwd"] == str(model_dir)
+    # The model directory is handed to MaltParser via its -w argument, NOT by
+    # changing the JVM's working directory; the process cwd stays untouched.
+    assert captured["cmd"][captured["cmd"].index("-w") + 1] == str(model_dir)
     assert captured["process_cwd"] == str(service_dir)
     assert os.getcwd() == str(service_dir)
     assert not captured["input_file"].exists()
@@ -88,8 +90,8 @@ def test_malt_parse_cleans_temp_files_and_preserves_cwd_on_execute_exception(
 
     captured = {}
 
-    def fake_execute(cmd, verbose=False, cwd=None):
-        captured["cwd"] = cwd
+    def fake_execute(cmd, verbose=False):
+        captured["cmd"] = cmd
         captured["process_cwd"] = os.getcwd()
         captured["input_file"] = Path(cmd[cmd.index("-i") + 1])
         captured["output_file"] = Path(cmd[cmd.index("-o") + 1])
@@ -102,7 +104,7 @@ def test_malt_parse_cleans_temp_files_and_preserves_cwd_on_execute_exception(
     with pytest.raises(RuntimeError, match="forced parser failure"):
         list(parser.parse_tagged_sents([[("hello", "NN")]]))
 
-    assert captured["cwd"] == str(model_dir)
+    assert captured["cmd"][captured["cmd"].index("-w") + 1] == str(model_dir)
     assert captured["process_cwd"] == str(service_dir)
     assert os.getcwd() == str(service_dir)
     assert not captured["input_file"].exists()

--- a/nltk/test/unit/test_platform_detection.py
+++ b/nltk/test/unit/test_platform_detection.py
@@ -53,12 +53,31 @@ def test_maltparser_command_uses_os_pathsep(monkeypatch, tmp_path):
     jar_b = data_root / "b.jar"
     jar_b.touch()
     monkeypatch.setattr("nltk.data.path", [str(data_root)])
+    monkeypatch.setattr("nltk.internals._java_bin", "java")
 
     parser = MaltParser.__new__(MaltParser)
     parser.additional_java_args = []
     parser.malt_jars = [str(jar_a), str(jar_b)]
     parser.model = "model.mco"
 
-    cmd = parser.generate_malt_command("input.conll", mode="learn")
+    captured = {}
 
-    assert cmd[2] == f"{jar_a};{jar_b}"
+    def _fake_popen(cmd, *a, **k):
+        captured["cmd"] = list(cmd)
+
+        class _P:
+            returncode = 0
+
+            def communicate(self):
+                return ("", "")
+
+        return _P()
+
+    monkeypatch.setattr("nltk.internals.subprocess.Popen", _fake_popen)
+
+    # MaltParser hands its jars to internals.java(), which joins the classpath with
+    # os.pathsep; the launcher command's -cp value must use it.
+    argv = parser.generate_malt_command("input.conll", mode="learn")
+    parser._execute(argv)
+    cmd = captured["cmd"]
+    assert cmd[cmd.index("-cp") + 1] == f"{jar_a};{jar_b}"

--- a/nltk/test/unit/test_stanford_java_wrappers.py
+++ b/nltk/test/unit/test_stanford_java_wrappers.py
@@ -12,7 +12,7 @@ def test_java_call_options_do_not_mutate_global_java_options(tmp_path):
     with mock.patch.dict(os.environ, {"NLTK_ALLOW_UNSAFE_JARS": "1"}), mock.patch(
         "nltk.data.path", [str(tmp_path)]
     ), mock.patch.object(nltk.internals, "_java_bin", ["java"]), mock.patch.object(
-        nltk.internals, "_java_options", ["-XmxGLOBAL"]
+        nltk.internals, "_java_options", ["-Xmx111m"]
     ):
 
         captured_cmd = []
@@ -30,12 +30,12 @@ def test_java_call_options_do_not_mutate_global_java_options(tmp_path):
                 classpath="example.jar",
                 stdout="pipe",
                 stderr="pipe",
-                options="-XmxLOCAL -verbose:gc",
+                options="-Xmx222m -verbose:gc",
             )
 
-        expected = ["java", "-XmxLOCAL", "-verbose:gc", "-cp", "example.jar", "Main"]
+        expected = ["java", "-Xmx222m", "-verbose:gc", "-cp", "example.jar", "Main"]
         assert captured_cmd[0] == expected
-        assert nltk.internals._java_options == ["-XmxGLOBAL"]
+        assert nltk.internals._java_options == ["-Xmx111m"]
 
 
 def test_cwe94_jar_sandbox_allows_safe_paths_string(tmp_path):


### PR DESCRIPTION
Follow-up hardening of `internals.java()` (extends #3771), with `develop` merged in. An exhaustive adversarial audit of **every** channel into the JVM launcher — options, cmd, classpath, environment, binary/jar discovery, temp files, and both the blocking and non-blocking launch paths — plus routing the one wrapper that still bypassed `java()` (MaltParser) through it, so **every** NLTK JVM launch now shares a single hardened entry point.

Relates to CVE-2026-12841 / GHSA-m4rf (CWE-88). The separate str/bytes wrapper-decode fix is #3777 (merged).

## Injection vectors found & fixed

**Classpath sandbox (`_verify_jar_sandbox`)**
- **Empty classpath element = the JVM's CWD** (`a.jar::`, `:a.jar`, `a.jar::b.jar`, or `""` / `None` in a list): empty parts were dropped *before* verification and the raw string handed to `-cp`, silently adding the working directory to the classpath. Empty entries are refused and `-cp` is rebuilt from the verified entries only.
- **A list entry embedding `os.pathsep`** (`trusted.jar:/etc/passwd`) passed the per-entry realpath/root check as one path but re-split in the JVM into extra **unverified** elements — refused.
- **Non-string entry, NUL-byte entry, relative path, out-of-root, symlink-escape** — all refused with accurate per-case errors (the empty-vs-non-string messages are split; NUL is a clear `UntrustedJarError` instead of a bare `ValueError`).
- Trusted roots are `normcase`d to match the candidate entry (fixes a Windows false-reject).

**Option allowlist (`_validate_java_options`)**
- Prefix matching replaced with **anchored shapes**: sizing flags must be `number+optional-unit`, `-verbose` a known category, mode flags exact — so no arbitrary suffix can ride a safe prefix (`-Xmx512m@/file`, `-verbose:gc:file=…`, `-Xbatchevil`). Empirically inert on the JVM, refused for defense in depth.
- Shape guard rejects whitespace / control chars / shell metacharacters (incl. tab, CR, NBSP, DEL); `@argfile` rejected in any position; matching is case-insensitive. `config_java()` validates its global options too.

**Environment (`_java_child_env`)**
- Strips `JAVA_TOOL_OPTIONS`, `_JAVA_OPTIONS`, `JDK_JAVA_OPTIONS`, `IBM_JAVA_OPTIONS`, `OPENJ9_JAVA_OPTIONS` (arbitrary flags incl. `-XX:OnError` / `-javaagent`) and `CLASSPATH` (unverified code) from the child environment, case-insensitively; `PATH` and benign vars are preserved.

**Binary / jar discovery**
- `find_binary` refuses a CWD-relative match even when a **bare** `path_to_bin` is supplied — a plain `config_java(bin="java")` was hijackable by a planted `./java/java` (CWE-426 / CWE-427). A path with a directory component is still honored as the caller's explicit choice.
- `find_jar_iter`'s regex + searchpath branch had a mis-indented `yield` that returned **any** directory entry (subdirs / unrelated files), not the matching jar — fixed to yield only a matching file.
- Discovery composes with the sandbox: a jar returned from an attacker-poisoned env var (e.g. `STANFORD_POSTAGGER`) is still refused by the classpath sandbox when out of root.

**Temp files (CWE-377)** — audited every wrapper; all use a secure API (`NamedTemporaryFile` / `mkstemp` / `mkdtemp`), none a predictable-name one; a regression guard locks this.

## MaltParser now routes through `internals.java()`

MaltParser was the last wrapper that built and ran its own subprocess, hand-duplicating the protections — which is exactly why the env sanitisation had been missing on that path. It now calls `internals.java()`, inheriting the classpath sandbox, option allowlist and env-strip, so they cannot drift out of sync again. It passes MaltParser's own `-w <workingdir>` as a **program argument** instead of chdir-ing the JVM process — deliberately avoiding adding a `cwd` parameter to `java()`, which would reopen a CWD class-injection hole (verified live: with no explicit `-cp` the JVM runs `.class` files from the working directory). It also now honours `config_java(bin=…)` instead of hard-coding bare `java`.

## Tests

The harness gains a large attack matrix — 71 option / cmd / classpath / env attacks, each with a **load-bearing mutation** (neuter the guard → the exploit becomes reachable) — plus discovery-composition tests, non-blocking-launch guards, the MaltParser-routing tests, and the CWE-377 guard. **224 java-related tests pass** across the 16 java test files; the full attack matrix shows zero leaks.

**Verified live against a real OpenJDK 26** (not mocked, using the official Stanford tagger/parser, MaltParser 1.9.2 and Weka 3.8.6 distributions): StanfordPOSTagger, StanfordTokenizer, StanfordParser (constituency + dependency), MaltParser (train + parse) and WekaClassifier all produce correct output through the hardened path.

black 25.11.0 / isort / pyupgrade (`--py310-plus`) clean.
