### PR TITLE
Bound decompression entry points in nltk (zip/gzip layers + pathsec.ZipFile + weka), CWE-409

### DIFF
--- a/nltk/classify/weka.py
+++ b/nltk/classify/weka.py
@@ -74,9 +74,8 @@ def config_weka(classpath=None):
 
 def _check_weka_version(jar):
     try:
-        # Secured wrapper: path containment (traversal/symlink) + the
-        # decompression-bomb cap on read() (a malicious weka.jar could declare a
-        # gigabyte version.txt, CWE-409). Never open an archive bare.
+        # Secured wrapper (never bare): path containment + the read() bomb cap, so a
+        # jar declaring a gigabyte version.txt cannot exhaust RAM (CWE-409).
         zf = SecureZipFile(jar)
     except (SystemExit, KeyboardInterrupt):
         raise

--- a/nltk/classify/weka.py
+++ b/nltk/classify/weka.py
@@ -14,12 +14,12 @@ import re
 import subprocess
 import tempfile
 import time
-import zipfile
 from sys import stdin
 
 from nltk.classify.api import ClassifierI
 from nltk.data import make_staging_dir
 from nltk.internals import config_java, java
+from nltk.pathsec import ZipFile as SecureZipFile
 from nltk.pathsec import open as pathsec_open
 from nltk.probability import DictionaryProbDist
 
@@ -74,7 +74,10 @@ def config_weka(classpath=None):
 
 def _check_weka_version(jar):
     try:
-        zf = zipfile.ZipFile(jar)
+        # Secured wrapper: path containment (traversal/symlink) + the
+        # decompression-bomb cap on read() (a malicious weka.jar could declare a
+        # gigabyte version.txt, CWE-409). Never open an archive bare.
+        zf = SecureZipFile(jar)
     except (SystemExit, KeyboardInterrupt):
         raise
     except Exception:

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -620,53 +620,48 @@ def _check_decompression_bomb(info):
         )
 
 
-def _bounded_gzip_decompress(gz_bytes, name="<member>"):
-    """Decompress a gzip byte string, applying the decompression-bomb policy to
-    the actual output (CWE-409).
+def _bounded_stream_read(stream, compress_size, name="<member>", kind="zip"):
+    """Read a decompressing file-like *stream* under the decompression-bomb policy,
+    capping the **actual** bytes it produces against *compress_size* (CWE-409).
 
