### PR TITLE
Reject a non-positive n-gram order

### DIFF
--- a/nltk/test/unit/test_util.py
+++ b/nltk/test/unit/test_util.py
@@ -106,5 +106,12 @@ def test_transitive_closure_empty():
 
 def test_transitive_closure_does_not_mutate_input():
     graph = {"a": {"b"}, "b": set()}
+    original_sets = {k: v for k, v in graph.items()}
+    snapshot = {k: set(v) for k, v in graph.items()}
+
     transitive_closure(graph)
-    assert graph == {"a": {"b"}, "b": set()}
+
+    assert graph == snapshot
+    assert set(graph) == set(snapshot)
+    # the same set objects, not new-but-equal ones
+    assert all(graph[k] is original_sets[k] for k in snapshot)

--- a/nltk/test/unit/test_util.py
+++ b/nltk/test/unit/test_util.py
@@ -1,6 +1,6 @@
 import pytest
 
-from nltk.util import everygrams
+from nltk.util import everygrams, transitive_closure
 
 
 @pytest.fixture
@@ -80,3 +80,31 @@ def test_everygrams_pad_left(everygram_input):
     ]
     output = list(everygrams(everygram_input, max_len=3, pad_left=True))
     assert output == expected_output
+
+
+def test_transitive_closure_chain():
+    graph = {"a": {"b"}, "b": {"c"}, "c": set()}
+    expected = {"a": {"b", "c"}, "b": {"c"}, "c": set()}
+    assert transitive_closure(graph) == expected
+
+
+def test_transitive_closure_reflexive():
+    graph = {"a": {"b"}, "b": {"c"}, "c": set()}
+    expected = {"a": {"a", "b", "c"}, "b": {"b", "c"}, "c": {"c"}}
+    assert transitive_closure(graph, reflexive=True) == expected
+
+
+def test_transitive_closure_cycle():
+    graph = {"a": {"b"}, "b": {"a"}}
+    expected = {"a": {"a", "b"}, "b": {"a", "b"}}
+    assert transitive_closure(graph) == expected
+
+
+def test_transitive_closure_empty():
+    assert transitive_closure({}) == {}
+
+
+def test_transitive_closure_does_not_mutate_input():
+    graph = {"a": {"b"}, "b": set()}
+    transitive_closure(graph)
+    assert graph == {"a": {"b"}, "b": set()}

--- a/nltk/test/unit/test_util.py
+++ b/nltk/test/unit/test_util.py
@@ -1,6 +1,6 @@
 import pytest
 
-from nltk.util import everygrams, transitive_closure
+from nltk.util import everygrams, ngrams, transitive_closure
 
 
 @pytest.fixture
@@ -80,6 +80,26 @@ def test_everygrams_pad_left(everygram_input):
     ]
     output = list(everygrams(everygram_input, max_len=3, pad_left=True))
     assert output == expected_output
+
+
+@pytest.mark.parametrize("n", [0, -1])
+def test_ngrams_rejects_non_positive_order(n):
+    """A non-positive order has no meaningful n-gram, so it is refused."""
+    with pytest.raises(ValueError, match="n must be positive"):
+        list(ngrams(["a", "b", "c"], n))
+
+
+@pytest.mark.parametrize("n", [1, 2, 3])
+def test_ngrams_accepts_positive_order(n):
+    output = list(ngrams(["a", "b", "c"], n))
+    assert all(len(gram) == n for gram in output)
+
+
+@pytest.mark.parametrize("min_len", [0, -1])
+def test_everygrams_rejects_non_positive_min_len(everygram_input, min_len):
+    """min_len below one would emit empty tuples alongside the real n-grams."""
+    with pytest.raises(ValueError, match="min_len must be positive"):
+        list(everygrams(everygram_input, min_len=min_len, max_len=2))
 
 
 def test_transitive_closure_chain():

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -983,8 +983,12 @@ def ngrams(sequence, n, **kwargs):
     :type left_pad_symbol: any
     :param right_pad_symbol: the symbol to use for right padding (default is None)
     :type right_pad_symbol: any
+    :raise ValueError: if ``n`` is not positive
     :rtype: sequence or iter
     """
+    if n < 1:
+        raise ValueError(f"n must be positive, got {n}")
+
     sequence = pad_sequence(sequence, n, **kwargs)
 
     # sliding_window('ABCDEFG', 4) --> ABCD BCDE CDEF DEFG
@@ -1078,11 +1082,15 @@ def everygrams(
     :param pad_right: whether the ngrams should be right-padded
     :type pad_right: bool
     :rtype: iter(tuple)
+    :raise ValueError: if ``min_len`` is not positive
     :raise ValueError: if ``max_len`` is left at its default and the sequence is
         longer than ``MAX_EVERYGRAMS_DEFAULT_LEN``, since enumerating every
         n-gram of every length would allocate O(n**3) elements and exhaust
         memory (CWE-770). Pass an explicit ``max_len`` to bound the n-gram order.
     """
+
+    if min_len < 1:
+        raise ValueError(f"min_len must be positive, got {min_len}")
 
     # Get max_len for padding.
     if max_len == -1:


### PR DESCRIPTION
`ngrams(sequence, 0)` returns one empty tuple per item rather than nothing:

```python
>>> list(ngrams([1, 2, 3], 0))
[(), (), (), ()]
>>> list(ngrams([1, 2, 3], -1))
ValueError: Stop argument for islice() must be None or an integer: 0 <= x <= sys.maxsize.
```

`pad_sequence` still yields the sequence and a zero-width window matches at every position, so the empty tuples fall out of the sliding window. The negative case surfaces an `islice` error that says nothing about the argument the caller passed.

`everygrams` has the same gap through `min_len`: at zero it emits an empty tuple before each real n-gram.

`skipgrams` in the same module already refuses a negative order ("r must be non-negative"), so this makes the three behave the same way.

Reverting the change fails the four new tests