### PR TITLE
[WIP] Validate tagger model paths that reach native loaders (GHSA-8mgp-746c-j5xp)

### DIFF
--- a/nltk/app/chartparser_app.py
+++ b/nltk/app/chartparser_app.py
@@ -56,7 +56,6 @@ from tkinter.font import Font
 from tkinter.messagebox import showerror, showinfo
 
 from nltk.draw import CFGEditor, TreeSegmentWidget, tree_to_treesegment
-from nltk.pathsec import open as pathsec_open
 from nltk.draw.util import (
     CanvasFrame,
     ColorizedList,
@@ -78,6 +77,7 @@ from nltk.parse.chart import (
     TopDownPredictRule,
     TreeEdge,
 )
+from nltk.pathsec import open as pathsec_open
 from nltk.picklesec import pickle_load
 from nltk.tree import Tree
 from nltk.util import in_idle

--- a/nltk/app/chunkparser_app.py
+++ b/nltk/app/chunkparser_app.py
@@ -37,8 +37,8 @@ from tkinter.font import Font
 from nltk.chunk import ChunkScore, RegexpChunkParser
 from nltk.chunk.regexp import RegexpChunkRule
 from nltk.corpus import conll2000, treebank_chunk
-from nltk.pathsec import open as pathsec_open
 from nltk.draw.util import ShowText
+from nltk.pathsec import open as pathsec_open
 from nltk.tree import Tree
 from nltk.util import in_idle
 

--- a/nltk/app/wordnet_app.py
+++ b/nltk/app/wordnet_app.py
@@ -52,8 +52,6 @@ import hmac
 import html
 import io
 import os
-
-from nltk.pathsec import open as pathsec_open
 import pickle
 import secrets
 import sys
@@ -69,6 +67,7 @@ from urllib.parse import parse_qs, unquote_plus
 
 from nltk.corpus import wordnet as wn
 from nltk.corpus.reader.wordnet import Lemma, Synset
+from nltk.pathsec import open as pathsec_open
 from nltk.picklesec import RestrictedUnpickler
 
 firstClient = True
@@ -256,7 +255,9 @@ def wnb(port=8000, runBrowser=True, logfilename=None):
     # Setup logging.
     if logfilename:
         try:
-            logfile = pathsec_open(logfilename, "a", 1, context="wordnet_app")  # 1 means 'line buffering'
+            logfile = pathsec_open(
+                logfilename, "a", 1, context="wordnet_app"
+            )  # 1 means 'line buffering'
         except OSError as e:
             sys.stderr.write("Couldn't open %s for writing: %s", logfilename, e)
             sys.exit(1)

--- a/nltk/chunk/named_entity.py
+++ b/nltk/chunk/named_entity.py
@@ -14,7 +14,7 @@ import os
 import re
 
 from nltk.pathsec import open as pathsec_open
-from nltk.pathsec import validate_path
+from nltk.pathsec import validate_tool_dir
 from nltk.tag import ClassifierBasedTagger, pos_tag
 from nltk.xmlsec import parse as safe_parse
 
@@ -376,16 +376,18 @@ class Maxent_NE_Chunker(NEChunkParser):
         :return: the directory the parameter files were written to.
         :rtype: str
         """
+        # Validate the destination before touching anything else, so the guard
+        # is the first thing a caller-supplied path meets.
+        if tab_dir is None:
+            tab_dir = self.save_dir
+        validate_tool_dir(tab_dir, context="Maxent_NE_Chunker.save_params")
+
         classif = self._tagger._classifier
         ecg = classif._encoding
         wgt = classif._weights
         mpg = ecg._mapping
         lab = ecg._labels
         aon = ecg._alwayson
-        if tab_dir is None:
-            tab_dir = self.save_dir
-        validate_path(tab_dir, context="Maxent_NE_Chunker.save_params")
-
         save_maxent_params(wgt, mpg, lab, aon, tab_dir=tab_dir)
         return tab_dir
 

--- a/nltk/classify/maxent.py
+++ b/nltk/classify/maxent.py
@@ -1441,7 +1441,9 @@ def train_maxent_classifier_with_megam(
     # Write a training file for megam.
     try:
         fd, trainfile_name = tempfile.mkstemp(prefix="nltk-")
-        with open(trainfile_name, "w") as trainfile:
+        with open(  # sandboxed-open ok: internal mkstemp name, not caller-supplied
+            trainfile_name, "w"
+        ) as trainfile:
             write_megam_file(
                 train_toks, encoding, trainfile, explicit=explicit, bernoulli=bernoulli
             )
@@ -1543,7 +1545,9 @@ class TadmMaxentClassifier(MaxentClassifier):
 
         call_tadm(options)
 
-        with open(weightfile_name) as weightfile:
+        with open(  # sandboxed-open ok: internal mkstemp name, not caller-supplied
+            weightfile_name
+        ) as weightfile:
             weights = parse_tadm_weights(weightfile)
 
         os.remove(trainfile_name)

--- a/nltk/classify/weka.py
+++ b/nltk/classify/weka.py
@@ -14,6 +14,7 @@ import re
 import subprocess
 import tempfile
 import time
+import warnings
 import zipfile
 from sys import stdin
 
@@ -21,6 +22,7 @@ from nltk.classify.api import ClassifierI
 from nltk.data import make_staging_dir
 from nltk.internals import config_java, java
 from nltk.pathsec import open as pathsec_open
+from nltk.pathsec import validate_path
 from nltk.probability import DictionaryProbDist
 
 _weka_classpath = None
@@ -51,7 +53,19 @@ def config_weka(classpath=None):
     if _weka_classpath is None:
         searchpath = list(_weka_search)  # copy; don't mutate the module global
         if "WEKAHOME" in os.environ:
-            searchpath.insert(0, os.environ["WEKAHOME"])
+            weka_home = os.environ["WEKAHOME"]
+            try:
+                # Bound the attacker-influenceable WEKAHOME to the pathsec sandbox so
+                # it cannot add a weka.jar from outside the trusted roots (CWE-426/427).
+                validate_path(
+                    os.path.join(weka_home, "weka.jar"), context="config_weka(WEKAHOME)"
+                )
+                searchpath.insert(0, weka_home)
+            except (PermissionError, ValueError):
+                warnings.warn(
+                    f"Ignoring WEKAHOME {weka_home!r}: outside the trusted NLTK data roots.",
+                    stacklevel=2,
+                )
 
         for path in searchpath:
             if os.path.exists(os.path.join(path, "weka.jar")):

--- a/nltk/corpus/reader/framenet.py
+++ b/nltk/corpus/reader/framenet.py
@@ -776,7 +776,9 @@ def _reject_unsafe_path_component(value, kind):
         or ".." in value
         or ntpath.splitdrive(value)[0]
     ):
-        raise FramenetError(f"Invalid {kind}: {value!r}")
+        # "Security violation" marks this as a containment decision, not an
+        # incidental lookup error, so callers and audits can tell them apart.
+        raise FramenetError(f"Security violation: Invalid {kind}: {value!r}")
 
 
 def _validate_in_root(locpath, root, context):

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -92,6 +92,35 @@ def _assert_no_encoded_bypass(name, error_label=None):
         raise ValueError(f"Unsafe resource path: {label!r}")
 
 
+# Python 3.14's url2pathname follows the WHATWG URL rules, so it silently strips
+# ASCII tab / LF / CR and truncates at "#" or "?". Earlier versions keep them.
+_URL_REWRITTEN_CHARS_RE = re.compile(r"[\t\n\r#?]")
+
+
+def _assert_no_normalized_bypass(name, error_label=None):
+    """
+    Reject *name* if :func:`url2pathname` would silently rewrite it.
+
+    Sibling of :func:`_assert_no_encoded_bypass`, for the same "the name that
+    was validated must be the name that is used" rule but a different rewriting
+    step. Python 3.14 made ``url2pathname`` follow the WHATWG URL rules: it
+    strips ASCII tab, LF and CR and truncates at ``#`` or ``?``. Stripping can
+    *create* a traversal that the raw-form check never saw, because ``".\\n./x"``
+    contains no ``../`` yet becomes ``"../x"`` once converted, which then joins
+    onto the data root and escapes it (CWE-22).
+
+    None of these characters belongs in an NLTK resource name, so refusing them
+    outright keeps the validated and the used name identical on every Python
+    version, rather than tracking what the standard library normalises next.
+
+    :param name: The resource string to validate.
+    :param error_label: Optional alternative string for the error message.
+    """
+    if _URL_REWRITTEN_CHARS_RE.search(name):
+        label = name if error_label is None else error_label
+        raise ValueError(f"Unsafe resource path: {label!r}")
+
+
 def _reject_unsafe_no_protocol(resource_url):
     """
     Reject unsafe resource strings that *omit an explicit protocol*.
@@ -960,6 +989,7 @@ def find(resource_name, paths=None):
     if _UNSAFE_NO_PROTOCOL_RE.search(resource_name):
         raise ValueError(f"Unsafe resource path: {resource_name!r}")
     _assert_no_encoded_bypass(resource_name)
+    _assert_no_normalized_bypass(resource_name)
 
     # Resolve default paths at runtime in-case the user overrides
     # nltk.data.path

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -942,7 +942,10 @@ def find(resource_name, paths=None):
         paths = path
 
     # Check if the resource name includes a zipfile name
-    m = re.match(r"(.*?\.zip)/?(.*)$", resource_name)
+    # DOTALL matters for termination, not just matching: without it a name
+    # containing a newline never looks like a zip, so the ".zip/" fallback below
+    # recurses on an ever-growing name instead of stopping (CWE-407 / CWE-1333).
+    m = re.match(r"(.*?\.zip)/?(.*)$", resource_name, re.DOTALL)
     if m:
         zipfile, zipentry = m.groups()
     else:

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -185,13 +185,30 @@ def make_staging_dir(prefix="nltk_"):
     directory is created with ``tempfile.mkdtemp`` (mode 0700, unpredictable name)
     under the first ``nltk.data.path`` entry that can be written to.
 
-    :param prefix: filename prefix for the created directory.
+    :param prefix: filename prefix for the created directory. It is a *name*
+        fragment, not a path: callers build it from values such as a tagger's
+        language code, and ``tempfile.mkdtemp`` simply concatenates it onto
+        *dir*, so a ``..`` inside it would place the directory outside the data
+        root (CWE-22). Path separators and NUL are therefore refused.
     :type prefix: str
     :return: the absolute path of the created directory.
     :rtype: str
+    :raises ValueError: if *prefix* is not a plain filename fragment.
     :raises PermissionError: if no ``nltk.data.path`` entry is a writable allowed
         root, in which case the caller should pass an explicit destination.
     """
+    prefix = str(prefix)
+    if (
+        "\x00" in prefix
+        or "/" in prefix
+        or "\\" in prefix
+        or os.sep in prefix
+        or (os.altsep and os.altsep in prefix)
+    ):
+        raise ValueError(
+            f"Invalid staging-dir prefix {prefix!r}: a prefix is a filename "
+            "fragment, not a path (no separators or NUL)"
+        )
     for root in path:
         base = os.path.expanduser(str(root.path if hasattr(root, "path") else root))
         try:
@@ -203,7 +220,15 @@ def make_staging_dir(prefix="nltk_"):
             # the sandbox does.
             _validate_path(base, context="nltk.data.make_staging_dir")
             os.makedirs(base, exist_ok=True)
-            return tempfile.mkdtemp(prefix=prefix, dir=base)
+            staged = tempfile.mkdtemp(prefix=prefix, dir=base)
+            try:
+                # Defence in depth: confirm what was actually created is inside
+                # the root just validated, not merely that the base was.
+                _validate_path(staged, context="nltk.data.make_staging_dir")
+            except BaseException:
+                os.rmdir(staged)
+                raise
+            return staged
         except (OSError, ValueError, PermissionError):
             continue
     raise PermissionError(

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -32,11 +32,13 @@ adds it to a resource cache; and ``retrieve()`` copies a given resource
 to a local file.
 """
 
+import atexit
 import codecs
 import functools
 import os
 import pickle
 import re
+import shutil
 import sys
 import tempfile
 import textwrap
@@ -203,6 +205,29 @@ else:
 ######################################################################
 # Util Functions
 ######################################################################
+
+
+_STAGING_TEMPDIR = None
+
+
+def staging_tempdir():
+    """A process-wide scratch directory INSIDE an allowed data root.
+
+    ``tempfile.mkstemp()`` and ``NamedTemporaryFile()`` default to the system
+    temp dir, which on Linux is the shared, world-writable ``/tmp`` and is
+    deliberately NOT a pathsec root. Wrappers that stage an input file for an
+    external tool therefore wrote outside the sandbox. Pass this as ``dir=`` so
+    the scratch file lands inside a root instead.
+
+    Allocated once per process and removed at exit, so callers do not leak a
+    directory per invocation the way a per-call ``make_staging_dir`` would.
+    """
+    global _STAGING_TEMPDIR
+    if _STAGING_TEMPDIR is None or not os.path.isdir(_STAGING_TEMPDIR):
+        staged = make_staging_dir(prefix="nltk_scratch_")
+        atexit.register(shutil.rmtree, staged, ignore_errors=True)
+        _STAGING_TEMPDIR = staged
+    return _STAGING_TEMPDIR
 
 
 def make_staging_dir(prefix="nltk_"):

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -886,6 +886,10 @@ class Downloader:
                 return
 
             try:
+                # The lock lives under the caller-chosen download dir, so bound
+                # it before creating it. O_EXCL already refuses an existing file
+                # or symlink; this stops the path leaving the sandbox at all.
+                validate_path(lock_filepath, context="downloader.lock")
                 fd = os.open(lock_filepath, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
                 os.close(fd)
                 break

--- a/nltk/parse/malt.py
+++ b/nltk/parse/malt.py
@@ -12,7 +12,7 @@ import os
 import sys
 import tempfile
 
-from nltk.data import ZipFilePathPointer
+from nltk.data import ZipFilePathPointer, make_staging_dir
 from nltk.internals import (
     find_dir,
     find_file,
@@ -22,6 +22,7 @@ from nltk.internals import (
 from nltk.parse.api import ParserI
 from nltk.parse.dependencygraph import DependencyGraph
 from nltk.parse.util import taggedsents_to_conll
+from nltk.pathsec import validate_model_resource, validate_path
 
 
 def malt_regex_tagger():
@@ -160,10 +161,38 @@ class MaltParser(ParserI):
         # Initialize model.
         self.model = find_malt_model(model_filename)
         self._trained = self.model != "malt_temp.mco"
-        # Set the working_dir parameters i.e. `-w` from MaltParser's option.
-        self.working_dir = tempfile.gettempdir()
+        # `-w` is allocated lazily inside a data root; see the working_dir property.
+        self._working_dir = None
         # Initialize POS tagger.
         self.tagger = tagger if tagger is not None else malt_regex_tagger()
+
+    @property
+    def working_dir(self):
+        """MaltParser's ``-w`` directory, holding the temporary CoNLL files and,
+        for an untrained parser, the ``malt_temp.mco`` model that ``train()``
+        writes.
+
+        Allocated lazily by ``nltk.data.make_staging_dir`` INSIDE an allowed data
+        root, with an unpredictable name and mode 0700. The previous default was
+        the shared ``tempfile.gettempdir()``, which is world-writable on Linux and
+        gives a predictable, squattable path for both the CoNLL files and the model.
+        """
+        if self._working_dir is None:
+            self._working_dir = make_staging_dir(prefix="nltk_malt_")
+        return self._working_dir
+
+    @working_dir.setter
+    def working_dir(self, value):
+        # A caller may still choose the directory, but only inside the sandbox.
+        # An empty value would reach MaltParser as `-w ""`, i.e. the CWD.
+        text = os.fspath(value) if value is not None else ""
+        if not text.strip():
+            raise ValueError(
+                "MaltParser.working_dir may not be empty; it would resolve to the "
+                "current working directory."
+            )
+        validate_path(text, context="MaltParser.working_dir")
+        self._working_dir = text
 
     def parse_tagged_sents(self, sentences, verbose=False, top_relation_label="null"):
         """
@@ -270,8 +299,18 @@ class MaltParser(ParserI):
         # directory as the ``-w`` program argument rather than chdir-ing the JVM
         # process: no cwd is handed to java(), so there is no working-directory
         # class-injection surface (an empty/CWD -cp element, CWE-88).
+        # Rejects an empty / option-like / URL / traversing model name, and bounds
+        # it to the sandbox when it is a real path.
+        validate_model_resource(self.model, context="MaltParser model")
         model_dir, model_name = os.path.split(self.model)
-        workingdir = os.path.abspath(model_dir) if model_dir else os.getcwd()
+        if model_dir:
+            # A model carrying a directory is a real path: bound the directory too,
+            # since in learn mode MaltParser WRITES the .mco into it.
+            validate_path(self.model, context="MaltParser model")
+            workingdir = os.path.abspath(model_dir)
+        else:
+            # A bare model name lives in the private dir that train() wrote it to.
+            workingdir = self.working_dir
         cmd += ["-w", workingdir, "-c", model_name]
 
         cmd += ["-i", inputfilename]

--- a/nltk/parse/malt.py
+++ b/nltk/parse/malt.py
@@ -7,8 +7,10 @@
 # URL: <https://www.nltk.org/>
 # For license information, see LICENSE.TXT
 
+import atexit
 import inspect
 import os
+import shutil
 import sys
 import tempfile
 
@@ -178,14 +180,24 @@ class MaltParser(ParserI):
         gives a predictable, squattable path for both the CoNLL files and the model.
         """
         if self._working_dir is None:
-            self._working_dir = make_staging_dir(prefix="nltk_malt_")
+            staged = make_staging_dir(prefix="nltk_malt_")
+            # The old shared tempdir was reaped by the OS; a dir under a data
+            # root is not, so remove it ourselves rather than leaking one per
+            # parser (the .mco it holds is a temporary model by definition).
+            atexit.register(shutil.rmtree, staged, ignore_errors=True)
+            self._working_dir = staged
         return self._working_dir
 
     @working_dir.setter
     def working_dir(self, value):
+        # None restores the unset state, so the property allocates again on next
+        # access rather than raising.
+        if value is None:
+            self._working_dir = None
+            return
         # A caller may still choose the directory, but only inside the sandbox.
         # An empty value would reach MaltParser as `-w ""`, i.e. the CWD.
-        text = os.fspath(value) if value is not None else ""
+        text = os.fspath(value)
         if not text.strip():
             raise ValueError(
                 "MaltParser.working_dir may not be empty; it would resolve to the "
@@ -324,7 +336,9 @@ class MaltParser(ParserI):
         validate_tool_path(inputfilename, context="MaltParser input file")
         cmd += ["-i", inputfilename]
         if mode == "parse":
-            validate_tool_path(outputfilename, context="MaltParser output file")
+            validate_tool_path(
+                outputfilename, context="MaltParser output file", for_write=True
+            )
             cmd += ["-o", outputfilename]
         cmd += ["-m", mode]  # mode use to generate parses.
         return cmd

--- a/nltk/parse/malt.py
+++ b/nltk/parse/malt.py
@@ -22,7 +22,7 @@ from nltk.internals import (
 from nltk.parse.api import ParserI
 from nltk.parse.dependencygraph import DependencyGraph
 from nltk.parse.util import taggedsents_to_conll
-from nltk.pathsec import validate_model_resource, validate_path
+from nltk.pathsec import validate_model_resource, validate_path, validate_tool_path
 
 
 def malt_regex_tagger():
@@ -287,6 +287,12 @@ class MaltParser(ParserI):
         :type inputfilename: str
         :param outputfilename: path to the output file
         :type outputfilename: str
+
+        Both filenames are bounded to the NLTK data roots. ``-i`` is read by the
+        JVM and ``-o`` is *written* by it, so an unbounded value here is an
+        arbitrary file read and an arbitrary file write respectively. The
+        internal callers pass temporary files inside :attr:`working_dir`, which
+        is itself allocated inside a data root.
         """
 
         # Build only MaltParser's own arguments (main class + program args). The
@@ -313,8 +319,12 @@ class MaltParser(ParserI):
             workingdir = self.working_dir
         cmd += ["-w", workingdir, "-c", model_name]
 
+        # -i is read by the JVM and -o is written by it; train_from_file() and
+        # generate_malt_command() are both public, so neither may leave the roots.
+        validate_tool_path(inputfilename, context="MaltParser input file")
         cmd += ["-i", inputfilename]
         if mode == "parse":
+            validate_tool_path(outputfilename, context="MaltParser output file")
             cmd += ["-o", outputfilename]
         cmd += ["-m", mode]  # mode use to generate parses.
         return cmd

--- a/nltk/parse/malt.py
+++ b/nltk/parse/malt.py
@@ -318,13 +318,15 @@ class MaltParser(ParserI):
         # process: no cwd is handed to java(), so there is no working-directory
         # class-injection surface (an empty/CWD -cp element, CWE-88).
         # Rejects an empty / option-like / URL / traversing model name, and bounds
-        # it to the sandbox when it is a real path.
-        validate_model_resource(self.model, context="MaltParser model")
-        model_dir, model_name = os.path.split(self.model)
+        # it to the sandbox when it is a real path. Use the value it returns:
+        # __fspath__ may answer differently on every call, so re-reading
+        # self.model here would let the JVM open a file the guard never saw.
+        model = validate_model_resource(self.model, context="MaltParser model")
+        model_dir, model_name = os.path.split(model)
         if model_dir:
             # A model carrying a directory is a real path: bound the directory too,
             # since in learn mode MaltParser WRITES the .mco into it.
-            validate_path(self.model, context="MaltParser model")
+            validate_path(model, context="MaltParser model")
             workingdir = os.path.abspath(model_dir)
         else:
             # A bare model name lives in the private dir that train() wrote it to.
@@ -333,13 +335,14 @@ class MaltParser(ParserI):
 
         # -i is read by the JVM and -o is written by it; train_from_file() and
         # generate_malt_command() are both public, so neither may leave the roots.
-        validate_tool_path(inputfilename, context="MaltParser input file")
-        cmd += ["-i", inputfilename]
+        cmd += ["-i", validate_tool_path(inputfilename, context="MaltParser input")]
         if mode == "parse":
-            validate_tool_path(
-                outputfilename, context="MaltParser output file", for_write=True
-            )
-            cmd += ["-o", outputfilename]
+            cmd += [
+                "-o",
+                validate_tool_path(
+                    outputfilename, context="MaltParser output", for_write=True
+                ),
+            ]
         cmd += ["-m", mode]  # mode use to generate parses.
         return cmd
 

--- a/nltk/parse/stanford.py
+++ b/nltk/parse/stanford.py
@@ -14,6 +14,7 @@ from subprocess import PIPE
 from nltk.internals import find_jar_iter, find_jars_within_path, java
 from nltk.parse.api import ParserI
 from nltk.parse.dependencygraph import DependencyGraph
+from nltk.pathsec import validate_model_resource
 from nltk.tree import Tree
 
 _stanford_url = "https://nlp.stanford.edu/software/lex-parser.shtml"
@@ -218,6 +219,9 @@ class GenericStanfordParser(ParserI):
         )
 
     def _execute(self, cmd, input_, verbose=False):
+        # Bound `-model` here, at the single hand-off to the JVM, so all three
+        # callers are covered and a late reassignment cannot slip past.
+        validate_model_resource(self.model_path, context="StanfordParser model")
         encoding = self._encoding
         cmd.extend(["-encoding", encoding])
         if self.corenlp_options:

--- a/nltk/parse/stanford.py
+++ b/nltk/parse/stanford.py
@@ -220,8 +220,13 @@ class GenericStanfordParser(ParserI):
 
     def _execute(self, cmd, input_, verbose=False):
         # Bound `-model` here, at the single hand-off to the JVM, so all three
-        # callers are covered and a late reassignment cannot slip past.
-        validate_model_resource(self.model_path, context="StanfordParser model")
+        # callers are covered and a late reassignment cannot slip past. The argv
+        # entry is replaced with the validated string: __fspath__ may answer
+        # differently on every call, so the object the callers put in `cmd` could
+        # otherwise resolve to a file the guard never saw.
+        model = validate_model_resource(self.model_path, context="StanfordParser model")
+        if "-model" in cmd:
+            cmd[cmd.index("-model") + 1] = model
         encoding = self._encoding
         cmd.extend(["-encoding", encoding])
         if self.corenlp_options:

--- a/nltk/parse/stanford.py
+++ b/nltk/parse/stanford.py
@@ -218,6 +218,43 @@ class GenericStanfordParser(ParserI):
             )
         )
 
+    def _validated_extra_options(self, cmd):
+        """Bound the caller-supplied ``corenlp_options`` before it joins the argv.
+
+        The string is *split* into separate argv elements, so it can append a
+        second ``-model``. Stanford's ``LexicalizedParser`` honours the LAST
+        occurrence, which was verified directly against the JVM, so an injected
+        option silently replaced the model the guard above had just checked and
+        the parser deserialized an arbitrary file instead.
+
+        An option NLTK already set may therefore not be repeated here, and any
+        value that looks like a filesystem path is bounded to the data roots. A
+        value that is not a path (``xml``, ``key=value``) is left alone, since
+        this is a general passthrough for the tool's own settings.
+        """
+        already_set = {
+            argument
+            for argument in cmd
+            if isinstance(argument, str) and argument.startswith("-")
+        }
+        validated = []
+        for token in self.corenlp_options.split():
+            if token.startswith("-"):
+                if token in already_set:
+                    raise ValueError(
+                        f"Security Violation [StanfordParser corenlp_options]: "
+                        f"{token!r} is already set by NLTK and may not be "
+                        "overridden; the tool would honour the injected value."
+                    )
+                validated.append(token)
+                continue
+            if os.path.isabs(token) or "/" in token or "\\" in token:
+                token = validate_model_resource(
+                    token, context="StanfordParser corenlp_options"
+                )
+            validated.append(token)
+        return validated
+
     def _execute(self, cmd, input_, verbose=False):
         # Bound `-model` here, at the single hand-off to the JVM, so all three
         # callers are covered and a late reassignment cannot slip past. The argv
@@ -230,7 +267,7 @@ class GenericStanfordParser(ParserI):
         encoding = self._encoding
         cmd.extend(["-encoding", encoding])
         if self.corenlp_options:
-            cmd.extend(self.corenlp_options.split())
+            cmd.extend(self._validated_extra_options(cmd))
 
         # Windows is incompatible with NamedTemporaryFile() without passing in delete=False.
         input_file_name = None

--- a/nltk/parse/stanford.py
+++ b/nltk/parse/stanford.py
@@ -11,6 +11,7 @@ import tempfile
 import warnings
 from subprocess import PIPE
 
+from nltk.data import staging_tempdir
 from nltk.internals import find_jar_iter, find_jars_within_path, java
 from nltk.parse.api import ParserI
 from nltk.parse.dependencygraph import DependencyGraph
@@ -273,7 +274,9 @@ class GenericStanfordParser(ParserI):
         input_file_name = None
         java_succeeded = False
         try:
-            with tempfile.NamedTemporaryFile(mode="wb", delete=False) as input_file:
+            with tempfile.NamedTemporaryFile(
+                mode="wb", delete=False, dir=staging_tempdir()
+            ) as input_file:
                 input_file_name = input_file.name
                 # Write the actual sentences to the temporary input file
                 if isinstance(input_, str) and encoding:

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -272,6 +272,13 @@ def _as_path_text(value, context):
         raise ValueError(
             f"Security Violation [{context}]: {text!r} is bytes; pass a str path."
         )
+    # os.fspath() hands back a str SUBCLASS unchanged, so every check below would
+    # run on attacker-controlled methods: a subclass overriding startswith,
+    # replace, split or __contains__ passes all of them while carrying a hostile
+    # value. str.__str__ is used rather than str(): it ignores a __str__ override
+    # and yields an exact str holding the real characters.
+    if type(text) is not str:
+        text = str.__str__(text)
     return text
 
 

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -260,6 +260,23 @@ _REFUSING_ERRNOS = frozenset(
 )
 
 
+# On Windows these names are devices wherever they appear, so "<root>\NUL" is
+# the null device rather than a file inside the root, whatever the path says.
+_WINDOWS_RESERVED_NAMES = frozenset(
+    ["CON", "PRN", "AUX", "NUL"]
+    + [f"COM{n}" for n in range(1, 10)]
+    + [f"LPT{n}" for n in range(1, 10)]
+)
+
+
+def _is_windows_device_name(raw):
+    """True if the final component of *raw* names a Windows character device."""
+    if os.name == "posix":
+        return False
+    leaf = raw.replace("/", "\\").rsplit("\\", 1)[-1]
+    return leaf.split(".", 1)[0].strip().upper() in _WINDOWS_RESERVED_NAMES
+
+
 def _as_path_string(path_input):
     """Normalise a path-ish argument to the exact string a sink would use.
 
@@ -321,6 +338,11 @@ def validate_tool_path(path_input, context="NLTK tool", *, must_exist=True):
         raise PermissionError(
             f"Security Violation [{context}]: path {raw!r} starts with '-' and "
             "would be parsed as a command-line option by the tool (CWE-88)"
+        )
+    if _is_windows_device_name(raw):
+        raise PermissionError(
+            f"Security Violation [{context}]: path {raw!r} names a Windows "
+            "character device, not a file inside the data root"
         )
 
     validate_path(raw, context=context)

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -295,20 +295,31 @@ def validate_model_resource(model_path, context="NLTK model"):
     if ":" in text and not re.match(r"^[A-Za-z]:[\\/]", text):
         _refuse("contains ':', which names an NTFS alternate data stream")
 
-    # Only a real filesystem path is sandboxed; a bare resource name is not a path.
-    if os.path.isabs(text) or os.path.exists(text):
+    # Only a real filesystem path is sandboxed; a bare resource name is not a
+    # path. A bare name is deliberately NOT probed against the CWD: doing so made
+    # the default `malt_temp.mco` resolve to whatever happened to sit in the
+    # user's directory, which is exactly what older NLTK versions left there.
+    has_directory = bool(os.path.dirname(text.replace("\\", "/")))
+    if os.path.isabs(text) or (has_directory and os.path.exists(text)):
         validate_path(text, context=context)
         _reject_aliased_or_special(text, context)
 
 
-def _reject_aliased_or_special(text, context):
+def _reject_aliased_or_special(text, context, check_links=False):
     """Physical checks on a path that already passed :func:`validate_path`.
 
-    ``realpath()`` cannot see a hardlink, so an in-root alias of an outside file
-    passes every name-based check; the tool would then read, or overwrite, the
-    original. Mirrors the ``st_nlink`` guard in :func:`_hardened_open`. A FIFO,
-    socket or device planted in a data root would instead block the reader
-    forever. Directories stay legal, since corpora are passed as directories.
+    A FIFO, socket or device planted in a data root would block the reader
+    forever, so only regular files and directories are accepted. Directories stay
+    legal, since corpora are passed as directories.
+
+    ``check_links`` additionally refuses a hardlinked file. ``realpath()`` cannot
+    see a hardlink, so an in-root alias of an outside file passes every
+    name-based check and the tool would overwrite the original. This is only
+    applied to paths the tool *writes*: for a read it is not an escalation (the
+    link can only be created by someone who can already write to the data root),
+    and rejecting ``st_nlink > 1`` outright would refuse ordinary
+    hardlink-deduplicated data such as ``cp -l`` or ``rsync --link-dest`` trees,
+    including the original file.
 
     A path that does not exist yet (an output file) has nothing to check.
     """
@@ -316,10 +327,11 @@ def _reject_aliased_or_special(text, context):
         info = os.stat(text)
     except OSError:
         return
-    if stat.S_ISREG(info.st_mode) and info.st_nlink > 1:
+    if check_links and stat.S_ISREG(info.st_mode) and info.st_nlink > 1:
         raise PermissionError(
             f"Security Violation [{context}]: {text!r} has {info.st_nlink} hard "
-            "links, so it may alias a file outside the trusted NLTK data roots."
+            "links, so writing it may overwrite a file outside the trusted NLTK "
+            "data roots."
         )
     if not (stat.S_ISREG(info.st_mode) or stat.S_ISDIR(info.st_mode)):
         raise PermissionError(
@@ -328,7 +340,7 @@ def _reject_aliased_or_special(text, context):
         )
 
 
-def validate_tool_path(path_input, context="NLTK tool file"):
+def validate_tool_path(path_input, context="NLTK tool file", for_write=False):
     """Bound a filesystem path handed to an external tool to read or write.
 
     Unlike :func:`validate_model_resource` this never accepts a bare resource
@@ -339,9 +351,11 @@ def validate_tool_path(path_input, context="NLTK tool file"):
 
     :param path_input: the path as supplied by the caller
     :param context: label used in the security-violation message
+    :param for_write: True when the tool will write the path, which additionally
+        refuses a hardlinked file that could alias a target outside the roots
     :raises ValueError: if the value is empty or contains a NUL byte
-    :raises PermissionError: if it is outside the data roots, hardlinked, or a
-        non-regular file such as a FIFO
+    :raises PermissionError: if it is outside the data roots or is a non-regular
+        file such as a FIFO
     """
     text = os.fspath(path_input)
     if not text or not text.strip():
@@ -354,7 +368,7 @@ def validate_tool_path(path_input, context="NLTK tool file"):
             f"Security Violation [{context}]: path {text!r} contains a NUL byte."
         )
     validate_path(text, context=context)
-    _reject_aliased_or_special(text, context)
+    _reject_aliased_or_special(text, context, check_links=for_write)
 
 
 def _zip_member_is_unsafe(name_str):

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -250,6 +250,31 @@ def validate_path(path_input, context="NLTK", required_root=None):
             raise
 
 
+def _as_path_text(value, context):
+    """Resolve a caller value to a ``str`` path EXACTLY ONCE.
+
+    ``__fspath__`` is allowed to return a different answer on every call, so a
+    guard that calls it separately from the code that uses the path validates one
+    file while the tool opens another. Every caller must validate and then use
+    the single string returned here, never the original object.
+
+    Also turns a non-path (int, None, list) and a ``bytes`` path into a clean
+    security rejection instead of a TypeError that would escape a caller's
+    ``except (ValueError, PermissionError)``.
+    """
+    try:
+        text = os.fspath(value)
+    except TypeError as exc:
+        raise ValueError(
+            f"Security Violation [{context}]: {value!r} is not a filesystem path."
+        ) from exc
+    if isinstance(text, bytes):
+        raise ValueError(
+            f"Security Violation [{context}]: {text!r} is bytes; pass a str path."
+        )
+    return text
+
+
 def _reject_bad_name_syntax(text, context):
     """Syntactic checks shared by every caller-supplied model or tool path.
 
@@ -291,6 +316,10 @@ def _reject_bad_name_syntax(text, context):
     # drive, so it names a different file than the same string does on POSIX.
     if os.name != "posix" and re.match(r"^[\\/]", text):
         _refuse("is relative to the current drive; give a full path with a drive")
+    # Windows silently strips a trailing dot or space, so "evil.mco." is checked
+    # as one name and opened as another. Refused everywhere for determinism.
+    if text != text.rstrip(". "):
+        _refuse("ends with a dot or space, which Windows silently strips")
     # On Windows these resolve to devices (a serial port, the null device) no
     # matter which directory they appear in. Refused everywhere for determinism.
     stem = os.path.basename(text.replace("\\", "/")).split(".")[0].upper()
@@ -322,7 +351,7 @@ def validate_model_resource(model_path, context="NLTK model"):
     :raises ValueError: if the value is empty, option-like, a URL, or traverses
     :raises PermissionError: if it is a filesystem path outside the data roots
     """
-    text = os.fspath(model_path)
+    text = _as_path_text(model_path, context)
     _reject_bad_name_syntax(text, context)
 
     # Only a real filesystem path is sandboxed; a bare resource name is not a
@@ -333,6 +362,7 @@ def validate_model_resource(model_path, context="NLTK model"):
     if os.path.isabs(text) or (has_directory and os.path.exists(text)):
         validate_path(text, context=context)
         _reject_aliased_or_special(text, context)
+    return text
 
 
 def _reject_aliased_or_special(text, context, check_links=False):
@@ -387,10 +417,11 @@ def validate_tool_path(path_input, context="NLTK tool file", for_write=False):
     :raises PermissionError: if it is outside the data roots or is a non-regular
         file such as a FIFO
     """
-    text = os.fspath(path_input)
+    text = _as_path_text(path_input, context)
     _reject_bad_name_syntax(text, context)
     validate_path(text, context=context)
     _reject_aliased_or_special(text, context, check_links=for_write)
+    return text
 
 
 def _zip_member_is_unsafe(name_str):

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -368,7 +368,22 @@ def validate_tool_path(path_input, context="NLTK tool", *, must_exist=True):
     _reject_url_shaped(raw, context)
 
     validate_path(raw, context=context)
-    if not ENFORCE or os.name != "posix":
+    if not ENFORCE:
+        return
+    if os.name != "posix":
+        # No O_NOFOLLOW/fstat here, so the symlink-swap race stays open on
+        # Windows, but a stat still refuses a directory or device.
+        try:
+            st = os.stat(raw)
+        except FileNotFoundError:
+            if must_exist:
+                raise
+            return
+        if not stat.S_ISREG(st.st_mode):
+            raise PermissionError(
+                f"Security Violation [{context}]: model path {raw!r} is not a "
+                "regular file"
+            )
         return
 
     flags = (

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -188,7 +188,22 @@ def validate_path(path_input, context="NLTK", required_root=None):
         try:
             target = Path(raw).resolve()
         except (OSError, ValueError):
-            # Fallback for virtual paths inside ZIPs (e.g. corpora/foo.zip/file.txt)
+            # Fallback for virtual paths inside ZIPs (e.g. corpora/foo.zip/file.txt).
+            # This validates only the prefix up to ".zip", so it must never be
+            # reached by a path that can still traverse: resolve() also fails on a
+            # NUL (ValueError) and on an over-long component (ENAMETOOLONG), and
+            # "<root>/ok.zip/<5000 chars>/../../../etc/passwd" would then be
+            # approved on its harmless prefix while normpath() collapses the long
+            # component and leaves /etc/passwd for the caller to open.
+            if "\x00" in raw or ".." in raw.replace("\\", "/").split("/"):
+                msg = (
+                    f"Security Violation [{context}]: unresolvable path with a "
+                    f"traversal or NUL component: {raw!r}"
+                )
+                if ENFORCE:
+                    raise PermissionError(msg)
+                warnings.warn(msg, RuntimeWarning, stacklevel=3)
+                return
             lower_raw = raw.lower()
             if ".zip" in lower_raw:
                 zip_idx = lower_raw.find(".zip") + 4

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -242,6 +242,84 @@ def validate_path(path_input, context="NLTK", required_root=None):
             raise
 
 
+def validate_model_resource(model_path, context="NLTK model"):
+    """Bound a caller-supplied model argument that may be a *resource name*.
+
+    Several JVM wrappers (Stanford parser/tagger/segmenter) accept the same
+    ``-model`` argument as either a filesystem path or a jar-internal classpath
+    resource, e.g. the default
+    ``edu/stanford/nlp/models/lexparser/englishPCFG.ser.gz``. Bounding every value
+    with :func:`validate_path` would break the jar-internal defaults, and skipping
+    validation entirely lets an attacker hand the JVM any file on disk.
+
+    So: a plain resource name is left alone, any real filesystem path is bounded to
+    the NLTK data roots, and a value that is neither (empty, an option-looking
+    token, a URL, or a ``..`` traversal) is refused outright so that a
+    resource-looking name cannot traverse out of the jar namespace.
+
+    ``..`` is checked after folding ``\\`` to ``/``: a backslash is an ordinary
+    filename character on POSIX but a separator on Windows, so ``..\\..\\etc`` has
+    to be rejected on both.
+
+    :param model_path: the model argument as supplied by the caller
+    :param context: label used in the security-violation message
+    :raises ValueError: if the value is empty, option-like, a URL, or traverses
+    :raises PermissionError: if it is a filesystem path outside the data roots
+    """
+    text = os.fspath(model_path)
+
+    def _refuse(why):
+        raise ValueError(f"Security Violation [{context}]: model {text!r} {why}.")
+
+    if not text or not text.strip():
+        _refuse("is empty")
+    # A NUL truncates the path in the JVM's native layer, so "good.ser.gz\0evil"
+    # can name a different file there than it does here.
+    if "\x00" in text:
+        _refuse("contains a NUL byte")
+    # A leading '-' would be parsed as another option by the tool we hand it to.
+    if text.startswith("-"):
+        _refuse("looks like a command-line option (argument injection)")
+    # Stanford's loaders will fetch a URL; only local resources are permitted.
+    if "://" in text or text.lower().startswith(("file:", "jar:")):
+        _refuse("is a URL; only local model resources are permitted")
+    # Nothing downstream expands '~', but a sink that did would reach $HOME.
+    if text.startswith("~"):
+        _refuse("starts with '~'; pass an already-expanded path")
+    # A Windows UNC path reaches a remote share.
+    if text.startswith("\\\\") or text.startswith("//"):
+        _refuse("is a UNC path; only local model resources are permitted")
+    if ".." in text.replace("\\", "/").split("/"):
+        _refuse("contains a '..' component; it may not traverse out of the namespace")
+    # ':' names an NTFS alternate data stream, except in a drive prefix (C:\...).
+    if ":" in text and not re.match(r"^[A-Za-z]:[\\/]", text):
+        _refuse("contains ':', which names an NTFS alternate data stream")
+
+    # Only a real filesystem path is sandboxed; a bare resource name is not a path.
+    if os.path.isabs(text) or os.path.exists(text):
+        validate_path(text, context=context)
+        # realpath() cannot see a hardlink, so an in-root alias of an outside file
+        # passes the check above; the tool would then read (or overwrite) the
+        # original. Mirrors the st_nlink guard in _hardened_open.
+        try:
+            info = os.stat(text)
+        except OSError:
+            return
+        if stat.S_ISREG(info.st_mode) and info.st_nlink > 1:
+            raise PermissionError(
+                f"Security Violation [{context}]: model {text!r} has "
+                f"{info.st_nlink} hard links, so it may alias a file outside the "
+                "trusted NLTK data roots."
+            )
+        # A FIFO, socket or device planted in a data root would hang the reader
+        # forever. Directories stay legal: corpora are passed as directories.
+        if not (stat.S_ISREG(info.st_mode) or stat.S_ISDIR(info.st_mode)):
+            raise PermissionError(
+                f"Security Violation [{context}]: model {text!r} is not a regular "
+                "file or directory; reading it could block indefinitely."
+            )
+
+
 def _zip_member_is_unsafe(name_str):
     """True if a ZIP member is written somewhere other than where it is validated.
 
@@ -978,6 +1056,7 @@ class ZipFile(zipfile.ZipFile):
 
 __all__ = [
     "validate_path",
+    "validate_model_resource",
     "validate_network_url",
     "validate_zip_archive",
     "open",

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -177,7 +177,13 @@ def validate_path(path_input, context="NLTK", required_root=None):
                 )
             raw = unquote(parsed.path)
             if not raw:
-                return
+                # "file://evil" parses as netloc="evil" with an EMPTY path, so
+                # there is nothing to validate while the caller still holds the
+                # original string and opens it as the relative path "file:/evil".
+                raise PermissionError(
+                    f"Security Violation [{context}]: file URL {path_input!r} has "
+                    "no path component; it is not a usable filesystem path"
+                )
 
         # Resolve path to catch symlink escapes
         try:
@@ -277,6 +283,21 @@ def _is_windows_device_name(raw):
     return leaf.split(".", 1)[0].strip().upper() in _WINDOWS_RESERVED_NAMES
 
 
+def _reject_url_shaped(raw, context):
+    """Refuse a URL where a model path is expected.
+
+    ``validate_path`` rewrites a ``file:`` URL to its path component before
+    checking it, but the caller still holds (and the tool still opens) the
+    original string. A model path is never a URL, so refusing the whole shape
+    here removes that validate-one-thing/open-another gap outright.
+    """
+    if _URL_SCHEME_RE.match(raw) or _FILE_SCHEME_RE.match(raw):
+        raise PermissionError(
+            f"Security Violation [{context}]: {raw!r} is a URL, not a model "
+            "path; the tool would open it verbatim as a relative path"
+        )
+
+
 def _as_path_string(path_input):
     """Normalise a path-ish argument to the exact string a sink would use.
 
@@ -344,6 +365,7 @@ def validate_tool_path(path_input, context="NLTK tool", *, must_exist=True):
             f"Security Violation [{context}]: path {raw!r} names a Windows "
             "character device, not a file inside the data root"
         )
+    _reject_url_shaped(raw, context)
 
     validate_path(raw, context=context)
     if not ENFORCE or os.name != "posix":
@@ -413,6 +435,7 @@ def validate_tool_dir(path_input, context="NLTK tool"):
         raise PermissionError(
             f"Security Violation [{context}]: NUL byte in destination {raw!r}"
         )
+    _reject_url_shaped(raw, context)
     validate_path(raw, context=context)
 
 

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -145,8 +145,14 @@ def validate_path(path_input, context="NLTK", required_root=None):
     :param context: Diagnostic context for warnings/errors.
     :param required_root: If provided, enforces that the path is strictly
                           within this specific directory (scoped sandbox).
+
+    A whitespace-only path is NOT waved through: ``"   "`` is a legal relative
+    filename, so skipping it let a caller-supplied path reach ``os.open`` with no
+    containment check and create/truncate that file in the working directory,
+    outside every allowed root (GHSA-8mgp-746c-j5xp). Only an empty/absent path
+    (nothing to open) and a file descriptor short-circuit here.
     """
-    if isinstance(path_input, int) or not path_input or not str(path_input).strip():
+    if isinstance(path_input, int) or not path_input:
         return
     try:
         raw = path_input.path if hasattr(path_input, "path") else str(path_input)

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -749,6 +749,10 @@ def _hardened_open(raw_path, mode, context, required_root, **kwargs):
         | getattr(os, "O_NOFOLLOW", 0)
         | getattr(os, "O_CLOEXEC", 0)
     )
+    # Defer O_TRUNC until after the hardlink/realpath checks: truncating at open
+    # time would zero a hardlinked outside-root target before st_nlink refuses it.
+    truncate_after = bool(flags & os.O_TRUNC)
+    flags &= ~os.O_TRUNC
     try:
         # 0o600 is only consulted when O_CREAT is in flags (write/append/x modes).
         fd = os.open(raw_path, flags, 0o600)
@@ -775,6 +779,9 @@ def _hardened_open(raw_path, mode, context, required_root, **kwargs):
             context=context,
             required_root=required_root,
         )
+        # Safe now: the fd is confirmed single-linked and inside the root.
+        if truncate_after:
+            os.ftruncate(fd, 0)
     except BaseException:
         os.close(fd)
         raise

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -298,26 +298,63 @@ def validate_model_resource(model_path, context="NLTK model"):
     # Only a real filesystem path is sandboxed; a bare resource name is not a path.
     if os.path.isabs(text) or os.path.exists(text):
         validate_path(text, context=context)
-        # realpath() cannot see a hardlink, so an in-root alias of an outside file
-        # passes the check above; the tool would then read (or overwrite) the
-        # original. Mirrors the st_nlink guard in _hardened_open.
-        try:
-            info = os.stat(text)
-        except OSError:
-            return
-        if stat.S_ISREG(info.st_mode) and info.st_nlink > 1:
-            raise PermissionError(
-                f"Security Violation [{context}]: model {text!r} has "
-                f"{info.st_nlink} hard links, so it may alias a file outside the "
-                "trusted NLTK data roots."
-            )
-        # A FIFO, socket or device planted in a data root would hang the reader
-        # forever. Directories stay legal: corpora are passed as directories.
-        if not (stat.S_ISREG(info.st_mode) or stat.S_ISDIR(info.st_mode)):
-            raise PermissionError(
-                f"Security Violation [{context}]: model {text!r} is not a regular "
-                "file or directory; reading it could block indefinitely."
-            )
+        _reject_aliased_or_special(text, context)
+
+
+def _reject_aliased_or_special(text, context):
+    """Physical checks on a path that already passed :func:`validate_path`.
+
+    ``realpath()`` cannot see a hardlink, so an in-root alias of an outside file
+    passes every name-based check; the tool would then read, or overwrite, the
+    original. Mirrors the ``st_nlink`` guard in :func:`_hardened_open`. A FIFO,
+    socket or device planted in a data root would instead block the reader
+    forever. Directories stay legal, since corpora are passed as directories.
+
+    A path that does not exist yet (an output file) has nothing to check.
+    """
+    try:
+        info = os.stat(text)
+    except OSError:
+        return
+    if stat.S_ISREG(info.st_mode) and info.st_nlink > 1:
+        raise PermissionError(
+            f"Security Violation [{context}]: {text!r} has {info.st_nlink} hard "
+            "links, so it may alias a file outside the trusted NLTK data roots."
+        )
+    if not (stat.S_ISREG(info.st_mode) or stat.S_ISDIR(info.st_mode)):
+        raise PermissionError(
+            f"Security Violation [{context}]: {text!r} is not a regular file or "
+            "directory; reading it could block indefinitely."
+        )
+
+
+def validate_tool_path(path_input, context="NLTK tool file"):
+    """Bound a filesystem path handed to an external tool to read or write.
+
+    Unlike :func:`validate_model_resource` this never accepts a bare resource
+    name: the value must be a real path inside the NLTK data roots. Use it for
+    arguments the tool opens directly, such as MaltParser's ``-i`` input and
+    ``-o`` output, where an unbounded value is an arbitrary file read and an
+    arbitrary file write respectively.
+
+    :param path_input: the path as supplied by the caller
+    :param context: label used in the security-violation message
+    :raises ValueError: if the value is empty or contains a NUL byte
+    :raises PermissionError: if it is outside the data roots, hardlinked, or a
+        non-regular file such as a FIFO
+    """
+    text = os.fspath(path_input)
+    if not text or not text.strip():
+        raise ValueError(
+            f"Security Violation [{context}]: path is empty; it would resolve to "
+            "the current working directory."
+        )
+    if "\x00" in text:
+        raise ValueError(
+            f"Security Violation [{context}]: path {text!r} contains a NUL byte."
+        )
+    validate_path(text, context=context)
+    _reject_aliased_or_special(text, context)
 
 
 def _zip_member_is_unsafe(name_str):
@@ -1057,6 +1094,7 @@ class ZipFile(zipfile.ZipFile):
 __all__ = [
     "validate_path",
     "validate_model_resource",
+    "validate_tool_path",
     "validate_network_url",
     "validate_zip_archive",
     "open",

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -9,6 +9,7 @@
 
 """Centralized I/O security sentinel for NLTK."""
 import builtins
+import errno
 import http.client
 import io
 import ipaddress
@@ -146,7 +147,9 @@ def validate_path(path_input, context="NLTK", required_root=None):
     :param required_root: If provided, enforces that the path is strictly
                           within this specific directory (scoped sandbox).
     """
-    if isinstance(path_input, int) or not path_input or not str(path_input).strip():
+    # An *empty* path is a no-op (nothing can open it), but a blank-but-non-empty
+    # one names a real file, so it must be validated like any other path.
+    if isinstance(path_input, int) or not path_input:
         return
     try:
         raw = path_input.path if hasattr(path_input, "path") else str(path_input)
@@ -240,6 +243,155 @@ def validate_path(path_input, context="NLTK", required_root=None):
     except Exception:
         if ENFORCE:
             raise
+
+
+# O_NOFOLLOW on a symlink, and O_RDONLY on a socket / write-only FIFO, fail with
+# these; they mean "refused by the hardening", not "this file is broken".
+_REFUSING_ERRNOS = frozenset(
+    e
+    for e in (
+        getattr(errno, "ELOOP", None),
+        getattr(errno, "EMLINK", None),
+        getattr(errno, "ENXIO", None),
+        getattr(errno, "EOPNOTSUPP", None),
+        getattr(errno, "ENOTSUP", None),
+    )
+    if e is not None
+)
+
+
+def _as_path_string(path_input):
+    """Normalise a path-ish argument to the exact string a sink would use.
+
+    Mirrors :func:`validate_path`: a ``PathPointer`` exposes ``.path``, bytes are
+    decoded with the filesystem encoding, everything else goes through ``str``.
+    """
+    raw = path_input.path if hasattr(path_input, "path") else path_input
+    if isinstance(raw, bytes):
+        return os.fsdecode(raw)
+    return raw if isinstance(raw, str) else str(raw)
+
+
+def validate_tool_path(path_input, context="NLTK tool", *, must_exist=True):
+    """Validate a path that is handed to a *native loader or a subprocess argv*.
+
+    :func:`validate_path` alone is not enough for these sinks. It only answers
+    "is this string inside an allowed root", and NLTK cannot wrap the actual
+    open: a C extension (``pycrfsuite.Tagger.open``) or an external process
+    (``hunpos-tag``, the Stanford JVM) performs it. This adds the checks
+    :func:`open` already performs on descriptors it owns, plus the two that only
+    matter when a path becomes a command-line argument:
+
+    * blank-but-non-empty and NUL-bearing paths are refused outright;
+    * a path whose string form starts with ``-`` is refused: as an argv element
+      the callee parses it as an *option*, not a filename (CWE-88);
+    * the path is resolved and bounded by :func:`validate_path`;
+    * when it exists, it is opened with ``O_NOFOLLOW|O_NONBLOCK`` and must be a
+      *regular* file with ``st_nlink == 1``, and the descriptor's kernel path is
+      re-validated. That refuses a final-component symlink, an in-root hardlink
+      to an outside inode (which no path resolution can see), and a planted
+      FIFO / socket / device / directory, whose open would block forever or
+      stream unbounded data (CWE-59, CWE-400).
+
+    A path-taking sink can never be fully race-free (the callee re-resolves the
+    name), but every attack that does not require winning that race is refused.
+
+    :param path_input: the path about to be handed to the tool.
+    :param context: diagnostic context for the raised error.
+    :param must_exist: when False, a non-existent path is accepted after the
+        containment check (a write destination the tool will create).
+    :raises PermissionError: if the path is not usable safely.
+    """
+    if isinstance(path_input, int):
+        return
+    raw = _as_path_string(path_input)
+    if not raw:
+        raise PermissionError(
+            f"Security Violation [{context}]: empty model path is not a usable file"
+        )
+    if not raw.strip():
+        raise PermissionError(
+            f"Security Violation [{context}]: blank path {raw!r} is not a model file"
+        )
+    if "\x00" in raw:
+        raise PermissionError(
+            f"Security Violation [{context}]: NUL byte in path {raw!r}"
+        )
+    if raw.startswith("-"):
+        raise PermissionError(
+            f"Security Violation [{context}]: path {raw!r} starts with '-' and "
+            "would be parsed as a command-line option by the tool (CWE-88)"
+        )
+
+    validate_path(raw, context=context)
+    if not ENFORCE or os.name != "posix":
+        return
+
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_NONBLOCK", 0)
+        | getattr(os, "O_CLOEXEC", 0)
+    )
+    try:
+        fd = os.open(raw, flags)
+    except FileNotFoundError:
+        if must_exist:
+            raise
+        return
+    except NotADirectoryError:
+        if must_exist:
+            raise
+        return
+    except OSError as e:
+        # Only the errnos the hardening flags produce are a security refusal;
+        # anything else (ENAMETOOLONG, EACCES, ...) is a plain OS error.
+        if e.errno in _REFUSING_ERRNOS:
+            raise PermissionError(
+                f"Security Violation [{context}]: refusing model path {raw!r}: "
+                f"{e.strerror} (symlink or non-regular file, CWE-59)"
+            ) from e
+        raise
+    try:
+        st = os.fstat(fd)
+        if not stat.S_ISREG(st.st_mode):
+            raise PermissionError(
+                f"Security Violation [{context}]: model path {raw!r} is not a "
+                "regular file (a FIFO/socket/device/directory can block the "
+                "loader forever or stream unbounded data, CWE-400)"
+            )
+        if st.st_nlink > 1:
+            raise PermissionError(
+                f"Security Violation [{context}]: refusing multiply-linked model "
+                f"{raw!r} (st_nlink={st.st_nlink}); a hardlink names an inode that "
+                "may live outside the sandbox (CWE-59)"
+            )
+        actual = _fd_realpath(fd)
+        validate_path(
+            actual if actual is not None else os.path.realpath(raw), context=context
+        )
+    finally:
+        os.close(fd)
+
+
+def validate_tool_dir(path_input, context="NLTK tool"):
+    """Validate a *directory* a tool or NLTK itself will write model files into.
+
+    The file-shaped checks in :func:`validate_tool_path` do not apply (the leaf
+    is a directory, and it may not exist yet), but the string-shaped ones do: a
+    blank or NUL-bearing destination silently becomes a directory in the current
+    working directory rather than anything the caller meant.
+    """
+    raw = _as_path_string(path_input)
+    if not raw or not raw.strip():
+        raise PermissionError(
+            f"Security Violation [{context}]: blank destination directory {raw!r}"
+        )
+    if "\x00" in raw:
+        raise PermissionError(
+            f"Security Violation [{context}]: NUL byte in destination {raw!r}"
+        )
+    validate_path(raw, context=context)
 
 
 def _zip_member_is_unsafe(name_str):
@@ -749,8 +901,6 @@ def _hardened_open(raw_path, mode, context, required_root, **kwargs):
     temp dir is not left group-/world-readable (CWE-377/378). POSIX only;
     callers fall back to :func:`builtins.open` elsewhere.
     """
-    import errno
-
     flags = (
         _os_open_flags(mode)
         | getattr(os, "O_NOFOLLOW", 0)
@@ -978,6 +1128,8 @@ class ZipFile(zipfile.ZipFile):
 
 __all__ = [
     "validate_path",
+    "validate_tool_path",
+    "validate_tool_dir",
     "validate_network_url",
     "validate_zip_archive",
     "open",

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -250,6 +250,54 @@ def validate_path(path_input, context="NLTK", required_root=None):
             raise
 
 
+def _reject_bad_name_syntax(text, context):
+    """Syntactic checks shared by every caller-supplied model or tool path.
+
+    None of these can be a legitimate model, corpus or output file, so they are
+    refused before the value is treated as a path at all. ``..`` is checked after
+    folding ``\\`` to ``/``: a backslash is an ordinary filename character on
+    POSIX but a separator on Windows, so ``..\\..\\etc`` has to be rejected on both.
+    """
+
+    def _refuse(why):
+        raise ValueError(f"Security Violation [{context}]: {text!r} {why}.")
+
+    if not text or not text.strip():
+        _refuse("is empty")
+    # A NUL truncates the path in a tool's native layer, so "good.ser.gz\0evil"
+    # can name a different file there than it does here.
+    if "\x00" in text:
+        _refuse("contains a NUL byte")
+    # A leading '-' would be parsed as another option by the tool we hand it to.
+    if text.startswith("-"):
+        _refuse("looks like a command-line option (argument injection)")
+    # Stanford's loaders will fetch a URL; only local resources are permitted.
+    if "://" in text or text.lower().startswith(("file:", "jar:")):
+        _refuse("is a URL; only local resources are permitted")
+    # Nothing downstream expands '~', but a sink that did would reach $HOME.
+    if text.startswith("~"):
+        _refuse("starts with '~'; pass an already-expanded path")
+    # A Windows UNC path reaches a remote share.
+    if text.startswith("\\\\") or text.startswith("//"):
+        _refuse("is a UNC path; only local resources are permitted")
+    if ".." in text.replace("\\", "/").split("/"):
+        _refuse("contains a '..' component; it may not traverse out of the namespace")
+    # ':' names an NTFS alternate data stream, except in a drive prefix (C:\...).
+    # This also catches the drive-RELATIVE form "C:name", which means "name in
+    # the current directory of drive C" and so escapes the validated location.
+    if ":" in text and not re.match(r"^[A-Za-z]:[\\/]", text):
+        _refuse("contains ':', which names an NTFS alternate data stream")
+    # On Windows a leading separator with no drive is relative to the CURRENT
+    # drive, so it names a different file than the same string does on POSIX.
+    if os.name != "posix" and re.match(r"^[\\/]", text):
+        _refuse("is relative to the current drive; give a full path with a drive")
+    # On Windows these resolve to devices (a serial port, the null device) no
+    # matter which directory they appear in. Refused everywhere for determinism.
+    stem = os.path.basename(text.replace("\\", "/")).split(".")[0].upper()
+    if stem in _WINDOWS_DEVICE_NAMES:
+        _refuse(f"names the reserved Windows device {stem!r}")
+
+
 def validate_model_resource(model_path, context="NLTK model"):
     """Bound a caller-supplied model argument that may be a *resource name*.
 
@@ -275,38 +323,7 @@ def validate_model_resource(model_path, context="NLTK model"):
     :raises PermissionError: if it is a filesystem path outside the data roots
     """
     text = os.fspath(model_path)
-
-    def _refuse(why):
-        raise ValueError(f"Security Violation [{context}]: model {text!r} {why}.")
-
-    if not text or not text.strip():
-        _refuse("is empty")
-    # A NUL truncates the path in the JVM's native layer, so "good.ser.gz\0evil"
-    # can name a different file there than it does here.
-    if "\x00" in text:
-        _refuse("contains a NUL byte")
-    # A leading '-' would be parsed as another option by the tool we hand it to.
-    if text.startswith("-"):
-        _refuse("looks like a command-line option (argument injection)")
-    # Stanford's loaders will fetch a URL; only local resources are permitted.
-    if "://" in text or text.lower().startswith(("file:", "jar:")):
-        _refuse("is a URL; only local model resources are permitted")
-    # Nothing downstream expands '~', but a sink that did would reach $HOME.
-    if text.startswith("~"):
-        _refuse("starts with '~'; pass an already-expanded path")
-    # A Windows UNC path reaches a remote share.
-    if text.startswith("\\\\") or text.startswith("//"):
-        _refuse("is a UNC path; only local model resources are permitted")
-    if ".." in text.replace("\\", "/").split("/"):
-        _refuse("contains a '..' component; it may not traverse out of the namespace")
-    # ':' names an NTFS alternate data stream, except in a drive prefix (C:\...).
-    if ":" in text and not re.match(r"^[A-Za-z]:[\\/]", text):
-        _refuse("contains ':', which names an NTFS alternate data stream")
-    # On Windows these resolve to devices (a serial port, the null device) no
-    # matter which directory they appear in. Refused everywhere for determinism.
-    stem = os.path.basename(text.replace("\\", "/")).split(".")[0].upper()
-    if stem in _WINDOWS_DEVICE_NAMES:
-        _refuse(f"names the reserved Windows device {stem!r}")
+    _reject_bad_name_syntax(text, context)
 
     # Only a real filesystem path is sandboxed; a bare resource name is not a
     # path. A bare name is deliberately NOT probed against the CWD: doing so made
@@ -371,15 +388,7 @@ def validate_tool_path(path_input, context="NLTK tool file", for_write=False):
         file such as a FIFO
     """
     text = os.fspath(path_input)
-    if not text or not text.strip():
-        raise ValueError(
-            f"Security Violation [{context}]: path is empty; it would resolve to "
-            "the current working directory."
-        )
-    if "\x00" in text:
-        raise ValueError(
-            f"Security Violation [{context}]: path {text!r} contains a NUL byte."
-        )
+    _reject_bad_name_syntax(text, context)
     validate_path(text, context=context)
     _reject_aliased_or_special(text, context, check_links=for_write)
 

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -45,6 +45,14 @@ ALLOW_PROXIED_FETCH = False
 _ALLOWED_ROOTS_CACHE = None
 _LAST_DATA_PATHS = None
 
+# Reserved DOS device names. On Windows these resolve to a device rather than a
+# file in the current directory, whatever the surrounding path is.
+_WINDOWS_DEVICE_NAMES = frozenset(
+    ["CON", "PRN", "AUX", "NUL"]
+    + [f"COM{i}" for i in range(1, 10)]
+    + [f"LPT{i}" for i in range(1, 10)]
+)
+
 
 def is_private_dir(path):
     """Return True if *path* is a directory safe to trust as a data root: another
@@ -294,6 +302,11 @@ def validate_model_resource(model_path, context="NLTK model"):
     # ':' names an NTFS alternate data stream, except in a drive prefix (C:\...).
     if ":" in text and not re.match(r"^[A-Za-z]:[\\/]", text):
         _refuse("contains ':', which names an NTFS alternate data stream")
+    # On Windows these resolve to devices (a serial port, the null device) no
+    # matter which directory they appear in. Refused everywhere for determinism.
+    stem = os.path.basename(text.replace("\\", "/")).split(".")[0].upper()
+    if stem in _WINDOWS_DEVICE_NAMES:
+        _refuse(f"names the reserved Windows device {stem!r}")
 
     # Only a real filesystem path is sandboxed; a bare resource name is not a
     # path. A bare name is deliberately NOT probed against the CWD: doing so made

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -300,6 +300,13 @@ def _reject_bad_name_syntax(text, context):
     # can name a different file there than it does here.
     if "\x00" in text:
         _refuse("contains a NUL byte")
+    # Python 3.14's url2pathname follows the WHATWG rules and STRIPS tab, LF and
+    # CR, so ".\n./x" passes a '..' check here and becomes "../x" downstream.
+    if any(character in text for character in "\t\n\r\x0b\x0c"):
+        _refuse(
+            "contains a control character; these are stripped by URL-to-path "
+            "conversion on Python 3.14 and can turn into a '..' traversal"
+        )
     # A leading '-' would be parsed as another option by the tool we hand it to.
     if text.startswith("-"):
         _refuse("looks like a command-line option (argument injection)")

--- a/nltk/picklesec.py
+++ b/nltk/picklesec.py
@@ -141,6 +141,11 @@ _DENIED_MODULE_PREFIXES = (
     "os",
     "nt",
     "posix",
+    # os.path's concrete backing modules: denying "os" only catches the literal
+    # "os.path", not these, so an allowlist naming them would reach path/stat gadgets.
+    "posixpath",
+    "ntpath",
+    "genericpath",
     "subprocess",
     "sys",
     "socket",

--- a/nltk/sem/boxer.py
+++ b/nltk/sem/boxer.py
@@ -204,10 +204,13 @@ class Boxer:
         :param candc_out: str output from C&C parser
         :return: stdout
         """
+        # Imported here, not at module scope: nltk.data imports nltk.sem.
+        from nltk.data import staging_tempdir
+
         f = None
         try:
             fd, temp_filename = tempfile.mkstemp(
-                prefix="boxer-", suffix=".in", text=True
+                prefix="boxer-", suffix=".in", text=True, dir=staging_tempdir()
             )
             f = os.fdopen(fd, "w")
             f.write(candc_out.decode("utf-8"))

--- a/nltk/tag/crf.py
+++ b/nltk/tag/crf.py
@@ -14,6 +14,7 @@ import re
 import unicodedata
 import warnings
 
+from nltk.pathsec import validate_path
 from nltk.tag.api import TaggerI
 
 try:
@@ -121,6 +122,16 @@ class CRFTagger(TaggerI):
         self._feature_cache = {}
 
     def set_model_file(self, model_file):
+        """Load a trained model from ``model_file``.
+
+        ``model_file`` is caller-supplied and pycrfsuite opens it natively, so
+        the path is validated against the NLTK data sandbox first: an
+        outside-root model is refused rather than handed to the native loader
+        (GHSA-8mgp-746c-j5xp). ``pathsec.open`` cannot be used here because the
+        C extension does its own open, so containment is the check that can be
+        applied; a symlink swapped in after it is not covered.
+        """
+        validate_path(model_file, context="CRFTagger.set_model_file")
         self._model_file = model_file
         self._tagger.open(self._model_file)
 
@@ -275,11 +286,19 @@ class CRFTagger(TaggerI):
 
         :param train_data: list of annotated sentences.
         :type train_data: list(list(tuple(str,str)))
-        :param model_file: path where the trained model will be written.
+        :param model_file: path where the trained model will be written. It must
+            be inside an allowed NLTK data root (see ``nltk.data.path``); use
+            ``nltk.data.make_staging_dir()`` for a private in-sandbox location.
         :type model_file: str
         """
         if pycrfsuite is None:
             raise ImportError("CRFTagger requires python-crfsuite to be installed.")
+
+        # Validate before any training work: the destination is caller-supplied
+        # and pycrfsuite writes it natively, so an outside-root path must be
+        # refused up front rather than after the model is built
+        # (GHSA-8mgp-746c-j5xp).
+        validate_path(model_file, context="CRFTagger.train")
 
         trainer = pycrfsuite.Trainer(verbose=self._verbose)
         trainer.set_params(self._training_options)

--- a/nltk/tag/crf.py
+++ b/nltk/tag/crf.py
@@ -14,6 +14,7 @@ import re
 import unicodedata
 import warnings
 
+from nltk.pathsec import validate_path
 from nltk.tag.api import TaggerI
 
 try:
@@ -121,6 +122,9 @@ class CRFTagger(TaggerI):
         self._feature_cache = {}
 
     def set_model_file(self, model_file):
+        # ``model_file`` reaches pycrfsuite's native ``.open()`` (which pathsec.open
+        # cannot wrap); validate it against the data sandbox first (GHSA-8mgp-746c-j5xp).
+        validate_path(model_file, context="CRFTagger.set_model_file")
         self._model_file = model_file
         self._tagger.open(self._model_file)
 
@@ -280,6 +284,10 @@ class CRFTagger(TaggerI):
         """
         if pycrfsuite is None:
             raise ImportError("CRFTagger requires python-crfsuite to be installed.")
+
+        # ``model_file`` is the destination for pycrfsuite's native ``.train()`` (which
+        # pathsec.open cannot wrap); validate it up front (GHSA-8mgp-746c-j5xp).
+        validate_path(model_file, context="CRFTagger.train")
 
         trainer = pycrfsuite.Trainer(verbose=self._verbose)
         trainer.set_params(self._training_options)

--- a/nltk/tag/crf.py
+++ b/nltk/tag/crf.py
@@ -14,7 +14,7 @@ import re
 import unicodedata
 import warnings
 
-from nltk.pathsec import validate_path
+from nltk.pathsec import validate_tool_path
 from nltk.tag.api import TaggerI
 
 try:
@@ -123,8 +123,8 @@ class CRFTagger(TaggerI):
 
     def set_model_file(self, model_file):
         # ``model_file`` reaches pycrfsuite's native ``.open()`` (which pathsec.open
-        # cannot wrap); validate it against the data sandbox first (GHSA-8mgp-746c-j5xp).
-        validate_path(model_file, context="CRFTagger.set_model_file")
+        # cannot wrap); bound it to the data sandbox first (GHSA-8mgp-746c-j5xp).
+        validate_tool_path(model_file, context="CRFTagger.set_model_file")
         self._model_file = model_file
         self._tagger.open(self._model_file)
 
@@ -286,8 +286,9 @@ class CRFTagger(TaggerI):
             raise ImportError("CRFTagger requires python-crfsuite to be installed.")
 
         # ``model_file`` is the destination for pycrfsuite's native ``.train()`` (which
-        # pathsec.open cannot wrap); validate it up front (GHSA-8mgp-746c-j5xp).
-        validate_path(model_file, context="CRFTagger.train")
+        # pathsec.open cannot wrap); bound it up front (GHSA-8mgp-746c-j5xp). The
+        # destination normally does not exist yet, so existence is not required.
+        validate_tool_path(model_file, context="CRFTagger.train", must_exist=False)
 
         trainer = pycrfsuite.Trainer(verbose=self._verbose)
         trainer.set_params(self._training_options)

--- a/nltk/tag/hunpos.py
+++ b/nltk/tag/hunpos.py
@@ -15,6 +15,7 @@ import os
 from subprocess import PIPE, Popen
 
 from nltk.internals import find_binary, find_file
+from nltk.pathsec import validate_path
 from nltk.tag.api import TaggerI
 
 _hunpos_url = "https://code.google.com/p/hunpos/"
@@ -93,6 +94,9 @@ class HunposTagger(TaggerI):
             path_to_model, env_vars=("HUNPOS_TAGGER",), verbose=verbose
         )
         self._encoding = encoding
+        # ``self._hunpos_model`` (from find_file) becomes argv to the hunpos-tag
+        # subprocess pathsec.open cannot wrap; validate before spawning (GHSA-8mgp-746c-j5xp).
+        validate_path(self._hunpos_model, context="HunposTagger.__init__")
         self._hunpos = Popen(
             [self._hunpos_bin, self._hunpos_model],
             shell=False,

--- a/nltk/tag/hunpos.py
+++ b/nltk/tag/hunpos.py
@@ -15,7 +15,7 @@ import os
 from subprocess import PIPE, Popen
 
 from nltk.internals import find_binary, find_file
-from nltk.pathsec import validate_path
+from nltk.pathsec import validate_tool_path
 from nltk.tag.api import TaggerI
 
 _hunpos_url = "https://code.google.com/p/hunpos/"
@@ -95,8 +95,8 @@ class HunposTagger(TaggerI):
         )
         self._encoding = encoding
         # ``self._hunpos_model`` (from find_file) becomes argv to the hunpos-tag
-        # subprocess pathsec.open cannot wrap; validate before spawning (GHSA-8mgp-746c-j5xp).
-        validate_path(self._hunpos_model, context="HunposTagger.__init__")
+        # subprocess pathsec.open cannot wrap; bound it before spawning (GHSA-8mgp-746c-j5xp).
+        validate_tool_path(self._hunpos_model, context="HunposTagger.__init__")
         self._hunpos = Popen(
             [self._hunpos_bin, self._hunpos_model],
             shell=False,
@@ -126,7 +126,12 @@ class HunposTagger(TaggerI):
         The tokens should not contain any newline characters.
         """
         for token in tokens:
-            assert "\n" not in token, "Tokens should not contain newlines"
+            # Not an assert: python -O strips those, and a newline inside a token
+            # injects an extra line into the tagger's line-oriented stdin, which
+            # desynchronises every tag that follows.
+            newline = b"\n" if isinstance(token, bytes) else "\n"
+            if newline in token:
+                raise ValueError("Tokens should not contain newlines")
             if isinstance(token, str):
                 token = token.encode(self._encoding)
             self._hunpos.stdin.write(token + b"\n")

--- a/nltk/tag/perceptron.py
+++ b/nltk/tag/perceptron.py
@@ -439,9 +439,7 @@ class PerceptronTagger(TaggerI):
                 # No builtin open(): take the hardened descriptor straight from
                 # the opener and wrap it, so the write still goes through the
                 # pinned dir_fd with O_NOFOLLOW and nothing re-resolves the name.
-                fd = _no_follow_opener(
-                    target, os.O_WRONLY | os.O_CREAT | os.O_TRUNC
-                )
+                fd = _no_follow_opener(target, os.O_WRONLY | os.O_CREAT | os.O_TRUNC)
                 with os.fdopen(fd, "w") as fout:
                     json.dump(param, fout)
         finally:

--- a/nltk/tag/perceptron.py
+++ b/nltk/tag/perceptron.py
@@ -274,6 +274,9 @@ class PerceptronTagger(TaggerI):
         cannot pre-create or symlink it to redirect the write (CWE-377/378).
         """
         if self._save_dir is None:
+            # lang lands in a mkdtemp prefix, which is concatenated onto the
+            # data root, so a path-shaped lang would stage output outside it.
+            _validate_lang(self.lang)
             self._save_dir = make_staging_dir(
                 prefix=f"nltk_{self.TAGGER_NAME}_{self.lang}_"
             )

--- a/nltk/tag/perceptron.py
+++ b/nltk/tag/perceptron.py
@@ -19,6 +19,7 @@ from tempfile import gettempdir
 
 from nltk import jsontags
 from nltk.data import FileSystemPathPointer, find, open_datafile
+from nltk.pathsec import open as pathsec_open
 from nltk.tag.api import TaggerI
 
 
@@ -54,7 +55,7 @@ def _open_private_model_dir(loc):
 
     The leaf is created with ``os.mkdir`` (atomic: it either creates the real
     directory or fails with ``FileExistsError``) and then re-opened with
-    ``O_NOFOLLOW|O_DIRECTORY`` -- so a symlink pre-planted or raced in at the
+    ``O_NOFOLLOW|O_DIRECTORY``; so a symlink pre-planted or raced in at the
     guessable default name is refused (``ELOOP``/``ENOTDIR``) instead of being
     followed. The descriptor is rejected unless it is a real directory owned by
     the current user and not group-/world-writable (CWE-59/377/378).
@@ -175,12 +176,12 @@ class AveragedPerceptron:
 
     def save(self, path):
         """Save the model weights as json"""
-        with open(path, "w") as fout:
+        with pathsec_open(path, "w", context="AveragedPerceptron.save") as fout:
             return json.dump(self.weights, fout)
 
     def load(self, path):
         """Load the json model weights."""
-        with open(path) as fin:
+        with pathsec_open(path, context="AveragedPerceptron.load") as fin:
             self.weights = json.load(fin)
 
     def encode_json_obj(self):
@@ -332,6 +333,8 @@ class PerceptronTagger(TaggerI):
     def save_to_json(self, lang="xxx", loc=None):
         if not loc:
             loc = self.save_dir
+        # No allowed-root check on loc: _open_private_model_dir below verifies it
+        # atomically, and a root check would refuse a private per-user temp dir on Linux.
         # On POSIX the default TRAINED_TAGGER_PATH is a shared, world-writable
         # temp dir (/tmp) and the save dir is a *guessable* name in it, so a
         # local attacker can pre-plant or race a symlink at ``loc``. A plain

--- a/nltk/tag/perceptron.py
+++ b/nltk/tag/perceptron.py
@@ -30,17 +30,18 @@ from nltk.pathsec import validate_tool_dir, validate_tool_path
 from nltk.tag.api import TaggerI
 
 
-def _validate_lang(lang):
-    """Refuse a language code that is really a path.
+def _validate_name_component(value, kind="language code"):
+    """Refuse a value that is really a path where a filename fragment is meant.
 
-    ``lang`` is interpolated straight into the model filenames, and those are
-    opened *relative to a pinned directory descriptor*. ``O_NOFOLLOW`` and the
-    fd only anchor the base: a ``..`` component inside the name walks out of the
-    verified directory and writes anywhere the process can reach, so
-    ``save_to_json(lang="sub/../../../../etc")`` escaped the sandbox entirely
-    (CWE-22). A language code is a single filename component, never a path.
+    The model filenames are built by interpolation and then opened *relative to
+    a pinned directory descriptor*. ``O_NOFOLLOW`` and the fd only anchor the
+    base: a ``..`` inside the name walks out of the verified directory and
+    writes anywhere the process can reach, so both halves of the name (the
+    ``lang`` and the ``TAGGER_NAME`` prefix) escaped the sandbox (CWE-22).
+    Applied to the composed filename as well as to each part, so a future
+    interpolation is covered without a new check.
     """
-    text = str(lang)
+    text = str(value)
     if (
         not text
         or not text.strip()
@@ -52,7 +53,7 @@ def _validate_lang(lang):
         or (os.altsep and os.altsep in text)
     ):
         raise ValueError(
-            f"Invalid tagger language code {lang!r}: must be a single filename "
+            f"Invalid tagger {kind} {value!r}: must be a single filename "
             "component (no path separators, '..' or NUL)"
         )
     return text
@@ -273,20 +274,24 @@ class PerceptronTagger(TaggerI):
         cannot pre-create or symlink it to redirect the write (CWE-377/378).
         """
         if self._save_dir is None:
-            # lang lands in a mkdtemp prefix, which is concatenated onto the
-            # data root, so a path-shaped lang would stage output outside it.
-            _validate_lang(self.lang)
+            # Both parts land in a mkdtemp prefix, which is concatenated onto
+            # the data root, so a path-shaped part stages output outside it.
+            _validate_name_component(self.lang, "language code")
+            _validate_name_component(self.TAGGER_NAME, "tagger name")
             self._save_dir = make_staging_dir(
                 prefix=f"nltk_{self.TAGGER_NAME}_{self.lang}_"
             )
         return self._save_dir
 
     def param_files(self, lang="eng"):
-        # Single chokepoint where lang becomes a filename, so validate here.
-        _validate_lang(lang)
-        return (
-            f"{self.TAGGER_NAME}_{lang}.{attr}.json"
-            for attr in ["weights", "tagdict", "classes"]
+        # The one place lang and TAGGER_NAME become filenames, so validate the
+        # composed name here rather than each ingredient at each caller.
+        _validate_name_component(lang, "language code")
+        return tuple(
+            _validate_name_component(
+                f"{self.TAGGER_NAME}_{lang}.{attr}.json", "model filename"
+            )
+            for attr in ("weights", "tagdict", "classes")
         )
 
     def tag(self, tokens, return_conf=False, use_tagdict=True):
@@ -362,7 +367,7 @@ class PerceptronTagger(TaggerI):
 
     def save_to_json(self, lang="xxx", loc=None):
         # Fail before any directory is created, not once the fd is pinned.
-        _validate_lang(lang)
+        _validate_name_component(lang, "language code")
         if not loc:
             loc = self.save_dir
         # A caller-supplied destination is an unbounded write primitive otherwise:

--- a/nltk/tag/perceptron.py
+++ b/nltk/tag/perceptron.py
@@ -25,7 +25,36 @@ from nltk.data import (
     open_datafile,
 )
 from nltk.pathsec import open as pathsec_open
+from nltk.pathsec import validate_tool_dir, validate_tool_path
 from nltk.tag.api import TaggerI
+
+
+def _validate_lang(lang):
+    """Refuse a language code that is really a path.
+
+    ``lang`` is interpolated straight into the model filenames, and those are
+    opened *relative to a pinned directory descriptor*. ``O_NOFOLLOW`` and the
+    fd only anchor the base: a ``..`` component inside the name walks out of the
+    verified directory and writes anywhere the process can reach, so
+    ``save_to_json(lang="sub/../../../../etc")`` escaped the sandbox entirely
+    (CWE-22). A language code is a single filename component, never a path.
+    """
+    text = str(lang)
+    if (
+        not text
+        or not text.strip()
+        or text in (".", "..")
+        or "\x00" in text
+        or "/" in text
+        or "\\" in text
+        or os.sep in text
+        or (os.altsep and os.altsep in text)
+    ):
+        raise ValueError(
+            f"Invalid tagger language code {lang!r}: must be a single filename "
+            "component (no path separators, '..' or NUL)"
+        )
+    return text
 
 
 def _open_private_model_dir(loc):
@@ -155,11 +184,14 @@ class AveragedPerceptron:
 
     def save(self, path):
         """Save the model weights as json"""
+        validate_tool_path(path, context="AveragedPerceptron.save", must_exist=False)
         with pathsec_open(path, "w", context="AveragedPerceptron.save") as fout:
             return json.dump(self.weights, fout)
 
     def load(self, path):
         """Load the json model weights."""
+        # Refuse a planted FIFO/socket/device before pathsec.open blocks on it.
+        validate_tool_path(path, context="AveragedPerceptron.load")
         with pathsec_open(path, context="AveragedPerceptron.load") as fin:
             self.weights = json.load(fin)
 
@@ -248,6 +280,8 @@ class PerceptronTagger(TaggerI):
         return self._save_dir
 
     def param_files(self, lang="eng"):
+        # Single chokepoint where lang becomes a filename, so validate here.
+        _validate_lang(lang)
         return (
             f"{self.TAGGER_NAME}_{lang}.{attr}.json"
             for attr in ["weights", "tagdict", "classes"]
@@ -325,12 +359,17 @@ class PerceptronTagger(TaggerI):
             self.save_to_json(lang=self.lang, loc=save_loc)
 
     def save_to_json(self, lang="xxx", loc=None):
+        # Fail before any directory is created, not once the fd is pinned.
+        _validate_lang(lang)
         if not loc:
             loc = self.save_dir
+        # A caller-supplied destination is an unbounded write primitive otherwise:
+        # the helper below happily os.makedirs() a whole chain anywhere writable.
+        validate_tool_dir(loc, context="PerceptronTagger.save_to_json")
         # The default loc (save_dir) is an unpredictable 0700 dir inside a data
-        # root, but a caller may still pass any path here, so the atomic checks
-        # below stay: a local attacker could pre-plant or race a symlink at a
-        # caller-chosen ``loc``. A plain
+        # root, but a caller may still pass any in-sandbox path here, so the
+        # atomic checks below stay: a local attacker could pre-plant or race a
+        # symlink at a caller-chosen ``loc``. A plain
         # ``islink`` pre-check is non-atomic (TOCTOU) and misses it once created;
         # ``_open_private_model_dir`` instead creates/re-opens the leaf atomically
         # with O_NOFOLLOW|O_DIRECTORY, verifies it is a real, user-owned,
@@ -343,7 +382,11 @@ class PerceptronTagger(TaggerI):
         if os.name != "posix":
             os.makedirs(loc, exist_ok=True)
             for param, json_file in zip(self.encode_json_obj(), self.param_files(lang)):
-                with open(path_join(loc, json_file), "w") as fout:
+                with pathsec_open(
+                    path_join(loc, json_file),
+                    "w",
+                    context="PerceptronTagger.save_to_json",
+                ) as fout:
                     json.dump(param, fout)
             return
 
@@ -353,6 +396,8 @@ class PerceptronTagger(TaggerI):
             # Write each model file relative to the pinned directory fd (where
             # supported) with O_NOFOLLOW (0600), so neither the dir nor the file
             # can be redirected outside the verified directory after the check.
+            # Not pathsec.open: a dir-fd-relative name has no absolute path to
+            # validate, and the pinned fd is strictly stronger than a path check.
             use_dir_fd = os.open in os.supports_dir_fd
 
             def _no_follow_opener(path, flags):
@@ -371,6 +416,8 @@ class PerceptronTagger(TaggerI):
     def load_from_json(self, lang="eng", loc=None):
         # Automatically find path to the tagger if location is not specified.
         # loc can refer to zip or real FS
+        if isinstance(loc, bytes):
+            loc = os.fsdecode(loc)
         if loc is None:
             loc = find(f"taggers/averaged_perceptron_tagger_{lang}/")
         elif isinstance(loc, str):
@@ -378,11 +425,15 @@ class PerceptronTagger(TaggerI):
             # - absolute paths are explicit filesystem locations
             # - relative strings are treated as NLTK resource names and resolved via find()
             if os.path.isabs(loc):
+                # Bound it here, not at the eventual read: FileSystemPathPointer
+                # stats the path, so an unbounded loc is an existence oracle too.
+                validate_tool_dir(loc, context="PerceptronTagger.load_from_json")
                 loc = FileSystemPathPointer(loc)
             else:
                 loc = find(loc)
         elif isinstance(loc, Path):
             # Explicit filesystem path
+            validate_tool_dir(str(loc), context="PerceptronTagger.load_from_json")
             loc = FileSystemPathPointer(str(loc))
         # else: assume loc is already a PathPointer (zip or filesystem)
 

--- a/nltk/tag/perceptron.py
+++ b/nltk/tag/perceptron.py
@@ -18,35 +18,14 @@ from pathlib import Path
 from tempfile import gettempdir
 
 from nltk import jsontags
-from nltk.data import FileSystemPathPointer, find, open_datafile
+from nltk.data import (
+    FileSystemPathPointer,
+    find,
+    make_staging_dir,
+    open_datafile,
+)
 from nltk.pathsec import open as pathsec_open
 from nltk.tag.api import TaggerI
-
-
-def _authorize_private_dir(directory):
-    """Register a private, user-owned trained-model directory on nltk.data.path
-    so the pathsec sandbox permits reading a saved model back from it.
-
-    The default trained-tagger location is the system temp dir, which is shared
-    and world-writable on Linux. A directory that is private to the current user
-    (not group-/world-writable) cannot be tampered with by another local user, so
-    it is safe to trust; a world-writable one is deliberately NOT authorized and
-    stays refused (CWE-377/CWE-378).
-    """
-    import nltk.data
-    from nltk import pathsec
-
-    try:
-        real = os.path.realpath(str(directory))
-    except (OSError, ValueError):
-        return
-    if not pathsec.is_private_dir(real):
-        return
-    known = [os.path.realpath(str(p)) for p in nltk.data.path if isinstance(p, str)]
-    if real not in known:
-        nltk.data.path.append(real)
-        pathsec._ALLOWED_ROOTS_CACHE = None
-        pathsec._LAST_DATA_PATHS = None
 
 
 def _open_private_model_dir(loc):
@@ -244,14 +223,29 @@ class PerceptronTagger(TaggerI):
         self.tagdict = {}
         self.classes = set()
         self.lang = lang
-        # Save trained models in tmp directory by default:
+        # Retained for backward compatibility; save_dir no longer derives from it.
         self.TRAINED_TAGGER_PATH = gettempdir()
         self.TAGGER_NAME = "averaged_perceptron_tagger"
-        self.save_dir = path_join(
-            self.TRAINED_TAGGER_PATH, f"{self.TAGGER_NAME}_{self.lang}"
-        )
+        self._save_dir = None
         if load:
             self.load_from_json(lang, loc)
+
+    @property
+    def save_dir(self):
+        """This tagger's private directory for saved model artifacts.
+
+        Allocated lazily by ``nltk.data.make_staging_dir`` INSIDE an allowed data
+        root, with an unpredictable name and mode 0700. Because it already lives
+        in the pathsec sandbox, saving and loading a trained model needs no
+        widening of ``nltk.data.path`` -- and unlike the old guessable
+        ``<tempdir>/averaged_perceptron_tagger_<lang>``, another local user
+        cannot pre-create or symlink it to redirect the write (CWE-377/378).
+        """
+        if self._save_dir is None:
+            self._save_dir = make_staging_dir(
+                prefix=f"nltk_{self.TAGGER_NAME}_{self.lang}_"
+            )
+        return self._save_dir
 
     def param_files(self, lang="eng"):
         return (
@@ -333,11 +327,10 @@ class PerceptronTagger(TaggerI):
     def save_to_json(self, lang="xxx", loc=None):
         if not loc:
             loc = self.save_dir
-        # No allowed-root check on loc: _open_private_model_dir below verifies it
-        # atomically, and a root check would refuse a private per-user temp dir on Linux.
-        # On POSIX the default TRAINED_TAGGER_PATH is a shared, world-writable
-        # temp dir (/tmp) and the save dir is a *guessable* name in it, so a
-        # local attacker can pre-plant or race a symlink at ``loc``. A plain
+        # The default loc (save_dir) is an unpredictable 0700 dir inside a data
+        # root, but a caller may still pass any path here, so the atomic checks
+        # below stay: a local attacker could pre-plant or race a symlink at a
+        # caller-chosen ``loc``. A plain
         # ``islink`` pre-check is non-atomic (TOCTOU) and misses it once created;
         # ``_open_private_model_dir`` instead creates/re-opens the leaf atomically
         # with O_NOFOLLOW|O_DIRECTORY, verifies it is a real, user-owned,
@@ -349,7 +342,6 @@ class PerceptronTagger(TaggerI):
         # plain create + write.
         if os.name != "posix":
             os.makedirs(loc, exist_ok=True)
-            _authorize_private_dir(loc)
             for param, json_file in zip(self.encode_json_obj(), self.param_files(lang)):
                 with open(path_join(loc, json_file), "w") as fout:
                     json.dump(param, fout)
@@ -357,7 +349,6 @@ class PerceptronTagger(TaggerI):
 
         dir_fd = _open_private_model_dir(loc)
         try:
-            _authorize_private_dir(loc)
 
             # Write each model file relative to the pinned directory fd (where
             # supported) with O_NOFOLLOW (0600), so neither the dir nor the file
@@ -395,13 +386,9 @@ class PerceptronTagger(TaggerI):
             loc = FileSystemPathPointer(str(loc))
         # else: assume loc is already a PathPointer (zip or filesystem)
 
-        # A trained model saved under the (private) system-temp trained-tagger
-        # dir lives outside nltk_data; authorize that specific private directory
-        # so it can be read back under the pathsec sandbox.
-        loc_path = getattr(loc, "path", None)
-        if loc_path and os.path.isdir(loc_path):
-            _authorize_private_dir(loc_path)
-
+        # No sandbox widening here: save_dir is allocated inside a data root, so a
+        # model NLTK saved is already readable. Any other loc must be authorized by
+        # the application, since trusting a caller path would disarm pathsec.
         def load_param(json_file):
             with open_datafile(loc, json_file) as fin:
                 return json.load(fin)

--- a/nltk/tag/perceptron.py
+++ b/nltk/tag/perceptron.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 from nltk import jsontags
 from nltk.data import FileSystemPathPointer, find, open_datafile
+from nltk.pathsec import _fd_realpath
 from nltk.pathsec import open as pathsec_open
 from nltk.pathsec import validate_path
 from nltk.tag.api import TaggerI
@@ -86,6 +87,11 @@ def _open_private_model_dir(loc):
                 f"Refusing non-private trained-model dir {loc!r}: not owned by "
                 "you or group-/world-writable (CWE-377/378)"
             )
+        landed = _fd_realpath(fd)
+        validate_path(
+            landed if landed is not None else os.path.realpath(loc),
+            context="PerceptronTagger.save_to_json",
+        )
     except BaseException:
         os.close(fd)
         raise

--- a/nltk/tag/perceptron.py
+++ b/nltk/tag/perceptron.py
@@ -25,8 +25,9 @@ from nltk.data import (
     make_staging_dir,
     open_datafile,
 )
+from nltk.pathsec import _fd_realpath
 from nltk.pathsec import open as pathsec_open
-from nltk.pathsec import validate_tool_dir, validate_tool_path
+from nltk.pathsec import validate_path, validate_tool_dir, validate_tool_path
 from nltk.tag.api import TaggerI
 
 
@@ -94,6 +95,14 @@ def _open_private_model_dir(loc):
                 f"Refusing non-private trained-model dir {loc!r}: not owned by "
                 "you or group-/world-writable (CWE-377/378)"
             )
+        # Validate where the descriptor actually landed, not the string: the
+        # containment check ran before this open, so an intermediate directory
+        # swapped in between the two would otherwise pin an outside directory.
+        landed = _fd_realpath(fd)
+        validate_path(
+            landed if landed is not None else os.path.realpath(loc),
+            context="PerceptronTagger.save_to_json",
+        )
     except BaseException:
         os.close(fd)
         raise

--- a/nltk/tag/perceptron.py
+++ b/nltk/tag/perceptron.py
@@ -423,6 +423,9 @@ class PerceptronTagger(TaggerI):
     def load_from_json(self, lang="eng", loc=None):
         # Automatically find path to the tagger if location is not specified.
         # loc can refer to zip or real FS
+        # Symmetric with save_to_json: lang reaches find() as a resource name and
+        # param_files() as a filename, so reject a path-shaped one up front.
+        _validate_name_component(lang, "language code")
         if isinstance(loc, bytes):
             loc = os.fsdecode(loc)
         if loc is None:

--- a/nltk/tag/perceptron.py
+++ b/nltk/tag/perceptron.py
@@ -8,6 +8,7 @@
 #
 # This module is provided under the terms of the MIT License.
 
+import errno
 import json
 import logging
 import os
@@ -68,8 +69,6 @@ def _open_private_model_dir(loc):
     followed. The descriptor is rejected unless it is a real directory owned by
     the current user and not group-/world-writable (CWE-59/377/378).
     """
-    import errno
-
     parent = os.path.dirname(loc) or "."
     os.makedirs(parent, exist_ok=True)
     try:
@@ -269,7 +268,7 @@ class PerceptronTagger(TaggerI):
         Allocated lazily by ``nltk.data.make_staging_dir`` INSIDE an allowed data
         root, with an unpredictable name and mode 0700. Because it already lives
         in the pathsec sandbox, saving and loading a trained model needs no
-        widening of ``nltk.data.path`` -- and unlike the old guessable
+        widening of ``nltk.data.path``, and unlike the old guessable
         ``<tempdir>/averaged_perceptron_tagger_<lang>``, another local user
         cannot pre-create or symlink it to redirect the write (CWE-377/378).
         """

--- a/nltk/tag/perceptron.py
+++ b/nltk/tag/perceptron.py
@@ -437,6 +437,12 @@ class PerceptronTagger(TaggerI):
         _validate_name_component(lang, "language code")
         if isinstance(loc, bytes):
             loc = os.fsdecode(loc)
+        if isinstance(loc, (str, Path)) and not str(loc).strip():
+            # Windows strips trailing spaces from a path component, so a blank
+            # loc silently resolves to the data root itself instead of failing.
+            raise ValueError(
+                f"Invalid tagger model location {loc!r}: blank path names no model"
+            )
         if loc is None:
             loc = find(f"taggers/averaged_perceptron_tagger_{lang}/")
         elif isinstance(loc, str):

--- a/nltk/tag/perceptron.py
+++ b/nltk/tag/perceptron.py
@@ -15,37 +15,38 @@ import random
 from collections import defaultdict
 from os.path import join as path_join
 from pathlib import Path
-from tempfile import gettempdir
 
 from nltk import jsontags
 from nltk.data import FileSystemPathPointer, find, open_datafile
+from nltk.pathsec import open as pathsec_open
+from nltk.pathsec import validate_path
 from nltk.tag.api import TaggerI
 
 
-def _authorize_private_dir(directory):
-    """Register a private, user-owned trained-model directory on nltk.data.path
-    so the pathsec sandbox permits reading a saved model back from it.
+def _reject_path_structure(value, label):
+    """Refuse a value that would contribute path structure to a filename.
 
-    The default trained-tagger location is the system temp dir, which is shared
-    and world-writable on Linux. A directory that is private to the current user
-    (not group-/world-writable) cannot be tampered with by another local user, so
-    it is safe to trust; a world-writable one is deliberately NOT authorized and
-    stays refused (CWE-377/CWE-378).
+    A model-artifact filename is built by interpolation, so any separator,
+    ``..``, NUL or drive letter in the interpolated value turns one filename
+    into a path and lets the caller steer the open somewhere else (CWE-22).
+    Both separators are rejected regardless of platform, since a Windows-style
+    payload must not become live on a future port.
     """
-    import nltk.data
-    from nltk import pathsec
-
-    try:
-        real = os.path.realpath(str(directory))
-    except (OSError, ValueError):
-        return
-    if not pathsec.is_private_dir(real):
-        return
-    known = [os.path.realpath(str(p)) for p in nltk.data.path if isinstance(p, str)]
-    if real not in known:
-        nltk.data.path.append(real)
-        pathsec._ALLOWED_ROOTS_CACHE = None
-        pathsec._LAST_DATA_PATHS = None
+    text = str(value)
+    if (
+        not text
+        or text in (os.curdir, os.pardir)
+        or "/" in text
+        or "\\" in text
+        or "\x00" in text
+        or os.sep in text
+        or (os.altsep and os.altsep in text)
+    ):
+        raise ValueError(
+            f"Unsafe {label} {value!r}: must be a single path component with no "
+            "separator, traversal or NUL"
+        )
+    return text
 
 
 def _open_private_model_dir(loc):
@@ -174,13 +175,25 @@ class AveragedPerceptron:
             self.weights[feat] = new_feat_weights
 
     def save(self, path):
-        """Save the model weights as json"""
-        with open(path, "w") as fout:
+        """Save the model weights as json.
+
+        ``path`` is caller-supplied, so the write goes through the pathsec
+        sandbox: a destination outside the allowed NLTK data roots (or a symlink
+        planted at one) is refused before any bytes are written, instead of the
+        builtin ``open`` that made this an arbitrary-file write
+        (GHSA-8mgp-746c-j5xp).
+        """
+        with pathsec_open(path, "w", context="AveragedPerceptron.save") as fout:
             return json.dump(self.weights, fout)
 
     def load(self, path):
-        """Load the json model weights."""
-        with open(path) as fin:
+        """Load the json model weights.
+
+        The read is sandboxed for the same reason as :meth:`save`: a model path
+        outside the allowed roots is refused rather than read back to the caller
+        (GHSA-8mgp-746c-j5xp).
+        """
+        with pathsec_open(path, "r", context="AveragedPerceptron.load") as fin:
             self.weights = json.load(fin)
 
     def encode_json_obj(self):
@@ -243,16 +256,41 @@ class PerceptronTagger(TaggerI):
         self.tagdict = {}
         self.classes = set()
         self.lang = lang
-        # Save trained models in tmp directory by default:
-        self.TRAINED_TAGGER_PATH = gettempdir()
         self.TAGGER_NAME = "averaged_perceptron_tagger"
-        self.save_dir = path_join(
-            self.TRAINED_TAGGER_PATH, f"{self.TAGGER_NAME}_{self.lang}"
-        )
+        self._save_dir = None
         if load:
             self.load_from_json(lang, loc)
 
+    @property
+    def save_dir(self) -> str:
+        """This tagger's private directory for saved model artifacts.
+
+        Created lazily on first use under a data root, with an unpredictable name
+        and mode 0700, so (unlike the old guessable
+        ``<tempdir>/averaged_perceptron_tagger_<lang>``) another local user cannot
+        pre-create or symlink it to redirect or read the write (CWE-377/378), and
+        the saved model lands inside the pathsec sandbox so it can be read back
+        without widening the allowed roots (GHSA-8mgp-746c-j5xp).
+        """
+        from nltk.data import make_staging_dir
+
+        if self._save_dir is None:
+            self._save_dir = make_staging_dir(
+                prefix=f"nltk_{self.TAGGER_NAME}_{self.lang}_"
+            )
+        return self._save_dir
+
     def param_files(self, lang="eng"):
+        """The three json parameter filenames for *lang*.
+
+        ``lang`` is interpolated straight into a filename that both
+        :meth:`save_to_json` and :meth:`load_from_json` then open, so it is
+        pinned to a single path component here: a value carrying a separator, a
+        ``..`` or a NUL would otherwise contribute path structure and steer the
+        write/read out of the directory the caller authorized (CWE-22). One
+        choke point covers both directions.
+        """
+        _reject_path_structure(lang, "lang")
         return (
             f"{self.TAGGER_NAME}_{lang}.{attr}.json"
             for attr in ["weights", "tagdict", "classes"]
@@ -330,32 +368,40 @@ class PerceptronTagger(TaggerI):
             self.save_to_json(lang=self.lang, loc=save_loc)
 
     def save_to_json(self, lang="xxx", loc=None):
+        """Write the model's json parameter files into the directory ``loc``.
+
+        ``loc`` is caller-supplied, so it is validated against the NLTK data
+        sandbox before the directory is created or any file is written: an
+        outside-root destination is refused instead of being written through
+        (GHSA-8mgp-746c-j5xp). It defaults to :attr:`save_dir`, which is already
+        inside a data root.
+        """
         if not loc:
             loc = self.save_dir
-        # On POSIX the default TRAINED_TAGGER_PATH is a shared, world-writable
-        # temp dir (/tmp) and the save dir is a *guessable* name in it, so a
-        # local attacker can pre-plant or race a symlink at ``loc``. A plain
-        # ``islink`` pre-check is non-atomic (TOCTOU) and misses it once created;
+        validate_path(loc, context="PerceptronTagger.save_to_json")
+        # A ``loc`` inside an allowed root can still be a *guessable* name that a
+        # local attacker pre-plants or races a symlink at. A plain ``islink``
+        # pre-check is non-atomic (TOCTOU) and misses it once created;
         # ``_open_private_model_dir`` instead creates/re-opens the leaf atomically
         # with O_NOFOLLOW|O_DIRECTORY, verifies it is a real, user-owned,
         # non-world-writable directory, and returns a pinned fd we write relative
         # to (CWE-59/377/378).
         #
-        # On Windows ``%TEMP%`` is per-user and ACL-protected (no such squat), and
+        # On Windows the per-user profile is ACL-protected (no such squat), and
         # ``os.open`` cannot open a directory as a descriptor there, so use a
-        # plain create + write.
+        # plain create + sandboxed write.
         if os.name != "posix":
             os.makedirs(loc, exist_ok=True)
-            _authorize_private_dir(loc)
             for param, json_file in zip(self.encode_json_obj(), self.param_files(lang)):
-                with open(path_join(loc, json_file), "w") as fout:
+                target = path_join(loc, json_file)
+                with pathsec_open(
+                    target, "w", context="PerceptronTagger.save_to_json"
+                ) as fout:
                     json.dump(param, fout)
             return
 
         dir_fd = _open_private_model_dir(loc)
         try:
-            _authorize_private_dir(loc)
-
             # Write each model file relative to the pinned directory fd (where
             # supported) with O_NOFOLLOW (0600), so neither the dir nor the file
             # can be redirected outside the verified directory after the check.
@@ -367,9 +413,15 @@ class PerceptronTagger(TaggerI):
                     path, flags | getattr(os, "O_NOFOLLOW", 0), 0o600, **extra
                 )
 
+            # builtins.open with an explicit ``opener`` (not pathsec.open, which
+            # owns its own os.open and takes no opener): ``loc`` is already
+            # sandbox-validated above and the pinned dir_fd + O_NOFOLLOW is the
+            # stronger, race-free containment for the leaf write.
             for param, json_file in zip(self.encode_json_obj(), self.param_files(lang)):
                 target = json_file if use_dir_fd else path_join(loc, json_file)
-                with open(target, "w", opener=_no_follow_opener) as fout:
+                with open(  # sandboxed-open ok: dir_fd + O_NOFOLLOW opener
+                    target, "w", opener=_no_follow_opener
+                ) as fout:
                     json.dump(param, fout)
         finally:
             os.close(dir_fd)
@@ -392,13 +444,12 @@ class PerceptronTagger(TaggerI):
             loc = FileSystemPathPointer(str(loc))
         # else: assume loc is already a PathPointer (zip or filesystem)
 
-        # A trained model saved under the (private) system-temp trained-tagger
-        # dir lives outside nltk_data; authorize that specific private directory
-        # so it can be read back under the pathsec sandbox.
-        loc_path = getattr(loc, "path", None)
-        if loc_path and os.path.isdir(loc_path):
-            _authorize_private_dir(loc_path)
-
+        # No sandbox widening here: a trained model is saved under save_dir,
+        # which is already inside a data root, so the read below goes through
+        # open_datafile -> pathsec.open unaided. Appending a caller-supplied
+        # directory to nltk.data.path would make it an allowed root
+        # process-wide and disarm the containment check for every later read
+        # (GHSA-8mgp-746c-j5xp).
         def load_param(json_file):
             with open_datafile(loc, json_file) as fin:
                 return json.load(fin)

--- a/nltk/tag/stanford.py
+++ b/nltk/tag/stanford.py
@@ -22,6 +22,7 @@ import warnings
 from abc import abstractmethod
 from subprocess import PIPE
 
+from nltk.data import staging_tempdir
 from nltk.internals import find_file, find_jar, java
 from nltk.pathsec import validate_tool_path
 from nltk.tag.api import TaggerI
@@ -100,7 +101,9 @@ class StanfordTagger(TaggerI):
         java_succeeded = False
         try:
             # Create a temporary input file
-            _input_fh, input_file_path = tempfile.mkstemp(text=True)
+            _input_fh, input_file_path = tempfile.mkstemp(
+                text=True, dir=staging_tempdir()
+            )
             self._input_file_path = input_file_path
 
             cmd = list(self._cmd)

--- a/nltk/tag/stanford.py
+++ b/nltk/tag/stanford.py
@@ -23,6 +23,7 @@ from abc import abstractmethod
 from subprocess import PIPE
 
 from nltk.internals import find_file, find_jar, java
+from nltk.pathsec import validate_path
 from nltk.tag.api import TaggerI
 
 _stanford_url = "https://nlp.stanford.edu/software"
@@ -108,6 +109,10 @@ class StanfordTagger(TaggerI):
                 if isinstance(_input, str) and encoding:
                     _input = _input.encode(encoding)
                 input_fh.write(_input)
+
+            # ``self._stanford_model`` (from find_file) is handed to the JVM subprocess
+            # pathsec.open cannot wrap; validate it before spawning (GHSA-8mgp-746c-j5xp).
+            validate_path(self._stanford_model, context="StanfordTagger.tag_sents")
 
             # Run the tagger and get the output
             stanpos_output, _stderr = java(

--- a/nltk/tag/stanford.py
+++ b/nltk/tag/stanford.py
@@ -23,7 +23,7 @@ from abc import abstractmethod
 from subprocess import PIPE
 
 from nltk.internals import find_file, find_jar, java
-from nltk.pathsec import validate_path
+from nltk.pathsec import validate_tool_path
 from nltk.tag.api import TaggerI
 
 _stanford_url = "https://nlp.stanford.edu/software"
@@ -75,6 +75,9 @@ class StanfordTagger(TaggerI):
         self._stanford_model = find_file(
             model_filename, env_vars=("STANFORD_MODELS",), verbose=verbose
         )
+        # Fail fast: the model is a JVM subprocess argument, so bound it here as
+        # well as at the hand-off, and never keep an out-of-sandbox path around.
+        validate_tool_path(self._stanford_model, context=f"{type(self).__name__}")
 
         self._encoding = encoding
         self.java_options = java_options
@@ -111,8 +114,8 @@ class StanfordTagger(TaggerI):
                 input_fh.write(_input)
 
             # ``self._stanford_model`` (from find_file) is handed to the JVM subprocess
-            # pathsec.open cannot wrap; validate it before spawning (GHSA-8mgp-746c-j5xp).
-            validate_path(self._stanford_model, context="StanfordTagger.tag_sents")
+            # pathsec.open cannot wrap; bound it before spawning (GHSA-8mgp-746c-j5xp).
+            validate_tool_path(self._stanford_model, context="StanfordTagger.tag_sents")
 
             # Run the tagger and get the output
             stanpos_output, _stderr = java(

--- a/nltk/tbl/demo.py
+++ b/nltk/tbl/demo.py
@@ -13,6 +13,7 @@ import random
 import time
 
 from nltk.corpus import treebank
+from nltk.pathsec import open as pathsec_open
 from nltk.picklesec import pickle_load
 from nltk.tag import BrillTaggerTrainer, RegexpTagger, UnigramTagger
 from nltk.tag.brill import Pos, Word
@@ -246,14 +247,20 @@ def postag(
             baseline_tagger = UnigramTagger(
                 baseline_data, backoff=baseline_backoff_tagger
             )
-            with open(cache_baseline_tagger, "wb") as print_rules:
+            # ``cache_baseline_tagger`` is caller-supplied, so the model
+            # write/read goes through the pathsec sandbox (GHSA-8mgp-746c-j5xp).
+            with pathsec_open(
+                cache_baseline_tagger, "wb", context="tbl.demo.cache_baseline_tagger"
+            ) as print_rules:
                 pickle.dump(baseline_tagger, print_rules)
             print(
                 "Trained baseline tagger, pickled it to {}".format(
                     cache_baseline_tagger
                 )
             )
-        with open(cache_baseline_tagger, "rb") as print_rules:
+        with pathsec_open(
+            cache_baseline_tagger, "rb", context="tbl.demo.cache_baseline_tagger"
+        ) as print_rules:
             baseline_tagger = pickle_load(print_rules)
             print(f"Reloaded pickled tagger from {cache_baseline_tagger}")
     else:
@@ -314,18 +321,24 @@ def postag(
 
     # writing error analysis to file
     if error_output is not None:
-        with open(error_output, "w") as f:
+        with pathsec_open(
+            error_output, "w", context="tbl.demo.error_output", encoding="utf-8"
+        ) as f:
             f.write("Errors for Brill Tagger %r\n\n" % serialize_output)
-            f.write("\n".join(error_list(gold_data, taggedtest)).encode("utf-8") + "\n")
+            f.write("\n".join(error_list(gold_data, taggedtest)) + "\n")
         print(f"Wrote tagger errors including context to {error_output}")
 
     # serializing the tagger to a pickle file and reloading (just to see it works)
     if serialize_output is not None:
         taggedtest = brill_tagger.tag_sents(testing_data)
-        with open(serialize_output, "wb") as print_rules:
+        with pathsec_open(
+            serialize_output, "wb", context="tbl.demo.serialize_output"
+        ) as print_rules:
             pickle.dump(brill_tagger, print_rules)
         print(f"Wrote pickled tagger to {serialize_output}")
-        with open(serialize_output, "rb") as print_rules:
+        with pathsec_open(
+            serialize_output, "rb", context="tbl.demo.serialize_output"
+        ) as print_rules:
             brill_tagger_reloaded = pickle_load(print_rules)
         print(f"Reloaded pickled tagger from {serialize_output}")
         taggedtest_reloaded = brill_tagger_reloaded.tag_sents(testing_data)

--- a/nltk/tbl/demo.py
+++ b/nltk/tbl/demo.py
@@ -14,6 +14,7 @@ import time
 
 from nltk.corpus import treebank
 from nltk.pathsec import open as pathsec_open
+from nltk.pathsec import validate_path
 from nltk.picklesec import pickle_load
 from nltk.tag import BrillTaggerTrainer, RegexpTagger, UnigramTagger
 from nltk.tag.brill import Pos, Word
@@ -389,6 +390,13 @@ def _demo_prepare_data(
 
 
 def _demo_plot(learning_curve_output, teststats, trainstats=None, take=None):
+    """Write the learning-curve plot to ``learning_curve_output``.
+
+    The destination is caller-supplied and matplotlib writes it itself, so the
+    path is checked against the NLTK data sandbox before any work is done
+    (GHSA-8mgp-746c-j5xp); ``pathsec.open`` cannot wrap a ``savefig``.
+    """
+    validate_path(learning_curve_output, context="tbl.demo.learning_curve_output")
     testcurve = [teststats["initialerrors"]]
     for rulescore in teststats["rulescores"]:
         testcurve.append(testcurve[-1] - rulescore)

--- a/nltk/test/internals.doctest
+++ b/nltk/test/internals.doctest
@@ -178,12 +178,32 @@ wrappers pass are equivalent and also permitted:
 >>> _validate_java_options(["-mx2g"])
 >>> _validate_java_options(["-ms128m"])
 >>> _validate_java_options(["-ss4m"])
->>> _validate_java_options(["-XX:+UseG1GC"])
 >>> _validate_java_options(["-verbose:gc"])
 >>> _validate_java_options(["-server"])
 >>> _validate_java_options(["-client"])
->>> _validate_java_options(["-Dsome.property=value"])
->>> _validate_java_options(["-Xmx1g", "-Dsome.key=val", "-server"])
+>>> _validate_java_options(["-Xmx1g", "-server"])
+
+The filter is an allowlist, so ``-XX:`` and ``-D`` flags are refused even though
+they look innocuous: ``-XX:`` can name a file the JVM executes on error and
+``-D`` can redirect class loading or disarm the security manager. Pass a genuinely
+needed one through ``java(trusted_raw_options=...)``:
+
+>>> _validate_java_options(["-XX:+UseG1GC"])  # doctest: +ELLIPSIS
+Traceback (most recent call last):
+    ...
+ValueError: java_options contains a disallowed JVM/launcher flag: '-XX:+UseG1GC'...
+
+>>> _validate_java_options(["-Dsome.property=value"])  # doctest: +ELLIPSIS
+Traceback (most recent call last):
+    ...
+ValueError: java_options contains a disallowed JVM/launcher flag: '-Dsome.property=value'...
+
+A single bad flag rejects the whole list, even mixed with permitted ones:
+
+>>> _validate_java_options(["-Xmx1g", "-Dsome.key=val", "-server"])  # doctest: +ELLIPSIS
+Traceback (most recent call last):
+    ...
+ValueError: java_options contains a disallowed JVM/launcher flag: '-Dsome.key=val'...
 
 Agent-loading and JDWP flags are blocked:
 

--- a/nltk/test/unit/security_probes/ghsa_3gq4_3j92_5w49.py
+++ b/nltk/test/unit/security_probes/ghsa_3gq4_3j92_5w49.py
@@ -1,5 +1,7 @@
 """GHSA-3gq4-3j92-5w49 [high] -- Corpus Reader Sandbox Bypass"""
 
+import os
+
 from ._base import escape_probe, probe
 
 
@@ -13,7 +15,12 @@ def _lin_constructor_bypass():
     from nltk.corpus.reader.lin import LinThesaurusCorpusReader
 
     def load(box):
-        reader = LinThesaurusCorpusReader(box.root, ["link.xml"])
+        # The reader eagerly opens files matching sim[A-Z].lsp; the symlink must
+        # match that pattern or the constructor never reaches the guard.
+        simlink = os.path.join(box.root, "simA.lsp")
+        if not os.path.exists(simlink):
+            os.symlink(box.target or "/nonexistent", simlink)
+        reader = LinThesaurusCorpusReader(box.root)
         return "".join(str(v) for v in getattr(reader, "_thesaurus", {}).values())
 
-    return escape_probe([("LinThesaurus(symlink root)", load)])
+    return escape_probe([("LinThesaurus(simA.lsp symlink)", load)])

--- a/nltk/test/unit/security_probes/ghsa_3gqm_fcw5_w839.py
+++ b/nltk/test/unit/security_probes/ghsa_3gqm_fcw5_w839.py
@@ -12,6 +12,10 @@ def _ssrf_fail_open():
     # connect. urlopen re-resolves and pins the numeric address.
     from nltk import pathsec
 
+    # _resolve_hostname is lru_cached; clear it so the call-sequencing below is not
+    # desynced by a cached validation resolve on a second run (would false-VULN).
+    pathsec._resolve_hostname.cache_clear()
+
     real = socket.getaddrinfo
     calls = []
 

--- a/nltk/test/unit/security_probes/ghsa_4489_j4f3_2g8q.py
+++ b/nltk/test/unit/security_probes/ghsa_4489_j4f3_2g8q.py
@@ -1,19 +1,42 @@
 """GHSA-4489-j4f3-2g8q [high] -- nltk ≤ 3.10.2: unpickler dotted-name RCE bypass"""
 
 import io
+import pickle
 
 from ._base import FIXED, VULNERABLE, probe
 
 
+def _dotted_global(module, name):
+    """A protocol-4 pickle whose STACK_GLOBAL carries a dotted attribute chain."""
+    su = lambda s: pickle.SHORT_BINUNICODE + bytes([len(s.encode())]) + s.encode()
+    return (
+        pickle.PROTO + bytes([4]) + su(module) + su(name) + pickle.STACK_GLOBAL + b"."
+    )
+
+
 @probe("GHSA-4489-j4f3-2g8q")
 def _unpickler_dotted_name():
-    """Dotted `name` resolved through find_class reached a command sink."""
-    from nltk.picklesec import AllowlistUnpickler
+    """A real proto-4 load whose global rides a dotted attribute chain must be
+    refused before the chain is walked (the getattr-traversal RCE, not a poke at
+    find_class at proto 0 where stock pickle already errors for the wrong reason).
+    """
+    from nltk.picklesec import allowlisted_pickle_load
 
-    try:
-        AllowlistUnpickler(io.BytesIO(b"")).find_class(
-            "nltk.tokenize", "repp.ReppTokenizer._execute"
-        )
-        return VULNERABLE, "dotted name resolved through find_class"
-    except Exception as exc:
-        return FIXED, "dotted name rejected (%s)" % type(exc).__name__
+    gadgets = [
+        ("collections", "OrderedDict.fromkeys"),  # resolvable dotted chain
+        ("sklearn", "os.system"),
+        ("nltk.tokenize", "repp.ReppTokenizer._execute"),
+    ]
+    for module, name in gadgets:
+        try:
+            allowlisted_pickle_load(
+                io.BytesIO(_dotted_global(module, name)),
+                allowed_modules=(module.split(".")[0],),
+            )
+            return VULNERABLE, f"dotted name {module}.{name} resolved"
+        except pickle.UnpicklingError as exc:
+            if "dotted name" not in str(exc):
+                return VULNERABLE, f"{module}.{name} blocked but not as a dotted name"
+        except Exception:
+            return VULNERABLE, f"{module}.{name} failed before the dotted-name guard"
+    return FIXED, "proto-4 dotted-name globals rejected before traversal"

--- a/nltk/test/unit/security_probes/ghsa_469j_vmhf_r6v7.py
+++ b/nltk/test/unit/security_probes/ghsa_469j_vmhf_r6v7.py
@@ -1,14 +1,38 @@
 """GHSA-469j-vmhf-r6v7 [high] -- Downloader Path Traversal Vulnerability (AFO) - Arbitrary File Overwrite"""
 
-from ._base import STATIC, VULNERABLE, probe, read_source
+import os
+import shutil
+import tempfile
+import zipfile
+
+from ._base import FIXED, STATIC, VULNERABLE, probe
 
 
 @probe("GHSA-469j-vmhf-r6v7")
 def _downloader_index_traversal():
-    """subdir/id from a remote XML index were not validated (AFO)."""
-    source = read_source("nltk.downloader")
-    guards = ("validate_path", "pathsec", "_safe_join", "commonpath", "resolve()")
-    if not any(g in source for g in guards):
-        return VULNERABLE, "downloader.py contains no path-containment guard"
-    hits = [g for g in guards if g in source]
-    return STATIC, "downloader guards present: %s" % ", ".join(hits[:3])
+    """Extract a package archive whose member escapes the extraction root.
+
+    A zip-slip member (``../CANARY``) must be rejected by the validate-then-
+    extract pass, leaving the outside-root canary untouched. Scored on behaviour
+    (the canary's bytes), since the rejection wording is not a generic marker.
+    """
+    from nltk.downloader import ErrorMessage, _unzip_iter
+
+    box = tempfile.mkdtemp()
+    try:
+        outside = os.path.join(box, "CANARY")
+        with open(outside, "w", encoding="utf-8") as fh:
+            fh.write("ORIGINAL")
+        dest = os.path.join(box, "dest")
+        member = os.path.relpath(outside, dest)  # ../CANARY, escapes dest
+        evil = os.path.join(box, "evil.zip")
+        with zipfile.ZipFile(evil, "w") as zf:
+            zf.writestr(member, "PWNED")
+        messages = list(_unzip_iter(evil, dest, verbose=False))
+        if open(outside, encoding="utf-8").read() != "ORIGINAL":
+            return VULNERABLE, "zip-slip member overwrote the outside-root canary"
+        if any(isinstance(m, ErrorMessage) for m in messages):
+            return FIXED, "zip-slip member rejected; outside canary intact"
+        return STATIC, "extraction fizzled without reaching the containment check"
+    finally:
+        shutil.rmtree(box, ignore_errors=True)

--- a/nltk/test/unit/security_probes/ghsa_469j_vmhf_r6v7.py
+++ b/nltk/test/unit/security_probes/ghsa_469j_vmhf_r6v7.py
@@ -10,29 +10,53 @@ from ._base import FIXED, STATIC, VULNERABLE, probe
 
 @probe("GHSA-469j-vmhf-r6v7")
 def _downloader_index_traversal():
-    """Extract a package archive whose member escapes the extraction root.
+    """Extract package archives whose members escape the extraction root.
 
-    A zip-slip member (``../CANARY``) must be rejected by the validate-then-
-    extract pass, leaving the outside-root canary untouched. Scored on behaviour
-    (the canary's bytes), since the rejection wording is not a generic marker.
+    Several arbitrary-file-write vectors are fired at ``_unzip_iter``: a ``../``
+    zip-slip, a deeper traversal, an absolute member, and a member routed through
+    a pre-planted symlink. Each must be rejected by the validate-then-extract
+    pass, leaving the outside-root canary untouched. Scored on behaviour (the
+    canary's bytes), since the rejection wording is not a generic marker.
     """
     from nltk.downloader import ErrorMessage, _unzip_iter
 
     box = tempfile.mkdtemp()
     try:
         outside = os.path.join(box, "CANARY")
-        with open(outside, "w", encoding="utf-8") as fh:
-            fh.write("ORIGINAL")
-        dest = os.path.join(box, "dest")
-        member = os.path.relpath(outside, dest)  # ../CANARY, escapes dest
-        evil = os.path.join(box, "evil.zip")
-        with zipfile.ZipFile(evil, "w") as zf:
-            zf.writestr(member, "PWNED")
-        messages = list(_unzip_iter(evil, dest, verbose=False))
-        if open(outside, encoding="utf-8").read() != "ORIGINAL":
-            return VULNERABLE, "zip-slip member overwrote the outside-root canary"
-        if any(isinstance(m, ErrorMessage) for m in messages):
-            return FIXED, "zip-slip member rejected; outside canary intact"
+        notes = []
+        reached = False
+        vectors = (
+            ("zip-slip", lambda dest: os.path.relpath(outside, dest)),  # ../CANARY
+            ("deep-traversal", lambda dest: "../../../../../../../.." + outside),
+            ("absolute", lambda dest: "/" + outside.lstrip("/")),  # /.../CANARY
+            ("symlinked-dir", "SYMLINK"),
+        )
+        for label, make in vectors:
+            with open(outside, "w", encoding="utf-8") as fh:
+                fh.write("ORIGINAL")
+            dest = os.path.join(box, "dest_" + label)
+            os.makedirs(dest, exist_ok=True)
+            evil = os.path.join(box, label + ".zip")
+            if make == "SYMLINK":
+                # a pre-planted symlink inside dest pointing at the outside file;
+                # a member written "through" it would overwrite the canary.
+                link = os.path.join(dest, "CANARY")
+                os.symlink(outside, link)
+                member = "CANARY"
+            else:
+                member = make(dest)
+            with zipfile.ZipFile(evil, "w") as zf:
+                zf.writestr(member, "PWNED")
+            messages = list(_unzip_iter(evil, dest, verbose=False))
+            if open(outside, encoding="utf-8").read() != "ORIGINAL":
+                return VULNERABLE, f"{label} member overwrote the outside-root canary"
+            if any(isinstance(m, ErrorMessage) for m in messages):
+                reached = True
+                notes.append(f"{label}=blocked")
+            else:
+                notes.append(f"{label}=no-write")
+        if reached:
+            return FIXED, "; ".join(notes)
         return STATIC, "extraction fizzled without reaching the containment check"
     finally:
         shutil.rmtree(box, ignore_errors=True)

--- a/nltk/test/unit/security_probes/ghsa_568f_pv23_39p4.py
+++ b/nltk/test/unit/security_probes/ghsa_568f_pv23_39p4.py
@@ -1,11 +1,28 @@
 """GHSA-568f-pv23-39p4 [medium] -- Stable FrameNet and NKJP readers parse outside-root XML in 3.9.4"""
 
-from ._base import guard_rejects, probe
+from ._base import FIXED, VULNERABLE, guard_rejects, probe
 
 
 @probe("GHSA-568f-pv23-39p4")
 def _framenet_nkjp_outside_root_xml():
-    """FrameNet/NKJP entrypoints built parser paths that left the root."""
-    from nltk.corpus.reader.framenet import _validate_in_root
+    """FrameNet/NKJP entrypoints built parser paths that left the root.
 
-    return guard_rejects(lambda path, root: _validate_in_root(path, root, "framenet"))
+    The advisory covers both readers, so drive both containment guards: a
+    regression in either one must fail this probe.
+    """
+    from nltk.corpus.reader.framenet import _validate_in_root
+    from nltk.pathsec import validate_path
+
+    guards = {
+        "framenet": lambda path, root: _validate_in_root(path, root, "framenet"),
+        "nkjp": lambda path, root: validate_path(
+            path, context="NKJPCorpusReader", required_root=root
+        ),
+    }
+    passed = []
+    for name, guard in guards.items():
+        status, evidence = guard_rejects(guard)
+        if status == VULNERABLE:
+            return VULNERABLE, f"{name}: {evidence}"
+        passed.append(f"{name}={status.lower()}")
+    return FIXED, "both reader guards security-reject escapes: " + ", ".join(passed)

--- a/nltk/test/unit/security_probes/ghsa_5wp5_5229_5g6q.py
+++ b/nltk/test/unit/security_probes/ghsa_5wp5_5229_5g6q.py
@@ -6,6 +6,8 @@ import shutil
 import tempfile
 import zipfile
 
+from nltk import pathsec
+
 from ._base import FIXED, STATIC, VULNERABLE, probe
 
 
@@ -25,7 +27,9 @@ def _downloader_integrity():
     nltk.data.path.insert(0, box)
     try:
         pkgzip = os.path.join(box, "evil.zip")
-        with zipfile.ZipFile(pkgzip, "w") as zf:
+        # box is registered as a data root above, so this stages INSIDE the
+        # sandbox and must go through pathsec like any other in-root write.
+        with pathsec.ZipFile(pkgzip, "w") as zf:
             zf.writestr("evil/data.txt", "payload")
         size = os.path.getsize(pkgzip)
         with open(pkgzip, "rb") as fh:

--- a/nltk/test/unit/security_probes/ghsa_5wp5_5229_5g6q.py
+++ b/nltk/test/unit/security_probes/ghsa_5wp5_5229_5g6q.py
@@ -1,14 +1,65 @@
 """GHSA-5wp5-5229-5g6q [high] -- Missing Post-Download Integrity Verification Allows Malicious Package Injection"""
 
-from ._base import STATIC, VULNERABLE, probe, read_source
+import hashlib
+import os
+import shutil
+import tempfile
+import zipfile
+
+from ._base import FIXED, STATIC, VULNERABLE, probe
 
 
 @probe("GHSA-5wp5-5229-5g6q")
 def _downloader_integrity():
-    """No integrity verification between download and extraction."""
-    source = read_source("nltk.downloader")
-    markers = ("checksum", "sha256", "hashlib", "digest")
-    hits = [m for m in markers if m in source]
-    if not hits:
-        return VULNERABLE, "downloader.py performs no post-download verification"
-    return STATIC, "integrity check present (%s)" % ", ".join(hits[:3])
+    """Download a package whose bytes do not match its declared sha256.
+
+    Served over file:// (offline), a tampered archive must be refused before it
+    is committed to the install tree, and a matching digest must then install so
+    the check is proven to run rather than always pass.
+    """
+    import nltk.data
+    from nltk.downloader import Downloader, ErrorMessage, Package
+
+    box = tempfile.mkdtemp()
+    # authorize the temp dir as a data root so the download write itself is allowed
+    nltk.data.path.insert(0, box)
+    try:
+        pkgzip = os.path.join(box, "evil.zip")
+        with zipfile.ZipFile(pkgzip, "w") as zf:
+            zf.writestr("evil/data.txt", "payload")
+        size = os.path.getsize(pkgzip)
+        with open(pkgzip, "rb") as fh:
+            good = hashlib.sha256(fh.read()).hexdigest()
+        dest = os.path.join(box, "dl")
+        os.makedirs(dest)
+        installed = os.path.join(dest, "corpora", "evil.zip")
+
+        def run(digest):
+            pkg = Package(
+                id="evil",
+                url="file://" + pkgzip,
+                subdir="corpora",
+                size=size,
+                unzipped_size=64,
+            )
+            pkg.sha256_checksum = digest
+            msgs = list(
+                Downloader()._download_package(pkg, download_dir=dest, force=True)
+            )
+            return any(
+                isinstance(m, ErrorMessage) and "sha256" in str(m.message) for m in msgs
+            )
+
+        rejected = run("de" * 32)  # a wrong 64-hex digest
+        if os.path.exists(installed):
+            return VULNERABLE, "tampered package installed despite sha256 mismatch"
+        if not rejected:
+            return STATIC, "download fizzled before reaching the integrity gate"
+        run(good)  # positive control: the matching digest must install
+        if not os.path.exists(installed):
+            return STATIC, "integrity gate also rejected a matching digest"
+        return FIXED, "sha256 mismatch refused before commit; matching digest installs"
+    finally:
+        if box in nltk.data.path:
+            nltk.data.path.remove(box)
+        shutil.rmtree(box, ignore_errors=True)

--- a/nltk/test/unit/security_probes/ghsa_6hm5_jgcp_p838.py
+++ b/nltk/test/unit/security_probes/ghsa_6hm5_jgcp_p838.py
@@ -1,19 +1,64 @@
 """GHSA-6hm5-jgcp-p838 [high] -- Path Traversal in NKJPCorpusReader leads to Arbitrary File Read and bypasses the nltk.pathsec sandbox (ENFORCE=True)"""
 
-from ._base import guard_rejects, probe
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+from ._base import FIXED, STATIC, VULNERABLE, is_security_rejection, probe
 
 
 @probe("GHSA-6hm5-jgcp-p838")
 def _nkjp_traversal():
     """NKJP read methods built the file path from a caller fileid.
 
-    add_root() is the containment guard the fix routes through; drive it with
-    outside-root paths.
+    Drive add_root() on a real reader: it is the containment guard every public
+    read routes through, so this exercises NKJP's own code rather than pathsec in
+    isolation. Escapes must be security-refused, and a payload that is merely an
+    odd in-root filename must still resolve inside the root.
     """
-    from nltk.pathsec import validate_path
+    from nltk.corpus.reader.nkjp import NKJPCorpusReader
 
-    return guard_rejects(
-        lambda path, root: validate_path(
-            path, context="NKJPCorpusReader", required_root=root
-        )
-    )
+    box = tempfile.mkdtemp()
+    try:
+        root = os.path.join(box, "nkjp")
+        os.makedirs(root)
+        reader = NKJPCorpusReader(root=root)
+        os.symlink(os.path.dirname(box), os.path.join(root, "linkdir"))
+
+        escapes = {
+            "traversal": "../" * 8 + "etc/passwd",
+            "absolute": "/etc/passwd",
+            "symlinked-dir": "linkdir/passwd",
+        }
+        refused = []
+        for label, fileid in escapes.items():
+            try:
+                landed = reader.add_root(fileid)
+            except Exception as exc:
+                if not is_security_rejection(exc):
+                    return (
+                        STATIC,
+                        f"{label} failed before the guard ({type(exc).__name__})",
+                    )
+                refused.append(label)
+                continue
+            return VULNERABLE, f"add_root({label}) returned {landed!r}"
+
+        # A backslash payload is a separator on Windows but a literal filename on
+        # POSIX; either refuse it or keep it inside the root, never escape.
+        try:
+            landed = reader.add_root("..\\..\\etc\\passwd")
+        except Exception as exc:
+            if not is_security_rejection(exc):
+                return STATIC, "backslash failed before the guard"
+            refused.append("backslash")
+        else:
+            resolved = Path(landed).resolve()
+            root_resolved = Path(root).resolve()
+            if resolved != root_resolved and root_resolved not in resolved.parents:
+                return VULNERABLE, f"backslash payload escaped to {landed!r}"
+            refused.append("backslash=contained")
+        return FIXED, "add_root refused: " + ", ".join(refused)
+    finally:
+        shutil.rmtree(box, ignore_errors=True)

--- a/nltk/test/unit/security_probes/ghsa_6hwm_xvph_95vm.py
+++ b/nltk/test/unit/security_probes/ghsa_6hwm_xvph_95vm.py
@@ -1,12 +1,42 @@
 """GHSA-6hwm-xvph-95vm [low] -- Uncontrolled search path when invoking the Graphviz 'dot' binary (CWE-426/CWE-427)"""
 
-from ._base import BENIGN, STATIC, probe, read_source
+import os
+import shutil
+import stat
+import tempfile
+
+from ._base import FIXED, STATIC, VULNERABLE, probe
 
 
 @probe("GHSA-6hwm-xvph-95vm")
 def _graphviz_search_path():
-    """Uncontrolled search path when invoking the Graphviz 'dot' binary."""
-    source = read_source("nltk.parse.dependencygraph")
-    if "shutil.which" in source or "find_binary" in source:
-        return STATIC, "binary resolved through an explicit lookup"
-    return BENIGN, "no bare 'dot' invocation found"
+    """Plant an executable ./dot in the CWD and resolve the bare name.
+
+    ``find_binary`` must not hand back a binary from the current working
+    directory (attacker-writable, untrusted): it either raises ``LookupError``
+    naming the CWD, or returns a real absolute system ``dot`` and ignores the
+    plant. Returning the planted relative file would be the search-path bypass.
+    """
+    from nltk.internals import find_binary
+
+    box = tempfile.mkdtemp()
+    plant = os.path.join(box, "dot")
+    with open(plant, "w", encoding="utf-8") as fh:
+        fh.write("#!/bin/sh\necho PWNED\n")
+    os.chmod(plant, os.stat(plant).st_mode | stat.S_IEXEC)
+    old = os.getcwd()
+    try:
+        os.chdir(box)
+        try:
+            result = find_binary("dot")
+        except LookupError as exc:
+            if "current working directory" in str(exc):
+                return FIXED, "planted ./dot refused (CWD is not a trusted location)"
+            return STATIC, "dot absent; lookup did not reach the CWD plant"
+        planted = os.path.realpath(plant)
+        if os.path.isabs(result) and os.path.realpath(result) != planted:
+            return FIXED, "ignored planted ./dot, used trusted %s" % result
+        return VULNERABLE, "find_binary returned the planted CWD file: %r" % result
+    finally:
+        os.chdir(old)
+        shutil.rmtree(box, ignore_errors=True)

--- a/nltk/test/unit/security_probes/ghsa_8846_p9w9_5frf.py
+++ b/nltk/test/unit/security_probes/ghsa_8846_p9w9_5frf.py
@@ -1,18 +1,22 @@
-from ._base import FIXED, VULNERABLE, probe
 from nltk.util import acyclic_depth_first
+
+from ._base import FIXED, VULNERABLE, probe
+
 
 class MockNode:
     def __init__(self, name, children=None):
         self.name = name
         self._children = children or []
+
     def rel(self):
         return self._children
+
 
 @probe("GHSA-8846-p9w9-5frf")
 def test_wordnet_recursion():
     nodes = [MockNode(str(i)) for i in range(1500)]
     for i in range(1499):
-        nodes[i]._children = [nodes[i+1]]
+        nodes[i]._children = [nodes[i + 1]]
     try:
         list(acyclic_depth_first(nodes[0], lambda x: x.rel(), depth=-1))
         return (FIXED, "Depth cap prevents recursion overflow")

--- a/nltk/test/unit/security_probes/ghsa_8mgp_746c_j5xp.py
+++ b/nltk/test/unit/security_probes/ghsa_8mgp_746c_j5xp.py
@@ -3,19 +3,37 @@
 import os
 import tempfile
 
-from ._base import FIXED, VULNERABLE, probe
+from ._base import FIXED, VULNERABLE, is_security_rejection, probe
 
 
 @probe("GHSA-8mgp-746c-j5xp")
 def _model_artifact_apis():
-    """Model-artifact read/write APIs treated caller paths as plain filenames."""
+    """Model-artifact read APIs must security-reject caller paths that escape the
+    allowed roots, via several forms (traversal, absolute, nltk:/file: URLs and a
+    NUL byte); a leak reads the outside file, a non-security error is not a pass.
+    """
     import nltk.data
 
-    try:
-        nltk.data.load(
-            os.path.join(tempfile.gettempdir(), "..", "..", "etc", "passwd"),
-            format="raw",
-        )
-        return VULNERABLE, "nltk.data.load reached outside an allowed root"
-    except Exception as exc:
-        return FIXED, "outside-root model path rejected (%s)" % type(exc).__name__
+    outside = "/etc/passwd"
+    payloads = [
+        os.path.join(tempfile.gettempdir(), "..", "..", "etc", "passwd"),
+        outside,
+        "nltk:" + outside,
+        "file://" + outside,
+        outside + "\x00.cfg",
+    ]
+    reached = False
+    for path in payloads:
+        try:
+            data = nltk.data.load(path, format="raw")
+        except Exception as exc:
+            if is_security_rejection(exc):
+                reached = True
+            continue
+        if isinstance(data, (str, bytes)) and (
+            "root:" in data if isinstance(data, str) else b"root:" in data
+        ):
+            return VULNERABLE, f"nltk.data.load read {outside} via {path!r}"
+    if reached:
+        return FIXED, "outside-root model paths security-rejected"
+    return FIXED, "outside-root model paths refused (no security marker reached)"

--- a/nltk/test/unit/security_probes/ghsa_8mgp_746c_j5xp.py
+++ b/nltk/test/unit/security_probes/ghsa_8mgp_746c_j5xp.py
@@ -1,42 +1,236 @@
 """GHSA-8mgp-746c-j5xp [high] -- Model-artifact APIs bypass pathsec and touch files outside allowed roots"""
 
+import contextlib
+import io
+import json
 import os
+import pathlib
+import shutil
 import tempfile
 
-from ._base import FIXED, VULNERABLE, is_security_rejection, probe
+from ._base import FIXED, STATIC, VULNERABLE, is_security_rejection, probe
+
+#: The canary an escaping read must hand back, and an escaping write must leave
+#: on disk outside the allowed roots.
+CANARY = "GHSA-8MGP-CANARY"
+
+#: ``lang`` for the throwaway tagger, so a probe run can never collide with a
+#: real ``averaged_perceptron_tagger_eng`` model.
+LANG = "probe8mgp"
+
+
+@contextlib.contextmanager
+def _outside_dir():
+    """A writable directory that is genuinely OUTSIDE every allowed pathsec root.
+
+    Not ``tempfile.mkdtemp()``: a *private* per-user system temp dir is itself an
+    allowed root on macOS/Windows, so an attack target staged there would be
+    correctly permitted and the probe would prove nothing. ``$HOME`` is not a
+    root (only ``~/nltk_data`` is), so a directory made there is a real escape
+    target. Yields ``None`` when it turns out to be inside a root anyway (an
+    operator may have put ``$HOME`` on ``nltk.data.path``), so the caller can
+    report STATIC instead of a bogus result.
+
+    Containment is compared against the allowed roots directly, never by calling
+    ``validate_path``: that answers "would this be refused", which is False once
+    ``ENFORCE`` is off, so the negative control would lose its escape target at
+    exactly the moment it needs one.
+    """
+    from nltk import pathsec
+
+    path = pathlib.Path(
+        tempfile.mkdtemp(prefix=".nltk_probe8mgp_", dir=str(pathlib.Path.home()))
+    )
+    try:
+        resolved = path.resolve()
+        inside = any(
+            resolved == root or resolved.is_relative_to(root)
+            for root in pathsec._get_allowed_roots()
+        )
+        yield None if inside else path
+    finally:
+        shutil.rmtree(path, ignore_errors=True)
+
+
+def _weights_files(loc, lang):
+    """Write the three json files ``PerceptronTagger.load_from_json`` reads.
+
+    Written with the stdlib writer on purpose: this is the *attacker's* plant,
+    staged outside the sandbox before the attack runs, not NLTK doing I/O.
+    """
+    payload = {
+        "weights": {CANARY: {"NN": 1.0}},
+        "tagdict": {},
+        "classes": ["NN"],
+    }
+    os.makedirs(loc, mode=0o700, exist_ok=True)
+    for attr, value in payload.items():
+        target = os.path.join(loc, f"averaged_perceptron_tagger_{lang}.{attr}.json")
+        pathlib.Path(target).write_text(json.dumps(value), encoding="utf-8")
+
+
+def _attempts(outside):
+    """(label, callable) for every API the advisory names, read and write.
+
+    Each callable must either be security-refused or leave evidence: a read
+    returns something containing ``CANARY``, a write returns the paths it
+    created outside the root. Returning a falsy value means "ran, escaped
+    nothing".
+    """
+    from nltk.parse.transitionparser import TransitionParser
+    from nltk.tag.perceptron import AveragedPerceptron, PerceptronTagger
+
+    def _tagger():
+        tagger = PerceptronTagger(load=False)
+        tagger.model.weights = {CANARY: {"NN": 1.0}}
+        tagger.tagdict = {}
+        tagger.classes = {"NN"}
+        return tagger
+
+    def perceptron_load():
+        target = os.path.join(outside, "weights.json")
+        pathlib.Path(target).write_text(
+            json.dumps({CANARY: {"NN": 1.0}}), encoding="utf-8"
+        )
+        model = AveragedPerceptron()
+        model.load(target)
+        return repr(model.weights)
+
+    def perceptron_save():
+        target = os.path.join(outside, "saved.json")
+        AveragedPerceptron({CANARY: {"NN": 1.0}}).save(target)
+        return pathlib.Path(target).read_text(encoding="utf-8")
+
+    def perceptron_save_symlink():
+        """A symlink inside a root pointing out of it must not carry the write."""
+        victim = os.path.join(outside, "victim.json")
+        pathlib.Path(victim).write_text("untouched", encoding="utf-8")
+        root = tempfile.mkdtemp(prefix="nltk_probe8mgp_root_")
+        link = os.path.join(root, "link.json")
+        try:
+            os.symlink(victim, link)
+        except OSError:
+            shutil.rmtree(root, ignore_errors=True)
+            return None
+        try:
+            AveragedPerceptron({CANARY: {"NN": 1.0}}).save(link)
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+        return pathlib.Path(victim).read_text(encoding="utf-8")
+
+    def tagger_save_to_json():
+        loc = os.path.join(outside, "tagger_save")
+        _tagger().save_to_json(lang=LANG, loc=loc)
+        return CANARY + " " + repr(sorted(os.listdir(loc)))
+
+    def tagger_load_from_json():
+        loc = os.path.join(outside, "tagger_load")
+        _weights_files(loc, LANG)
+        tagger = PerceptronTagger(load=False)
+        tagger.load_from_json(lang=LANG, loc=loc)
+        return repr(tagger.model.weights)
+
+    def tagger_ctor_loc():
+        loc = os.path.join(outside, "tagger_ctor")
+        _weights_files(loc, LANG)
+        return repr(PerceptronTagger(load=True, lang=LANG, loc=loc).model.weights)
+
+    def transition_parse():
+        target = os.path.join(outside, "model.pickle")
+        pathlib.Path(target).write_bytes(b"\x80\x04N.")
+        TransitionParser("arc-standard").parse([], target)
+        return CANARY + " read " + target
+
+    def maxent_save():
+        import numpy
+
+        from nltk.classify.maxent import save_maxent_params
+
+        loc = os.path.join(outside, "maxent_out")
+        save_maxent_params(
+            numpy.array([1.0]), {("a", "b"): 0}, ["L"], {"alwayson": 0}, tab_dir=loc
+        )
+        return CANARY + " " + repr(sorted(os.listdir(loc)))
+
+    def transition_train():
+        target = os.path.join(outside, "trained.pickle")
+        TransitionParser("arc-standard").train([], target, verbose=False)
+        return CANARY + " wrote " + target
+
+    def data_load_urls():
+        """The generic loader underneath the model APIs, in several path forms."""
+        import nltk.data
+
+        target = os.path.join(outside, "resource.txt")
+        pathlib.Path(target).write_text(CANARY, encoding="utf-8")
+        forms = [
+            target,
+            "nltk:" + target,
+            "file://" + target,
+            target + "\x00.cfg",
+            os.path.join(tempfile.gettempdir(), "..", "..", "etc", "passwd"),
+            "/etc/passwd",
+        ]
+        seen = []
+        for form in forms:
+            with contextlib.suppress(Exception):
+                # cache=False: nltk.data.load memoises by URL, so a read that
+                # succeeded in an earlier run would be replayed here and
+                # reported as a leak that is not there.
+                seen.append(str(nltk.data.load(form, format="raw", cache=False)))
+        return " ".join(seen)
+
+    return [
+        ("AveragedPerceptron.load", perceptron_load),
+        ("AveragedPerceptron.save", perceptron_save),
+        ("AveragedPerceptron.save/symlink", perceptron_save_symlink),
+        ("PerceptronTagger.save_to_json", tagger_save_to_json),
+        ("PerceptronTagger.load_from_json", tagger_load_from_json),
+        ("PerceptronTagger(loc=...)", tagger_ctor_loc),
+        ("TransitionParser.parse", transition_parse),
+        ("TransitionParser.train", transition_train),
+        ("save_maxent_params", maxent_save),
+        ("nltk.data.load", data_load_urls),
+    ]
 
 
 @probe("GHSA-8mgp-746c-j5xp")
 def _model_artifact_apis():
-    """Model-artifact read APIs must security-reject caller paths that escape the
-    allowed roots, via several forms (traversal, absolute, nltk:/file: URLs and a
-    NUL byte); a leak reads the outside file, a non-security error is not a pass.
+    """Every model-artifact API the advisory names must refuse an outside-root path.
 
-    Loads are uncached: nltk.data.load memoises by URL, so a successful read in
-    one run would be replayed to the next and report a leak that is not there.
+    The advisory is about ``TransitionParser.train``/``parse``,
+    ``AveragedPerceptron.save``/``load``, ``PerceptronTagger.save_to_json`` and
+    ``save_maxent_params`` treating a caller path as a plain filename, so the
+    probe drives those APIs, not only the generic loader underneath them: a
+    regression in any one of them is invisible to a probe that exercises
+    ``nltk.data.load`` alone.
+
+    A leak is evidence, not merely "the call returned": a read must hand back the
+    canary and a write must land outside the allowed roots. A refusal only counts
+    when it is security-marked, so an incidental ImportError/FileNotFoundError is
+    never scored as a defence.
     """
-    import nltk.data
-
-    outside = "/etc/passwd"
-    payloads = [
-        os.path.join(tempfile.gettempdir(), "..", "..", "etc", "passwd"),
-        outside,
-        "nltk:" + outside,
-        "file://" + outside,
-        outside + "\x00.cfg",
-    ]
-    reached = False
-    for path in payloads:
-        try:
-            data = nltk.data.load(path, format="raw", cache=False)
-        except Exception as exc:
-            if is_security_rejection(exc):
-                reached = True
-            continue
-        if isinstance(data, (str, bytes)) and (
-            "root:" in data if isinstance(data, str) else b"root:" in data
-        ):
-            return VULNERABLE, f"nltk.data.load read {outside} via {path!r}"
-    if reached:
-        return FIXED, "outside-root model paths security-rejected"
-    return FIXED, "outside-root model paths refused (no security marker reached)"
+    with _outside_dir() as outside:
+        if outside is None:
+            return STATIC, "$HOME is inside an allowed root here; no escape target"
+        reached, notes = False, []
+        for label, run in _attempts(str(outside)):
+            try:
+                # Several of these APIs print progress; a probe reports through
+                # its return value, so keep the harness output clean.
+                with contextlib.redirect_stdout(io.StringIO()):
+                    result = run()
+            except Exception as exc:
+                if is_security_rejection(exc):
+                    reached = True
+                    notes.append(f"{label}=blocked")
+                else:
+                    notes.append(f"{label}=unreached({type(exc).__name__})")
+                continue
+            if result and CANARY in str(result):
+                return VULNERABLE, f"{label} escaped the sandbox: {str(result)[:120]}"
+            notes.append(f"{label}=no-escape")
+        detail = "; ".join(notes)
+        if reached:
+            return FIXED, detail
+        return STATIC, "attack never reached a security check: " + detail

--- a/nltk/test/unit/security_probes/ghsa_8mgp_746c_j5xp.py
+++ b/nltk/test/unit/security_probes/ghsa_8mgp_746c_j5xp.py
@@ -157,6 +157,24 @@ def _attempts(outside):
         TransitionParser("arc-standard").train([], target, verbose=False)
         return CANARY + " wrote " + target
 
+    def crf_train():
+        """A native (pycrfsuite) writer given a caller path."""
+        from nltk.tag.crf import CRFTagger
+
+        target = os.path.join(outside, "model.crf")
+        CRFTagger().train(
+            [[("the", "DT"), ("dog", "NN")], [("a", "DT"), ("cat", "NN")]], target
+        )
+        return CANARY + " wrote " + target if os.path.exists(target) else None
+
+    def crf_load():
+        from nltk.tag.crf import CRFTagger
+
+        target = os.path.join(outside, "planted.crf")
+        pathlib.Path(target).write_bytes(b"not-a-real-model")
+        CRFTagger().set_model_file(target)
+        return CANARY + " opened " + target
+
     def data_load_urls():
         """The generic loader underneath the model APIs, in several path forms."""
         import nltk.data
@@ -190,6 +208,8 @@ def _attempts(outside):
         ("TransitionParser.parse", transition_parse),
         ("TransitionParser.train", transition_train),
         ("save_maxent_params", maxent_save),
+        ("CRFTagger.train", crf_train),
+        ("CRFTagger.set_model_file", crf_load),
         ("nltk.data.load", data_load_urls),
     ]
 

--- a/nltk/test/unit/security_probes/ghsa_8mgp_746c_j5xp.py
+++ b/nltk/test/unit/security_probes/ghsa_8mgp_746c_j5xp.py
@@ -3,19 +3,40 @@
 import os
 import tempfile
 
-from ._base import FIXED, VULNERABLE, probe
+from ._base import FIXED, VULNERABLE, is_security_rejection, probe
 
 
 @probe("GHSA-8mgp-746c-j5xp")
 def _model_artifact_apis():
-    """Model-artifact read/write APIs treated caller paths as plain filenames."""
+    """Model-artifact read APIs must security-reject caller paths that escape the
+    allowed roots, via several forms (traversal, absolute, nltk:/file: URLs and a
+    NUL byte); a leak reads the outside file, a non-security error is not a pass.
+
+    Loads are uncached: nltk.data.load memoises by URL, so a successful read in
+    one run would be replayed to the next and report a leak that is not there.
+    """
     import nltk.data
 
-    try:
-        nltk.data.load(
-            os.path.join(tempfile.gettempdir(), "..", "..", "etc", "passwd"),
-            format="raw",
-        )
-        return VULNERABLE, "nltk.data.load reached outside an allowed root"
-    except Exception as exc:
-        return FIXED, "outside-root model path rejected (%s)" % type(exc).__name__
+    outside = "/etc/passwd"
+    payloads = [
+        os.path.join(tempfile.gettempdir(), "..", "..", "etc", "passwd"),
+        outside,
+        "nltk:" + outside,
+        "file://" + outside,
+        outside + "\x00.cfg",
+    ]
+    reached = False
+    for path in payloads:
+        try:
+            data = nltk.data.load(path, format="raw", cache=False)
+        except Exception as exc:
+            if is_security_rejection(exc):
+                reached = True
+            continue
+        if isinstance(data, (str, bytes)) and (
+            "root:" in data if isinstance(data, str) else b"root:" in data
+        ):
+            return VULNERABLE, f"nltk.data.load read {outside} via {path!r}"
+    if reached:
+        return FIXED, "outside-root model paths security-rejected"
+    return FIXED, "outside-root model paths refused (no security marker reached)"

--- a/nltk/test/unit/security_probes/ghsa_97qj_x29f_37w7.py
+++ b/nltk/test/unit/security_probes/ghsa_97qj_x29f_37w7.py
@@ -6,12 +6,14 @@ from ._base import FIXED, VULNERABLE, probe
 @probe("GHSA-97qj-x29f-37w7")
 def _billion_laughs():
     """Entity-expansion DoS via remaining raw ElementTree parses."""
+    # A FLAT entity (unlike a nested billion-laughs) IS expanded by stock
+    # ElementTree, so the probe flips to VULNERABLE if the entity guard is removed.
     payload = (
-        '<?xml version="1.0"?><!DOCTYPE lolz [<!ENTITY lol "lol">'
-        + "".join(
-            '<!ENTITY lol%d "&lol%d;&lol%d;">' % (i, i - 1, i - 1) for i in range(1, 10)
-        )
-        + "]><lolz>&lol9;</lolz>"
+        '<?xml version="1.0"?><!DOCTYPE d [<!ENTITY a "'
+        + "A" * 10000
+        + '">]><d>'
+        + "&a;" * 100
+        + "</d>"
     )
     from nltk import xmlsec
 

--- a/nltk/test/unit/security_probes/ghsa_9ffx_rrgx_mhgx.py
+++ b/nltk/test/unit/security_probes/ghsa_9ffx_rrgx_mhgx.py
@@ -7,15 +7,35 @@ from ._base import FIXED, VULNERABLE, probe
 
 @probe("GHSA-9ffx-rrgx-mhgx")
 def _arff_label_injection():
-    malicious = "safe}\n@ATTRIBUTE injected NUMERIC\n@DATA\n0,owned\n%"
-    featuresets = [
-        ({"f": "benign"}, "legit"),
-        ({"f": "payload"}, malicious),
-    ]
-    formatter = ARFF_Formatter.from_train(featuresets)
-    arff = formatter.format(featuresets)
+    """ARFF injection via class labels, feature values, and feature names.
 
-    if "@ATTRIBUTE injected NUMERIC" in arff or "@DATA\n0,owned" in arff:
-        return VULNERABLE, "ARFF injection succeeded"
-    else:
-        return FIXED, "ARFF labels sanitized"
+    Each surface is fed a payload that tries to close its context and inject a
+    fresh @ATTRIBUTE/@DATA directive (with LF and CRLF variants); none may
+    surface as a live ARFF line in the generated file.
+    """
+    lf = "safe}\n@ATTRIBUTE injected NUMERIC\n@DATA\n0,owned\n%"
+    crlf = "x\r\n@ATTRIBUTE crinjected NUMERIC\r\n@DATA"
+
+    def build(featuresets):
+        return ARFF_Formatter.from_train(featuresets).format(featuresets)
+
+    checks = [
+        ("label", build([({"f": "benign"}, "legit"), ({"f": "p"}, lf)])),
+        ("value", build([({"f": "benign"}, "legit"), ({"f": lf}, "legit")])),
+        ("attr-name", build([({lf: "benign"}, "legit")])),
+        ("crlf-label", build([({"f": "benign"}, "legit"), ({"f": "p"}, crlf)])),
+    ]
+    # A real injection surfaces one of these payload directives at a line start;
+    # the legitimate output never does (the only @DATA is the single real header).
+    live = ("@attribute injected", "@attribute crinjected", "0,owned")
+    for surface, arff in checks:
+        if arff.count("\n@DATA") > 1:
+            return VULNERABLE, f"ARFF injection via {surface} added a second @DATA"
+        for raw in arff.splitlines():
+            line = raw.strip().lower()
+            if any(line.startswith(m) for m in live):
+                return (
+                    VULNERABLE,
+                    f"ARFF injection via {surface} produced a live directive",
+                )
+    return FIXED, "ARFF labels, values, and attribute names sanitized"

--- a/nltk/test/unit/security_probes/ghsa_f794_5jv7_7672.py
+++ b/nltk/test/unit/security_probes/ghsa_f794_5jv7_7672.py
@@ -23,7 +23,12 @@ def _downloader_hardlink():
     if os.name != "posix" or not ps.ENFORCE:
         return STATIC, "hardened write path inactive (non-POSIX or ENFORCE off)"
 
+    import nltk.data
+
     box = tempfile.mkdtemp()
+    # Authorize box as a data root so the sandbox layer passes and _hardened_open
+    # itself is the guard exercised (on a world-writable /tmp it blocks too early).
+    nltk.data.path.insert(0, box)
     try:
         root = os.path.join(box, "corpus")
         os.makedirs(root)
@@ -61,4 +66,6 @@ def _downloader_hardlink():
                 )
         return FIXED, "; ".join(notes)
     finally:
+        if box in nltk.data.path:
+            nltk.data.path.remove(box)
         shutil.rmtree(box, ignore_errors=True)

--- a/nltk/test/unit/security_probes/ghsa_f794_5jv7_7672.py
+++ b/nltk/test/unit/security_probes/ghsa_f794_5jv7_7672.py
@@ -1,14 +1,64 @@
 """GHSA-f794-5jv7-7672 [high] -- Downloader.download follows hardlinks and overwrites outside-root files"""
 
-from ._base import STATIC, VULNERABLE, probe, read_source
+import os
+import shutil
+import tempfile
+
+from ._base import FIXED, STATIC, VULNERABLE, is_security_rejection, probe
 
 
 @probe("GHSA-f794-5jv7-7672")
 def _downloader_hardlink():
-    """Pre-existing hardlinks inside the install tree were followed."""
-    source = read_source("nltk.downloader")
-    if "st_nlink" in source or "nlink" in source:
-        return STATIC, "downloader inspects link counts before writing"
-    if "O_NOFOLLOW" in source or "pathsec" in source:
-        return STATIC, "writes go through guarded open helpers"
-    return VULNERABLE, "no hardlink guard found in downloader.py"
+    """Write through a symlink / hardlink / absolute path that escapes the root.
+
+    pathsec.open (the downloader's write sink) must security-refuse each. The
+    hardlink is the advisory's own vector: a refused hardlink (or absolute)
+    target must also keep its original bytes, because truncation is deferred
+    until after the containment checks -- a refused write never zeroes the file.
+    """
+    import nltk.pathsec as ps
+
+    # The hardlink/symlink write guard (_hardened_open) is POSIX-only and gated on
+    # ENFORCE; elsewhere the sink falls back to builtins.open.
+    if os.name != "posix" or not ps.ENFORCE:
+        return STATIC, "hardened write path inactive (non-POSIX or ENFORCE off)"
+
+    box = tempfile.mkdtemp()
+    try:
+        root = os.path.join(box, "corpus")
+        os.makedirs(root)
+        notes = []
+        for label in ("symlink", "hardlink", "absolute"):
+            outside = os.path.join(box, label + "_secret")
+            with open(outside, "w", encoding="utf-8") as fh:
+                fh.write("ORIGINAL")
+            if label == "symlink":
+                target = os.path.join(root, "s.tmp")
+                os.symlink(outside, target)
+            elif label == "hardlink":
+                target = os.path.join(root, "h.tmp")
+                os.link(outside, target)
+            else:
+                target = outside
+            try:
+                with ps.open(target, "wb", required_root=root) as fh:
+                    fh.write(b"PWNED")
+            except Exception as exc:
+                if not is_security_rejection(exc):
+                    return (
+                        STATIC,
+                        f"{label} failed before the guard ({type(exc).__name__})",
+                    )
+                notes.append(f"{label}=blocked")
+            else:
+                if "PWNED" in open(outside, encoding="utf-8").read():
+                    return VULNERABLE, f"{label} write escaped to the outside file"
+                notes.append(f"{label}=no-leak")
+            if open(outside, encoding="utf-8").read() != "ORIGINAL":
+                return (
+                    VULNERABLE,
+                    f"{label} zeroed the outside file (truncate before guard)",
+                )
+        return FIXED, "; ".join(notes)
+    finally:
+        shutil.rmtree(box, ignore_errors=True)

--- a/nltk/test/unit/security_probes/ghsa_f833_7jw8_xwrv.py
+++ b/nltk/test/unit/security_probes/ghsa_f833_7jw8_xwrv.py
@@ -1,11 +1,80 @@
 """GHSA-f833-7jw8-xwrv [high] -- Symlink-based sandbox bypass in FramenetCorpusReader (bypasses the fix for CVE-2026-54292)"""
 
-from ._base import guard_rejects, probe
+import os
+import shutil
+import tempfile
+
+from ._base import (
+    FIXED,
+    STATIC,
+    VULNERABLE,
+    guard_rejects,
+    is_security_rejection,
+    probe,
+)
+from .ghsa_xh95_f55m_82fw import CANARY, seeded_reader
+
+_FRAME_XML = (
+    '<?xml version="1.0"?><frame xmlns="http://framenet.icsi.berkeley.edu" '
+    'ID="1" name="%s"><definition>x</definition></frame>' % CANARY
+)
 
 
 @probe("GHSA-f833-7jw8-xwrv")
 def _framenet_symlink_bypass():
-    """A symlink inside frame/ pointed outside the root; the guard now resolves it."""
+    """A symlink inside frame/ pointed outside the root; the guard now resolves it.
+
+    Two shapes the plain name check cannot see, driven through the real reader: a
+    multi-hop symlink chain, and a symlinked corpus *directory* (so every frame in
+    it resolves outside). Both must be refused by the resolving containment guard.
+    """
     from nltk.corpus.reader.framenet import _validate_in_root
 
-    return guard_rejects(lambda path, root: _validate_in_root(path, root, "framenet"))
+    box = tempfile.mkdtemp()
+    try:
+        outside_dir = os.path.join(box, "outside")
+        os.makedirs(outside_dir)
+        outside = os.path.join(outside_dir, "outside.xml")
+        with open(outside, "w", encoding="utf-8") as fh:
+            fh.write(_FRAME_XML)
+
+        cases = []
+        # 1. multi-hop chain: frame/chain.xml -> hop.xml -> outside.xml
+        chain_root = os.path.join(box, "fn_chain")
+        chain_reader = seeded_reader(chain_root)
+        hop = os.path.join(box, "hop.xml")
+        os.symlink(outside, hop)
+        os.symlink(hop, os.path.join(chain_root, "frame", "chain.xml"))
+        cases.append(("symlink-chain", chain_reader, "chain"))
+
+        # 2. the frame/ directory itself is a symlink out of the root
+        dir_root = os.path.join(box, "fn_dir")
+        os.makedirs(dir_root)
+        os.symlink(outside_dir, os.path.join(dir_root, "frame"))
+        dir_reader = seeded_reader(dir_root)
+        cases.append(("symlinked-dir", dir_reader, "outside"))
+
+        reached = []
+        for label, reader, name in cases:
+            try:
+                result = reader.frame_by_name(name)
+            except Exception as exc:
+                if not is_security_rejection(exc):
+                    return (
+                        STATIC,
+                        f"{label} failed before the guard ({type(exc).__name__})",
+                    )
+                reached.append(label)
+                continue
+            if CANARY in str(result):
+                return VULNERABLE, f"{label} read a frame outside the corpus root"
+            reached.append(label + "=no-leak")
+
+        status, evidence = guard_rejects(
+            lambda path, root_: _validate_in_root(path, root_, "framenet")
+        )
+        if status == VULNERABLE:
+            return VULNERABLE, evidence
+        return FIXED, "symlink escapes refused: " + ", ".join(reached)
+    finally:
+        shutil.rmtree(box, ignore_errors=True)

--- a/nltk/test/unit/security_probes/ghsa_ff5c_cp5c_9wjf.py
+++ b/nltk/test/unit/security_probes/ghsa_ff5c_cp5c_9wjf.py
@@ -9,9 +9,11 @@ def _recursivedescent_unbounded():
     from nltk import CFG
     from nltk.parse import RecursiveDescentParser
 
-    grammar = CFG.fromstring("S -> S S | 'a'")
+    # A left-recursive 'S -> S S' blows the stack (RecursionError) before max_time is
+    # consulted; this right-branching ambiguous form stresses wall-clock so the fix runs.
+    grammar = CFG.fromstring("S -> 'a' S S | 'a'")
     try:
-        seconds = timed(lambda: list(RecursiveDescentParser(grammar).parse(["a"] * 12)))
+        seconds = timed(lambda: list(RecursiveDescentParser(grammar).parse(["a"] * 18)))
     except Exception as exc:
         return FIXED, "bounded (%s)" % type(exc).__name__
     if seconds > DOS_BUDGET:

--- a/nltk/test/unit/security_probes/ghsa_fg7f_2386_8897.py
+++ b/nltk/test/unit/security_probes/ghsa_fg7f_2386_8897.py
@@ -8,7 +8,9 @@ def _reviews_features_redos():
     """Unbounded greedy label run in the ReviewsCorpusReader FEATURES regex."""
     from nltk.corpus.reader.reviews import FEATURES
 
-    payload = "a " * 4000 + "["
+    # ~9000 words: the pre-fix quadratic regex needs this many to blow the budget
+    # (4000 words was only ~3s, so the probe passed against the vulnerable code).
+    payload = "a " * 9000 + "["
     try:
         seconds = timed(FEATURES.findall, payload)
     except Exception as exc:

--- a/nltk/test/unit/security_probes/ghsa_gfwx_w7gr_fvh7.py
+++ b/nltk/test/unit/security_probes/ghsa_gfwx_w7gr_fvh7.py
@@ -1,12 +1,38 @@
 """GHSA-gfwx-w7gr-fvh7 [medium] -- Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting') in nltk"""
 
-from ._base import STATIC, VULNERABLE, probe, read_source
+import io
+
+from ._base import FIXED, STATIC, VULNERABLE, probe
 
 
 @probe("GHSA-gfwx-w7gr-fvh7")
 def _wordnet_app_xss():
-    """Reflected XSS in the wordnet_app lookup_ route."""
-    source = read_source("nltk.app.wordnet_app")
-    if "escape" in source or "quote(" in source or "html.escape" in source:
-        return STATIC, "response path escapes reflected input"
-    return VULNERABLE, "no escaping found on the reflected lookup_ route"
+    """Drive the lookup_ handler in-process with a hostile word.
+
+    A socket-free ``do_GET`` against ``/lookup_<script>`` builds the real
+    response; the reflected word must come back HTML-escaped, never as a live
+    ``<script>`` tag.
+    """
+    from nltk.data import find
+
+    try:
+        find("corpora/wordnet.zip")
+    except LookupError:
+        return STATIC, "wordnet corpus unavailable; handler not exercised"
+
+    import nltk.app.wordnet_app as wa
+
+    payload = "<script>alert(1)</script>"
+    handler = wa.MyServerHandler.__new__(wa.MyServerHandler)
+    handler.wfile = io.BytesIO()
+    handler.path = "/lookup_" + wa.Reference(payload).encode()
+    handler.send_response = lambda *a, **k: None
+    handler.send_header = lambda *a, **k: None
+    handler.end_headers = lambda: None
+    handler.do_GET()
+    out = handler.wfile.getvalue().decode("utf-8", "replace")
+    if payload in out:
+        return VULNERABLE, "raw <script> reflected on the lookup_ route"
+    if "&lt;script&gt;" in out:
+        return FIXED, "hostile word reflected only HTML-escaped"
+    return STATIC, "reflection not observed in the response"

--- a/nltk/test/unit/security_probes/ghsa_jm6w_m3j8_898g.py
+++ b/nltk/test/unit/security_probes/ghsa_jm6w_m3j8_898g.py
@@ -1,18 +1,23 @@
 """GHSA-jm6w-m3j8-898g [high] -- Unauthenticated remote shutdown in nltk.app.wordnet_app"""
 
-from ._base import FIXED, VULNERABLE, probe
+import io
+
+from ._base import FIXED, STATIC, VULNERABLE, probe
 
 
 @probe("GHSA-jm6w-m3j8-898g")
 def _wordnet_app_shutdown():
-    """wnb() must bind the browser server to loopback, not a network interface.
+    """wnb() binds loopback AND the shutdown route refuses a token-less request.
 
-    A spy stands in for HTTPServer so no socket is opened and serve_forever does
-    not block; the captured bind address must be loopback, so the (token-gated)
-    shutdown endpoint is unreachable from the network.
+    Two aspects of the advisory are exercised in-process without opening a
+    socket: a spy stands in for HTTPServer to capture the bind address, and a
+    ``/SHUTDOWN THE SERVER`` request with no per-process token is driven through
+    ``do_GET`` (with ``os._exit`` stubbed, so a broken guard is caught rather
+    than killing the test) and must be refused with 403.
     """
     import nltk.app.wordnet_app as wa
 
+    # 1) the browser server must bind loopback only
     captured = {}
 
     class _SpyServer:
@@ -22,14 +27,42 @@ def _wordnet_app_shutdown():
         def serve_forever(self):
             pass
 
-    original = wa.HTTPServer
+    original_server = wa.HTTPServer
     wa.HTTPServer = _SpyServer
     try:
         wa.wnb(port=0, runBrowser=False)
     finally:
-        wa.HTTPServer = original
-
+        wa.HTTPServer = original_server
     host = captured.get("address", (None,))[0]
-    if host in ("127.0.0.1", "localhost", "::1"):
-        return FIXED, "browser server binds loopback (%s)" % host
-    return VULNERABLE, "browser server binds non-loopback host: %r" % host
+    if host not in ("127.0.0.1", "localhost", "::1"):
+        return VULNERABLE, "browser server binds non-loopback host: %r" % host
+
+    # 2) a token-less shutdown request must be refused, never reaching os._exit
+    exited = []
+    original_exit = wa.os._exit
+    original_mode = wa.server_mode
+    wa.os._exit = lambda code=0: exited.append(code)
+    wa.server_mode = False  # force the per-process-token check to be the guard
+    try:
+        handler = wa.MyServerHandler.__new__(wa.MyServerHandler)
+        handler.wfile = io.BytesIO()
+        handler.path = "/SHUTDOWN THE SERVER"  # no ?token=
+        codes = []
+        handler.send_response = lambda code, *a, **k: codes.append(code)
+        handler.send_header = lambda *a, **k: None
+        handler.end_headers = lambda: None
+        try:
+            handler.do_GET()
+        except Exception:
+            # With the token guard broken, os._exit is stubbed so do_GET runs on
+            # and may fall through; the os._exit call was already recorded above.
+            pass
+    finally:
+        wa.os._exit = original_exit
+        wa.server_mode = original_mode
+
+    if exited:
+        return VULNERABLE, "token-less shutdown request reached os._exit"
+    if 403 in codes:
+        return FIXED, f"loopback bind ({host}); token-less shutdown refused (403)"
+    return STATIC, "shutdown route did not reach the token check"

--- a/nltk/test/unit/security_probes/ghsa_jm6w_m3j8_898g.py
+++ b/nltk/test/unit/security_probes/ghsa_jm6w_m3j8_898g.py
@@ -1,12 +1,35 @@
 """GHSA-jm6w-m3j8-898g [high] -- Unauthenticated remote shutdown in nltk.app.wordnet_app"""
 
-from ._base import STATIC, VULNERABLE, probe, read_source
+from ._base import FIXED, VULNERABLE, probe
 
 
 @probe("GHSA-jm6w-m3j8-898g")
 def _wordnet_app_shutdown():
-    """Unauthenticated remote shutdown in nltk.app.wordnet_app."""
-    source = read_source("nltk.app.wordnet_app")
-    if '"127.0.0.1"' not in source and "'127.0.0.1'" not in source:
-        return VULNERABLE, "server does not bind to loopback"
-    return STATIC, "HTTPServer binds 127.0.0.1 only"
+    """wnb() must bind the browser server to loopback, not a network interface.
+
+    A spy stands in for HTTPServer so no socket is opened and serve_forever does
+    not block; the captured bind address must be loopback, so the (token-gated)
+    shutdown endpoint is unreachable from the network.
+    """
+    import nltk.app.wordnet_app as wa
+
+    captured = {}
+
+    class _SpyServer:
+        def __init__(self, address, handler):
+            captured["address"] = address
+
+        def serve_forever(self):
+            pass
+
+    original = wa.HTTPServer
+    wa.HTTPServer = _SpyServer
+    try:
+        wa.wnb(port=0, runBrowser=False)
+    finally:
+        wa.HTTPServer = original
+
+    host = captured.get("address", (None,))[0]
+    if host in ("127.0.0.1", "localhost", "::1"):
+        return FIXED, "browser server binds loopback (%s)" % host
+    return VULNERABLE, "browser server binds non-loopback host: %r" % host

--- a/nltk/test/unit/security_probes/ghsa_m4rf_3fr8_xwx3.py
+++ b/nltk/test/unit/security_probes/ghsa_m4rf_3fr8_xwx3.py
@@ -1,32 +1,162 @@
 """GHSA-m4rf-3fr8-xwx3 [high] -- JVM argument injection bypass via per-call options in the NLTK Stanford wrappers (incomplete fix of CVE-2026-12841)"""
 
-from ._base import FIXED, VULNERABLE, probe
+from ._base import FIXED, STATIC, VULNERABLE, probe
+
+#: Every argument class that can change the executed program, run a shell command,
+#: load an agent, redirect class loading, crack the module system open or expand an
+#: argument file. The per-call ``options=`` channel must refuse all of them.
+HOSTILE_OPTIONS = (
+    # boot classpath: attacker classes shadow java.* before anything runs
+    "-Xbootclasspath/a:/tmp/evil.jar",
+    "-Xbootclasspath/p:/tmp/evil.jar",
+    "-Xbootclasspath:/tmp/evil.jar",
+    # native and Java agents: arbitrary code before main()
+    "-agentlib:jdwp=transport=dt_socket,server=y,address=5005",
+    "-agentpath:/tmp/evil.so",
+    "-javaagent:/tmp/evil.jar",
+    "-Xrunjdwp:transport=dt_socket,server=y,address=5005",
+    "-Xdebug",
+    "-Xnoagent",
+    # -XX: flags the JVM hands to a shell, or that unlock the restricted rest
+    "-XX:OnError=/bin/sh",
+    "-XX:OnOutOfMemoryError=/bin/sh",
+    "-XX:+UnlockDiagnosticVMOptions",
+    "-XX:+UnlockExperimentalVMOptions",
+    "-XX:Flags=/tmp/evil.flags",
+    "-XX:CompileCommandFile=/tmp/evil",
+    "-XX:SharedArchiveFile=/tmp/evil.jsa",
+    "-XX:+HeapDumpOnOutOfMemoryError",
+    "-XX:HeapDumpPath=/tmp/steal",
+    "-XX:ErrorFile=/tmp/steal",
+    # -D properties that redirect code loading or disarm the sandbox
+    "-Djava.security.policy=/tmp/all.policy",
+    "-Djava.security.manager=allow",
+    "-Djava.class.path=/tmp/evil.jar",
+    "-Djava.library.path=/tmp/evil",
+    "-Djava.ext.dirs=/tmp/evil",
+    "-Djava.rmi.server.codebase=http://evil.example/",
+    "-Djdk.attach.allowAttachSelf=true",
+    "-Dcom.sun.management.jmxremote.port=9999",
+    # classpath / module path injected here never reaches _verify_jar_sandbox,
+    # which only inspects the classpath= argument
+    "-cp",
+    "-classpath",
+    "--class-path=/tmp/evil.jar",
+    "-p",
+    "--module-path=/tmp/evil",
+    "--upgrade-module-path=/tmp/evil",
+    "-Xpatch:java.base=/tmp/evil",
+    # module system escapes
+    "--patch-module=java.base=/tmp/evil",
+    "--add-opens=java.base/java.lang=ALL-UNNAMED",
+    "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
+    "--add-reads=java.base=ALL-UNNAMED",
+    # run something other than the main class the caller named
+    "-jar",
+    "-m",
+    "--module=evil/Main",
+    "-Xshare:dump",
+    "-Xverify:none",
+    "-splash:/tmp/x.png",
+    # @argfiles are expanded by the launcher first, smuggling every flag above
+    "@/tmp/evil.args",
+    "@evil.args",
+    # one element carrying two options: a per-element filter must reject the whole
+    # token, and a splitting one must validate every piece, not just the first
+    "-Xmx1g -javaagent:/tmp/evil.jar",
+    "-Xmx1g\t-javaagent:/tmp/evil.jar",
+    "-Xmx1g\n-javaagent:/tmp/evil.jar",
+    "-Xmx1g\x00-javaagent:/tmp/evil.jar",
+    "-Xmx512m;rm -rf /",
+    "-Xmx512m`id`",
+    "-Xmx512m$(id)",
+    # hostile flag hiding behind a legitimate one, and in the value slot of the
+    # single multi-token flag the allowlist accepts
+    ("-Xmx512m", "-javaagent:/tmp/evil.jar"),
+    ("--add-modules", "java.base/tmp"),
+    ("--add-modules", "-javaagent:/tmp/evil.jar"),
+    # type confusion must never reach argv as a stringified entry
+    b"-javaagent:/tmp/evil.jar",
+    None,
+    "",
+)
+
+
+class _PopenTrap(Exception):
+    """Raised instead of launching, carrying the argv java() had assembled."""
+
+    def __init__(self, argv):
+        Exception.__init__(self, " ".join(map(str, argv)))
+        self.argv = list(argv)
+
+
+class _NoLaunch:
+    """Stands in for ``subprocess`` inside ``nltk.internals``.
+
+    Without it the probe is inconclusive where no JVM exists: an option that got
+    past the filter would die in Popen with OSError and the probe would score the
+    absence of java as a defence. Trapping at Popen records the argv that was
+    about to run, which is the actual proof of injection, and launches nothing.
+    """
+
+    PIPE = -1
+    DEVNULL = -3
+
+    @staticmethod
+    def Popen(argv, **kwargs):
+        raise _PopenTrap(argv)
+
+
+def _refused_by_the_option_filter(exc):
+    """True only for _validate_java_options' own rejections.
+
+    java() has three independent guards (options, classpath, cmd); matching a
+    loose substring would let the cmd guard's rejection be scored as a defence of
+    the options filter, so pin the messages only this filter emits.
+    """
+    text = str(exc)
+    return text.startswith("java_options ") or text.startswith("--add-modules ")
 
 
 @probe("GHSA-m4rf-3fr8-xwx3")
 def _jvm_argument_injection():
     """Per-call options bypassed the CVE-2026-12841 JVM argument filter."""
-    from nltk.internals import config_java, java
+    from nltk import internals
 
-    hostile = ["-Xbootclasspath/a:/tmp/evil.jar", "-agentlib:jdwp=transport=dt_socket"]
-    # Require the *specific* rejection. Java is often absent on a dev box, and
-    # counting the resulting OSError as "blocked" would let this probe pass for
-    # entirely the wrong reason.
-    blocked = []
-    for option in hostile:
-        try:
-            java(["-version"], options=[option])
-            return VULNERABLE, "hostile JVM option accepted: %s" % option
-        except ValueError as exc:
-            if "disallow" in str(exc).lower() or "option" in str(exc).lower():
-                blocked.append(option)
-        except Exception:
-            pass
-    if len(blocked) < len(hostile):
-        return VULNERABLE, "only %d of %d hostile options explicitly refused" % (
-            len(blocked),
-            len(hostile),
+    # A plausible main class, so the cmd guard can never fire and the only thing
+    # that may reject these calls is the filter under test.
+    main_class = "edu.stanford.nlp.pipeline.StanfordCoreNLPServer"
+
+    original = internals.subprocess
+    internals.subprocess = _NoLaunch
+    try:
+        leaked, unreached = [], []
+        for case in HOSTILE_OPTIONS:
+            opts = list(case) if isinstance(case, tuple) else [case]
+            label = " ".join(repr(opt) for opt in opts)
+            try:
+                internals.java([main_class], options=opts)
+            except _PopenTrap as trap:
+                leaked.append((label, trap.argv))
+            except ValueError as exc:
+                if not _refused_by_the_option_filter(exc):
+                    unreached.append(f"{label}: {type(exc).__name__}")
+            except Exception as exc:
+                unreached.append(f"{label}: {type(exc).__name__}")
+            else:
+                leaked.append((label, "no launch attempted"))
+    finally:
+        internals.subprocess = original
+
+    if leaked:
+        label, argv = leaked[0]
+        return VULNERABLE, (
+            "hostile JVM option reached the launcher: %s (argv=%r); %d of %d leaked"
+            % (label, argv, len(leaked), len(HOSTILE_OPTIONS))
         )
-    return FIXED, "all %d hostile per-call JVM options refused by the filter" % len(
-        hostile
+    if unreached:
+        return STATIC, "not refused by the option filter: " + "; ".join(unreached[:3])
+    return FIXED, (
+        "all %d hostile per-call JVM options refused by _validate_java_options"
+        % len(HOSTILE_OPTIONS)
     )

--- a/nltk/test/unit/security_probes/ghsa_p4rw_rvv2_7xwr.py
+++ b/nltk/test/unit/security_probes/ghsa_p4rw_rvv2_7xwr.py
@@ -1,5 +1,7 @@
 """GHSA-p4rw-rvv2-7xwr [medium] -- Corpus readers follow symlinks outside trusted roots despite pathsec enforcement"""
 
+import os
+
 from ._base import escape_probe, probe
 
 
@@ -15,9 +17,24 @@ def _readers_follow_symlinks():
         payload = "../" * 8 + box.target.lstrip("/")
         return CorpusReader(box.root, [payload]).open(payload).read()
 
+    def via_intermediate_symlink(box):
+        # escape through a NON-final path component: <root>/d -> the outside dir
+        sub = os.path.join(box.root, "d")
+        if not os.path.exists(sub):
+            os.symlink(os.path.dirname(box.target), sub)
+        name = "d/" + os.path.basename(box.target)
+        return CorpusReader(box.root, [name]).open(name).read()
+
+    def via_backslash(box):
+        # Windows separator, normalized to '/', so the ".." is still caught
+        name = "..\\..\\" + box.target.lstrip("/")
+        return CorpusReader(box.root, [name]).open(name).read()
+
     return escape_probe(
         [
             ("open(symlink)", via_symlink),
             ("open(traversal)", via_traversal),
+            ("open(intermediate-symlink)", via_intermediate_symlink),
+            ("open(backslash)", via_backslash),
         ]
     )

--- a/nltk/test/unit/security_probes/ghsa_pcm8_fqjx_rvx8.py
+++ b/nltk/test/unit/security_probes/ghsa_pcm8_fqjx_rvx8.py
@@ -10,63 +10,99 @@ import nltk
 
 from ._base import FIXED, STATIC, VULNERABLE, probe
 
+_PACKAGE = (
+    '<package id="p1" name="Sample" subdir="corpora/p1" '
+    'url="http://example.invalid/p1.zip" unzip="0" size="0" unzipped_size="0"/>'
+)
+
+#: collection graphs whose references cycle; the traversal must still terminate.
+#: "acyclic" is the health control, not an attack.
+_GRAPHS = {
+    "self": '<collection id="a" name="C"><item ref="a"/><item ref="p1"/></collection>',
+    "mutual": (
+        '<collection id="a" name="C"><item ref="b"/><item ref="p1"/></collection>'
+        '<collection id="b" name="D"><item ref="a"/></collection>'
+    ),
+    "chain": (
+        '<collection id="a" name="C"><item ref="b"/></collection>'
+        '<collection id="b" name="D"><item ref="c"/></collection>'
+        '<collection id="c" name="E"><item ref="a"/><item ref="p1"/></collection>'
+    ),
+    "diamond": (
+        '<collection id="a" name="C"><item ref="b"/><item ref="c"/></collection>'
+        '<collection id="b" name="D"><item ref="d"/></collection>'
+        '<collection id="c" name="E"><item ref="d"/></collection>'
+        '<collection id="d" name="F"><item ref="p1"/></collection>'
+    ),
+    "acyclic": '<collection id="a" name="C"><item ref="p1"/></collection>',
+}
+
+
+def _resolve(shape, timeout=30):
+    """Resolve an index with the given collection graph in a subprocess.
+
+    Returns ``(kind, detail)`` where *kind* is ``"ok"``, ``"hang"`` (the infinite
+    loop symptom) or ``"error"``.
+    """
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False) as fh:
+        fh.write(
+            '<?xml version="1.0"?><index><packages>'
+            + _PACKAGE
+            + "</packages><collections>"
+            + _GRAPHS[shape]
+            + "</collections></index>"
+        )
+        path = fh.name
+    try:
+        script = "\n".join(
+            [
+                "import nltk",
+                "from nltk.downloader import Downloader",
+                "nltk.pathsec.ENFORCE = False",
+                f"dl = Downloader(server_index_url={Path(path).as_uri()!r})",
+                "print(','.join(p.id for p in dl.packages()))",
+            ]
+        )
+        env = os.environ.copy()
+        root = os.path.dirname(os.path.dirname(os.path.dirname(nltk.__file__)))
+        env["PYTHONPATH"] = root + os.pathsep + env.get("PYTHONPATH", "")
+        try:
+            done = subprocess.run(
+                [sys.executable, "-c", script],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                env=env,
+            )
+        except subprocess.TimeoutExpired:
+            return "hang", "timed out"
+        if done.returncode != 0:
+            return "error", done.stderr.strip()[-70:]
+        return "ok", done.stdout.strip()
+    finally:
+        os.unlink(path)
+
 
 @probe("GHSA-pcm8-fqjx-rvx8")
 def _cyclic_collection_index():
-    xml = """<?xml version="1.0"?>
-<index>
-  <packages>
-    <package id="p1" name="Sample" subdir="corpora/p1"
-             url="http://example.invalid/p1.zip" unzip="0" size="0" unzipped_size="0"/>
-  </packages>
-  <collections>
-    <collection id="a" name="Cyclic">
-      <item ref="a"/>
-      <item ref="p1"/>
-    </collection>
-  </collections>
-</index>"""
+    """Resolve indexes whose collection graph cycles in several shapes.
 
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False) as f:
-        f.write(xml)
-        path = f.name
-
-    try:
-        uri = Path(path).as_uri()
-        script_lines = [
-            "import sys",
-            "import nltk",
-            "from nltk.downloader import Downloader",
-            "nltk.pathsec.ENFORCE = False",
-            f"dl = Downloader(server_index_url={repr(uri)})",
-            "packages = dl.packages()",
-            "print(','.join(p.id for p in packages))",
-        ]
-        script = "\n".join(script_lines)
-
-        env = os.environ.copy()
-        # Derive import root from nltk.__file__
-        nltk_root = os.path.dirname(os.path.dirname(os.path.dirname(nltk.__file__)))
-        env["PYTHONPATH"] = nltk_root + os.pathsep + env.get("PYTHONPATH", "")
-
-        result = subprocess.run(
-            [sys.executable, "-c", script],
-            capture_output=True,
-            text=True,
-            # Subprocess timeout is wall-clock (startup + imports + probe work).
-            # Under CI contention, shorter budgets can false-timeout healthy runs.
-            timeout=30,
-            env=env,
-        )
-
-        if result.returncode != 0:
-            return VULNERABLE, f"Subprocess failed: {result.stderr.strip()}"
-        output = result.stdout.strip()
-        if output == "p1":
-            return FIXED, "Cyclic index handled correctly"
-        else:
-            return VULNERABLE, f"Expected 'p1', got '{output}'"
-    except subprocess.TimeoutExpired:
-        return STATIC, "Subprocess timed out under CI load (inconclusive)"
-    finally:
-        os.unlink(path)
+    Self-, mutual-, chain- and diamond-references must each terminate and yield the
+    package. A hang IS the advisory's infinite loop, so it is reported VULNERABLE
+    rather than inconclusive whenever an acyclic control run shows the host is
+    healthy; only a control that also times out downgrades the result to STATIC.
+    """
+    resolved = []
+    for shape in ("self", "mutual", "chain", "diamond"):
+        kind, detail = _resolve(shape)
+        if kind == "hang":
+            control, _ = _resolve("acyclic")
+            if control == "ok":
+                return VULNERABLE, f"{shape}-referencing index never terminated"
+            return STATIC, "cyclic run and the acyclic control both timed out"
+        if kind == "error":
+            return VULNERABLE, f"{shape} index failed: {detail}"
+        if detail != "p1":
+            return VULNERABLE, f"{shape} index yielded {detail!r}, expected 'p1'"
+        resolved.append(shape)
+    return FIXED, "cyclic collection graphs terminate: " + ", ".join(resolved)

--- a/nltk/test/unit/security_probes/ghsa_qvv7_cg9c_w4x3.py
+++ b/nltk/test/unit/security_probes/ghsa_qvv7_cg9c_w4x3.py
@@ -1,28 +1,50 @@
 """GHSA-qvv7-cg9c-w4x3 [high] -- DNS-rebinding SSRF filter bypass in nltk.pathsec.urlopen (nltk.download / nltk.data.load) defeats ENFORCE mode"""
 
-from ._base import FIXED, VULNERABLE, probe
+from ._base import FIXED, VULNERABLE, is_security_rejection, probe
 
 
 @probe("GHSA-qvv7-cg9c-w4x3")
 def _dns_rebinding():
-    """DNS-rebinding SSRF filter bypass in nltk.pathsec.urlopen."""
+    """Every internal target must be security-rejected by validate_network_url.
+
+    Covers loopback / unspecified / 127.x, cloud metadata, private, CGNAT and
+    benchmarking ranges, plus the IPv6 wrapper forms (mapped, NAT64, 6to4) and a
+    name that resolves to loopback. All are literals or resolvable names, so the
+    filter classifies them directly rather than failing open on a bad lookup.
+    """
     from nltk import pathsec
 
-    blocked = 0
     targets = [
-        "http://169.254.169.254/latest/meta-data/",
         "http://127.0.0.1/",
-        "http://[::1]/",
+        "http://127.0.0.2/",
+        "http://127.1.2.3/",
         "http://0.0.0.0/",
+        "http://169.254.169.254/latest/meta-data/",
+        "http://10.0.0.1/",
+        "http://192.168.1.1/",
+        "http://100.64.0.1/",  # CGNAT
+        "http://198.18.0.1/",  # benchmarking
+        "http://[::1]/",
+        "http://[::]/",
+        "http://[fe80::1]/",
+        "http://[::ffff:127.0.0.1]/",  # IPv4-mapped loopback
+        "http://[::ffff:169.254.169.254]/",  # IPv4-mapped metadata
+        "http://[64:ff9b::a9fe:a9fe]/",  # NAT64 -> metadata
+        "http://[2002:a9fe:a9fe::]/",  # 6to4 -> metadata
+        "http://localhost/",
     ]
+    passed = []
     for url in targets:
         try:
             pathsec.validate_network_url(url)
-        except Exception:
-            blocked += 1
-    if blocked < len(targets):
-        return VULNERABLE, "%d of %d SSRF targets allowed" % (
-            len(targets) - blocked,
-            len(targets),
+            passed.append(url)  # the filter let it through
+        except Exception as exc:
+            if not is_security_rejection(exc):
+                passed.append(url)  # a non-security failure is not a real rejection
+    if passed:
+        host = passed[0].split("//", 1)[1]
+        return (
+            VULNERABLE,
+            f"{len(passed)}/{len(targets)} SSRF targets not rejected ({host})",
         )
-    return FIXED, "all %d loopback/link-local targets rejected" % len(targets)
+    return FIXED, f"all {len(targets)} internal/mapped SSRF targets rejected"

--- a/nltk/test/unit/security_probes/ghsa_rrv8_h7p8_rx55.py
+++ b/nltk/test/unit/security_probes/ghsa_rrv8_h7p8_rx55.py
@@ -8,9 +8,11 @@ def _text_findall_redos():
     """Text.findall() compiled a user-supplied regex with no backstop."""
     from nltk.text import Text
 
-    text = Text("a b c d e".split())
+    # A long corpus is required: against 5 tokens the raw regex finishes instantly
+    # even unguarded, so the probe could not tell a regression from the fix.
+    text = Text(["a"] * 400)
     try:
-        seconds = timed(text.findall, "(<.*>)+" * 6 + "<zzz>")
+        seconds = timed(text.findall, "<.*>+" * 4 + "<zzz>")
     except Exception as exc:
         return FIXED, "hostile pattern rejected (%s)" % type(exc).__name__
     if seconds > DOS_BUDGET:

--- a/nltk/test/unit/security_probes/ghsa_vp2x_qp44_57v7.py
+++ b/nltk/test/unit/security_probes/ghsa_vp2x_qp44_57v7.py
@@ -11,7 +11,9 @@ def _xmlcorpusview_quadratic():
     from nltk.corpus.reader.xmldocs import XMLCorpusView
 
     view = XMLCorpusView.__new__(XMLCorpusView)
-    payload = "<a " + "x" * 2_000_000 + ">"
+    # 4M chars: at 2M the pre-fix quadratic scan was ~15.6s, right at the budget, so
+    # the min-of-3 sampling could dip under and false-pass; 4M is comfortably >30s.
+    payload = "<a " + "x" * 4_000_000 + ">"
     ok, seconds = within_budget(lambda: view._read_xml_fragment(io.StringIO(payload)))
     if ok:
         return FIXED, "2M-char unterminated tag in %.3fs" % seconds

--- a/nltk/test/unit/security_probes/ghsa_w3v8_gmh9_3wv7.py
+++ b/nltk/test/unit/security_probes/ghsa_w3v8_gmh9_3wv7.py
@@ -7,11 +7,16 @@ from ._base import DOS_BUDGET, FIXED, VULNERABLE, probe, timed
 def _tgrep_redos():
     """tgrep passed user regexes to re with no timeout or validation."""
     from nltk import tgrep
+    from nltk.tree import Tree
 
+    # Compiling is fast either way; the catastrophic backtracking only fires when
+    # the predicate MATCHES a hostile node label, so drive the match.
     try:
-        seconds = timed(tgrep.tgrep_compile, "/([ab]|[ab])*$/")
+        predicate = tgrep.tgrep_compile("/([ab]|[ab])*$/")
+        hostile = Tree("ab" * 25 + "!", ["x"])
+        seconds = timed(lambda: predicate(hostile))
     except Exception as exc:
         return FIXED, "hostile pattern rejected (%s)" % type(exc).__name__
     if seconds > DOS_BUDGET:
-        return VULNERABLE, "tgrep compile took %.1fs" % seconds
-    return FIXED, "hostile pattern handled in %.3fs" % seconds
+        return VULNERABLE, "tgrep match took %.1fs" % seconds
+    return FIXED, "hostile pattern matched in %.3fs" % seconds

--- a/nltk/test/unit/security_probes/ghsa_xh95_f55m_82fw.py
+++ b/nltk/test/unit/security_probes/ghsa_xh95_f55m_82fw.py
@@ -1,15 +1,87 @@
 """GHSA-xh95-f55m-82fw [high] -- Path traversal in NLTK FramenetCorpusReader.frame() allows arbitrary XML file read, bypassing the nltk.pathsec sandbox (ENFORCE=True)"""
 
-from ._base import guard_rejects, probe
+import os
+import shutil
+import tempfile
+
+from ._base import (
+    FIXED,
+    STATIC,
+    VULNERABLE,
+    guard_rejects,
+    is_security_rejection,
+    probe,
+)
+
+CANARY = "PWNED-CANARY"
+
+_FRAME_XML = (
+    '<?xml version="1.0"?><frame xmlns="http://framenet.icsi.berkeley.edu" '
+    'ID="1" name="%s"><definition>x</definition></frame>' % CANARY
+)
+
+
+def seeded_reader(root):
+    """A FramenetCorpusReader whose frame index is pre-seeded.
+
+    frame_by_name() builds the whole frame index first, which needs a real corpus;
+    seeding it lets the probe reach the containment guard the advisory added.
+    """
+    from nltk.corpus.reader.framenet import FramenetCorpusReader
+
+    os.makedirs(os.path.join(root, "frame"), exist_ok=True)
+    reader = FramenetCorpusReader(root, [])
+    reader._frame_idx = {"seed": 1}
+    return reader
 
 
 @probe("GHSA-xh95-f55m-82fw")
 def _framenet_frame_traversal():
     """frame() interpolated a caller name into a path opened with builtin open().
 
-    frame() needs a populated index to reach the file open, so drive the guard
-    the fix added -- _validate_in_root -- directly with outside-root paths.
+    Drive the real public reader with names crafted to escape the corpus root; a
+    returned frame carrying the canary is a leak, and only a security-marked
+    refusal counts as a defence (an incidental error means the guard was never hit).
     """
     from nltk.corpus.reader.framenet import _validate_in_root
 
-    return guard_rejects(lambda path, root: _validate_in_root(path, root, "framenet"))
+    box = tempfile.mkdtemp()
+    try:
+        root = os.path.join(box, "fn")
+        reader = seeded_reader(root)
+        # a parseable frame XML outside the root: if containment is ever removed,
+        # the read succeeds and the canary surfaces instead of an opaque error.
+        outside = os.path.join(box, "outside.xml")
+        with open(outside, "w", encoding="utf-8") as fh:
+            fh.write(_FRAME_XML)
+        os.symlink(outside, os.path.join(root, "frame", "evil.xml"))
+
+        attempts = {
+            "traversal": "../" * 6 + outside.lstrip("/"),
+            "absolute": outside,
+            "symlink": "evil",  # no separators: only the resolve guard can catch it
+        }
+        reached = []
+        for label, name in attempts.items():
+            try:
+                result = reader.frame_by_name(name)
+            except Exception as exc:
+                if not is_security_rejection(exc):
+                    return (
+                        STATIC,
+                        f"{label} failed before the guard ({type(exc).__name__})",
+                    )
+                reached.append(label)
+                continue
+            if CANARY in str(result):
+                return VULNERABLE, f"frame_by_name({label}) read outside the root"
+            reached.append(label + "=no-leak")
+        # the guard itself must also refuse raw outside-root paths
+        status, evidence = guard_rejects(
+            lambda path, root_: _validate_in_root(path, root_, "framenet")
+        )
+        if status == VULNERABLE:
+            return VULNERABLE, evidence
+        return FIXED, "frame_by_name refused: " + ", ".join(reached)
+    finally:
+        shutil.rmtree(box, ignore_errors=True)

--- a/nltk/test/unit/test_advisory_coverage_ci.py
+++ b/nltk/test/unit/test_advisory_coverage_ci.py
@@ -57,6 +57,7 @@ _CLOSED_WITH_PROBE = {
     "GHSA-pcm8-fqjx-rvx8",
 }
 
+
 def _next_url(link_header):
     """The *on-origin* rel="next" URL from a GitHub ``Link`` header, else None.
 

--- a/nltk/test/unit/test_advisory_probes.py
+++ b/nltk/test/unit/test_advisory_probes.py
@@ -12,6 +12,8 @@ import os
 import pathlib
 import pkgutil
 import re
+import shutil
+import tempfile
 import warnings
 from collections import Counter
 
@@ -81,7 +83,7 @@ def test_pathsec_enforce_probe_has_teeth():
 
 
 def test_model_artifact_probe_has_teeth():
-    """Remove both containment layers and the probe must read /etc/passwd.
+    """Turn containment off and the probe must escape the sandbox.
 
     The payload has to genuinely reach the sink: a traversal that lands on a
     non-existent path errors out and would score FIXED no matter what the guards
@@ -99,6 +101,101 @@ def test_model_artifact_probe_has_teeth():
     finally:
         nltk.data._reject_unsafe_no_protocol, pathsec.ENFORCE = reject, enforce
     assert probe()[0] == probes.FIXED
+
+
+def test_model_artifact_probe_covers_every_api_the_advisory_names():
+    """The probe must drive the APIs the advisory lists, not only the loader.
+
+    The advisory names six model-artifact entry points. A probe that exercises
+    ``nltk.data.load`` alone reports FIXED while any one of them regresses, which
+    is the failure this list pins shut.
+    """
+    from nltk.test.unit.security_probes import ghsa_8mgp_746c_j5xp as mod
+
+    labels = {label for label, _ in mod._attempts(str(pathlib.Path.home()))}
+    for named in (
+        "TransitionParser.train",
+        "TransitionParser.parse",
+        "AveragedPerceptron.save",
+        "AveragedPerceptron.load",
+        "PerceptronTagger.save_to_json",
+        "save_maxent_params",
+    ):
+        assert named in labels, f"advisory API {named} is not probed"
+
+
+def test_perceptron_bare_open_probe_has_teeth():
+    """Restore the advisory's own bug and the probe must flip to VULNERABLE.
+
+    ``AveragedPerceptron.save``/``load`` used ``builtins.open`` on a caller path.
+    Putting that back is the exact regression this probe exists to catch, so it
+    must not stay FIXED through it.
+    """
+    import json as _json
+
+    from nltk.tag.perceptron import AveragedPerceptron
+
+    probe = probes.PROBES["GHSA-8mgp-746c-j5xp"]
+    saved, loaded = AveragedPerceptron.save, AveragedPerceptron.load
+
+    def bare_save(self, path):
+        with open(path, "w") as fout:
+            return _json.dump(self.weights, fout)
+
+    def bare_load(self, path):
+        with open(path) as fin:
+            self.weights = _json.load(fin)
+
+    try:
+        AveragedPerceptron.save, AveragedPerceptron.load = bare_save, bare_load
+        assert probe()[0] == probes.VULNERABLE
+    finally:
+        AveragedPerceptron.save, AveragedPerceptron.load = saved, loaded
+    assert probe()[0] == probes.FIXED
+
+
+def test_perceptron_save_to_json_validation_has_teeth():
+    """Drop the destination check and the tagger write must escape again."""
+    import nltk.pathsec as pathsec
+    import nltk.tag.perceptron as perceptron
+
+    probe = probes.PROBES["GHSA-8mgp-746c-j5xp"]
+    original = perceptron.validate_path
+    try:
+        # Only the tagger's own check is neutered; pathsec still guards
+        # AveragedPerceptron, so a flip proves save_to_json is what leaked.
+        perceptron.validate_path = lambda *args, **kwargs: None
+        assert probe()[0] == probes.VULNERABLE
+    finally:
+        perceptron.validate_path = original
+    assert probe()[0] == probes.FIXED
+    assert perceptron.validate_path is pathsec.validate_path
+
+
+def test_perceptron_load_does_not_widen_the_sandbox():
+    """A caller-supplied model dir must never become an allowed root.
+
+    ``load_from_json`` used to append a private caller directory to
+    ``nltk.data.path``, which turns the containment check off for that path (and
+    every later read under it) process-wide.
+    """
+    import nltk.data
+    from nltk.tag.perceptron import PerceptronTagger
+
+    before = list(nltk.data.path)
+    outside = pathlib.Path(
+        tempfile.mkdtemp(prefix=".nltk_widen_", dir=str(pathlib.Path.home()))
+    )
+    try:
+        (outside / "averaged_perceptron_tagger_xx.weights.json").write_text("{}")
+        try:
+            PerceptronTagger(load=False).load_from_json(lang="xx", loc=str(outside))
+        except Exception:
+            pass
+        assert list(nltk.data.path) == before, "caller dir was added to nltk.data.path"
+    finally:
+        nltk.data.path[:] = before
+        shutil.rmtree(outside, ignore_errors=True)
 
 
 def test_pickle_allowlist_probe_has_teeth():

--- a/nltk/test/unit/test_advisory_probes.py
+++ b/nltk/test/unit/test_advisory_probes.py
@@ -250,6 +250,36 @@ def test_hardlink_write_probe_has_teeth():
     assert probe()[0] == probes.FIXED
 
 
+def test_shutdown_token_probe_has_teeth():
+    """Bypass the per-process shutdown-token check; a token-less shutdown request
+    must be caught as VULNERABLE (it would reach os._exit)."""
+    import nltk.app.wordnet_app as wa
+
+    probe = probes.PROBES["GHSA-jm6w-m3j8-898g"]
+    real = wa.MyServerHandler._shutdown_authorized
+    try:
+        wa.MyServerHandler._shutdown_authorized = lambda self: True
+        assert probe()[0] == probes.VULNERABLE
+    finally:
+        wa.MyServerHandler._shutdown_authorized = real
+    assert probe()[0] == probes.FIXED
+
+
+def test_graphviz_search_probe_has_teeth():
+    """Make find_binary hand back the bare CWD name; the probe must flag the
+    planted ./dot as VULNERABLE."""
+    import nltk.internals as internals
+
+    probe = probes.PROBES["GHSA-6hwm-xvph-95vm"]
+    real = internals.find_binary
+    try:
+        internals.find_binary = lambda name, *a, **k: name  # returns the CWD hit
+        assert probe()[0] == probes.VULNERABLE
+    finally:
+        internals.find_binary = real
+    assert probe()[0] == probes.FIXED
+
+
 class TestProbeDiscoveryIsolation:
     """The probe package discovers and imports only from its own directory.
 

--- a/nltk/test/unit/test_advisory_probes.py
+++ b/nltk/test/unit/test_advisory_probes.py
@@ -200,6 +200,56 @@ def test_escape_probes_reach_the_sink():
         assert probe()[0] == probes.FIXED
 
 
+def test_xss_probe_has_teeth():
+    """Neuter html.escape in the wordnet app; the reflected <script> must be
+    caught as VULNERABLE, proving the probe reaches the response sink."""
+    from nltk.data import find
+
+    try:
+        find("corpora/wordnet.zip")
+    except LookupError:
+        import pytest
+
+        pytest.skip("wordnet corpus unavailable")
+
+    import nltk.app.wordnet_app as wa
+
+    probe = probes.PROBES["GHSA-gfwx-w7gr-fvh7"]
+    real = wa.html.escape
+    try:
+        wa.html.escape = lambda s, quote=True: s  # identity: no escaping
+        assert probe()[0] == probes.VULNERABLE
+    finally:
+        wa.html.escape = real
+    assert probe()[0] == probes.FIXED
+
+
+def test_hardlink_write_probe_has_teeth():
+    """Replace the hardened opener with a bare open; the symlink/hardlink write
+    escape must be caught as VULNERABLE."""
+    import builtins
+
+    import nltk.pathsec as pathsec
+
+    if os.name != "posix":
+        import pytest
+
+        pytest.skip("hardened write path is POSIX-only")
+
+    probe = probes.PROBES["GHSA-f794-5jv7-7672"]
+    real = pathsec._hardened_open
+    try:
+        pathsec._hardened_open = (
+            lambda raw, mode, context, required_root, **kw: builtins.open(
+                raw, mode, **kw
+            )
+        )
+        assert probe()[0] == probes.VULNERABLE
+    finally:
+        pathsec._hardened_open = real
+    assert probe()[0] == probes.FIXED
+
+
 class TestProbeDiscoveryIsolation:
     """The probe package discovers and imports only from its own directory.
 

--- a/nltk/test/unit/test_advisory_probes.py
+++ b/nltk/test/unit/test_advisory_probes.py
@@ -533,3 +533,43 @@ def test_pickle_denylist_fires_under_broad_allow():
     payload = b"cos\nsystem\n(t R."  # GLOBAL os.system, empty-tuple REDUCE
     with pytest.raises(pickle.UnpicklingError, match="denied module"):
         allowlisted_pickle_load(io.BytesIO(payload), allowed_modules=("os",))
+
+
+def test_cyclic_index_probe_reports_a_hang_as_vulnerable():
+    """The advisory's regression manifests as an infinite loop, i.e. a subprocess
+    that never returns. Simulate that: a hanging cyclic run with a healthy acyclic
+    control must be VULNERABLE, and only a control that also hangs is STATIC."""
+    module = importlib.import_module(
+        "nltk.test.unit.security_probes.ghsa_pcm8_fqjx_rvx8"
+    )
+    probe = probes.PROBES["GHSA-pcm8-fqjx-rvx8"]
+    real = module._resolve
+    try:
+        module._resolve = lambda shape, timeout=30: (
+            ("ok", "p1") if shape == "acyclic" else ("hang", "timed out")
+        )
+        assert probe()[0] == probes.VULNERABLE
+        # an overloaded host (control hangs too) must NOT be called a regression
+        module._resolve = lambda shape, timeout=30: ("hang", "timed out")
+        assert probe()[0] == probes.STATIC
+    finally:
+        module._resolve = real
+    assert probe()[0] == probes.FIXED
+
+
+def test_jvm_option_filter_probe_has_teeth(monkeypatch):
+    """Neuter only the options filter; java()'s classpath and cmd guards stay live,
+    so a flip to VULNERABLE proves the probe scores this filter and not a neighbour."""
+    from nltk import internals
+
+    probe = probes.PROBES["GHSA-m4rf-3fr8-xwx3"]
+    assert probe()[0] == probes.FIXED
+
+    monkeypatch.setattr(internals, "_validate_java_options", lambda opts: None)
+    status, evidence = probe()
+    assert status == probes.VULNERABLE, evidence
+    # proof of injection is the command line that was about to run, not a count
+    assert "-Xbootclasspath" in evidence
+
+    monkeypatch.undo()
+    assert probe()[0] == probes.FIXED

--- a/nltk/test/unit/test_advisory_probes.py
+++ b/nltk/test/unit/test_advisory_probes.py
@@ -155,21 +155,31 @@ def test_perceptron_bare_open_probe_has_teeth():
 
 
 def test_perceptron_save_to_json_validation_has_teeth():
-    """Drop the destination check and the tagger write must escape again."""
+    """Restore the tagger's pre-fix destination handling and it must escape again.
+
+    Both of its guards go: the sandbox check on ``loc``, and (on the Windows
+    branch, where there is no pinned dir_fd to write through) the sandboxed
+    per-file open. Neutering only one leaves the other holding, which is the
+    point of having both -- and is why this control has to remove the pair.
+    """
+    import builtins
+
     import nltk.pathsec as pathsec
     import nltk.tag.perceptron as perceptron
 
     probe = probes.PROBES["GHSA-8mgp-746c-j5xp"]
-    original = perceptron.validate_path
+    validate, opener = perceptron.validate_path, perceptron.pathsec_open
     try:
-        # Only the tagger's own check is neutered; pathsec still guards
-        # AveragedPerceptron, so a flip proves save_to_json is what leaked.
         perceptron.validate_path = lambda *args, **kwargs: None
+        perceptron.pathsec_open = lambda path, mode="r", **kwargs: builtins.open(
+            path, mode
+        )
         assert probe()[0] == probes.VULNERABLE
     finally:
-        perceptron.validate_path = original
+        perceptron.validate_path, perceptron.pathsec_open = validate, opener
     assert probe()[0] == probes.FIXED
     assert perceptron.validate_path is pathsec.validate_path
+    assert perceptron.pathsec_open is pathsec.open
 
 
 def test_perceptron_load_does_not_widen_the_sandbox():

--- a/nltk/test/unit/test_advisory_probes.py
+++ b/nltk/test/unit/test_advisory_probes.py
@@ -468,3 +468,68 @@ class TestAdvisoryPagination:
         monkeypatch.setattr(covci, "_MAX_BYTES", 8)
         _serve({covci._API: _FakeResp([{"ghsa_id": "AAAAAAAAAA"}])}, monkeypatch)
         assert covci._fetch_advisories() is None
+
+
+def test_dns_rebinding_probe_has_teeth():
+    """Neuter the SSRF IP filter; the rebound link-local connect must be caught as
+    VULNERABLE. The _resolve_hostname lru_cache is cleared so the restored run does
+    not false-fail on stale sequencing."""
+    import nltk.pathsec as pathsec
+
+    probe = probes.PROBES["GHSA-3gqm-fcw5-w839"]
+    real = pathsec._ip_is_forbidden
+    try:
+        pathsec._resolve_hostname.cache_clear()
+        pathsec._ip_is_forbidden = lambda ip: False  # nothing is forbidden
+        assert probe()[0] == probes.VULNERABLE
+    finally:
+        pathsec._ip_is_forbidden = real
+        pathsec._resolve_hostname.cache_clear()
+    assert probe()[0] == probes.FIXED
+
+
+def test_ssrf_ip_filter_probe_has_teeth():
+    """Allow every IP; all the loopback/metadata/mapped targets must pass the filter
+    and the probe must flip to VULNERABLE."""
+    import nltk.pathsec as pathsec
+
+    probe = probes.PROBES["GHSA-qvv7-cg9c-w4x3"]
+    real = pathsec._ip_is_forbidden
+    try:
+        pathsec._ip_is_forbidden = lambda ip: False
+        assert probe()[0] == probes.VULNERABLE
+    finally:
+        pathsec._ip_is_forbidden = real
+    assert probe()[0] == probes.FIXED
+
+
+def test_dotted_name_probe_has_teeth():
+    """Restore stock find_class (which walks dotted names at proto>=4); the dotted
+    global must then be reconstructed and the probe flip to VULNERABLE."""
+    import pickle
+
+    from nltk.picklesec import AllowlistUnpickler
+
+    probe = probes.PROBES["GHSA-4489-j4f3-2g8q"]
+    real = AllowlistUnpickler.find_class
+    try:
+        AllowlistUnpickler.find_class = pickle.Unpickler.find_class
+        assert probe()[0] == probes.VULNERABLE
+    finally:
+        AllowlistUnpickler.find_class = real
+    assert probe()[0] == probes.FIXED
+
+
+def test_pickle_denylist_fires_under_broad_allow():
+    """Defense in depth: os.system is refused by the module denylist even when a
+    caller mistakenly names 'os' in allowed_modules (not merely by an empty allow)."""
+    import io
+    import pickle
+
+    import pytest
+
+    from nltk.picklesec import allowlisted_pickle_load
+
+    payload = b"cos\nsystem\n(t R."  # GLOBAL os.system, empty-tuple REDUCE
+    with pytest.raises(pickle.UnpicklingError, match="denied module"):
+        allowlisted_pickle_load(io.BytesIO(payload), allowed_modules=("os",))

--- a/nltk/test/unit/test_advisory_probes.py
+++ b/nltk/test/unit/test_advisory_probes.py
@@ -80,6 +80,27 @@ def test_pathsec_enforce_probe_has_teeth():
     assert probe()[0] == probes.FIXED
 
 
+def test_model_artifact_probe_has_teeth():
+    """Remove both containment layers and the probe must read /etc/passwd.
+
+    The payload has to genuinely reach the sink: a traversal that lands on a
+    non-existent path errors out and would score FIXED no matter what the guards
+    do, which is how this probe used to pass with every guard disabled.
+    """
+    import nltk.data
+    import nltk.pathsec as pathsec
+
+    probe = probes.PROBES["GHSA-8mgp-746c-j5xp"]
+    reject, enforce = nltk.data._reject_unsafe_no_protocol, pathsec.ENFORCE
+    try:
+        nltk.data._reject_unsafe_no_protocol = lambda url: None
+        pathsec.ENFORCE = False
+        assert probe()[0] == probes.VULNERABLE
+    finally:
+        nltk.data._reject_unsafe_no_protocol, pathsec.ENFORCE = reject, enforce
+    assert probe()[0] == probes.FIXED
+
+
 def test_pickle_allowlist_probe_has_teeth():
     from nltk.picklesec import AllowlistUnpickler
 

--- a/nltk/test/unit/test_data_security.py
+++ b/nltk/test/unit/test_data_security.py
@@ -192,7 +192,7 @@ def test_load_rejects_encoded_traversal_end_to_end(url):
 def test_find_zip_split_is_non_greedy(tmp_path):
     # Create a.zip containing an entry whose name includes another ".zip".
     zpath = tmp_path / "a.zip"
-    with zipfile.ZipFile(zpath, "w") as zf:
+    with pathsec.ZipFile(zpath, "w") as zf:
         zf.writestr("b.zip/c.txt", "ok")
 
     ptr = data.find("a.zip/b.zip/c.txt", paths=[str(tmp_path)])
@@ -236,7 +236,7 @@ def test_gzip_pointer_open_enforces_sandbox(tmp_path, monkeypatch):
 
     # legitimate gzip INSIDE the allowed root -> reads (decompressed)
     good = allowed / "good.gz"
-    with gzip.open(good, "wb") as fh:
+    with gzip.open(pathsec.open(good, "wb", context="test-fixture"), "wb") as fh:
         fh.write(b"hello-gz")
     with data.GzipFileSystemPathPointer(str(good)).open() as fp:
         assert fp.read() == b"hello-gz"

--- a/nltk/test/unit/test_downloader_atomic.py
+++ b/nltk/test/unit/test_downloader_atomic.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 
 import nltk.data
 import nltk.pathsec
+from nltk import pathsec
 from nltk.downloader import Downloader, Package
 
 from . import _mp_ctx
@@ -21,13 +22,13 @@ BIG_PAYLOAD = b"x" * (1024 * 1024)
 def _build_source_zip(source_dir):
     os.makedirs(source_dir, exist_ok=True)
     zip_path = os.path.join(source_dir, "abc.zip")
-    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_STORED) as zf:
+    with pathsec.ZipFile(zip_path, "w", zipfile.ZIP_STORED) as zf:
         zf.writestr("abc/dummy.txt", BIG_PAYLOAD)
     return zip_path
 
 
 def _zip_metadata(zip_path):
-    with open(zip_path, "rb") as f:
+    with pathsec.open(zip_path, "rb", context="test-fixture") as f:
         data = f.read()
     with zipfile.ZipFile(zip_path, "r") as zf:
         unzipped_size = sum(info.file_size for info in zf.infolist())
@@ -94,7 +95,7 @@ def _collect_debug(download_dir, pkg):
     }
 
     if os.path.exists(zip_path):
-        with open(zip_path, "rb") as f:
+        with pathsec.open(zip_path, "rb", context="test-fixture") as f:
             content = f.read()
         data["zip_md5"] = hashlib.md5(content).hexdigest()
         data["zip_sha256"] = hashlib.sha256(content).hexdigest()
@@ -207,7 +208,7 @@ class TestDownloaderAtomic(unittest.TestCase):
             self.assertTrue(os.path.exists(zip_path), msg=f"debug={debug}")
             self.assertTrue(os.path.exists(extracted_file), msg=f"debug={debug}")
 
-            with open(extracted_file, "rb") as f:
+            with pathsec.open(extracted_file, "rb", context="test-fixture") as f:
                 self.assertEqual(f.read(), BIG_PAYLOAD, msg=f"debug={debug}")
 
             dl = Downloader(download_dir=self.test_dir)
@@ -256,7 +257,8 @@ class TestDownloaderAtomic(unittest.TestCase):
                 zf.writestr(path, content)
         zb = buf.getvalue()
         zip_path = os.path.join(srv_dir, "evil.zip")
-        open(zip_path, "wb").write(zb)
+        with pathsec.open(zip_path, "wb", context="test-fixture") as _fh:
+            _fh.write(zb)
         return srv_dir, zip_path, zb
 
     def _make_pkg(self, zip_path, zb, pkg_id, subdir, members):

--- a/nltk/test/unit/test_downloader_unzip.py
+++ b/nltk/test/unit/test_downloader_unzip.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
+from nltk import pathsec
 from nltk.downloader import ErrorMessage, _unzip_iter, _validate_member
 
 
@@ -13,7 +14,7 @@ def _make_zip(file_path: Path, members: dict[str, bytes]) -> None:
     """
     Create a ZIP file at file_path, with the given arcname->content mapping.
     """
-    with zipfile.ZipFile(file_path, "w") as zf:
+    with pathsec.ZipFile(file_path, "w") as zf:
         for arcname, content in members.items():
             zf.writestr(arcname, content)
 

--- a/nltk/test/unit/test_java_injection_exploit.py
+++ b/nltk/test/unit/test_java_injection_exploit.py
@@ -187,6 +187,12 @@ def _malt_stub(jars, args, tmp_path):
     m.model = str(model)
     m._trained = True
     m._working_dir = None
+    # -i and -o are bounded to the data roots, so give the stub real in-root paths.
+    m._nltk_test_io = (
+        str(tmp_path / "nltk_data" / "in.conll"),
+        str(tmp_path / "nltk_data" / "out.conll"),
+    )
+    (tmp_path / "nltk_data" / "in.conll").touch()
     return m
 
 
@@ -202,7 +208,7 @@ def test_malt_untrusted_jar_is_blocked(tmp_path, monkeypatch):
     evil.parent.mkdir()
     evil.touch()
     m = _malt_stub([str(evil)], [], tmp_path)
-    cmd = m.generate_malt_command("in", "out", mode="parse")
+    cmd = m.generate_malt_command(*m._nltk_test_io, mode="parse")
     with pytest.raises(UntrustedJarError):  # java()'s classpath sandbox refuses it
         m._execute(cmd)
 
@@ -216,7 +222,7 @@ def test_malt_arg_injection_is_blocked(tmp_path, monkeypatch):
     monkeypatch.setattr("nltk.data.path", [str(data_dir)])
     monkeypatch.setattr("nltk.internals._java_bin", "/usr/bin/java")
     m = _malt_stub([str(good)], ["-XX:OnOutOfMemoryError=touch /tmp/x"], tmp_path)
-    cmd = m.generate_malt_command("in", "out", mode="parse")
+    cmd = m.generate_malt_command(*m._nltk_test_io, mode="parse")
     with pytest.raises(ValueError):  # java()'s option allowlist refuses it
         m._execute(cmd)
 
@@ -236,7 +242,7 @@ def test_malt_trusted_jar_and_safe_args_build_command(tmp_path, monkeypatch):
     monkeypatch.setattr("nltk.internals._java_bin", "java")
 
     m = _malt_stub([str(good)], ["-Xmx1024m"], tmp_path)
-    argv = m.generate_malt_command("in", "out", mode="parse")
+    argv = m.generate_malt_command(*m._nltk_test_io, mode="parse")
     # generate_malt_command now returns only the maltparser argv (no java/-cp/opts)
     assert argv[0] == "org.maltparser.Malt" and "-w" in argv
     assert "java" not in argv and "-Xmx1024m" not in argv

--- a/nltk/test/unit/test_java_injection_exploit.py
+++ b/nltk/test/unit/test_java_injection_exploit.py
@@ -180,8 +180,13 @@ def _malt_stub(jars, args, tmp_path):
     m = MaltParser.__new__(MaltParser)
     m.malt_jars = jars
     m.additional_java_args = args
-    m.model = "model.mco"
-    m.working_dir = str(tmp_path)
+    # The model must sit inside the allowed data root: generate_malt_command bounds
+    # it with validate_path before handing -w/-c to the JVM.
+    model = tmp_path / "nltk_data" / "model.mco"
+    model.touch()
+    m.model = str(model)
+    m._trained = True
+    m._working_dir = None
     return m
 
 

--- a/nltk/test/unit/test_model_artifact_pathsec.py
+++ b/nltk/test/unit/test_model_artifact_pathsec.py
@@ -1,0 +1,714 @@
+"""Exploit matrix for the model-artifact read/write APIs (GHSA-8mgp-746c-j5xp).
+
+The advisory names six entry points that treated a caller-supplied model path as
+an ordinary filename: ``TransitionParser.train``/``parse``,
+``AveragedPerceptron.save``/``load``, ``PerceptronTagger.save_to_json`` and
+``save_maxent_params``. This file drives all of them, plus the sibling
+save/load helpers in the same family and the constructor/train routes that reach
+them, with every path form an attacker can supply.
+
+Three kinds of case are kept side by side on purpose:
+
+* **escapes** -- must be refused, and must leave nothing behind outside the root.
+* **benign / probable-but-harmless** -- pinned so that if a future change starts
+  expanding, decoding or following them, the pin turns into a failure.
+* **over-block controls** -- the legitimate in-sandbox flows must keep working,
+  so a fix cannot be "refuse everything".
+
+Plus negative controls: each guard is neutered in-process and the exploit must
+become reachable again, so none of these tests can pass by never reaching a sink.
+
+Staging note: an "outside" target is created under ``$HOME`` (the ``sandbox`` /
+``pathsec_sandbox`` fixtures in conftest.py), never in ``tempfile.mkdtemp()`` --
+a private per-user system temp dir IS an allowed root on macOS/Windows, so a
+target staged there would be correctly permitted and prove nothing.
+"""
+
+import json
+import os
+import pathlib
+import shutil
+import socket
+import stat
+import tempfile
+
+import pytest
+
+import nltk.data
+import nltk.pathsec as pathsec
+import nltk.tag.perceptron as perceptron
+from nltk.tag.perceptron import AveragedPerceptron, PerceptronTagger
+
+CANARY = "MODEL-ARTIFACT-CANARY"
+LANG = "probeartifact"
+
+POSIX_ONLY = pytest.mark.skipif(os.name != "posix", reason="POSIX-only path form")
+
+
+@pytest.fixture
+def outside_only(monkeypatch):
+    """An out-of-sandbox directory that leaves ``nltk.data.path`` alone.
+
+    The ``sandbox`` fixtures narrow the allowed roots to one empty directory,
+    which also hides the installed corpora; tests that must load a real corpus
+    (or a real shipped model) use this instead. ``$HOME`` is not an allowed root
+    on its own, so a directory made there is still a genuine escape target, and
+    that is asserted rather than assumed.
+    """
+    monkeypatch.setattr(pathsec, "ENFORCE", True)
+    path = pathlib.Path(
+        tempfile.mkdtemp(prefix=".nltk_artifact_outside_", dir=str(pathlib.Path.home()))
+    )
+    resolved = path.resolve()
+    inside = any(
+        resolved == root or resolved.is_relative_to(root)
+        for root in pathsec._get_allowed_roots()
+    )
+    try:
+        if inside:
+            pytest.skip("$HOME is inside an allowed root here; no escape target")
+        yield path
+    finally:
+        shutil.rmtree(path, ignore_errors=True)
+
+
+def _weights():
+    return {CANARY: {"NN": 1.0}}
+
+
+def _tagger():
+    tagger = PerceptronTagger(load=False)
+    tagger.model.weights = _weights()
+    tagger.tagdict = {}
+    tagger.classes = {"NN"}
+    return tagger
+
+
+def _plant_model_dir(loc, lang=LANG):
+    """Stage the three json files ``load_from_json`` reads, as an attacker would.
+
+    Written with the stdlib writer deliberately: this is the attacker's plant,
+    staged outside the sandbox before the attack runs, not NLTK doing the I/O.
+    """
+    os.makedirs(loc, mode=0o700, exist_ok=True)
+    for attr, value in (
+        ("weights", _weights()),
+        ("tagdict", {}),
+        ("classes", ["NN"]),
+    ):
+        target = os.path.join(loc, f"averaged_perceptron_tagger_{lang}.{attr}.json")
+        pathlib.Path(target).write_text(json.dumps(value), encoding="utf-8")
+
+
+def _refused(call, *args, **kwargs):
+    """Run *call*; return the security exception it raised, or fail loudly."""
+    with pytest.raises((PermissionError, ValueError, OSError)) as excinfo:
+        call(*args, **kwargs)
+    return excinfo.value
+
+
+# ==========================================================================
+# AveragedPerceptron.save / load -- the advisory's bare-open pair
+# ==========================================================================
+
+
+class TestAveragedPerceptronEscapes:
+    def test_load_outside_root_is_refused(self, sandbox):
+        target = sandbox / "weights.json"
+        target.write_text(json.dumps(_weights()), encoding="utf-8")
+        model = AveragedPerceptron()
+        _refused(model.load, str(target))
+        assert model.weights == {}, "outside-root weights reached the caller"
+
+    def test_save_outside_root_is_refused_and_writes_nothing(self, sandbox):
+        target = sandbox / "written.json"
+        _refused(AveragedPerceptron(_weights()).save, str(target))
+        assert not target.exists(), "refused write still created the file"
+
+    @POSIX_ONLY
+    def test_save_through_in_root_symlink_is_refused(self, pathsec_sandbox):
+        victim = pathsec_sandbox.outside / "victim.json"
+        victim.write_text("untouched", encoding="utf-8")
+        link = pathsec_sandbox.root / "link.json"
+        os.symlink(str(victim), str(link))
+        _refused(AveragedPerceptron(_weights()).save, str(link))
+        assert victim.read_text(encoding="utf-8") == "untouched"
+
+    @POSIX_ONLY
+    def test_save_through_symlinked_parent_is_refused(self, pathsec_sandbox):
+        victim_dir = pathsec_sandbox.outside / "parent"
+        victim_dir.mkdir()
+        link = pathsec_sandbox.root / "plink"
+        os.symlink(str(victim_dir), str(link))
+        _refused(AveragedPerceptron(_weights()).save, str(link / "w.json"))
+        assert not list(victim_dir.iterdir()), "write escaped via the parent symlink"
+
+    @POSIX_ONLY
+    def test_load_through_in_root_hardlink_is_refused(self, pathsec_sandbox):
+        secret = pathsec_sandbox.outside / "secret.json"
+        secret.write_text(json.dumps(_weights()), encoding="utf-8")
+        link = pathsec_sandbox.root / "hard.json"
+        try:
+            os.link(str(secret), str(link))
+        except OSError:
+            pytest.skip("cross-device hardlink not possible here")
+        model = AveragedPerceptron()
+        _refused(model.load, str(link))
+        assert model.weights == {}
+
+    def test_traversal_out_of_the_root_is_refused(self, pathsec_sandbox):
+        target = pathsec_sandbox.outside / "trav.json"
+        target.write_text(json.dumps(_weights()), encoding="utf-8")
+        hop = os.path.join(
+            str(pathsec_sandbox.root), *([os.pardir] * 12), str(target).lstrip("/")
+        )
+        model = AveragedPerceptron()
+        _refused(model.load, hop)
+        assert model.weights == {}
+
+    def test_sibling_directory_sharing_the_root_prefix_is_refused(
+        self, outside_only, monkeypatch
+    ):
+        """``<root>_evil`` starts with the root's characters but is not under it.
+
+        The root has to sit somewhere that is not itself a root, or the sibling
+        would be legitimately allowed by the parent and prove nothing.
+        """
+        root = outside_only / "root"
+        root.mkdir()
+        sibling = outside_only / "root_evil"
+        sibling.mkdir()
+        monkeypatch.setattr(nltk.data, "path", [str(root)])
+        monkeypatch.setattr(pathsec, "_ALLOWED_ROOTS_CACHE", None, raising=False)
+        monkeypatch.setattr(pathsec, "_LAST_DATA_PATHS", None, raising=False)
+        target = sibling / "x.json"
+        target.write_text(json.dumps(_weights()), encoding="utf-8")
+        model = AveragedPerceptron()
+        _refused(model.load, str(target))
+        assert model.weights == {}
+
+    def test_case_folded_root_prefix_is_refused(self, pathsec_sandbox):
+        """An upper-cased path is a different string, so containment fails closed.
+
+        On a case-insensitive filesystem it names the same file; the check must
+        still refuse rather than accidentally accept a non-matching prefix.
+        """
+        inside = pathsec_sandbox.root / "cf.json"
+        AveragedPerceptron(_weights()).save(str(inside))
+        model = AveragedPerceptron()
+        _refused(model.load, str(inside).upper())
+        assert model.weights == {}
+
+    def test_bytes_and_pathlike_forms_are_validated_too(self, sandbox):
+        _refused(AveragedPerceptron(_weights()).save, str(sandbox / "b.json").encode())
+        _refused(AveragedPerceptron(_weights()).save, pathlib.Path(sandbox / "p.json"))
+        assert not list(sandbox.iterdir())
+
+    def test_directory_where_a_file_is_expected_is_refused(self, sandbox):
+        _refused(AveragedPerceptron().load, str(sandbox))
+
+
+class TestAveragedPerceptronBenignForms:
+    """Forms that are harmless today, pinned so a future decode/expand regresses.
+
+    None of these may reach a file outside the sandbox: the assertion is that the
+    call fails and leaves the outside directory empty.
+    """
+
+    @pytest.mark.parametrize(
+        "form",
+        [
+            "nul-trailing",
+            "nul-middle",
+            "newline",
+            "tilde",
+            "relative",
+            "dot-slash",
+            "unc-forward",
+            "backslash",
+            "ads-stream",
+            "overlong",
+            "leading-dash",
+        ],
+    )
+    def test_probable_but_harmless_write_forms_touch_nothing(self, form, sandbox):
+        base = str(sandbox / "x.json")
+        payloads = {
+            "nul-trailing": base + "\x00",
+            "nul-middle": base + "\x00.cfg",
+            "newline": base + "\n",
+            "tilde": "~/" + os.path.basename(base),
+            "relative": os.path.basename(base),
+            "dot-slash": "./" + os.path.basename(base),
+            "unc-forward": "//" + base.lstrip("/"),
+            "backslash": base.replace("/", "\\"),
+            "ads-stream": base + ":stream",
+            "overlong": os.path.join(str(sandbox), "a" * 5000),
+            "leading-dash": "-rf",
+        }
+        with pytest.raises(Exception):
+            AveragedPerceptron(_weights()).save(payloads[form])
+        assert not list(sandbox.iterdir()), f"{form} created a file outside the root"
+
+    @pytest.mark.parametrize("blank", ["   ", "\t", "\n", "  \t "])
+    def test_whitespace_only_paths_do_not_create_a_file(self, blank, outside_only):
+        """A whitespace-only name is a legal relative filename, not "no path".
+
+        Waving it through skipped containment entirely and let the open create
+        that file in the working directory. The CWD is an out-of-sandbox
+        directory here, so a created file is a real escape (on macOS the private
+        system temp dir IS an allowed root, and a temp CWD would hide this).
+        """
+        saved = os.getcwd()
+        os.chdir(outside_only)
+        try:
+            with pytest.raises(Exception):
+                AveragedPerceptron(_weights()).save(blank)
+            assert not list(outside_only.iterdir()), "whitespace path created a file"
+        finally:
+            os.chdir(saved)
+
+    def test_empty_path_is_not_a_write(self, restricted_sandbox):
+        with pytest.raises(OSError):
+            AveragedPerceptron(_weights()).save("")
+
+    @POSIX_ONLY
+    @pytest.mark.parametrize("device", ["/dev/stdin", "/dev/fd/0", "/dev/null"])
+    def test_device_nodes_outside_the_root_are_refused(
+        self, device, restricted_sandbox
+    ):
+        """Never opened: containment refuses the path string before any open().
+
+        That ordering is what keeps a blocking device/FIFO from hanging the
+        reader, so it is asserted rather than assumed.
+        """
+        if not os.path.exists(device):
+            pytest.skip(f"{device} not present")
+        _refused(AveragedPerceptron().load, device)
+
+
+@POSIX_ONLY
+class TestBlockingSpecialFilesAreContained:
+    """A FIFO / unix socket blocks a reader forever, so containment must decide
+    before anything is opened.
+
+    An outside-root FIFO is refused on the path string. One planted *inside* a
+    trusted data root is deliberately still permitted (a root is trusted by
+    definition), so that decision is pinned here rather than left implicit, and
+    neither case is ever opened by this test.
+    """
+
+    def test_outside_fifo_is_refused_without_opening_it(self, pathsec_sandbox):
+        fifo = pathsec_sandbox.outside / "fifo"
+        os.mkfifo(str(fifo))
+        assert stat.S_ISFIFO(os.stat(str(fifo)).st_mode)
+        _refused(AveragedPerceptron().load, str(fifo))
+
+    def test_outside_unix_socket_is_refused_without_opening_it(self, pathsec_sandbox):
+        target = pathsec_sandbox.outside / "sock"
+        server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            server.bind(str(target))
+            _refused(AveragedPerceptron().load, str(target))
+        finally:
+            server.close()
+
+    def test_in_root_special_file_is_inside_the_sandbox(self, restricted_sandbox):
+        fifo = os.path.join(restricted_sandbox, "fifo")
+        os.mkfifo(fifo)
+        # No exception: a path inside a trusted root is contained. Not opened --
+        # a FIFO read blocks until a writer appears.
+        pathsec.validate_path(fifo, context="test")
+
+
+class TestAveragedPerceptronRoundTrip:
+    """Over-block control: the legitimate in-sandbox flow must keep working."""
+
+    def test_save_load_round_trip_inside_a_data_root(self, restricted_sandbox):
+        target = os.path.join(restricted_sandbox, "weights.json")
+        AveragedPerceptron(_weights()).save(target)
+        assert os.path.exists(target)
+        reloaded = AveragedPerceptron()
+        reloaded.load(target)
+        assert reloaded.weights == _weights()
+
+
+# ==========================================================================
+# PerceptronTagger.save_to_json / load_from_json / train / __init__
+# ==========================================================================
+
+
+class TestPerceptronTaggerEscapes:
+    def test_save_to_json_outside_root_is_refused(self, sandbox):
+        loc = str(sandbox / "tagger_out")
+        _refused(_tagger().save_to_json, LANG, loc)
+        assert not os.path.exists(loc), "refused save still created the directory"
+
+    def test_train_save_loc_outside_root_is_refused(self, sandbox):
+        loc = str(sandbox / "trained")
+        tagger = PerceptronTagger(load=False)
+        _refused(tagger.train, [[("a", "DT")]], loc, 1)
+        assert not os.path.exists(loc)
+
+    def test_forced_save_dir_outside_root_is_refused(self, sandbox):
+        tagger = _tagger()
+        tagger._save_dir = str(sandbox / "forced")
+        _refused(tagger.save_to_json, LANG)
+        assert not list(sandbox.iterdir())
+
+    @POSIX_ONLY
+    def test_save_to_json_into_a_symlinked_dir_is_refused(self, pathsec_sandbox):
+        victim = pathsec_sandbox.outside / "sym_victim"
+        victim.mkdir()
+        link = pathsec_sandbox.root / "symloc"
+        os.symlink(str(victim), str(link))
+        _refused(_tagger().save_to_json, LANG, str(link))
+        assert not list(victim.iterdir()), "write leaked through the symlink"
+
+    def test_save_to_json_traversal_out_of_the_root_is_refused(self, pathsec_sandbox):
+        hop = os.path.join(
+            str(pathsec_sandbox.root),
+            *([os.pardir] * 12),
+            str(pathsec_sandbox.outside / "trav").lstrip("/"),
+        )
+        _refused(_tagger().save_to_json, LANG, hop)
+        assert not list(pathsec_sandbox.outside.iterdir())
+
+    def test_load_from_json_outside_root_is_refused(self, sandbox):
+        loc = str(sandbox / "tagger_in")
+        _plant_model_dir(loc)
+        tagger = PerceptronTagger(load=False)
+        _refused(tagger.load_from_json, LANG, loc)
+        assert tagger.model.weights == {}
+
+    @pytest.mark.parametrize("wrap", [str, pathlib.Path, "pointer"])
+    def test_every_loc_type_reaches_the_same_guard(self, wrap, sandbox):
+        """str, pathlib.Path and PathPointer are three separate branches in
+        load_from_json; a guard on one is not a guard on the siblings."""
+        loc = str(sandbox / f"tagger_{getattr(wrap, '__name__', wrap)}")
+        _plant_model_dir(loc)
+        value = nltk.data.FileSystemPathPointer(loc) if wrap == "pointer" else wrap(loc)
+        tagger = PerceptronTagger(load=False)
+        _refused(tagger.load_from_json, LANG, value)
+        assert tagger.model.weights == {}
+
+    def test_constructor_loc_reaches_the_same_guard(self, sandbox):
+        loc = str(sandbox / "tagger_ctor")
+        _plant_model_dir(loc)
+        _refused(PerceptronTagger, True, LANG, loc)
+
+    def test_relative_traversal_loc_is_refused(self, restricted_sandbox):
+        _refused(PerceptronTagger(load=False).load_from_json, LANG, "../../../etc")
+
+    def test_load_from_json_does_not_widen_the_sandbox(self, sandbox):
+        """A caller-supplied dir must never be appended to nltk.data.path.
+
+        That primitive turns containment off for the path and everything under
+        it, process-wide, for every later read.
+        """
+        loc = str(sandbox / "tagger_widen")
+        _plant_model_dir(loc)
+        before = list(nltk.data.path)
+        with pytest.raises(Exception):
+            PerceptronTagger(load=False).load_from_json(LANG, loc)
+        assert list(nltk.data.path) == before
+
+
+class TestPerceptronTaggerLangComponent:
+    """``lang`` is interpolated into the filename both directions open."""
+
+    @pytest.mark.parametrize(
+        "lang",
+        [
+            "../evil",
+            "sub/../../evil",
+            "/abs",
+            "a\x00b",
+            "..",
+            ".",
+            "",
+            "e\\v",
+            "a/b",
+        ],
+    )
+    def test_lang_cannot_contribute_path_structure(self, lang, restricted_sandbox):
+        loc = os.path.join(restricted_sandbox, "d")
+        os.makedirs(loc, exist_ok=True)
+        with pytest.raises(ValueError):
+            _tagger().save_to_json(lang=lang, loc=loc)
+        assert not os.listdir(loc)
+
+    @pytest.mark.parametrize("lang", ["eng", "rus", "probeartifact", "xx"])
+    def test_ordinary_language_codes_still_work(self, lang, restricted_sandbox):
+        loc = os.path.join(restricted_sandbox, "ok")
+        os.makedirs(loc, exist_ok=True)
+        _tagger().save_to_json(lang=lang, loc=loc)
+        assert sorted(os.listdir(loc)) == sorted(
+            _tagger().param_files(lang)
+        ), "a legitimate language code was blocked or renamed"
+
+
+class TestPerceptronTaggerRoundTrip:
+    """Over-block controls for the whole train/save/load path."""
+
+    @pytest.fixture
+    def staged(self):
+        """A tagger whose lazily created staging dir is removed afterwards, so a
+        test run does not leave directories behind in the user's data root."""
+        made = []
+
+        def build(**kwargs):
+            tagger = (
+                _tagger() if not kwargs.get("plain") else PerceptronTagger(load=False)
+            )
+            made.append(tagger)
+            return tagger
+
+        try:
+            yield build
+        finally:
+            for tagger in made:
+                if tagger._save_dir:
+                    shutil.rmtree(tagger._save_dir, ignore_errors=True)
+
+    def test_default_save_dir_is_inside_a_data_root(self, staged):
+        tagger = staged(plain=True)
+        resolved = pathlib.Path(tagger.save_dir).resolve()
+        assert any(
+            resolved == root or resolved.is_relative_to(root)
+            for root in pathsec._get_allowed_roots()
+        ), f"{tagger.save_dir} is not inside an allowed root"
+        assert stat.S_IMODE(os.stat(tagger.save_dir).st_mode) == 0o700
+
+    def test_save_dir_is_memoized(self, staged):
+        tagger = staged(plain=True)
+        assert tagger.save_dir == tagger.save_dir
+
+    def test_save_then_load_round_trip(self, staged):
+        tagger = staged()
+        loc = tagger.save_dir
+        tagger.save_to_json(lang=LANG, loc=loc)
+        reloaded = PerceptronTagger(load=False)
+        reloaded.load_from_json(lang=LANG, loc=loc)
+        assert reloaded.model.weights == _weights()
+        assert reloaded.classes == {"NN"}
+
+    def test_train_with_default_save_loc_round_trips(self, staged):
+        tagger = staged(plain=True)
+        sentences = [[("the", "DT"), ("dog", "NN")], [("a", "DT"), ("cat", "NN")]]
+        tagger.train(sentences, save_loc=tagger.save_dir, nr_iter=2)
+        reloaded = PerceptronTagger(load=False)
+        reloaded.load_from_json(lang=tagger.lang, loc=tagger.save_dir)
+        assert reloaded.tag(["the", "dog"]) == [("the", "DT"), ("dog", "NN")]
+
+    def test_shipped_english_tagger_still_loads_and_tags(self):
+        pytest.importorskip("numpy")
+        try:
+            tagger = PerceptronTagger(load=True, lang="eng")
+        except LookupError:
+            pytest.skip("averaged_perceptron_tagger_eng not installed")
+        tagged = tagger.tag(["The", "dog", "barks", "."])
+        assert [word for word, _ in tagged] == ["The", "dog", "barks", "."]
+        assert [tag for _, tag in tagged][:2] == ["DT", "NN"]
+        assert all(tag for _, tag in tagged), "a token came back untagged"
+
+
+# ==========================================================================
+# The rest of the model-artifact family reached from the same threat
+# ==========================================================================
+
+
+class TestSiblingModelArtifactApis:
+    def test_transition_parser_parse_outside_root_is_refused(self, sandbox):
+        from nltk.parse.transitionparser import TransitionParser
+
+        target = sandbox / "model.pickle"
+        target.write_bytes(b"\x80\x04N.")
+        _refused(TransitionParser("arc-standard").parse, [], str(target))
+
+    def test_transition_parser_train_outside_root_is_refused(self, sandbox):
+        pytest.importorskip("sklearn")
+        from nltk.parse.transitionparser import TransitionParser
+
+        target = str(sandbox / "trained.pickle")
+        _refused(TransitionParser("arc-standard").train, [], target, False)
+        assert not os.path.exists(target)
+
+    def test_save_maxent_params_outside_root_is_refused(self, sandbox):
+        numpy = pytest.importorskip("numpy")
+        from nltk.classify.maxent import save_maxent_params
+
+        loc = str(sandbox / "maxent_out")
+        _refused(
+            save_maxent_params,
+            numpy.array([1.0]),
+            {("a", "b"): 0},
+            ["L"],
+            {"alwayson": 0},
+            loc,
+        )
+        assert not os.path.exists(loc)
+
+    def test_load_maxent_params_outside_root_is_refused(self, sandbox):
+        pytest.importorskip("numpy")
+        from nltk.classify.maxent import load_maxent_params
+
+        loc = sandbox / "maxent_in"
+        loc.mkdir()
+        for name, body in (
+            ("weights.txt", "1.0"),
+            ("mapping.tab", ""),
+            ("labels.txt", "L"),
+            ("alwayson.tab", ""),
+        ):
+            (loc / name).write_text(body, encoding="utf-8")
+        _refused(load_maxent_params, nltk.data.FileSystemPathPointer(str(loc)))
+
+    def test_save_punkt_params_outside_root_is_refused(self, sandbox):
+        from nltk.tokenize.punkt import PunktParameters, save_punkt_params
+
+        loc = str(sandbox / "punkt_out")
+        _refused(save_punkt_params, PunktParameters(), loc)
+        assert not os.path.exists(loc)
+
+    def test_maxent_ne_chunker_save_params_outside_root_is_refused(self, outside_only):
+        pytest.importorskip("numpy")
+        from nltk.chunk.named_entity import Maxent_NE_Chunker
+
+        try:
+            chunker = Maxent_NE_Chunker("multiclass")
+        except LookupError:
+            pytest.skip("maxent_ne_chunker_tab not installed")
+        loc = str(outside_only / "ne_out")
+        _refused(chunker.save_params, loc)
+        assert not os.path.exists(loc)
+
+
+class TestTblDemoModelPaths:
+    """``nltk.tbl.demo.postag`` pickles a tagger to caller-supplied paths."""
+
+    @staticmethod
+    def _postag(**kwargs):
+        """Run the demo, tolerating one pre-existing, unrelated failure.
+
+        Re-tagging with the *reloaded* tagger raises ``ValueError: timeout not
+        float or None`` on ``develop`` too (a redos-wrapped pattern does not
+        survive a pickle round trip). That happens after the model file is
+        written, so it does not affect what these tests assert; anything else
+        propagates.
+        """
+        from nltk.tbl import demo as tbl_demo
+
+        try:
+            tbl_demo.postag(
+                num_sents=10,
+                max_rules=1,
+                trace=0,
+                separate_baseline_data=True,
+                **kwargs,
+            )
+        except ValueError as exc:
+            if "timeout not float or None" not in str(exc):
+                raise
+
+    @pytest.fixture(autouse=True)
+    def _needs_treebank(self):
+        pytest.importorskip("numpy")
+        try:
+            nltk.data.find("corpora/treebank")
+        except LookupError:
+            pytest.skip("treebank corpus not installed")
+
+    @pytest.mark.parametrize(
+        "kwarg", ["serialize_output", "cache_baseline_tagger", "error_output"]
+    )
+    def test_outside_root_destinations_are_refused(self, kwarg, outside_only):
+        target = outside_only / f"{kwarg}.out"
+        with pytest.raises((PermissionError, ValueError, OSError)):
+            self._postag(**{kwarg: str(target)})
+        assert not target.exists(), f"{kwarg} wrote outside the sandbox"
+
+    @pytest.mark.parametrize(
+        "kwarg", ["serialize_output", "cache_baseline_tagger", "error_output"]
+    )
+    def test_in_root_destinations_still_work(self, kwarg):
+        staging = nltk.data.make_staging_dir(prefix="nltk_tbl_demo_")
+        try:
+            target = os.path.join(staging, f"{kwarg}.out")
+            self._postag(**{kwarg: target})
+            assert os.path.getsize(target) > 0, f"{kwarg} wrote nothing in-sandbox"
+        finally:
+            shutil.rmtree(staging, ignore_errors=True)
+
+
+# ==========================================================================
+# Negative controls: neuter a guard, the exploit must come back
+# ==========================================================================
+
+
+class TestNegativeControls:
+    def test_enforce_off_lets_the_read_escape(self, sandbox, monkeypatch):
+        target = sandbox / "weights.json"
+        target.write_text(json.dumps(_weights()), encoding="utf-8")
+        monkeypatch.setattr(pathsec, "ENFORCE", False)
+        model = AveragedPerceptron()
+        model.load(str(target))
+        assert model.weights == _weights(), "guard disabled but read still blocked"
+
+    def test_bare_open_reopens_the_advisory_write(self, sandbox, monkeypatch):
+        """Put the advisory's own bug back and the escape must return."""
+        target = sandbox / "bare.json"
+
+        def bare_save(self, path):
+            with open(path, "w") as fout:
+                return json.dump(self.weights, fout)
+
+        monkeypatch.setattr(AveragedPerceptron, "save", bare_save)
+        AveragedPerceptron(_weights()).save(str(target))
+        assert CANARY in target.read_text(encoding="utf-8")
+
+    def test_dropping_save_to_json_validation_reopens_the_write(
+        self, sandbox, monkeypatch
+    ):
+        monkeypatch.setattr(perceptron, "validate_path", lambda *a, **k: None)
+        loc = str(sandbox / "unguarded")
+        _tagger().save_to_json(lang=LANG, loc=loc)
+        assert sorted(os.listdir(loc)), "no files written with the guard removed"
+
+    def test_widening_nltk_data_path_reopens_the_read(self, sandbox, monkeypatch):
+        """The removed ``_authorize_private_dir`` primitive, reconstructed."""
+        loc = str(sandbox / "widened")
+        _plant_model_dir(loc)
+        monkeypatch.setattr(nltk.data, "path", list(nltk.data.path) + [loc])
+        monkeypatch.setattr(pathsec, "_ALLOWED_ROOTS_CACHE", None, raising=False)
+        monkeypatch.setattr(pathsec, "_LAST_DATA_PATHS", None, raising=False)
+        tagger = PerceptronTagger(load=False)
+        tagger.load_from_json(LANG, loc)
+        assert tagger.model.weights == _weights()
+
+    def test_dropping_the_lang_check_lets_lang_carry_a_separator(self):
+        assert "/" in "".join(
+            f"averaged_perceptron_tagger_{'a/b'}.{attr}.json" for attr in ("weights",)
+        ), "the filename template no longer interpolates lang"
+        with pytest.raises(ValueError):
+            perceptron._reject_path_structure("a/b", "lang")
+
+    def test_whitespace_waiver_reopens_the_cwd_write(self, outside_only, monkeypatch):
+        """Restoring the whitespace early-return must let the write land again."""
+        real = pathsec.validate_path
+
+        def waives_whitespace(path_input, *args, **kwargs):
+            if isinstance(path_input, str) and path_input and not path_input.strip():
+                return
+            return real(path_input, *args, **kwargs)
+
+        monkeypatch.setattr(pathsec, "validate_path", waives_whitespace)
+        monkeypatch.setattr(perceptron, "validate_path", waives_whitespace)
+        saved = os.getcwd()
+        os.chdir(outside_only)
+        try:
+            with pytest.raises(Exception):
+                AveragedPerceptron(_weights()).save("   ")
+            assert list(outside_only.iterdir()), "waiver did not reopen the write"
+        finally:
+            os.chdir(saved)

--- a/nltk/test/unit/test_model_artifact_pathsec.py
+++ b/nltk/test/unit/test_model_artifact_pathsec.py
@@ -24,7 +24,9 @@ a private per-user system temp dir IS an allowed root on macOS/Windows, so a
 target staged there would be correctly permitted and prove nothing.
 """
 
+import ast
 import builtins
+import contextlib
 import json
 import os
 import pathlib
@@ -37,6 +39,7 @@ import time
 
 import pytest
 
+import nltk
 import nltk.data
 import nltk.pathsec as pathsec
 import nltk.tag.perceptron as perceptron
@@ -219,6 +222,28 @@ class TestAveragedPerceptronEscapes:
 
     def test_directory_where_a_file_is_expected_is_refused(self, sandbox):
         _refused(AveragedPerceptron().load, str(sandbox))
+
+    def test_an_open_descriptor_is_passed_through_by_design(self, sandbox):
+        """An int is a descriptor the caller already holds, not a path.
+
+        pathsec deliberately lets one through: opening it grants no capability
+        the caller did not already have. Pinned because it is the one input that
+        skips containment, so the exemption must stay a deliberate, narrow one
+        (an int) and never widen to something a caller could supply as text.
+        """
+        target = sandbox / "weights.json"
+        target.write_text(json.dumps(_weights()), encoding="utf-8")
+        # os.open, not the builtin: this deliberately stages a descriptor for a
+        # file outside the sandbox, which is the whole point of the case.
+        descriptor = os.open(str(target), os.O_RDONLY)
+        try:
+            model = AveragedPerceptron()
+            model.load(descriptor)
+            assert model.weights == _weights()
+        finally:
+            with contextlib.suppress(OSError):
+                os.close(descriptor)
+        _refused(AveragedPerceptron().load, str(target))
 
     @POSIX_ONLY
     def test_dangling_in_root_symlink_destination_creates_nothing(
@@ -925,6 +950,45 @@ class TestModelReadsRefuseAPickleGadget:
         target = self._planted(restricted_sandbox)
         with pytest.raises(pickle.UnpicklingError):
             nltk.data.load(os.path.basename(target), format="pickle", cache=False)
+
+
+class TestNoOtherCodeWidensTheSandbox:
+    """Repo-wide invariant behind the ``load_from_json`` fix.
+
+    Appending to ``nltk.data.path`` makes a directory an allowed root for the
+    rest of the process, which disarms containment for it and everything under
+    it. Exactly one place may do that: ``nltk.download(download_dir=...)``, where
+    the caller explicitly names the destination for NLTK's own data and the
+    downloader refuses a non-private one. Any new occurrence is the primitive
+    that made the advisory's read succeed, coming back.
+    """
+
+    ALLOWED = {("nltk/downloader.py", "_authorize_data_dir")}
+
+    def test_only_the_downloader_appends_to_nltk_data_path(self):
+        root = pathlib.Path(nltk.__file__).parent
+        offenders = []
+        for source in sorted(root.rglob("*.py")):
+            relative = source.relative_to(root.parent).as_posix()
+            if relative.startswith("nltk/test/"):
+                continue
+            tree = ast.parse(source.read_text(encoding="utf-8"), relative)
+            for parent in ast.walk(tree):
+                if not isinstance(parent, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                for node in ast.walk(parent):
+                    if (
+                        isinstance(node, ast.Call)
+                        and isinstance(node.func, ast.Attribute)
+                        and node.func.attr in ("append", "insert", "extend")
+                        and isinstance(node.func.value, ast.Attribute)
+                        and node.func.value.attr == "path"
+                        and getattr(node.func.value.value, "attr", None) == "data"
+                    ):
+                        offenders.append((relative, parent.name))
+        assert (
+            set(offenders) <= self.ALLOWED
+        ), "new nltk.data.path widening: %s" % sorted(set(offenders) - self.ALLOWED)
 
 
 class TestNegativeControls:

--- a/nltk/test/unit/test_model_artifact_pathsec.py
+++ b/nltk/test/unit/test_model_artifact_pathsec.py
@@ -24,6 +24,7 @@ a private per-user system temp dir IS an allowed root on macOS/Windows, so a
 target staged there would be correctly permitted and prove nothing.
 """
 
+import builtins
 import json
 import os
 import pathlib
@@ -478,7 +479,9 @@ class TestPerceptronTaggerRoundTrip:
             resolved == root or resolved.is_relative_to(root)
             for root in pathsec._get_allowed_roots()
         ), f"{tagger.save_dir} is not inside an allowed root"
-        assert stat.S_IMODE(os.stat(tagger.save_dir).st_mode) == 0o700
+        if os.name == "posix":
+            # Windows has no POSIX mode bits; the per-user profile ACLs govern.
+            assert stat.S_IMODE(os.stat(tagger.save_dir).st_mode) == 0o700
 
     def test_save_dir_is_memoized(self, staged):
         tagger = staged(plain=True)
@@ -641,6 +644,109 @@ class TestTblDemoModelPaths:
             shutil.rmtree(staging, ignore_errors=True)
 
 
+class TestCRFTaggerModelPaths:
+    """``CRFTagger`` hands a caller path to a native (pycrfsuite) loader/writer.
+
+    Not in the advisory's list, but the same threat: the C extension does its
+    own open, so nothing downstream would have contained it.
+    """
+
+    TRAIN = [[("the", "DT"), ("dog", "NN")], [("a", "DT"), ("cat", "NN")]]
+
+    def test_train_outside_root_is_refused_before_writing(self, sandbox):
+        pytest.importorskip("pycrfsuite")
+        from nltk.tag.crf import CRFTagger
+
+        target = str(sandbox / "model.crf")
+        _refused(CRFTagger().train, self.TRAIN, target)
+        assert not os.path.exists(target), "refused train still wrote the model"
+
+    def test_set_model_file_outside_root_is_refused(self, sandbox):
+        pytest.importorskip("pycrfsuite")
+        from nltk.tag.crf import CRFTagger
+
+        target = sandbox / "model.crf"
+        target.write_bytes(b"not-a-real-model")
+        _refused(CRFTagger().set_model_file, str(target))
+
+    def test_in_root_train_and_tag_round_trip(self, restricted_sandbox):
+        pytest.importorskip("pycrfsuite")
+        from nltk.tag.crf import CRFTagger
+
+        target = os.path.join(restricted_sandbox, "model.crf")
+        tagger = CRFTagger()
+        tagger.train(self.TRAIN, target)
+        assert os.path.getsize(target) > 0
+        reloaded = CRFTagger()
+        reloaded.set_model_file(target)
+        assert reloaded.tag(["the", "dog"]) == [("the", "DT"), ("dog", "NN")]
+
+
+class TestResourceNameSteering:
+    """Caller-supplied *resource names* that steer a model load.
+
+    None of these escape a data root, so they are pinned as audited-benign: the
+    assertion is the containment property, so a future change that lets one
+    resolve outside turns into a failure here.
+    """
+
+    def test_punkt_lang_traversal_stays_inside_a_data_root(self):
+        """``PunktTokenizer(lang)`` climbs at most within the trusted root.
+
+        ``normalize_resource_name`` collapses ``punkt_tab/..`` to ``tokenizers/``
+        before ``find`` sees it, so the lookup moves inside the root but cannot
+        leave it; a leading ``..`` survives normalisation and ``find`` rejects it.
+        """
+        from nltk.tokenize import PunktTokenizer
+
+        with pytest.raises((LookupError, OSError, ValueError)) as excinfo:
+            PunktTokenizer("../..")
+        message = str(excinfo.value)
+        assert "/etc/" not in message and "passwd" not in message
+
+    @pytest.mark.parametrize(
+        "resource",
+        [
+            "tokenizers/punkt/../x.pickle",
+            "tokenizers/punkt/../../../etc/passwd.pickle",
+            "chunkers/maxent_ne_chunker/../../../etc/x.pickle",
+        ],
+    )
+    def test_pickle_shim_resource_names_cannot_traverse(self, resource):
+        """load() routes a *.pickle name to a pickle-free loader; the name that
+        picks the model must not carry traversal."""
+        with pytest.raises((ValueError, LookupError, OSError)):
+            nltk.data.load(resource)
+
+    def test_pos_tag_rejects_an_unknown_language(self):
+        with pytest.raises(NotImplementedError):
+            nltk.pos_tag(["a"], lang="../../etc")
+
+    def test_ne_chunker_format_cannot_traverse(self):
+        from nltk.chunk import ne_chunker
+
+        with pytest.raises((ValueError, LookupError, OSError)):
+            ne_chunker("../../../etc")
+
+    def test_retrieve_without_a_filename_does_not_write_to_an_outside_cwd(
+        self, outside_only
+    ):
+        """``retrieve`` derives the destination from the URL and writes it to the
+        working directory; that destination is still sandbox-checked."""
+        try:
+            source = str(nltk.data.find("corpora/city_database/city.db"))
+        except LookupError:
+            pytest.skip("city_database corpus not installed")
+        saved = os.getcwd()
+        os.chdir(outside_only)
+        try:
+            with pytest.raises((PermissionError, ValueError, OSError)):
+                nltk.data.retrieve("file://" + source, verbose=False)
+            assert not list(outside_only.iterdir())
+        finally:
+            os.chdir(saved)
+
+
 # ==========================================================================
 # Negative controls: neuter a guard, the exploit must come back
 # ==========================================================================
@@ -670,7 +776,14 @@ class TestNegativeControls:
     def test_dropping_save_to_json_validation_reopens_the_write(
         self, sandbox, monkeypatch
     ):
+        """Both destination guards go: the sandbox check on ``loc`` and, on the
+        branch that has no pinned dir_fd, the sandboxed per-file open."""
         monkeypatch.setattr(perceptron, "validate_path", lambda *a, **k: None)
+        monkeypatch.setattr(
+            perceptron,
+            "pathsec_open",
+            lambda path, mode="r", **kwargs: builtins.open(path, mode),
+        )
         loc = str(sandbox / "unguarded")
         _tagger().save_to_json(lang=LANG, loc=loc)
         assert sorted(os.listdir(loc)), "no files written with the guard removed"
@@ -712,3 +825,16 @@ class TestNegativeControls:
             assert list(outside_only.iterdir()), "waiver did not reopen the write"
         finally:
             os.chdir(saved)
+
+    def test_dropping_the_crf_check_reopens_the_native_write(
+        self, sandbox, monkeypatch
+    ):
+        pytest.importorskip("pycrfsuite")
+        import nltk.tag.crf as crf
+
+        monkeypatch.setattr(crf, "validate_path", lambda *a, **k: None)
+        target = str(sandbox / "unguarded.crf")
+        crf.CRFTagger().train(
+            [[("the", "DT"), ("dog", "NN")], [("a", "DT"), ("cat", "NN")]], target
+        )
+        assert os.path.getsize(target) > 0, "no model written with the guard removed"

--- a/nltk/test/unit/test_model_artifact_pathsec.py
+++ b/nltk/test/unit/test_model_artifact_pathsec.py
@@ -28,10 +28,12 @@ import builtins
 import json
 import os
 import pathlib
+import pickle
 import shutil
 import socket
 import stat
 import tempfile
+import time
 
 import pytest
 
@@ -415,6 +417,64 @@ class TestPerceptronTaggerEscapes:
         assert list(nltk.data.path) == before
 
 
+class TestPerceptronTaggerDirectoryOpen:
+    """The pinned-descriptor layer under ``save_to_json``."""
+
+    @POSIX_ONLY
+    def test_a_swapped_intermediate_directory_is_caught_by_the_fd_recheck(
+        self, pathsec_sandbox, monkeypatch
+    ):
+        """O_NOFOLLOW only covers the leaf.
+
+        With the caller-path check skipped (as a swapped parent between check and
+        open would leave it), the descriptor's own real path must still be
+        refused, so the model write cannot land outside the roots.
+        """
+        victim = pathsec_sandbox.outside / "redirected"
+        victim.mkdir()
+        link = pathsec_sandbox.root / "plink"
+        os.symlink(str(victim), str(link))
+
+        real = perceptron.validate_path
+        calls = []
+
+        def skip_the_caller_check(*args, **kwargs):
+            calls.append(args)
+            if len(calls) == 1:
+                return None
+            return real(*args, **kwargs)
+
+        monkeypatch.setattr(perceptron, "validate_path", skip_the_caller_check)
+        _refused(_tagger().save_to_json, LANG, str(link / "leaf"))
+        assert (
+            not any((victim / "leaf").iterdir()) if (victim / "leaf").exists() else True
+        )
+        assert len(calls) > 1, "the descriptor was never re-validated"
+
+    def test_a_regular_file_as_the_destination_is_refused(self, restricted_sandbox):
+        target = os.path.join(restricted_sandbox, "not_a_dir")
+        with pathsec.open(target, "w", context="test") as handle:
+            handle.write("{}")
+        _refused(_tagger().save_to_json, LANG, target)
+
+    @POSIX_ONLY
+    def test_an_in_root_symlink_destination_is_refused_fail_closed(
+        self, restricted_sandbox
+    ):
+        """Even a symlink pointing at another in-root file is refused.
+
+        Model artifacts are never symlinks, so refusing the final component
+        outright is the fail-closed choice; it is asserted so a future
+        "follow it, it stays in-root anyway" relaxation shows up here.
+        """
+        real = os.path.join(restricted_sandbox, "real.json")
+        with pathsec.open(real, "w", context="test") as handle:
+            handle.write("{}")
+        link = os.path.join(restricted_sandbox, "link.json")
+        os.symlink(real, link)
+        _refused(AveragedPerceptron(_weights()).save, link)
+
+
 class TestPerceptronTaggerLangComponent:
     """``lang`` is interpolated into the filename both directions open."""
 
@@ -631,6 +691,23 @@ class TestTblDemoModelPaths:
             self._postag(**{kwarg: str(target)})
         assert not target.exists(), f"{kwarg} wrote outside the sandbox"
 
+    def test_learning_curve_output_outside_root_is_refused(self, outside_only):
+        """matplotlib writes the plot itself, so the path is checked up front."""
+        target = outside_only / "curve.png"
+        with pytest.raises((PermissionError, ValueError, OSError)):
+            self._postag(incremental_stats=True, learning_curve_output=str(target))
+        assert not target.exists()
+
+    def test_learning_curve_output_in_root_still_works(self):
+        pytest.importorskip("matplotlib")
+        staging = nltk.data.make_staging_dir(prefix="nltk_tbl_curve_")
+        try:
+            target = os.path.join(staging, "curve.png")
+            self._postag(incremental_stats=True, learning_curve_output=target)
+            assert os.path.getsize(target) > 0
+        finally:
+            shutil.rmtree(staging, ignore_errors=True)
+
     @pytest.mark.parametrize(
         "kwarg", ["serialize_output", "cache_baseline_tagger", "error_output"]
     )
@@ -750,6 +827,51 @@ class TestResourceNameSteering:
 # ==========================================================================
 # Negative controls: neuter a guard, the exploit must come back
 # ==========================================================================
+
+
+class TestModelReadsAreBounded:
+    """A hostile *in-root* model must fail fast, not hang or exhaust the process."""
+
+    def test_deeply_nested_json_weights_are_rejected_quickly(self, restricted_sandbox):
+        target = os.path.join(restricted_sandbox, "nested.json")
+        with pathsec.open(target, "w", context="test") as handle:
+            handle.write("[" * 200000 + "]" * 200000)
+        started = time.perf_counter()
+        with pytest.raises((RecursionError, ValueError)):
+            AveragedPerceptron().load(target)
+        assert time.perf_counter() - started < 15.0
+
+
+class TestModelReadsRefuseAPickleGadget:
+    """Containment is not the only guard on a model read.
+
+    A model file *inside* a trusted root still goes through an allowlisting
+    unpickler, so a reachable-path model cannot execute a reduce gadget. Pinned
+    here because these are the same read paths the sandbox guards: fixing one
+    must not be mistaken for covering the other.
+    """
+
+    class _Boom:
+        def __reduce__(self):
+            return (os.system, ("exit 0",))
+
+    def _planted(self, root):
+        target = os.path.join(root, "gadget.pickle")
+        with pathsec.open(target, "wb", context="test") as handle:
+            pickle.dump(self._Boom(), handle)
+        return target
+
+    def test_transition_parser_refuses_a_gadget_model(self, restricted_sandbox):
+        from nltk.parse.transitionparser import TransitionParser
+
+        target = self._planted(restricted_sandbox)
+        with pytest.raises(pickle.UnpicklingError):
+            TransitionParser("arc-standard").parse([], target)
+
+    def test_data_load_pickle_refuses_a_gadget_model(self, restricted_sandbox):
+        target = self._planted(restricted_sandbox)
+        with pytest.raises(pickle.UnpicklingError):
+            nltk.data.load(os.path.basename(target), format="pickle", cache=False)
 
 
 class TestNegativeControls:

--- a/nltk/test/unit/test_model_artifact_pathsec.py
+++ b/nltk/test/unit/test_model_artifact_pathsec.py
@@ -210,6 +210,49 @@ class TestAveragedPerceptronEscapes:
     def test_directory_where_a_file_is_expected_is_refused(self, sandbox):
         _refused(AveragedPerceptron().load, str(sandbox))
 
+    @POSIX_ONLY
+    def test_dangling_in_root_symlink_destination_creates_nothing(
+        self, pathsec_sandbox
+    ):
+        """A symlink to a path that does not exist yet is the sharper write case.
+
+        ``os.path.exists`` says False, so an "already there?" pre-check waves it
+        through, and the open would then create the victim at the far end.
+        """
+        victim = pathsec_sandbox.outside / "victim.json"
+        link = pathsec_sandbox.root / "dangling.json"
+        os.symlink(str(victim), str(link))
+        _refused(AveragedPerceptron(_weights()).save, str(link))
+        assert not victim.exists(), "the write created the outside-root victim"
+
+    @POSIX_ONLY
+    def test_retrieve_to_a_dangling_in_root_symlink_creates_nothing(
+        self, pathsec_sandbox
+    ):
+        source = pathsec_sandbox.root / "src.txt"
+        with pathsec.open(str(source), "w", context="test") as handle:
+            handle.write("inside-payload")
+        victim = pathsec_sandbox.outside / "victim.txt"
+        link = pathsec_sandbox.root / "dangling.txt"
+        os.symlink(str(victim), str(link))
+        with pytest.raises((PermissionError, ValueError, OSError)):
+            nltk.data.retrieve("file://" + str(source), str(link), verbose=False)
+        assert not victim.exists()
+
+    def test_empty_resource_name_resolves_to_the_root_not_outside_it(
+        self, restricted_sandbox
+    ):
+        """``load("")`` normalises to the data root itself.
+
+        Harmless (a directory is not a readable model) but pinned: the point is
+        that it lands *on* the root rather than anywhere above it.
+        """
+        with pytest.raises((OSError, ValueError, LookupError)) as excinfo:
+            nltk.data.load("", format="raw", cache=False)
+        assert os.path.dirname(str(restricted_sandbox)) not in str(excinfo.value) or (
+            str(restricted_sandbox) in str(excinfo.value)
+        )
+
 
 class TestAveragedPerceptronBenignForms:
     """Forms that are harmless today, pinned so a future decode/expand regresses.

--- a/nltk/test/unit/test_model_artifact_pathsec.py
+++ b/nltk/test/unit/test_model_artifact_pathsec.py
@@ -553,6 +553,63 @@ class TestPerceptronTaggerDirectoryOpen:
         _refused(AveragedPerceptron(_weights()).save, link)
 
 
+class TestDestinationSpellings:
+    """The same outside directory, written several legal ways.
+
+    Trailing separators/dots/spaces and the non-``str`` path types are the
+    spellings a prefix comparison is most likely to disagree with the kernel
+    about, so each is asserted to end at the same refusal.
+    """
+
+    @pytest.mark.parametrize("suffix", ["/", ".", " ", "//", "/."])
+    def test_trailing_characters_do_not_change_the_verdict(self, suffix, sandbox):
+        _refused(_tagger().save_to_json, LANG, str(sandbox / "dest") + suffix)
+        assert not list(sandbox.iterdir())
+
+    @pytest.mark.parametrize("wrap", ["path", "bytes"])
+    def test_non_string_destinations_are_validated_too(self, wrap, sandbox):
+        raw = str(sandbox / "dest")
+        loc = pathlib.Path(raw) if wrap == "path" else raw.encode()
+        _refused(_tagger().save_to_json, LANG, loc)
+        assert not list(sandbox.iterdir())
+
+    @POSIX_ONLY
+    def test_a_symlink_chain_is_followed_to_its_real_end(self, pathsec_sandbox):
+        """Two in-root hops to an outside file, not one.
+
+        A check that resolves only one level would call the second hop in-root
+        and let the read through.
+        """
+        target = pathsec_sandbox.outside / "chain.json"
+        target.write_text(json.dumps(_weights()), encoding="utf-8")
+        second = pathsec_sandbox.root / "second.json"
+        first = pathsec_sandbox.root / "first.json"
+        os.symlink(str(target), str(second))
+        os.symlink(str(second), str(first))
+        model = AveragedPerceptron()
+        _refused(model.load, str(first))
+        assert model.weights == {}
+
+    @POSIX_ONLY
+    def test_maxent_tab_dir_symlinked_out_of_the_root_is_refused(self, pathsec_sandbox):
+        numpy = pytest.importorskip("numpy")
+        from nltk.classify.maxent import save_maxent_params
+
+        victim = pathsec_sandbox.outside / "mx"
+        victim.mkdir()
+        link = pathsec_sandbox.root / "symdir"
+        os.symlink(str(victim), str(link))
+        _refused(
+            save_maxent_params,
+            numpy.array([1.0]),
+            {("a", "b"): 0},
+            ["L"],
+            {"alwayson": 0},
+            str(link),
+        )
+        assert not list(victim.iterdir())
+
+
 class TestPerceptronTaggerLangComponent:
     """``lang`` is interpolated into the filename both directions open."""
 
@@ -576,6 +633,29 @@ class TestPerceptronTaggerLangComponent:
         with pytest.raises(ValueError):
             _tagger().save_to_json(lang=lang, loc=loc)
         assert not os.listdir(loc)
+
+    def test_an_overlong_lang_cannot_be_written(self, restricted_sandbox):
+        """Rejected by the filesystem, not by a guard, so it is a pin: nothing is
+        created and the failure never lands outside the directory."""
+        loc = os.path.join(restricted_sandbox, "long")
+        os.makedirs(loc, exist_ok=True)
+        with pytest.raises(OSError):
+            _tagger().save_to_json(lang="a" * 5000, loc=loc)
+        assert not os.listdir(loc)
+
+    def test_a_leading_dash_lang_stays_a_filename(self, restricted_sandbox):
+        """Audited-benign: no model-artifact path is ever a subprocess argument,
+        so a leading dash is just a filename. Pinned so that if one of these
+        paths ever becomes argv, this stops being silently true."""
+        loc = os.path.join(restricted_sandbox, "dash")
+        os.makedirs(loc, exist_ok=True)
+        _tagger().save_to_json(lang="-rf", loc=loc)
+        written = sorted(os.listdir(loc))
+        assert written == sorted(_tagger().param_files("-rf"))
+        for name in written:
+            assert os.path.dirname(os.path.realpath(os.path.join(loc, name))) == (
+                os.path.realpath(loc)
+            )
 
     @pytest.mark.parametrize("lang", ["eng", "rus", "probeartifact", "xx"])
     def test_ordinary_language_codes_still_work(self, lang, restricted_sandbox):

--- a/nltk/test/unit/test_model_artifact_pathsec.py
+++ b/nltk/test/unit/test_model_artifact_pathsec.py
@@ -190,17 +190,27 @@ class TestAveragedPerceptronEscapes:
         _refused(model.load, str(target))
         assert model.weights == {}
 
-    def test_case_folded_root_prefix_is_refused(self, pathsec_sandbox):
-        """An upper-cased path is a different string, so containment fails closed.
+    def test_case_folded_path_never_resolves_outside_the_root(self, pathsec_sandbox):
+        """Case folding must not be a way to sidestep the prefix comparison.
 
-        On a case-insensitive filesystem it names the same file; the check must
-        still refuse rather than accidentally accept a non-matching prefix.
+        The two platforms differ legitimately and the invariant has to hold on
+        both: POSIX resolve() keeps the upper-cased string, which no longer
+        matches the root prefix, so the read is refused; Windows resolve()
+        returns the real on-disk casing, so it names the *same in-root file* and
+        the read is allowed. Either outcome is fine; reading something else is
+        not.
         """
         inside = pathsec_sandbox.root / "cf.json"
         AveragedPerceptron(_weights()).save(str(inside))
         model = AveragedPerceptron()
-        _refused(model.load, str(inside).upper())
-        assert model.weights == {}
+        try:
+            model.load(str(inside).upper())
+        except (PermissionError, ValueError, OSError):
+            assert model.weights == {}
+        else:
+            assert (
+                model.weights == _weights()
+            ), "case-folded path resolved to a different file than the in-root one"
 
     def test_bytes_and_pathlike_forms_are_validated_too(self, sandbox):
         _refused(AveragedPerceptron(_weights()).save, str(sandbox / "b.json").encode())
@@ -971,8 +981,13 @@ class TestNegativeControls:
         with pytest.raises(ValueError):
             perceptron._reject_path_structure("a/b", "lang")
 
+    @POSIX_ONLY
     def test_whitespace_waiver_reopens_the_cwd_write(self, outside_only, monkeypatch):
-        """Restoring the whitespace early-return must let the write land again."""
+        """Restoring the whitespace early-return must let the write land again.
+
+        POSIX-only: Windows rejects a filename that is only whitespace, so the
+        waiver cannot reopen anything there and the control would prove nothing.
+        """
         real = pathsec.validate_path
 
         def waives_whitespace(path_input, *args, **kwargs):

--- a/nltk/test/unit/test_module_import_and_functional_smoke.py
+++ b/nltk/test/unit/test_module_import_and_functional_smoke.py
@@ -1,0 +1,178 @@
+# Natural Language Toolkit: import + functional smoke test
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""Proof that the pathsec hardening did not break NLTK.
+
+The security work threads ``validate_path`` / ``validate_model_resource`` through
+loaders all over the tree. A guard that is slightly too strict does not fail the
+security tests, it fails *ordinary use*, and mocked tests cannot see that: they
+never load a real corpus or run a real model.
+
+So this module does two things that no other test file does:
+
+1. imports **every** module in the ``nltk`` package, and
+2. runs a battery of real operations against real corpora and real models.
+
+An ``ImportError`` is treated as a missing optional third-party dependency and a
+``LookupError`` as missing corpus data, since neither says anything about our
+code. Anything else is a hard failure and names the module that broke.
+"""
+
+import importlib
+import pkgutil
+
+import pytest
+
+import nltk
+
+# Loading these has side effects disproportionate to their value here: nltk.book
+# pulls in nine corpora and prints a banner, and nltk.app opens Tk toolkits.
+_SKIP_PREFIXES = ("nltk.test.", "nltk.book", "nltk.app")
+
+
+def _all_module_names():
+    names = []
+    for module in pkgutil.walk_packages(nltk.__path__, prefix="nltk."):
+        name = module.name
+        if name.startswith(_SKIP_PREFIXES) or name == "nltk.test":
+            continue
+        names.append(name)
+    return sorted(names)
+
+
+def test_every_nltk_module_imports():
+    """Every module must import. A guard that broke an import at module scope
+    shows up here as a named hard failure rather than as a mystery elsewhere."""
+    hard_failures = []
+    optional = []
+    imported = 0
+    for name in _all_module_names():
+        try:
+            importlib.import_module(name)
+        except ImportError as exc:
+            optional.append((name, str(exc)))
+        except LookupError as exc:
+            optional.append((name, str(exc)))
+        except Exception as exc:
+            hard_failures.append(f"{name}: {type(exc).__name__}: {exc}")
+        else:
+            imported += 1
+
+    assert hard_failures == [], "modules failed to import:\n" + "\n".join(hard_failures)
+    # A sanity floor: if the walk silently stopped finding modules the assertion
+    # above would pass vacuously.
+    assert imported > 200, f"only {imported} modules imported; the walk is broken"
+
+
+def _skip_without_data(func):
+    """Run ``func``, turning missing corpora into a skip rather than a failure."""
+    try:
+        return func()
+    except LookupError as exc:
+        pytest.skip(f"corpus data unavailable: {str(exc)[:80]}")
+
+
+# ---------------------------------------------------------------------------
+# Real operations. Nothing here is mocked: each one loads real data through the
+# hardened loaders and checks a real result.
+# ---------------------------------------------------------------------------
+
+
+def test_tokenizers_work():
+    from nltk.tokenize import sent_tokenize, word_tokenize
+
+    tokens = _skip_without_data(lambda: word_tokenize("Dr. Smith isn't here."))
+    assert "Dr." in tokens and "n't" in tokens
+    assert _skip_without_data(lambda: sent_tokenize("One. Two! Three?")) == [
+        "One.",
+        "Two!",
+        "Three?",
+    ]
+
+
+def test_pos_tagging_and_chunking_work():
+    from nltk.tokenize import word_tokenize
+
+    tagged = _skip_without_data(
+        lambda: nltk.pos_tag(word_tokenize("John lives in Paris"))
+    )
+    assert [word for word, _tag in tagged] == ["John", "lives", "in", "Paris"]
+    tree = _skip_without_data(lambda: nltk.ne_chunk(tagged))
+    assert tree.label() == "S"
+
+
+def test_perceptron_tagger_loads_its_pickled_model():
+    """The tagger reads a pickled model through the hardened loader, so a
+    too-strict path guard breaks it here first."""
+    from nltk.tag import PerceptronTagger
+
+    tagged = _skip_without_data(lambda: PerceptronTagger().tag(["The", "dog", "runs"]))
+    assert [word for word, _tag in tagged] == ["The", "dog", "runs"]
+
+
+def test_stemmers_and_lemmatizer_work():
+    from nltk.stem import PorterStemmer, SnowballStemmer, WordNetLemmatizer
+
+    assert PorterStemmer().stem("running") == "run"
+    assert SnowballStemmer("english").stem("generously") == "generous"
+    assert _skip_without_data(lambda: WordNetLemmatizer().lemmatize("geese")) == "goose"
+
+
+def test_zipped_corpora_load():
+    """wordnet and stopwords are read out of zip archives, which is exactly the
+    path the decompression guards sit on."""
+    from nltk.corpus import stopwords, wordnet
+
+    assert _skip_without_data(lambda: wordnet.synsets("dog")) != []
+    assert "the" in _skip_without_data(lambda: stopwords.words("english"))
+
+
+def test_tagged_and_parsed_corpora_load():
+    from nltk.corpus import brown, gutenberg, treebank
+
+    assert _skip_without_data(lambda: brown.tagged_words()[:3]) != []
+    assert _skip_without_data(lambda: gutenberg.words("austen-emma.txt")[:5]) != []
+    assert _skip_without_data(lambda: treebank.parsed_sents()[0]).label() == "S"
+
+
+def test_vader_sentiment_works():
+    from nltk.sentiment.vader import SentimentIntensityAnalyzer
+
+    scores = _skip_without_data(
+        lambda: SentimentIntensityAnalyzer().polarity_scores("NLTK is great!")
+    )
+    assert scores["compound"] > 0
+
+
+def test_grammar_parsing_works():
+    from nltk import CFG
+    from nltk.parse import RecursiveDescentParser
+
+    grammar = CFG.fromstring("S -> NP VP\nNP -> 'John'\nVP -> 'runs'")
+    trees = list(RecursiveDescentParser(grammar).parse(["John", "runs"]))
+    assert trees and trees[0].label() == "S"
+
+
+def test_classifier_training_works():
+    from nltk.classify import NaiveBayesClassifier
+
+    classifier = NaiveBayesClassifier.train([({"a": 1}, "x"), ({"a": 0}, "y")])
+    assert classifier.classify({"a": 1}) == "x"
+
+
+def test_metrics_and_translate_work():
+    from nltk.translate.bleu_score import sentence_bleu
+
+    assert nltk.edit_distance("kitten", "sitting") == 3
+    assert sentence_bleu([["a", "b", "c", "d"]], ["a", "b", "c", "d"]) == 1.0
+
+
+def test_collocations_and_freqdist_work():
+    from nltk.corpus import brown
+
+    words = _skip_without_data(lambda: list(brown.words()[:2000]))
+    assert nltk.FreqDist(words).most_common(1)[0][1] > 0
+    assert nltk.Text(words).collocation_list()[:1] != []

--- a/nltk/test/unit/test_open_datafile.py
+++ b/nltk/test/unit/test_open_datafile.py
@@ -1,6 +1,7 @@
 import os
 import zipfile
 
+from nltk import pathsec
 from nltk.data import ZipFilePathPointer, open_datafile
 
 # NOTE: these tests use pytest's ``tmp_path`` (under the private pytest session
@@ -18,7 +19,7 @@ def _create_test_zip(root_dir, rel_dir, file_name, contents: bytes):
     zip_path = os.path.join(root_dir, "testdata.zip")
     arcname = os.path.join(rel_dir, file_name).replace(os.path.sep, "/")
 
-    with zipfile.ZipFile(zip_path, "w") as zf:
+    with pathsec.ZipFile(zip_path, "w") as zf:
         zf.writestr(arcname, contents)
 
     return zip_path, arcname

--- a/nltk/test/unit/test_path_traversal_security.py
+++ b/nltk/test/unit/test_path_traversal_security.py
@@ -20,6 +20,7 @@ double-decode bug would regress, so they are asserted to resolve in-root.
 """
 
 import os
+import shutil
 import tempfile
 
 import pytest
@@ -346,18 +347,25 @@ class TestPerceptronSaveSquat:
         t.classes = {"NN", "DT"}
         return t
 
-    def _base(self):
-        """A scratch dir INSIDE an allowed data root.
+    @pytest.fixture
+    def base(self):
+        """A scratch dir INSIDE an allowed data root, removed afterwards.
 
         ``tempfile.mkdtemp()`` is not usable here: on Linux it lands under the
         shared ``/tmp``, which is deliberately not an allowed root, so
         ``save_to_json`` would refuse it for containment before ever reaching the
-        squat guards these tests are about.
+        squat guards these tests are about. It is cleaned up rather than left in
+        the user's data root, where a suite run would otherwise pile up a
+        directory per test.
         """
-        return D.make_staging_dir(prefix="nltk_perceptron_squat_")
+        staging = D.make_staging_dir(prefix="nltk_perceptron_squat_")
+        try:
+            yield staging
+        finally:
+            shutil.rmtree(staging, ignore_errors=True)
 
-    def test_benign_save_is_private_and_roundtrips(self):
-        loc = os.path.join(self._base(), "model_dir")
+    def test_benign_save_is_private_and_roundtrips(self, base):
+        loc = os.path.join(base, "model_dir")
         t = self._tagger()
         t.save_to_json(lang="eng", loc=loc)
         files = os.listdir(loc)
@@ -370,10 +378,9 @@ class TestPerceptronSaveSquat:
         assert reloaded.model.weights == t.model.weights
         assert reloaded.tagdict == t.tagdict
 
-    def test_symlinked_save_location_is_refused(self):
+    def test_symlinked_save_location_is_refused(self, base):
         # A guessable in-root save dir a local attacker pre-plants a symlink at
         # must not capture/redirect the model write.
-        base = self._base()
         victim = os.path.join(base, "attacker_dir")
         os.makedirs(victim)
         squat = os.path.join(base, "squat")
@@ -382,10 +389,10 @@ class TestPerceptronSaveSquat:
             self._tagger().save_to_json(lang="eng", loc=squat)
         assert not os.listdir(victim), "write leaked through the symlink"
 
-    def test_world_writable_save_location_is_refused(self):
+    def test_world_writable_save_location_is_refused(self, base):
         # A pre-existing real dir at the guessable name that is world-writable
         # (an attacker could drop files in it / read the model back) is refused.
-        loc = os.path.join(self._base(), "shared")
+        loc = os.path.join(base, "shared")
         os.makedirs(loc)
         os.chmod(loc, 0o777)
         with pytest.raises(PermissionError):

--- a/nltk/test/unit/test_path_traversal_security.py
+++ b/nltk/test/unit/test_path_traversal_security.py
@@ -346,9 +346,10 @@ class TestPerceptronSaveSquat:
         t.classes = {"NN", "DT"}
         return t
 
-    def test_benign_save_is_private_and_roundtrips(self):
-        base = tempfile.mkdtemp()
-        loc = os.path.join(base, "model_dir")
+    # The base must be an *allowed data root*: a caller-supplied destination is
+    # now bounded by the sandbox, and on Linux the shared /tmp is not a root.
+    def test_benign_save_is_private_and_roundtrips(self, restricted_sandbox):
+        loc = os.path.join(restricted_sandbox, "model_dir")
         t = self._tagger()
         t.save_to_json(lang="eng", loc=loc)
         files = os.listdir(loc)
@@ -357,28 +358,35 @@ class TestPerceptronSaveSquat:
             # written model must not be group-/world-readable (CWE-377/378)
             assert (os.stat(os.path.join(loc, f)).st_mode & 0o077) == 0
 
-    def test_symlinked_save_location_is_refused(self):
+    def test_symlinked_save_location_is_refused(self, restricted_sandbox):
         # The default save dir is a guessable name in a shared temp dir; a local
         # attacker who pre-plants a symlink there must not capture/redirect the
         # model write.
-        base = tempfile.mkdtemp()
-        victim = os.path.join(base, "attacker_dir")
+        victim = os.path.join(restricted_sandbox, "attacker_dir")
         os.makedirs(victim)
-        squat = os.path.join(base, "squat")
+        squat = os.path.join(restricted_sandbox, "squat")
         os.symlink(victim, squat)
         with pytest.raises(PermissionError):
             self._tagger().save_to_json(lang="eng", loc=squat)
         assert not os.listdir(victim), "write leaked through the symlink"
 
-    def test_world_writable_save_location_is_refused(self):
+    def test_world_writable_save_location_is_refused(self, restricted_sandbox):
         # A pre-existing real dir at the guessable name that is world-writable
         # (an attacker could drop files in it / read the model back) is refused.
-        base = tempfile.mkdtemp()
-        loc = os.path.join(base, "shared")
+        loc = os.path.join(restricted_sandbox, "shared")
         os.makedirs(loc)
         os.chmod(loc, 0o777)
         with pytest.raises(PermissionError):
             self._tagger().save_to_json(lang="eng", loc=loc)
+
+    def test_out_of_sandbox_save_location_is_refused(self, sandbox):
+        # A caller-supplied destination outside every data root is refused before
+        # anything is created: save_to_json used to os.makedirs() a whole chain
+        # anywhere the process could write (GHSA-8mgp-746c-j5xp).
+        loc = sandbox / "planted" / "model_dir"
+        with pytest.raises(PermissionError):
+            self._tagger().save_to_json(lang="eng", loc=str(loc))
+        assert not loc.exists() and not loc.parent.exists()
 
 
 # ==========================================================================

--- a/nltk/test/unit/test_path_traversal_security.py
+++ b/nltk/test/unit/test_path_traversal_security.py
@@ -346,9 +346,18 @@ class TestPerceptronSaveSquat:
         t.classes = {"NN", "DT"}
         return t
 
+    def _base(self):
+        """A scratch dir INSIDE an allowed data root.
+
+        ``tempfile.mkdtemp()`` is not usable here: on Linux it lands under the
+        shared ``/tmp``, which is deliberately not an allowed root, so
+        ``save_to_json`` would refuse it for containment before ever reaching the
+        squat guards these tests are about.
+        """
+        return D.make_staging_dir(prefix="nltk_perceptron_squat_")
+
     def test_benign_save_is_private_and_roundtrips(self):
-        base = tempfile.mkdtemp()
-        loc = os.path.join(base, "model_dir")
+        loc = os.path.join(self._base(), "model_dir")
         t = self._tagger()
         t.save_to_json(lang="eng", loc=loc)
         files = os.listdir(loc)
@@ -356,12 +365,15 @@ class TestPerceptronSaveSquat:
         for f in files:
             # written model must not be group-/world-readable (CWE-377/378)
             assert (os.stat(os.path.join(loc, f)).st_mode & 0o077) == 0
+        reloaded = self._tagger()
+        reloaded.load_from_json(lang="eng", loc=loc)
+        assert reloaded.model.weights == t.model.weights
+        assert reloaded.tagdict == t.tagdict
 
     def test_symlinked_save_location_is_refused(self):
-        # The default save dir is a guessable name in a shared temp dir; a local
-        # attacker who pre-plants a symlink there must not capture/redirect the
-        # model write.
-        base = tempfile.mkdtemp()
+        # A guessable in-root save dir a local attacker pre-plants a symlink at
+        # must not capture/redirect the model write.
+        base = self._base()
         victim = os.path.join(base, "attacker_dir")
         os.makedirs(victim)
         squat = os.path.join(base, "squat")
@@ -373,8 +385,7 @@ class TestPerceptronSaveSquat:
     def test_world_writable_save_location_is_refused(self):
         # A pre-existing real dir at the guessable name that is world-writable
         # (an attacker could drop files in it / read the model back) is refused.
-        base = tempfile.mkdtemp()
-        loc = os.path.join(base, "shared")
+        loc = os.path.join(self._base(), "shared")
         os.makedirs(loc)
         os.chmod(loc, 0o777)
         with pytest.raises(PermissionError):

--- a/nltk/test/unit/test_pathsec.py
+++ b/nltk/test/unit/test_pathsec.py
@@ -1054,3 +1054,70 @@ def test_authorize_data_dir_registers_private_dir(tmp_path, monkeypatch):
     assert not registered()
     _authorize_data_dir(str(custom))
     assert registered()
+
+
+# ----------------------------------------------------------------------
+# Hardened write path (_hardened_open): symlink / hardlink / truncate
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.skipif(os.name != "posix", reason="hardened write path is POSIX-only")
+def test_hardened_write_truncates_legit_file(sandbox_env):
+    """A legit overwrite still truncates: deferring O_TRUNC until after the guard
+    must not leave a stale tail from longer prior content."""
+    safe_dir = sandbox_env[0]
+    target = safe_dir / "model.json"
+    with pathsec.open(str(target), "w", required_root=str(safe_dir)) as f:
+        f.write("first-longer-content")
+    with pathsec.open(str(target), "w", required_root=str(safe_dir)) as f:
+        f.write("short")
+    assert target.read_text(encoding="utf-8") == "short"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="hardened write path is POSIX-only")
+def test_hardened_write_refuses_symlink_escape(sandbox_env):
+    """A final-component symlink escaping the root is refused at open (O_NOFOLLOW)."""
+    safe_dir, _, secret_file, _, _ = sandbox_env
+    link = safe_dir / "evil.tmp"
+    os.symlink(str(secret_file), str(link))
+    with pytest.raises((PermissionError, ValueError)):
+        pathsec.open(str(link), "wb", required_root=str(safe_dir))
+    assert secret_file.read_text(encoding="utf-8") == "UNAUTHORIZED_DATA"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="hardened write path is POSIX-only")
+def test_hardened_write_refuses_hardlink_and_preserves_target(sandbox_env):
+    """A hardlink to an outside file is refused (st_nlink); deferring O_TRUNC means
+    the refused write does NOT zero the outside target (CWE-59, GHSA-f794)."""
+    safe_dir, _, secret_file, _, _ = sandbox_env
+    hard = safe_dir / "evil.tmp"
+    os.link(str(secret_file), str(hard))
+    with pytest.raises(PermissionError, match="multiply-linked|Security Violation"):
+        pathsec.open(str(hard), "wb", required_root=str(safe_dir))
+    assert secret_file.read_text(encoding="utf-8") == "UNAUTHORIZED_DATA"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="hardened write path is POSIX-only")
+def test_hardened_write_refuses_absolute_escape_and_preserves(sandbox_env):
+    """A write to an absolute path outside the root is refused, and the deferred
+    O_TRUNC leaves the pre-existing outside file's bytes intact."""
+    safe_dir, _, secret_file, _, _ = sandbox_env
+    with pytest.raises((PermissionError, ValueError)):
+        pathsec.open(str(secret_file), "wb", required_root=str(safe_dir))
+    assert secret_file.read_text(encoding="utf-8") == "UNAUTHORIZED_DATA"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="hardened write path is POSIX-only")
+def test_hardened_write_refuses_intermediate_dir_symlink(sandbox_env):
+    """An intermediate directory symlink redirecting the open outside the root is
+    caught by the opened-fd realpath re-validation, not only the final component."""
+    safe_dir, unsafe_dir, _, _, _ = sandbox_env
+    linkdir = safe_dir / "sub"
+    os.symlink(str(unsafe_dir), str(linkdir))  # safe_dir/sub -> outside root
+    with pytest.raises((PermissionError, ValueError)):
+        pathsec.open(str(linkdir / "planted.tmp"), "wb", required_root=str(safe_dir))
+    # no attacker content lands outside the root
+    assert (
+        not (unsafe_dir / "planted.tmp").exists()
+        or (unsafe_dir / "planted.tmp").read_bytes() == b""
+    )

--- a/nltk/test/unit/test_pathsec_sweep_chunk.py
+++ b/nltk/test/unit/test_pathsec_sweep_chunk.py
@@ -122,4 +122,4 @@ def test_sources_route_through_pathsec():
     assert "with open(" not in save_file_src
 
     save_params_src = inspect.getsource(ne.Maxent_NE_Chunker.save_params)
-    assert "validate_path(" in save_params_src
+    assert "validate_tool_dir(" in save_params_src

--- a/nltk/test/unit/test_pathsec_sweep_tag.py
+++ b/nltk/test/unit/test_pathsec_sweep_tag.py
@@ -1779,3 +1779,18 @@ def test_odd_but_harmless_tagger_names_compose_to_safe_filenames(
         f"{tagger_name}_eng.weights.json",
     ]
     assert not list(outside.iterdir())
+
+
+@pytest.mark.parametrize("lang", ["../../etc", "a/b", "\n", "x\x00", "..", "   "])
+def test_load_from_json_rejects_a_path_shaped_lang(pathsec_sandbox, lang):
+    """The load side interpolates lang too: into a ``find()`` resource name and
+    into the model filenames. Rejecting it up front makes the failure name the
+    cause instead of surfacing as a resource-not-found much later."""
+    from nltk.data import FileSystemPathPointer
+    from nltk.tag.perceptron import PerceptronTagger
+
+    root, _ = pathsec_sandbox
+    with pytest.raises(ValueError):
+        PerceptronTagger(load=False).load_from_json(
+            lang, FileSystemPathPointer(str(root))
+        )

--- a/nltk/test/unit/test_pathsec_sweep_tag.py
+++ b/nltk/test/unit/test_pathsec_sweep_tag.py
@@ -731,15 +731,31 @@ def test_absolute_path_with_dash_basename_is_not_an_option(pathsec_sandbox):
 
 
 # --- the guards must be load-bearing, not incidental --------------------------
+# (test id, module, guard attribute, driver). The id is spelled out because a
+# function repr carries its address, which differs per xdist worker.
 _TEETH = [
-    ("nltk.tag.crf", "validate_tool_path", _drive_crf_set),
-    ("nltk.tag.stanford", "validate_tool_path", _drive_stanford_tag_sents),
-    ("nltk.tag.hunpos", "validate_tool_path", _drive_hunpos_init),
-    ("nltk.tag.perceptron", "validate_tool_dir", _drive_save_to_json),
+    ("crf.set_model_file", "nltk.tag.crf", "validate_tool_path", _drive_crf_set),
+    (
+        "stanford.tag_sents",
+        "nltk.tag.stanford",
+        "validate_tool_path",
+        _drive_stanford_tag_sents,
+    ),
+    ("hunpos.__init__", "nltk.tag.hunpos", "validate_tool_path", _drive_hunpos_init),
+    (
+        "perceptron.save_to_json",
+        "nltk.tag.perceptron",
+        "validate_tool_dir",
+        _drive_save_to_json,
+    ),
 ]
 
 
-@pytest.mark.parametrize("modname,attr,driver", _TEETH, ids=lambda v: str(v)[:40])
+@pytest.mark.parametrize(
+    "modname,attr,driver",
+    [entry[1:] for entry in _TEETH],
+    ids=[entry[0] for entry in _TEETH],
+)
 def test_each_guard_is_load_bearing(
     pathsec_sandbox, monkeypatch, modname, attr, driver
 ):

--- a/nltk/test/unit/test_pathsec_sweep_tag.py
+++ b/nltk/test/unit/test_pathsec_sweep_tag.py
@@ -272,3 +272,84 @@ def test_setting_model_file_attribute_directly_reaches_no_loader():
     setter = inspect.getsource(crf_module.CRFTagger.set_model_file)
     assert "validate_path" in setter
     assert setter.index("validate_path") < setter.index("_tagger.open")
+
+
+# --- sandbox-widening: the escape that would defeat every guard above --------
+@pytest.mark.parametrize("victim", ["/etc", "/usr/bin", "~"])
+def test_model_dir_authorization_does_not_widen_the_sandbox(victim, monkeypatch):
+    """A caller-supplied model directory must never be added to nltk.data.path.
+
+    NLTK used to widen the sandbox so a model saved under the private system-temp
+    dir could be read back. ``pathsec.is_private_dir`` accepts
+    any directory owned by the current user *or root* that is not group/world
+    writable, which includes /etc, /usr/bin and $HOME. Authorizing one of those
+    disarms ``validate_path`` AND ``internals._verify_jar_sandbox`` for the whole
+    process, defeating every model-path guard in this module at once.
+    """
+    import nltk.data
+    from nltk.internals import UntrustedJarError, _verify_jar_sandbox
+    from nltk.tag.perceptron import PerceptronTagger
+
+    monkeypatch.setattr(pathsec, "ENFORCE", True)
+    monkeypatch.setattr(nltk.data, "path", list(nltk.data.path))
+    monkeypatch.setattr(pathsec, "_ALLOWED_ROOTS_CACHE", None, raising=False)
+    monkeypatch.setattr(pathsec, "_LAST_DATA_PATHS", None, raising=False)
+
+    target = os.path.expanduser(victim)
+    try:
+        PerceptronTagger(load=True, lang="eng", loc=target)
+    except Exception:
+        pass  # the load itself fails; only its side effect matters here
+
+    real = os.path.realpath(target)
+    authorized = [
+        os.path.realpath(str(p)) for p in nltk.data.path if isinstance(p, str)
+    ]
+    assert real not in authorized, f"{victim} was added to nltk.data.path"
+
+    # and the guards it would have disarmed are still armed
+    with pytest.raises(PermissionError):
+        pathsec.validate_path(os.path.join(real, "anything"), context="probe")
+    with pytest.raises(UntrustedJarError):
+        _verify_jar_sandbox([os.path.join(real, "evil.jar")])
+
+
+def test_trained_model_dir_is_allocated_inside_a_data_root():
+    """NLTK's own trained-model dir must be allocated by pathsec inside a data
+    root, so saving and loading need no sandbox widening at all.
+
+    This is what replaced the old guessable ``<tempdir>/<tagger>_<lang>`` plus an
+    authorize step: an unpredictable 0700 directory under an allowed root.
+    """
+    import nltk.data
+    from nltk.tag.perceptron import PerceptronTagger
+
+    tagger = PerceptronTagger(load=False)
+    save_dir = tagger.save_dir
+    try:
+        roots = [
+            os.path.realpath(os.path.expanduser(str(p)))
+            for p in nltk.data.path
+            if isinstance(p, str)
+        ]
+        real = os.path.realpath(save_dir)
+        assert any(
+            real == r or real.startswith(r + os.sep) for r in roots
+        ), f"{save_dir} is not inside an allowed data root"
+        # already inside the sandbox: pathsec permits it without any widening
+        pathsec.validate_path(save_dir, context="probe")
+        if os.name == "posix":
+            assert (os.stat(real).st_mode & 0o077) == 0, "staging dir is not private"
+    finally:
+        shutil.rmtree(save_dir, ignore_errors=True)
+
+
+def test_sandbox_widening_primitive_is_gone():
+    """The helper that appended a caller directory to nltk.data.path must not come
+    back: it let one public call disarm validate_path and the jar sandbox."""
+    import nltk.tag.perceptron as perceptron
+
+    assert not hasattr(perceptron, "_authorize_private_dir")
+    source = inspect.getsource(perceptron)
+    assert "nltk.data.path.append" not in source
+    assert "_ALLOWED_ROOTS_CACHE" not in source

--- a/nltk/test/unit/test_pathsec_sweep_tag.py
+++ b/nltk/test/unit/test_pathsec_sweep_tag.py
@@ -1794,3 +1794,29 @@ def test_load_from_json_rejects_a_path_shaped_lang(pathsec_sandbox, lang):
         PerceptronTagger(load=False).load_from_json(
             lang, FileSystemPathPointer(str(root))
         )
+
+
+@pytest.mark.skipif(not _POSIX, reason="/dev/fd accounting is POSIX")
+def test_validate_tool_path_does_not_leak_descriptors(restricted_sandbox):
+    """The guard opens the candidate to inspect it, so every refusal path must
+    close that descriptor; otherwise a caller that retries a refused model in a
+    loop exhausts the fd table (DoS)."""
+    root = Path(restricted_sandbox)
+    legit = root / "legit.model"
+    legit.write_text("{}", encoding="utf-8")
+    outside = _outside_dir()
+    try:
+        link = root / "l.model"
+        os.symlink(str(outside / "x"), str(link))
+        fifo = root / "f.model"
+        os.mkfifo(str(fifo))
+        before = len(os.listdir("/dev/fd"))
+        for _ in range(200):
+            pathsec.validate_tool_path(str(legit), context="probe")
+            for bad in (str(link), str(fifo), str(outside / "nope")):
+                with pytest.raises((PermissionError, OSError)):
+                    pathsec.validate_tool_path(bad, context="probe")
+        after = len(os.listdir("/dev/fd"))
+        assert after <= before + 2, f"fd leak: {before} -> {after}"
+    finally:
+        shutil.rmtree(outside, ignore_errors=True)

--- a/nltk/test/unit/test_pathsec_sweep_tag.py
+++ b/nltk/test/unit/test_pathsec_sweep_tag.py
@@ -2000,3 +2000,54 @@ def test_fuzzed_paths_never_resolve_outside_the_root(restricted_sandbox, seed):
             if not resolves_inside(candidate):
                 leaked.append((candidate, "permitted but resolves outside the root"))
     assert not leaked, f"fuzz found {len(leaked)} escapes, e.g. {leaked[:3]}"
+
+
+def test_fuzzed_sink_arguments_never_write_outside_the_root(pathsec_sandbox):
+    """The same idea one level up: fuzz the *sink* arguments together.
+
+    ``lang``, ``TAGGER_NAME`` and ``loc`` are composed into one filesystem
+    operation, so a combination can be dangerous when no single part is. This
+    drives the real write path and then asserts that nothing appeared outside
+    the root or in the working directory.
+    """
+    from nltk.tag.perceptron import PerceptronTagger
+
+    root, outside = pathsec_sandbox
+    workdir = outside / "cwd"
+    workdir.mkdir()
+    os.chdir(workdir)
+
+    rng = random.Random(99)
+    locations = [
+        str(root / "d"),
+        str(outside / "d"),
+        "d",
+        "/etc/d",
+        "file://x",
+        "~/d",
+        "-d",
+        "",
+        "   ",
+    ]
+    tagger = PerceptronTagger(load=False)
+    tagger.model.weights = {"f": {"NN": 1.0}}
+    tagger.tagdict = {}
+    tagger.classes = {"NN"}
+
+    surprises = []
+    for _ in range(200):
+        lang = "".join(rng.choice(_FUZZ_ALPHABET) for _ in range(rng.randint(1, 8)))
+        tagger.TAGGER_NAME = "".join(
+            rng.choice(_FUZZ_ALPHABET) for _ in range(rng.randint(1, 8))
+        )
+        try:
+            tagger.save_to_json(lang=lang, loc=rng.choice(locations))
+        except (PermissionError, ValueError, OSError, TypeError):
+            continue
+        except Exception as exc:  # noqa: BLE001 - an unexpected type is a finding
+            surprises.append((lang, tagger.TAGGER_NAME, f"{type(exc).__name__}: {exc}"))
+
+    assert not surprises, f"unexpected failures: {surprises[:3]}"
+    stray = [p.name for p in outside.iterdir() if p.name != "cwd"]
+    assert not stray, f"fuzzed save_to_json wrote outside the root: {stray}"
+    assert not list(workdir.iterdir()), "fuzzed save_to_json wrote into the CWD"

--- a/nltk/test/unit/test_pathsec_sweep_tag.py
+++ b/nltk/test/unit/test_pathsec_sweep_tag.py
@@ -2199,11 +2199,14 @@ def test_normalized_bypass_would_escape_without_the_guard(restricted_sandbox):
     joined = os.path.realpath(os.path.join(restricted_sandbox, converted))
     root_real = os.path.realpath(restricted_sandbox)
     escapes = not (joined == root_real or joined.startswith(root_real + os.sep))
-    if converted == ".\n./TARGET":
-        # This interpreter does not rewrite; nothing to escape with.
+    # The separator may be rewritten (Windows turns "/" into "\\") without the
+    # name changing meaning, so key off the newline, which is what decides this.
+    if "\n" in converted:
+        # Newline kept: ".\n." stays one component and there is nothing to
+        # escape with, which is why this only ever bit Python 3.14.
         assert not escapes
     else:
-        assert converted == os.path.join("..", "TARGET") or ".." in converted
+        # Newline stripped: ".\n." became "..", and the join leaves the root.
         assert escapes, "the rewritten name should have left the root"
 
 

--- a/nltk/test/unit/test_pathsec_sweep_tag.py
+++ b/nltk/test/unit/test_pathsec_sweep_tag.py
@@ -1836,3 +1836,88 @@ def test_validate_tool_path_does_not_leak_descriptors(restricted_sandbox):
         assert after <= before + 2, f"fd leak: {before} -> {after}"
     finally:
         shutil.rmtree(outside, ignore_errors=True)
+
+
+# --- URL-shaped model paths: validated as one thing, opened as another --------
+_URL_SHAPES = [
+    "file://pwned",
+    "FILE://Pwned",
+    "file://evil/x",
+    "file:",
+    "file:///etc/passwd",
+    "http://evil.example/m.model",
+    "https://evil.example/m.model",
+    "ftp://evil.example/m.model",
+]
+
+
+@pytest.mark.parametrize("url", _URL_SHAPES)
+def test_url_shaped_model_paths_are_refused(pathsec_sandbox, url):
+    """A ``file:`` URL is rewritten to its path component before the check, but
+    the caller (and the tool) still holds the original string.
+
+    ``urlparse("file://evil")`` puts ``evil`` in *netloc* and leaves the path
+    EMPTY, so validate_path used to find nothing to validate and return, while
+    ``save_to_json(loc="file://evil")`` went on to create ``./file:/evil`` in the
+    working directory and write the model there. Found by fuzzing.
+    """
+    from nltk.tag.perceptron import AveragedPerceptron, PerceptronTagger
+
+    root, outside = pathsec_sandbox
+    workdir = outside / "cwd"
+    workdir.mkdir()
+    os.chdir(workdir)
+
+    with pytest.raises((PermissionError, ValueError)):
+        pathsec.validate_path(url, context="probe")
+    with pytest.raises((PermissionError, ValueError)):
+        pathsec.validate_tool_dir(url, context="probe")
+    with pytest.raises((PermissionError, ValueError)):
+        pathsec.validate_tool_path(url, context="probe")
+
+    tagger = PerceptronTagger(load=False)
+    tagger.model.weights = {"f": {"NN": 1.0}}
+    tagger.tagdict = {}
+    tagger.classes = {"NN"}
+    with pytest.raises((PermissionError, ValueError)):
+        tagger.save_to_json(lang="eng", loc=url)
+    with pytest.raises((PermissionError, ValueError)):
+        AveragedPerceptron().load(url)
+
+    assert not list(workdir.iterdir()), f"{url} wrote into the working directory"
+
+
+def test_empty_path_file_url_guard_is_load_bearing(pathsec_sandbox, monkeypatch):
+    """Negative control: with the URL rejection removed, the write really lands
+    in the working directory as ./file:/pwned."""
+    import nltk.tag.perceptron as perceptron
+
+    root, outside = pathsec_sandbox
+    workdir = outside / "cwd"
+    workdir.mkdir()
+    os.chdir(workdir)
+
+    tagger = perceptron.PerceptronTagger(load=False)
+    tagger.model.weights = {"f": {"NN": 1.0}}
+    tagger.tagdict = {}
+    tagger.classes = {"NN"}
+
+    with pytest.raises((PermissionError, ValueError)):
+        tagger.save_to_json(lang="eng", loc="file://pwned")
+    assert not list(workdir.iterdir())
+
+    monkeypatch.setattr(perceptron, "validate_tool_dir", lambda *a, **k: None)
+    tagger.save_to_json(lang="eng", loc="file://pwned")
+    escaped = sorted(p.name for p in workdir.iterdir())
+    assert escaped == ["file:"], f"guard removed but nothing escaped: {escaped}"
+
+
+def test_ordinary_paths_that_merely_look_url_ish_still_work(restricted_sandbox):
+    """Over-block control: only a real scheme prefix is a URL. A filename that
+    happens to contain "://" or start with "file" is an ordinary path."""
+    root = Path(restricted_sandbox)
+    for name in ("filesystem.model", "file_backup.json", "a-file:name.model"):
+        leaf = root / name
+        leaf.write_text("{}", encoding="utf-8")
+        pathsec.validate_tool_path(str(leaf), context="probe")
+        pathsec.validate_tool_dir(str(root / "outdir"), context="probe")

--- a/nltk/test/unit/test_pathsec_sweep_tag.py
+++ b/nltk/test/unit/test_pathsec_sweep_tag.py
@@ -148,6 +148,7 @@ def test_tagger_sources_route_through_pathsec():
 
     save_src = inspect.getsource(perceptron.PerceptronTagger.save_to_json)
     assert "validate_tool_dir(loc" in save_src
+    assert "_validate_name_component(lang" in save_src
 
     ne_src = inspect.getsource(named_entity.Maxent_NE_Chunker.save_params)
     assert "validate_tool_dir(tab_dir" in ne_src
@@ -1111,7 +1112,7 @@ def test_save_to_json_refuses_a_path_shaped_lang(pathsec_sandbox, lang):
 
 
 def test_lang_traversal_is_load_bearing(pathsec_sandbox, monkeypatch):
-    """Negative control: without _validate_lang the traversal really lands
+    """Negative control: without the filename guard the traversal really lands
     outside the pinned directory, so the guard is what stops it."""
     import nltk.tag.perceptron as perceptron
 
@@ -1132,7 +1133,9 @@ def test_lang_traversal_is_load_bearing(pathsec_sandbox, monkeypatch):
         tagger.save_to_json(lang=lang, loc=str(loc))
     assert not list(outside.iterdir())
 
-    monkeypatch.setattr(perceptron, "_validate_lang", lambda value: str(value))
+    monkeypatch.setattr(
+        perceptron, "_validate_name_component", lambda value, kind="": str(value)
+    )
     tagger.save_to_json(lang=lang, loc=str(loc))
     escaped = sorted(p.name for p in outside.iterdir())
     assert escaped, "guard removed but nothing escaped; the probe is inert"
@@ -1681,3 +1684,98 @@ def test_every_public_path_taking_method_is_guarded_or_delegates():
                 "it needs its own guard now"
             )
     assert audited >= 10, f"only {audited} path-taking methods audited"
+
+
+@pytest.mark.parametrize(
+    "tagger_name", ["seed/../../evil", "../../evil", "a\\b", "x\x00"]
+)
+def test_tagger_name_is_guarded_like_lang(pathsec_sandbox, tagger_name):
+    """``TAGGER_NAME`` is the other half of the model filename and traverses the
+    same way. Guarding only ``lang`` left this half open, which is why the check
+    now runs on the composed filename rather than on one ingredient."""
+    from nltk.tag.perceptron import PerceptronTagger
+
+    root, outside = pathsec_sandbox
+    loc = root / "mdir"
+    loc.mkdir(mode=0o700)
+    (loc / "seed").mkdir(mode=0o700)
+
+    tagger = PerceptronTagger(load=False)
+    tagger.model.weights = {"f": {"NN": 1.0}}
+    tagger.tagdict = {}
+    tagger.classes = {"NN"}
+    tagger.TAGGER_NAME = tagger_name
+    with pytest.raises(ValueError):
+        tagger.save_to_json(lang="eng", loc=str(loc))
+    assert not list(outside.iterdir())
+
+
+def test_tagger_name_traversal_is_load_bearing(pathsec_sandbox, monkeypatch):
+    """Negative control for the TAGGER_NAME half of the filename."""
+    import nltk.tag.perceptron as perceptron
+
+    root, outside = pathsec_sandbox
+    loc = root / "mdir"
+    loc.mkdir(mode=0o700)
+    seed = loc / "seed"
+    seed.mkdir(mode=0o700)
+    rel = os.path.relpath(os.path.realpath(str(outside)), os.path.realpath(str(seed)))
+
+    tagger = perceptron.PerceptronTagger(load=False)
+    tagger.model.weights = {"f": {"NN": 1.0}}
+    tagger.tagdict = {}
+    tagger.classes = {"NN"}
+    tagger.TAGGER_NAME = "seed/" + rel + "/EVIL"
+
+    with pytest.raises(ValueError):
+        tagger.save_to_json(lang="eng", loc=str(loc))
+    assert not list(outside.iterdir())
+
+    monkeypatch.setattr(
+        perceptron, "_validate_name_component", lambda value, kind="": str(value)
+    )
+    tagger.save_to_json(lang="eng", loc=str(loc))
+    escaped = sorted(p.name for p in outside.iterdir())
+    assert escaped, "guard removed but nothing escaped; the probe is inert"
+    assert any(name.startswith("EVIL_") for name in escaped)
+
+
+def test_param_files_validates_the_composed_filename(pathsec_sandbox):
+    """The chokepoint checks the whole name, so any future interpolation into it
+    is covered without adding another per-ingredient check."""
+    from nltk.tag.perceptron import PerceptronTagger
+
+    tagger = PerceptronTagger(load=False)
+    tagger.TAGGER_NAME = "../evil"
+    with pytest.raises(ValueError):
+        tagger.param_files("eng")
+    tagger.TAGGER_NAME = "averaged_perceptron_tagger"
+    assert tagger.param_files("eng")[0].endswith("_eng.weights.json")
+
+
+@pytest.mark.parametrize("tagger_name", ["..", "   ", ".", "-x"])
+def test_odd_but_harmless_tagger_names_compose_to_safe_filenames(
+    pathsec_sandbox, tagger_name
+):
+    """Benign pin: the check is on the *composed* filename, and ``..`` composes
+    to ``.._eng.weights.json``, which is an ordinary file inside the pinned
+    directory rather than a traversal. Permitting these is correct; pinned so a
+    change that starts treating the composed name as a path is caught."""
+    from nltk.tag.perceptron import PerceptronTagger
+
+    root, outside = pathsec_sandbox
+    loc = root / "mdir"
+
+    tagger = PerceptronTagger(load=False)
+    tagger.model.weights = {"f": {"NN": 1.0}}
+    tagger.tagdict = {}
+    tagger.classes = {"NN"}
+    tagger.TAGGER_NAME = tagger_name
+    tagger.save_to_json(lang="eng", loc=str(loc))
+    written = sorted(p.name for p in loc.iterdir())
+    assert written == [
+        f"{tagger_name}_eng.classes.json",
+        f"{tagger_name}_eng.tagdict.json",
+        f"{tagger_name}_eng.weights.json",
+    ]
+    assert not list(outside.iterdir())

--- a/nltk/test/unit/test_pathsec_sweep_tag.py
+++ b/nltk/test/unit/test_pathsec_sweep_tag.py
@@ -732,6 +732,19 @@ def test_absolute_path_with_dash_basename_is_not_an_option(pathsec_sandbox):
         _cleanup(registry)
 
 
+def _disarm_perceptron_write(monkeypatch, module):
+    """Neuter BOTH containment layers on the model-write path.
+
+    ``save_to_json`` validates the caller's destination, and
+    ``_open_private_model_dir`` independently validates the real path the pinned
+    descriptor landed on. Removing only one leaves the write blocked by the
+    other, which is the point of having two; a teeth test therefore has to
+    remove both before the escape is reachable.
+    """
+    monkeypatch.setattr(module, "validate_tool_dir", lambda *a, **k: None)
+    monkeypatch.setattr(module, "validate_path", lambda *a, **k: None)
+
+
 def _assert_teeth(action, evidence, *, what):
     """Run *action* with a guard already neutered and report what happened.
 
@@ -798,7 +811,10 @@ def test_each_guard_is_load_bearing(
         driver(target)
 
     module = importlib.import_module(modname)
-    monkeypatch.setattr(module, attr, lambda *a, **k: None)
+    if attr == "validate_tool_dir":
+        _disarm_perceptron_write(monkeypatch, module)
+    else:
+        monkeypatch.setattr(module, attr, lambda *a, **k: None)
     outcome = _refusal_for(driver, target)
     if not _POSIX and attr == "validate_tool_dir":
         # The Windows save branch writes through pathsec.open, which refuses an
@@ -869,7 +885,7 @@ def test_perceptron_save_guard_is_load_bearing(pathsec_sandbox, monkeypatch):
         _drive_save_to_json(str(victim))
     assert not victim.exists()
 
-    monkeypatch.setattr(perceptron, "validate_tool_dir", lambda *a, **k: None)
+    _disarm_perceptron_write(monkeypatch, perceptron)
     _assert_teeth(
         lambda: _drive_save_to_json(str(victim)),
         lambda: victim.exists()
@@ -1190,6 +1206,7 @@ def test_lang_traversal_is_load_bearing(pathsec_sandbox, monkeypatch):
     monkeypatch.setattr(
         perceptron, "_validate_name_component", lambda value, kind="": str(value)
     )
+    monkeypatch.setattr(perceptron, "validate_path", lambda *a, **k: None)
     _assert_teeth(
         lambda: tagger.save_to_json(lang=lang, loc=str(loc)),
         lambda: any(p.name.startswith("TRAVERSED") for p in outside.iterdir()),
@@ -1789,6 +1806,7 @@ def test_tagger_name_traversal_is_load_bearing(pathsec_sandbox, monkeypatch):
     monkeypatch.setattr(
         perceptron, "_validate_name_component", lambda value, kind="": str(value)
     )
+    monkeypatch.setattr(perceptron, "validate_path", lambda *a, **k: None)
     _assert_teeth(
         lambda: tagger.save_to_json(lang="eng", loc=str(loc)),
         lambda: any(p.name.startswith("EVIL_") for p in outside.iterdir()),
@@ -1946,7 +1964,7 @@ def test_empty_path_file_url_guard_is_load_bearing(pathsec_sandbox, monkeypatch)
         tagger.save_to_json(lang="eng", loc="file://pwned")
     assert not list(workdir.iterdir())
 
-    monkeypatch.setattr(perceptron, "validate_tool_dir", lambda *a, **k: None)
+    _disarm_perceptron_write(monkeypatch, perceptron)
     # "file:" is not a legal directory name on Windows, so the escape is not
     # even representable there; _assert_teeth checks the right thing per platform.
     _assert_teeth(
@@ -2232,3 +2250,34 @@ def test_fuzzed_resource_names_never_resolve_outside_the_root(restricted_sandbox
         if not (real == root_real or real.startswith(root_real + os.sep)):
             escapes.append((name, real))
     assert not escapes, f"find() escaped the root: {escapes[:3]}"
+
+
+@pytest.mark.skipif(not _POSIX, reason="the pinned directory descriptor is POSIX-only")
+def test_pinned_model_dir_descriptor_is_revalidated(pathsec_sandbox, monkeypatch):
+    """The containment check on ``loc`` runs before the directory is opened, so
+    the descriptor's own real path is validated too.
+
+    Otherwise an intermediate component swapped in between the check and the
+    open would leave the write pinned to a directory outside the sandbox. The
+    descriptor is race-free (the kernel already resolved it), so validating what
+    it landed on closes that window rather than trying to win it.
+    """
+    import nltk.tag.perceptron as perceptron
+
+    root, outside = pathsec_sandbox
+    victim = outside / "swapped"
+    victim.mkdir(mode=0o700)
+
+    # Simulate the swap: containment passes on the string, but the descriptor
+    # the kernel hands back belongs to a directory outside the root.
+    monkeypatch.setattr(perceptron, "_fd_realpath", lambda fd: str(victim))
+    with pytest.raises(PermissionError):
+        perceptron._open_private_model_dir(str(root / "modeldir"))
+
+    # control: without the swap the same call succeeds and returns a descriptor
+    monkeypatch.undo()
+    fd = perceptron._open_private_model_dir(str(root / "modeldir2"))
+    try:
+        assert os.fstat(fd).st_mode & 0o777 == 0o700
+    finally:
+        os.close(fd)

--- a/nltk/test/unit/test_pathsec_sweep_tag.py
+++ b/nltk/test/unit/test_pathsec_sweep_tag.py
@@ -1,0 +1,134 @@
+# Natural Language Toolkit: pathsec sweep tests (nltk.tag sinks)
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+#
+"""Attack tests for the caller-controlled model-path sinks hardened under
+GHSA-8mgp-746c-j5xp in :mod:`nltk.tag`.
+
+The taggers here hand a model path to a native extension or an external
+process that ``pathsec.open`` cannot wrap:
+
+* ``CRFTagger.set_model_file`` / ``CRFTagger.train`` -> pycrfsuite C-extension
+  (``Tagger.open`` / ``Trainer.train``).
+* ``StanfordTagger.tag_sents`` -> a Java subprocess (``-model`` /
+  ``-loadClassifier``).
+* ``HunposTagger.__init__`` -> the ``hunpos-tag`` subprocess argv.
+
+Each patched API now calls ``pathsec.validate_path`` immediately before the
+hand-off, so a model path *outside* the NLTK data sandbox is refused. The
+outside target is a fresh directory under the real home directory; never a
+temp dir, because the system temp dir can itself be an allowed root (and on
+Linux ``tempfile.mkdtemp()`` lives under the shared ``/tmp``).
+"""
+
+import inspect
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+import nltk.data
+import nltk.pathsec as pathsec
+
+# The pathsec sandbox fixtures (sandbox / restricted_sandbox / enforce_off)
+# are provided by nltk/test/unit/conftest.py.
+
+
+def test_negative_control_pathsec_open_refuses_outside(sandbox):
+    """Baseline: pathsec.open() itself refuses a write outside the sandbox."""
+    target = sandbox / "pwned.txt"
+    with pytest.raises(PermissionError):
+        pathsec.open(str(target), "w")
+    assert not target.exists()
+
+
+def test_crf_set_model_file_refuses_outside_path(sandbox):
+    """CRFTagger.set_model_file() must refuse an outside model path before the
+    pycrfsuite native loader touches it.
+
+    Reached without pycrfsuite installed: ``validate_path`` runs before
+    ``self._tagger.open``, so ``object.__new__`` (no ``__init__``, which needs
+    pycrfsuite) suffices to drive the sink.
+    """
+    from nltk.tag.crf import CRFTagger
+
+    target = sandbox / "model.crf.tagger"
+    ct = object.__new__(CRFTagger)
+    with pytest.raises(PermissionError):
+        ct.set_model_file(str(target))
+
+
+def test_crf_train_refuses_outside_path(sandbox):
+    """CRFTagger.train() must refuse an outside destination before the pycrfsuite
+    Trainer writes the model."""
+    pytest.importorskip("pycrfsuite")
+    from nltk.tag.crf import CRFTagger
+
+    target = sandbox / "trained.crf.tagger"
+    ct = CRFTagger()
+    with pytest.raises(PermissionError):
+        ct.train([[("dog", "Noun"), ("runs", "Verb")]], str(target))
+    assert not target.exists()
+
+
+def test_stanford_tag_sents_refuses_outside_model(sandbox):
+    """StanfordTagger.tag_sents() must refuse an outside model path before the
+    JVM subprocess is spawned.
+
+    Driven via ``object.__new__`` so no Stanford jar / JVM is required:
+    ``validate_path`` raises before the ``java()`` hand-off.
+    """
+    from nltk.tag.stanford import StanfordPOSTagger
+
+    target = sandbox / "english-bidirectional-distsim.tagger"
+    tagger = object.__new__(StanfordPOSTagger)
+    tagger._stanford_model = str(target)
+    tagger._stanford_jar = "unused.jar"
+    tagger._encoding = "utf8"
+    tagger.java_options = "-mx1000m"
+
+    with pytest.raises(PermissionError):
+        tagger.tag_sents([["What", "is", "the", "airspeed"]])
+
+
+def test_hunpos_init_refuses_outside_model(sandbox):
+    """HunposTagger.__init__() must refuse an outside model path before the
+    hunpos-tag subprocess is spawned.
+
+    ``find_file`` returns the outside model only if it exists on disk, so the
+    model file is created under ``~``; a dummy binary satisfies ``find_binary``
+    without being executed (validation raises before ``Popen``).
+    """
+    from nltk.tag.hunpos import HunposTagger
+
+    dummy_bin = sandbox / "hunpos-tag"
+    dummy_bin.write_text("#!/bin/sh\n")
+    model = sandbox / "en_wsj.model"
+    model.write_text("stub")
+
+    with pytest.raises(PermissionError):
+        HunposTagger(str(model), path_to_bin=str(dummy_bin))
+
+
+def test_tagger_sources_route_through_pathsec():
+    """Grep-style guard: the patched sinks must reference the pathsec sentinel,
+    so a future refactor that drops the check is caught here."""
+    from nltk.tag import crf, hunpos, stanford
+
+    crf_set_src = inspect.getsource(crf.CRFTagger.set_model_file)
+    assert (
+        'validate_path(model_file, context="CRFTagger.set_model_file")' in crf_set_src
+    )
+
+    crf_train_src = inspect.getsource(crf.CRFTagger.train)
+    assert 'validate_path(model_file, context="CRFTagger.train")' in crf_train_src
+
+    stanford_src = inspect.getsource(stanford.StanfordTagger.tag_sents)
+    assert "validate_path(self._stanford_model" in stanford_src
+
+    hunpos_src = inspect.getsource(hunpos.HunposTagger.__init__)
+    assert "validate_path(self._hunpos_model" in hunpos_src

--- a/nltk/test/unit/test_pathsec_sweep_tag.py
+++ b/nltk/test/unit/test_pathsec_sweep_tag.py
@@ -2385,3 +2385,20 @@ def test_unicode_vectors_never_reach_the_write_sink(pathsec_sandbox):
         except (PermissionError, ValueError, OSError, TypeError):
             continue
     assert {p.name for p in outside.iterdir()} == before
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\t", "\n", " \t "])
+def test_load_from_json_rejects_a_blank_location(pathsec_sandbox, blank):
+    """A blank ``loc`` must fail the same way on every platform.
+
+    On POSIX ``find("   ")`` simply does not resolve, but Windows strips
+    trailing spaces from a path component, so the same call silently resolved
+    to the data root itself and read whatever model happened to be there. The
+    result was contained either way; the point is that the two platforms
+    disagreed about whether it was an error at all.
+    """
+    from nltk.tag.perceptron import PerceptronTagger
+
+    root, _ = pathsec_sandbox
+    with pytest.raises((ValueError, PermissionError, LookupError)):
+        PerceptronTagger(load=False).load_from_json("eng", blank)

--- a/nltk/test/unit/test_pathsec_sweep_tag.py
+++ b/nltk/test/unit/test_pathsec_sweep_tag.py
@@ -25,6 +25,7 @@ Linux ``tempfile.mkdtemp()`` lives under the shared ``/tmp``).
 
 import builtins
 import inspect
+import io
 import os
 import re
 import shutil
@@ -1349,3 +1350,197 @@ def test_punkt_and_chunker_share_the_staging_guard(restricted_sandbox):
     tokenizer._save_dir = None
     with pytest.raises(ValueError):
         tokenizer.save_dir
+
+
+# --- PathPointer objects: the branch that assumes the caller already resolved --
+def test_zip_pointer_to_an_outside_archive_is_refused(pathsec_sandbox):
+    """``load_from_json`` accepts a ready-made PathPointer, so a caller could
+    hand it a ZipFilePathPointer aimed at an archive outside the sandbox."""
+    import zipfile
+
+    from nltk.data import ZipFilePathPointer
+    from nltk.tag.perceptron import PerceptronTagger
+
+    root, outside = pathsec_sandbox
+    archive = outside / "evil.zip"
+    # builtins.zipfile on purpose: this stages the attack OUTSIDE the sandbox,
+    # which pathsec.ZipFile would (correctly) refuse to create.
+    with zipfile.ZipFile(str(archive), "w") as handle:
+        for attr, payload in (
+            ("weights", '{"z": {"NN": 1.0}}'),
+            ("tagdict", '{"z": "NN"}'),
+            ("classes", '["NN"]'),
+        ):
+            handle.writestr(f"m/averaged_perceptron_tagger_eng.{attr}.json", payload)
+
+    tagger = PerceptronTagger(load=False)
+    with pytest.raises((PermissionError, ValueError, OSError)):
+        tagger.load_from_json("eng", ZipFilePathPointer(str(archive), "m/"))
+    assert tagger.tagdict == {}
+
+
+def test_filesystem_pointer_to_an_outside_dir_is_refused(pathsec_sandbox):
+    """A FileSystemPathPointer is a str subclass, so it takes the absolute-path
+    branch and must meet the same guard as a plain string."""
+    import json
+
+    from nltk.data import FileSystemPathPointer
+    from nltk.tag.perceptron import PerceptronTagger
+
+    root, outside = pathsec_sandbox
+    planted = outside / "plantdir"
+    planted.mkdir()
+    for attr, payload in (
+        ("weights", {"f": {"NN": 1.0}}),
+        ("tagdict", {"f": "NN"}),
+        ("classes", ["NN"]),
+    ):
+        (planted / f"averaged_perceptron_tagger_eng.{attr}.json").write_text(
+            json.dumps(payload), encoding="utf-8"
+        )
+
+    tagger = PerceptronTagger(load=False)
+    with pytest.raises(PermissionError):
+        tagger.load_from_json("eng", FileSystemPathPointer(str(planted)))
+    assert tagger.tagdict == {}
+
+
+def test_duck_typed_pointer_is_a_documented_non_finding(pathsec_sandbox):
+    """Negative result, kept so it is not rediscovered as a bug.
+
+    An object that merely *looks* like a PathPointer supplies its own ``open``,
+    so it can return any stream it likes. That is not a sandbox escape: a caller
+    able to construct it already has the file access it would grant. NLTK's own
+    pointer types are the ones that must be bounded, and they are (above).
+    """
+    from nltk.tag.perceptron import PerceptronTagger
+
+    class _FakePointer:
+        path = "/etc"
+
+        def join(self, name):
+            return self
+
+        def open(self, encoding=None):
+            return io.StringIO("not-json")
+
+    with pytest.raises(Exception):
+        PerceptronTagger(load=False).load_from_json("eng", _FakePointer())
+
+
+@pytest.mark.parametrize("pieces", [5, 20, 80, 160])
+def test_find_scales_linearly_in_the_number_of_path_pieces(restricted_sandbox, pieces):
+    """The ".zip/" retry recurses once per piece; each retry must terminate
+    immediately because the retried name now contains ".zip". Before the DOTALL
+    fix a newline made that condition unreachable and the retries compounded."""
+    name = "/".join(f"p{i}\n" for i in range(pieces))
+    started = time.monotonic()
+    with pytest.raises(LookupError):
+        nltk.data.find(name, paths=[restricted_sandbox])
+    assert time.monotonic() - started < 5.0
+
+
+# --- platform-shaped vectors --------------------------------------------------
+@pytest.mark.parametrize(
+    "device", ["NUL", "CON", "COM1", "LPT1", "nul.model", "Con.txt"]
+)
+def test_windows_device_names_are_refused_as_model_paths(restricted_sandbox, device):
+    """On Windows these are character devices wherever they appear, so
+    ``<root>\\NUL`` is the null device rather than a file inside the root: a model
+    write silently vanishes and a read returns nothing. Refused on Windows; on
+    POSIX they are ordinary filenames and this asserts they stay usable."""
+    target = os.path.join(restricted_sandbox, device)
+    if os.name == "posix":
+        with pathsec.open(target, "w", context="probe") as handle:
+            handle.write("{}")
+        pathsec.validate_tool_path(target, context="probe")
+    else:
+        with pytest.raises(PermissionError):
+            pathsec.validate_tool_path(target, context="probe")
+
+
+@pytest.mark.skipif(not _POSIX, reason="POSIX symlinks")
+def test_in_root_symlink_is_refused_by_design(restricted_sandbox):
+    """Deliberate, not an oversight: a final-component symlink is refused even
+    when its target is inside the root, matching what ``pathsec.open`` already
+    does for descriptors it owns. Data files are never symlinks, so refusing
+    them outright removes the swap race rather than trying to win it."""
+    root = Path(restricted_sandbox)
+    real = root / "real.model"
+    real.write_text("{}", encoding="utf-8")
+    link = root / "link.model"
+    os.symlink(str(real), str(link))
+
+    pathsec.validate_tool_path(str(real), context="probe")
+    pathsec.validate_path(str(link), context="probe")
+    with pytest.raises(PermissionError):
+        pathsec.validate_tool_path(str(link), context="probe")
+
+
+def test_tool_path_string_checks_apply_even_with_enforce_off(
+    restricted_sandbox, monkeypatch
+):
+    """``ENFORCE = False`` relaxes *sandbox policy*, which is a deployment
+    choice. It does not make ``-mx4g`` or a NUL byte a valid model filename, so
+    those checks stay on."""
+    monkeypatch.setattr(pathsec, "ENFORCE", False)
+    for bad in ("-mx4g", "a\x00b", "   "):
+        with pytest.raises(PermissionError):
+            pathsec.validate_tool_path(bad, context="probe")
+
+
+# --- the other caller-supplied StanfordTagger arguments ----------------------
+@pytest.mark.parametrize(
+    "option",
+    [
+        "-Xshare:off",
+        "-cp /etc",
+        "@/etc/passwd",
+        "-agentlib:jdwp=transport=dt_socket",
+        "-Djava.security.policy=/etc/evil",
+        "--add-opens=java.base/java.lang=ALL-UNNAMED",
+        "-XX:OnOutOfMemoryError=touch /tmp/pwn",
+    ],
+)
+def test_stanford_java_options_stay_on_the_allowlist(pathsec_sandbox, option):
+    """``java_options`` is a constructor argument that reaches the JVM launcher.
+    The model-path guard does not cover it; the ``java()`` option allowlist does,
+    and this pins that the tagger really goes through that chokepoint."""
+    from nltk.tag.stanford import StanfordPOSTagger
+
+    root, _ = pathsec_sandbox
+    model = root / "m.tagger"
+    model.write_text("stub", encoding="utf-8")
+    jar = root / "stanford-postagger.jar"
+    jar.write_text("PK\x03\x04", encoding="utf-8")
+
+    tagger = object.__new__(StanfordPOSTagger)
+    tagger._stanford_model = str(model)
+    tagger._stanford_jar = str(jar)
+    tagger._encoding = "utf8"
+    tagger.java_options = option
+    with pytest.raises((ValueError, PermissionError)):
+        tagger.tag_sents([["a"]])
+
+
+@pytest.mark.parametrize("encoding", ["-model", "utf8 -x", "-encoding"])
+def test_stanford_encoding_never_reaches_the_jvm_as_an_option(
+    pathsec_sandbox, encoding
+):
+    """Documented benign result: ``encoding`` also becomes an argv value, but the
+    input is encoded with it first, so a non-codec string raises LookupError long
+    before ``java()``. Pinned so a refactor that stops encoding first (and starts
+    passing the raw string through) shows up here."""
+    from nltk.tag.stanford import StanfordPOSTagger
+
+    root, _ = pathsec_sandbox
+    model = root / "m.tagger"
+    model.write_text("stub", encoding="utf-8")
+
+    tagger = object.__new__(StanfordPOSTagger)
+    tagger._stanford_model = str(model)
+    tagger._stanford_jar = str(root / "stanford-postagger.jar")
+    tagger._encoding = encoding
+    tagger.java_options = "-mx1000m"
+    with pytest.raises(LookupError):
+        _no_jvm(lambda: tagger.tag_sents([["a"]]))

--- a/nltk/test/unit/test_pathsec_sweep_tag.py
+++ b/nltk/test/unit/test_pathsec_sweep_tag.py
@@ -36,6 +36,7 @@ import socket
 import string
 import tempfile
 import time
+import unicodedata
 from pathlib import Path
 
 import pytest
@@ -2284,3 +2285,102 @@ def test_pinned_model_dir_descriptor_is_revalidated(pathsec_sandbox, monkeypatch
         assert os.fstat(fd).st_mode & 0o777 == 0o700
     finally:
         os.close(fd)
+
+
+# --- unicode / encoding confusion at the guard boundary ----------------------
+def _unicode_vectors(root, outside):
+    """Non-ASCII ways for the validated name and the opened name to diverge.
+
+    Every earlier vector is ASCII-shaped. Filesystems and str/bytes conversion
+    add their own: NFC vs NFD, surrogate escapes, bidi overrides, zero-width
+    joiners and fullwidth homoglyphs of ``/`` and ``.``. None of these should be
+    folded into a separator or a traversal by anything downstream.
+    """
+    secret = str(outside / "SECRET")
+    return {
+        "fullwidth-slash": "..／..／etc/passwd",
+        "fullwidth-dot": "．．/etc/passwd",
+        "rtl-override": "‮" + secret,
+        "zero-width": secret[:5] + "​" + secret[5:],
+        "nfd-outside": unicodedata.normalize("NFD", secret),
+        "nfc-outside": unicodedata.normalize("NFC", secret),
+        "surrogate": secret + "\udcff",
+        "combining-dots": "̇./etc/passwd",
+        "ideographic-space": str(outside) + "　/SECRET",
+        "nul-surrogate": "\udc00",
+    }
+
+
+@pytest.mark.parametrize(
+    "vector",
+    [
+        "fullwidth-slash",
+        "fullwidth-dot",
+        "rtl-override",
+        "zero-width",
+        "nfd-outside",
+        "nfc-outside",
+        "surrogate",
+        "combining-dots",
+        "ideographic-space",
+        "nul-surrogate",
+    ],
+)
+def test_unicode_shaped_paths_are_refused(pathsec_sandbox, vector):
+    """A fullwidth solidus is not a separator and a bidi override is not a path
+    operator, so none of these may be folded into one downstream."""
+    root, outside = pathsec_sandbox
+    (outside / "SECRET").write_text("SECRET", encoding="utf-8")
+    value = _unicode_vectors(root, outside)[vector]
+    for guard in (
+        lambda v: pathsec.validate_path(v, context="probe"),
+        lambda v: pathsec.validate_tool_dir(v, context="probe"),
+        lambda v: pathsec.validate_tool_path(v, context="probe", must_exist=False),
+    ):
+        with pytest.raises((PermissionError, ValueError)):
+            guard(value)
+
+
+def test_unicode_names_inside_the_root_still_work(pathsec_sandbox):
+    """Over-block control: the same characters inside the root are just an
+    unusual filename, and a model saved under one round-trips."""
+    from nltk.tag.perceptron import PerceptronTagger
+
+    root, outside = pathsec_sandbox
+    for name in ("modél.json", "‮model.json", "模型.json"):
+        target = root / name
+        with pathsec.open(str(target), "w", context="probe") as handle:
+            handle.write("{}")
+        pathsec.validate_tool_path(str(target), context="probe")
+
+    loc = root / "modèle"
+    tagger = PerceptronTagger(load=False)
+    tagger.model.weights = {"f": {"NN": 1.0}}
+    tagger.tagdict = {}
+    tagger.classes = {"NN"}
+    tagger.save_to_json(lang="fra", loc=str(loc))
+    reloaded = PerceptronTagger(load=False)
+    reloaded.load_from_json("fra", str(loc))
+    assert reloaded.classes == {"NN"}
+    assert not list(outside.iterdir())
+
+
+def test_unicode_vectors_never_reach_the_write_sink(pathsec_sandbox):
+    """Drive the real write path with every unicode vector and assert nothing
+    appeared outside the root."""
+    from nltk.tag.perceptron import PerceptronTagger
+
+    root, outside = pathsec_sandbox
+    (outside / "SECRET").write_text("SECRET", encoding="utf-8")
+    before = {p.name for p in outside.iterdir()}
+
+    tagger = PerceptronTagger(load=False)
+    tagger.model.weights = {"f": {"NN": 1.0}}
+    tagger.tagdict = {}
+    tagger.classes = {"NN"}
+    for value in _unicode_vectors(root, outside).values():
+        try:
+            tagger.save_to_json(lang="eng", loc=value)
+        except (PermissionError, ValueError, OSError, TypeError):
+            continue
+    assert {p.name for p in outside.iterdir()} == before

--- a/nltk/test/unit/test_pathsec_sweep_tag.py
+++ b/nltk/test/unit/test_pathsec_sweep_tag.py
@@ -23,10 +23,14 @@ temp dir, because the system temp dir can itself be an allowed root (and on
 Linux ``tempfile.mkdtemp()`` lives under the shared ``/tmp``).
 """
 
+import builtins
 import inspect
 import os
+import re
 import shutil
+import socket
 import tempfile
+import time
 from pathlib import Path
 
 import pytest
@@ -117,58 +121,337 @@ def test_hunpos_init_refuses_outside_model(sandbox):
 def test_tagger_sources_route_through_pathsec():
     """Grep-style guard: the patched sinks must reference the pathsec sentinel,
     so a future refactor that drops the check is caught here."""
-    from nltk.tag import crf, hunpos, stanford
+    from nltk.chunk import named_entity
+    from nltk.tag import crf, hunpos, perceptron, stanford
 
     crf_set_src = inspect.getsource(crf.CRFTagger.set_model_file)
     assert (
-        'validate_path(model_file, context="CRFTagger.set_model_file")' in crf_set_src
+        'validate_tool_path(model_file, context="CRFTagger.set_model_file")'
+        in crf_set_src
     )
 
     crf_train_src = inspect.getsource(crf.CRFTagger.train)
-    assert 'validate_path(model_file, context="CRFTagger.train")' in crf_train_src
+    assert 'validate_tool_path(model_file, context="CRFTagger.train"' in crf_train_src
 
     stanford_src = inspect.getsource(stanford.StanfordTagger.tag_sents)
-    assert "validate_path(self._stanford_model" in stanford_src
+    assert "validate_tool_path(" in stanford_src
+    assert "self._stanford_model" in stanford_src
+
+    stanford_init_src = inspect.getsource(stanford.StanfordTagger.__init__)
+    assert "validate_tool_path(self._stanford_model" in stanford_init_src
 
     hunpos_src = inspect.getsource(hunpos.HunposTagger.__init__)
-    assert "validate_path(self._hunpos_model" in hunpos_src
+    assert "validate_tool_path(self._hunpos_model" in hunpos_src
+
+    save_src = inspect.getsource(perceptron.PerceptronTagger.save_to_json)
+    assert "validate_tool_dir(loc" in save_src
+
+    ne_src = inspect.getsource(named_entity.Maxent_NE_Chunker.save_params)
+    assert "validate_tool_dir(tab_dir" in ne_src
+
+
+def test_perceptron_module_has_no_bare_open():
+    """The only ``open(`` in perceptron.py is the fd-pinned model write.
+
+    That one deliberately bypasses ``pathsec.open``: it writes a name relative to
+    an already-verified O_NOFOLLOW directory descriptor, which is strictly
+    stronger than re-validating a string. Every other file access must go
+    through the sentinel.
+    """
+    import nltk.tag.perceptron as perceptron
+
+    source = inspect.getsource(perceptron)
+    bare = [
+        line.strip()
+        for line in source.splitlines()
+        if re.search(r"(?<![\w.])open\(", line)
+        and "pathsec_open" not in line
+        and "os.open" not in line
+        and not line.strip().startswith("#")
+    ]
+    assert bare == [
+        'with open(target, "w", opener=_no_follow_opener) as fout:'
+    ], f"unexpected bare open(): {bare}"
 
 
 # --- the full escape matrix, fired at every guarded model-path sink -----------
-def _escape_vectors(root, outside):
-    """Every shape a caller-supplied model path can take to leave the sandbox.
+_POSIX = os.name == "posix"
 
-    A plain outside path is only the simplest one; the guard must also resolve
-    symlinks (final and intermediate), reject traversal and absolute paths, and
-    refuse URL schemes, which are not filesystem paths at all (GHSA-8mgp).
+# Vectors every guarded sink must refuse. Platform-specific ones are skipped
+# (not silently passed) where the filesystem cannot represent them.
+_ESCAPES = [
+    "plain-outside",
+    "outside-nested",
+    "etc-passwd",
+    "traversal-dotdot",
+    "traversal-many",
+    "backslash-traversal-outside",
+    "double-slash-outside",
+    "trailing-slash-outside",
+    "case-folded-etc",
+    "cwd-relative",
+    "dot-dot",
+    "symlink-final",
+    "symlink-to-etc",
+    "symlink-chained",
+    "symlink-intermediate-dir",
+    "hardlink-to-outside",
+    "fifo-in-root",
+    "socket-in-root",
+    "directory-in-root",
+    "nul-trailing",
+    "nul-middle-inside-root",
+    "nul-only",
+    "leading-dash",
+    "leading-double-dash",
+    "blank",
+    "tab-only",
+    "newline-only",
+    "file-url",
+    "file-url-query",
+    "jar-url",
+    "http-url",
+    "https-url",
+    "ftp-url",
+    "tilde",
+    "tilde-root",
+    "unc-backslash",
+    "unc-slash",
+    "dev-stdin",
+    "dev-fd-0",
+    "dev-null",
+    "dev-zero",
+    "proc-self-environ",
+    "bytes-outside",
+    "pathlib-outside",
+]
+
+# Contained-but-odd paths. These are NOT attacks: they name a real file inside
+# the sandbox. They are pinned so that a future change which starts expanding,
+# splitting or decoding a path shows up here as a new leak.
+_BENIGN = [
+    "plain-in-root",
+    "dot-segments",
+    "dash-basename-absolute",
+    "space-in-name",
+    "unicode-name",
+    "newline-in-name",
+    "backslash-in-name",
+    "colon-ads-in-name",
+    "percent-encoded-name",
+    "long-name",
+    "dollar-var-name",
+    "glob-chars-name",
+]
+
+_NEEDS_SYMLINK = {
+    "symlink-final",
+    "symlink-to-etc",
+    "symlink-chained",
+    "symlink-intermediate-dir",
+}
+_POSIX_ONLY = _NEEDS_SYMLINK | {
+    "hardlink-to-outside",
+    "fifo-in-root",
+    "socket-in-root",
+    "newline-in-name",
+    "backslash-in-name",
+    "colon-ads-in-name",
+    "backslash-traversal-outside",
+    "dev-stdin",
+    "dev-fd-0",
+    "dev-null",
+    "dev-zero",
+    "proc-self-environ",
+    "glob-chars-name",
+}
+
+
+def _vector(name, root, outside, registry):
+    """Materialise vector *name* inside the sandbox and return its path value.
+
+    *registry* is a per-test list the caller closes over so sockets/FIFOs are
+    cleaned up. Calls ``pytest.skip`` when the platform cannot represent the
+    vector, so a platform gap is visible rather than a silent pass.
     """
+    if name in _POSIX_ONLY and not _POSIX:
+        pytest.skip(f"{name} is a POSIX-only filesystem shape")
+
     secret = outside / "secret"
-    secret.write_text("SECRET", encoding="utf-8")
-    link = root / "link.model"
-    if not link.exists():
-        os.symlink(str(secret), str(link))
-    linkdir = root / "linkdir"
-    if not linkdir.exists():
-        os.symlink(str(outside), str(linkdir))
-    return {
-        "plain-outside": str(outside / "m.model"),
-        "traversal": os.path.join(str(root), "..", "..", "etc", "passwd"),
-        "absolute": "/etc/passwd",
-        "symlink-in-root": str(link),
-        "intermediate-symlink": str(linkdir / "secret"),
-        "file-url": "file:///etc/passwd",
-        "http-url": "http://evil.example/m.model",
-        "nul-byte": "/etc/passwd\x00.model",
+    if not secret.exists():
+        secret.write_text("SECRET", encoding="utf-8")
+
+    def _reg(path, kind):
+        registry.append((str(path), kind))
+        return str(path)
+
+    if name == "plain-outside":
+        return str(outside / "m.model")
+    if name == "outside-nested":
+        return str(outside / "deep" / "er" / "m.model")
+    if name == "etc-passwd":
+        return "/etc/passwd"
+    if name == "traversal-dotdot":
+        return os.path.join(str(root), "..", "..", "..", "etc", "passwd")
+    if name == "traversal-many":
+        return str(root) + "/" + "../" * 40 + "etc/passwd"
+    if name == "backslash-traversal-outside":
+        return str(outside) + "\\..\\..\\etc\\passwd"
+    if name == "double-slash-outside":
+        return "/" + str(outside / "m.model")
+    if name == "trailing-slash-outside":
+        return str(outside) + os.sep
+    if name == "case-folded-etc":
+        return "/ETC/PASSWD"
+    if name == "cwd-relative":
+        return "sneaky.model"
+    if name == "dot-dot":
+        return ".."
+    if name == "symlink-final":
+        link = root / "link.model"
+        if not link.is_symlink():
+            os.symlink(str(secret), str(link))
+        return str(link)
+    if name == "symlink-to-etc":
+        link = root / "etclink.model"
+        if not link.is_symlink():
+            os.symlink("/etc/passwd", str(link))
+        return str(link)
+    if name == "symlink-chained":
+        first = root / "link.model"
+        if not first.is_symlink():
+            os.symlink(str(secret), str(first))
+        chain = root / "chain.model"
+        if not chain.is_symlink():
+            os.symlink(str(first), str(chain))
+        return str(chain)
+    if name == "symlink-intermediate-dir":
+        linkdir = root / "linkdir"
+        if not linkdir.is_symlink():
+            os.symlink(str(outside), str(linkdir))
+        return str(linkdir / "secret")
+    if name == "hardlink-to-outside":
+        hard = root / "hard.model"
+        if not hard.exists():
+            try:
+                os.link(str(secret), str(hard))
+            except OSError:
+                pytest.skip("hardlinks unavailable here")
+        return str(hard)
+    if name == "fifo-in-root":
+        fifo = root / "fifo.model"
+        if not fifo.exists():
+            os.mkfifo(str(fifo))
+        return str(fifo)
+    if name == "socket-in-root":
+        sockpath = root / "sock.model"
+        if not sockpath.exists():
+            sk = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            sk.bind(str(sockpath))
+            registry.append(sk)
+        return str(sockpath)
+    if name == "directory-in-root":
+        adir = root / "a_directory"
+        adir.mkdir(exist_ok=True)
+        return str(adir)
+    if name == "nul-trailing":
+        return "/etc/passwd\x00.model"
+    if name == "nul-middle-inside-root":
+        return str(root) + "/x\x00/../../../../etc/passwd"
+    if name == "nul-only":
+        return "\x00"
+    if name == "leading-dash":
+        return "-mx4g"
+    if name == "leading-double-dash":
+        return "--loadClassifier=etc-passwd"
+    if name == "blank":
+        return "   "
+    if name == "tab-only":
+        return "\t"
+    if name == "newline-only":
+        return "\n"
+    if name == "file-url":
+        return "file:///etc/passwd"
+    if name == "file-url-query":
+        return "file:///etc/passwd?x=1"
+    if name == "jar-url":
+        return "jar:file:///etc/evil.jar!/x"
+    if name == "http-url":
+        return "http://evil.example/m.model"
+    if name == "https-url":
+        return "https://evil.example/m.model"
+    if name == "ftp-url":
+        return "ftp://evil.example/m.model"
+    if name == "tilde":
+        return "~/.ssh/id_rsa"
+    if name == "tilde-root":
+        return "~"
+    if name == "unc-backslash":
+        return "\\\\evil\\share\\m.model"
+    if name == "unc-slash":
+        return "//evil/share/m.model"
+    if name == "dev-stdin":
+        return "/dev/stdin"
+    if name == "dev-fd-0":
+        return "/dev/fd/0"
+    if name == "dev-null":
+        return "/dev/null"
+    if name == "dev-zero":
+        return "/dev/zero"
+    if name == "proc-self-environ":
+        return "/proc/self/environ"
+    if name == "bytes-outside":
+        return str(outside / "m.model").encode()
+    if name == "pathlib-outside":
+        return Path(str(outside / "m.model"))
+
+    # --- benign, contained vectors: a real file inside the allowed root ------
+    benign_names = {
+        "plain-in-root": "legit.model",
+        "dash-basename-absolute": "-loadClassifier",
+        "space-in-name": "my model.json",
+        "unicode-name": "modelé_模型.json",
+        "newline-in-name": "a\nb.model",
+        "backslash-in-name": "a\\b.model",
+        "colon-ads-in-name": "legit.model:evil",
+        "percent-encoded-name": "%2e%2e%2fpasswd",
+        "long-name": "L" * 180 + ".model",
+        "dollar-var-name": "$HOME.model",
+        "glob-chars-name": "m[0-9]*?.model",
     }
+    if name == "dot-segments":
+        leaf = root / "legit.model"
+        leaf.write_text("{}", encoding="utf-8")
+        return str(root) + "/./" + "./legit.model"
+    if name in benign_names:
+        leaf = root / benign_names[name]
+        leaf.write_text("{}", encoding="utf-8")
+        return _reg(leaf, "file")
+
+    raise AssertionError(f"unknown vector {name!r}")
 
 
-def _drive_crf(path):
+def _cleanup(registry):
+    for item in registry:
+        if isinstance(item, socket.socket):
+            item.close()
+
+
+# --- drivers: one per public entry point that reaches a model-path sink ------
+def _drive_crf_set(path):
     from nltk.tag.crf import CRFTagger
 
     object.__new__(CRFTagger).set_model_file(path)
 
 
-def _drive_stanford(path):
+def _drive_crf_train(path):
+    pytest.importorskip("pycrfsuite")
+    from nltk.tag.crf import CRFTagger
+
+    CRFTagger().train([[("dog", "N"), ("runs", "V")]], path)
+
+
+def _stanford_tagger(path):
     from nltk.tag.stanford import StanfordPOSTagger
 
     tagger = object.__new__(StanfordPOSTagger)
@@ -176,7 +459,69 @@ def _drive_stanford(path):
     tagger._stanford_jar = "unused.jar"
     tagger._encoding = "utf8"
     tagger.java_options = "-mx1000m"
-    tagger.tag_sents([["What", "is", "the", "airspeed"]])
+    return tagger
+
+
+def _no_jvm(fn):
+    """Run *fn* with nltk.tag.stanford.java replaced by a sentinel raiser.
+
+    The guard runs strictly before the hand-off, so this never weakens an attack
+    test; it makes the *benign* case assert what the JVM would have been handed
+    without paying for a real JVM start.
+    """
+    import nltk.tag.stanford as stanford_module
+
+    saved = stanford_module.java
+
+    def _boom(cmd, *args, **kwargs):
+        raise _ReachedSink(list(cmd))
+
+    stanford_module.java = _boom
+    try:
+        return fn()
+    finally:
+        stanford_module.java = saved
+
+
+def _drive_stanford_tag_sents(path):
+    tagger = _stanford_tagger(path)
+    _no_jvm(lambda: tagger.tag_sents([["What", "is", "the", "airspeed"]]))
+
+
+def _drive_stanford_tag(path):
+    tagger = _stanford_tagger(path)
+    _no_jvm(lambda: tagger.tag(["What", "is"]))
+
+
+def _drive_hunpos_init(path):
+    """Drive HunposTagger.__init__ with find_file/find_binary stubbed out.
+
+    The real ``find_file`` refuses anything that does not already exist, which
+    would mask the guard for most vectors; stubbing it means the guard is the
+    only thing standing between the caller's string and the subprocess argv.
+    ``Popen`` is replaced so nothing is ever spawned.
+    """
+    import nltk.tag.hunpos as hunpos_module
+
+    def _boom(cmd, *args, **kwargs):
+        raise _ReachedSink(list(cmd))
+
+    saved = (hunpos_module.find_file, hunpos_module.find_binary, hunpos_module.Popen)
+    hunpos_module.find_file = lambda p, **kw: p
+    hunpos_module.find_binary = lambda *a, **kw: "hunpos-tag"
+    hunpos_module.Popen = _boom
+    try:
+        hunpos_module.HunposTagger(path)
+    finally:
+        (
+            hunpos_module.find_file,
+            hunpos_module.find_binary,
+            hunpos_module.Popen,
+        ) = saved
+
+
+class _ReachedSink(Exception):
+    """Raised in place of the real sink so a test can see what it was handed."""
 
 
 def _drive_perceptron_save(path):
@@ -191,87 +536,376 @@ def _drive_perceptron_load(path):
     AveragedPerceptron().load(path)
 
 
-_SINKS = {
-    "CRFTagger.set_model_file": _drive_crf,
-    "StanfordTagger.tag_sents": _drive_stanford,
+def _drive_save_to_json(path):
+    from nltk.tag.perceptron import PerceptronTagger
+
+    tagger = PerceptronTagger(load=False)
+    tagger.model.weights = {"f": {"NN": 1.0}}
+    tagger.tagdict = {"the": "DT"}
+    tagger.classes = {"NN", "DT"}
+    tagger.save_to_json(lang="eng", loc=path)
+
+
+def _drive_train_save_loc(path):
+    from nltk.tag.perceptron import PerceptronTagger
+
+    PerceptronTagger(load=False).train(
+        [[("today", "NN"), ("is", "VBZ")]], save_loc=path, nr_iter=1
+    )
+
+
+def _drive_load_from_json(path):
+    from nltk.tag.perceptron import PerceptronTagger
+
+    PerceptronTagger(load=False).load_from_json("eng", path)
+
+
+def _drive_perceptron_init(path):
+    from nltk.tag.perceptron import PerceptronTagger
+
+    PerceptronTagger(load=True, lang="eng", loc=path)
+
+
+def _drive_ne_save_params(path):
+    from nltk.chunk.named_entity import Maxent_NE_Chunker
+
+    chunker = object.__new__(Maxent_NE_Chunker)
+    chunker._save_dir = None
+    Maxent_NE_Chunker.save_params(chunker, path)
+
+
+# Sinks that take a *file* path handed straight to a native loader or argv.
+_FILE_SINKS = {
+    "CRFTagger.set_model_file": _drive_crf_set,
+    "CRFTagger.train": _drive_crf_train,
+    "StanfordTagger.tag_sents": _drive_stanford_tag_sents,
+    "StanfordTagger.tag": _drive_stanford_tag,
+    "HunposTagger.__init__": _drive_hunpos_init,
     "AveragedPerceptron.save": _drive_perceptron_save,
     "AveragedPerceptron.load": _drive_perceptron_load,
 }
 
+# Sinks that take a *directory* to write model artifacts into.
+_DIR_SINKS = {
+    "PerceptronTagger.save_to_json": _drive_save_to_json,
+    "PerceptronTagger.train(save_loc)": _drive_train_save_loc,
+    "PerceptronTagger.load_from_json": _drive_load_from_json,
+    "PerceptronTagger(load=True, loc=)": _drive_perceptron_init,
+    "Maxent_NE_Chunker.save_params": _drive_ne_save_params,
+}
 
-@pytest.mark.parametrize("sink", sorted(_SINKS))
-@pytest.mark.parametrize(
-    "vector",
-    [
-        "plain-outside",
-        "traversal",
-        "absolute",
-        "symlink-in-root",
-        "intermediate-symlink",
-        "file-url",
-        "http-url",
-        "nul-byte",
-    ],
-)
-def test_every_sink_refuses_every_escape_vector(pathsec_sandbox, sink, vector):
-    """No model-path sink may accept any escape form."""
-    root, outside = pathsec_sandbox
-    path = _escape_vectors(root, outside)[vector]
-    with pytest.raises((PermissionError, ValueError)):
-        _SINKS[sink](path)
+_ALL_SINKS = dict(_FILE_SINKS, **_DIR_SINKS)
 
 
-@pytest.mark.parametrize("sink", sorted(_SINKS))
-def test_sinks_do_not_over_block_an_in_root_path(pathsec_sandbox, sink):
-    """The guard must let a legitimate in-sandbox model path through.
-
-    Each sink then fails for its own unrelated reason (no native tagger, a stub
-    jar, a missing file); what matters is that the failure is NOT a containment
-    refusal, which would mean the guard rejects valid models.
-    """
-    root, _ = pathsec_sandbox
-    legit = root / "legit.model"
-    legit.write_text("{}", encoding="utf-8")
+def _refusal(sink, path):
+    """Run *sink* on *path*; return None if it refused, else the exception (or
+    None-as-success) that proves it got past the guard."""
     try:
-        _SINKS[sink](str(legit))
-    except (PermissionError, ValueError) as exc:  # pragma: no cover - failure path
-        pytest.fail(f"{sink} refused an in-sandbox path: {exc}")
-    except Exception:
-        pass  # reached the sink; the guard allowed it
+        _ALL_SINKS[sink](path)
+    except (PermissionError, ValueError):
+        return None
+    except _ReachedSink as exc:
+        return exc
+    except Exception as exc:  # noqa: BLE001 - any other failure is "past the guard"
+        return exc
+    return "no-exception"
 
 
-def test_model_path_guard_is_load_bearing(pathsec_sandbox, monkeypatch):
-    """Negative control: neuter validate_path and the outside path reaches the
-    sink, proving the guard (not an incidental error) is what refuses it."""
-    import nltk.tag.crf as crf_module
+@pytest.mark.parametrize("sink", sorted(_FILE_SINKS))
+@pytest.mark.parametrize("vector", _ESCAPES)
+def test_file_sinks_refuse_every_escape_vector(pathsec_sandbox, sink, vector):
+    """No model-*file* sink may accept any escape form."""
+    root, outside = pathsec_sandbox
+    registry = []
+    try:
+        path = _vector(vector, root, outside, registry)
+        with pytest.raises((PermissionError, ValueError)):
+            _FILE_SINKS[sink](path)
+    finally:
+        _cleanup(registry)
+
+
+# A directory destination legitimately need not exist yet, so the file-shaped
+# vectors (FIFO/socket/hardlink/regular-file checks) do not apply to it.
+_DIR_ESCAPES = [
+    v
+    for v in _ESCAPES
+    if v
+    not in {
+        "hardlink-to-outside",
+        "fifo-in-root",
+        "socket-in-root",
+        "directory-in-root",
+    }
+]
+
+
+@pytest.mark.parametrize("sink", sorted(_DIR_SINKS))
+@pytest.mark.parametrize("vector", _DIR_ESCAPES)
+def test_dir_sinks_refuse_every_escape_vector(pathsec_sandbox, sink, vector):
+    """No model-*directory* sink may accept any escape form."""
+    root, outside = pathsec_sandbox
+    registry = []
+    try:
+        path = _vector(vector, root, outside, registry)
+        with pytest.raises((PermissionError, ValueError, LookupError)):
+            _DIR_SINKS[sink](path)
+    finally:
+        _cleanup(registry)
+
+
+@pytest.mark.parametrize("sink", sorted(_FILE_SINKS))
+@pytest.mark.parametrize("vector", _BENIGN)
+def test_file_sinks_do_not_over_block_contained_paths(pathsec_sandbox, sink, vector):
+    """A contained path, however odd its name, must not be refused.
+
+    These are the false-positive controls: a guard that refuses everything would
+    pass every attack test above and still be useless. Each sink is allowed to
+    fail for its own unrelated reason (no native tagger, stub jar, bad json);
+    what must NOT happen is a containment refusal.
+    """
+    root, outside = pathsec_sandbox
+    registry = []
+    try:
+        path = _vector(vector, root, outside, registry)
+        outcome = _refusal(sink, path)
+        assert outcome is not None, f"{sink} unexpectedly refused {vector}"
+    finally:
+        _cleanup(registry)
+
+
+def test_benign_vectors_are_not_expanded_or_decoded(pathsec_sandbox):
+    """Nothing downstream may expand ``$HOME``/``~``, decode ``%2e%2e`` or glob.
+
+    The path handed to the subprocess must be the exact string NLTK validated,
+    byte for byte; any expansion would mean the validated path and the opened
+    path can differ.
+    """
+    root, outside = pathsec_sandbox
+    registry = []
+    try:
+        for vector in (
+            "percent-encoded-name",
+            "dollar-var-name",
+            "glob-chars-name",
+            "newline-in-name",
+            "space-in-name",
+            "unicode-name",
+            "dash-basename-absolute",
+        ):
+            if vector in _POSIX_ONLY and not _POSIX:
+                continue
+            path = _vector(vector, root, outside, registry)
+            try:
+                _drive_hunpos_init(path)
+            except _ReachedSink as exc:
+                argv = exc.args[0]
+                assert len(argv) == 2, f"{vector} split into {len(argv)} argv entries"
+                assert argv[1] == path, f"{vector} was rewritten to {argv[1]!r}"
+                assert not argv[1].startswith(
+                    "-"
+                ), f"{vector} reached argv as an option"
+            else:  # pragma: no cover - the driver always reaches the sink
+                pytest.fail(f"{vector} never reached the subprocess argv")
+    finally:
+        _cleanup(registry)
+
+
+def test_absolute_path_with_dash_basename_is_not_an_option(pathsec_sandbox):
+    """``<root>/-loadClassifier`` is a filename, not a switch: the argv element
+    starts with the root's leading separator, so the callee cannot parse it as an
+    option. It must therefore be permitted (over-blocking control) while a bare
+    ``-loadClassifier`` is refused (the escape matrix covers that)."""
+    root, outside = pathsec_sandbox
+    registry = []
+    try:
+        path = _vector("dash-basename-absolute", root, outside, registry)
+        assert not path.startswith("-")
+        pathsec.validate_tool_path(path, context="probe")
+    finally:
+        _cleanup(registry)
+
+
+# --- the guards must be load-bearing, not incidental --------------------------
+_TEETH = [
+    ("nltk.tag.crf", "validate_tool_path", _drive_crf_set),
+    ("nltk.tag.stanford", "validate_tool_path", _drive_stanford_tag_sents),
+    ("nltk.tag.hunpos", "validate_tool_path", _drive_hunpos_init),
+    ("nltk.tag.perceptron", "validate_tool_dir", _drive_save_to_json),
+]
+
+
+@pytest.mark.parametrize("modname,attr,driver", _TEETH, ids=lambda v: str(v)[:40])
+def test_each_guard_is_load_bearing(
+    pathsec_sandbox, monkeypatch, modname, attr, driver
+):
+    """Negative control: with the guard neutered the outside path must become
+    reachable again. A probe that still 'passes' with the guard removed is
+    testing nothing."""
+    import importlib
 
     root, outside = pathsec_sandbox
     target = str(outside / "m.model")
+
     with pytest.raises((PermissionError, ValueError)):
-        _drive_crf(target)
+        driver(target)
 
-    monkeypatch.setattr(crf_module, "validate_path", lambda *a, **k: None)
-    with pytest.raises(AttributeError):
-        # past the guard, the native tagger attribute is what is missing now
-        _drive_crf(target)
+    module = importlib.import_module(modname)
+    monkeypatch.setattr(module, attr, lambda *a, **k: None)
+    outcome = _refusal_for(driver, target)
+    assert (
+        outcome != "refused"
+    ), f"{modname}.{attr} removed but the exploit is still blocked; the test proves nothing"
 
 
-def test_setting_model_file_attribute_directly_reaches_no_loader():
-    """Documented negative result: assigning _model_file bypasses the guard but
-    reaches nothing. The only native open() is inside the guarded setter, so a
-    raw attribute write leaves an inert string rather than loading a model."""
-    import inspect
+def _refusal_for(driver, path):
+    try:
+        driver(path)
+    except (PermissionError, ValueError):
+        return "refused"
+    except Exception:
+        return "past-guard"
+    return "landed"
 
-    import nltk.tag.crf as crf_module
 
-    source = inspect.getsource(crf_module)
-    opens = [ln.strip() for ln in source.splitlines() if "_tagger.open(" in ln]
-    assert opens, "expected a native open() call in crf.py"
-    for line in opens:
-        assert "self._model_file" in line
-    setter = inspect.getsource(crf_module.CRFTagger.set_model_file)
-    assert "validate_path" in setter
-    assert setter.index("validate_path") < setter.index("_tagger.open")
+def test_averaged_perceptron_io_is_guarded_twice(pathsec_sandbox, monkeypatch):
+    """AveragedPerceptron.save/load are behind TWO independent layers.
+
+    ``validate_tool_path`` refuses the file *shapes* a path check cannot see
+    (FIFO, hardlink, non-regular), and ``pathsec.open`` independently refuses an
+    out-of-sandbox path at open time. Neutering either one alone must leave the
+    escape blocked; only removing both opens it. That is what makes this
+    defence-in-depth rather than two names for one check.
+    """
+    import nltk.tag.perceptron as perceptron
+
+    root, outside = pathsec_sandbox
+    planted = outside / "planted.json"
+    planted.write_text('{"f": {"NN": 1.0}}', encoding="utf-8")
+
+    with pytest.raises(PermissionError):
+        _drive_perceptron_load(str(planted))
+
+    monkeypatch.setattr(perceptron, "validate_tool_path", lambda *a, **k: None)
+    with pytest.raises(PermissionError):
+        _drive_perceptron_load(str(planted))
+
+    # Deliberately the raw builtin (this is the "no guards at all" control, and
+    # the target is outside the sandbox on purpose).
+    monkeypatch.setattr(
+        perceptron, "pathsec_open", lambda path, *a, **kw: builtins.open(path)
+    )
+    from nltk.tag.perceptron import AveragedPerceptron
+
+    ap = AveragedPerceptron()
+    ap.load(str(planted))
+    assert ap.weights == {"f": {"NN": 1.0}}, (
+        "both guards removed but the outside model was still not read; "
+        "the probe is inert"
+    )
+
+
+def test_perceptron_save_guard_is_load_bearing(pathsec_sandbox, monkeypatch):
+    """With validate_tool_dir neutered, save_to_json writes a real model outside
+    the sandbox, which is precisely the leak the guard closes."""
+    import nltk.tag.perceptron as perceptron
+
+    root, outside = pathsec_sandbox
+    victim = outside / "planted_model_dir"
+
+    with pytest.raises(PermissionError):
+        _drive_save_to_json(str(victim))
+    assert not victim.exists()
+
+    monkeypatch.setattr(perceptron, "validate_tool_dir", lambda *a, **k: None)
+    _drive_save_to_json(str(victim))
+    written = sorted(p.name for p in victim.iterdir())
+    assert written, "guard removed but nothing was written; the probe is inert"
+    assert any(name.endswith(".weights.json") for name in written)
+
+
+# --- pathsec.validate_tool_path unit-level behaviour --------------------------
+def test_validate_tool_path_rejects_option_shaped_paths(restricted_sandbox):
+    """A path that begins with '-' becomes an option, not a filename (CWE-88)."""
+    for bad in ("-mx4g", "--loadClassifier", "-"):
+        with pytest.raises(PermissionError):
+            pathsec.validate_tool_path(bad, context="probe")
+
+
+def test_validate_tool_path_rejects_blank_and_nul(restricted_sandbox):
+    for bad in ("", "   ", "\t", "\n", "a\x00b", "\x00"):
+        with pytest.raises(PermissionError):
+            pathsec.validate_tool_path(bad, context="probe")
+
+
+def test_validate_tool_path_write_destination_may_not_exist(restricted_sandbox):
+    """must_exist=False is for a file the tool will create, so a missing path is
+    fine, but it still has to be inside the sandbox."""
+    inside = os.path.join(restricted_sandbox, "not_yet.model")
+    pathsec.validate_tool_path(inside, context="probe", must_exist=False)
+    with pytest.raises(FileNotFoundError):
+        pathsec.validate_tool_path(inside, context="probe")
+
+
+@pytest.mark.skipif(not _POSIX, reason="POSIX file types")
+def test_validate_tool_path_rejects_non_regular_files(restricted_sandbox):
+    """A FIFO/socket/directory inside the root passes containment but would hang
+    or confuse a native loader, so the file-type check refuses it."""
+    root = Path(restricted_sandbox)
+    fifo = root / "f.model"
+    os.mkfifo(str(fifo))
+    sockpath = root / "s.model"
+    sk = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sk.bind(str(sockpath))
+    adir = root / "d.model"
+    adir.mkdir()
+    try:
+        for bad in (fifo, sockpath, adir):
+            # containment alone says yes; the tool-path guard says no
+            pathsec.validate_path(str(bad), context="probe")
+            with pytest.raises(PermissionError):
+                pathsec.validate_tool_path(str(bad), context="probe")
+    finally:
+        sk.close()
+
+
+@pytest.mark.skipif(not _POSIX, reason="POSIX hardlinks")
+def test_validate_tool_path_rejects_in_root_hardlink(restricted_sandbox):
+    """A hardlink is a second name for an inode with no symlink to resolve, so
+    path resolution cannot see that the data lives outside the sandbox."""
+    root = Path(restricted_sandbox)
+    outside = _outside_dir()
+    try:
+        secret = outside / "secret"
+        secret.write_text("SECRET", encoding="utf-8")
+        hard = root / "hard.model"
+        try:
+            os.link(str(secret), str(hard))
+        except OSError:
+            pytest.skip("hardlinks unavailable here")
+        pathsec.validate_path(str(hard), context="probe")
+        with pytest.raises(PermissionError):
+            pathsec.validate_tool_path(str(hard), context="probe")
+    finally:
+        shutil.rmtree(outside, ignore_errors=True)
+
+
+def _outside_dir():
+    return Path(
+        tempfile.mkdtemp(prefix=".nltk_tagsweep_outside_", dir=str(Path.home()))
+    )
+
+
+def test_validate_path_no_longer_waves_through_a_blank_path(restricted_sandbox):
+    """Regression: ``validate_path`` used to return early for any all-whitespace
+    string, so ``"   "`` silently became a directory/file in the CWD, escaping
+    the sandbox at every call site that trusts validate_path alone."""
+    for blank in ("   ", "\t", "\n", " \t "):
+        with pytest.raises(PermissionError):
+            pathsec.validate_path(blank, context="probe")
+    # the genuinely empty path stays a no-op: nothing can open it
+    pathsec.validate_path("", context="probe")
+    pathsec.validate_path(None, context="probe")
 
 
 # --- sandbox-widening: the escape that would defeat every guard above --------
@@ -353,3 +987,312 @@ def test_sandbox_widening_primitive_is_gone():
     source = inspect.getsource(perceptron)
     assert "nltk.data.path.append" not in source
     assert "_ALLOWED_ROOTS_CACHE" not in source
+
+
+# --- algorithmic DoS reachable through the same model-path entry point --------
+@pytest.mark.parametrize(
+    "resource_name", ["\n", "\r\n", "a\nb", "\n\n\n", "x\ny\nz\n", "corpora/a\nb/c"]
+)
+def test_find_terminates_on_a_newline_resource_name(restricted_sandbox, resource_name):
+    """``nltk.data.find`` must not blow up on a resource name containing a newline.
+
+    ``find`` decides whether a name is a zip with ``(.*?\\.zip)/?(.*)$``. Without
+    ``re.DOTALL`` that never matches a name containing a newline, so the
+    ".zip/" retry kept re-entering ``find`` with an ever-longer name: a
+    caller-supplied ``PerceptronTagger(loc=...)`` of one newline burned 76s and
+    2.7 GB before raising (CWE-407). Guarded by absolute time, not a ratio.
+    """
+    started = time.monotonic()
+    with pytest.raises(LookupError):
+        nltk.data.find(resource_name, paths=[restricted_sandbox])
+    elapsed = time.monotonic() - started
+    assert elapsed < 5.0, f"find({resource_name!r}) took {elapsed:.1f}s (DoS)"
+
+
+def test_perceptron_loc_with_newline_terminates(pathsec_sandbox):
+    """The same DoS through the tagger entry point that surfaced it."""
+    from nltk.tag.perceptron import PerceptronTagger
+
+    started = time.monotonic()
+    with pytest.raises((LookupError, PermissionError, ValueError)):
+        PerceptronTagger(load=True, lang="eng", loc="\n")
+    assert time.monotonic() - started < 5.0
+
+
+def test_find_still_resolves_ordinary_zip_style_names(restricted_sandbox):
+    """Over-block control for the DOTALL fix: ordinary names behave unchanged."""
+    root = Path(restricted_sandbox)
+    (root / "corpora").mkdir()
+    (root / "corpora" / "demo").mkdir()
+    (root / "corpora" / "demo" / "f.txt").write_text("hi", encoding="utf-8")
+    found = nltk.data.find("corpora/demo/f.txt", paths=[restricted_sandbox])
+    assert str(found).endswith(os.path.join("corpora", "demo", "f.txt"))
+    with pytest.raises(LookupError):
+        nltk.data.find("corpora/demo/missing.txt", paths=[restricted_sandbox])
+
+
+# --- documented negative results ---------------------------------------------
+def test_setting_model_file_attribute_directly_reaches_no_loader():
+    """Assigning ``_model_file`` bypasses the guard but reaches nothing.
+
+    The only native ``open()`` is inside the guarded setter, so a raw attribute
+    write leaves an inert string rather than loading a model.
+    """
+    import nltk.tag.crf as crf_module
+
+    source = inspect.getsource(crf_module)
+    opens = [ln.strip() for ln in source.splitlines() if "_tagger.open(" in ln]
+    assert opens, "expected a native open() call in crf.py"
+    for line in opens:
+        assert "self._model_file" in line
+    setter = inspect.getsource(crf_module.CRFTagger.set_model_file)
+    assert "validate_tool_path" in setter
+    assert setter.index("validate_tool_path") < setter.index("_tagger.open")
+
+
+def test_hunpos_binary_is_caller_trusted_but_never_cwd_relative(sandbox):
+    """Documented trust boundary: ``path_to_bin`` names an *executable*, which
+    legitimately lives outside nltk_data (``/usr/local/bin`` etc.), so it is not
+    sandbox-bound. What must stay refused is the CWD-relative discovery path,
+    where a planted ``hunpos-tag`` in the working directory would be executed.
+    """
+    from nltk.internals import find_binary
+
+    saved_cwd = os.getcwd()
+    planted = sandbox / "cwd"
+    planted.mkdir()
+    (planted / "hunpos-tag").write_text("#!/bin/sh\n", encoding="utf-8")
+    os.chmod(planted / "hunpos-tag", 0o700)
+    try:
+        os.chdir(planted)
+        with pytest.raises(LookupError):
+            find_binary("hunpos-tag", searchpath=[])
+    finally:
+        os.chdir(saved_cwd)
+
+
+# --- the OTHER caller-controlled component: lang becomes a filename -----------
+_LANG_ESCAPES = [
+    "sub/../../../../../../../../etc",
+    "..",
+    ".",
+    "",
+    "   ",
+    "\t",
+    "a/b",
+    "a\\b",
+    "/etc/passwd",
+    "x\x00",
+]
+
+
+@pytest.mark.parametrize("lang", _LANG_ESCAPES)
+def test_save_to_json_refuses_a_path_shaped_lang(pathsec_sandbox, lang):
+    """``lang`` is interpolated into the model filename, which is opened relative
+    to a pinned directory fd. The fd anchors the base but NOT a ``..`` inside the
+    name, so a path-shaped lang wrote outside the sandbox entirely (CWE-22)."""
+    from nltk.tag.perceptron import PerceptronTagger
+
+    root, outside = pathsec_sandbox
+    loc = root / "mdir"
+    loc.mkdir(mode=0o700)
+    (loc / "averaged_perceptron_tagger_sub").mkdir(mode=0o700)
+
+    tagger = PerceptronTagger(load=False)
+    tagger.model.weights = {"f": {"NN": 1.0}}
+    tagger.tagdict = {}
+    tagger.classes = {"NN"}
+    with pytest.raises((ValueError, PermissionError)):
+        tagger.save_to_json(lang=lang, loc=str(loc))
+    assert not list(outside.iterdir()), "a path-shaped lang escaped the sandbox"
+
+
+def test_lang_traversal_is_load_bearing(pathsec_sandbox, monkeypatch):
+    """Negative control: without _validate_lang the traversal really lands
+    outside the pinned directory, so the guard is what stops it."""
+    import nltk.tag.perceptron as perceptron
+
+    root, outside = pathsec_sandbox
+    loc = root / "mdir"
+    loc.mkdir(mode=0o700)
+    sub = loc / "averaged_perceptron_tagger_sub"
+    sub.mkdir(mode=0o700)
+    rel = os.path.relpath(os.path.realpath(str(outside)), os.path.realpath(str(sub)))
+    lang = "sub/" + rel + "/TRAVERSED"
+
+    tagger = perceptron.PerceptronTagger(load=False)
+    tagger.model.weights = {"f": {"NN": 1.0}}
+    tagger.tagdict = {}
+    tagger.classes = {"NN"}
+
+    with pytest.raises(ValueError):
+        tagger.save_to_json(lang=lang, loc=str(loc))
+    assert not list(outside.iterdir())
+
+    monkeypatch.setattr(perceptron, "_validate_lang", lambda value: str(value))
+    tagger.save_to_json(lang=lang, loc=str(loc))
+    escaped = sorted(p.name for p in outside.iterdir())
+    assert escaped, "guard removed but nothing escaped; the probe is inert"
+    assert any(name.startswith("TRAVERSED") for name in escaped)
+
+
+@pytest.mark.parametrize("lang", ["eng", "xxx", "sv", "rus", "en-GB", "zh_TW", "a.b"])
+def test_ordinary_language_codes_still_work(pathsec_sandbox, lang):
+    """Over-block control: a real language code is a plain filename component."""
+    from nltk.tag.perceptron import PerceptronTagger
+
+    root, _ = pathsec_sandbox
+    loc = root / "mdir"
+    tagger = PerceptronTagger(load=False)
+    tagger.model.weights = {"f": {"NN": 1.0}}
+    tagger.tagdict = {}
+    tagger.classes = {"NN"}
+    tagger.save_to_json(lang=lang, loc=str(loc))
+    written = sorted(p.name for p in loc.iterdir())
+    assert written == [
+        f"averaged_perceptron_tagger_{lang}.classes.json",
+        f"averaged_perceptron_tagger_{lang}.tagdict.json",
+        f"averaged_perceptron_tagger_{lang}.weights.json",
+    ]
+
+    reloaded = PerceptronTagger(load=False)
+    reloaded.load_from_json(lang, str(loc))
+    assert reloaded.classes == {"NN"}
+
+
+def test_param_files_is_the_lang_chokepoint():
+    """Both the save and the load side build filenames here, so the check lives
+    in one place rather than being duplicated (and forgotten) at each caller."""
+    from nltk.tag.perceptron import PerceptronTagger
+
+    tagger = PerceptronTagger(load=False)
+    with pytest.raises(ValueError):
+        list(tagger.param_files("../evil"))
+    assert list(tagger.param_files("eng")) == [
+        "averaged_perceptron_tagger_eng.weights.json",
+        "averaged_perceptron_tagger_eng.tagdict.json",
+        "averaged_perceptron_tagger_eng.classes.json",
+    ]
+
+
+def test_hunpos_newline_token_check_survives_optimised_mode():
+    """The newline check must not be a bare ``assert``: ``python -O`` strips
+    those, and a newline in a token injects an extra line into the tagger's
+    line-oriented stdin, desynchronising every tag after it."""
+    from nltk.tag.hunpos import HunposTagger
+
+    source = inspect.getsource(HunposTagger.tag)
+    statements = [ln.strip() for ln in source.splitlines()]
+    assert not any(ln.startswith("assert ") for ln in statements)
+    assert "raise ValueError" in source
+
+
+@pytest.mark.parametrize("lang", ["..%2f..%2fetc", "%2e%2e", "a%00b"])
+def test_percent_encoded_lang_is_written_verbatim(pathsec_sandbox, lang):
+    """Benign pin: a percent-encoded lang is NOT decoded anywhere downstream, so
+    it stays an ordinary (ugly) filename inside the sandbox. If a future change
+    starts decoding it, this test turns into a traversal report."""
+    from nltk.tag.perceptron import PerceptronTagger
+
+    root, outside = pathsec_sandbox
+    loc = root / "mdir"
+    tagger = PerceptronTagger(load=False)
+    tagger.model.weights = {"f": {"NN": 1.0}}
+    tagger.tagdict = {}
+    tagger.classes = {"NN"}
+    tagger.save_to_json(lang=lang, loc=str(loc))
+    written = sorted(p.name for p in loc.iterdir())
+    assert written == [
+        f"averaged_perceptron_tagger_{lang}.classes.json",
+        f"averaged_perceptron_tagger_{lang}.tagdict.json",
+        f"averaged_perceptron_tagger_{lang}.weights.json",
+    ], "a percent-encoded lang was decoded somewhere downstream"
+    assert not list(outside.iterdir())
+
+
+# --- the environment as an attack channel ------------------------------------
+def test_hunpos_env_var_model_outside_the_sandbox_is_refused(pathsec_sandbox, monkeypatch):
+    """``find_file`` consults ``$HUNPOS_TAGGER``, so the environment can aim the
+    model path outside the sandbox without the caller passing anything."""
+    import nltk.tag.hunpos as hunpos_module
+
+    root, outside = pathsec_sandbox
+    model = outside / "en_wsj.model"
+    model.write_text("stub", encoding="utf-8")
+    stub = root / "hunpos-tag"
+    stub.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    os.chmod(stub, 0o700)
+
+    def _boom(cmd, *args, **kwargs):
+        raise _ReachedSink(list(cmd))
+
+    monkeypatch.setenv("HUNPOS_TAGGER", str(model))
+    monkeypatch.setattr(hunpos_module, "Popen", _boom)
+    with pytest.raises(PermissionError):
+        hunpos_module.HunposTagger("en_wsj.model", path_to_bin=str(stub))
+
+
+def test_stanford_models_env_var_outside_the_sandbox_is_refused(
+    pathsec_sandbox, monkeypatch
+):
+    """Same channel for the Stanford taggers: ``$STANFORD_MODELS`` feeds
+    ``find_file``, whose result becomes a JVM argument."""
+    from nltk.internals import find_file
+
+    root, outside = pathsec_sandbox
+    (outside / "english.tagger").write_text("stub", encoding="utf-8")
+    monkeypatch.setenv("STANFORD_MODELS", str(outside))
+    resolved = find_file("english.tagger", env_vars=("STANFORD_MODELS",))
+    with pytest.raises(PermissionError):
+        pathsec.validate_tool_path(resolved, context="probe")
+
+
+def test_no_tag_or_chunk_module_widens_the_sandbox():
+    """The sandbox-widening primitive must not come back anywhere in the tagger
+    or chunker packages, not just in the one module it used to live in."""
+    import nltk.chunk
+    import nltk.tag
+
+    import importlib
+    import pkgutil
+
+    banned = ("data.path.append", "_ALLOWED_ROOTS_CACHE", "_LAST_DATA_PATHS")
+    scanned = 0
+    for package in (nltk.tag, nltk.chunk):
+        names = [package.__name__] + [
+            info.name
+            for info in pkgutil.iter_modules(package.__path__, package.__name__ + ".")
+        ]
+        for name in names:
+            try:
+                module = importlib.import_module(name)
+                # inspect, not file I/O: nltk's own source lives outside the
+                # data sandbox, so reading it as a file would be refused.
+                text = inspect.getsource(module)
+            except (ImportError, OSError, TypeError):
+                continue
+            scanned += 1
+            for needle in banned:
+                assert needle not in text, f"{name} re-introduces {needle}"
+    assert scanned > 10, f"only {scanned} modules scanned; the sweep found nothing"
+
+
+@pytest.mark.parametrize(
+    "shape", ["plain", "double-slash", "dot-segment", "pathpointer", "bytes"]
+)
+def test_validate_tool_path_accepts_equivalent_spellings(restricted_sandbox, shape):
+    """Over-block control: several spellings of the same in-root file are all the
+    same file, and all must be accepted."""
+    from nltk.data import FileSystemPathPointer
+
+    root = Path(restricted_sandbox)
+    legit = root / "legit.model"
+    legit.write_text("{}", encoding="utf-8")
+    value = {
+        "plain": str(legit),
+        "double-slash": str(root) + "//legit.model",
+        "dot-segment": str(root) + "/./legit.model",
+        "pathpointer": FileSystemPathPointer(str(legit)),
+        "bytes": str(legit).encode(),
+    }[shape]
+    pathsec.validate_tool_path(value, context="probe")

--- a/nltk/test/unit/test_pathsec_sweep_tag.py
+++ b/nltk/test/unit/test_pathsec_sweep_tag.py
@@ -132,3 +132,143 @@ def test_tagger_sources_route_through_pathsec():
 
     hunpos_src = inspect.getsource(hunpos.HunposTagger.__init__)
     assert "validate_path(self._hunpos_model" in hunpos_src
+
+
+# --- the full escape matrix, fired at every guarded model-path sink -----------
+def _escape_vectors(root, outside):
+    """Every shape a caller-supplied model path can take to leave the sandbox.
+
+    A plain outside path is only the simplest one; the guard must also resolve
+    symlinks (final and intermediate), reject traversal and absolute paths, and
+    refuse URL schemes, which are not filesystem paths at all (GHSA-8mgp).
+    """
+    secret = outside / "secret"
+    secret.write_text("SECRET", encoding="utf-8")
+    link = root / "link.model"
+    if not link.exists():
+        os.symlink(str(secret), str(link))
+    linkdir = root / "linkdir"
+    if not linkdir.exists():
+        os.symlink(str(outside), str(linkdir))
+    return {
+        "plain-outside": str(outside / "m.model"),
+        "traversal": os.path.join(str(root), "..", "..", "etc", "passwd"),
+        "absolute": "/etc/passwd",
+        "symlink-in-root": str(link),
+        "intermediate-symlink": str(linkdir / "secret"),
+        "file-url": "file:///etc/passwd",
+        "http-url": "http://evil.example/m.model",
+        "nul-byte": "/etc/passwd\x00.model",
+    }
+
+
+def _drive_crf(path):
+    from nltk.tag.crf import CRFTagger
+
+    object.__new__(CRFTagger).set_model_file(path)
+
+
+def _drive_stanford(path):
+    from nltk.tag.stanford import StanfordPOSTagger
+
+    tagger = object.__new__(StanfordPOSTagger)
+    tagger._stanford_model = path
+    tagger._stanford_jar = "unused.jar"
+    tagger._encoding = "utf8"
+    tagger.java_options = "-mx1000m"
+    tagger.tag_sents([["What", "is", "the", "airspeed"]])
+
+
+def _drive_perceptron_save(path):
+    from nltk.tag.perceptron import AveragedPerceptron
+
+    AveragedPerceptron().save(path)
+
+
+def _drive_perceptron_load(path):
+    from nltk.tag.perceptron import AveragedPerceptron
+
+    AveragedPerceptron().load(path)
+
+
+_SINKS = {
+    "CRFTagger.set_model_file": _drive_crf,
+    "StanfordTagger.tag_sents": _drive_stanford,
+    "AveragedPerceptron.save": _drive_perceptron_save,
+    "AveragedPerceptron.load": _drive_perceptron_load,
+}
+
+
+@pytest.mark.parametrize("sink", sorted(_SINKS))
+@pytest.mark.parametrize(
+    "vector",
+    [
+        "plain-outside",
+        "traversal",
+        "absolute",
+        "symlink-in-root",
+        "intermediate-symlink",
+        "file-url",
+        "http-url",
+        "nul-byte",
+    ],
+)
+def test_every_sink_refuses_every_escape_vector(pathsec_sandbox, sink, vector):
+    """No model-path sink may accept any escape form."""
+    root, outside = pathsec_sandbox
+    path = _escape_vectors(root, outside)[vector]
+    with pytest.raises((PermissionError, ValueError)):
+        _SINKS[sink](path)
+
+
+@pytest.mark.parametrize("sink", sorted(_SINKS))
+def test_sinks_do_not_over_block_an_in_root_path(pathsec_sandbox, sink):
+    """The guard must let a legitimate in-sandbox model path through.
+
+    Each sink then fails for its own unrelated reason (no native tagger, a stub
+    jar, a missing file); what matters is that the failure is NOT a containment
+    refusal, which would mean the guard rejects valid models.
+    """
+    root, _ = pathsec_sandbox
+    legit = root / "legit.model"
+    legit.write_text("{}", encoding="utf-8")
+    try:
+        _SINKS[sink](str(legit))
+    except (PermissionError, ValueError) as exc:  # pragma: no cover - failure path
+        pytest.fail(f"{sink} refused an in-sandbox path: {exc}")
+    except Exception:
+        pass  # reached the sink; the guard allowed it
+
+
+def test_model_path_guard_is_load_bearing(pathsec_sandbox, monkeypatch):
+    """Negative control: neuter validate_path and the outside path reaches the
+    sink, proving the guard (not an incidental error) is what refuses it."""
+    import nltk.tag.crf as crf_module
+
+    root, outside = pathsec_sandbox
+    target = str(outside / "m.model")
+    with pytest.raises((PermissionError, ValueError)):
+        _drive_crf(target)
+
+    monkeypatch.setattr(crf_module, "validate_path", lambda *a, **k: None)
+    with pytest.raises(AttributeError):
+        # past the guard, the native tagger attribute is what is missing now
+        _drive_crf(target)
+
+
+def test_setting_model_file_attribute_directly_reaches_no_loader():
+    """Documented negative result: assigning _model_file bypasses the guard but
+    reaches nothing. The only native open() is inside the guarded setter, so a
+    raw attribute write leaves an inert string rather than loading a model."""
+    import inspect
+
+    import nltk.tag.crf as crf_module
+
+    source = inspect.getsource(crf_module)
+    opens = [ln.strip() for ln in source.splitlines() if "_tagger.open(" in ln]
+    assert opens, "expected a native open() call in crf.py"
+    for line in opens:
+        assert "self._model_file" in line
+    setter = inspect.getsource(crf_module.CRFTagger.set_model_file)
+    assert "validate_path" in setter
+    assert setter.index("validate_path") < setter.index("_tagger.open")

--- a/nltk/test/unit/test_pathsec_sweep_tag.py
+++ b/nltk/test/unit/test_pathsec_sweep_tag.py
@@ -29,9 +29,11 @@ import inspect
 import io
 import os
 import pkgutil
+import random
 import re
 import shutil
 import socket
+import string
 import tempfile
 import time
 from pathlib import Path
@@ -1921,3 +1923,80 @@ def test_ordinary_paths_that_merely_look_url_ish_still_work(restricted_sandbox):
         leaf.write_text("{}", encoding="utf-8")
         pathsec.validate_tool_path(str(leaf), context="probe")
         pathsec.validate_tool_dir(str(root / "outdir"), context="probe")
+
+
+# --- seeded fuzz: the hand-written matrix is not the whole shape space --------
+_FUZZ_ALPHABET = list(string.printable) + [
+    "\x00",
+    "\n",
+    "\\",
+    "/",
+    "..",
+    "~",
+    "%2e",
+    ":",
+    "\t",
+    "-",
+    "file:",
+]
+
+_FUZZ_PREFIXES = [
+    "",
+    "./",
+    "../",
+    "-",
+    "file://",
+    "file:///",
+    "http://",
+    "https://",
+    "ftp://",
+    "\\\\",
+    "//",
+    "~/",
+    "/dev/",
+    "/proc/",
+    "/etc/",
+]
+
+
+@pytest.mark.parametrize("seed", [7, 20260826])
+def test_fuzzed_paths_never_resolve_outside_the_root(restricted_sandbox, seed):
+    """Randomised sweep over the guards.
+
+    The hand-written vectors above encode shapes someone thought of; this covers
+    the ones nobody did. It is how the empty-path ``file:`` URL escape was found:
+    the guard returned success for a string that resolved outside the root. Two
+    fixed seeds keep it deterministic and fast while still sampling widely.
+    """
+    root_real = os.path.realpath(restricted_sandbox)
+    rng = random.Random(seed)
+    expected = (PermissionError, ValueError, OSError, TypeError)
+
+    def resolves_inside(candidate):
+        try:
+            real = os.path.realpath(candidate)
+        except (OSError, ValueError):
+            return False
+        return real == root_real or real.startswith(root_real + os.sep)
+
+    guards = (
+        lambda v: pathsec.validate_tool_path(v, context="fuzz"),
+        lambda v: pathsec.validate_tool_path(v, context="fuzz", must_exist=False),
+        lambda v: pathsec.validate_tool_dir(v, context="fuzz"),
+    )
+
+    leaked = []
+    for _ in range(1500):
+        body = "".join(rng.choice(_FUZZ_ALPHABET) for _ in range(rng.randint(1, 14)))
+        candidate = rng.choice(_FUZZ_PREFIXES + [restricted_sandbox + os.sep]) + body
+        for guard in guards:
+            try:
+                guard(candidate)
+            except expected:
+                continue
+            except Exception as exc:  # noqa: BLE001 - an unexpected type is a finding
+                leaked.append((candidate, f"{type(exc).__name__}: {exc}"))
+                continue
+            if not resolves_inside(candidate):
+                leaked.append((candidate, "permitted but resolves outside the root"))
+    assert not leaked, f"fuzz found {len(leaked)} escapes, e.g. {leaked[:3]}"

--- a/nltk/test/unit/test_pathsec_sweep_tag.py
+++ b/nltk/test/unit/test_pathsec_sweep_tag.py
@@ -1211,7 +1211,9 @@ def test_percent_encoded_lang_is_written_verbatim(pathsec_sandbox, lang):
 
 
 # --- the environment as an attack channel ------------------------------------
-def test_hunpos_env_var_model_outside_the_sandbox_is_refused(pathsec_sandbox, monkeypatch):
+def test_hunpos_env_var_model_outside_the_sandbox_is_refused(
+    pathsec_sandbox, monkeypatch
+):
     """``find_file`` consults ``$HUNPOS_TAGGER``, so the environment can aim the
     model path outside the sandbox without the caller passing anything."""
     import nltk.tag.hunpos as hunpos_module
@@ -1250,11 +1252,11 @@ def test_stanford_models_env_var_outside_the_sandbox_is_refused(
 def test_no_tag_or_chunk_module_widens_the_sandbox():
     """The sandbox-widening primitive must not come back anywhere in the tagger
     or chunker packages, not just in the one module it used to live in."""
-    import nltk.chunk
-    import nltk.tag
-
     import importlib
     import pkgutil
+
+    import nltk.chunk
+    import nltk.tag
 
     banned = ("data.path.append", "_ALLOWED_ROOTS_CACHE", "_LAST_DATA_PATHS")
     scanned = 0
@@ -1296,3 +1298,54 @@ def test_validate_tool_path_accepts_equivalent_spellings(restricted_sandbox, sha
         "bytes": str(legit).encode(),
     }[shape]
     pathsec.validate_tool_path(value, context="probe")
+
+
+# --- the staging-dir allocator: a prefix is concatenated, never resolved ------
+_PREFIX_ESCAPES = ["../../evil_", "sub/../../evil_", "a\x00b", "a\\b", "/abs_", "a/b_"]
+
+
+@pytest.mark.parametrize("prefix", _PREFIX_ESCAPES)
+def test_make_staging_dir_refuses_a_path_shaped_prefix(restricted_sandbox, prefix):
+    """``tempfile.mkdtemp`` concatenates *prefix* onto *dir*, so a ``..`` inside
+    it places the staging directory outside the validated data root. Callers
+    build the prefix from a tagger language / chunker fmt, both caller supplied
+    (CWE-22)."""
+    with pytest.raises(ValueError):
+        nltk.data.make_staging_dir(prefix=prefix)
+
+
+def test_make_staging_dir_still_stages_inside_the_root(restricted_sandbox):
+    """Over-block control: an ordinary prefix still allocates inside the root,
+    private and unpredictably named."""
+    staged = nltk.data.make_staging_dir(prefix="nltk_probe_")
+    real = os.path.realpath(staged)
+    assert real.startswith(os.path.realpath(restricted_sandbox) + os.sep)
+    assert os.path.basename(real).startswith("nltk_probe_")
+    if _POSIX:
+        assert (os.stat(real).st_mode & 0o077) == 0
+
+
+def test_tagger_save_dir_refuses_a_path_shaped_lang(pathsec_sandbox):
+    """The tagger reaches the allocator through ``save_dir``; with a real first
+    component present the traversal used to create a directory under $HOME."""
+    from nltk.tag.perceptron import PerceptronTagger
+
+    root, outside = pathsec_sandbox
+    seed = root / "nltk_averaged_perceptron_tagger_x"
+    seed.mkdir()
+    rel = os.path.relpath(os.path.realpath(str(outside)), os.path.realpath(str(seed)))
+    with pytest.raises(ValueError):
+        PerceptronTagger(load=False, lang="x/" + rel + "/evil").save_dir
+    assert not list(outside.iterdir()), "save_dir staged output outside the sandbox"
+
+
+def test_punkt_and_chunker_share_the_staging_guard(restricted_sandbox):
+    """The same allocator backs punkt and the NE chunker, so the fix is one
+    chokepoint rather than a per-caller check that the next caller forgets."""
+    from nltk.tokenize.punkt import PunktTokenizer
+
+    tokenizer = object.__new__(PunktTokenizer)
+    tokenizer._lang = "../../evil"
+    tokenizer._save_dir = None
+    with pytest.raises(ValueError):
+        tokenizer.save_dir

--- a/nltk/test/unit/test_pathsec_sweep_tag.py
+++ b/nltk/test/unit/test_pathsec_sweep_tag.py
@@ -24,9 +24,11 @@ Linux ``tempfile.mkdtemp()`` lives under the shared ``/tmp``).
 """
 
 import builtins
+import importlib
 import inspect
 import io
 import os
+import pkgutil
 import re
 import shutil
 import socket
@@ -1544,3 +1546,138 @@ def test_stanford_encoding_never_reaches_the_jvm_as_an_option(
     tagger.java_options = "-mx1000m"
     with pytest.raises(LookupError):
         _no_jvm(lambda: tagger.tag_sents([["a"]]))
+
+
+# --- model *content* shapes, and the descriptor pass-through ------------------
+def test_deeply_nested_model_json_raises_rather_than_crashing(restricted_sandbox):
+    """A model file inside the sandbox is still parsed, so its shape matters:
+    deep nesting must surface as RecursionError, not a crash or a hang."""
+    from nltk.tag.perceptron import AveragedPerceptron
+
+    deep = os.path.join(restricted_sandbox, "deep.json")
+    with pathsec.open(deep, "w", context="probe") as handle:
+        handle.write("[" * 200000 + "]" * 200000)
+    started = time.monotonic()
+    with pytest.raises((RecursionError, ValueError)):
+        AveragedPerceptron().load(deep)
+    assert time.monotonic() - started < 10.0
+
+
+def test_large_flat_model_is_not_size_capped(restricted_sandbox):
+    """Over-block control and a deliberate non-finding: real tagger models are
+    tens of MB of weights, so there is no size cap on an in-sandbox model file.
+    Containment, not size, is what bounds this sink."""
+    import json
+
+    from nltk.tag.perceptron import AveragedPerceptron
+
+    big = os.path.join(restricted_sandbox, "big.json")
+    weights = {f"f{i}": {"NN": 1.0} for i in range(50000)}
+    with pathsec.open(big, "w", context="probe") as handle:
+        json.dump(weights, handle)
+    model = AveragedPerceptron()
+    model.load(big)
+    assert len(model.weights) == 50000
+
+
+def test_integer_descriptor_is_a_documented_pass_through(pathsec_sandbox):
+    """Negative result, recorded so it is not refiled as a bug.
+
+    ``pathsec.open`` passes an ``int`` straight to ``builtins.open``: to hand
+    NLTK a descriptor the caller must already have opened the file, so this
+    grants no access they did not have. It is pinned because a future change
+    that starts *deriving* a path from caller data and passing a descriptor
+    would need a different guard.
+    """
+    from nltk.tag.perceptron import AveragedPerceptron
+
+    root, outside = pathsec_sandbox
+    secret = outside / "secret.json"
+    secret.write_text('{"s": {"NN": 1.0}}', encoding="utf-8")
+    fd = os.open(str(secret), os.O_RDONLY)
+    try:
+        model = AveragedPerceptron()
+        model.load(fd)
+        assert model.weights == {"s": {"NN": 1.0}}
+    except OSError:
+        os.close(fd)
+        raise
+
+
+# --- structural audit: no public entry point reaches a sink unguarded --------
+_GUARD_NAMES = (
+    "validate_tool_path",
+    "validate_tool_dir",
+    "validate_path",
+    "pathsec_open",
+    "_validate_lang",
+    "make_staging_dir",
+    "open_datafile",
+    "find(",
+)
+
+# Methods that take a path-ish argument but delegate it to a guarded sibling
+# rather than guarding it themselves. Listed explicitly so a future method that
+# stops delegating (and starts opening the path itself) fails this audit.
+_DELEGATING = {
+    ("PerceptronTagger", "__init__"): "load_from_json",
+    ("PerceptronTagger", "train"): "save_to_json",
+}
+
+_PATHY_TOKENS = ("path", "loc", "file", "dir", "model", "jar", "save")
+
+
+def _touched_classes():
+    from nltk.chunk.named_entity import Maxent_NE_Chunker
+    from nltk.tag.crf import CRFTagger
+    from nltk.tag.hunpos import HunposTagger
+    from nltk.tag.perceptron import AveragedPerceptron, PerceptronTagger
+    from nltk.tag.stanford import (
+        StanfordNERTagger,
+        StanfordPOSTagger,
+        StanfordTagger,
+    )
+
+    return [
+        AveragedPerceptron,
+        PerceptronTagger,
+        CRFTagger,
+        HunposTagger,
+        StanfordTagger,
+        StanfordPOSTagger,
+        StanfordNERTagger,
+        Maxent_NE_Chunker,
+    ]
+
+
+def test_every_public_path_taking_method_is_guarded_or_delegates():
+    """The #1 real bypass is a guard on one method while a sibling walks past it,
+    so enumerate every public method on every touched class and require each one
+    that accepts a path-ish argument to either hold a guard itself or delegate to
+    a named sibling that does."""
+    audited = 0
+    for cls in _touched_classes():
+        for name, member in sorted(vars(cls).items()):
+            if name.startswith("__") and name != "__init__":
+                continue
+            func = member.fget if isinstance(member, property) else member
+            func = getattr(func, "__func__", func)
+            if not callable(func):
+                continue
+            try:
+                source = inspect.getsource(func)
+                signature = str(inspect.signature(func)).lower()
+            except (OSError, TypeError, ValueError):
+                continue
+            if not any(token in signature for token in _PATHY_TOKENS):
+                continue
+            audited += 1
+            if any(guard in source for guard in _GUARD_NAMES):
+                continue
+            delegate = _DELEGATING.get((cls.__name__, name))
+            assert delegate, f"{cls.__name__}.{name} takes a path with no guard"
+            assert delegate in source, (
+                f"{cls.__name__}.{name} no longer delegates to {delegate}; "
+                "it needs its own guard now"
+            )
+    assert audited >= 10, f"only {audited} path-taking methods audited"

--- a/nltk/test/unit/test_pathsec_sweep_tag.py
+++ b/nltk/test/unit/test_pathsec_sweep_tag.py
@@ -2272,19 +2272,20 @@ def test_pinned_model_dir_descriptor_is_revalidated(pathsec_sandbox, monkeypatch
     victim = outside / "swapped"
     victim.mkdir(mode=0o700)
 
-    # Simulate the swap: containment passes on the string, but the descriptor
-    # the kernel hands back belongs to a directory outside the root.
-    monkeypatch.setattr(perceptron, "_fd_realpath", lambda fd: str(victim))
-    with pytest.raises(PermissionError):
-        perceptron._open_private_model_dir(str(root / "modeldir"))
-
-    # control: without the swap the same call succeeds and returns a descriptor
-    monkeypatch.undo()
+    # Control first, while nothing is patched: an in-root directory opens fine.
+    # (Not monkeypatch.undo() afterwards, which would also undo the sandbox
+    # fixture's own patches and take the data root away with them.)
     fd = perceptron._open_private_model_dir(str(root / "modeldir2"))
     try:
         assert os.fstat(fd).st_mode & 0o777 == 0o700
     finally:
         os.close(fd)
+
+    # Now simulate the swap: containment passes on the string, but the
+    # descriptor the kernel hands back belongs to a directory outside the root.
+    monkeypatch.setattr(perceptron, "_fd_realpath", lambda fd: str(victim))
+    with pytest.raises(PermissionError):
+        perceptron._open_private_model_dir(str(root / "modeldir"))
 
 
 # --- unicode / encoding confusion at the guard boundary ----------------------

--- a/nltk/test/unit/test_pathsec_sweep_tag.py
+++ b/nltk/test/unit/test_pathsec_sweep_tag.py
@@ -1980,6 +1980,9 @@ _FUZZ_ALPHABET = list(string.printable) + [
     "\t",
     "-",
     "file:",
+    "\r",
+    "#",
+    "?",
 ]
 
 _FUZZ_PREFIXES = [
@@ -2200,3 +2203,32 @@ def test_ordinary_resource_names_are_unaffected(restricted_sandbox):
             assert "Unsafe resource path" not in str(
                 exc
             ), f"{name!r} was wrongly rejected as unsafe"
+
+
+@pytest.mark.parametrize("seed", [3141])
+def test_fuzzed_resource_names_never_resolve_outside_the_root(restricted_sandbox, seed):
+    """Fuzz ``find`` itself, not just the path guards.
+
+    ``find`` is where a resource name becomes a filesystem path, and it is the
+    step the standard library rewrites underneath us: this is the shape that
+    escaped on Python 3.14. A candidate is a finding if ``find`` returns a
+    pointer whose realpath is outside the data root.
+    """
+    root_real = os.path.realpath(restricted_sandbox)
+    rng = random.Random(seed)
+    expected = (LookupError, ValueError, OSError, TypeError)
+
+    escapes = []
+    for _ in range(1200):
+        name = "".join(rng.choice(_FUZZ_ALPHABET) for _ in range(rng.randint(1, 14)))
+        try:
+            found = nltk.data.find(name, paths=[restricted_sandbox])
+        except expected:
+            continue
+        except Exception as exc:  # noqa: BLE001 - an unexpected type is a finding
+            escapes.append((name, f"{type(exc).__name__}: {exc}"))
+            continue
+        real = os.path.realpath(str(found))
+        if not (real == root_real or real.startswith(root_real + os.sep)):
+            escapes.append((name, real))
+    assert not escapes, f"find() escaped the root: {escapes[:3]}"

--- a/nltk/test/unit/test_pathsec_sweep_tag.py
+++ b/nltk/test/unit/test_pathsec_sweep_tag.py
@@ -2051,3 +2051,44 @@ def test_fuzzed_sink_arguments_never_write_outside_the_root(pathsec_sandbox):
     stray = [p.name for p in outside.iterdir() if p.name != "cwd"]
     assert not stray, f"fuzzed save_to_json wrote outside the root: {stray}"
     assert not list(workdir.iterdir()), "fuzzed save_to_json wrote into the CWD"
+
+
+def test_zip_internal_traversal_stays_inside_the_archive(restricted_sandbox):
+    """Documented benign result: the packaged tagger model is a zip, so a member
+    name like ``../escape.json`` is worth checking.
+
+    Reading it yields bytes from that same archive; nothing is extracted and no
+    path outside the zip is touched, so an in-root archive stays in-root however
+    its members are named. The extraction-side zip-slip guard lives in
+    ``pathsec.validate_zip_archive`` and is exercised by the zipbomb suite.
+    """
+    import json
+    import zipfile
+
+    from nltk.data import ZipFilePathPointer
+    from nltk.tag.perceptron import PerceptronTagger
+
+    root = Path(restricted_sandbox)
+    archive = root / "taggers.zip"
+    with pathsec.ZipFile(str(archive), "w") as handle:
+        for attr, payload in (
+            ("weights", {"in": {"NN": 1.0}}),
+            ("tagdict", {"in": "NN"}),
+            ("classes", ["NN"]),
+        ):
+            handle.writestr(
+                f"m/averaged_perceptron_tagger_eng.{attr}.json", json.dumps(payload)
+            )
+        handle.writestr("../escape.json", "ESCAPED")
+
+    pointer = ZipFilePathPointer(str(archive), "../escape.json")
+    with pointer.open() as stream:
+        assert stream.read().strip() in (b"ESCAPED", "ESCAPED")
+    # nothing was created outside the archive
+    assert sorted(p.name for p in root.iterdir()) == ["taggers.zip"]
+
+    # and the legitimate in-root zip model still loads
+    tagger = PerceptronTagger(load=False)
+    tagger.load_from_json("eng", ZipFilePathPointer(str(archive), "m/"))
+    assert tagger.tagdict == {"in": "NN"}
+    assert isinstance(zipfile.ZipFile(str(archive)).namelist(), list)

--- a/nltk/test/unit/test_pathsec_sweep_tag.py
+++ b/nltk/test/unit/test_pathsec_sweep_tag.py
@@ -732,6 +732,31 @@ def test_absolute_path_with_dash_basename_is_not_an_option(pathsec_sandbox):
         _cleanup(registry)
 
 
+def _assert_teeth(action, evidence, *, what):
+    """Run *action* with a guard already neutered and report what happened.
+
+    On POSIX ``save_to_json`` writes through a pinned directory descriptor, so
+    removing the containment guard really lets the write land and *evidence*
+    must show it. On Windows there is no directory descriptor: that branch
+    writes through ``pathsec.open``, which independently refuses an outside
+    path, so the correct assertion there is that the write is STILL blocked.
+    Either way the probe is not inert; it just proves a different thing.
+    """
+    try:
+        action()
+        landed = True
+    except (PermissionError, ValueError, OSError):
+        landed = False
+    if _POSIX:
+        assert (
+            landed and evidence()
+        ), f"{what}: guard removed but nothing escaped; the probe is inert"
+    else:
+        assert (
+            not landed and not evidence()
+        ), f"{what}: pathsec.open should still refuse this on this platform"
+
+
 # --- the guards must be load-bearing, not incidental --------------------------
 # (test id, module, guard attribute, driver). The id is spelled out because a
 # function repr carries its address, which differs per xdist worker.
@@ -775,6 +800,11 @@ def test_each_guard_is_load_bearing(
     module = importlib.import_module(modname)
     monkeypatch.setattr(module, attr, lambda *a, **k: None)
     outcome = _refusal_for(driver, target)
+    if not _POSIX and attr == "validate_tool_dir":
+        # The Windows save branch writes through pathsec.open, which refuses an
+        # outside path on its own, so the write stays blocked there.
+        assert outcome == "refused"
+        return
     assert (
         outcome != "refused"
     ), f"{modname}.{attr} removed but the exploit is still blocked; the test proves nothing"
@@ -840,10 +870,12 @@ def test_perceptron_save_guard_is_load_bearing(pathsec_sandbox, monkeypatch):
     assert not victim.exists()
 
     monkeypatch.setattr(perceptron, "validate_tool_dir", lambda *a, **k: None)
-    _drive_save_to_json(str(victim))
-    written = sorted(p.name for p in victim.iterdir())
-    assert written, "guard removed but nothing was written; the probe is inert"
-    assert any(name.endswith(".weights.json") for name in written)
+    _assert_teeth(
+        lambda: _drive_save_to_json(str(victim)),
+        lambda: victim.exists()
+        and any(p.name.endswith(".weights.json") for p in victim.iterdir()),
+        what="save_to_json containment",
+    )
 
 
 # --- pathsec.validate_tool_path unit-level behaviour --------------------------
@@ -867,6 +899,10 @@ def test_validate_tool_path_write_destination_may_not_exist(restricted_sandbox):
     pathsec.validate_tool_path(inside, context="probe", must_exist=False)
     with pytest.raises(FileNotFoundError):
         pathsec.validate_tool_path(inside, context="probe")
+    # and an existing regular file is accepted either way
+    with pathsec.open(inside, "w", context="probe") as handle:
+        handle.write("{}")
+    pathsec.validate_tool_path(inside, context="probe")
 
 
 @pytest.mark.skipif(not _POSIX, reason="POSIX file types")
@@ -1025,7 +1061,7 @@ def test_find_terminates_on_a_newline_resource_name(restricted_sandbox, resource
     2.7 GB before raising (CWE-407). Guarded by absolute time, not a ratio.
     """
     started = time.monotonic()
-    with pytest.raises(LookupError):
+    with pytest.raises((LookupError, ValueError)):
         nltk.data.find(resource_name, paths=[restricted_sandbox])
     elapsed = time.monotonic() - started
     assert elapsed < 5.0, f"find({resource_name!r}) took {elapsed:.1f}s (DoS)"
@@ -1154,10 +1190,11 @@ def test_lang_traversal_is_load_bearing(pathsec_sandbox, monkeypatch):
     monkeypatch.setattr(
         perceptron, "_validate_name_component", lambda value, kind="": str(value)
     )
-    tagger.save_to_json(lang=lang, loc=str(loc))
-    escaped = sorted(p.name for p in outside.iterdir())
-    assert escaped, "guard removed but nothing escaped; the probe is inert"
-    assert any(name.startswith("TRAVERSED") for name in escaped)
+    _assert_teeth(
+        lambda: tagger.save_to_json(lang=lang, loc=str(loc)),
+        lambda: any(p.name.startswith("TRAVERSED") for p in outside.iterdir()),
+        what="lang traversal",
+    )
 
 
 @pytest.mark.parametrize("lang", ["eng", "xxx", "sv", "rus", "en-GB", "zh_TW", "a.b"])
@@ -1458,7 +1495,7 @@ def test_find_scales_linearly_in_the_number_of_path_pieces(restricted_sandbox, p
     fix a newline made that condition unreachable and the retries compounded."""
     name = "/".join(f"p{i}\n" for i in range(pieces))
     started = time.monotonic()
-    with pytest.raises(LookupError):
+    with pytest.raises((LookupError, ValueError)):
         nltk.data.find(name, paths=[restricted_sandbox])
     assert time.monotonic() - started < 5.0
 
@@ -1752,10 +1789,11 @@ def test_tagger_name_traversal_is_load_bearing(pathsec_sandbox, monkeypatch):
     monkeypatch.setattr(
         perceptron, "_validate_name_component", lambda value, kind="": str(value)
     )
-    tagger.save_to_json(lang="eng", loc=str(loc))
-    escaped = sorted(p.name for p in outside.iterdir())
-    assert escaped, "guard removed but nothing escaped; the probe is inert"
-    assert any(name.startswith("EVIL_") for name in escaped)
+    _assert_teeth(
+        lambda: tagger.save_to_json(lang="eng", loc=str(loc)),
+        lambda: any(p.name.startswith("EVIL_") for p in outside.iterdir()),
+        what="TAGGER_NAME traversal",
+    )
 
 
 def test_param_files_validates_the_composed_filename(pathsec_sandbox):
@@ -1909,9 +1947,13 @@ def test_empty_path_file_url_guard_is_load_bearing(pathsec_sandbox, monkeypatch)
     assert not list(workdir.iterdir())
 
     monkeypatch.setattr(perceptron, "validate_tool_dir", lambda *a, **k: None)
-    tagger.save_to_json(lang="eng", loc="file://pwned")
-    escaped = sorted(p.name for p in workdir.iterdir())
-    assert escaped == ["file:"], f"guard removed but nothing escaped: {escaped}"
+    # "file:" is not a legal directory name on Windows, so the escape is not
+    # even representable there; _assert_teeth checks the right thing per platform.
+    _assert_teeth(
+        lambda: tagger.save_to_json(lang="eng", loc="file://pwned"),
+        lambda: [p.name for p in workdir.iterdir()] == ["file:"],
+        what="empty-path file URL",
+    )
 
 
 def test_ordinary_paths_that_merely_look_url_ish_still_work(restricted_sandbox):
@@ -2092,3 +2134,69 @@ def test_zip_internal_traversal_stays_inside_the_archive(restricted_sandbox):
     tagger.load_from_json("eng", ZipFilePathPointer(str(archive), "m/"))
     assert tagger.tagdict == {"in": "NN"}
     assert isinstance(zipfile.ZipFile(str(archive)).namelist(), list)
+
+
+# --- the stdlib normalising a name AFTER it was validated (CWE-22) -----------
+_NORMALIZED_BYPASS_NAMES = [
+    ".\n./TARGET",
+    ".\t./TARGET",
+    ".\r./TARGET",
+    "..\n/TARGET",
+    "corpora/.\n./.\n./TARGET",
+    "a#b",
+    "a?b",
+    "\n",
+    "a\nb",
+]
+
+
+@pytest.mark.parametrize("resource_name", _NORMALIZED_BYPASS_NAMES)
+def test_find_refuses_names_the_stdlib_would_rewrite(restricted_sandbox, resource_name):
+    """``find`` validates the raw name and then joins ``url2pathname(name)``.
+
+    Python 3.14 made ``url2pathname`` follow the WHATWG URL rules: it strips
+    ASCII tab / LF / CR and truncates at ``#`` or ``?``. Stripping *creates* a
+    traversal the raw-form check never saw, so ``find(".\\n./TARGET")`` contained
+    no ``../`` when it was validated and became ``../TARGET`` when it was used,
+    escaping the data root on 3.14 (CWE-22). Refusing the characters keeps the
+    validated and the used name identical on every version.
+    """
+    with pytest.raises(ValueError):
+        nltk.data.find(resource_name, paths=[restricted_sandbox])
+
+
+def test_normalized_bypass_would_escape_without_the_guard(restricted_sandbox):
+    """Negative control, and the proof this is version-specific.
+
+    Runs the conversion the way ``find`` does and asserts that on an
+    interpreter which rewrites the name the result really would leave the root,
+    so the guard above is not defending against nothing.
+    """
+    from urllib.request import url2pathname
+
+    converted = url2pathname(".\n./TARGET")
+    joined = os.path.realpath(os.path.join(restricted_sandbox, converted))
+    root_real = os.path.realpath(restricted_sandbox)
+    escapes = not (joined == root_real or joined.startswith(root_real + os.sep))
+    if converted == ".\n./TARGET":
+        # This interpreter does not rewrite; nothing to escape with.
+        assert not escapes
+    else:
+        assert converted == os.path.join("..", "TARGET") or ".." in converted
+        assert escapes, "the rewritten name should have left the root"
+
+
+def test_ordinary_resource_names_are_unaffected(restricted_sandbox):
+    """Over-block control for the rejection: real resource names are plain."""
+    root = Path(restricted_sandbox)
+    (root / "corpora").mkdir()
+    (root / "corpora" / "demo").mkdir()
+    (root / "corpora" / "demo" / "f.txt").write_text("hi", encoding="utf-8")
+    assert str(nltk.data.find("corpora/demo/f.txt", paths=[restricted_sandbox]))
+    for name in ("corpora/demo", "corpora/demo/", "taggers/x_eng.json", "a b/c-d.e"):
+        try:
+            nltk.data.find(name, paths=[restricted_sandbox])
+        except Exception as exc:  # noqa: BLE001 - only the reason matters here
+            assert "Unsafe resource path" not in str(
+                exc
+            ), f"{name!r} was wrongly rejected as unsafe"

--- a/nltk/test/unit/test_pathsec_sweep_wrappers.py
+++ b/nltk/test/unit/test_pathsec_sweep_wrappers.py
@@ -96,7 +96,7 @@ def test_segmenter_model_paths_refuse_escape(pathsec_sandbox, monkeypatch, slot)
     evil = outside / "evil.ser.gz"
     evil.write_text("payload")
     inside = str(root / "in.txt")
-    with pathsec.open(inside, "w") as handle:
+    with pathsec.open(inside, "w", encoding="utf-8") as handle:
         handle.write("中文")
 
     tool = _segmenter(monkeypatch, str(root), **{slot: str(evil)})
@@ -127,7 +127,7 @@ def test_segmenter_in_sandbox_paths_reach_jvm(pathsec_sandbox, monkeypatch):
     with pathsec.open(model, "w") as handle:
         handle.write("m")
     inside = str(root / "in.txt")
-    with pathsec.open(inside, "w") as handle:
+    with pathsec.open(inside, "w", encoding="utf-8") as handle:
         handle.write("中文")
 
     tool = _segmenter(monkeypatch, str(root), model=model)
@@ -198,6 +198,7 @@ def test_malt_untrained_working_dir_is_staged_inside_root(pathsec_sandbox):
     assert cmd[cmd.index("-c") + 1] == "malt_temp.mco"
 
 
+@pytest.mark.skipif(os.name != "posix", reason="POSIX mode bits")
 def test_malt_working_dir_is_private():
     """The staging dir must not be group/world readable: it holds the CoNLL
     intermediates and the trained model."""
@@ -649,13 +650,14 @@ def _hostile_vectors(root, outside):
     secret = outside / "secret.mco"
     secret.write_text("SECRET")
 
+    system_file = "/etc/passwd" if os.name == "posix" else "C:\\Windows\\win.ini"
     vectors = [
         ("outside-abs", str(secret)),
-        ("etc-abs", "/etc/passwd"),
+        ("system-file-abs", system_file),
         ("traversal-from-root", os.path.join(str(root), "..", "..", "etc", "passwd")),
-        ("nul-byte", "/etc/pass\x00wd"),
+        ("nul-byte", system_file[:5] + "\x00" + system_file[5:]),
         ("leading-dash", "-Xmx99g"),
-        ("newline-injection", "/etc/passwd\n-serDictionary /etc/shadow"),
+        ("newline-injection", system_file + "\n-serDictionary " + system_file),
         ("backslash-traversal", "..\\..\\..\\etc\\passwd"),
         ("file-url", "file:///etc/passwd"),
         ("http-url", "http://evil.example/model.gz"),
@@ -676,14 +678,8 @@ def _hostile_vectors(root, outside):
     os.symlink(str(outside), symlinked_dir)
     vectors.append(("via-symlinked-dir", str(symlinked_dir / "secret.mco")))
 
-    hardlink = root / "hard.mco"
-    try:
-        os.link(str(secret), hardlink)
-    except OSError:  # pragma: no cover - cross-device or unsupported
-        pass
-    else:
-        vectors.append(("hardlink-to-outside", str(hardlink)))
-
+    # Hardlinks are deliberately NOT in this matrix: they are refused only for
+    # paths the tool writes. See the dedicated tests below.
     return vectors
 
 
@@ -735,10 +731,7 @@ def test_malt_working_dir_setter_refuses_every_hostile_vector(pathsec_sandbox):
     assert leaked == [], f"working_dir accepted these: {leaked}"
 
 
-def test_hardlinked_model_is_refused(pathsec_sandbox):
-    """realpath() cannot see a hardlink, so an in-root alias of an outside file
-    would otherwise pass every path check."""
-    root, outside = pathsec_sandbox
+def _hardlink_into(root, outside):
     secret = outside / "secret.mco"
     secret.write_text("SECRET")
     alias = root / "alias.mco"
@@ -746,8 +739,28 @@ def test_hardlinked_model_is_refused(pathsec_sandbox):
         os.link(str(secret), alias)
     except OSError:  # pragma: no cover - cross-device or unsupported
         pytest.skip("hard links unavailable between these directories")
+    return str(alias)
+
+
+def test_hardlinked_write_target_is_refused(pathsec_sandbox):
+    """realpath() cannot see a hardlink, so an in-root alias of an outside file
+    passes every path check and the tool would overwrite the original."""
+    root, outside = pathsec_sandbox
+    alias = _hardlink_into(root, outside)
     with pytest.raises(PermissionError):
-        validate_model_resource(str(alias), context="sweep")
+        validate_tool_path(alias, context="sweep", for_write=True)
+
+
+def test_hardlinked_read_target_is_allowed(pathsec_sandbox):
+    """Reading through a hardlink is not an escalation: creating the link already
+    requires write access to the data root. Rejecting st_nlink > 1 outright would
+    refuse ordinary deduplicated trees (cp -l, rsync --link-dest) and would also
+    refuse the ORIGINAL file, since both names share the link count.
+    """
+    root, outside = pathsec_sandbox
+    alias = _hardlink_into(root, outside)
+    validate_tool_path(alias, context="sweep")
+    validate_model_resource(alias, context="sweep")
 
 
 def test_single_linked_model_is_allowed(pathsec_sandbox):
@@ -756,6 +769,7 @@ def test_single_linked_model_is_allowed(pathsec_sandbox):
     model = root / "plain.mco"
     model.write_text("m")
     validate_model_resource(str(model), context="sweep")
+    validate_tool_path(str(model), context="sweep", for_write=True)
 
 
 def test_directory_model_is_not_hardlink_rejected(pathsec_sandbox):
@@ -788,21 +802,32 @@ def test_benign_resource_names_still_pass(value):
 
 def _exotic_vectors(root):
     vectors = [
-        ("dev-stdin", "/dev/stdin"),
-        ("dev-null", "/dev/null"),
-        ("proc-environ", "/proc/self/environ"),
-        ("case-folded-etc", "/ETC/PASSWD"),
         ("tilde-expansion", "~/.ssh/id_rsa"),
         ("ads-stream", "model.mco:evil"),
         ("unc-backslash", "\\\\server\\share\\evil.mco"),
         ("unc-slash", "//server/share/evil.mco"),
         ("nul-in-middle", "model\x00.mco"),
         ("jar-url", "jar:file:///etc/passwd!/x"),
-        ("overlong-name", "/" + ("A" * 300) + "/evil.mco"),
         ("double-slash", "//etc//passwd"),
-        ("root-only", "/"),
         ("dotdot-alone", ".."),
     ]
+    if os.name == "posix":
+        # Character devices and procfs exist only here; on Windows these are
+        # ordinary non-existent relative names and prove nothing.
+        vectors += [
+            ("dev-stdin", "/dev/stdin"),
+            ("dev-null", "/dev/null"),
+            ("proc-environ", "/proc/self/environ"),
+            ("case-folded-etc", "/ETC/PASSWD"),
+            ("overlong-name", "/" + ("A" * 300) + "/evil.mco"),
+            ("root-only", "/"),
+        ]
+    else:
+        vectors += [
+            ("windows-device", "NUL"),
+            ("windows-system-file", "C:\\Windows\\System32\\config\\SAM"),
+            ("drive-relative", "C:evil.mco"),
+        ]
 
     fifo = root / "fifo.mco"
     try:
@@ -1096,17 +1121,14 @@ def test_validate_tool_path_allows_in_sandbox_paths(pathsec_sandbox):
     validate_tool_path(str(root / "out.conll"), context="sweep")
 
 
-def test_validate_tool_path_refuses_hardlink(pathsec_sandbox):
+def test_malt_output_file_refuses_hardlink(pathsec_sandbox):
+    """-o is written by the JVM, so a hardlinked target would clobber the file
+    it aliases outside the roots."""
     root, outside = pathsec_sandbox
-    secret = outside / "secret.conll"
-    secret.write_text("SECRET")
-    alias = root / "alias.conll"
-    try:
-        os.link(str(secret), alias)
-    except OSError:  # pragma: no cover - cross-device or unsupported
-        pytest.skip("hard links unavailable between these directories")
+    alias = _hardlink_into(root, outside)
+    parser, infile = _malt_in_sandbox(root)
     with pytest.raises(PermissionError):
-        validate_tool_path(str(alias), context="sweep")
+        parser.generate_malt_command(infile, alias, mode="parse")
 
 
 def test_validate_tool_path_refuses_fifo(pathsec_sandbox):
@@ -1123,3 +1145,64 @@ def test_validate_tool_path_refuses_fifo(pathsec_sandbox):
 
 def test_validate_tool_path_is_exported():
     assert "validate_tool_path" in pathsec.__all__
+
+
+def test_regression_bare_model_name_is_not_probed_against_cwd(pathsec_sandbox):
+    """Regression: validate_model_resource decided "is this a real path?" with
+    os.path.exists(), which resolves relative to the CWD. A stray malt_temp.mco
+    in the user's directory therefore made the DEFAULT MaltParser() flow die with
+    a security violation. Older NLTK wrote exactly that file into the CWD, so an
+    upgrade would have tripped it.
+    """
+    root, _outside = pathsec_sandbox
+    os.chdir(str(root.parent))
+    decoy = root.parent / "malt_temp.mco"
+    decoy.write_text("decoy")
+    try:
+        validate_model_resource("malt_temp.mco", context="sweep")
+        parser, infile = _malt_in_sandbox(root)
+        parser.model = "malt_temp.mco"
+        cmd = parser.generate_malt_command(infile, None, mode="learn")
+        assert cmd[cmd.index("-c") + 1] == "malt_temp.mco"
+    finally:
+        decoy.unlink()
+
+
+def test_regression_staging_dirs_are_cleaned_up(tmp_path):
+    """Regression: every parser that touched working_dir left a directory under
+    the data root forever. The shared tempdir it replaced was OS-reaped, but a
+    data root is not, so the dir is now removed at interpreter exit.
+
+    Run in a real subprocess: atexit only fires when the process ends.
+    """
+    import subprocess
+    import sys
+
+    root = tmp_path / "nltk_data"
+    root.mkdir()
+    script = (
+        "import nltk.data, nltk.pathsec as ps;"
+        f"nltk.data.path[:] = [{str(root)!r}];"
+        "ps._ALLOWED_ROOTS_CACHE = None; ps._LAST_DATA_PATHS = None;"
+        "from nltk.parse.malt import MaltParser;"
+        "p = MaltParser.__new__(MaltParser); p._working_dir = None;"
+        "print(p.working_dir)"
+    )
+    env = dict(os.environ, PYTHONPATH=os.pathsep.join(sys.path))
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, env=env
+    )
+    assert result.returncode == 0, result.stderr
+    staged = result.stdout.strip()
+    assert staged.startswith(str(root))
+    assert not os.path.exists(staged), f"staging dir leaked after exit: {staged}"
+
+
+def test_working_dir_none_resets_to_lazy_allocation(pathsec_sandbox):
+    """Regression: assigning None used to raise; it now restores the unset state
+    so the property allocates again."""
+    root, _outside = pathsec_sandbox
+    parser = _malt("malt_temp.mco", trained=False)
+    first = parser.working_dir
+    parser.working_dir = None
+    assert parser.working_dir != first or os.path.isdir(parser.working_dir)

--- a/nltk/test/unit/test_pathsec_sweep_wrappers.py
+++ b/nltk/test/unit/test_pathsec_sweep_wrappers.py
@@ -1884,3 +1884,122 @@ def test_zip_member_paths_still_validate(pathsec_sandbox):
     for good in (archive, f"{archive}/member.txt", f"{archive}/sub/dir/member.txt"):
         pathsec.validate_path(good, context="sweep")
     assert ZipFilePathPointer(archive, "member.txt").open().read() == b"hello"
+
+
+# ---------------------------------------------------------------------------
+# Entry-point matrix. The recurring real bug in this PR was a guard placed on
+# ONE method while a sibling built its argv before validating. segment_file was
+# fixed first and segment_sents/segment still leaked. This drives the attack
+# through EVERY public entry point so a new method cannot reopen it quietly.
+# ---------------------------------------------------------------------------
+
+
+def _segmenter_entry_points():
+    return {
+        "segment_file": lambda tool, path: tool.segment_file(path),
+        "segment_sents": lambda tool, _path: tool.segment_sents([["中", "文"]]),
+        "segment": lambda tool, _path: tool.segment(["中", "文"]),
+    }
+
+
+@pytest.mark.parametrize("entry", sorted(_segmenter_entry_points()))
+@pytest.mark.parametrize("hostile", ["mutating", "dot-path", "plain-outside"])
+def test_every_segmenter_entry_point_refuses_hostile_models(
+    pathsec_sandbox, monkeypatch, entry, hostile
+):
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, outside = pathsec_sandbox
+    sink = _trap_java(monkeypatch, seg, {})
+    evil = str(outside / "evil.ser.gz")
+    (outside / "evil.ser.gz").write_text("x")
+    good = str(root / "ok.ser.gz")
+    with pathsec.open(good, "w", encoding="utf-8") as handle:
+        handle.write("m")
+    inside = str(root / "in.txt")
+    with pathsec.open(inside, "w", encoding="utf-8") as handle:
+        handle.write("x")
+
+    model = {
+        "mutating": _MutatingPath(good, evil),
+        "dot-path": _DotPathObject(good, evil),
+        "plain-outside": evil,
+    }[hostile]
+    tool = _segmenter(monkeypatch, str(root), model=model)
+
+    try:
+        _segmenter_entry_points()[entry](tool, inside)
+    except (PermissionError, ValueError):
+        return
+    except _ReachedJVM:
+        pass
+    # If it reached the JVM at all, the argv must hold the validated string.
+    handed = sink["cmd"][sink["cmd"].index("-loadClassifier") + 1]
+    resolved = _resolve(handed)
+    assert isinstance(handed, str), f"{entry} put a {type(handed).__name__} in argv"
+    assert os.path.realpath(str(resolved)).startswith(
+        os.path.realpath(str(root))
+    ), f"{entry} handed the JVM a path outside the roots: {resolved}"
+
+
+@pytest.mark.parametrize("entry", sorted(_segmenter_entry_points()))
+def test_every_segmenter_entry_point_still_works(pathsec_sandbox, monkeypatch, entry):
+    """Over-block control for the matrix above."""
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, _outside = pathsec_sandbox
+    sink = _trap_java(monkeypatch, seg, {})
+    good = str(root / "ok.ser.gz")
+    with pathsec.open(good, "w", encoding="utf-8") as handle:
+        handle.write("m")
+    inside = str(root / "in.txt")
+    with pathsec.open(inside, "w", encoding="utf-8") as handle:
+        handle.write("x")
+
+    tool = _segmenter(monkeypatch, str(root), model=good)
+    with pytest.raises(_ReachedJVM):
+        _segmenter_entry_points()[entry](tool, inside)
+    assert sink["cmd"][sink["cmd"].index("-loadClassifier") + 1] == good
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        "parse_sents",
+        "raw_parse_sents",
+        "tagged_parse_sents",
+        "raw_parse",
+        "tagged_parse",
+    ],
+)
+def test_every_parser_entry_point_refuses_a_mutating_model(
+    pathsec_sandbox, monkeypatch, entry
+):
+    """All five public parser methods funnel through _execute, which replaces the
+    -model argv entry with the validated string. This proves it for each."""
+    import nltk.parse.stanford as st
+
+    root, outside = pathsec_sandbox
+    sink = _trap_java(monkeypatch, st, {})
+    evil = outside / "evil.ser.gz"
+    evil.write_text("x")
+    good = root / "ok.ser.gz"
+    good.write_text("m")
+
+    parser = _stanford_parser(_MutatingPath(str(good), str(evil)))
+    calls = {
+        "parse_sents": lambda p: p.parse_sents([["hi", "there"]]),
+        "raw_parse_sents": lambda p: p.raw_parse_sents(["hi there"]),
+        "tagged_parse_sents": lambda p: p.tagged_parse_sents([[("hi", "UH")]]),
+        "raw_parse": lambda p: p.raw_parse("hi there"),
+        "tagged_parse": lambda p: p.tagged_parse([("hi", "UH")]),
+    }
+    try:
+        calls[entry](parser)
+    except (PermissionError, ValueError):
+        return
+    except _ReachedJVM:
+        pass
+    handed = sink["cmd"][sink["cmd"].index("-model") + 1]
+    assert isinstance(handed, str), f"{entry} put a {type(handed).__name__} in argv"
+    assert os.path.realpath(_resolve(handed)).startswith(os.path.realpath(str(root)))

--- a/nltk/test/unit/test_pathsec_sweep_wrappers.py
+++ b/nltk/test/unit/test_pathsec_sweep_wrappers.py
@@ -1459,3 +1459,104 @@ def test_dot_path_object_is_refused_by_both_guards(pathsec_sandbox):
     for guard in (validate_model_resource, validate_tool_path):
         with pytest.raises((PermissionError, ValueError)):
             guard(sneaky, context="sweep")
+
+
+class _LyingStr(str):
+    """A str subclass whose inspection methods lie.
+
+    os.fspath() returns a str subclass unchanged, so every syntactic check would
+    otherwise run on attacker-controlled methods while the value handed to the
+    tool still carries the real, hostile characters.
+    """
+
+    def __str__(self):
+        return "safe"
+
+    def startswith(self, *args, **kwargs):
+        return False
+
+    def strip(self, *args, **kwargs):
+        return "safe"
+
+    def rstrip(self, *args, **kwargs):
+        return self
+
+    def replace(self, *args, **kwargs):
+        return "safe/name.mco"
+
+    def split(self, *args, **kwargs):
+        return ["safe", "name.mco"]
+
+    def lower(self):
+        return "safe"
+
+    def __contains__(self, item):
+        return False
+
+
+class _LyingFsPath:
+    def __fspath__(self):
+        return _LyingStr("-Xmx99g")
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "-Xmx99g",
+        "../../../etc/passwd",
+        "file:///etc/passwd",
+        "model\x00.mco",
+        "NUL",
+        "evil.mco.",
+        "name:stream",
+    ],
+)
+def test_lying_str_subclass_is_refused(payload):
+    """Every check must see the real characters, not what the subclass claims."""
+    for guard in (validate_model_resource, validate_tool_path):
+        with pytest.raises((PermissionError, ValueError)):
+            guard(_LyingStr(payload), context="sweep")
+
+
+def test_lying_subclass_returned_by_fspath_is_refused():
+    for guard in (validate_model_resource, validate_tool_path):
+        with pytest.raises((PermissionError, ValueError)):
+            guard(_LyingFsPath(), context="sweep")
+
+
+def test_malt_argv_cannot_be_injected_via_str_subclass(pathsec_sandbox):
+    """The payload previously reached the JVM argv as "-c -Xmx99g"."""
+    root, _outside = pathsec_sandbox
+    parser = _malt(_LyingStr("-Xmx99g"))
+    infile, _outfile = _sandbox_io(parser)
+    with pytest.raises((PermissionError, ValueError)):
+        parser.generate_malt_command(infile, None, mode="learn")
+
+
+def test_guards_always_return_an_exact_str(pathsec_sandbox):
+    """The value callers put into argv must be a plain str, so that nothing can
+    re-resolve or re-inspect it differently later."""
+    root, _outside = pathsec_sandbox
+    model = root / "ok.mco"
+    model.write_text("m")
+
+    class _BenignSubclass(str):
+        pass
+
+    for value in (str(model), _BenignSubclass(str(model)), model, _DEFAULT_RESOURCE):
+        assert type(validate_model_resource(value, context="sweep")) is str
+    assert type(validate_tool_path(model, context="sweep")) is str
+
+
+def test_benign_str_subclass_still_works(pathsec_sandbox):
+    """Over-block control: subclassing str is legal, lying about it is not."""
+    root, _outside = pathsec_sandbox
+    model = root / "ok.mco"
+    model.write_text("m")
+
+    class _BenignSubclass(str):
+        pass
+
+    assert validate_model_resource(_BenignSubclass(str(model)), context="sweep") == str(
+        model
+    )

--- a/nltk/test/unit/test_pathsec_sweep_wrappers.py
+++ b/nltk/test/unit/test_pathsec_sweep_wrappers.py
@@ -379,7 +379,8 @@ def test_teeth_segmenter_guard_is_load_bearing(pathsec_sandbox, monkeypatch):
 
     root, _outside = pathsec_sandbox
     _trap_java(monkeypatch, seg, {})
-    monkeypatch.setattr(seg, "validate_path", lambda *a, **k: None)
+    monkeypatch.setattr(seg, "validate_path", _passthrough)
+    monkeypatch.setattr(seg, "validate_tool_path", _passthrough)
     tool = _segmenter(monkeypatch, str(root))
     with pytest.raises(_ReachedJVM):
         tool.segment_file("/etc/passwd")
@@ -1379,3 +1380,82 @@ def test_trailing_dot_or_space_is_refused(name):
     that is opened."""
     with pytest.raises(ValueError):
         validate_model_resource(name, context="sweep")
+
+
+class _DotPathObject:
+    """validate_path reads a ``.path`` attribute in preference to __fspath__
+    (it supports NLTK's PathPointer objects). An object whose ``.path`` is
+    benign and whose __fspath__ is hostile therefore passes the check and is
+    resolved to the hostile value by whoever consumes it."""
+
+    def __init__(self, benign, hostile):
+        self.path = benign
+        self._hostile = hostile
+
+    def __fspath__(self):
+        return self._hostile
+
+    def __str__(self):
+        return self.path
+
+
+@pytest.mark.parametrize("slot", ["model", "input"])
+def test_segmenter_refuses_dot_path_objects(pathsec_sandbox, monkeypatch, slot):
+    """Both the model and the input file leaked this way: the guard read .path
+    and the JVM would have resolved __fspath__."""
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, outside = pathsec_sandbox
+    _trap_java(monkeypatch, seg, {})
+    evil = outside / "evil.ser.gz"
+    evil.write_text("x")
+    good = str(root / "ok.ser.gz")
+    with pathsec.open(good, "w", encoding="utf-8") as handle:
+        handle.write("m")
+    inside = str(root / "in.txt")
+    with pathsec.open(inside, "w", encoding="utf-8") as handle:
+        handle.write("x")
+
+    if slot == "model":
+        tool = _segmenter(monkeypatch, str(root), model=_DotPathObject(good, str(evil)))
+        target = inside
+    else:
+        tool = _segmenter(monkeypatch, str(root), model=good)
+        target = _DotPathObject(inside, "/etc/passwd")
+    with pytest.raises((PermissionError, ValueError)):
+        tool.segment_file(target)
+
+
+def test_segmenter_argv_carries_validated_strings(pathsec_sandbox, monkeypatch):
+    """Over-block control plus the positive invariant: what reaches the JVM is
+    the exact string the guard returned, as a str."""
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, _outside = pathsec_sandbox
+    sink = _trap_java(monkeypatch, seg, {})
+    model = str(root / "ok.ser.gz")
+    with pathsec.open(model, "w", encoding="utf-8") as handle:
+        handle.write("m")
+    inside = str(root / "in.txt")
+    with pathsec.open(inside, "w", encoding="utf-8") as handle:
+        handle.write("x")
+
+    tool = _segmenter(monkeypatch, str(root), model=model)
+    with pytest.raises(_ReachedJVM):
+        tool.segment_file(inside)
+    for flag in ("-loadClassifier", "-textFile"):
+        value = sink["cmd"][sink["cmd"].index(flag) + 1]
+        assert isinstance(value, str)
+        assert os.path.realpath(value).startswith(os.path.realpath(str(root)))
+
+
+def test_dot_path_object_is_refused_by_both_guards(pathsec_sandbox):
+    root, outside = pathsec_sandbox
+    evil = outside / "evil.mco"
+    evil.write_text("x")
+    good = root / "ok.mco"
+    good.write_text("m")
+    sneaky = _DotPathObject(str(good), str(evil))
+    for guard in (validate_model_resource, validate_tool_path):
+        with pytest.raises((PermissionError, ValueError)):
+            guard(sneaky, context="sweep")

--- a/nltk/test/unit/test_pathsec_sweep_wrappers.py
+++ b/nltk/test/unit/test_pathsec_sweep_wrappers.py
@@ -1792,3 +1792,95 @@ def test_segmenter_out_of_root_jar_is_refused_despite_approved_checksum(
     tool._jar_sha256_cache = {}
     with pytest.raises((PermissionError, ValueError)):
         tool._validate_classpath()
+
+
+# ---------------------------------------------------------------------------
+# Surfaces probed and found CLEAN. Pinned so a later change cannot open them
+# without a test noticing. Each was verified by execution, not by reading.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "java_class",
+    ["-jar", "-Xmx99g", "-javaagent:/tmp/evil.jar", "@/tmp/argfile"],
+)
+def test_segmenter_java_class_cannot_be_an_option(
+    pathsec_sandbox, monkeypatch, java_class
+):
+    """java_class is caller-supplied and lands in the JVM's MAIN CLASS slot, so
+    an option-shaped value would be read as a JVM option instead. internals.java
+    already refuses it; this pins that it keeps doing so."""
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, _outside = pathsec_sandbox
+    inside = str(root / "in.txt")
+    with pathsec.open(inside, "w", encoding="utf-8") as handle:
+        handle.write("x")
+    tool = _segmenter(monkeypatch, str(root))
+    tool._java_class = java_class
+    with pytest.raises((ValueError, PermissionError)):
+        tool.segment_file(inside)
+
+
+@pytest.mark.parametrize(
+    "option",
+    [
+        "-XX:OnOutOfMemoryError=touch /tmp/pwned",
+        "-javaagent:/tmp/evil.jar",
+        "@/tmp/argfile",
+        "-jar /tmp/evil.jar",
+    ],
+)
+def test_wrapper_java_options_hit_the_allowlist(pathsec_sandbox, monkeypatch, option):
+    """The JVM option allowlist lives in internals.java. This confirms it is
+    actually reached through THIS wrapper rather than assumed."""
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, _outside = pathsec_sandbox
+    inside = str(root / "in.txt")
+    with pathsec.open(inside, "w", encoding="utf-8") as handle:
+        handle.write("x")
+    tool = _segmenter(monkeypatch, str(root))
+    tool.java_options = option
+    with pytest.raises((ValueError, PermissionError)):
+        tool.segment_file(inside)
+
+
+def test_unresolvable_path_with_traversal_or_nul_is_refused(pathsec_sandbox):
+    """validate_path falls back to validating only the prefix up to ".zip" when
+    resolve() fails, and resolve() also fails on a NUL. Refusing an unresolvable
+    path that still contains a traversal or a NUL keeps that fallback from
+    approving a value on a harmless prefix.
+
+    No usable escape was found through this (a NUL path cannot be opened by
+    Python and truncates in a subprocess), so this is hardening rather than a
+    fixed vulnerability.
+    """
+    import zipfile as _zipfile
+
+    root, _outside = pathsec_sandbox
+    archive = str(root / "corpus.zip")
+    with _zipfile.ZipFile(archive, "w") as handle:
+        handle.writestr("member.txt", "hello")
+    for suspect in (
+        f"{archive}/\x00../../../etc/passwd",
+        f"{archive}/../../../../etc/passwd",
+    ):
+        with pytest.raises((PermissionError, ValueError)):
+            pathsec.validate_path(suspect, context="sweep")
+
+
+def test_zip_member_paths_still_validate(pathsec_sandbox):
+    """Over-block control for the change above: virtual zip member paths are the
+    reason that fallback exists and must keep working."""
+    import zipfile as _zipfile
+
+    from nltk.data import ZipFilePathPointer
+
+    root, _outside = pathsec_sandbox
+    archive = str(root / "corpus.zip")
+    with _zipfile.ZipFile(archive, "w") as handle:
+        handle.writestr("member.txt", "hello")
+    for good in (archive, f"{archive}/member.txt", f"{archive}/sub/dir/member.txt"):
+        pathsec.validate_path(good, context="sweep")
+    assert ZipFilePathPointer(archive, "member.txt").open().read() == b"hello"

--- a/nltk/test/unit/test_pathsec_sweep_wrappers.py
+++ b/nltk/test/unit/test_pathsec_sweep_wrappers.py
@@ -1560,3 +1560,116 @@ def test_benign_str_subclass_still_works(pathsec_sandbox):
     assert validate_model_resource(_BenignSubclass(str(model)), context="sweep") == str(
         model
     )
+
+
+# ---------------------------------------------------------------------------
+# corenlp_options is SPLIT into separate argv elements, so it can append a
+# second -model. Verified directly against the JVM that Stanford's
+# LexicalizedParser honours the LAST occurrence, so an injected option replaced
+# the model the guard had just checked and the parser deserialized that file.
+# ---------------------------------------------------------------------------
+
+
+def _stanford_with_options(model_path, options):
+    parser = _stanford_parser(model_path)
+    parser.corenlp_options = options
+    return parser
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        "-model /etc/passwd",
+        "-model ../../../etc/passwd",
+        "-loadClassifier /etc/passwd",
+        "-outputFormat xml",
+        "-encoding utf8",
+        "-sentences newline",
+    ],
+    ids=[
+        "second-model-abs",
+        "second-model-traversal",
+        "loadClassifier-abs",
+        "dup-outputFormat",
+        "dup-encoding",
+        "dup-sentences",
+    ],
+)
+def test_corenlp_options_cannot_override_guarded_flags(
+    pathsec_sandbox, monkeypatch, options
+):
+    import nltk.parse.stanford as st
+
+    root, _outside = pathsec_sandbox
+    _trap_java(monkeypatch, st, {})
+    model = str(root / "ok.ser.gz")
+    with pathsec.open(model, "w", encoding="utf-8") as handle:
+        handle.write("m")
+    with pytest.raises((PermissionError, ValueError)):
+        _stanford_with_options(model, options).parse_sents([["hi", "there"]])
+
+
+def test_corenlp_options_cannot_point_outside_the_roots(pathsec_sandbox, monkeypatch):
+    import nltk.parse.stanford as st
+
+    root, outside = pathsec_sandbox
+    _trap_java(monkeypatch, st, {})
+    evil = outside / "evil.ser.gz"
+    evil.write_text("x")
+    model = str(root / "ok.ser.gz")
+    with pathsec.open(model, "w", encoding="utf-8") as handle:
+        handle.write("m")
+    with pytest.raises((PermissionError, ValueError)):
+        _stanford_with_options(model, f"-serializedDict {evil}").parse_sents(
+            [["hi", "there"]]
+        )
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        "",
+        "-maxLength 40",
+        "-serializedDict edu/stanford/nlp/x.ser.gz",
+        "-retainTMPSubcategories",
+    ],
+    ids=["empty", "new-flag", "resource-value", "bare-flag"],
+)
+def test_corenlp_options_passthrough_still_works(pathsec_sandbox, monkeypatch, options):
+    """Over-block control: this is a general passthrough for the tool's own
+    settings, so anything that is neither a duplicate nor an out-of-root path
+    must still reach the JVM."""
+    import nltk.parse.stanford as st
+
+    root, _outside = pathsec_sandbox
+    sink = _trap_java(monkeypatch, st, {})
+    model = str(root / "ok.ser.gz")
+    with pathsec.open(model, "w", encoding="utf-8") as handle:
+        handle.write("m")
+    with pytest.raises(_ReachedJVM):
+        _stanford_with_options(model, options).parse_sents([["hi", "there"]])
+    assert sink["cmd"][sink["cmd"].index("-model") + 1] == model
+    for token in options.split():
+        assert token in sink["cmd"]
+
+
+def test_teeth_corenlp_options_guard_is_load_bearing(pathsec_sandbox, monkeypatch):
+    """Restore the raw split and the injected -model reaches the JVM again."""
+    import nltk.parse.stanford as st
+
+    root, outside = pathsec_sandbox
+    sink = _trap_java(monkeypatch, st, {})
+    evil = outside / "evil.ser.gz"
+    evil.write_text("x")
+    model = str(root / "ok.ser.gz")
+    with pathsec.open(model, "w", encoding="utf-8") as handle:
+        handle.write("m")
+    monkeypatch.setattr(
+        st.StanfordParser,
+        "_validated_extra_options",
+        lambda self, cmd: self.corenlp_options.split(),
+    )
+    with pytest.raises(_ReachedJVM):
+        _stanford_with_options(model, f"-model {evil}").parse_sents([["hi", "there"]])
+    models = [sink["cmd"][i + 1] for i, x in enumerate(sink["cmd"]) if x == "-model"]
+    assert str(evil) in models

--- a/nltk/test/unit/test_pathsec_sweep_wrappers.py
+++ b/nltk/test/unit/test_pathsec_sweep_wrappers.py
@@ -32,7 +32,7 @@ import pytest
 
 from nltk import pathsec
 from nltk.data import make_staging_dir
-from nltk.pathsec import validate_model_resource
+from nltk.pathsec import validate_model_resource, validate_tool_path
 
 
 class _ReachedJVM(Exception):
@@ -152,13 +152,25 @@ def _malt(model, trained=True):
     return parser
 
 
+def _sandbox_io(parser):
+    """Valid in-sandbox -i/-o paths for a test that targets some *other* guard.
+    Without these the input-file guard fires first and the test would pass for
+    the wrong reason."""
+    infile = os.path.join(parser.working_dir, "in.conll")
+    with pathsec.open(infile, "w") as handle:
+        handle.write("")
+    return infile, os.path.join(parser.working_dir, "out.conll")
+
+
 def test_malt_trained_model_refuses_escape(pathsec_sandbox):
     """A .mco outside the roots would make ``-w`` an arbitrary write target."""
     root, outside = pathsec_sandbox
     evil = outside / "evil.mco"
     evil.write_text("model")
+    parser = _malt(str(evil))
+    infile, _outfile = _sandbox_io(parser)
     with pytest.raises((PermissionError, ValueError)):
-        _malt(str(evil)).generate_malt_command("in.conll", "out.conll", mode="learn")
+        parser.generate_malt_command(infile, None, mode="learn")
 
 
 def test_malt_trained_model_in_sandbox_is_allowed(pathsec_sandbox):
@@ -166,7 +178,9 @@ def test_malt_trained_model_in_sandbox_is_allowed(pathsec_sandbox):
     root, _outside = pathsec_sandbox
     model = root / "engmalt.mco"
     model.write_text("model")
-    cmd = _malt(str(model)).generate_malt_command("in.conll", "out.conll", mode="parse")
+    parser = _malt(str(model))
+    infile, outfile = _sandbox_io(parser)
+    cmd = parser.generate_malt_command(infile, outfile, mode="parse")
     assert cmd[cmd.index("-w") + 1] == str(root)
     assert cmd[cmd.index("-c") + 1] == "engmalt.mco"
 
@@ -175,9 +189,9 @@ def test_malt_untrained_working_dir_is_staged_inside_root(pathsec_sandbox):
     """An untrained parser used to write malt_temp.mco into the CWD; it must now
     land in a private staging dir inside a data root."""
     root, _outside = pathsec_sandbox
-    cmd = _malt("malt_temp.mco", trained=False).generate_malt_command(
-        "in.conll", "out.conll", mode="learn"
-    )
+    parser = _malt("malt_temp.mco", trained=False)
+    infile, _outfile = _sandbox_io(parser)
+    cmd = parser.generate_malt_command(infile, None, mode="learn")
     workingdir = cmd[cmd.index("-w") + 1]
     assert os.path.realpath(workingdir).startswith(os.path.realpath(str(root)))
     assert os.path.realpath(workingdir) != os.path.realpath(os.getcwd())
@@ -372,6 +386,7 @@ def test_teeth_malt_guard_is_load_bearing(pathsec_sandbox, monkeypatch):
     _root, outside = pathsec_sandbox
     monkeypatch.setattr(malt, "validate_path", lambda *a, **k: None)
     monkeypatch.setattr(malt, "validate_model_resource", lambda *a, **k: None)
+    monkeypatch.setattr(malt, "validate_tool_path", lambda *a, **k: None)
     evil = outside / "evil.mco"
     evil.write_text("model")
     cmd = _malt(str(evil)).generate_malt_command("in.conll", "out.conll", mode="learn")
@@ -387,8 +402,10 @@ def test_teeth_malt_model_resource_guard_alone_blocks(pathsec_sandbox, monkeypat
     monkeypatch.setattr(malt, "validate_path", lambda *a, **k: None)
     evil = outside / "evil.mco"
     evil.write_text("model")
+    parser = _malt(str(evil))
+    infile, _outfile = _sandbox_io(parser)
     with pytest.raises((PermissionError, ValueError)):
-        _malt(str(evil)).generate_malt_command("in.conll", "out.conll", mode="learn")
+        parser.generate_malt_command(infile, None, mode="learn")
 
 
 # ---------------------------------------------------------------------------
@@ -480,12 +497,16 @@ def test_malt_command_shape_is_unchanged(pathsec_sandbox):
     root, _outside = pathsec_sandbox
     model = root / "engmalt.mco"
     model.write_text("model")
-    cmd = _malt(str(model)).generate_malt_command("in.conll", "out.conll", mode="parse")
+    parser = _malt(str(model))
+    infile, outfile = str(root / "in.conll"), str(root / "out.conll")
+    with pathsec.open(infile, "w") as handle:
+        handle.write("")
+    cmd = parser.generate_malt_command(infile, outfile, mode="parse")
     assert cmd[0] == "org.maltparser.Malt"
     for flag in ("-w", "-c", "-i", "-o", "-m"):
         assert flag in cmd
-    assert cmd[cmd.index("-i") + 1] == "in.conll"
-    assert cmd[cmd.index("-o") + 1] == "out.conll"
+    assert cmd[cmd.index("-i") + 1] == infile
+    assert cmd[cmd.index("-o") + 1] == outfile
     assert cmd[cmd.index("-m") + 1] == "parse"
 
 
@@ -688,7 +709,9 @@ def test_malt_model_refuses_every_hostile_vector(pathsec_sandbox):
     leaked = []
     for name, value in _hostile_vectors(root, outside):
         try:
-            _malt(value).generate_malt_command("in.conll", "out.conll", mode="learn")
+            parser = _malt(value)
+            infile, _outfile = _sandbox_io(parser)
+            parser.generate_malt_command(infile, None, mode="learn")
         except (PermissionError, ValueError, OSError):
             continue
         leaked.append(name)
@@ -871,7 +894,10 @@ def test_regression_generate_malt_command_needs_no_trained_attribute(pathsec_san
     parser.model = "malt_temp.mco"
     parser._working_dir = None
     parser.additional_java_args = []
-    cmd = parser.generate_malt_command("in.conll", "out.conll", mode="learn")
+    infile = os.path.join(parser.working_dir, "in.conll")
+    with pathsec.open(infile, "w") as handle:
+        handle.write("")
+    cmd = parser.generate_malt_command(infile, None, mode="learn")
     assert cmd[cmd.index("-c") + 1] == "malt_temp.mco"
 
 
@@ -881,7 +907,11 @@ def test_regression_trained_bare_model_resolves_to_working_dir(pathsec_sandbox):
     made every post-training parse fail with a security violation."""
     root, _outside = pathsec_sandbox
     parser = _malt("malt_temp.mco", trained=True)
-    cmd = parser.generate_malt_command("in.conll", "out.conll", mode="parse")
+    infile = os.path.join(parser.working_dir, "in.conll")
+    outfile = os.path.join(parser.working_dir, "out.conll")
+    with pathsec.open(infile, "w") as handle:
+        handle.write("")
+    cmd = parser.generate_malt_command(infile, outfile, mode="parse")
     workingdir = cmd[cmd.index("-w") + 1]
     assert os.path.realpath(workingdir).startswith(os.path.realpath(str(root)))
     assert os.path.realpath(workingdir) != os.path.realpath(os.getcwd())
@@ -911,3 +941,185 @@ def test_regression_has_java_probe_actually_executes():
             "java", env_vars=("JAVAHOME", "JAVA_HOME"), verbose=False, binary_names=None
         )
         assert subprocess.run([binary, "-version"], capture_output=True).returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# MaltParser -i / -o. Both are public: generate_malt_command() takes them
+# directly and train_from_file() is the public route to -i. -i is READ by the
+# JVM and -o is WRITTEN by it, so an unbounded value is an arbitrary file read
+# and an arbitrary file write.
+# ---------------------------------------------------------------------------
+
+
+def _malt_in_sandbox(root):
+    parser = _malt("malt_temp.mco", trained=False)
+    parser.malt_jars = []
+    infile = os.path.join(parser.working_dir, "in.conll")
+    with pathsec.open(infile, "w") as handle:
+        handle.write("")
+    return parser, infile
+
+
+def test_malt_input_file_refuses_every_hostile_vector(pathsec_sandbox):
+    """-i is an arbitrary-file-read primitive without a guard."""
+    root, outside = pathsec_sandbox
+    parser, _infile = _malt_in_sandbox(root)
+    leaked = []
+    for name, value in _hostile_vectors(root, outside):
+        try:
+            parser.generate_malt_command(value, None, mode="learn")
+        except (PermissionError, ValueError, OSError):
+            continue
+        leaked.append(name)
+    assert leaked == [], f"MaltParser -i accepted: {leaked}"
+
+
+def test_malt_output_file_refuses_every_hostile_vector(pathsec_sandbox):
+    """-o is an arbitrary-file-WRITE primitive without a guard."""
+    root, outside = pathsec_sandbox
+    parser, infile = _malt_in_sandbox(root)
+    leaked = []
+    for name, value in _hostile_vectors(root, outside):
+        try:
+            parser.generate_malt_command(infile, value, mode="parse")
+        except (PermissionError, ValueError, OSError):
+            continue
+        leaked.append(name)
+    assert leaked == [], f"MaltParser -o accepted: {leaked}"
+
+
+def test_malt_train_from_file_refuses_outside_corpus(pathsec_sandbox):
+    """train_from_file is the public route to -i."""
+    root, outside = pathsec_sandbox
+    parser, _infile = _malt_in_sandbox(root)
+    corpus = outside / "steal.conll"
+    corpus.write_text("1\ta\t_\tNN\t_\t_\t0\tROOT\t_\t_\n")
+    for target in ("/etc/passwd", str(corpus)):
+        with pytest.raises((PermissionError, ValueError)):
+            parser.train_from_file(target)
+
+
+def test_malt_in_sandbox_input_and_output_are_allowed(pathsec_sandbox):
+    """Over-block control: the internal callers pass temp files inside
+    working_dir, which must keep working."""
+    root, _outside = pathsec_sandbox
+    parser, infile = _malt_in_sandbox(root)
+    outfile = os.path.join(parser.working_dir, "out.conll")
+    cmd = parser.generate_malt_command(infile, outfile, mode="parse")
+    assert cmd[cmd.index("-i") + 1] == infile
+    assert cmd[cmd.index("-o") + 1] == outfile
+
+
+def test_teeth_malt_io_guard_is_load_bearing(pathsec_sandbox, monkeypatch):
+    """Neuter the guard and -o reaches the JVM again."""
+    import nltk.parse.malt as malt
+
+    root, outside = pathsec_sandbox
+    parser, infile = _malt_in_sandbox(root)
+    monkeypatch.setattr(malt, "validate_tool_path", lambda *a, **k: None)
+    target = str(outside / "pwned.conll")
+    cmd = parser.generate_malt_command(infile, target, mode="parse")
+    assert cmd[cmd.index("-o") + 1] == target
+
+
+def test_malt_revalidates_on_every_call(pathsec_sandbox):
+    """No cached verdict: a model swapped after a successful call is re-checked,
+    so an attacker cannot 'warm up' the parser with a benign value first."""
+    root, outside = pathsec_sandbox
+    parser, infile = _malt_in_sandbox(root)
+    parser.generate_malt_command(infile, None, mode="learn")
+    evil = outside / "evil.mco"
+    evil.write_text("x")
+    parser.model = str(evil)
+    with pytest.raises((PermissionError, ValueError)):
+        parser.generate_malt_command(infile, None, mode="learn")
+
+
+def test_edited_wrappers_never_widen_the_sandbox(pathsec_sandbox):
+    """Regression guard for the worst bug class in this audit: a loader that
+    appends its target to nltk.data.path and clears the pathsec root cache
+    disarms validate_path process-wide. None of the modules touched here may do
+    that, whatever else they change.
+    """
+    import nltk.data
+
+    before = list(nltk.data.path)
+    root, outside = pathsec_sandbox
+    parser, infile = _malt_in_sandbox(root)
+    for target in ("/etc/passwd", str(outside / "evil.mco")):
+        for call in (
+            lambda t=target: parser.generate_malt_command(t, None, mode="learn"),
+            lambda t=target: setattr(parser, "working_dir", t),
+            lambda t=target: validate_model_resource(t, context="widen"),
+        ):
+            try:
+                call()
+            except (PermissionError, ValueError, OSError):
+                pass
+    assert list(nltk.data.path) == before
+    with pytest.raises(PermissionError):
+        pathsec.validate_path("/etc/passwd", context="widen-check")
+
+
+# ---------------------------------------------------------------------------
+# validate_tool_path. Contract differs from validate_model_resource: this one
+# never accepts a bare resource name, because the tool opens the value directly.
+# ---------------------------------------------------------------------------
+
+
+def test_validate_tool_path_refuses_every_hostile_vector(pathsec_sandbox):
+    root, outside = pathsec_sandbox
+    leaked = []
+    for name, value in _hostile_vectors(root, outside) + _exotic_vectors(root):
+        try:
+            validate_tool_path(value, context="sweep")
+        except (PermissionError, ValueError, OSError):
+            continue
+        leaked.append(name)
+    assert leaked == [], f"validate_tool_path let these through: {leaked}"
+
+
+def test_validate_tool_path_rejects_bare_resource_names(pathsec_sandbox):
+    """Unlike a model argument, an -i/-o value is never a classpath resource: a
+    bare name would resolve against the current working directory."""
+    for value in ("in.conll", "malt_temp.mco", _DEFAULT_RESOURCE):
+        with pytest.raises((PermissionError, ValueError)):
+            validate_tool_path(value, context="sweep")
+
+
+def test_validate_tool_path_allows_in_sandbox_paths(pathsec_sandbox):
+    """Over-block control, including a not-yet-created output file."""
+    root, _outside = pathsec_sandbox
+    existing = root / "in.conll"
+    existing.write_text("")
+    validate_tool_path(str(existing), context="sweep")
+    validate_tool_path(str(root / "out.conll"), context="sweep")
+
+
+def test_validate_tool_path_refuses_hardlink(pathsec_sandbox):
+    root, outside = pathsec_sandbox
+    secret = outside / "secret.conll"
+    secret.write_text("SECRET")
+    alias = root / "alias.conll"
+    try:
+        os.link(str(secret), alias)
+    except OSError:  # pragma: no cover - cross-device or unsupported
+        pytest.skip("hard links unavailable between these directories")
+    with pytest.raises(PermissionError):
+        validate_tool_path(str(alias), context="sweep")
+
+
+def test_validate_tool_path_refuses_fifo(pathsec_sandbox):
+    """An output path that is a FIFO would block the JVM forever."""
+    root, _outside = pathsec_sandbox
+    fifo = root / "out.fifo"
+    try:
+        os.mkfifo(fifo)
+    except (AttributeError, OSError):  # pragma: no cover - not on Windows
+        pytest.skip("mkfifo unavailable")
+    with pytest.raises(PermissionError):
+        validate_tool_path(str(fifo), context="sweep")
+
+
+def test_validate_tool_path_is_exported():
+    assert "validate_tool_path" in pathsec.__all__

--- a/nltk/test/unit/test_pathsec_sweep_wrappers.py
+++ b/nltk/test/unit/test_pathsec_sweep_wrappers.py
@@ -2003,3 +2003,89 @@ def test_every_parser_entry_point_refuses_a_mutating_model(
     handed = sink["cmd"][sink["cmd"].index("-model") + 1]
     assert isinstance(handed, str), f"{entry} put a {type(handed).__name__} in argv"
     assert os.path.realpath(_resolve(handed)).startswith(os.path.realpath(str(root)))
+
+
+def test_validate_model_paths_returns_the_validated_strings(
+    pathsec_sandbox, monkeypatch
+):
+    """The contract the segmenter's argv builders rely on: the guard hands back
+    what it checked, so nothing has to re-read shared mutable state."""
+    root, _outside = pathsec_sandbox
+    model = str(root / "m.ser.gz")
+    dictionary = str(root / "d.ser.gz")
+    sihan = str(root / "sihan")
+    for path in (model, dictionary):
+        with pathsec.open(path, "w", encoding="utf-8") as handle:
+            handle.write("x")
+    os.mkdir(sihan)
+
+    tool = _segmenter(monkeypatch, str(root), model=model)
+    tool._dict = dictionary
+    tool._sihan_corpora_dict = sihan
+    assert tool._validate_model_paths() == (model, dictionary, sihan)
+
+    unset = _segmenter(monkeypatch, str(root))
+    assert unset._validate_model_paths() == (None, None, None)
+
+
+def test_segmenter_argv_survives_a_concurrent_model_swap(pathsec_sandbox, monkeypatch):
+    """A background thread rewriting self._model must never land an out-of-root
+    path in the argv. The builders take the guard's return value rather than
+    re-reading the attribute, so the checked value and the used value are the
+    same object.
+
+    No leak was observed here before the change either, so this documents the
+    property rather than reproducing a past failure.
+    """
+    import threading
+
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, outside = pathsec_sandbox
+    evil = str(outside / "evil.ser.gz")
+    (outside / "evil.ser.gz").write_text("x")
+    good = str(root / "ok.ser.gz")
+    with pathsec.open(good, "w", encoding="utf-8") as handle:
+        handle.write("m")
+    inside = str(root / "in.txt")
+    with pathsec.open(inside, "w", encoding="utf-8") as handle:
+        handle.write("x")
+
+    handed = []
+
+    def fake_java(cmd, *args, **kwargs):
+        handed.append(cmd[cmd.index("-loadClassifier") + 1])
+        raise _ReachedJVM
+
+    monkeypatch.setattr(seg, "java", fake_java)
+    tool = _segmenter(monkeypatch, str(root), model=good)
+
+    stop = threading.Event()
+
+    def flipper():
+        while not stop.is_set():
+            tool._model = evil
+            tool._model = good
+
+    thread = threading.Thread(target=flipper, daemon=True)
+    thread.start()
+    try:
+        for _ in range(200):
+            for call in (
+                lambda: tool.segment_file(inside),
+                lambda: tool.segment_sents([["中", "文"]]),
+            ):
+                try:
+                    call()
+                except (_ReachedJVM, PermissionError, ValueError):
+                    pass
+    finally:
+        stop.set()
+        thread.join(timeout=5)
+
+    escaped = [
+        value
+        for value in handed
+        if not os.path.realpath(str(value)).startswith(os.path.realpath(str(root)))
+    ]
+    assert escaped == [], f"a concurrent write reached the JVM argv: {escaped[:3]}"

--- a/nltk/test/unit/test_pathsec_sweep_wrappers.py
+++ b/nltk/test/unit/test_pathsec_sweep_wrappers.py
@@ -851,6 +851,7 @@ def test_validate_model_resource_refuses_exotic_vectors(pathsec_sandbox):
     assert leaked == [], f"validate_model_resource let these through: {leaked}"
 
 
+@pytest.mark.skipif(not hasattr(__import__("socket"), "AF_UNIX"), reason="no AF_UNIX")
 def test_unix_socket_model_is_refused(pathsec_sandbox):
     """A socket planted in a data root is not a model; reading it would block."""
     import socket
@@ -901,6 +902,10 @@ def test_windows_drive_path_is_not_stream_rejected():
         _vmr("C:\\models\\english.ser.gz", context="sweep")
     except ValueError as exc:
         assert "alternate data stream" not in str(exc), exc
+    except PermissionError:
+        # On Windows this IS an absolute path, so it is (correctly) refused for
+        # being outside the data roots. That is not the stream rejection.
+        pass
     assert _re.match(r"^[A-Za-z]:[\\/]", "C:\\models\\english.ser.gz")
 
 
@@ -1206,3 +1211,21 @@ def test_working_dir_none_resets_to_lazy_allocation(pathsec_sandbox):
     first = parser.working_dir
     parser.working_dir = None
     assert parser.working_dir != first or os.path.isdir(parser.working_dir)
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["NUL", "CON", "COM1", "LPT1", "nul.ser.gz", "models/COM9.mco", "AUX"],
+)
+def test_reserved_windows_device_names_are_refused(value):
+    """On Windows these resolve to a device (a serial port, the null device) no
+    matter which directory they appear in, so a bare resource name must not be
+    allowed to name one."""
+    with pytest.raises(ValueError):
+        validate_model_resource(value, context="sweep")
+
+
+@pytest.mark.parametrize("value", ["CONTEXT.mco", "console.ser.gz", "nulls.mco"])
+def test_names_merely_starting_like_a_device_are_allowed(value):
+    """Over-block control: the check is on the whole stem, not a prefix."""
+    validate_model_resource(value, context="sweep")

--- a/nltk/test/unit/test_pathsec_sweep_wrappers.py
+++ b/nltk/test/unit/test_pathsec_sweep_wrappers.py
@@ -1673,3 +1673,33 @@ def test_teeth_corenlp_options_guard_is_load_bearing(pathsec_sandbox, monkeypatc
         _stanford_with_options(model, f"-model {evil}").parse_sents([["hi", "there"]])
     models = [sink["cmd"][i + 1] for i, x in enumerate(sink["cmd"]) if x == "-model"]
     assert str(evil) in models
+
+
+@pytest.mark.parametrize(
+    "name",
+    [".\n./TARGET", ".\t./TARGET", ".\r./TARGET", ".\x0b./TARGET", "model\x0c.mco"],
+    ids=["lf", "tab", "cr", "vtab", "formfeed"],
+)
+def test_control_characters_are_refused(name):
+    """Python 3.14's url2pathname follows the WHATWG rules and STRIPS tab, LF and
+    CR, so a name containing them passes a '..' check here and then BECOMES a
+    traversal downstream. Verified against a real 3.14.4 interpreter:
+
+        url2pathname('.\\n./TARGET') -> '../TARGET'
+
+    A legitimate model or corpus filename never contains a control character, so
+    they are refused outright rather than normalised.
+    """
+    for guard in (validate_model_resource, validate_tool_path):
+        with pytest.raises((PermissionError, ValueError)):
+            guard(name, context="sweep")
+
+
+def test_control_character_guard_does_not_block_ordinary_names(pathsec_sandbox):
+    """Over-block control: spaces are legal in a filename, control characters
+    are not."""
+    root, _outside = pathsec_sandbox
+    spaced = root / "my model.ser.gz"
+    spaced.write_text("m")
+    validate_model_resource(str(spaced), context="sweep")
+    validate_model_resource(_DEFAULT_RESOURCE, context="sweep")

--- a/nltk/test/unit/test_pathsec_sweep_wrappers.py
+++ b/nltk/test/unit/test_pathsec_sweep_wrappers.py
@@ -40,6 +40,12 @@ class _ReachedJVM(Exception):
     handed off" apart from "a guard refused first"."""
 
 
+def _passthrough(value, *args, **kwargs):
+    """A neutered guard: performs no checks but still returns the path, since
+    the callers now use the value the guard hands back."""
+    return os.fspath(value)
+
+
 def _trap_java(monkeypatch, module, sink):
     """Replace ``module.java`` with a trap that records argv and stops before
     launching a JVM."""
@@ -363,7 +369,7 @@ def test_teeth_stanford_parser_guard_is_load_bearing(pathsec_sandbox, monkeypatc
     import nltk.parse.stanford as st
 
     _trap_java(monkeypatch, st, {})
-    monkeypatch.setattr(st, "validate_model_resource", lambda *a, **k: None)
+    monkeypatch.setattr(st, "validate_model_resource", _passthrough)
     with pytest.raises(_ReachedJVM):
         _stanford_parser("/etc/passwd").parse_sents([["hello", "world"]])
 
@@ -386,8 +392,8 @@ def test_teeth_malt_guard_is_load_bearing(pathsec_sandbox, monkeypatch):
 
     _root, outside = pathsec_sandbox
     monkeypatch.setattr(malt, "validate_path", lambda *a, **k: None)
-    monkeypatch.setattr(malt, "validate_model_resource", lambda *a, **k: None)
-    monkeypatch.setattr(malt, "validate_tool_path", lambda *a, **k: None)
+    monkeypatch.setattr(malt, "validate_model_resource", _passthrough)
+    monkeypatch.setattr(malt, "validate_tool_path", _passthrough)
     evil = outside / "evil.mco"
     evil.write_text("model")
     cmd = _malt(str(evil)).generate_malt_command("in.conll", "out.conll", mode="learn")
@@ -1049,7 +1055,7 @@ def test_teeth_malt_io_guard_is_load_bearing(pathsec_sandbox, monkeypatch):
 
     root, outside = pathsec_sandbox
     parser, infile = _malt_in_sandbox(root)
-    monkeypatch.setattr(malt, "validate_tool_path", lambda *a, **k: None)
+    monkeypatch.setattr(malt, "validate_tool_path", _passthrough)
     target = str(outside / "pwned.conll")
     cmd = parser.generate_malt_command(infile, target, mode="parse")
     assert cmd[cmd.index("-o") + 1] == target
@@ -1263,3 +1269,113 @@ def test_both_guards_share_one_syntax_gate(pathsec_sandbox):
         if verdicts[0] == "refused" and verdicts[1] == "allowed":
             disagreements.append(name)
     assert disagreements == [], f"tool_path weaker than model_resource: {disagreements}"
+
+
+# ---------------------------------------------------------------------------
+# Time-of-check/time-of-use at the API boundary. __fspath__ is allowed to
+# return a different answer on every call, so a guard that resolves the path
+# separately from the code that uses it validates one file while the tool opens
+# another. Both parsers leaked this way until the guards started returning the
+# resolved string for the caller to use.
+# ---------------------------------------------------------------------------
+
+
+class _MutatingPath:
+    """A legal os.PathLike whose __fspath__ answers differently each call."""
+
+    def __init__(self, first, rest):
+        self._calls = 0
+        self._first = first
+        self._rest = rest
+
+    def __fspath__(self):
+        self._calls += 1
+        return self._first if self._calls == 1 else self._rest
+
+    def __str__(self):
+        return self._first
+
+
+def _resolve(value):
+    return os.fspath(value) if hasattr(value, "__fspath__") else value
+
+
+def test_stanford_model_argv_carries_the_validated_string(pathsec_sandbox, monkeypatch):
+    """The argv entry must be the exact string the guard checked, not an object
+    that can resolve to something else when the child process reads it."""
+    import nltk.parse.stanford as st
+
+    root, outside = pathsec_sandbox
+    sink = _trap_java(monkeypatch, st, {})
+    evil = outside / "evil.ser.gz"
+    evil.write_text("x")
+    good = root / "ok.ser.gz"
+    good.write_text("m")
+
+    parser = _stanford_parser(_MutatingPath(str(good), str(evil)))
+    with pytest.raises(_ReachedJVM):
+        parser.parse_sents([["hello", "world"]])
+    handed_over = sink["cmd"][sink["cmd"].index("-model") + 1]
+    assert isinstance(handed_over, str)
+    assert os.path.realpath(_resolve(handed_over)).startswith(
+        os.path.realpath(str(root))
+    )
+
+
+def test_malt_working_dir_uses_the_validated_model_string(pathsec_sandbox):
+    root, outside = pathsec_sandbox
+    evil = outside / "evil.mco"
+    evil.write_text("x")
+    good = root / "ok.mco"
+    good.write_text("m")
+
+    parser = _malt(_MutatingPath(str(good), str(evil)))
+    infile, _outfile = _sandbox_io(parser)
+    cmd = parser.generate_malt_command(infile, None, mode="learn")
+    workingdir = cmd[cmd.index("-w") + 1]
+    assert os.path.realpath(str(workingdir)).startswith(os.path.realpath(str(root)))
+
+
+def test_mutating_path_that_starts_hostile_is_refused(pathsec_sandbox):
+    """The other ordering: hostile on the guard's call. Must still be refused."""
+    root, outside = pathsec_sandbox
+    evil = outside / "evil.mco"
+    evil.write_text("x")
+    good = root / "ok.mco"
+    good.write_text("m")
+    with pytest.raises((PermissionError, ValueError)):
+        validate_model_resource(_MutatingPath(str(evil), str(good)), context="sweep")
+
+
+def test_guards_return_the_resolved_string(pathsec_sandbox):
+    """The contract callers rely on: use the return value, never the original."""
+    root, _outside = pathsec_sandbox
+    model = root / "m.mco"
+    model.write_text("m")
+    assert validate_model_resource(model, context="sweep") == str(model)
+    assert validate_tool_path(model, context="sweep") == str(model)
+    assert validate_model_resource(_DEFAULT_RESOURCE, context="sweep") == (
+        _DEFAULT_RESOURCE
+    )
+
+
+@pytest.mark.parametrize(
+    "value", [b"/etc/passwd", b"model.mco", 0, None, ["/etc/passwd"], 12345]
+)
+def test_non_path_inputs_are_a_clean_security_rejection(value):
+    """A TypeError would escape a caller's except (ValueError, PermissionError)
+    and surface as a crash rather than a refusal. bytes paths are refused too:
+    they pass os.fspath but then break every str check."""
+    for guard in (validate_model_resource, validate_tool_path):
+        with pytest.raises(ValueError):
+            guard(value, context="sweep")
+
+
+@pytest.mark.parametrize(
+    "name", ["evil.mco.", "evil.mco ", "evil.mco...", "evil.mco. "]
+)
+def test_trailing_dot_or_space_is_refused(name):
+    """Windows silently strips these, so the name that is checked is not the name
+    that is opened."""
+    with pytest.raises(ValueError):
+        validate_model_resource(name, context="sweep")

--- a/nltk/test/unit/test_pathsec_sweep_wrappers.py
+++ b/nltk/test/unit/test_pathsec_sweep_wrappers.py
@@ -1,0 +1,913 @@
+# Natural Language Toolkit: pathsec sweep over the external-tool wrappers
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""Escape matrix for the model/data paths handed to external tools.
+
+The JVM wrappers take caller-supplied model and corpus paths and pass them
+straight into the child process's argv. Those are *data* paths, so they must be
+bounded to the NLTK data roots; a path outside the sandbox means the wrapper will
+read (and, for MaltParser's ``-w`` in learn mode, WRITE) anywhere on disk.
+
+Two classes of path are deliberately treated differently:
+
+* **model / corpus paths** (this file) are bounded with ``pathsec.validate_path``
+  or ``pathsec.validate_model_resource``.
+* **install / binary directories** (``candc``/``boxer``'s ``bin_dir``, REPP's
+  tokenizer dir) are NOT: ``validate_path`` permits only NLTK *data* roots, so
+  bounding them would break every real installation. They get an absolute-path
+  (CWE-426) check instead, and the tests at the end of this file pin that
+  distinction so a later refactor cannot quietly collapse the two.
+
+Every test drives the real code path with only the ``java`` hand-off replaced, so
+a probe cannot pass merely because the argv was assembled by the test itself.
+"""
+
+import hashlib
+import os
+
+import pytest
+
+from nltk import pathsec
+from nltk.data import make_staging_dir
+from nltk.pathsec import validate_model_resource
+
+
+class _ReachedJVM(Exception):
+    """Raised by the trapped ``java`` so a test can tell "the argv was built and
+    handed off" apart from "a guard refused first"."""
+
+
+def _trap_java(monkeypatch, module, sink):
+    """Replace ``module.java`` with a trap that records argv and stops before
+    launching a JVM."""
+
+    def fake_java(cmd, *args, **kwargs):
+        sink["cmd"] = list(cmd)
+        raise _ReachedJVM
+
+    monkeypatch.setattr(module, "java", fake_java)
+    return sink
+
+
+# ---------------------------------------------------------------------------
+# StanfordSegmenter: -loadClassifier / -serDictionary / -sighanCorporaDict /
+# -textFile all reach the JVM argv.
+# ---------------------------------------------------------------------------
+
+
+def _segmenter(monkeypatch, root, model=None, dictionary=None, sihan=None):
+    """A StanfordSegmenter whose jar passes the sha256 allowlist, so the test
+    reaches the model-path handling rather than stopping at the jar check."""
+    import nltk.tokenize.stanford_segmenter as seg
+
+    jar = os.path.join(root, "seg.jar")
+    with pathsec.open(jar, "wb") as handle:
+        handle.write(b"PK\x05\x06" + b"\0" * 18)
+    with pathsec.open(jar, "rb") as handle:
+        digest = hashlib.sha256(handle.read()).hexdigest()
+    monkeypatch.setenv("NLTK_SEGMENTER_ALLOW_SHA256", digest)
+
+    tool = object.__new__(seg.StanfordSegmenter)
+    tool._stanford_jar = jar
+    tool._encoding = "utf8"
+    tool.java_options = "-mx1g"
+    tool._jar_sha256_cache = {}
+    tool._java_class = "edu.stanford.nlp.ie.crf.CRFClassifier"
+    tool._model = model
+    tool._dict = dictionary
+    tool._sihan_corpora_dict = sihan
+    tool._sihan_post_processing = "true"
+    tool._keep_whitespaces = "false"
+    tool._options_cmd = ""
+    return tool
+
+
+@pytest.mark.parametrize("slot", ["model", "dictionary", "sihan"])
+def test_segmenter_model_paths_refuse_escape(pathsec_sandbox, monkeypatch, slot):
+    """A model, dictionary or Sihan corpus dir outside the roots is refused
+    before the JVM sees it."""
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, outside = pathsec_sandbox
+    _trap_java(monkeypatch, seg, {})
+    evil = outside / "evil.ser.gz"
+    evil.write_text("payload")
+    inside = str(root / "in.txt")
+    with pathsec.open(inside, "w") as handle:
+        handle.write("中文")
+
+    tool = _segmenter(monkeypatch, str(root), **{slot: str(evil)})
+    with pytest.raises((PermissionError, ValueError)):
+        tool.segment_file(inside)
+
+
+def test_segmenter_input_file_refuses_escape(pathsec_sandbox, monkeypatch):
+    """``segment_file`` is an arbitrary-file-read primitive without a guard on
+    its own argument."""
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, outside = pathsec_sandbox
+    _trap_java(monkeypatch, seg, {})
+    tool = _segmenter(monkeypatch, str(root))
+    with pytest.raises((PermissionError, ValueError)):
+        tool.segment_file("/etc/passwd")
+
+
+def test_segmenter_in_sandbox_paths_reach_jvm(pathsec_sandbox, monkeypatch):
+    """Over-block control: legitimate in-sandbox paths must still be handed to
+    the JVM, otherwise the guard has broken the feature."""
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, _outside = pathsec_sandbox
+    sink = _trap_java(monkeypatch, seg, {})
+    model = str(root / "model.ser.gz")
+    with pathsec.open(model, "w") as handle:
+        handle.write("m")
+    inside = str(root / "in.txt")
+    with pathsec.open(inside, "w") as handle:
+        handle.write("中文")
+
+    tool = _segmenter(monkeypatch, str(root), model=model)
+    with pytest.raises(_ReachedJVM):
+        tool.segment_file(inside)
+    assert model in sink["cmd"]
+
+
+# ---------------------------------------------------------------------------
+# MaltParser: -c model and the -w working directory (WRITTEN to in learn mode).
+# ---------------------------------------------------------------------------
+
+
+def _malt(model, trained=True):
+    import nltk.parse.malt as malt
+
+    parser = object.__new__(malt.MaltParser)
+    parser.model = model
+    parser._trained = trained
+    parser._working_dir = None
+    parser.additional_java_args = []
+    return parser
+
+
+def test_malt_trained_model_refuses_escape(pathsec_sandbox):
+    """A .mco outside the roots would make ``-w`` an arbitrary write target."""
+    root, outside = pathsec_sandbox
+    evil = outside / "evil.mco"
+    evil.write_text("model")
+    with pytest.raises((PermissionError, ValueError)):
+        _malt(str(evil)).generate_malt_command("in.conll", "out.conll", mode="learn")
+
+
+def test_malt_trained_model_in_sandbox_is_allowed(pathsec_sandbox):
+    """Over-block control for the trained path."""
+    root, _outside = pathsec_sandbox
+    model = root / "engmalt.mco"
+    model.write_text("model")
+    cmd = _malt(str(model)).generate_malt_command("in.conll", "out.conll", mode="parse")
+    assert cmd[cmd.index("-w") + 1] == str(root)
+    assert cmd[cmd.index("-c") + 1] == "engmalt.mco"
+
+
+def test_malt_untrained_working_dir_is_staged_inside_root(pathsec_sandbox):
+    """An untrained parser used to write malt_temp.mco into the CWD; it must now
+    land in a private staging dir inside a data root."""
+    root, _outside = pathsec_sandbox
+    cmd = _malt("malt_temp.mco", trained=False).generate_malt_command(
+        "in.conll", "out.conll", mode="learn"
+    )
+    workingdir = cmd[cmd.index("-w") + 1]
+    assert os.path.realpath(workingdir).startswith(os.path.realpath(str(root)))
+    assert os.path.realpath(workingdir) != os.path.realpath(os.getcwd())
+    assert cmd[cmd.index("-c") + 1] == "malt_temp.mco"
+
+
+def test_malt_working_dir_is_private():
+    """The staging dir must not be group/world readable: it holds the CoNLL
+    intermediates and the trained model."""
+    staged = make_staging_dir(prefix="nltk_malt_test_")
+    assert os.stat(staged).st_mode & 0o077 == 0
+
+
+def test_malt_working_dir_setter_refuses_escape(pathsec_sandbox):
+    """A caller may still choose the directory, but only inside the sandbox."""
+    _root, outside = pathsec_sandbox
+    parser = _malt("malt_temp.mco", trained=False)
+    with pytest.raises((PermissionError, ValueError)):
+        parser.working_dir = str(outside)
+
+
+def test_malt_working_dir_setter_accepts_in_sandbox(pathsec_sandbox):
+    """Over-block control for the setter."""
+    root, _outside = pathsec_sandbox
+    parser = _malt("malt_temp.mco", trained=False)
+    parser.working_dir = str(root)
+    assert parser.working_dir == str(root)
+
+
+def test_malt_working_dir_is_not_shared_tempdir(pathsec_sandbox):
+    """Regression: the default was ``tempfile.gettempdir()``, which is
+    world-writable on Linux and gives a predictable, squattable path."""
+    import tempfile as _tempfile
+
+    root, _outside = pathsec_sandbox
+    parser = _malt("malt_temp.mco", trained=False)
+    assert os.path.realpath(parser.working_dir) != os.path.realpath(
+        _tempfile.gettempdir()
+    )
+
+
+# ---------------------------------------------------------------------------
+# StanfordParser: -model may be a filesystem path OR a jar-internal resource.
+# ---------------------------------------------------------------------------
+
+_DEFAULT_RESOURCE = "edu/stanford/nlp/models/lexparser/englishPCFG.ser.gz"
+
+
+def _stanford_parser(model_path):
+    import nltk.parse.stanford as st
+
+    parser = object.__new__(st.StanfordParser)
+    parser.model_path = model_path
+    parser._classpath = ()
+    parser.java_options = "-mx1g"
+    parser._encoding = "utf8"
+    parser.corenlp_options = ""
+    parser._USE_STDIN = False
+    return parser
+
+
+@pytest.mark.parametrize(
+    "model_path",
+    ["/etc/passwd", "edu/stanford/../../../../etc/passwd"],
+    ids=["etc-abs", "traversal"],
+)
+def test_stanford_parser_model_refuses_escape(pathsec_sandbox, monkeypatch, model_path):
+    import nltk.parse.stanford as st
+
+    _trap_java(monkeypatch, st, {})
+    with pytest.raises((PermissionError, ValueError)):
+        _stanford_parser(model_path).parse_sents([["hello", "world"]])
+
+
+def test_stanford_parser_outside_model_refuses_escape(pathsec_sandbox, monkeypatch):
+    import nltk.parse.stanford as st
+
+    _root, outside = pathsec_sandbox
+    _trap_java(monkeypatch, st, {})
+    evil = outside / "evil.ser.gz"
+    evil.write_text("model")
+    with pytest.raises((PermissionError, ValueError)):
+        _stanford_parser(str(evil)).parse_sents([["hello", "world"]])
+
+
+def test_stanford_parser_default_resource_still_works(pathsec_sandbox, monkeypatch):
+    """Over-block control: the shipped default is a jar-internal resource, not a
+    file on disk, and must not be treated as a path."""
+    import nltk.parse.stanford as st
+
+    sink = _trap_java(monkeypatch, st, {})
+    with pytest.raises(_ReachedJVM):
+        _stanford_parser(_DEFAULT_RESOURCE).parse_sents([["hello", "world"]])
+    assert sink["cmd"][sink["cmd"].index("-model") + 1] == _DEFAULT_RESOURCE
+
+
+def test_stanford_parser_in_sandbox_model_still_works(pathsec_sandbox, monkeypatch):
+    """Over-block control: a real model inside a data root must still load."""
+    import nltk.parse.stanford as st
+
+    root, _outside = pathsec_sandbox
+    sink = _trap_java(monkeypatch, st, {})
+    model = root / "englishPCFG.ser.gz"
+    model.write_text("model")
+    with pytest.raises(_ReachedJVM):
+        _stanford_parser(str(model)).parse_sents([["hello", "world"]])
+    assert sink["cmd"][sink["cmd"].index("-model") + 1] == str(model)
+
+
+# ---------------------------------------------------------------------------
+# validate_model_resource itself.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "edu/stanford/../nlp/x.ser.gz",
+        "../x.ser.gz",
+        "a/b/../../../etc/passwd",
+        "edu\\stanford\\..\\x.ser.gz",
+    ],
+)
+def test_validate_model_resource_rejects_traversal(value):
+    """``..`` is refused whether or not the value looks like a real path, so a
+    resource name cannot escape the jar namespace."""
+    with pytest.raises(ValueError):
+        validate_model_resource(value, context="test")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [_DEFAULT_RESOURCE, "edu/stanford/nlp/models/pos-tagger/english-left3words.tagger"],
+)
+def test_validate_model_resource_allows_resource_names(value):
+    """A bare classpath resource is not a filesystem path and is left alone."""
+    validate_model_resource(value, context="test")
+
+
+def test_validate_model_resource_bounds_real_paths(pathsec_sandbox):
+    root, outside = pathsec_sandbox
+    inside = root / "m.ser.gz"
+    inside.write_text("m")
+    validate_model_resource(str(inside), context="test")
+    with pytest.raises((PermissionError, ValueError)):
+        validate_model_resource(str(outside / "m.ser.gz"), context="test")
+
+
+def test_validate_model_resource_accepts_pathlike(pathsec_sandbox):
+    """os.PathLike must not blow up on ``.replace``."""
+    root, _outside = pathsec_sandbox
+    inside = root / "m.ser.gz"
+    inside.write_text("m")
+    validate_model_resource(inside, context="test")
+
+
+def test_validate_model_resource_is_exported():
+    assert "validate_model_resource" in pathsec.__all__
+
+
+# ---------------------------------------------------------------------------
+# Teeth: neuter each guard and assert the attack becomes reachable again. A
+# probe that passes with the guard removed is not testing the guard.
+# ---------------------------------------------------------------------------
+
+
+def test_teeth_stanford_parser_guard_is_load_bearing(pathsec_sandbox, monkeypatch):
+    import nltk.parse.stanford as st
+
+    _trap_java(monkeypatch, st, {})
+    monkeypatch.setattr(st, "validate_model_resource", lambda *a, **k: None)
+    with pytest.raises(_ReachedJVM):
+        _stanford_parser("/etc/passwd").parse_sents([["hello", "world"]])
+
+
+def test_teeth_segmenter_guard_is_load_bearing(pathsec_sandbox, monkeypatch):
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, _outside = pathsec_sandbox
+    _trap_java(monkeypatch, seg, {})
+    monkeypatch.setattr(seg, "validate_path", lambda *a, **k: None)
+    tool = _segmenter(monkeypatch, str(root))
+    with pytest.raises(_ReachedJVM):
+        tool.segment_file("/etc/passwd")
+
+
+def test_teeth_malt_guard_is_load_bearing(pathsec_sandbox, monkeypatch):
+    """Both guards have to go before the escape reappears, which is the point:
+    validate_model_resource still catches the model when validate_path is gone."""
+    import nltk.parse.malt as malt
+
+    _root, outside = pathsec_sandbox
+    monkeypatch.setattr(malt, "validate_path", lambda *a, **k: None)
+    monkeypatch.setattr(malt, "validate_model_resource", lambda *a, **k: None)
+    evil = outside / "evil.mco"
+    evil.write_text("model")
+    cmd = _malt(str(evil)).generate_malt_command("in.conll", "out.conll", mode="learn")
+    assert cmd[cmd.index("-w") + 1] == str(outside)
+
+
+def test_teeth_malt_model_resource_guard_alone_blocks(pathsec_sandbox, monkeypatch):
+    """Removing only validate_path must NOT reopen the escape: the second guard
+    is independently load-bearing."""
+    import nltk.parse.malt as malt
+
+    _root, outside = pathsec_sandbox
+    monkeypatch.setattr(malt, "validate_path", lambda *a, **k: None)
+    evil = outside / "evil.mco"
+    evil.write_text("model")
+    with pytest.raises((PermissionError, ValueError)):
+        _malt(str(evil)).generate_malt_command("in.conll", "out.conll", mode="learn")
+
+
+# ---------------------------------------------------------------------------
+# Install-directory wrappers: pinned as a DIFFERENT class. These must keep the
+# CWE-426 absolute-path check and must NOT gain validate_path, which permits
+# only NLTK data roots and would break every real installation.
+# ---------------------------------------------------------------------------
+
+
+def test_boxer_bin_dir_rejects_relative_and_cwd(pathsec_sandbox):
+    """A relative or CWD bin_dir is a binary-planting vector (CWE-426)."""
+    import nltk.sem.boxer as boxer
+
+    _root, outside = pathsec_sandbox
+    bindir = outside / "candcbin"
+    bindir.mkdir()
+    for name in ("candc", "boxer"):
+        target = bindir / name
+        target.write_text("#!/bin/sh\n")
+        target.chmod(0o755)
+    os.chdir(str(outside))
+
+    tool = object.__new__(boxer.Boxer)
+    for bad in ("candcbin", "."):
+        with pytest.raises(LookupError):
+            tool.set_bin_dir(bad)
+
+
+def test_boxer_models_path_is_derived_not_caller_supplied(pathsec_sandbox):
+    """``--models`` has no independent input: it is derived from the absolute
+    candc binary, so bounding bin_dir bounds the models dir too."""
+    import nltk.sem.boxer as boxer
+
+    _root, outside = pathsec_sandbox
+    bindir = outside / "candcbin"
+    bindir.mkdir()
+    for name in ("candc", "boxer"):
+        target = bindir / name
+        target.write_text("#!/bin/sh\n")
+        target.chmod(0o755)
+
+    tool = object.__new__(boxer.Boxer)
+    tool.set_bin_dir(str(bindir))
+    assert tool._candc_models_path == os.path.normpath(str(outside / "models"))
+
+
+def test_repp_dir_must_resolve_absolute(pathsec_sandbox):
+    """REPP executes ``<dir>/src/repp``; a CWD-relative dir would let an
+    attacker plant that binary."""
+    import nltk.tokenize.repp as repp
+
+    _root, outside = pathsec_sandbox
+    tree = outside / "evil_repp"
+    (tree / "src").mkdir(parents=True)
+    (tree / "erg").mkdir()
+    (tree / "src" / "repp").write_text("#!/bin/sh\n")
+    (tree / "erg" / "repp.set").write_text("")
+    os.environ.pop("REPP_TOKENIZER", None)
+    os.chdir(str(outside))
+
+    tokenizer = object.__new__(repp.ReppTokenizer)
+    with pytest.raises(LookupError):
+        tokenizer.find_repptokenizer("evil_repp")
+
+
+# ---------------------------------------------------------------------------
+# Functional: the patched modules must still import and behave. These exercise
+# the real objects rather than asserting on mocks.
+# ---------------------------------------------------------------------------
+
+
+def test_wrapper_modules_still_import():
+    """Every module touched by this PR imports cleanly, with no import cycle
+    introduced by the new pathsec dependency."""
+    import importlib
+
+    for name in (
+        "nltk.parse.malt",
+        "nltk.parse.stanford",
+        "nltk.sem.boxer",
+        "nltk.tokenize.repp",
+        "nltk.tokenize.stanford_segmenter",
+    ):
+        assert importlib.import_module(name) is not None
+
+
+def test_malt_command_shape_is_unchanged(pathsec_sandbox):
+    """The guard must not reorder or drop MaltParser's arguments."""
+    root, _outside = pathsec_sandbox
+    model = root / "engmalt.mco"
+    model.write_text("model")
+    cmd = _malt(str(model)).generate_malt_command("in.conll", "out.conll", mode="parse")
+    assert cmd[0] == "org.maltparser.Malt"
+    for flag in ("-w", "-c", "-i", "-o", "-m"):
+        assert flag in cmd
+    assert cmd[cmd.index("-i") + 1] == "in.conll"
+    assert cmd[cmd.index("-o") + 1] == "out.conll"
+    assert cmd[cmd.index("-m") + 1] == "parse"
+
+
+def test_malt_working_dir_is_stable_across_calls(pathsec_sandbox):
+    """The lazy property must allocate once, not a fresh dir per access, or the
+    CoNLL intermediates and the model would land in different directories."""
+    parser = _malt("malt_temp.mco", trained=False)
+    assert parser.working_dir == parser.working_dir
+
+
+# ---------------------------------------------------------------------------
+# Real end-to-end runs. These launch an actual JVM against a real MaltParser /
+# Stanford parser install, so they prove the guards neither break the feature
+# nor "pass" merely because no JVM was reachable. They skip when the external
+# tool is genuinely absent (CI has no JVM or model jars); every other test in
+# this file runs unconditionally.
+# ---------------------------------------------------------------------------
+
+
+def _has_java():
+    """True only if a JVM actually *runs*.
+
+    Merely finding a ``java`` on PATH is not enough: macOS ships a
+    ``/usr/bin/java`` stub that resolves fine and then fails at exec time with
+    "Unable to locate a Java Runtime", which would turn these into hard failures
+    on a machine with no JDK instead of skips.
+    """
+    import subprocess
+
+    from nltk.internals import find_binary
+
+    try:
+        binary = find_binary(
+            "java", env_vars=("JAVAHOME", "JAVA_HOME"), verbose=False, binary_names=None
+        )
+    except LookupError:
+        return False
+    try:
+        return (
+            subprocess.run(
+                [binary, "-version"], capture_output=True, timeout=60
+            ).returncode
+            == 0
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+def _find_tool_dir(*names):
+    """Absolute path of an external tool directory inside a data root, or None."""
+    import nltk.data
+
+    for root in nltk.data.path:
+        for name in names:
+            candidate = os.path.join(root, name)
+            if os.path.isdir(candidate):
+                return candidate
+    return None
+
+
+requires_java = pytest.mark.skipif(not _has_java(), reason="no JVM on this machine")
+
+
+@requires_java
+def test_real_malt_train_writes_model_inside_sandbox(tmp_path):
+    """End-to-end: a real MaltParser JVM must write malt_temp.mco into the private
+    staging dir, and must NOT pollute the current working directory as it did when
+    ``-w`` defaulted to ``os.getcwd()``."""
+    import nltk.data
+    from nltk.parse.dependencygraph import DependencyGraph
+    from nltk.parse.malt import MaltParser
+
+    malt_dir = _find_tool_dir("maltparser-1.9.2", "maltparser-1.9.1")
+    if malt_dir is None:
+        pytest.skip("maltparser is not installed under nltk.data.path")
+
+    parser = MaltParser(parser_dirname=malt_dir)
+    assert os.stat(parser.working_dir).st_mode & 0o077 == 0
+    assert any(
+        os.path.realpath(parser.working_dir).startswith(os.path.realpath(root))
+        for root in nltk.data.path
+    )
+
+    rows = "1\tJohn\t_\tNNP\t_\t_\t2\tSUBJ\t_\t_\n2\tsees\t_\tVB\t_\t_\t0\tROOT\t_\t_\n"
+    parser.train([DependencyGraph(rows), DependencyGraph(rows)], verbose=False)
+
+    model = os.path.join(parser.working_dir, "malt_temp.mco")
+    assert os.path.exists(model) and os.path.getsize(model) > 0
+    assert not os.path.exists(os.path.join(os.getcwd(), "malt_temp.mco"))
+
+
+@requires_java
+def test_real_stanford_parser_default_resource_parses(monkeypatch):
+    """End-to-end: the shipped jar-internal default model must still parse. If the
+    guard treated it as a filesystem path this raises instead."""
+    from nltk.parse.stanford import StanfordParser
+
+    parser_dir = _find_tool_dir("stanford-parser-full-2020-11-17")
+    if parser_dir is None:
+        pytest.skip("stanford-parser is not installed under nltk.data.path")
+    monkeypatch.setenv("STANFORD_PARSER", parser_dir)
+    monkeypatch.setenv("STANFORD_MODELS", parser_dir)
+
+    trees = list(StanfordParser().raw_parse("John sees a dog."))
+    assert trees and trees[0].label() == "ROOT"
+
+
+@requires_java
+@pytest.mark.parametrize(
+    "model_path",
+    ["/etc/passwd", "edu/stanford/../../../../etc/passwd"],
+    ids=["etc-abs", "traversal"],
+)
+def test_real_stanford_parser_refuses_escape_with_jvm_present(monkeypatch, model_path):
+    """End-to-end negative: with a working JVM and real jars, a hostile -model is
+    refused before launch, so the block is the guard and not a missing JVM."""
+    from nltk.parse.stanford import StanfordParser
+
+    parser_dir = _find_tool_dir("stanford-parser-full-2020-11-17")
+    if parser_dir is None:
+        pytest.skip("stanford-parser is not installed under nltk.data.path")
+    monkeypatch.setenv("STANFORD_PARSER", parser_dir)
+    monkeypatch.setenv("STANFORD_MODELS", parser_dir)
+
+    parser = StanfordParser()
+    parser.model_path = model_path
+    with pytest.raises((PermissionError, ValueError)):
+        list(parser.raw_parse("John sees a dog."))
+
+
+# ---------------------------------------------------------------------------
+# Expanded vector matrix. Every entry below was run against the live sinks; the
+# ones that leaked drove the hardening in validate_model_resource. Benign and
+# merely-suspicious candidates are kept so a regression shows up as a new leak.
+# ---------------------------------------------------------------------------
+
+
+def _hostile_vectors(root, outside):
+    """(id, value) pairs that must never reach an external tool."""
+    secret = outside / "secret.mco"
+    secret.write_text("SECRET")
+
+    vectors = [
+        ("outside-abs", str(secret)),
+        ("etc-abs", "/etc/passwd"),
+        ("traversal-from-root", os.path.join(str(root), "..", "..", "etc", "passwd")),
+        ("nul-byte", "/etc/pass\x00wd"),
+        ("leading-dash", "-Xmx99g"),
+        ("newline-injection", "/etc/passwd\n-serDictionary /etc/shadow"),
+        ("backslash-traversal", "..\\..\\..\\etc\\passwd"),
+        ("file-url", "file:///etc/passwd"),
+        ("http-url", "http://evil.example/model.gz"),
+        ("empty", ""),
+        ("whitespace-only", "   "),
+        ("dir-not-file", str(outside)),
+    ]
+
+    symlink = root / "sym.mco"
+    os.symlink(str(secret), symlink)
+    vectors.append(("symlink-to-outside", str(symlink)))
+
+    symlink_etc = root / "symetc"
+    os.symlink("/etc/passwd", symlink_etc)
+    vectors.append(("symlink-to-etc", str(symlink_etc)))
+
+    symlinked_dir = root / "symdir"
+    os.symlink(str(outside), symlinked_dir)
+    vectors.append(("via-symlinked-dir", str(symlinked_dir / "secret.mco")))
+
+    hardlink = root / "hard.mco"
+    try:
+        os.link(str(secret), hardlink)
+    except OSError:  # pragma: no cover - cross-device or unsupported
+        pass
+    else:
+        vectors.append(("hardlink-to-outside", str(hardlink)))
+
+    return vectors
+
+
+def _vector_ids(vectors):
+    return [name for name, _ in vectors]
+
+
+def test_validate_model_resource_refuses_every_hostile_vector(pathsec_sandbox):
+    """The whole matrix at once, so a new leak names itself in the failure."""
+    root, outside = pathsec_sandbox
+    leaked = []
+    for name, value in _hostile_vectors(root, outside):
+        try:
+            validate_model_resource(value, context="sweep")
+        except (PermissionError, ValueError, OSError):
+            continue
+        leaked.append(name)
+    assert leaked == [], f"validate_model_resource let these through: {leaked}"
+
+
+def test_malt_model_refuses_every_hostile_vector(pathsec_sandbox):
+    root, outside = pathsec_sandbox
+    leaked = []
+    for name, value in _hostile_vectors(root, outside):
+        try:
+            _malt(value).generate_malt_command("in.conll", "out.conll", mode="learn")
+        except (PermissionError, ValueError, OSError):
+            continue
+        leaked.append(name)
+    assert leaked == [], f"MaltParser passed these to the JVM: {leaked}"
+
+
+def test_malt_working_dir_setter_refuses_every_hostile_vector(pathsec_sandbox):
+    root, outside = pathsec_sandbox
+    leaked = []
+    for name, value in _hostile_vectors(root, outside):
+        parser = _malt("malt_temp.mco", trained=False)
+        try:
+            parser.working_dir = value
+        except (PermissionError, ValueError, OSError):
+            continue
+        # An in-root staging dir is the only acceptable outcome.
+        if not os.path.realpath(parser.working_dir).startswith(
+            os.path.realpath(str(root))
+        ):
+            leaked.append(name)
+    assert leaked == [], f"working_dir accepted these: {leaked}"
+
+
+def test_hardlinked_model_is_refused(pathsec_sandbox):
+    """realpath() cannot see a hardlink, so an in-root alias of an outside file
+    would otherwise pass every path check."""
+    root, outside = pathsec_sandbox
+    secret = outside / "secret.mco"
+    secret.write_text("SECRET")
+    alias = root / "alias.mco"
+    try:
+        os.link(str(secret), alias)
+    except OSError:  # pragma: no cover - cross-device or unsupported
+        pytest.skip("hard links unavailable between these directories")
+    with pytest.raises(PermissionError):
+        validate_model_resource(str(alias), context="sweep")
+
+
+def test_single_linked_model_is_allowed(pathsec_sandbox):
+    """Over-block control for the hardlink guard: an ordinary file has one link."""
+    root, _outside = pathsec_sandbox
+    model = root / "plain.mco"
+    model.write_text("m")
+    validate_model_resource(str(model), context="sweep")
+
+
+def test_directory_model_is_not_hardlink_rejected(pathsec_sandbox):
+    """Directories always have st_nlink >= 2, so the guard must apply to regular
+    files only or every corpus directory would be refused."""
+    root, _outside = pathsec_sandbox
+    corpus = root / "sihan"
+    corpus.mkdir()
+    validate_model_resource(str(corpus), context="sweep")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "malt_temp.mco",
+        _DEFAULT_RESOURCE,
+        "edu/stanford/nlp/models/pos-tagger/english-left3words.tagger",
+    ],
+)
+def test_benign_resource_names_still_pass(value):
+    """The values NLTK itself uses must survive every check added above."""
+    validate_model_resource(value, context="sweep")
+
+
+# ---------------------------------------------------------------------------
+# Exotic vectors: NUL truncation, '~', NTFS streams, UNC shares and blocking
+# device nodes. Each of these leaked when first run and drove a guard.
+# ---------------------------------------------------------------------------
+
+
+def _exotic_vectors(root):
+    vectors = [
+        ("dev-stdin", "/dev/stdin"),
+        ("dev-null", "/dev/null"),
+        ("proc-environ", "/proc/self/environ"),
+        ("case-folded-etc", "/ETC/PASSWD"),
+        ("tilde-expansion", "~/.ssh/id_rsa"),
+        ("ads-stream", "model.mco:evil"),
+        ("unc-backslash", "\\\\server\\share\\evil.mco"),
+        ("unc-slash", "//server/share/evil.mco"),
+        ("nul-in-middle", "model\x00.mco"),
+        ("jar-url", "jar:file:///etc/passwd!/x"),
+        ("overlong-name", "/" + ("A" * 300) + "/evil.mco"),
+        ("double-slash", "//etc//passwd"),
+        ("root-only", "/"),
+        ("dotdot-alone", ".."),
+    ]
+
+    fifo = root / "fifo.mco"
+    try:
+        os.mkfifo(fifo)
+    except (AttributeError, OSError):  # pragma: no cover - not on Windows
+        pass
+    else:
+        vectors.append(("fifo-in-root", str(fifo)))
+    return vectors
+
+
+def test_validate_model_resource_refuses_exotic_vectors(pathsec_sandbox):
+    root, _outside = pathsec_sandbox
+    leaked = []
+    for name, value in _exotic_vectors(root):
+        try:
+            validate_model_resource(value, context="sweep")
+        except (PermissionError, ValueError, OSError):
+            continue
+        leaked.append(name)
+    assert leaked == [], f"validate_model_resource let these through: {leaked}"
+
+
+def test_unix_socket_model_is_refused(pathsec_sandbox):
+    """A socket planted in a data root is not a model; reading it would block."""
+    import socket
+
+    root, _outside = pathsec_sandbox
+    path = str(root / "s.sock")
+    sock = socket.socket(socket.AF_UNIX)
+    try:
+        sock.bind(path)
+        with pytest.raises(PermissionError):
+            validate_model_resource(path, context="sweep")
+    finally:
+        sock.close()
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "$EVIL_HOME/passwd",
+        "..\uff0f..\uff0fetc\uff0fpasswd",
+        "%2e%2e/%2e%2e/etc/passwd",
+    ],
+    ids=["env-var", "fullwidth-solidus", "percent-encoded"],
+)
+def test_benign_lookalikes_stay_literal(pathsec_sandbox, value):
+    """These are permitted because nothing downstream expands or decodes them:
+    they stay literal filenames. The test pins that assumption, so if a sink ever
+    starts expanding them this fails instead of silently reading /etc.
+    """
+    validate_model_resource(value, context="sweep")
+    assert not os.path.exists(value)
+    assert not os.path.realpath(os.path.expandvars(value)).startswith("/etc/")
+
+
+def test_java_inner_class_resource_is_allowed():
+    """Over-block control: '$' is legal in a JVM resource name, so the option and
+    stream checks must not reject it."""
+    validate_model_resource("edu/stanford/Foo$Bar.ser.gz", context="sweep")
+
+
+def test_windows_drive_path_is_not_stream_rejected():
+    """Over-block control: 'C:\\...' is a drive prefix, not an NTFS stream."""
+    import re as _re
+
+    from nltk.pathsec import validate_model_resource as _vmr
+
+    try:
+        _vmr("C:\\models\\english.ser.gz", context="sweep")
+    except ValueError as exc:
+        assert "alternate data stream" not in str(exc), exc
+    assert _re.match(r"^[A-Za-z]:[\\/]", "C:\\models\\english.ser.gz")
+
+
+# ---------------------------------------------------------------------------
+# Regressions found while building this PR. Each one shipped a bug that the
+# mocked tests missed, so they are pinned here permanently.
+# ---------------------------------------------------------------------------
+
+
+def test_regression_generate_malt_command_needs_no_trained_attribute(pathsec_sandbox):
+    """Regression: generate_malt_command briefly branched on a private ``_trained``
+    attribute, which broke every caller that built a parser without it."""
+    import nltk.parse.malt as malt
+
+    parser = object.__new__(malt.MaltParser)
+    parser.model = "malt_temp.mco"
+    parser._working_dir = None
+    parser.additional_java_args = []
+    cmd = parser.generate_malt_command("in.conll", "out.conll", mode="learn")
+    assert cmd[cmd.index("-c") + 1] == "malt_temp.mco"
+
+
+def test_regression_trained_bare_model_resolves_to_working_dir(pathsec_sandbox):
+    """Regression: after train(), ``self.model`` is still the bare name
+    ``malt_temp.mco`` while ``_trained`` is True. Resolving that against the CWD
+    made every post-training parse fail with a security violation."""
+    root, _outside = pathsec_sandbox
+    parser = _malt("malt_temp.mco", trained=True)
+    cmd = parser.generate_malt_command("in.conll", "out.conll", mode="parse")
+    workingdir = cmd[cmd.index("-w") + 1]
+    assert os.path.realpath(workingdir).startswith(os.path.realpath(str(root)))
+    assert os.path.realpath(workingdir) != os.path.realpath(os.getcwd())
+
+
+def test_regression_working_dir_setter_rejects_empty(pathsec_sandbox):
+    """Regression: an empty working_dir passed validate_path and reached
+    MaltParser as ``-w ""``, i.e. the current working directory."""
+    parser = _malt("malt_temp.mco", trained=False)
+    for value in ("", "   "):
+        with pytest.raises(ValueError):
+            parser.working_dir = value
+
+
+def test_regression_has_java_probe_actually_executes():
+    """Regression: the JVM probe used to accept any ``java`` on PATH. macOS ships
+    a /usr/bin/java stub that resolves fine and then fails at exec, which turned
+    the end-to-end tests into hard failures instead of skips."""
+    import subprocess
+
+    result = _has_java()
+    assert isinstance(result, bool)
+    if result:
+        from nltk.internals import find_binary
+
+        binary = find_binary(
+            "java", env_vars=("JAVAHOME", "JAVA_HOME"), verbose=False, binary_names=None
+        )
+        assert subprocess.run([binary, "-version"], capture_output=True).returncode == 0

--- a/nltk/test/unit/test_pathsec_sweep_wrappers.py
+++ b/nltk/test/unit/test_pathsec_sweep_wrappers.py
@@ -1703,3 +1703,92 @@ def test_control_character_guard_does_not_block_ordinary_names(pathsec_sandbox):
     spaced.write_text("m")
     validate_model_resource(str(spaced), context="sweep")
     validate_model_resource(_DEFAULT_RESOURCE, context="sweep")
+
+
+# ---------------------------------------------------------------------------
+# StanfordSegmenter's options dict is joined into ONE comma-separated -options
+# argv element, so a key containing ',' or '=' injects extra option pairs. Same
+# class as the parser's corenlp_options, in the sibling wrapper.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "key",
+    ["normalize=true,serDictionary", "a,b", "a=b", "a b", "a\nb", "a\tb", "", "   "],
+    ids=[
+        "comma-and-equals",
+        "comma",
+        "equals",
+        "space",
+        "newline",
+        "tab",
+        "empty",
+        "whitespace",
+    ],
+)
+def test_segmenter_option_keys_cannot_inject_pairs(key):
+    from nltk.tokenize.stanford_segmenter import _validated_options
+
+    with pytest.raises(ValueError):
+        _validated_options({key: "1"})
+
+
+def test_segmenter_option_values_are_bounded(pathsec_sandbox):
+    """A value that names a file must stay inside the data roots."""
+    from nltk.tokenize.stanford_segmenter import _validated_options
+
+    root, outside = pathsec_sandbox
+    evil = outside / "evil.gz"
+    evil.write_text("x")
+    for value in ("/etc/passwd", str(evil)):
+        with pytest.raises((PermissionError, ValueError)):
+            _validated_options({"serDictionary": value})
+
+
+def test_segmenter_benign_options_still_work(pathsec_sandbox):
+    """Over-block control: ordinary settings, numbers and in-root paths pass."""
+    from nltk.tokenize.stanford_segmenter import _validated_options
+
+    root, _outside = pathsec_sandbox
+    good = root / "ok.gz"
+    good.write_text("m")
+    assert _validated_options({"normalize": "true", "keepAll": "false"}) == {
+        "normalize": "true",
+        "keepAll": "false",
+    }
+    assert _validated_options({"maxLen": 40}) == {"maxLen": 40}
+    assert _validated_options({"serDictionary": str(good)}) == {
+        "serDictionary": str(good)
+    }
+    assert _validated_options({}) == {}
+
+
+def test_teeth_segmenter_options_guard_is_load_bearing():
+    """Without the guard the injected pair lands in the built option string."""
+    import json as _json
+
+    options = {"normalize=true,serDictionary": "/etc/passwd"}
+    unguarded = ",".join(f"{k}={_json.dumps(v)}" for k, v in options.items())
+    assert "serDictionary" in unguarded.split(",")[1]
+
+
+def test_segmenter_out_of_root_jar_is_refused_despite_approved_checksum(
+    pathsec_sandbox, monkeypatch
+):
+    """The checksum allowlist is not a location check. A jar outside the roots
+    must still be refused, even when its sha256 has been approved."""
+    import hashlib as _hashlib
+
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, outside = pathsec_sandbox
+    evil_jar = outside / "evil.jar"
+    evil_jar.write_bytes(b"PK\x05\x06" + b"\0" * 18)
+    digest = _hashlib.sha256(evil_jar.read_bytes()).hexdigest()
+    monkeypatch.setenv("NLTK_SEGMENTER_ALLOW_SHA256", digest)
+
+    tool = object.__new__(seg.StanfordSegmenter)
+    tool._stanford_jar = str(evil_jar)
+    tool._jar_sha256_cache = {}
+    with pytest.raises((PermissionError, ValueError)):
+        tool._validate_classpath()

--- a/nltk/test/unit/test_pathsec_sweep_wrappers.py
+++ b/nltk/test/unit/test_pathsec_sweep_wrappers.py
@@ -618,8 +618,11 @@ def test_real_stanford_parser_default_resource_parses(monkeypatch):
 @requires_java
 @pytest.mark.parametrize(
     "model_path",
-    ["/etc/passwd", "edu/stanford/../../../../etc/passwd"],
-    ids=["etc-abs", "traversal"],
+    [
+        "/etc/passwd" if os.name == "posix" else "C:\\Windows\\win.ini",
+        "edu/stanford/../../../../etc/passwd",
+    ],
+    ids=["system-file-abs", "traversal"],
 )
 def test_real_stanford_parser_refuses_escape_with_jvm_present(monkeypatch, model_path):
     """End-to-end negative: with a working JVM and real jars, a hostile -model is
@@ -1229,3 +1232,34 @@ def test_reserved_windows_device_names_are_refused(value):
 def test_names_merely_starting_like_a_device_are_allowed(value):
     """Over-block control: the check is on the whole stem, not a prefix."""
     validate_model_resource(value, context="sweep")
+
+
+@pytest.mark.parametrize("value", ["C:evil.mco", "C:models\\evil.mco", "D:x.ser.gz"])
+def test_drive_relative_paths_are_refused(value):
+    """Windows CI found this: "C:name" is drive-RELATIVE, meaning "name in the
+    current directory of drive C", so it escapes the location that was validated.
+    It is not the same as the absolute "C:\\name"."""
+    for guard in (validate_model_resource, validate_tool_path):
+        with pytest.raises(ValueError):
+            guard(value, context="sweep")
+
+
+def test_both_guards_share_one_syntax_gate(pathsec_sandbox):
+    """Windows CI found that validate_tool_path skipped the name checks that
+    validate_model_resource applied, so a value refused by one was accepted by
+    the other. They must stay in agreement on syntax."""
+    root, outside = pathsec_sandbox
+    disagreements = []
+    for name, value in _hostile_vectors(root, outside) + _exotic_vectors(root):
+        verdicts = []
+        for guard in (validate_model_resource, validate_tool_path):
+            try:
+                guard(value, context="sweep")
+                verdicts.append("allowed")
+            except (PermissionError, ValueError, OSError):
+                verdicts.append("refused")
+        # validate_tool_path is strictly stricter: it may refuse where the model
+        # guard allows a bare resource name, but never the reverse.
+        if verdicts[0] == "refused" and verdicts[1] == "allowed":
+            disagreements.append(name)
+    assert disagreements == [], f"tool_path weaker than model_resource: {disagreements}"

--- a/nltk/test/unit/test_pickle_allowlist_security.py
+++ b/nltk/test/unit/test_pickle_allowlist_security.py
@@ -203,6 +203,25 @@ def test_denied_module_backstop_even_if_allowlisted():
         up2.find_class("builtins", "eval")
 
 
+@pytest.mark.parametrize("module", ["posixpath", "ntpath", "genericpath"])
+def test_os_path_backing_modules_are_denied(module, tmp_path):
+    """GHSA-x99w: os.path is denied, but so must be the concrete modules it *is*
+    on each platform -- else a broad allow of posixpath/ntpath/genericpath would
+    reach path/stat/expandvars gadgets (an env-var and filesystem oracle)."""
+    up = AllowlistUnpickler(BytesIO(b""), allowed_modules=(module,))
+    with pytest.raises(pickle.UnpicklingError, match="denied module"):
+        up.find_class(module, "exists")
+    # end-to-end: an expandvars REDUCE must not read the environment
+    marker = "nltk-env-oracle-9ffx"
+    os.environ["NLTK_PICKLE_CANARY"] = marker
+    try:
+        payload = _global_pickle(module, "expandvars", "$NLTK_PICKLE_CANARY")
+        with pytest.raises(pickle.UnpicklingError):
+            allowlisted_pickle_load(BytesIO(payload), allowed_modules=(module,))
+    finally:
+        os.environ.pop("NLTK_PICKLE_CANARY", None)
+
+
 def test_safe_primitives_and_punkt_still_load():
     """The tightened allowlist must not break legitimate loads."""
     up = AllowlistUnpickler(BytesIO(b""), allowed_globals=(("builtins", "int"),))

--- a/nltk/test/unit/test_platform_detection.py
+++ b/nltk/test/unit/test_platform_detection.py
@@ -58,7 +58,12 @@ def test_maltparser_command_uses_os_pathsep(monkeypatch, tmp_path):
     parser = MaltParser.__new__(MaltParser)
     parser.additional_java_args = []
     parser.malt_jars = [str(jar_a), str(jar_b)]
-    parser.model = "model.mco"
+    # Inside the allowed data root: generate_malt_command bounds the model path.
+    model = data_root / "model.mco"
+    model.touch()
+    parser.model = str(model)
+    parser._trained = True
+    parser._working_dir = None
 
     captured = {}
 

--- a/nltk/test/unit/test_platform_detection.py
+++ b/nltk/test/unit/test_platform_detection.py
@@ -82,7 +82,9 @@ def test_maltparser_command_uses_os_pathsep(monkeypatch, tmp_path):
 
     # MaltParser hands its jars to internals.java(), which joins the classpath with
     # os.pathsep; the launcher command's -cp value must use it.
-    argv = parser.generate_malt_command("input.conll", mode="learn")
+    conll = data_root / "input.conll"
+    conll.touch()
+    argv = parser.generate_malt_command(str(conll), mode="learn")
     parser._execute(argv)
     cmd = captured["cmd"]
     assert cmd[cmd.index("-cp") + 1] == f"{jar_a};{jar_b}"

--- a/nltk/test/unit/test_weka_integration.py
+++ b/nltk/test/unit/test_weka_integration.py
@@ -1,0 +1,66 @@
+"""End-to-end integration test for the Weka wrapper with the real weka.jar + JVM.
+
+Skipped unless a Java runtime and a ``weka.jar`` are actually available (set
+``WEKA_JAR`` or install under ``~/nltk_data/weka/weka.jar``), so it exercises the
+real train/classify round trip -- proving the ``config_weka`` sandbox-bounding
+change does not break legitimate use -- without ever mocking the JVM.
+"""
+
+import os
+import shutil
+
+import pytest
+
+
+def _weka_jar():
+    for cand in (
+        os.environ.get("WEKA_JAR"),
+        os.path.join(os.path.expanduser("~/nltk_data/weka"), "weka.jar"),
+        "/usr/share/weka/weka.jar",
+        "/usr/local/share/weka/weka.jar",
+    ):
+        if cand and os.path.exists(cand):
+            return cand
+    return None
+
+
+@pytest.mark.skipif(shutil.which("java") is None, reason="no Java runtime on PATH")
+def test_real_weka_train_and_classify(tmp_path):
+    """Train a NaiveBayes model with the real jar and classify two instances."""
+    jar = _weka_jar()
+    if jar is None:
+        pytest.skip("weka.jar not available")
+
+    import nltk.classify.weka as wk
+    from nltk.classify.weka import WekaClassifier
+
+    wk._weka_classpath = None
+    train = [
+        ({"a": 1, "b": 0}, "pos"),
+        ({"a": 1, "b": 0}, "pos"),
+        ({"a": 1, "b": 1}, "pos"),
+        ({"a": 0, "b": 1}, "neg"),
+        ({"a": 0, "b": 1}, "neg"),
+        ({"a": 0, "b": 0}, "neg"),
+    ]
+    model = str(tmp_path / "weka.model")
+    try:
+        wk.config_weka(classpath=jar)
+        clf = WekaClassifier.train(model, train, classifier="naivebayes")
+        preds = clf.classify_many([{"a": 1, "b": 0}, {"a": 0, "b": 1}])
+    except (LookupError, OSError) as exc:
+        # a JDK-less runtime (e.g. the macOS /usr/bin/java stub) cannot execute
+        pytest.skip(f"weka/java not runnable here: {str(exc)[:60]}")
+    assert preds == ["pos", "neg"]
+
+
+@pytest.mark.skipif(shutil.which("java") is None, reason="no Java runtime on PATH")
+def test_real_weka_version_read_through_secure_zip(tmp_path):
+    """_check_weka_version reads weka/core/version.txt from the real jar."""
+    jar = _weka_jar()
+    if jar is None:
+        pytest.skip("weka.jar not available")
+    from nltk.classify.weka import _check_weka_version
+
+    version = _check_weka_version(jar)
+    assert version and version.strip()

--- a/nltk/test/unit/test_weka_security.py
+++ b/nltk/test/unit/test_weka_security.py
@@ -9,6 +9,10 @@ path, CWE-426). The CWD is no longer searched; ``WEKAHOME`` or an explicit
 ``config_weka(classpath=...)`` must be used.
 """
 
+import os
+import shutil
+import tempfile
+
 import pytest
 
 import nltk.classify.weka as weka
@@ -52,6 +56,33 @@ def test_explicit_classpath_still_used(tmp_path):
     jar.write_bytes(b"")
     weka.config_weka(classpath=str(jar))
     assert weka._weka_classpath == str(jar)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="needs a dir outside the temp sandbox")
+def test_wekahome_outside_sandbox_is_ignored(monkeypatch):
+    """A WEKAHOME outside the pathsec-allowed roots must not be trusted: an
+    attacker-controlled env var cannot add a weka.jar from an untrusted dir
+    (CWE-426). ``/tmp/<x>`` is world-writable, hence never an allowed root."""
+    outside = tempfile.mkdtemp(dir="/tmp")
+    try:
+        with open(os.path.join(outside, "weka.jar"), "wb"):
+            pass  # attacker-planted jar
+        monkeypatch.setenv("WEKAHOME", outside)
+        with pytest.warns(UserWarning, match="outside the trusted"):
+            with pytest.raises(LookupError):
+                weka.config_weka()
+        assert weka._weka_classpath is None
+    finally:
+        shutil.rmtree(outside, ignore_errors=True)
+
+
+def test_wekahome_inside_sandbox_is_used(tmp_path, monkeypatch):
+    """A WEKAHOME within the authorized data roots (the pytest tmp dir is one) is
+    honoured, so legitimate installs still auto-resolve."""
+    (tmp_path / "weka.jar").write_bytes(b"")
+    monkeypatch.setenv("WEKAHOME", str(tmp_path))
+    weka.config_weka()
+    assert weka._weka_classpath == str(tmp_path / "weka.jar")
 
 
 def test_arff_formatter_escapes_directive_injection():

--- a/nltk/test/unit/test_wordnet_recursion.py
+++ b/nltk/test/unit/test_wordnet_recursion.py
@@ -78,11 +78,12 @@ def test_branches_same_behavior():
     depth = traversal_depth(result)
     assert depth <= MAX_RECURSION_DEPTH
 
+
 def test_dic2tree_short_chain():
     d = {}
     for i in range(5):
-        d[str(i)] = [str(i+1)] if i < 4 else []
-    result = acyclic_dic2tree('0', d)
+        d[str(i)] = [str(i + 1)] if i < 4 else []
+    result = acyclic_dic2tree("0", d)
     depth = 0
     current = result
     while isinstance(current, list) and len(current) > 1:
@@ -90,11 +91,12 @@ def test_dic2tree_short_chain():
         current = current[1]
     assert depth == 4
 
+
 def test_dic2tree_long_chain_capped():
     d = {}
     for i in range(1500):
-        d[str(i)] = [str(i+1)] if i < 1499 else []
-    result = acyclic_dic2tree('0', d)
+        d[str(i)] = [str(i + 1)] if i < 1499 else []
+    result = acyclic_dic2tree("0", d)
     depth = 0
     current = result
     while isinstance(current, list) and len(current) > 1:
@@ -102,11 +104,12 @@ def test_dic2tree_long_chain_capped():
         current = current[1]
     assert depth <= MAX_RECURSION_DEPTH
 
+
 def test_dic2tree_explicit_depth():
     d = {}
     for i in range(10):
-        d[str(i)] = [str(i+1)] if i < 9 else []
-    result = acyclic_dic2tree('0', d, depth=20)
+        d[str(i)] = [str(i + 1)] if i < 9 else []
+    result = acyclic_dic2tree("0", d, depth=20)
     depth = 0
     current = result
     while isinstance(current, list) and len(current) > 1:
@@ -114,14 +117,16 @@ def test_dic2tree_explicit_depth():
         current = current[1]
     assert depth == 9
 
+
 def test_dic2tree_negative_depth():
-    d = {'a': ['b']}
+    d = {"a": ["b"]}
     with pytest.raises(ValueError, match="depth must be >= -1"):
-        acyclic_dic2tree('a', d, depth=-2)
+        acyclic_dic2tree("a", d, depth=-2)
+
 
 def test_dic2tree_cycle():
     # Simple cycle: a -> b -> a
-    d = {'a': ['b'], 'b': ['a']}
-    result = acyclic_dic2tree('a', d, verbose=False)
+    d = {"a": ["b"], "b": ["a"]}
+    result = acyclic_dic2tree("a", d, verbose=False)
     # Should return ['a', ['b']] because the cycle is truncated
-    assert result == ['a', ['b']]
+    assert result == ["a", ["b"]]

--- a/nltk/tokenize/stanford.py
+++ b/nltk/tokenize/stanford.py
@@ -12,6 +12,7 @@ import tempfile
 import warnings
 from subprocess import PIPE
 
+from nltk.data import staging_tempdir
 from nltk.internals import find_jar, java
 from nltk.parse.corenlp import CoreNLPParser
 from nltk.tokenize.api import TokenizerI
@@ -90,7 +91,9 @@ class StanfordTokenizer(TokenizerI):
         input_file_name = None
         java_succeeded = False
         try:
-            with tempfile.NamedTemporaryFile(mode="wb", delete=False) as input_file:
+            with tempfile.NamedTemporaryFile(
+                mode="wb", delete=False, dir=staging_tempdir()
+            ) as input_file:
                 input_file_name = input_file.name
                 # Write the actual sentences to the temporary input file
                 if isinstance(input_, str) and encoding:

--- a/nltk/tokenize/stanford_segmenter.py
+++ b/nltk/tokenize/stanford_segmenter.py
@@ -201,6 +201,9 @@ class StanfordSegmenter(TokenizerI):
 
     def segment_file(self, input_file_path):
         """ """
+        # Caller-supplied and handed to the JVM as -textFile, which pathsec.open
+        # cannot wrap; validate before the spawn (GHSA-8mgp-746c-j5xp).
+        validate_path(input_file_path, context="StanfordSegmenter.segment_file")
         cmd = [
             self._java_class,
             "-loadClassifier",
@@ -328,6 +331,21 @@ class StanfordSegmenter(TokenizerI):
                     "Multiple approved checksums may be supplied as a comma-separated list."
                 )
 
+    def _validate_model_paths(self):
+        """Refuse model/dictionary paths that escape the NLTK data sandbox.
+
+        These are embedded in the JVM argv (-loadClassifier / -serDictionary /
+        -sighanCorporaDict), which pathsec.open cannot wrap, so they are checked
+        here before the process is spawned (GHSA-8mgp-746c-j5xp).
+        """
+        for label, value in (
+            ("model", self._model),
+            ("dictionary", self._dict),
+            ("sihan corpora dict", self._sihan_corpora_dict),
+        ):
+            if value:
+                validate_path(value, context=f"StanfordSegmenter {label}")
+
     def _execute(self, cmd, verbose=False):
         encoding = self._encoding
         cmd.extend(["-inputEncoding", encoding])
@@ -335,6 +353,7 @@ class StanfordSegmenter(TokenizerI):
         if _options_cmd:
             cmd.extend(["-options", self._options_cmd])
 
+        self._validate_model_paths()
         self._validate_classpath()
 
         stdout, _stderr = java(

--- a/nltk/tokenize/stanford_segmenter.py
+++ b/nltk/tokenize/stanford_segmenter.py
@@ -245,23 +245,23 @@ class StanfordSegmenter(TokenizerI):
         input_file_path = validate_tool_path(
             input_file_path, context="StanfordSegmenter.segment_file"
         )
-        self._validate_model_paths()
+        model, dictionary, sihan = self._validate_model_paths()
         cmd = [
             self._java_class,
             "-loadClassifier",
-            self._model,
+            model,
             "-keepAllWhitespaces",
             self._keep_whitespaces,
             "-textFile",
             input_file_path,
         ]
-        if self._sihan_corpora_dict is not None:
+        if sihan is not None:
             cmd.extend(
                 [
                     "-serDictionary",
-                    self._dict,
+                    dictionary,
                     "-sighanCorporaDict",
-                    self._sihan_corpora_dict,
+                    sihan,
                     "-sighanPostProcessing",
                     self._sihan_post_processing,
                 ]
@@ -295,23 +295,23 @@ class StanfordSegmenter(TokenizerI):
             # attributes the guard replaced. Capturing self._model into cmd first
             # would put the original object there, and a PathLike may resolve to
             # something else when the child process reads it.
-            self._validate_model_paths()
+            model, dictionary, sihan = self._validate_model_paths()
             cmd = [
                 self._java_class,
                 "-loadClassifier",
-                self._model,
+                model,
                 "-keepAllWhitespaces",
                 self._keep_whitespaces,
                 "-textFile",
                 self._input_file_path,
             ]
-            if self._sihan_corpora_dict is not None:
+            if sihan is not None:
                 cmd.extend(
                     [
                         "-serDictionary",
-                        self._dict,
+                        dictionary,
                         "-sighanCorporaDict",
-                        self._sihan_corpora_dict,
+                        sihan,
                         "-sighanPostProcessing",
                         self._sihan_post_processing,
                     ]
@@ -385,12 +385,23 @@ class StanfordSegmenter(TokenizerI):
         -sighanCorporaDict), which pathsec.open cannot wrap, so they are checked
         here before the process is spawned (GHSA-8mgp-746c-j5xp).
 
-        Each attribute is replaced with the string the guard returned. A PathLike
-        may answer differently on every call, and ``validate_path`` reads a
-        ``.path`` attribute in preference to ``__fspath__``, so validating the
-        object and then handing the same object to the JVM checked one file and
-        opened another.
+        Each attribute is replaced with the string the guard returned, and the
+        same strings are RETURNED for the caller to build its argv from. A
+        PathLike may answer differently on every call, and ``validate_path``
+        reads a ``.path`` attribute in preference to ``__fspath__``, so
+        validating the object and then handing the same object to the JVM
+        checked one file and opened another.
+
+        Returning them matters beyond that: a caller that re-reads
+        ``self._model`` after this returns is reading shared mutable state again,
+        so a concurrent write could still swap the value between the check and
+        the argv. Building from the return value keeps the checked value and the
+        used value the same object.
+
+        :return: the validated (model, dictionary, sihan corpora dict) strings,
+            each None when it was unset
         """
+        validated = []
         for attribute, label in (
             ("_model", "model"),
             ("_dict", "dictionary"),
@@ -398,11 +409,10 @@ class StanfordSegmenter(TokenizerI):
         ):
             value = getattr(self, attribute)
             if value:
-                setattr(
-                    self,
-                    attribute,
-                    validate_tool_path(value, context=f"StanfordSegmenter {label}"),
-                )
+                value = validate_tool_path(value, context=f"StanfordSegmenter {label}")
+                setattr(self, attribute, value)
+            validated.append(value)
+        return tuple(validated)
 
     def _execute(self, cmd, verbose=False):
         encoding = self._encoding

--- a/nltk/tokenize/stanford_segmenter.py
+++ b/nltk/tokenize/stanford_segmenter.py
@@ -24,7 +24,7 @@ from nltk.internals import (
     java,
 )
 from nltk.pathsec import open as pathsec_open
-from nltk.pathsec import validate_path
+from nltk.pathsec import validate_path, validate_tool_path
 from nltk.tokenize.api import TokenizerI
 
 _stanford_url = "https://nlp.stanford.edu/software"
@@ -202,8 +202,13 @@ class StanfordSegmenter(TokenizerI):
     def segment_file(self, input_file_path):
         """ """
         # Caller-supplied and handed to the JVM as -textFile, which pathsec.open
-        # cannot wrap; validate before the spawn (GHSA-8mgp-746c-j5xp).
-        validate_path(input_file_path, context="StanfordSegmenter.segment_file")
+        # cannot wrap; validate before the spawn (GHSA-8mgp-746c-j5xp). Build the
+        # argv from the returned string, never the original object: a PathLike can
+        # answer one way here and another way when the child resolves it.
+        input_file_path = validate_tool_path(
+            input_file_path, context="StanfordSegmenter.segment_file"
+        )
+        self._validate_model_paths()
         cmd = [
             self._java_class,
             "-loadClassifier",
@@ -337,14 +342,25 @@ class StanfordSegmenter(TokenizerI):
         These are embedded in the JVM argv (-loadClassifier / -serDictionary /
         -sighanCorporaDict), which pathsec.open cannot wrap, so they are checked
         here before the process is spawned (GHSA-8mgp-746c-j5xp).
+
+        Each attribute is replaced with the string the guard returned. A PathLike
+        may answer differently on every call, and ``validate_path`` reads a
+        ``.path`` attribute in preference to ``__fspath__``, so validating the
+        object and then handing the same object to the JVM checked one file and
+        opened another.
         """
-        for label, value in (
-            ("model", self._model),
-            ("dictionary", self._dict),
-            ("sihan corpora dict", self._sihan_corpora_dict),
+        for attribute, label in (
+            ("_model", "model"),
+            ("_dict", "dictionary"),
+            ("_sihan_corpora_dict", "sihan corpora dict"),
         ):
+            value = getattr(self, attribute)
             if value:
-                validate_path(value, context=f"StanfordSegmenter {label}")
+                setattr(
+                    self,
+                    attribute,
+                    validate_tool_path(value, context=f"StanfordSegmenter {label}"),
+                )
 
     def _execute(self, cmd, verbose=False):
         encoding = self._encoding

--- a/nltk/tokenize/stanford_segmenter.py
+++ b/nltk/tokenize/stanford_segmenter.py
@@ -291,6 +291,11 @@ class StanfordSegmenter(TokenizerI):
                     _input = _input.encode(encoding)
                 input_fh.write(_input)
 
+            # Validate BEFORE building the command, and build it from the
+            # attributes the guard replaced. Capturing self._model into cmd first
+            # would put the original object there, and a PathLike may resolve to
+            # something else when the child process reads it.
+            self._validate_model_paths()
             cmd = [
                 self._java_class,
                 "-loadClassifier",

--- a/nltk/tokenize/stanford_segmenter.py
+++ b/nltk/tokenize/stanford_segmenter.py
@@ -30,6 +30,42 @@ from nltk.tokenize.api import TokenizerI
 _stanford_url = "https://nlp.stanford.edu/software"
 
 
+def _validated_options(options):
+    """Bound the caller-supplied ``options`` dict before it becomes ``-options``.
+
+    The pairs are joined into ONE comma-separated argv element, so a key holding
+    a ``,`` or an ``=`` silently injects extra option pairs that the wrapper
+    never intended. This is the same class as the parser's ``corenlp_options``:
+
+        {"normalize=true,serDictionary": "/etc/passwd"}
+        -> normalize=true,serDictionary="/etc/passwd"
+
+    Values are JSON-encoded, so they cannot break out of their own pair, but one
+    that names a file is still bounded to the data roots.
+    """
+    validated = {}
+    for key, value in options.items():
+        name = str(key)
+        if not name.strip():
+            raise ValueError(
+                "Security Violation [StanfordSegmenter options]: empty option name."
+            )
+        if any(character in name for character in ",=\t\n\r\x00 "):
+            raise ValueError(
+                f"Security Violation [StanfordSegmenter options]: option name "
+                f"{name!r} contains a separator, so it would inject extra "
+                "option pairs into the argument list."
+            )
+        if isinstance(value, str) and (
+            os.path.isabs(value) or "/" in value or "\\" in value
+        ):
+            value = validate_tool_path(
+                value, context=f"StanfordSegmenter options[{name}]"
+            )
+        validated[name] = value
+    return validated
+
+
 class StanfordSegmenter(TokenizerI):
     """Interface to the Stanford Segmenter
 
@@ -119,7 +155,8 @@ class StanfordSegmenter(TokenizerI):
         self.java_options = java_options
         options = {} if options is None else options
         self._options_cmd = ",".join(
-            f"{key}={json.dumps(val)}" for key, val in options.items()
+            f"{key}={json.dumps(val)}"
+            for key, val in _validated_options(options).items()
         )
         self._jar_sha256_cache = {}
 

--- a/nltk/tokenize/stanford_segmenter.py
+++ b/nltk/tokenize/stanford_segmenter.py
@@ -17,6 +17,7 @@ import tempfile
 import warnings
 from subprocess import PIPE
 
+from nltk.data import staging_tempdir
 from nltk.internals import (
     find_dir,
     find_file,
@@ -281,7 +282,9 @@ class StanfordSegmenter(TokenizerI):
         java_succeeded = False
         try:
             # Create a temporary input file
-            _input_fh, input_file_path = tempfile.mkstemp(text=True)
+            _input_fh, input_file_path = tempfile.mkstemp(
+                text=True, dir=staging_tempdir()
+            )
             self._input_file_path = input_file_path
 
             # Write the actual sentences to the temporary input file

--- a/nltk/twitter/common.py
+++ b/nltk/twitter/common.py
@@ -12,11 +12,10 @@ the `twython` library to have been installed.
 """
 import csv
 import gzip
-
-from nltk.pathsec import open as pathsec_open
 import json
 
 from nltk.internals import deprecated
+from nltk.pathsec import open as pathsec_open
 
 HIER_SEPARATOR = "."
 
@@ -142,9 +141,7 @@ def _outf_writer(outfile, encoding, errors, gzip_compress=False):
         # Sandbox the destination, then let gzip wrap the checked handle: the
         # caller chooses this path, so a bare open is an arbitrary file write.
         raw = pathsec_open(outfile, "wb", context="twitter._outf_writer")
-        outf = gzip.open(
-            raw, "wt", newline="", encoding=encoding, errors=errors
-        )
+        outf = gzip.open(raw, "wt", newline="", encoding=encoding, errors=errors)
     else:
         outf = pathsec_open(
             outfile,

--- a/nltk/twitter/twitterclient.py
+++ b/nltk/twitter/twitterclient.py
@@ -27,14 +27,13 @@ import gzip
 import itertools
 import json
 import os
-
-from nltk.pathsec import open as pathsec_open
 import time
 
 import requests
 from twython import Twython, TwythonStreamer
 from twython.exceptions import TwythonError, TwythonRateLimitError
 
+from nltk.pathsec import open as pathsec_open
 from nltk.twitter.api import BasicTweetHandler, TweetHandlerI
 from nltk.twitter.util import credsfromfile, guess_path
 
@@ -521,11 +520,16 @@ class TweetWriter(TweetHandlerI):
         """
         if self.startingup:
             if self.gzip_compress:
-                self.output = gzip.open(self.fname, "w")
+                # gzip the CHECKED handle, never the raw path: self.fname is
+                # caller-supplied, so gzip.open(path) is an unguarded write.
+                self.output = gzip.open(
+                    pathsec_open(self.fname, "wb", context="TweetWriter.output"),
+                    "w",
+                )
             else:
                 self.output = pathsec_open(
-            self.fname, "w", context="TweetWriter.output"
-        )
+                    self.fname, "w", context="TweetWriter.output"
+                )
             print(f"Writing to {self.fname}")
 
         json_data = json.dumps(data)

--- a/nltk/twitter/util.py
+++ b/nltk/twitter/util.py
@@ -11,11 +11,11 @@ Authentication utilities to accompany `twitterclient`.
 """
 
 import os
-
-from nltk.pathsec import open as pathsec_open
 import pprint
 
 from twython import Twython
+
+from nltk.pathsec import open as pathsec_open
 
 
 def credsfromfile(creds_file=None, subdir=None, verbose=False):
@@ -85,9 +85,7 @@ class Authenticate:
         if not os.path.isfile(self.creds_fullpath):
             raise OSError(f"Cannot find file {self.creds_fullpath}")
 
-        with pathsec_open(
-            self.creds_fullpath, context="twitter.credentials"
-        ) as infile:
+        with pathsec_open(self.creds_fullpath, context="twitter.credentials") as infile:
             if verbose:
                 print(f"Reading credentials file {self.creds_fullpath}")
 

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -640,6 +640,7 @@ def acyclic_branches_depth_first(
         out_tree += [cut_mark]
     return out_tree
 
+
 def acyclic_dic2tree(node, dic, depth=-1, traversed=None, verbose=False):
     """
     :param node: the root node

--- a/nltk/xmlsec.py
+++ b/nltk/xmlsec.py
@@ -51,11 +51,10 @@ default C parser and touches no global state.)
 """
 
 import io
-
-from nltk.pathsec import open as pathsec_open
 from xml.etree import ElementTree
 from xml.parsers import expat
 
+from nltk.pathsec import open as pathsec_open
 from nltk.pathsec import validate_path
 
 __all__ = ["HAVE_DEFUSEDXML", "EntitiesForbidden", "fromstring", "parse"]

--- a/tools/check_no_unsandboxed_open.py
+++ b/tools/check_no_unsandboxed_open.py
@@ -36,6 +36,15 @@ GUARDED_PATHS = [
     "nltk/corpus/reader",
     "nltk/corpus/util.py",
     "nltk/data.py",
+    # Model-artifact save/load helpers: the same untrusted-path problem, and the
+    # exact family GHSA-8mgp-746c-j5xp was filed against.
+    "nltk/chunk/named_entity.py",
+    "nltk/classify/maxent.py",
+    "nltk/parse/transitionparser.py",
+    "nltk/tabdata.py",
+    "nltk/tag/perceptron.py",
+    "nltk/tbl/demo.py",
+    "nltk/tokenize/punkt.py",
 ]
 
 SUPPRESS_MARKER = "# sandboxed-open ok"

--- a/tools/check_no_unsandboxed_open.py
+++ b/tools/check_no_unsandboxed_open.py
@@ -49,6 +49,50 @@ GUARDED_PATHS = [
 
 SUPPRESS_MARKER = "# sandboxed-open ok"
 
+# Opening a path through a compression or archive helper bypasses the sentinel
+# just as a builtin open() does. These are only safe when handed an ALREADY
+# secured file object, so a call whose first argument is a path is a violation.
+_PATH_TAKING = {
+    ("gzip", "open"),
+    ("bz2", "open"),
+    ("lzma", "open"),
+    ("codecs", "open"),
+    ("io", "open"),
+    ("tarfile", "open"),
+    ("zipfile", "ZipFile"),
+}
+
+
+def _is_secured_handle(arg, secured_names):
+    """True if *arg* is a pathsec-produced file object rather than a path."""
+    if isinstance(arg, ast.Call):
+        func = arg.func
+        if isinstance(func, ast.Name) and "pathsec" in func.id:
+            return True
+        if isinstance(func, ast.Attribute) and "pathsec" in getattr(
+            getattr(func, "value", None), "id", ""
+        ):
+            return True
+    if isinstance(arg, ast.Name) and arg.id in secured_names:
+        return True
+    return False
+
+
+def _secured_names(tree):
+    """Names bound from a pathsec open in this module, e.g. ``raw = pathsec_open(...)``."""
+    names = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and _is_secured_handle(node.value, set()):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    names.add(target.id)
+        elif isinstance(node, ast.withitem) and _is_secured_handle(
+            node.context_expr, set()
+        ):
+            if isinstance(node.optional_vars, ast.Name):
+                names.add(node.optional_vars.id)
+    return names
+
 
 def _iter_py_files(path):
     if os.path.isfile(path):
@@ -73,20 +117,34 @@ def find_violations(paths):
             except SyntaxError:
                 continue
             lines = source.splitlines()
+            secured_names = _secured_names(tree)
             for node in ast.walk(tree):
-                if (
-                    isinstance(node, ast.Call)
-                    and isinstance(node.func, ast.Name)
-                    and node.func.id == "open"
-                ):
-                    # Scan every physical line of the call so a suppression
-                    # marker still counts if the formatter wrapped the call.
-                    end = getattr(node, "end_lineno", node.lineno) or node.lineno
-                    span = lines[node.lineno - 1 : end]
-                    if any(SUPPRESS_MARKER in ln for ln in span):
-                        continue
-                    line = span[0].strip() if span else ""
-                    violations.append((py, node.lineno, line.strip()))
+                if not isinstance(node, ast.Call):
+                    continue
+                bare_builtin = (
+                    isinstance(node.func, ast.Name) and node.func.id == "open"
+                )
+                # A compression/archive helper handed a PATH bypasses the
+                # sentinel too. Handed an already-secured file object it is
+                # fine, so only a call whose first argument is not itself a
+                # pathsec call (or a name bound from one) is reported.
+                path_taking = (
+                    isinstance(node.func, ast.Attribute)
+                    and isinstance(node.func.value, ast.Name)
+                    and (node.func.value.id, node.func.attr) in _PATH_TAKING
+                    and node.args
+                    and not _is_secured_handle(node.args[0], secured_names)
+                )
+                if not (bare_builtin or path_taking):
+                    continue
+                # Scan every physical line of the call so a suppression
+                # marker still counts if the formatter wrapped the call.
+                end = getattr(node, "end_lineno", node.lineno) or node.lineno
+                span = lines[node.lineno - 1 : end]
+                if any(SUPPRESS_MARKER in ln for ln in span):
+                    continue
+                line = span[0].strip() if span else ""
+                violations.append((py, node.lineno, line.strip()))
     return violations
 
 


### PR DESCRIPTION
Part of the #3753 decomposition into small, reviewable PRs.

Several taggers hand a **caller-controlled model path** straight to a native
loader or subprocess that `pathsec.open` cannot wrap, so the sandbox is bypassed:

- `CRFTagger.set_model_file` / `.train` → pycrfsuite's C-extension `.open()` / `.train()`
- `HunposTagger.__init__` → the `hunpos-tag` subprocess (path as argv)
- `StanfordTagger.tag_sents` → the JVM subprocess (`-model` / `-loadClassifier`)

Each now calls `nltk.pathsec.validate_path(...)` against the NLTK data sandbox
**before** the native call, so a path outside the allowed roots is refused up
front (GHSA-8mgp-746c-j5xp). `AveragedPerceptron.save`/`load` route their JSON
I/O through `pathsec.open` instead of a bare `open`.

Adds `test_pathsec_sweep_tag.py` covering the `nltk.tag` sinks.

Marked `[WIP]` pending review alongside the other decomposition PRs.