### PR TITLE
Fix Java wrappers decoding str output from java() (universal_newlines)

### DIFF
--- a/nltk/classify/weka.py
+++ b/nltk/classify/weka.py
@@ -117,7 +117,7 @@ class WekaClassifier(ClassifierI):
                 "-T",
                 test_filename,
             ] + options
-            (stdout, stderr) = java(
+            stdout, stderr = java(
                 cmd,
                 classpath=_weka_classpath,
                 stdout=subprocess.PIPE,
@@ -135,8 +135,11 @@ class WekaClassifier(ClassifierI):
                 else:
                     raise ValueError("Weka failed to generate output:\n%s" % stderr)
 
-            # Parse weka's output.
-            return self.parse_weka_output(stdout.decode(stdin.encoding).split("\n"))
+            # Parse weka's output. java() returns text (universal_newlines=True);
+            # only decode when an older bytes-returning path is in play.
+            if isinstance(stdout, bytes):
+                stdout = stdout.decode(stdin.encoding)
+            return self.parse_weka_output(stdout.split("\n"))
 
         finally:
             for f in os.listdir(temp_dir):

--- a/nltk/parse/corenlp.py
+++ b/nltk/parse/corenlp.py
@@ -140,10 +140,13 @@ class CoreNLPServer:
         returncode = self.popen.poll()
         if returncode is not None:
             _, stderrdata = self.popen.communicate()
+            # java() runs Popen with universal_newlines=True, so communicate()
+            # already returns text; only decode a bytes-returning path.
+            if isinstance(stderrdata, bytes):
+                stderrdata = stderrdata.decode("ascii")
             raise CoreNLPServerError(
                 returncode,
-                "Could not start the server. "
-                "The error was: {}".format(stderrdata.decode("ascii")),
+                f"Could not start the server. The error was: {stderrdata}",
             )
 
         for i in range(30):

--- a/nltk/parse/stanford.py
+++ b/nltk/parse/stanford.py
@@ -256,9 +256,14 @@ class GenericStanfordParser(ParserI):
                         options=self.java_options,
                     )
 
-                stdout = stdout.replace(b"\xc2\xa0", b" ")
-                stdout = stdout.replace(b"\x00\xa0", b" ")
-                stdout = stdout.decode(encoding)
+                # java() returns text (universal_newlines=True); only the older
+                # bytes path needs the byte-level NBSP fixups and decode.
+                if isinstance(stdout, bytes):
+                    stdout = stdout.replace(b"\xc2\xa0", b" ")
+                    stdout = stdout.replace(b"\x00\xa0", b" ")
+                    stdout = stdout.decode(encoding)
+                else:
+                    stdout = stdout.replace("\xa0", " ")
                 java_succeeded = True
         finally:
             if input_file_name:

--- a/nltk/tag/stanford.py
+++ b/nltk/tag/stanford.py
@@ -117,7 +117,10 @@ class StanfordTagger(TaggerI):
                 stderr=PIPE,
                 options=self.java_options,
             )
-            stanpos_output = stanpos_output.decode(encoding)
+            # java() returns text (universal_newlines=True), so only decode when
+            # an older/bytes-returning path is in play.
+            if isinstance(stanpos_output, bytes):
+                stanpos_output = stanpos_output.decode(encoding)
             java_succeeded = True
         finally:
             if input_file_path:

--- a/nltk/test/unit/test_java_wrapper_text_output.py
+++ b/nltk/test/unit/test_java_wrapper_text_output.py
@@ -60,6 +60,36 @@ def test_weka_classifier_handles_str_output(monkeypatch, tmp_path):
     assert out == ["no"]
 
 
+def test_corenlp_server_start_error_handles_str_stderr(monkeypatch):
+    """CoreNLPServer.start() reads the server's stderr via popen.communicate();
+    java()'s Popen is text-mode, so that is a str and must not be .decode()d."""
+    from nltk.parse import corenlp
+
+    monkeypatch.setattr(
+        corenlp,
+        "find_jar_iter",
+        lambda *a, **k: iter(["/x/stanford-corenlp-4.0.0.jar"]),
+    )
+    monkeypatch.setattr(corenlp, "try_port", lambda *a, **k: 9000)
+    monkeypatch.setattr(corenlp, "config_java", lambda *a, **k: None)
+
+    class _DeadPopen:
+        def poll(self):
+            return 1  # server exited immediately
+
+        def communicate(self):
+            return ("", "boom: CoreNLP failed to start")  # str, like text-mode Popen
+
+    monkeypatch.setattr(corenlp, "java", lambda *a, **k: _DeadPopen())
+    server = corenlp.CoreNLPServer(
+        path_to_jar="/x/stanford-corenlp-4.0.0.jar",
+        path_to_models_jar="/x/stanford-corenlp-4.0.0-models.jar",
+    )
+    with pytest.raises(corenlp.CoreNLPServerError) as exc:
+        server.start()
+    assert "boom" in str(exc.value)  # str stderr surfaced, no AttributeError
+
+
 @pytest.mark.parametrize(
     "modname",
     [
@@ -68,6 +98,7 @@ def test_weka_classifier_handles_str_output(monkeypatch, tmp_path):
         "nltk.parse.stanford",
         "nltk.tokenize.stanford_segmenter",
         "nltk.classify.weka",
+        "nltk.parse.corenlp",
     ],
 )
 def test_wrapper_guards_decode_with_isinstance(modname):