-    ``ZipFilePathPointer.open`` wraps a ``.gz`` zip member in a ``GzipFile``, a
-    second decompression layer that :func:`_check_decompression_bomb` (which only
-    inspects the zip member's declared sizes) does not bound. This streams the
-    gzip output and refuses it once it is both large (>= ``MAX_UNZIP_ACTIVATION``)
-    and expands beyond ``MAX_UNZIP_RATIO`` over the compressed member, or exceeds
-    the optional ``MAX_UNZIP_SIZE`` hard cap. Returns the decompressed bytes.
+    This never trusts a declared/metadata size and never materialises the member
+    through a raw one-shot read: it pulls fixed 1 MiB chunks and refuses once the
+    output is both large (>= ``MAX_UNZIP_ACTIVATION``) and expands beyond
+    ``MAX_UNZIP_RATIO`` over the compressed input, or exceeds the optional
+    ``MAX_UNZIP_SIZE`` hard cap. Returns the decompressed bytes. *kind* only tunes
+    the error wording (``"zip"`` / ``"gzip"``).
     """
-    compress_size = len(gz_bytes)
     ratio_limit = MAX_UNZIP_RATIO * compress_size
-
-    def _reject_reason(total):
-        if MAX_UNZIP_SIZE is not None and total > MAX_UNZIP_SIZE:
-            return (
-                "Refusing to decompress zip member %r: its nested gzip output "
-                "exceeds nltk.data.MAX_UNZIP_SIZE=%d bytes." % (name, MAX_UNZIP_SIZE)
-            )
-        if total >= MAX_UNZIP_ACTIVATION and total > ratio_limit:
-            return (
-                "Refusing to decompress suspected gzip bomb %r: its gzip layer "
-                "expands beyond nltk.data.MAX_UNZIP_RATIO=%d over the %d-byte "
-                "compressed input. Raise nltk.data.MAX_UNZIP_RATIO if this data is "
-                "trusted." % (name, MAX_UNZIP_RATIO, compress_size)
-            )
-        return None
-
-    # Cheap pre-check via the gzip ISIZE trailer (declared uncompressed size mod
-    # 2**32). It is attacker-forgeable (and wraps above 4 GiB), so the streaming
-    # cap below is the actual guarantee; this just rejects honest bombs for free.
-    if compress_size >= 4:
-        reason = _reject_reason(int.from_bytes(gz_bytes[-4:], "little"))
-        if reason:
-            raise ValueError(reason)
-
     out = []
     total = 0
-    with GzipFile(name, fileobj=BytesIO(gz_bytes)) as gz:
-        for chunk in iter(lambda: gz.read(1 << 20), b""):
-            total += len(chunk)
-            reason = _reject_reason(total)
-            if reason:
-                raise ValueError(reason)
-            out.append(chunk)
+    for chunk in iter(lambda: stream.read(1 << 20), b""):
+        total += len(chunk)
+        if MAX_UNZIP_SIZE is not None and total > MAX_UNZIP_SIZE:
+            raise ValueError(
+                "Refusing to decompress %r: its %s output exceeds "
+                "nltk.data.MAX_UNZIP_SIZE=%d bytes." % (name, kind, MAX_UNZIP_SIZE)
+            )
+        if total >= MAX_UNZIP_ACTIVATION and total > ratio_limit:
+            raise ValueError(
+                "Refusing to decompress suspected %s bomb %r: it expands beyond "
+                "nltk.data.MAX_UNZIP_RATIO=%d over the %d-byte compressed input. "
+                "Raise nltk.data.MAX_UNZIP_RATIO if this data is trusted."
+                % (kind, name, MAX_UNZIP_RATIO, compress_size)
+            )
+        out.append(chunk)
     return b"".join(out)
+
+
+def _bounded_gzip_decompress(gz_bytes, name="<member>"):
+    """Decompress gzip bytes under the decompression-bomb policy (CWE-409).
+
+    ``ZipFilePathPointer.open`` / ``GzipFileSystemPathPointer.open`` wrap a ``.gz``
+    in a ``GzipFile``, a decompression layer :func:`_check_decompression_bomb` (which
+    only inspects declared zip sizes) does not bound. The gzip ISIZE trailer is
+    attacker-forgeable, so the actual-byte streaming cap is the guarantee.
+    """
+    with GzipFile(name, fileobj=BytesIO(gz_bytes)) as gz:
+        return _bounded_stream_read(gz, len(gz_bytes), name, kind="gzip")
 
 
 class ZipFilePathPointer(PathPointer):
@@ -1441,10 +1436,13 @@ class OpenOnDemandZipFile(ZipFile):
         _check_decompression_bomb(self.getinfo(name))
         # This will be validated by pathsec.open
         self.fp = _secure_open(self.filename, "rb")
-        value = zipfile.ZipFile.read(self, name)
-        self.fp.close()
-        self.fp = None
-        return value
+        try:
+            # Delegate to the secured base read(), which also streams the member's
+            # ACTUAL bytes under the cap (CWE-409), not a raw one-shot read.
+            return super().read(name)
+        finally:
+            self.fp.close()
+            self.fp = None
 
     def write(self, *args, **kwargs):
         """:raise NotImplementedError: OpenOnDemandZipfile is read-only"""

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -644,6 +644,29 @@ MAX_UNZIP_SIZE = None
 #: resources regardless of ratio) are never rejected.
 MAX_UNZIP_ACTIVATION = 32 * 1024 * 1024  # 32 MiB
 
+#: Maximum number of entries an archive may declare (CWE-409). Metadata alone
+#: costs memory and CPU: reading the central directory of an archive with
+#: millions of entries exhausts both without decompressing a single byte, so the
+#: per-member ratio/size limits above never see it. The largest corpus NLTK
+#: ships declares ~15k members, so this leaves ample headroom. Configurable;
+#: ``None`` disables the check.
+MAX_UNZIP_MEMBERS = 100_000
+
+
+def _check_zip_member_count(count, name="<archive>"):
+    """Reject an archive declaring more entries than ``MAX_UNZIP_MEMBERS``.
+
+    A central-directory bomb needs no decompression: the entry table itself is
+    the payload, and every consumer that lists or iterates members pays for it.
+    """
+    if MAX_UNZIP_MEMBERS is not None and count > MAX_UNZIP_MEMBERS:
+        raise ValueError(
+            "Refusing to read zip %r: it declares %d entries, above "
+            "nltk.data.MAX_UNZIP_MEMBERS=%d (central-directory bomb). Raise "
+            "nltk.data.MAX_UNZIP_MEMBERS if this archive is trusted."
+            % (name, count, MAX_UNZIP_MEMBERS)
+        )
+
 
 def _check_decompression_bomb(info):
     """

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -250,10 +250,8 @@ class _BoundedGzipFile(GzipFile):
         return self._nltk_cached_compress_size
 
     def _nltk_guard_offset(self, reached):
-        # Enforce the policy at the given uncompressed offset, tracking its high-water
-        # mark so backward seeks / re-reads never re-count already-seen bytes. The
-        # offset is passed in (never self.tell(), which IOBase implements as
-        # seek(0, SEEK_CUR) and would recurse through the seek() override below).
+        # Guard at the high-water uncompressed offset (passed in, never self.tell(),
+        # which IOBase routes through seek() below and would recurse).
         if reached > getattr(self, "_nltk_read_total", 0):
             self._nltk_read_total = reached
             _reject_decompression_total(
@@ -263,17 +261,14 @@ class _BoundedGzipFile(GzipFile):
     def read(self, size=-1):
         chunk = super().read(size)
         if chunk:
-            # super().seek(0, SEEK_CUR) reports the post-read offset cheaply (no
-            # decompression) via the parent, bypassing this class's seek() override.
+            # super().seek(0, CUR) is the parent's cheap post-read offset (no
+            # decompression), bypassing this class's seek() override.
             self._nltk_guard_offset(super().seek(0, os.SEEK_CUR))
         return chunk
 
     def seek(self, offset, whence=os.SEEK_SET):
-        # A forward / SEEK_END seek makes GzipFile decompress-and-discard past the
-        # current point INSIDE its own buffer, never through read() above, so a bomb
-        # would slip the counter. GzipFile's seek discards in bounded chunks (it does
-        # not materialise the skipped bytes), so this is not itself a RAM bomb; we
-        # re-check the offset it lands on and refuse before the caller can read there.
+        # A forward / SEEK_END seek decompresses-and-discards inside GzipFile's buffer,
+        # never through read(); re-check the landed offset so a bomb cannot slip past.
         pos = super().seek(offset, whence)
         self._nltk_guard_offset(pos)
         return pos
@@ -616,13 +611,8 @@ class GzipFileSystemPathPointer(FileSystemPathPointer):
     """
 
     def open(self, encoding=None):
-        # Route through the sentinel like FileSystemPathPointer.open() so the path is
-        # validated against the allowed NLTK data roots (with symlinks resolved)
-        # before reading, then decompress the validated handle as a STREAM rather than
-        # re-opening the path directly (CWE-22 / CWE-73). A standalone .gz is a single
-        # gzip layer with no declared-size guard of its own; _BoundedGzipFile caps its
-        # ACTUAL output under the decompression-bomb policy (CWE-409) as it is read,
-        # so a large-but-legitimate gzip pickle is never buffered whole in memory.
+        # Validate the path via the sentinel (CWE-22 / CWE-73), then stream the handle
+        # through _BoundedGzipFile so a bomb is capped without buffering it whole (CWE-409).
         handle = _secure_open(self._path, "rb")
         try:
             stream = _BoundedGzipFile._nltk_wrap_secure_fileobj(self._path, handle)
@@ -814,9 +804,8 @@ class ZipFilePathPointer(PathPointer):
         data = self._zipfile.read(self._entry)
         stream = BytesIO(data)
         if self._entry.endswith(".gz"):
-            # GzipFile is a SECOND decompression layer the zip-member guard above
-            # does not see; bound its output with the same policy so a nested
-            # gzip bomb cannot exhaust memory (CWE-409).
+            # The .gz is a SECOND decompression layer the zip-member guard never
+            # sees; bound its output under the same policy (nested bomb, CWE-409).
             stream = BytesIO(_bounded_gzip_decompress(data, self._entry))
         elif encoding is not None:
             stream = SeekableUnicodeStreamReader(stream, encoding)

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -213,6 +213,30 @@ def make_staging_dir(prefix="nltk_"):
     )
 
 
+class _BoundedGzipFile(GzipFile):
+    """A ``GzipFile`` whose ``read()`` refuses a decompression bomb (CWE-409): it
+    tracks cumulative decompressed bytes and enforces nltk's ratio/size policy,
+    measured against the compressed file size when known (else the ``MAX_UNZIP_SIZE``
+    hard cap). Used wherever nltk opens a ``.gz`` for reading, so a raw unbounded
+    ``GzipFile.read`` is never the read path (``gzip_open_unicode``, the deprecated
+    ``BufferedGzipFile``). Writing is unaffected.
+    """
+
+    def read(self, size=-1):
+        chunk = super().read(size)
+        if chunk:
+            self._nltk_read_total = getattr(self, "_nltk_read_total", 0) + len(chunk)
+            compress_size = (
+                os.path.getsize(self.name)
+                if isinstance(self.name, str) and os.path.exists(self.name)
+                else None
+            )
+            _reject_decompression_total(
+                self._nltk_read_total, compress_size, self.name or "<gzip>", "gzip"
+            )
+        return chunk
+
+
 def gzip_open_unicode(
     filename,
     mode="rb",
@@ -223,7 +247,7 @@ def gzip_open_unicode(
     newline=None,
 ):
     if fileobj is None:
-        fileobj = GzipFile(filename, mode, compresslevel, fileobj)
+        fileobj = _BoundedGzipFile(filename, mode, compresslevel, fileobj)
     return TextIOWrapper(fileobj, encoding, errors, newline)
 
 
@@ -514,11 +538,11 @@ class FileSystemPathPointer(PathPointer, str):
 
 
 @deprecated("Use gzip.GzipFile instead as it also uses a buffer.")
-class BufferedGzipFile(GzipFile):
+class BufferedGzipFile(_BoundedGzipFile):
     """A ``GzipFile`` subclass for compatibility with older nltk releases.
 
     Use ``GzipFile`` directly as it also buffers in all supported
-    Python versions.
+    Python versions. (``read()`` is bomb-bounded via ``_BoundedGzipFile``.)
     """
 
     def __init__(
@@ -526,23 +550,6 @@ class BufferedGzipFile(GzipFile):
     ):
         """Return a buffered gzip file object."""
         GzipFile.__init__(self, filename, mode, compresslevel, fileobj)
-
-    def read(self, size=-1):
-        # GzipFile.read() is otherwise unbounded; refuse a decompression bomb
-        # (CWE-409). The ratio is measured against the compressed file size when
-        # known; a fileobj-backed stream with no size is bounded by MAX_UNZIP_SIZE.
-        chunk = super().read(size)
-        if chunk:
-            self._nltk_read_total = getattr(self, "_nltk_read_total", 0) + len(chunk)
-            compress_size = (
-                os.path.getsize(self.name)
-                if isinstance(self.name, str) and os.path.exists(self.name)
-                else None
-            )
-            _reject_decompression_total(
-                self._nltk_read_total, compress_size, self.name or "<gzip>", "gzip"
-            )
-        return chunk
 
     def write(self, data):
         # This is identical to GzipFile.write but does not return

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -41,7 +41,6 @@ import sys
 import tempfile
 import textwrap
 import urllib.request
-import zipfile
 from abc import ABCMeta, abstractmethod
 from gzip import WRITE as GZ_WRITE
 from gzip import GzipFile

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -527,6 +527,23 @@ class BufferedGzipFile(GzipFile):
         """Return a buffered gzip file object."""
         GzipFile.__init__(self, filename, mode, compresslevel, fileobj)
 
+    def read(self, size=-1):
+        # GzipFile.read() is otherwise unbounded; refuse a decompression bomb
+        # (CWE-409). The ratio is measured against the compressed file size when
+        # known; a fileobj-backed stream with no size is bounded by MAX_UNZIP_SIZE.
+        chunk = super().read(size)
+        if chunk:
+            self._nltk_read_total = getattr(self, "_nltk_read_total", 0) + len(chunk)
+            compress_size = (
+                os.path.getsize(self.name)
+                if isinstance(self.name, str) and os.path.exists(self.name)
+                else None
+            )
+            _reject_decompression_total(
+                self._nltk_read_total, compress_size, self.name or "<gzip>", "gzip"
+            )
+        return chunk
+
     def write(self, data):
         # This is identical to GzipFile.write but does not return
         # the bytes written to retain compatibility.
@@ -619,6 +636,29 @@ def _check_decompression_bomb(info):
         )
 
 
+def _reject_decompression_total(total, compress_size, name, kind):
+    """Raise ValueError if *total* decompressed bytes breach the bomb policy: the
+    optional ``MAX_UNZIP_SIZE`` hard cap, or (when *compress_size* is known and
+    non-zero) an expansion beyond ``MAX_UNZIP_RATIO`` above the ``MAX_UNZIP_ACTIVATION``
+    floor. *kind* (``"zip"`` / ``"gzip"``) only tunes the wording (CWE-409)."""
+    if MAX_UNZIP_SIZE is not None and total > MAX_UNZIP_SIZE:
+        raise ValueError(
+            "Refusing to decompress %r: its %s output exceeds "
+            "nltk.data.MAX_UNZIP_SIZE=%d bytes." % (name, kind, MAX_UNZIP_SIZE)
+        )
+    if (
+        compress_size
+        and total >= MAX_UNZIP_ACTIVATION
+        and (total > MAX_UNZIP_RATIO * compress_size)
+    ):
+        raise ValueError(
+            "Refusing to decompress suspected %s bomb %r: it expands beyond "
+            "nltk.data.MAX_UNZIP_RATIO=%d over the %d-byte compressed input. "
+            "Raise nltk.data.MAX_UNZIP_RATIO if this data is trusted."
+            % (kind, name, MAX_UNZIP_RATIO, compress_size)
+        )
+
+
 def _bounded_stream_read(stream, compress_size, name="<member>", kind="zip"):
     """Read a decompressing file-like *stream* under the decompression-bomb policy,
     capping the **actual** bytes it produces against *compress_size* (CWE-409).
@@ -630,23 +670,11 @@ def _bounded_stream_read(stream, compress_size, name="<member>", kind="zip"):
     ``MAX_UNZIP_SIZE`` hard cap. Returns the decompressed bytes. *kind* only tunes
     the error wording (``"zip"`` / ``"gzip"``).
     """
-    ratio_limit = MAX_UNZIP_RATIO * compress_size
     out = []
     total = 0
     for chunk in iter(lambda: stream.read(1 << 20), b""):
         total += len(chunk)
-        if MAX_UNZIP_SIZE is not None and total > MAX_UNZIP_SIZE:
-            raise ValueError(
-                "Refusing to decompress %r: its %s output exceeds "
-                "nltk.data.MAX_UNZIP_SIZE=%d bytes." % (name, kind, MAX_UNZIP_SIZE)
-            )
-        if total >= MAX_UNZIP_ACTIVATION and total > ratio_limit:
-            raise ValueError(
-                "Refusing to decompress suspected %s bomb %r: it expands beyond "
-                "nltk.data.MAX_UNZIP_RATIO=%d over the %d-byte compressed input. "
-                "Raise nltk.data.MAX_UNZIP_RATIO if this data is trusted."
-                % (kind, name, MAX_UNZIP_RATIO, compress_size)
-            )
+        _reject_decompression_total(total, compress_size, name, kind)
         out.append(chunk)
     return b"".join(out)
 

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -615,6 +615,55 @@ def _check_decompression_bomb(info):
         )
 
 
+def _bounded_gzip_decompress(gz_bytes, name="<member>"):
+    """Decompress a gzip byte string, applying the decompression-bomb policy to
+    the actual output (CWE-409).
+
+    ``ZipFilePathPointer.open`` wraps a ``.gz`` zip member in a ``GzipFile``, a
+    second decompression layer that :func:`_check_decompression_bomb` (which only
+    inspects the zip member's declared sizes) does not bound. This streams the
+    gzip output and refuses it once it is both large (>= ``MAX_UNZIP_ACTIVATION``)
+    and expands beyond ``MAX_UNZIP_RATIO`` over the compressed member, or exceeds
+    the optional ``MAX_UNZIP_SIZE`` hard cap. Returns the decompressed bytes.
+    """
+    compress_size = len(gz_bytes)
+    ratio_limit = MAX_UNZIP_RATIO * compress_size
+
+    def _reject_reason(total):
+        if MAX_UNZIP_SIZE is not None and total > MAX_UNZIP_SIZE:
+            return (
+                "Refusing to decompress zip member %r: its nested gzip output "
+                "exceeds nltk.data.MAX_UNZIP_SIZE=%d bytes." % (name, MAX_UNZIP_SIZE)
+            )
+        if total >= MAX_UNZIP_ACTIVATION and total > ratio_limit:
+            return (
+                "Refusing to decompress suspected nested gzip bomb %r: its gzip "
+                "layer expands beyond nltk.data.MAX_UNZIP_RATIO=%d over the %d-byte "
+                "compressed member. Raise nltk.data.MAX_UNZIP_RATIO if this data is "
+                "trusted." % (name, MAX_UNZIP_RATIO, compress_size)
+            )
+        return None
+
+    # Cheap pre-check via the gzip ISIZE trailer (declared uncompressed size mod
+    # 2**32). It is attacker-forgeable (and wraps above 4 GiB), so the streaming
+    # cap below is the actual guarantee; this just rejects honest bombs for free.
+    if compress_size >= 4:
+        reason = _reject_reason(int.from_bytes(gz_bytes[-4:], "little"))
+        if reason:
+            raise ValueError(reason)
+
+    out = []
+    total = 0
+    with GzipFile(name, fileobj=BytesIO(gz_bytes)) as gz:
+        for chunk in iter(lambda: gz.read(1 << 20), b""):
+            total += len(chunk)
+            reason = _reject_reason(total)
+            if reason:
+                raise ValueError(reason)
+            out.append(chunk)
+    return b"".join(out)
+
+
 class ZipFilePathPointer(PathPointer):
     """
     A path pointer that identifies a file contained within a zipfile,
@@ -677,7 +726,10 @@ class ZipFilePathPointer(PathPointer):
         data = self._zipfile.read(self._entry)
         stream = BytesIO(data)
         if self._entry.endswith(".gz"):
-            stream = GzipFile(self._entry, fileobj=stream)
+            # GzipFile is a SECOND decompression layer the zip-member guard above
+            # does not see; bound its output with the same policy so a nested
+            # gzip bomb cannot exhaust memory (CWE-409).
+            stream = BytesIO(_bounded_gzip_decompress(data, self._entry))
         elif encoding is not None:
             stream = SeekableUnicodeStreamReader(stream, encoding)
         return stream

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -546,7 +546,12 @@ class GzipFileSystemPathPointer(FileSystemPathPointer):
         # path is validated against the allowed NLTK data roots (with symlinks
         # resolved) before reading; decompress the validated stream rather than
         # re-opening the path directly (CWE-22 / CWE-73).
-        stream = GzipFile(self._path, fileobj=_secure_open(self._path, "rb"))
+        with _secure_open(self._path, "rb") as f:
+            data = f.read()
+        # A standalone .gz is a single gzip layer with no declared-size guard of
+        # its own; bound its output with the decompression-bomb policy the zip
+        # .gz-member path uses, so it cannot exhaust memory (CWE-409).
+        stream = BytesIO(_bounded_gzip_decompress(data, self._path))
         # ``encoding is not None`` (not truthiness) to match
         # FileSystemPathPointer.open() / ZipFilePathPointer.open().
         if encoding is not None:

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -215,26 +215,77 @@ def make_staging_dir(prefix="nltk_"):
 
 class _BoundedGzipFile(GzipFile):
     """A ``GzipFile`` whose ``read()`` refuses a decompression bomb (CWE-409): it
-    tracks cumulative decompressed bytes and enforces nltk's ratio/size policy,
+    tracks how far it has decompressed and enforces nltk's ratio/size policy,
     measured against the compressed file size when known (else the ``MAX_UNZIP_SIZE``
     hard cap). Used wherever nltk opens a ``.gz`` for reading, so a raw unbounded
-    ``GzipFile.read`` is never the read path (``gzip_open_unicode``, the deprecated
-    ``BufferedGzipFile``). Writing is unaffected.
+    ``GzipFile.read`` is never the read path (``gzip_open_unicode``,
+    ``GzipFileSystemPathPointer.open``, the deprecated ``BufferedGzipFile``).
+    Writing is unaffected.
+
+    The guard measures the maximum uncompressed offset reached (``tell()``), not the
+    sum of ``read()`` return sizes, so backward seeks and re-reads (e.g. by
+    ``SeekableUnicodeStreamReader`` or ``pickle``) never inflate the count into a
+    false positive, while a seek-to-end still forces the full member to decompress
+    and is caught. The compressed size is stat-ed once and cached, since re-stat-ing
+    on every ``read()`` is hot for chunked/line iteration.
     """
+
+    @classmethod
+    def _nltk_wrap_secure_fileobj(cls, filename, fileobj):
+        """Build a reader over an already-opened (path-validated) *fileobj* and make
+        the returned object own it, so closing the reader closes the handle: a plain
+        ``GzipFile`` never closes a fileobj it did not open itself."""
+        gz = cls(filename, "rb", 9, fileobj)
+        gz._nltk_owned_fileobj = fileobj
+        return gz
+
+    def _nltk_compress_size(self):
+        if not hasattr(self, "_nltk_cached_compress_size"):
+            name = self.name
+            self._nltk_cached_compress_size = (
+                os.path.getsize(name)
+                if isinstance(name, str) and os.path.exists(name)
+                else None
+            )
+        return self._nltk_cached_compress_size
+
+    def _nltk_guard_offset(self, reached):
+        # Enforce the policy at the given uncompressed offset, tracking its high-water
+        # mark so backward seeks / re-reads never re-count already-seen bytes. The
+        # offset is passed in (never self.tell(), which IOBase implements as
+        # seek(0, SEEK_CUR) and would recurse through the seek() override below).
+        if reached > getattr(self, "_nltk_read_total", 0):
+            self._nltk_read_total = reached
+            _reject_decompression_total(
+                reached, self._nltk_compress_size(), self.name or "<gzip>", "gzip"
+            )
 
     def read(self, size=-1):
         chunk = super().read(size)
         if chunk:
-            self._nltk_read_total = getattr(self, "_nltk_read_total", 0) + len(chunk)
-            compress_size = (
-                os.path.getsize(self.name)
-                if isinstance(self.name, str) and os.path.exists(self.name)
-                else None
-            )
-            _reject_decompression_total(
-                self._nltk_read_total, compress_size, self.name or "<gzip>", "gzip"
-            )
+            # super().seek(0, SEEK_CUR) reports the post-read offset cheaply (no
+            # decompression) via the parent, bypassing this class's seek() override.
+            self._nltk_guard_offset(super().seek(0, os.SEEK_CUR))
         return chunk
+
+    def seek(self, offset, whence=os.SEEK_SET):
+        # A forward / SEEK_END seek makes GzipFile decompress-and-discard past the
+        # current point INSIDE its own buffer, never through read() above, so a bomb
+        # would slip the counter. GzipFile's seek discards in bounded chunks (it does
+        # not materialise the skipped bytes), so this is not itself a RAM bomb; we
+        # re-check the offset it lands on and refuse before the caller can read there.
+        pos = super().seek(offset, whence)
+        self._nltk_guard_offset(pos)
+        return pos
+
+    def close(self):
+        try:
+            super().close()
+        finally:
+            owned = getattr(self, "_nltk_owned_fileobj", None)
+            if owned is not None:
+                self._nltk_owned_fileobj = None
+                owned.close()
 
 
 def gzip_open_unicode(
@@ -565,16 +616,19 @@ class GzipFileSystemPathPointer(FileSystemPathPointer):
     """
 
     def open(self, encoding=None):
-        # Route through the sentinel like FileSystemPathPointer.open() so the
-        # path is validated against the allowed NLTK data roots (with symlinks
-        # resolved) before reading; decompress the validated stream rather than
-        # re-opening the path directly (CWE-22 / CWE-73).
-        with _secure_open(self._path, "rb") as f:
-            data = f.read()
-        # A standalone .gz is a single gzip layer with no declared-size guard of
-        # its own; bound its output with the decompression-bomb policy the zip
-        # .gz-member path uses, so it cannot exhaust memory (CWE-409).
-        stream = BytesIO(_bounded_gzip_decompress(data, self._path))
+        # Route through the sentinel like FileSystemPathPointer.open() so the path is
+        # validated against the allowed NLTK data roots (with symlinks resolved)
+        # before reading, then decompress the validated handle as a STREAM rather than
+        # re-opening the path directly (CWE-22 / CWE-73). A standalone .gz is a single
+        # gzip layer with no declared-size guard of its own; _BoundedGzipFile caps its
+        # ACTUAL output under the decompression-bomb policy (CWE-409) as it is read,
+        # so a large-but-legitimate gzip pickle is never buffered whole in memory.
+        handle = _secure_open(self._path, "rb")
+        try:
+            stream = _BoundedGzipFile._nltk_wrap_secure_fileobj(self._path, handle)
+        except BaseException:
+            handle.close()
+            raise
         # ``encoding is not None`` (not truthiness) to match
         # FileSystemPathPointer.open() / ZipFilePathPointer.open().
         if encoding is not None:

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -642,9 +642,9 @@ def _bounded_gzip_decompress(gz_bytes, name="<member>"):
             )
         if total >= MAX_UNZIP_ACTIVATION and total > ratio_limit:
             return (
-                "Refusing to decompress suspected nested gzip bomb %r: its gzip "
-                "layer expands beyond nltk.data.MAX_UNZIP_RATIO=%d over the %d-byte "
-                "compressed member. Raise nltk.data.MAX_UNZIP_RATIO if this data is "
+                "Refusing to decompress suspected gzip bomb %r: its gzip layer "
+                "expands beyond nltk.data.MAX_UNZIP_RATIO=%d over the %d-byte "
+                "compressed input. Raise nltk.data.MAX_UNZIP_RATIO if this data is "
                 "trusted." % (name, MAX_UNZIP_RATIO, compress_size)
             )
         return None

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -10,6 +10,7 @@
 """Centralized I/O security sentinel for NLTK."""
 import builtins
 import http.client
+import io
 import ipaddress
 import os
 import re
@@ -841,6 +842,16 @@ def open(file, mode="r", *, context="pathsec.open", required_root=None, **kwargs
     return builtins.open(raw_path, mode=mode, **kwargs)
 
 
+def _decompression_guards():
+    # The decompression-bomb policy lives in nltk.data (its MAX_UNZIP_* limits are
+    # public API). nltk.data imports THIS module, so importing it at the top would
+    # be circular; this single deferred import runs at call time when both modules
+    # are fully loaded. Returns (_check_decompression_bomb, _bounded_stream_read).
+    from nltk.data import _bounded_stream_read, _check_decompression_bomb
+
+    return _check_decompression_bomb, _bounded_stream_read
+
+
 class ZipFile(zipfile.ZipFile):
     """Secure wrapper for zipfile.ZipFile."""
 
@@ -879,26 +890,28 @@ class ZipFile(zipfile.ZipFile):
         super().extractall(path, members, pwd)
 
     def read(self, name, pwd=None):
-        # zipfile.read() decompresses the whole member into memory with no cap; a
-        # tiny member declaring gigabytes exhausts RAM (decompression bomb,
-        # CWE-409). Bound it with nltk's policy before reading.
-        self._reject_decompression_bomb(name)
-        return super().read(name, pwd)
+        # Never use the raw one-shot super().read(): it decompresses the whole
+        # member into memory bounded only by the member's (attacker-controlled)
+        # declared size. Stream it and cap the ACTUAL bytes produced (CWE-409).
+        _check_decompression_bomb, _bounded_stream_read = _decompression_guards()
+        info = name if isinstance(name, zipfile.ZipInfo) else self.getinfo(name)
+        _check_decompression_bomb(info)  # cheap declared-size early reject
+        with super().open(info, mode="r", pwd=pwd) as raw:
+            return _bounded_stream_read(raw, info.compress_size, info.filename)
 
     def open(self, name, mode="r", pwd=None, *, force_zip64=False):
-        # A streaming member open still decompresses on read; bound it up front by
-        # the member's declared size (only for read mode; writes have no member).
-        if mode == "r":
-            self._reject_decompression_bomb(name)
-        return super().open(name, mode, pwd, force_zip64=force_zip64)
-
-    def _reject_decompression_bomb(self, name):
-        # Imported lazily: nltk.data imports this module, so a top-level import
-        # would be circular. The policy/limits live in nltk.data (public API).
-        from nltk.data import _check_decompression_bomb
-
+        # Write mode has no member to decompress; only reads are bounded.
+        if mode != "r":
+            return super().open(name, mode, pwd, force_zip64=force_zip64)
+        # Never hand back the raw streaming reader (unbounded on .read()); return a
+        # seekable in-memory stream of the actual-byte-capped decompressed bytes.
+        _check_decompression_bomb, _bounded_stream_read = _decompression_guards()
         info = name if isinstance(name, zipfile.ZipInfo) else self.getinfo(name)
         _check_decompression_bomb(info)
+        with super().open(info, mode="r", pwd=pwd, force_zip64=force_zip64) as raw:
+            return io.BytesIO(
+                _bounded_stream_read(raw, info.compress_size, info.filename)
+            )
 
 
 __all__ = [

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -276,6 +276,12 @@ def validate_zip_archive(
             members = (
                 [specific_member] if specific_member is not None else zf.namelist()
             )
+            # Covers the raw-zipfile branch below, which bypasses ZipFile.__init__'s
+            # entry-count guard on purpose (constructing one here would recurse).
+            if specific_member is None:
+                _member_count_guard()(
+                    len(members), getattr(zf, "filename", None) or "<archive>"
+                )
             for name in members:
                 name_str = name.filename if hasattr(name, "filename") else str(name)
                 if "\0" in name_str:
@@ -854,6 +860,13 @@ def _decompression_guards():
     return _check_decompression_bomb, _bounded_stream_read, _reject_decompression_total
 
 
+def _member_count_guard():
+    """Deferred import of the central-directory-bomb check (see above)."""
+    from nltk.data import _check_zip_member_count
+
+    return _check_zip_member_count
+
+
 class _BoundedZipExtFile(io.RawIOBase):
     """Wraps zipfile's streaming member reader and refuses a decompression bomb
     (CWE-409) as the member is consumed: it accumulates the ACTUAL decompressed
@@ -920,6 +933,12 @@ class ZipFile(zipfile.ZipFile):
             file_to_open = file
 
         super().__init__(file_to_open, *args, **kwargs)
+        # Refuse a central-directory bomb here, the earliest point the entry count
+        # is known, so no consumer pays to list, validate or extract its members.
+        if getattr(self, "mode", "r") == "r":
+            _member_count_guard()(
+                len(self.filelist), getattr(self, "filename", None) or "<archive>"
+            )
 
     def extract(self, member, path=None, pwd=None):
         validate_zip_archive(self, path or os.getcwd(), specific_member=member)

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -846,10 +846,53 @@ def _decompression_guards():
     # The decompression-bomb policy lives in nltk.data (its MAX_UNZIP_* limits are
     # public API). nltk.data imports THIS module, so importing it at the top would
     # be circular; this single deferred import runs at call time when both modules
-    # are fully loaded. Returns (_check_decompression_bomb, _bounded_stream_read).
-    from nltk.data import _bounded_stream_read, _check_decompression_bomb
+    # are fully loaded. Returns
+    # (_check_decompression_bomb, _bounded_stream_read, _reject_decompression_total).
+    from nltk.data import (
+        _bounded_stream_read,
+        _check_decompression_bomb,
+        _reject_decompression_total,
+    )
 
-    return _check_decompression_bomb, _bounded_stream_read
+    return _check_decompression_bomb, _bounded_stream_read, _reject_decompression_total
+
+
+class _BoundedZipExtFile(io.RawIOBase):
+    """Wraps zipfile's streaming member reader and refuses a decompression bomb
+    (CWE-409) as the member is consumed: it accumulates the ACTUAL decompressed
+    bytes and applies nltk's ratio/size policy on every read, so streaming and
+    partial reads keep working (unlike buffering the whole member into memory)
+    while an over-expanding member is cut off mid-stream before it can exhaust RAM.
+
+    All reads funnel through :meth:`readinto`; wrap this in an ``io.BufferedReader``
+    to get ``read``/``readline``/``peek``/iteration, every one of them bounded.
+    """
+
+    def __init__(self, raw, compress_size, name, reject):
+        self._raw = raw
+        self._compress_size = compress_size
+        self._name = name
+        self._reject = reject
+        self._total = 0
+
+    def readable(self):
+        return True
+
+    def readinto(self, b):
+        n = self._raw.readinto(b)
+        if n:
+            self._total += n
+            self._reject(self._total, self._compress_size, self._name, "zip")
+        return n
+
+    def close(self):
+        try:
+            raw = getattr(self, "_raw", None)
+            if raw is not None:
+                self._raw = None
+                raw.close()
+        finally:
+            super().close()
 
 
 class ZipFile(zipfile.ZipFile):
@@ -893,7 +936,7 @@ class ZipFile(zipfile.ZipFile):
         # Never use the raw one-shot super().read(): it decompresses the whole
         # member into memory bounded only by the member's (attacker-controlled)
         # declared size. Stream it and cap the ACTUAL bytes produced (CWE-409).
-        _check_decompression_bomb, _bounded_stream_read = _decompression_guards()
+        _check_decompression_bomb, _bounded_stream_read, _ = _decompression_guards()
         info = name if isinstance(name, zipfile.ZipInfo) else self.getinfo(name)
         _check_decompression_bomb(info)  # cheap declared-size early reject
         with super().open(info, mode="r", pwd=pwd) as raw:
@@ -903,15 +946,21 @@ class ZipFile(zipfile.ZipFile):
         # Write mode has no member to decompress; only reads are bounded.
         if mode != "r":
             return super().open(name, mode, pwd, force_zip64=force_zip64)
-        # Never hand back the raw streaming reader (unbounded on .read()); return a
-        # seekable in-memory stream of the actual-byte-capped decompressed bytes.
-        _check_decompression_bomb, _bounded_stream_read = _decompression_guards()
+        # Preserve zipfile.open()'s streaming/partial-read contract (a caller may read
+        # only a prefix) instead of buffering the whole member: hand back a bounded
+        # streaming reader that caps the ACTUAL bytes produced on every read and cuts
+        # off an over-expanding member mid-stream (CWE-409).
+        _check_decompression_bomb, _, _reject = _decompression_guards()
         info = name if isinstance(name, zipfile.ZipInfo) else self.getinfo(name)
         _check_decompression_bomb(info)
-        with super().open(info, mode="r", pwd=pwd, force_zip64=force_zip64) as raw:
-            return io.BytesIO(
-                _bounded_stream_read(raw, info.compress_size, info.filename)
+        raw = super().open(info, mode="r", pwd=pwd, force_zip64=force_zip64)
+        try:
+            return io.BufferedReader(
+                _BoundedZipExtFile(raw, info.compress_size, info.filename, _reject)
             )
+        except BaseException:
+            raw.close()
+            raise
 
 
 __all__ = [

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -843,11 +843,8 @@ def open(file, mode="r", *, context="pathsec.open", required_root=None, **kwargs
 
 
 def _decompression_guards():
-    # The decompression-bomb policy lives in nltk.data (its MAX_UNZIP_* limits are
-    # public API). nltk.data imports THIS module, so importing it at the top would
-    # be circular; this single deferred import runs at call time when both modules
-    # are fully loaded. Returns
-    # (_check_decompression_bomb, _bounded_stream_read, _reject_decompression_total).
+    # Deferred to break the nltk.data <-> nltk.pathsec import cycle (data owns the
+    # public MAX_UNZIP_* policy); runs once both modules are fully loaded.
     from nltk.data import (
         _bounded_stream_read,
         _check_decompression_bomb,
@@ -933,9 +930,8 @@ class ZipFile(zipfile.ZipFile):
         super().extractall(path, members, pwd)
 
     def read(self, name, pwd=None):
-        # Never use the raw one-shot super().read(): it decompresses the whole
-        # member into memory bounded only by the member's (attacker-controlled)
-        # declared size. Stream it and cap the ACTUAL bytes produced (CWE-409).
+        # Not the raw one-shot super().read() (bounded only by the attacker-declared
+        # size): stream it and cap the ACTUAL bytes produced (CWE-409).
         _check_decompression_bomb, _bounded_stream_read, _ = _decompression_guards()
         info = name if isinstance(name, zipfile.ZipInfo) else self.getinfo(name)
         _check_decompression_bomb(info)  # cheap declared-size early reject
@@ -946,10 +942,8 @@ class ZipFile(zipfile.ZipFile):
         # Write mode has no member to decompress; only reads are bounded.
         if mode != "r":
             return super().open(name, mode, pwd, force_zip64=force_zip64)
-        # Preserve zipfile.open()'s streaming/partial-read contract (a caller may read
-        # only a prefix) instead of buffering the whole member: hand back a bounded
-        # streaming reader that caps the ACTUAL bytes produced on every read and cuts
-        # off an over-expanding member mid-stream (CWE-409).
+        # Preserve zipfile.open()'s streaming/partial-read contract: hand back a bounded
+        # reader that caps the ACTUAL bytes and cuts off an over-expanding member (CWE-409).
         _check_decompression_bomb, _, _reject = _decompression_guards()
         info = name if isinstance(name, zipfile.ZipInfo) else self.getinfo(name)
         _check_decompression_bomb(info)

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -878,6 +878,28 @@ class ZipFile(zipfile.ZipFile):
         validate_zip_archive(self, path or os.getcwd())
         super().extractall(path, members, pwd)
 
+    def read(self, name, pwd=None):
+        # zipfile.read() decompresses the whole member into memory with no cap; a
+        # tiny member declaring gigabytes exhausts RAM (decompression bomb,
+        # CWE-409). Bound it with nltk's policy before reading.
+        self._reject_decompression_bomb(name)
+        return super().read(name, pwd)
+
+    def open(self, name, mode="r", pwd=None, *, force_zip64=False):
+        # A streaming member open still decompresses on read; bound it up front by
+        # the member's declared size (only for read mode; writes have no member).
+        if mode == "r":
+            self._reject_decompression_bomb(name)
+        return super().open(name, mode, pwd, force_zip64=force_zip64)
+
+    def _reject_decompression_bomb(self, name):
+        # Imported lazily: nltk.data imports this module, so a top-level import
+        # would be circular. The policy/limits live in nltk.data (public API).
+        from nltk.data import _check_decompression_bomb
+
+        info = name if isinstance(name, zipfile.ZipInfo) else self.getinfo(name)
+        _check_decompression_bomb(info)
+
 
 __all__ = [
     "validate_path",

--- a/nltk/test/unit/test_zipbomb_security.py
+++ b/nltk/test/unit/test_zipbomb_security.py
@@ -24,7 +24,11 @@ import zipfile  # for the ZIP_DEFLATED constant only; opens go through pathsec
 import pytest
 
 import nltk.data as data
-from nltk.data import GzipFileSystemPathPointer, ZipFilePathPointer
+from nltk.data import (
+    GzipFileSystemPathPointer,
+    OpenOnDemandZipFile,
+    ZipFilePathPointer,
+)
 from nltk.downloader import ErrorMessage, _unzip_iter
 from nltk.pathsec import ZipFile as SecureZipFile
 from nltk.pathsec import open as pathsec_open
@@ -33,9 +37,19 @@ from nltk.pathsec import open as pathsec_open
 @pytest.fixture(autouse=True)
 def _restore_limits():
     """Snapshot and restore the configurable limits around each test."""
-    saved = (data.MAX_UNZIP_RATIO, data.MAX_UNZIP_SIZE, data.MAX_UNZIP_ACTIVATION)
+    saved = (
+        data.MAX_UNZIP_RATIO,
+        data.MAX_UNZIP_SIZE,
+        data.MAX_UNZIP_ACTIVATION,
+        data.MAX_UNZIP_MEMBERS,
+    )
     yield
-    data.MAX_UNZIP_RATIO, data.MAX_UNZIP_SIZE, data.MAX_UNZIP_ACTIVATION = saved
+    (
+        data.MAX_UNZIP_RATIO,
+        data.MAX_UNZIP_SIZE,
+        data.MAX_UNZIP_ACTIVATION,
+        data.MAX_UNZIP_MEMBERS,
+    ) = saved
 
 
 # Sandbox helpers dogfood the pathsec-secured wrappers (never a bare open); tmp_path
@@ -498,3 +512,134 @@ def test_pathsec_data_import_order_has_no_cycle():
             env=env,
         )
         assert r.returncode == 0, r.stderr.decode()
+
+
+# --- central-directory bombs: metadata alone, no decompression (CWE-409) -------
+def _many_member_zip(path, count):
+    with SecureZipFile(str(path), "w", zipfile.ZIP_STORED) as zf:
+        for i in range(count):
+            zf.writestr(f"pkg/{i}", b"")
+    return path
+
+
+def test_member_count_bomb_blocked_at_construction(tmp_path):
+    """An archive whose payload is its entry table is refused as soon as the count
+    is known, so no consumer pays to list, validate or extract its members."""
+    data.MAX_UNZIP_MEMBERS = 100
+    z = _many_member_zip(tmp_path / "many.zip", 500)
+    with pytest.raises(ValueError, match="MAX_UNZIP_MEMBERS"):
+        SecureZipFile(str(z))
+
+
+@pytest.mark.parametrize(
+    "opener",
+    [
+        lambda p: SecureZipFile(str(p)),
+        lambda p: OpenOnDemandZipFile(str(p)),
+        lambda p: ZipFilePathPointer(str(p), "pkg/1"),
+    ],
+)
+def test_member_count_bomb_blocked_at_every_zip_entry_point(tmp_path, opener):
+    data.MAX_UNZIP_MEMBERS = 100
+    z = _many_member_zip(tmp_path / "many.zip", 500)
+    with pytest.raises(ValueError, match="MAX_UNZIP_MEMBERS"):
+        opener(z)
+
+
+def test_member_count_bomb_blocked_in_downloader_extract(tmp_path):
+    data.MAX_UNZIP_MEMBERS = 100
+    z = _many_member_zip(tmp_path / "many.zip", 500)
+    messages = list(_unzip_iter(str(z), str(tmp_path / "out"), verbose=False))
+    assert any(isinstance(m, ErrorMessage) for m in messages), messages
+
+
+def test_real_corpus_member_count_passes(tmp_path):
+    """The default cap must not refuse a legitimate corpus: the largest NLTK
+    ships declares ~15k members, well under MAX_UNZIP_MEMBERS."""
+    z = _many_member_zip(tmp_path / "corpus.zip", 200)
+    with SecureZipFile(str(z)) as zf:
+        assert len(zf.namelist()) == 200
+
+
+# --- dispatch layer: a plain path that becomes an archive read ----------------
+def test_dispatch_zip_member_path_bomb_blocked(tmp_path, monkeypatch):
+    """'<corpus>.zip/<member>' resolves to a zip read; the bomb must not leak."""
+    monkeypatch.setattr(data, "path", [str(tmp_path)])
+    (tmp_path / "corpora").mkdir()
+    _make_zip(tmp_path / "corpora" / "c.zip", "c/big.txt", b"\0" * (64 * 1024 * 1024))
+    with pytest.raises(ValueError, match="zip bomb"):
+        data.load("corpora/c.zip/c/big.txt", format="raw")
+
+
+def test_dispatch_auto_inserted_zip_bomb_blocked(tmp_path, monkeypatch):
+    """nltk.data.find auto-inserts '.zip', so a plain corpus path also reaches the
+    archive reader; it must be bounded there too."""
+    monkeypatch.setattr(data, "path", [str(tmp_path)])
+    (tmp_path / "corpora").mkdir()
+    _make_zip(tmp_path / "corpora" / "c.zip", "c/big.txt", b"\0" * (64 * 1024 * 1024))
+    with pytest.raises(ValueError, match="zip bomb"):
+        data.load("corpora/c/big.txt", format="raw")
+
+
+def test_dispatch_gz_suffix_bomb_blocked(tmp_path, monkeypatch):
+    monkeypatch.setattr(data, "path", [str(tmp_path)])
+    _write_gz(tmp_path / "b.gz", b"\0" * (64 * 1024 * 1024))
+    with pytest.raises(ValueError, match="gzip bomb"):
+        data.load("b.gz", format="raw")
+
+
+def test_dispatch_strips_gz_before_format_autodetect(tmp_path, monkeypatch):
+    """load() strips '.gz' and autodetects on the remaining suffix, so 'x.pickle.gz'
+    decompresses then unpickles; the decompression must still be bounded."""
+    monkeypatch.setattr(data, "path", [str(tmp_path)])
+    _write_gz(tmp_path / "p.pickle.gz", b"\0" * (64 * 1024 * 1024))
+    with pytest.raises(ValueError, match="gzip bomb"):
+        data.load("p.pickle.gz")
+
+
+def test_dispatch_lazy_corpus_loader_bomb_blocked(tmp_path, monkeypatch):
+    """LazyCorpusLoader maps a corpus name to '<name>.zip/<name>/', and its readers
+    return LAZY views: the guard must fire when the view is evaluated, not only on
+    the eager raw() path (an unforced view reads nothing and proves nothing)."""
+    from nltk.corpus.reader.plaintext import PlaintextCorpusReader
+    from nltk.corpus.util import LazyCorpusLoader
+
+    monkeypatch.setattr(data, "path", [str(tmp_path)])
+    (tmp_path / "corpora").mkdir()
+    with SecureZipFile(
+        str(tmp_path / "corpora" / "mycorp.zip"), "w", zipfile.ZIP_DEFLATED
+    ) as zf:
+        zf.writestr("mycorp/", b"")  # explicit directory entry
+        zf.writestr("mycorp/big.txt", b"\0" * (64 * 1024 * 1024))
+
+    corpus = LazyCorpusLoader("mycorp", PlaintextCorpusReader, r".*\.txt")
+    assert corpus.fileids() == ["big.txt"]  # metadata alone decompresses nothing
+    with pytest.raises(ValueError, match="zip bomb"):
+        corpus.raw("big.txt")
+    view = corpus.words("big.txt")  # lazy: nothing read yet
+    with pytest.raises(ValueError, match="zip bomb"):
+        len(view)
+
+
+def test_dispatch_corpus_reader_over_zip_root_bomb_blocked(tmp_path):
+    """A CorpusReader rooted at a ZipFilePathPointer lists members freely but must
+    not decompress one past the cap."""
+    from nltk.corpus.reader.api import CorpusReader
+
+    z = _make_zip(tmp_path / "c.zip", "c/big.txt", b"\0" * (64 * 1024 * 1024))
+    reader = CorpusReader(ZipFilePathPointer(str(z), "c/"), r".*\.txt")
+    assert reader.fileids() == ["big.txt"]
+    with pytest.raises(ValueError, match="zip bomb"):
+        reader.open("big.txt").read()
+
+
+def test_dispatch_vader_lexicon_in_zip_bomb_blocked(tmp_path, monkeypatch):
+    """VADER's default lexicon lives inside vader_lexicon.zip, so the analyzer is a
+    zip-read dispatch path too."""
+    from nltk.sentiment.vader import SentimentIntensityAnalyzer
+
+    monkeypatch.setattr(data, "path", [str(tmp_path)])
+    (tmp_path / "corpora").mkdir()
+    _make_zip(tmp_path / "corpora" / "v.zip", "v/lex.txt", b"\0" * (64 * 1024 * 1024))
+    with pytest.raises(ValueError, match="zip bomb"):
+        SentimentIntensityAnalyzer(lexicon_file="corpora/v.zip/v/lex.txt")

--- a/nltk/test/unit/test_zipbomb_security.py
+++ b/nltk/test/unit/test_zipbomb_security.py
@@ -296,3 +296,62 @@ def test_buffered_gzip_file_legit_passes(tmp_path):
     payload = b"corpus sentence.\n" * 1000
     p = _write_gz(tmp_path / "ok.gz", payload)
     assert BufferedGzipFile(str(p)).read() == payload
+
+
+# --- gzip_open_unicode (the last raw-GzipFile read path) + misc coverage --------
+def test_gzip_open_unicode_read_bomb_blocked(tmp_path):
+    from nltk.data import gzip_open_unicode
+
+    p = _write_gz(tmp_path / "b.gz", b"\0" * (64 * 1024 * 1024))
+    with pytest.raises(ValueError, match="gzip bomb"):
+        gzip_open_unicode(str(p), "rb").read()
+
+
+def test_gzip_open_unicode_write_read_roundtrip(tmp_path):
+    """The write path (used by maxent) still works and reads back correctly."""
+    from nltk.data import gzip_open_unicode
+
+    text = "corpus line\n" * 200
+    p = tmp_path / "w.gz"
+    with gzip_open_unicode(str(p), "w") as f:
+        f.write(text)
+    assert gzip_open_unicode(str(p), "rb").read() == text
+
+
+def test_buffered_gzip_file_chunked_bomb_blocked(tmp_path):
+    """Reading the bomb in fixed chunks is caught on cumulative bytes, not just a
+    single whole-file read()."""
+    from nltk.data import BufferedGzipFile
+
+    p = _write_gz(tmp_path / "b.gz", b"\0" * (64 * 1024 * 1024))
+    f = BufferedGzipFile(str(p))
+    with pytest.raises(ValueError, match="gzip bomb"):
+        while True:
+            if not f.read(1 << 20):
+                break
+
+
+def test_gzip_low_ratio_above_activation_passes(tmp_path):
+    """A large .gz crossing the activation floor but low-ratio (like a real language
+    model) still decompresses fully -- no false positive."""
+    from nltk.data import GzipFileSystemPathPointer
+
+    data.MAX_UNZIP_ACTIVATION = 1024 * 1024  # 1 MiB
+    data.MAX_UNZIP_RATIO = 1000
+    payload = os.urandom(2 * 1024 * 1024)  # incompressible: ratio ~1x, above activation
+    p = _write_gz(tmp_path / "big.gz", payload)
+    assert GzipFileSystemPathPointer(str(p)).open().read() == payload
+
+
+def test_pathsec_data_import_order_has_no_cycle():
+    """pathsec.ZipFile's decompression guards are imported lazily to break the
+    nltk.data <-> nltk.pathsec cycle; importing either module first must work."""
+    import subprocess
+    import sys
+
+    for first in ("nltk.pathsec", "nltk.data"):
+        r = subprocess.run(
+            [sys.executable, "-c", f"import {first}; import nltk.pathsec, nltk.data"],
+            capture_output=True,
+        )
+        assert r.returncode == 0, r.stderr.decode()

--- a/nltk/test/unit/test_zipbomb_security.py
+++ b/nltk/test/unit/test_zipbomb_security.py
@@ -164,3 +164,45 @@ def test_nested_gzip_ratio_cap_is_load_bearing(tmp_path):
     data.MAX_UNZIP_ACTIVATION = 1 << 30
     out = ZipFilePathPointer(str(z), "bomb.gz").open().read()
     assert len(out) == 256 * 1024
+
+
+# --- standalone .gz file (GzipFileSystemPathPointer, not inside a zip) ----------
+def test_standalone_gzip_bomb_blocked(tmp_path):
+    """A standalone .gz on disk read via GzipFileSystemPathPointer is bounded by
+    the same policy, so it cannot exhaust memory (CWE-409)."""
+    import gzip
+
+    from nltk.data import GzipFileSystemPathPointer
+
+    p = tmp_path / "bomb.gz"
+    with gzip.open(p, "wb") as f:
+        f.write(b"\0" * (64 * 1024 * 1024))  # tiny gz, huge ratio
+    with pytest.raises(ValueError, match="gzip bomb"):
+        GzipFileSystemPathPointer(str(p)).open().read()
+
+
+def test_standalone_gzip_legit_passes(tmp_path):
+    """A legit low-ratio standalone .gz still decompresses fully and correctly."""
+    import gzip
+
+    from nltk.data import GzipFileSystemPathPointer
+
+    payload = b"corpus sentence.\n" * 100000
+    p = tmp_path / "ok.gz"
+    with gzip.open(p, "wb") as f:
+        f.write(payload)
+    assert GzipFileSystemPathPointer(str(p)).open().read() == payload
+
+
+def test_standalone_gzip_absolute_cap(tmp_path):
+    """MAX_UNZIP_SIZE also caps the standalone .gz layer's output."""
+    import gzip
+
+    from nltk.data import GzipFileSystemPathPointer
+
+    data.MAX_UNZIP_SIZE = 1024
+    p = tmp_path / "big.gz"
+    with gzip.open(p, "wb") as f:
+        f.write(b"x" * 4096)
+    with pytest.raises(ValueError, match="MAX_UNZIP_SIZE"):
+        GzipFileSystemPathPointer(str(p)).open().read()

--- a/nltk/test/unit/test_zipbomb_security.py
+++ b/nltk/test/unit/test_zipbomb_security.py
@@ -38,10 +38,8 @@ def _restore_limits():
     data.MAX_UNZIP_RATIO, data.MAX_UNZIP_SIZE, data.MAX_UNZIP_ACTIVATION = saved
 
 
-# These sandbox helpers use the pathsec-secured wrappers, never a bare open: the
-# tmp_path fixtures live under an authorized data root (see conftest), so the whole
-# harness dogfoods the hardened API. A bare open is used only where a test must
-# create something *outside* the sandbox (none here).
+# Sandbox helpers dogfood the pathsec-secured wrappers (never a bare open); tmp_path
+# lives under an authorized data root (see conftest).
 def _secure_zip(path, members):
     with SecureZipFile(str(path), "w", zipfile.ZIP_DEFLATED) as zf:
         for name, payload in members.items():
@@ -240,9 +238,8 @@ def test_pathsec_bounded_zip_ext_file_caps_actual_bytes(tmp_path, how):
     data.MAX_UNZIP_RATIO = 10
     z = _make_zip(tmp_path / "m.zip", "m", b"\0" * (4 * 1024 * 1024))
     with SecureZipFile(str(z)) as zf:
-        # zipfile.ZipFile.open bypasses our bounded override to hand back the raw
-        # streaming ZipExtFile; wrap it with an UNDERSTATED compress_size so only the
-        # actual-byte cap (not the ratio-vs-declared pre-check) can stop it.
+        # Raw ZipExtFile (bypassing our override) wrapped with an UNDERSTATED
+        # compress_size, so only the actual-byte cap (not the pre-check) can stop it.
         raw = zipfile.ZipFile.open(zf, "m")
         stream = io.BufferedReader(
             _BoundedZipExtFile(raw, 1024, "m", _reject_decompression_total)

--- a/nltk/test/unit/test_zipbomb_security.py
+++ b/nltk/test/unit/test_zipbomb_security.py
@@ -7,6 +7,11 @@ exhausts RAM or disk. ``nltk.data._check_decompression_bomb`` now rejects a
 member that expands beyond ``MAX_UNZIP_RATIO`` (above an activation size) or past
 the optional absolute cap ``MAX_UNZIP_SIZE``. Ordinary corpora compress only a
 few-fold, so the guard does not affect legitimate data.
+
+The gzip layers are bounded too (``_bounded_gzip_decompress``): a ``.gz`` member
+inside a zip (``ZipFilePathPointer.open``) and a standalone ``.gz`` on disk
+(``GzipFileSystemPathPointer.open``) are second decompression layers the zip
+member-size guard never sees, so each is streamed under the same policy.
 """
 
 import os
@@ -106,7 +111,7 @@ def test_nested_gzip_bomb_blocked(tmp_path):
     z = _make_zip(tmp_path / "nested.zip", "bomb.gz", gz)
     # the zip member itself passes the guard (its declared sizes are tiny)
     data._check_decompression_bomb(zipfile.ZipFile(str(z)).getinfo("bomb.gz"))
-    with pytest.raises(ValueError, match="nested gzip bomb"):
+    with pytest.raises(ValueError, match="gzip bomb"):
         ZipFilePathPointer(str(z), "bomb.gz").open().read()
 
 
@@ -120,7 +125,7 @@ def test_nested_gzip_forged_isize_caught_by_streaming_cap(tmp_path):
     gz = bytearray(gzip.compress(b"\0" * (4 * 1024 * 1024)))
     gz[-4:] = (0).to_bytes(4, "little")  # lie about the uncompressed size
     z = _make_zip(tmp_path / "forged.zip", "bomb.gz", bytes(gz))
-    with pytest.raises(ValueError, match="nested gzip bomb"):
+    with pytest.raises(ValueError, match="gzip bomb"):
         ZipFilePathPointer(str(z), "bomb.gz").open().read()
 
 
@@ -157,7 +162,7 @@ def test_nested_gzip_ratio_cap_is_load_bearing(tmp_path):
     data.MAX_UNZIP_ACTIVATION = 64 * 1024
     data.MAX_UNZIP_RATIO = 10
     data.MAX_UNZIP_SIZE = None
-    with pytest.raises(ValueError, match="nested gzip bomb"):
+    with pytest.raises(ValueError, match="gzip bomb"):
         ZipFilePathPointer(str(z), "bomb.gz").open().read()
 
     # neuter the cap: activation above the 256 KiB output -> no longer refused

--- a/nltk/test/unit/test_zipbomb_security.py
+++ b/nltk/test/unit/test_zipbomb_security.py
@@ -15,6 +15,7 @@ member-size guard never sees, so each is streamed under the same policy.
 """
 
 import gzip
+import io
 import os
 import subprocess
 import sys
@@ -23,7 +24,7 @@ import zipfile  # for the ZIP_DEFLATED constant only; opens go through pathsec
 import pytest
 
 import nltk.data as data
-from nltk.data import ZipFilePathPointer
+from nltk.data import GzipFileSystemPathPointer, ZipFilePathPointer
 from nltk.downloader import ErrorMessage, _unzip_iter
 from nltk.pathsec import ZipFile as SecureZipFile
 from nltk.pathsec import open as pathsec_open
@@ -128,7 +129,8 @@ def test_nested_gzip_bomb_blocked(tmp_path):
     gz = gzip.compress(b"\0" * (256 * 1024))
     z = _make_zip(tmp_path / "nested.zip", "bomb.gz", gz)
     # the zip member itself passes the guard (its declared sizes are tiny)
-    data._check_decompression_bomb(SecureZipFile(str(z)).getinfo("bomb.gz"))
+    with SecureZipFile(str(z)) as zf:
+        data._check_decompression_bomb(zf.getinfo("bomb.gz"))
     with pytest.raises(ValueError, match="gzip bomb"):
         ZipFilePathPointer(str(z), "bomb.gz").open().read()
 
@@ -185,8 +187,6 @@ def test_nested_gzip_ratio_cap_is_load_bearing(tmp_path):
 def test_standalone_gzip_bomb_blocked(tmp_path):
     """A standalone .gz on disk read via GzipFileSystemPathPointer is bounded by
     the same policy, so it cannot exhaust memory (CWE-409)."""
-    from nltk.data import GzipFileSystemPathPointer
-
     p = _write_gz(tmp_path / "bomb.gz", b"\0" * (64 * 1024 * 1024))
     with pytest.raises(ValueError, match="gzip bomb"):
         GzipFileSystemPathPointer(str(p)).open().read()
@@ -194,8 +194,6 @@ def test_standalone_gzip_bomb_blocked(tmp_path):
 
 def test_standalone_gzip_legit_passes(tmp_path):
     """A legit low-ratio standalone .gz still decompresses fully and correctly."""
-    from nltk.data import GzipFileSystemPathPointer
-
     payload = b"corpus sentence.\n" * 100000
     p = _write_gz(tmp_path / "ok.gz", payload)
     assert GzipFileSystemPathPointer(str(p)).open().read() == payload
@@ -203,8 +201,6 @@ def test_standalone_gzip_legit_passes(tmp_path):
 
 def test_standalone_gzip_absolute_cap(tmp_path):
     """MAX_UNZIP_SIZE also caps the standalone .gz layer's output."""
-    from nltk.data import GzipFileSystemPathPointer
-
     data.MAX_UNZIP_SIZE = 1024
     p = _write_gz(tmp_path / "big.gz", b"x" * 4096)
     with pytest.raises(ValueError, match="MAX_UNZIP_SIZE"):
@@ -217,22 +213,72 @@ def test_pathsec_zipfile_read_bomb_blocked(tmp_path):
     secure wrapper cannot be used as a bomb (CWE-409)."""
     z = _make_zip(tmp_path / "b.zip", "m", b"\0" * (64 * 1024 * 1024))
     with pytest.raises(ValueError, match="zip bomb"):
-        SecureZipFile(str(z)).read("m")
+        with SecureZipFile(str(z)) as zf:
+            zf.read("m")
 
 
 def test_pathsec_zipfile_open_bomb_blocked(tmp_path):
     """pathsec.ZipFile.open() (streaming member) is bounded by the declared size."""
     z = _make_zip(tmp_path / "b.zip", "m", b"\0" * (64 * 1024 * 1024))
     with pytest.raises(ValueError, match="zip bomb"):
-        SecureZipFile(str(z)).open("m")
+        with SecureZipFile(str(z)) as zf:
+            zf.open("m")
+
+
+@pytest.mark.parametrize("how", ["read", "readline", "iter"])
+def test_pathsec_bounded_zip_ext_file_caps_actual_bytes(tmp_path, how):
+    """open()'s declared-size pre-check catches honest bombs, but the returned
+    streaming reader is the defense-in-depth backstop: it caps the ACTUAL
+    decompressed bytes on every read path even if the declared size understated
+    them. Drive _BoundedZipExtFile directly with a deliberately tiny compress_size
+    (the pre-check bypassed) and confirm read()/readline()/iteration each trip
+    (the reviewer's ask: preserve streaming semantics yet stay bounded, CWE-409)."""
+    from nltk.data import _reject_decompression_total
+    from nltk.pathsec import _BoundedZipExtFile
+
+    data.MAX_UNZIP_ACTIVATION = 1024 * 1024
+    data.MAX_UNZIP_RATIO = 10
+    z = _make_zip(tmp_path / "m.zip", "m", b"\0" * (4 * 1024 * 1024))
+    with SecureZipFile(str(z)) as zf:
+        # zipfile.ZipFile.open bypasses our bounded override to hand back the raw
+        # streaming ZipExtFile; wrap it with an UNDERSTATED compress_size so only the
+        # actual-byte cap (not the ratio-vs-declared pre-check) can stop it.
+        raw = zipfile.ZipFile.open(zf, "m")
+        stream = io.BufferedReader(
+            _BoundedZipExtFile(raw, 1024, "m", _reject_decompression_total)
+        )
+        with pytest.raises(ValueError, match="zip bomb"):
+            if how == "read":
+                stream.read()
+            elif how == "readline":
+                stream.readline()
+            else:
+                for _ in stream:
+                    pass
+
+
+def test_pathsec_zipfile_open_prefix_read_is_not_falsely_rejected(tmp_path):
+    """Reading only a prefix of a large legit member must NOT trip the cap (proves
+    streaming really streams instead of materialising the whole member)."""
+    data.MAX_UNZIP_ACTIVATION = 1024 * 1024
+    data.MAX_UNZIP_RATIO = 10
+    payload = os.urandom(8 * 1024 * 1024)  # incompressible, low ratio
+    z = _make_zip(tmp_path / "big.zip", "m", payload)
+    with SecureZipFile(str(z)) as zf:
+        with zf.open("m") as stream:
+            assert stream.read(4096) == payload[:4096]
 
 
 def test_pathsec_zipfile_legit_read_passes(tmp_path):
     """A legit member still reads correctly through pathsec.ZipFile."""
     payload = b"hello world\n" * 500
     z = _make_zip(tmp_path / "ok.zip", "m", payload)
-    assert SecureZipFile(str(z)).read("m") == payload
-    assert SecureZipFile(str(z)).open("m").read() == payload
+    with SecureZipFile(str(z)) as zf:
+        assert zf.read("m") == payload
+        assert zf.open("m").read() == payload
+        # readline / iteration on a legit member behave normally
+    with SecureZipFile(str(z)) as zf:
+        assert zf.open("m").readline() == b"hello world\n"
 
 
 def test_weka_version_check_refuses_bomb_jar(tmp_path):
@@ -263,7 +309,8 @@ def test_pathsec_zipfile_extract_bomb_blocked(tmp_path):
     dest = tmp_path / "out"
     dest.mkdir()
     with pytest.raises(ValueError, match="zip bomb"):
-        SecureZipFile(str(z)).extract("m", str(dest))
+        with SecureZipFile(str(z)) as zf:
+            zf.extract("m", str(dest))
     assert not (dest / "m").exists() or (dest / "m").stat().st_size < 2 * 1024 * 1024
 
 
@@ -272,7 +319,8 @@ def test_pathsec_zipfile_extractall_bomb_blocked(tmp_path):
     dest = tmp_path / "out"
     dest.mkdir()
     with pytest.raises(ValueError, match="zip bomb"):
-        SecureZipFile(str(z)).extractall(str(dest))
+        with SecureZipFile(str(z)) as zf:
+            zf.extractall(str(dest))
 
 
 def test_nltk_data_find_gz_bomb_blocked_end_to_end(tmp_path, monkeypatch):
@@ -336,13 +384,104 @@ def test_buffered_gzip_file_chunked_bomb_blocked(tmp_path):
 def test_gzip_low_ratio_above_activation_passes(tmp_path):
     """A large .gz crossing the activation floor but low-ratio (like a real language
     model) still decompresses fully -- no false positive."""
-    from nltk.data import GzipFileSystemPathPointer
-
     data.MAX_UNZIP_ACTIVATION = 1024 * 1024  # 1 MiB
     data.MAX_UNZIP_RATIO = 1000
     payload = os.urandom(2 * 1024 * 1024)  # incompressible: ratio ~1x, above activation
     p = _write_gz(tmp_path / "big.gz", payload)
     assert GzipFileSystemPathPointer(str(p)).open().read() == payload
+
+
+# --- GzipFileSystemPathPointer now STREAMS (no whole-file buffering); the guard
+#     must survive seeks, which decompress-and-discard OUTSIDE read() (CWE-409) -----
+def test_gzip_pointer_seek_to_end_bomb_blocked(tmp_path):
+    """seek(0, SEEK_END) makes GzipFile decompress the whole stream inside its own
+    buffer (never through read()); the seek() guard must still refuse the bomb."""
+    data.MAX_UNZIP_ACTIVATION = 1024 * 1024
+    data.MAX_UNZIP_RATIO = 10
+    p = _write_gz(tmp_path / "bomb.gz", b"\0" * (64 * 1024 * 1024))
+    with pytest.raises(ValueError, match="gzip bomb"):
+        with GzipFileSystemPathPointer(str(p)).open() as s:
+            s.seek(0, os.SEEK_END)
+
+
+def test_gzip_pointer_forward_seek_past_ratio_blocked(tmp_path):
+    """A forward absolute seek past the ratio threshold decompresses-and-discards up
+    to that offset; the guard refuses once the offset breaches the policy."""
+    data.MAX_UNZIP_ACTIVATION = 1024 * 1024
+    data.MAX_UNZIP_RATIO = 10
+    p = _write_gz(tmp_path / "bomb.gz", b"\0" * (64 * 1024 * 1024))
+    with pytest.raises(ValueError, match="gzip bomb"):
+        with GzipFileSystemPathPointer(str(p)).open() as s:
+            s.seek(60 * 1024 * 1024, os.SEEK_SET)
+
+
+def test_gzip_pointer_seek_roundtrip_legit_passes(tmp_path):
+    """seek(END) to size, seek(0), then a full read of a legit .gz must NOT be
+    falsely rejected: the guard tracks the max offset reached, not summed reads."""
+    payload = os.urandom(2 * 1024 * 1024)
+    p = _write_gz(tmp_path / "ok.gz", payload)
+    with GzipFileSystemPathPointer(str(p)).open() as s:
+        assert s.seek(0, os.SEEK_END) == len(payload)
+        s.seek(0)
+        assert s.read() == payload
+        # chunked reread after the seeks: still fine
+        s.seek(0)
+        acc = b""
+        while True:
+            chunk = s.read(65536)
+            if not chunk:
+                break
+            acc += chunk
+        assert acc == payload
+
+
+def test_gzip_pointer_prefix_read_does_not_buffer_whole_file(tmp_path):
+    """Reading only a prefix of a large legit .gz must succeed without tripping the
+    cap, proving the pointer streams instead of materialising the whole payload."""
+    data.MAX_UNZIP_ACTIVATION = 1024 * 1024
+    data.MAX_UNZIP_RATIO = 10
+    payload = os.urandom(8 * 1024 * 1024)  # incompressible, low ratio
+    p = _write_gz(tmp_path / "big.gz", payload)
+    with GzipFileSystemPathPointer(str(p)).open() as s:
+        assert s.read(4096) == payload[:4096]
+
+
+def test_gzip_pointer_compress_size_stat_is_cached(tmp_path):
+    """_BoundedGzipFile stats the compressed size once and caches it: re-stat-ing on
+    every read() is hot for chunked/line iteration (reviewer perf note)."""
+    payload = os.urandom(4 * 1024 * 1024)
+    p = _write_gz(tmp_path / "ok.gz", payload)
+    calls = {"n": 0}
+    real_getsize = os.path.getsize
+
+    def counting_getsize(path):
+        calls["n"] += 1
+        return real_getsize(path)
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr("nltk.data.os.path.getsize", counting_getsize)
+    try:
+        with GzipFileSystemPathPointer(str(p)).open() as s:
+            while s.read(65536):
+                pass
+    finally:
+        monkeypatch.undo()
+    assert calls["n"] == 1, f"compress_size stat not cached: {calls['n']} calls"
+
+
+def test_gzip_pointer_with_encoding_streams_and_blocks(tmp_path):
+    """The encoding path wraps the stream in SeekableUnicodeStreamReader (which seeks
+    heavily): a legit text .gz decodes correctly and a bomb is still refused."""
+    text = "corpus line éè\n" * 5000  # multibyte to exercise seek realignment
+    p = _write_gz(tmp_path / "text.gz", text.encode("utf-8"))
+    with GzipFileSystemPathPointer(str(p)).open(encoding="utf-8") as reader:
+        assert reader.readline() == "corpus line éè\n"
+
+    data.MAX_UNZIP_ACTIVATION = 1024 * 1024
+    data.MAX_UNZIP_RATIO = 10
+    pb = _write_gz(tmp_path / "bomb.gz", b"\0" * (64 * 1024 * 1024))
+    with pytest.raises(ValueError, match="gzip bomb"):
+        GzipFileSystemPathPointer(str(pb)).open(encoding="utf-8").read()
 
 
 def test_pathsec_data_import_order_has_no_cycle():

--- a/nltk/test/unit/test_zipbomb_security.py
+++ b/nltk/test/unit/test_zipbomb_security.py
@@ -90,3 +90,77 @@ def test_downloader_writes_nothing_when_a_later_member_is_a_bomb(tmp_path):
     # neither the benign member nor the bomb was written
     assert not (dest / "pkg" / "safe.txt").exists()
     assert not (dest / "pkg" / "big.txt").exists()
+
+
+# --- nested gzip inside a zip member (the .gz second decompression layer) ------
+
+
+def test_nested_gzip_bomb_blocked(tmp_path):
+    """A .gz zip member whose (tiny) gz bytes pass the member guard but whose gzip
+    layer expands past the ratio is refused (nested-gzip bomb, CWE-409)."""
+    import gzip
+
+    data.MAX_UNZIP_ACTIVATION = 64 * 1024
+    data.MAX_UNZIP_RATIO = 10
+    gz = gzip.compress(b"\0" * (256 * 1024))
+    z = _make_zip(tmp_path / "nested.zip", "bomb.gz", gz)
+    # the zip member itself passes the guard (its declared sizes are tiny)
+    data._check_decompression_bomb(zipfile.ZipFile(str(z)).getinfo("bomb.gz"))
+    with pytest.raises(ValueError, match="nested gzip bomb"):
+        ZipFilePathPointer(str(z), "bomb.gz").open().read()
+
+
+def test_nested_gzip_forged_isize_caught_by_streaming_cap(tmp_path):
+    """Even with a forged gzip ISIZE trailer (claims 0 bytes), the streaming cap
+    still refuses the bomb; the ISIZE pre-check is only an optimization."""
+    import gzip
+
+    data.MAX_UNZIP_ACTIVATION = 1024 * 1024
+    data.MAX_UNZIP_RATIO = 10
+    gz = bytearray(gzip.compress(b"\0" * (4 * 1024 * 1024)))
+    gz[-4:] = (0).to_bytes(4, "little")  # lie about the uncompressed size
+    z = _make_zip(tmp_path / "forged.zip", "bomb.gz", bytes(gz))
+    with pytest.raises(ValueError, match="nested gzip bomb"):
+        ZipFilePathPointer(str(z), "bomb.gz").open().read()
+
+
+def test_nested_gzip_absolute_cap(tmp_path):
+    """MAX_UNZIP_SIZE also caps the nested gzip layer's output."""
+    import gzip
+
+    data.MAX_UNZIP_SIZE = 64 * 1024
+    gz = gzip.compress(b"\0" * (256 * 1024))
+    z = _make_zip(tmp_path / "cap.zip", "big.gz", gz)
+    with pytest.raises(ValueError, match="MAX_UNZIP_SIZE"):
+        ZipFilePathPointer(str(z), "big.gz").open().read()
+
+
+def test_nested_gzip_legit_member_passes(tmp_path):
+    """A legitimate .gz member (low ratio) still decompresses to its content."""
+    import gzip
+
+    payload = b"legitimate corpus line\n" * 64
+    z = _make_zip(tmp_path / "ok.zip", "data.gz", gzip.compress(payload))
+    assert ZipFilePathPointer(str(z), "data.gz").open().read() == payload
+
+
+def test_nested_gzip_ratio_cap_is_load_bearing(tmp_path):
+    """Mutation test: with the activation/ratio cap tuned to catch it the nested
+    gzip bomb is refused; raise the activation threshold above the output and the
+    SAME payload decompresses, proving the cap (not another check) is the guard
+    that stops the second decompression layer (CWE-409)."""
+    import gzip
+
+    gz = gzip.compress(b"\0" * (256 * 1024))
+    z = _make_zip(tmp_path / "mut.zip", "bomb.gz", gz)
+
+    data.MAX_UNZIP_ACTIVATION = 64 * 1024
+    data.MAX_UNZIP_RATIO = 10
+    data.MAX_UNZIP_SIZE = None
+    with pytest.raises(ValueError, match="nested gzip bomb"):
+        ZipFilePathPointer(str(z), "bomb.gz").open().read()
+
+    # neuter the cap: activation above the 256 KiB output -> no longer refused
+    data.MAX_UNZIP_ACTIVATION = 1 << 30
+    out = ZipFilePathPointer(str(z), "bomb.gz").open().read()
+    assert len(out) == 256 * 1024

--- a/nltk/test/unit/test_zipbomb_security.py
+++ b/nltk/test/unit/test_zipbomb_security.py
@@ -16,6 +16,8 @@ member-size guard never sees, so each is streamed under the same policy.
 
 import gzip
 import os
+import subprocess
+import sys
 import zipfile  # for the ZIP_DEFLATED constant only; opens go through pathsec
 
 import pytest
@@ -345,13 +347,18 @@ def test_gzip_low_ratio_above_activation_passes(tmp_path):
 
 def test_pathsec_data_import_order_has_no_cycle():
     """pathsec.ZipFile's decompression guards are imported lazily to break the
-    nltk.data <-> nltk.pathsec cycle; importing either module first must work."""
-    import subprocess
-    import sys
+    nltk.data <-> nltk.pathsec cycle; importing either module first must work.
 
+    The child interpreter is given this process's import path so it can locate
+    nltk exactly where the running tests found it (editable checkout, installed
+    site-packages, or a PYTHONPATH override) rather than relying on its own cwd.
+    """
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(p for p in sys.path if p)
     for first in ("nltk.pathsec", "nltk.data"):
         r = subprocess.run(
             [sys.executable, "-c", f"import {first}; import nltk.pathsec, nltk.data"],
             capture_output=True,
+            env=env,
         )
         assert r.returncode == 0, r.stderr.decode()

--- a/nltk/test/unit/test_zipbomb_security.py
+++ b/nltk/test/unit/test_zipbomb_security.py
@@ -243,3 +243,56 @@ def test_weka_version_check_refuses_bomb_jar(tmp_path):
     )
     with pytest.raises(ValueError, match="zip bomb"):
         _check_weka_version(str(jar))
+
+
+# --- the remaining entry points: OpenOnDemandZipFile, extract/extractall,
+#     nltk.data.find end-to-end, and the deprecated BufferedGzipFile -------------
+def test_open_on_demand_zipfile_read_bomb_blocked(tmp_path):
+    from nltk.data import OpenOnDemandZipFile
+
+    z = _make_zip(tmp_path / "b.zip", "m", b"\0" * (64 * 1024 * 1024))
+    with pytest.raises(ValueError, match="zip bomb"):
+        OpenOnDemandZipFile(str(z)).read("m")
+
+
+def test_pathsec_zipfile_extract_bomb_blocked(tmp_path):
+    """extract() decompresses to disk via self.open(); the bounded open() stops it."""
+    z = _make_zip(tmp_path / "b.zip", "m", b"\0" * (64 * 1024 * 1024))
+    dest = tmp_path / "out"
+    dest.mkdir()
+    with pytest.raises(ValueError, match="zip bomb"):
+        SecureZipFile(str(z)).extract("m", str(dest))
+    assert not (dest / "m").exists() or (dest / "m").stat().st_size < 2 * 1024 * 1024
+
+
+def test_pathsec_zipfile_extractall_bomb_blocked(tmp_path):
+    z = _make_zip(tmp_path / "b.zip", "m", b"\0" * (64 * 1024 * 1024))
+    dest = tmp_path / "out"
+    dest.mkdir()
+    with pytest.raises(ValueError, match="zip bomb"):
+        SecureZipFile(str(z)).extractall(str(dest))
+
+
+def test_nltk_data_find_gz_bomb_blocked_end_to_end(tmp_path, monkeypatch):
+    """nltk.data.find(name).open().read() on a standalone .gz bomb is refused."""
+    _write_gz(tmp_path / "payload.gz", b"\0" * (64 * 1024 * 1024))
+    monkeypatch.setattr(data, "path", [str(tmp_path)])
+    with pytest.raises(ValueError, match="gzip bomb"):
+        data.find("payload.gz").open().read()
+
+
+def test_buffered_gzip_file_bomb_blocked(tmp_path):
+    """The deprecated BufferedGzipFile.read() is bounded too (CWE-409)."""
+    from nltk.data import BufferedGzipFile
+
+    p = _write_gz(tmp_path / "b.gz", b"\0" * (64 * 1024 * 1024))
+    with pytest.raises(ValueError, match="gzip bomb"):
+        BufferedGzipFile(str(p)).read()
+
+
+def test_buffered_gzip_file_legit_passes(tmp_path):
+    from nltk.data import BufferedGzipFile
+
+    payload = b"corpus sentence.\n" * 1000
+    p = _write_gz(tmp_path / "ok.gz", payload)
+    assert BufferedGzipFile(str(p)).read() == payload

--- a/nltk/test/unit/test_zipbomb_security.py
+++ b/nltk/test/unit/test_zipbomb_security.py
@@ -14,14 +14,17 @@ inside a zip (``ZipFilePathPointer.open``) and a standalone ``.gz`` on disk
 member-size guard never sees, so each is streamed under the same policy.
 """
 
+import gzip
 import os
-import zipfile
+import zipfile  # for the ZIP_DEFLATED constant only; opens go through pathsec
 
 import pytest
 
 import nltk.data as data
 from nltk.data import ZipFilePathPointer
 from nltk.downloader import ErrorMessage, _unzip_iter
+from nltk.pathsec import ZipFile as SecureZipFile
+from nltk.pathsec import open as pathsec_open
 
 
 @pytest.fixture(autouse=True)
@@ -32,9 +35,24 @@ def _restore_limits():
     data.MAX_UNZIP_RATIO, data.MAX_UNZIP_SIZE, data.MAX_UNZIP_ACTIVATION = saved
 
 
+# These sandbox helpers use the pathsec-secured wrappers, never a bare open: the
+# tmp_path fixtures live under an authorized data root (see conftest), so the whole
+# harness dogfoods the hardened API. A bare open is used only where a test must
+# create something *outside* the sandbox (none here).
+def _secure_zip(path, members):
+    with SecureZipFile(str(path), "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, payload in members.items():
+            zf.writestr(name, payload)
+    return path
+
+
 def _make_zip(path, member, payload):
-    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as zf:
-        zf.writestr(member, payload)
+    return _secure_zip(path, {member: payload})
+
+
+def _write_gz(path, payload):
+    with pathsec_open(str(path), "wb", context="test_zipbomb") as f:
+        f.write(gzip.compress(payload))
     return path
 
 
@@ -85,10 +103,10 @@ def test_downloader_writes_nothing_when_a_later_member_is_a_bomb(tmp_path):
     (validate-then-extract contract)."""
     data.MAX_UNZIP_ACTIVATION = 1024 * 1024  # 1 MiB
     data.MAX_UNZIP_RATIO = 100
-    zp = tmp_path / "pkg.zip"
-    with zipfile.ZipFile(zp, "w", zipfile.ZIP_DEFLATED) as zf:
-        zf.writestr("pkg/safe.txt", b"hello")  # benign member, comes first
-        zf.writestr("pkg/big.txt", b"\0" * (2 * 1024 * 1024))  # bomb, comes later
+    zp = _secure_zip(
+        tmp_path / "pkg.zip",
+        {"pkg/safe.txt": b"hello", "pkg/big.txt": b"\0" * (2 * 1024 * 1024)},
+    )
     dest = tmp_path / "out"
     messages = list(_unzip_iter(str(zp), str(dest), verbose=False))
     assert any(isinstance(m, ErrorMessage) for m in messages), messages
@@ -103,14 +121,12 @@ def test_downloader_writes_nothing_when_a_later_member_is_a_bomb(tmp_path):
 def test_nested_gzip_bomb_blocked(tmp_path):
     """A .gz zip member whose (tiny) gz bytes pass the member guard but whose gzip
     layer expands past the ratio is refused (nested-gzip bomb, CWE-409)."""
-    import gzip
-
     data.MAX_UNZIP_ACTIVATION = 64 * 1024
     data.MAX_UNZIP_RATIO = 10
     gz = gzip.compress(b"\0" * (256 * 1024))
     z = _make_zip(tmp_path / "nested.zip", "bomb.gz", gz)
     # the zip member itself passes the guard (its declared sizes are tiny)
-    data._check_decompression_bomb(zipfile.ZipFile(str(z)).getinfo("bomb.gz"))
+    data._check_decompression_bomb(SecureZipFile(str(z)).getinfo("bomb.gz"))
     with pytest.raises(ValueError, match="gzip bomb"):
         ZipFilePathPointer(str(z), "bomb.gz").open().read()
 
@@ -118,8 +134,6 @@ def test_nested_gzip_bomb_blocked(tmp_path):
 def test_nested_gzip_forged_isize_caught_by_streaming_cap(tmp_path):
     """Even with a forged gzip ISIZE trailer (claims 0 bytes), the streaming cap
     still refuses the bomb; the ISIZE pre-check is only an optimization."""
-    import gzip
-
     data.MAX_UNZIP_ACTIVATION = 1024 * 1024
     data.MAX_UNZIP_RATIO = 10
     gz = bytearray(gzip.compress(b"\0" * (4 * 1024 * 1024)))
@@ -131,8 +145,6 @@ def test_nested_gzip_forged_isize_caught_by_streaming_cap(tmp_path):
 
 def test_nested_gzip_absolute_cap(tmp_path):
     """MAX_UNZIP_SIZE also caps the nested gzip layer's output."""
-    import gzip
-
     data.MAX_UNZIP_SIZE = 64 * 1024
     gz = gzip.compress(b"\0" * (256 * 1024))
     z = _make_zip(tmp_path / "cap.zip", "big.gz", gz)
@@ -142,8 +154,6 @@ def test_nested_gzip_absolute_cap(tmp_path):
 
 def test_nested_gzip_legit_member_passes(tmp_path):
     """A legitimate .gz member (low ratio) still decompresses to its content."""
-    import gzip
-
     payload = b"legitimate corpus line\n" * 64
     z = _make_zip(tmp_path / "ok.zip", "data.gz", gzip.compress(payload))
     assert ZipFilePathPointer(str(z), "data.gz").open().read() == payload
@@ -154,8 +164,6 @@ def test_nested_gzip_ratio_cap_is_load_bearing(tmp_path):
     gzip bomb is refused; raise the activation threshold above the output and the
     SAME payload decompresses, proving the cap (not another check) is the guard
     that stops the second decompression layer (CWE-409)."""
-    import gzip
-
     gz = gzip.compress(b"\0" * (256 * 1024))
     z = _make_zip(tmp_path / "mut.zip", "bomb.gz", gz)
 
@@ -175,39 +183,63 @@ def test_nested_gzip_ratio_cap_is_load_bearing(tmp_path):
 def test_standalone_gzip_bomb_blocked(tmp_path):
     """A standalone .gz on disk read via GzipFileSystemPathPointer is bounded by
     the same policy, so it cannot exhaust memory (CWE-409)."""
-    import gzip
-
     from nltk.data import GzipFileSystemPathPointer
 
-    p = tmp_path / "bomb.gz"
-    with gzip.open(p, "wb") as f:
-        f.write(b"\0" * (64 * 1024 * 1024))  # tiny gz, huge ratio
+    p = _write_gz(tmp_path / "bomb.gz", b"\0" * (64 * 1024 * 1024))
     with pytest.raises(ValueError, match="gzip bomb"):
         GzipFileSystemPathPointer(str(p)).open().read()
 
 
 def test_standalone_gzip_legit_passes(tmp_path):
     """A legit low-ratio standalone .gz still decompresses fully and correctly."""
-    import gzip
-
     from nltk.data import GzipFileSystemPathPointer
 
     payload = b"corpus sentence.\n" * 100000
-    p = tmp_path / "ok.gz"
-    with gzip.open(p, "wb") as f:
-        f.write(payload)
+    p = _write_gz(tmp_path / "ok.gz", payload)
     assert GzipFileSystemPathPointer(str(p)).open().read() == payload
 
 
 def test_standalone_gzip_absolute_cap(tmp_path):
     """MAX_UNZIP_SIZE also caps the standalone .gz layer's output."""
-    import gzip
-
     from nltk.data import GzipFileSystemPathPointer
 
     data.MAX_UNZIP_SIZE = 1024
-    p = tmp_path / "big.gz"
-    with gzip.open(p, "wb") as f:
-        f.write(b"x" * 4096)
+    p = _write_gz(tmp_path / "big.gz", b"x" * 4096)
     with pytest.raises(ValueError, match="MAX_UNZIP_SIZE"):
         GzipFileSystemPathPointer(str(p)).open().read()
+
+
+# --- pathsec.ZipFile.read/open: the "secure" wrapper must bound decompression ---
+def test_pathsec_zipfile_read_bomb_blocked(tmp_path):
+    """pathsec.ZipFile.read() decompresses a whole member; it must be capped so the
+    secure wrapper cannot be used as a bomb (CWE-409)."""
+    z = _make_zip(tmp_path / "b.zip", "m", b"\0" * (64 * 1024 * 1024))
+    with pytest.raises(ValueError, match="zip bomb"):
+        SecureZipFile(str(z)).read("m")
+
+
+def test_pathsec_zipfile_open_bomb_blocked(tmp_path):
+    """pathsec.ZipFile.open() (streaming member) is bounded by the declared size."""
+    z = _make_zip(tmp_path / "b.zip", "m", b"\0" * (64 * 1024 * 1024))
+    with pytest.raises(ValueError, match="zip bomb"):
+        SecureZipFile(str(z)).open("m")
+
+
+def test_pathsec_zipfile_legit_read_passes(tmp_path):
+    """A legit member still reads correctly through pathsec.ZipFile."""
+    payload = b"hello world\n" * 500
+    z = _make_zip(tmp_path / "ok.zip", "m", payload)
+    assert SecureZipFile(str(z)).read("m") == payload
+    assert SecureZipFile(str(z)).open("m").read() == payload
+
+
+def test_weka_version_check_refuses_bomb_jar(tmp_path):
+    """_check_weka_version opens the jar and reads weka/core/version.txt; a
+    malicious jar declaring a gigabyte version.txt must not be read into RAM."""
+    from nltk.classify.weka import _check_weka_version
+
+    jar = _make_zip(
+        tmp_path / "weka.jar", "weka/core/version.txt", b"\0" * (64 * 1024 * 1024)
+    )
+    with pytest.raises(ValueError, match="zip bomb"):
+        _check_weka_version(str(jar))


### PR DESCRIPTION
## Problem

An empirical audit — **firing real bombs at every point where NLTK decompresses**, not reading code — found several unbounded decompression paths (**CWE-409**, draft GHSA-rv69). The zip-**member** read paths and the downloader extract were already bounded on `develop` by `_check_decompression_bomb`; these were not:

1. **Nested `.gz` inside a zip member** (`ZipFilePathPointer.open`) — a second gzip layer the member guard never sees.
2. **Standalone `.gz` on disk** (`GzipFileSystemPathPointer.open`) — returned a raw `GzipFile`.
3. **`pathsec.ZipFile.read()` / `.open()`** — the class advertised as the *Secure wrapper for `zipfile.ZipFile`* overrode only `extract`/`extractall`; its `read`/`open` inherited the **unchecked** `zipfile` methods, so `pathsec.ZipFile(z).read('m')` decompressed a bomb with no cap.
4. **`weka._check_weka_version`** opened `weka.jar` with a **bare `zipfile.ZipFile`** and read `weka/core/version.txt` unbounded — a malicious jar bombs `config_weka()`.

## Fix

- `_bounded_gzip_decompress()` streams a gzip layer under the ratio/activation/size policy; both the nested `.gz` member and the standalone `.gz` route through it.
- `pathsec.ZipFile.read()`/`.open()` now enforce `_check_decompression_bomb` on the member first (so `OpenOnDemandZipFile`, which extends it, is covered too).
- `weka._check_weka_version` uses `pathsec.ZipFile` (path containment **+** the bomb cap) instead of a bare open; it accepts absolute paths outside `nltk_data`, so real weka installs still work.

## Every decompression entry point, verified by firing a 64 MiB bomb

| Entry point | Result |
|---|---|
| `ZipFilePathPointer.open` (member) | ✅ existing |
| `OpenOnDemandZipFile.read` | ✅ existing |
| nested `.gz`-in-zip | ✅ this PR |
| standalone `.gz` (`GzipFileSystemPathPointer`) | ✅ this PR |
| `nltk.data.find/load` end-to-end | ✅ |
| downloader extract-to-disk | ✅ existing |
| **`pathsec.ZipFile.read` / `.open`** | ✅ this PR |
| **`weka._check_weka_version`** | ✅ this PR |

All eight refuse the bomb; corpus readers open through the guarded pointers (and don't decompress `.gz` themselves).

## Tests & functionality

`test_zipbomb_security.py` now covers all of the above (18 tests), and the **harness itself dogfoods the secured wrappers** — sandbox fixtures are created/read via `pathsec.ZipFile`/`pathsec.open`, never a bare open. Verified live (not mocked): **real Weka classification** (`['A','B']`, version `3-8-6`), real corpora (stopwords/wordnet/brown/…), and a **real 33 MB `.gz`** all load correctly. 18 zip-bomb + 422 data/weka/pathsec tests pass; black/isort/pyupgrade clean.

Split out of the security umbrella #3753.