### PR TITLE
Fix shared defaults in chat80 Concept

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -318,6 +318,7 @@
 - Volodymyr Matsko <https://github.com/Lemm1>
 - Nicola <https://github.com/trinik15>
 - medisean <https://github.com/medisean>
+- tandede <https://github.com/tandede>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 

--- a/nltk/sem/chat80.py
+++ b/nltk/sem/chat80.py
@@ -251,28 +251,29 @@ class Concept:
     (https://www.w3.org/TR/swbp-skos-core-guide/).
     """
 
-    def __init__(self, prefLabel, arity, altLabels=[], closures=[], extension=set()):
+    def __init__(self, prefLabel, arity, altLabels=None, closures=None, extension=None):
         """
         :param prefLabel: the preferred label for the concept
         :type prefLabel: str
         :param arity: the arity of the concept
         :type arity: int
-        :param altLabels: other (related) labels
-        :type altLabels: list
+        :param altLabels: other (related) labels, defaults to an empty list
+        :type altLabels: list or None
         :param closures: closure properties of the extension
-            (list items can be ``symmetric``, ``reflexive``, ``transitive``)
-        :type closures: list
-        :param extension: the extensional value of the concept
-        :type extension: set
+            (list items can be ``symmetric``, ``reflexive``, ``transitive``),
+            defaults to an empty list
+        :type closures: list or None
+        :param extension: the extensional value of the concept, defaults to an empty set
+        :type extension: set or None
         """
         self.prefLabel = prefLabel
         self.arity = arity
-        self.altLabels = altLabels
-        self.closures = closures
+        self.altLabels = [] if altLabels is None else altLabels
+        self.closures = [] if closures is None else closures
         # keep _extension internally as a set
-        self._extension = extension
+        self._extension = set() if extension is None else extension
         # public access is via a list (for slicing)
-        self.extension = sorted(list(extension))
+        self.extension = sorted(list(self._extension))
 
     def __str__(self):
         # _extension = ''

--- a/nltk/test/unit/test_chat80.py
+++ b/nltk/test/unit/test_chat80.py
@@ -1,0 +1,14 @@
+from nltk.sem.chat80 import Concept
+
+
+def test_concept_default_containers_are_independent():
+    first = Concept("first", arity=1)
+    second = Concept("second", arity=1)
+
+    first.altLabels.append("alias")
+    first.closures.append("symmetric")
+    first.augment("one")
+
+    assert second.altLabels == []
+    assert second.closures == []
+    assert second.augment("two") == {"two"}


### PR DESCRIPTION
## Summary

- replace the mutable default arguments in `Concept` with `None` sentinels
- allocate fresh default label, closure, and extension containers for each instance
- preserve caller-provided containers when arguments are supplied explicitly
- add a regression test covering state isolation across two default-constructed concepts
- add `tandede` to `AUTHORS.md` as required by the contribution guide

## Motivation

`Concept` currently uses a shared list for `altLabels`, a shared list for `closures`, and a shared set for `extension`. Mutating any of those defaults through one instance changes later instances. This addresses the three `Concept.__init__` cases identified in #2121 without changing explicit-container behavior.

## Validation

- `pytest -q nltk/test/unit/test_chat80.py nltk/test/chat80.doctest` (2 passed)
- `pytest -q nltk/test/unit` (1944 passed, 71 skipped, 9 xfailed)
- `pre-commit run --files AUTHORS.md nltk/sem/chat80.py nltk/test/unit/test_chat80.py` (all hooks passed)