### PR TITLE
Prevent classpath shadowing in GenericStanfordParser

### DIFF
--- a/nltk/parse/stanford.py
+++ b/nltk/parse/stanford.py
@@ -73,10 +73,15 @@ class GenericStanfordParser(ParserI):
 
         # Place trusted parser and supporting library jars first,
         # and append the data-only model_jar last to prevent class shadowing (CVE-2026-14582).
-        classpath_jars = list(find_jars_within_path(stanford_dir))
-        if stanford_jar not in classpath_jars:
-            classpath_jars = [stanford_jar] + classpath_jars
-        self._classpath = tuple(classpath_jars + [model_jar])
+        classpath_jars = [
+            j
+            for j in find_jars_within_path(stanford_dir)
+            if j not in (stanford_jar, model_jar)
+        ]
+        classpath = [stanford_jar] + classpath_jars
+        if model_jar != stanford_jar:
+            classpath.append(model_jar)
+        self._classpath = tuple(classpath)
 
         self.model_path = model_path
         self._encoding = encoding

--- a/nltk/parse/stanford.py
+++ b/nltk/parse/stanford.py
@@ -69,8 +69,14 @@ class GenericStanfordParser(ParserI):
         # self._classpath = (stanford_jar, model_jar)
 
         # Adding logging jar files to classpath
-        stanford_dir = os.path.split(stanford_jar)[0]
-        self._classpath = tuple([model_jar] + find_jars_within_path(stanford_dir))
+        stanford_dir = os.path.dirname(stanford_jar)
+
+        # Place trusted parser and supporting library jars first,
+        # and append the data-only model_jar last to prevent class shadowing (CVE-2026-14582).
+        classpath_jars = list(find_jars_within_path(stanford_dir))
+        if stanford_jar not in classpath_jars:
+            classpath_jars = [stanford_jar] + classpath_jars
+        self._classpath = tuple(classpath_jars + [model_jar])
 
         self.model_path = model_path
         self._encoding = encoding

--- a/nltk/test/unit/test_stanford_classpath.py
+++ b/nltk/test/unit/test_stanford_classpath.py
@@ -1,0 +1,51 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from nltk.parse.stanford import GenericStanfordParser
+
+
+class TestStanfordClasspathOrder(unittest.TestCase):
+    """Unit tests to verify classpath construction order in GenericStanfordParser (CVE-2026-14582)."""
+
+    @patch("nltk.parse.stanford.find_jar_iter")
+    @patch("nltk.parse.stanford.find_jars_within_path")
+    def test_model_jar_appended_at_end(self, mock_find_jars, mock_find_jar_iter):
+        # find_jar_iter returns an iterable (generator/list) of paths.
+        # We must return a LIST for each call, otherwise max() iterates over the string's characters!
+        mock_find_jar_iter.side_effect = [
+            ["/opt/stanford/stanford-parser.jar"],  # 1st call: stanford_jar
+            ["/untrusted/stanford-parser-4.2.0-models.jar"],  # 2nd call: model_jar
+        ]
+
+        # Mock additional supporting jars found in the stanford directory
+        mock_find_jars.return_value = [
+            "/opt/stanford/stanford-parser.jar",
+            "/opt/stanford/slf4j-api.jar",
+        ]
+
+        # Initialize the parser
+        parser = GenericStanfordParser(
+            path_to_jar="/opt/stanford/stanford-parser.jar",
+            path_to_models_jar="/untrusted/stanford-parser-4.2.0-models.jar",
+        )
+
+        # Verify classpath elements
+        classpath = parser._classpath
+
+        # The model jar must NOT be the first element (which would allow class shadowing)
+        self.assertNotEqual(
+            classpath[0],
+            "/untrusted/stanford-parser-4.2.0-models.jar",
+            "Vulnerability present: untrusted model_jar is prepended to the classpath.",
+        )
+
+        # The model jar MUST be at the very end of the classpath tuple
+        self.assertEqual(
+            classpath[-1],
+            "/untrusted/stanford-parser-4.2.0-models.jar",
+            "Expected model_jar to be appended at the end of the classpath.",
+        )
+
+        # Trusted jar/supporting paths should appear before the model jar
+        self.assertIn("/opt/stanford/stanford-parser.jar", classpath[:-1])

--- a/nltk/test/unit/test_stanford_classpath.py
+++ b/nltk/test/unit/test_stanford_classpath.py
@@ -18,9 +18,10 @@ class TestStanfordClasspathOrder(unittest.TestCase):
             ["/untrusted/stanford-parser-4.2.0-models.jar"],  # 2nd call: model_jar
         ]
 
-        # Mock additional supporting jars found in the stanford directory
+        # Mock additional supporting jars found in the stanford directory (including the models jar)
         mock_find_jars.return_value = [
             "/opt/stanford/stanford-parser.jar",
+            "/opt/stanford/stanford-parser-4.2.0-models.jar",
             "/opt/stanford/slf4j-api.jar",
         ]
 


### PR DESCRIPTION
### **Description**

This PR addresses **CVE-2026-14582**, a critical classpath hijacking vulnerability (CWE-115) where `GenericStanfordParser` prepended the untrusted, data-only `model_jar` to the front of the Java classpath. This flaw allowed a crafted models JAR to shadow core classes (such as `edu.stanford.nlp.parser.lexparser.LexicalizedParser`) and achieve arbitrary bytecode execution during parser startup.

#### **Changes Made**

* **Classpath Reordering:** Modified `GenericStanfordParser.__init__` in `nltk/parse/stanford.py` to append the data-only `model_jar` at the **end** of the classpath array rather than the front.
* **Privileged Class Precedence:** Ensured trusted parser and core library JARs are explicitly searched first by the JVM, preventing class-shadowing via untrusted model bundles.
* **Path Extraction:** Switched from `os.path.split(stanford_jar)[0]` to `os.path.dirname(stanford_jar)` for more robust directory resolution.
* **Unit Testing:** Added `test_stanford_classpath.py` under `nltk/test/unit/` to verify that the `model_jar` is always appended last and does not shadow trusted executable JARs, preventing future regressions.

---

### **Proposed Code Diff (`nltk/parse/stanford.py`)**

```diff
-        # Adding logging jar files to classpath
-        stanford_dir = os.path.split(stanford_jar)[0]
-        self._classpath = tuple([model_jar] + find_jars_within_path(stanford_dir))
+        # Adding logging jar files to classpath
+        stanford_dir = os.path.dirname(stanford_jar)
+        
+        # Place trusted parser and supporting library jars first, 
+        # and append the data-only model_jar last to prevent class shadowing (CVE-2026-14582).
+        classpath_jars = list(find_jars_within_path(stanford_dir))
+        if stanford_jar not in classpath_jars:
+            classpath_jars = [stanford_jar] + classpath_jars
+        self._classpath = tuple(classpath_jars + [model_jar])

```

---

### **Checklist**

* [x] Addressed CVE-2026-14582 by fixing classpath ordering.
* [x] Added `test_stanford_classpath.py` to unit test suite.
* [x] Ensured backward compatibility for standard model paths.