--- a/nltk/test/unit/test_java_wrapper_text_output.py
+++ b/nltk/test/unit/test_java_wrapper_text_output.py
@@ -36,6 +36,25 @@ def test_stanford_tokenizer_handles_str_output(monkeypatch, tmp_path):
     assert tok.tokenize("Hello, world!") == ["Hello", ",", "world", "!"]
 
 
+def test_stanford_parser_handles_str_output(monkeypatch, tmp_path):
+    from nltk.parse import stanford as sp
+
+    jar = tmp_path / "stanford-parser.jar"
+    jar.write_bytes(b"PK\x03\x04")
+    models = tmp_path / "stanford-parser-4.2.0-models.jar"
+    models.write_bytes(b"PK\x03\x04")
+    monkeypatch.setattr(sp, "find_jar_iter", lambda *a, **k: iter([str(jar)]))
+    monkeypatch.setattr(sp, "find_jars_within_path", lambda d: [str(jar), str(models)])
+    parser = sp.StanfordParser(path_to_jar=str(jar), path_to_models_jar=str(models))
+
+    # java() returns str; the parser must not b"...".replace()/decode() it.
+    tree_out = "(ROOT (S (NP (DT the) (NN fox)) (VP (VBZ runs))))\n\n"
+    monkeypatch.setattr(sp, "java", lambda *a, **k: (tree_out, ""))
+    tree = list(parser.raw_parse("the fox runs"))[0]
+    assert tree.label() == "ROOT"
+    assert "VP" in [t.label() for t in tree.subtrees()]
+
+
 def test_weka_classifier_handles_str_output(monkeypatch, tmp_path):
     from nltk.classify import weka as wk
 

--- a/nltk/test/unit/test_java_wrapper_text_output.py
+++ b/nltk/test/unit/test_java_wrapper_text_output.py
@@ -1,0 +1,83 @@
+"""Regression tests: nltk.internals.java() returns text (universal_newlines=True),
+so the Java wrappers must not call ``.decode()`` on its (already-str) output. A
+bytes-era ``stdout.decode(...)`` raised AttributeError and broke Stanford tagging,
+tokenizing, parsing and Weka classification whenever a real JVM ran.
+"""
+
+import pytest
+
+
+def test_stanford_pos_tagger_handles_str_output(monkeypatch, tmp_path):
+    from nltk.tag import stanford as st
+
+    jar = tmp_path / "stanford-postagger.jar"
+    jar.write_bytes(b"PK\x03\x04")
+    model = tmp_path / "m.tagger"
+    model.write_text("x")
+    monkeypatch.setattr(st, "find_jar", lambda *a, **k: str(jar))
+    monkeypatch.setattr(st, "find_file", lambda *a, **k: str(model))
+    tagger = st.StanfordPOSTagger(model_filename=str(model), path_to_jar=str(jar))
+
+    # java() returns str (universal_newlines); tagging must not .decode() it.
+    monkeypatch.setattr(st, "java", lambda *a, **k: ("The_DT fox_NN ._.\n", ""))
+    result = tagger.tag(["The", "fox", "."])
+    assert result == [("The", "DT"), ("fox", "NN"), (".", ".")]
+
+
+def test_stanford_tokenizer_handles_str_output(monkeypatch, tmp_path):
+    from nltk.tokenize import stanford as st
+
+    jar = tmp_path / "stanford-postagger.jar"
+    jar.write_bytes(b"PK\x03\x04")
+    monkeypatch.setattr(st, "find_jar", lambda *a, **k: str(jar))
+    tok = st.StanfordTokenizer(path_to_jar=str(jar))
+
+    monkeypatch.setattr(st, "java", lambda *a, **k: ("Hello\n,\nworld\n!\n", ""))
+    assert tok.tokenize("Hello, world!") == ["Hello", ",", "world", "!"]
+
+
+def test_weka_classifier_handles_str_output(monkeypatch, tmp_path):
+    from nltk.classify import weka as wk
+
+    # bypass jar discovery / java, feed a str weka report through the parser path
+    monkeypatch.setattr(wk, "config_weka", lambda *a, **k: None)
+    monkeypatch.setattr(
+        wk, "_weka_classpath", str(tmp_path / "weka.jar"), raising=False
+    )
+
+    class _Fmt:
+        def write(self, *a, **k):
+            pass
+
+        def labels(self):
+            return ["yes", "no"]
+
+    report = "inst# actual predicted error prediction\n1 1:? 2:no 0.9\n"
+    monkeypatch.setattr(wk, "java", lambda *a, **k: (report, ""))
+    clf = wk.WekaClassifier(_Fmt(), str(tmp_path / "model"))
+    # must not raise AttributeError on str .decode(); returns parsed predictions
+    out = clf.classify_many([{"a": 1}])
+    assert out == ["no"]
+
+
+@pytest.mark.parametrize(
+    "modname",
+    [
+        "nltk.tag.stanford",
+        "nltk.tokenize.stanford",
+        "nltk.parse.stanford",
+        "nltk.tokenize.stanford_segmenter",
+        "nltk.classify.weka",
+    ],
+)
+def test_wrapper_guards_decode_with_isinstance(modname):
+    """Every wrapper that decodes java() output must guard it with isinstance(...,
+    bytes) so it is safe on the str java() now returns."""
+    import importlib
+    import inspect
+
+    src = inspect.getsource(importlib.import_module(modname))
+    if ".decode(" in src:
+        assert (
+            "isinstance(" in src and "bytes" in src
+        ), f"{modname} calls .decode() without an isinstance(..., bytes) guard"

--- a/nltk/test/unit/test_weka_security.py
+++ b/nltk/test/unit/test_weka_security.py
@@ -52,3 +52,15 @@ def test_explicit_classpath_still_used(tmp_path):
     jar.write_bytes(b"")
     weka.config_weka(classpath=str(jar))
     assert weka._weka_classpath == str(jar)
+
+
+def test_arff_formatter_escapes_directive_injection():
+    """A newline in a feature name or value must not inject a new ARFF directive:
+    the formatter writes names/values via repr()/%r, which escapes newlines, so a
+    crafted feature cannot smuggle an @ATTRIBUTE/@DATA line into the file."""
+    evil = "x\n@ATTRIBUTE injected NUMERIC"
+    tokens = [({evil: "v\n@DATA\n9,pwn"}, "A"), ({evil: "w"}, "B")]
+    arff = weka.ARFF_Formatter.from_train(tokens).format(tokens)
+    assert "\n@ATTRIBUTE injected NUMERIC\n" not in arff  # no injected header line
+    assert "\n@DATA\n9,pwn" not in arff  # no injected data line
+    assert "\\n@ATTRIBUTE" in arff  # the newline was escaped by repr instead

--- a/nltk/tokenize/stanford.py
+++ b/nltk/tokenize/stanford.py
@@ -108,7 +108,8 @@ class StanfordTokenizer(TokenizerI):
                     stderr=PIPE,
                     options=self.java_options,
                 )
-                stdout = stdout.decode(encoding)
+                if isinstance(stdout, bytes):
+                    stdout = stdout.decode(encoding)
                 java_succeeded = True
         finally:
             if input_file_name:

--- a/nltk/tokenize/stanford_segmenter.py
+++ b/nltk/tokenize/stanford_segmenter.py
@@ -344,6 +344,7 @@ class StanfordSegmenter(TokenizerI):
             stderr=PIPE,
             options=self.java_options,
         )
-        stdout = stdout.decode(encoding)
+        if isinstance(stdout, bytes):
+            stdout = stdout.decode(encoding)
 
         return stdout


### PR DESCRIPTION
## Problem

`nltk.internals.java()` runs `subprocess.Popen(..., universal_newlines=True)`, so it returns **`str`**. But the Java wrappers still call `.decode()` on that output, raising `AttributeError: 'str' object has no attribute 'decode'` as soon as a real JVM produces any text.

Enumerated **every NLTK module that launches a JVM** and audited each:

| Module | JVM via | str/bytes bug |
|---|---|---|
| `tag/stanford.py` | `internals.java()` | ✅ fixed |
| `tokenize/stanford.py` | `internals.java()` | ✅ fixed |
| `parse/stanford.py` | `internals.java()` | ✅ fixed (also ran `b"...".replace()` on the str first) |
| `tokenize/stanford_segmenter.py` | `internals.java()` | ✅ fixed |
| `classify/weka.py` | `internals.java()` | ✅ fixed |
| `parse/corenlp.py` | `internals.java(blocking=False)` | ✅ fixed (server-start error path `stderrdata.decode('ascii')`) |
| `parse/malt.py` | own subprocess | n/a — reads result files, never decodes java stdout |

(`classify/senna.py` also `.decode()`s, but its *own* `Popen` is byte-mode, so that decode is correct and out of scope.)

The break is **latent in CI** because these tools require external jars/models CI doesn't have, but it makes every one of them unusable in practice.

## Fix

Guard each decode with `isinstance(x, bytes)` so the wrappers work on the `str` `java()` returns and stay backward-compatible with any bytes-returning path.

## Verification

Verified **end-to-end with a real OpenJDK 26** and the official Stanford POS tagger distribution:
- `StanfordPOSTagger.tag('The quick brown fox jumps over the lazy dog .'.split())` → `The/DT quick/JJ brown/JJ fox/NN jumps/VBZ over/IN the/DT lazy/JJ dog/NN ./.`
- `StanfordTokenizer.tokenize("Hello, world! It's a test.")` → `['Hello', ',', 'world', '!', 'It', "'s", 'a', 'test', '.']`

Added `test_java_wrapper_text_output.py`: str-path tests for the tagger, tokenizer, Weka and the CoreNLP server-start error path, plus a guard asserting no wrapper decodes `java()` output without the `isinstance` check.