### PR TITLE
[WIP] Execute every advisory security probe and tighten the guards they cover

### DIFF
--- a/nltk/classify/weka.py
+++ b/nltk/classify/weka.py
@@ -14,6 +14,7 @@ import re
 import subprocess
 import tempfile
 import time
+import warnings
 import zipfile
 from sys import stdin
 
@@ -21,6 +22,7 @@ from nltk.classify.api import ClassifierI
 from nltk.data import make_staging_dir
 from nltk.internals import config_java, java
 from nltk.pathsec import open as pathsec_open
+from nltk.pathsec import validate_path
 from nltk.probability import DictionaryProbDist
 
 _weka_classpath = None
@@ -51,7 +53,19 @@ def config_weka(classpath=None):
     if _weka_classpath is None:
         searchpath = list(_weka_search)  # copy; don't mutate the module global
         if "WEKAHOME" in os.environ:
-            searchpath.insert(0, os.environ["WEKAHOME"])
+            weka_home = os.environ["WEKAHOME"]
+            try:
+                # Bound the attacker-influenceable WEKAHOME to the pathsec sandbox so
+                # it cannot add a weka.jar from outside the trusted roots (CWE-426/427).
+                validate_path(
+                    os.path.join(weka_home, "weka.jar"), context="config_weka(WEKAHOME)"
+                )
+                searchpath.insert(0, weka_home)
+            except (PermissionError, ValueError):
+                warnings.warn(
+                    f"Ignoring WEKAHOME {weka_home!r}: outside the trusted NLTK data roots.",
+                    stacklevel=2,
+                )
 
         for path in searchpath:
             if os.path.exists(os.path.join(path, "weka.jar")):

--- a/nltk/corpus/reader/framenet.py
+++ b/nltk/corpus/reader/framenet.py
@@ -776,7 +776,9 @@ def _reject_unsafe_path_component(value, kind):
         or ".." in value
         or ntpath.splitdrive(value)[0]
     ):
-        raise FramenetError(f"Invalid {kind}: {value!r}")
+        # "Security violation" marks this as a containment decision, not an
+        # incidental lookup error, so callers and audits can tell them apart.
+        raise FramenetError(f"Security violation: Invalid {kind}: {value!r}")
 
 
 def _validate_in_root(locpath, root, context):

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -749,6 +749,10 @@ def _hardened_open(raw_path, mode, context, required_root, **kwargs):
         | getattr(os, "O_NOFOLLOW", 0)
         | getattr(os, "O_CLOEXEC", 0)
     )
+    # Defer O_TRUNC until after the hardlink/realpath checks: truncating at open
+    # time would zero a hardlinked outside-root target before st_nlink refuses it.
+    truncate_after = bool(flags & os.O_TRUNC)
+    flags &= ~os.O_TRUNC
     try:
         # 0o600 is only consulted when O_CREAT is in flags (write/append/x modes).
         fd = os.open(raw_path, flags, 0o600)
@@ -775,6 +779,9 @@ def _hardened_open(raw_path, mode, context, required_root, **kwargs):
             context=context,
             required_root=required_root,
         )
+        # Safe now: the fd is confirmed single-linked and inside the root.
+        if truncate_after:
+            os.ftruncate(fd, 0)
     except BaseException:
         os.close(fd)
         raise

--- a/nltk/picklesec.py
+++ b/nltk/picklesec.py
@@ -141,6 +141,11 @@ _DENIED_MODULE_PREFIXES = (
     "os",
     "nt",
     "posix",
+    # os.path's concrete backing modules: denying "os" only catches the literal
+    # "os.path", not these, so an allowlist naming them would reach path/stat gadgets.
+    "posixpath",
+    "ntpath",
+    "genericpath",
     "subprocess",
     "sys",
     "socket",

--- a/nltk/test/internals.doctest
+++ b/nltk/test/internals.doctest
@@ -178,12 +178,32 @@ wrappers pass are equivalent and also permitted:
 >>> _validate_java_options(["-mx2g"])
 >>> _validate_java_options(["-ms128m"])
 >>> _validate_java_options(["-ss4m"])
->>> _validate_java_options(["-XX:+UseG1GC"])
 >>> _validate_java_options(["-verbose:gc"])
 >>> _validate_java_options(["-server"])
 >>> _validate_java_options(["-client"])
->>> _validate_java_options(["-Dsome.property=value"])
->>> _validate_java_options(["-Xmx1g", "-Dsome.key=val", "-server"])
+>>> _validate_java_options(["-Xmx1g", "-server"])
+
+The filter is an allowlist, so ``-XX:`` and ``-D`` flags are refused even though
+they look innocuous: ``-XX:`` can name a file the JVM executes on error and
+``-D`` can redirect class loading or disarm the security manager. Pass a genuinely
+needed one through ``java(trusted_raw_options=...)``:
+
+>>> _validate_java_options(["-XX:+UseG1GC"])  # doctest: +ELLIPSIS
+Traceback (most recent call last):
+    ...
+ValueError: java_options contains a disallowed JVM/launcher flag: '-XX:+UseG1GC'...
+
+>>> _validate_java_options(["-Dsome.property=value"])  # doctest: +ELLIPSIS
+Traceback (most recent call last):
+    ...
+ValueError: java_options contains a disallowed JVM/launcher flag: '-Dsome.property=value'...
+
+A single bad flag rejects the whole list, even mixed with permitted ones:
+
+>>> _validate_java_options(["-Xmx1g", "-Dsome.key=val", "-server"])  # doctest: +ELLIPSIS
+Traceback (most recent call last):
+    ...
+ValueError: java_options contains a disallowed JVM/launcher flag: '-Dsome.key=val'...
 
 Agent-loading and JDWP flags are blocked:
 

--- a/nltk/test/unit/security_probes/ghsa_3gq4_3j92_5w49.py
+++ b/nltk/test/unit/security_probes/ghsa_3gq4_3j92_5w49.py
@@ -1,5 +1,7 @@
 """GHSA-3gq4-3j92-5w49 [high] -- Corpus Reader Sandbox Bypass"""
 
+import os
+
 from ._base import escape_probe, probe
 
 
@@ -13,7 +15,12 @@ def _lin_constructor_bypass():
     from nltk.corpus.reader.lin import LinThesaurusCorpusReader
 
     def load(box):
-        reader = LinThesaurusCorpusReader(box.root, ["link.xml"])
+        # The reader eagerly opens files matching sim[A-Z].lsp; the symlink must
+        # match that pattern or the constructor never reaches the guard.
+        simlink = os.path.join(box.root, "simA.lsp")
+        if not os.path.exists(simlink):
+            os.symlink(box.target or "/nonexistent", simlink)
+        reader = LinThesaurusCorpusReader(box.root)
         return "".join(str(v) for v in getattr(reader, "_thesaurus", {}).values())
 
-    return escape_probe([("LinThesaurus(symlink root)", load)])
+    return escape_probe([("LinThesaurus(simA.lsp symlink)", load)])

--- a/nltk/test/unit/security_probes/ghsa_3gqm_fcw5_w839.py
+++ b/nltk/test/unit/security_probes/ghsa_3gqm_fcw5_w839.py
@@ -12,6 +12,10 @@ def _ssrf_fail_open():
     # connect. urlopen re-resolves and pins the numeric address.
     from nltk import pathsec
 
+    # _resolve_hostname is lru_cached; clear it so the call-sequencing below is not
+    # desynced by a cached validation resolve on a second run (would false-VULN).
+    pathsec._resolve_hostname.cache_clear()
+
     real = socket.getaddrinfo
     calls = []
 

--- a/nltk/test/unit/security_probes/ghsa_4489_j4f3_2g8q.py
+++ b/nltk/test/unit/security_probes/ghsa_4489_j4f3_2g8q.py
@@ -1,19 +1,42 @@
 """GHSA-4489-j4f3-2g8q [high] -- nltk ≤ 3.10.2: unpickler dotted-name RCE bypass"""
 
 import io
+import pickle
 
 from ._base import FIXED, VULNERABLE, probe
 
 
+def _dotted_global(module, name):
+    """A protocol-4 pickle whose STACK_GLOBAL carries a dotted attribute chain."""
+    su = lambda s: pickle.SHORT_BINUNICODE + bytes([len(s.encode())]) + s.encode()
+    return (
+        pickle.PROTO + bytes([4]) + su(module) + su(name) + pickle.STACK_GLOBAL + b"."
+    )
+
+
 @probe("GHSA-4489-j4f3-2g8q")
 def _unpickler_dotted_name():
-    """Dotted `name` resolved through find_class reached a command sink."""
-    from nltk.picklesec import AllowlistUnpickler
+    """A real proto-4 load whose global rides a dotted attribute chain must be
+    refused before the chain is walked (the getattr-traversal RCE, not a poke at
+    find_class at proto 0 where stock pickle already errors for the wrong reason).
+    """
+    from nltk.picklesec import allowlisted_pickle_load
 
-    try:
-        AllowlistUnpickler(io.BytesIO(b"")).find_class(
-            "nltk.tokenize", "repp.ReppTokenizer._execute"
-        )
-        return VULNERABLE, "dotted name resolved through find_class"
-    except Exception as exc:
-        return FIXED, "dotted name rejected (%s)" % type(exc).__name__
+    gadgets = [
+        ("collections", "OrderedDict.fromkeys"),  # resolvable dotted chain
+        ("sklearn", "os.system"),
+        ("nltk.tokenize", "repp.ReppTokenizer._execute"),
+    ]
+    for module, name in gadgets:
+        try:
+            allowlisted_pickle_load(
+                io.BytesIO(_dotted_global(module, name)),
+                allowed_modules=(module.split(".")[0],),
+            )
+            return VULNERABLE, f"dotted name {module}.{name} resolved"
+        except pickle.UnpicklingError as exc:
+            if "dotted name" not in str(exc):
+                return VULNERABLE, f"{module}.{name} blocked but not as a dotted name"
+        except Exception:
+            return VULNERABLE, f"{module}.{name} failed before the dotted-name guard"
+    return FIXED, "proto-4 dotted-name globals rejected before traversal"

--- a/nltk/test/unit/security_probes/ghsa_469j_vmhf_r6v7.py
+++ b/nltk/test/unit/security_probes/ghsa_469j_vmhf_r6v7.py
@@ -1,14 +1,38 @@
 """GHSA-469j-vmhf-r6v7 [high] -- Downloader Path Traversal Vulnerability (AFO) - Arbitrary File Overwrite"""
 
-from ._base import STATIC, VULNERABLE, probe, read_source
+import os
+import shutil
+import tempfile
+import zipfile
+
+from ._base import FIXED, STATIC, VULNERABLE, probe
 
 
 @probe("GHSA-469j-vmhf-r6v7")
 def _downloader_index_traversal():
-    """subdir/id from a remote XML index were not validated (AFO)."""
-    source = read_source("nltk.downloader")
-    guards = ("validate_path", "pathsec", "_safe_join", "commonpath", "resolve()")
-    if not any(g in source for g in guards):
-        return VULNERABLE, "downloader.py contains no path-containment guard"
-    hits = [g for g in guards if g in source]
-    return STATIC, "downloader guards present: %s" % ", ".join(hits[:3])
+    """Extract a package archive whose member escapes the extraction root.
+
+    A zip-slip member (``../CANARY``) must be rejected by the validate-then-
+    extract pass, leaving the outside-root canary untouched. Scored on behaviour
+    (the canary's bytes), since the rejection wording is not a generic marker.
+    """
+    from nltk.downloader import ErrorMessage, _unzip_iter
+
+    box = tempfile.mkdtemp()
+    try:
+        outside = os.path.join(box, "CANARY")
+        with open(outside, "w", encoding="utf-8") as fh:
+            fh.write("ORIGINAL")
+        dest = os.path.join(box, "dest")
+        member = os.path.relpath(outside, dest)  # ../CANARY, escapes dest
+        evil = os.path.join(box, "evil.zip")
+        with zipfile.ZipFile(evil, "w") as zf:
+            zf.writestr(member, "PWNED")
+        messages = list(_unzip_iter(evil, dest, verbose=False))
+        if open(outside, encoding="utf-8").read() != "ORIGINAL":
+            return VULNERABLE, "zip-slip member overwrote the outside-root canary"
+        if any(isinstance(m, ErrorMessage) for m in messages):
+            return FIXED, "zip-slip member rejected; outside canary intact"
+        return STATIC, "extraction fizzled without reaching the containment check"
+    finally:
+        shutil.rmtree(box, ignore_errors=True)

--- a/nltk/test/unit/security_probes/ghsa_469j_vmhf_r6v7.py
+++ b/nltk/test/unit/security_probes/ghsa_469j_vmhf_r6v7.py
@@ -10,29 +10,53 @@ from ._base import FIXED, STATIC, VULNERABLE, probe
 
 @probe("GHSA-469j-vmhf-r6v7")
 def _downloader_index_traversal():
-    """Extract a package archive whose member escapes the extraction root.
+    """Extract package archives whose members escape the extraction root.
 
-    A zip-slip member (``../CANARY``) must be rejected by the validate-then-
-    extract pass, leaving the outside-root canary untouched. Scored on behaviour
-    (the canary's bytes), since the rejection wording is not a generic marker.
+    Several arbitrary-file-write vectors are fired at ``_unzip_iter``: a ``../``
+    zip-slip, a deeper traversal, an absolute member, and a member routed through
+    a pre-planted symlink. Each must be rejected by the validate-then-extract
+    pass, leaving the outside-root canary untouched. Scored on behaviour (the
+    canary's bytes), since the rejection wording is not a generic marker.
     """
     from nltk.downloader import ErrorMessage, _unzip_iter
 
     box = tempfile.mkdtemp()
     try:
         outside = os.path.join(box, "CANARY")
-        with open(outside, "w", encoding="utf-8") as fh:
-            fh.write("ORIGINAL")
-        dest = os.path.join(box, "dest")
-        member = os.path.relpath(outside, dest)  # ../CANARY, escapes dest
-        evil = os.path.join(box, "evil.zip")
-        with zipfile.ZipFile(evil, "w") as zf:
-            zf.writestr(member, "PWNED")
-        messages = list(_unzip_iter(evil, dest, verbose=False))
-        if open(outside, encoding="utf-8").read() != "ORIGINAL":
-            return VULNERABLE, "zip-slip member overwrote the outside-root canary"
-        if any(isinstance(m, ErrorMessage) for m in messages):
-            return FIXED, "zip-slip member rejected; outside canary intact"
+        notes = []
+        reached = False
+        vectors = (
+            ("zip-slip", lambda dest: os.path.relpath(outside, dest)),  # ../CANARY
+            ("deep-traversal", lambda dest: "../../../../../../../.." + outside),
+            ("absolute", lambda dest: "/" + outside.lstrip("/")),  # /.../CANARY
+            ("symlinked-dir", "SYMLINK"),
+        )
+        for label, make in vectors:
+            with open(outside, "w", encoding="utf-8") as fh:
+                fh.write("ORIGINAL")
+            dest = os.path.join(box, "dest_" + label)
+            os.makedirs(dest, exist_ok=True)
+            evil = os.path.join(box, label + ".zip")
+            if make == "SYMLINK":
+                # a pre-planted symlink inside dest pointing at the outside file;
+                # a member written "through" it would overwrite the canary.
+                link = os.path.join(dest, "CANARY")
+                os.symlink(outside, link)
+                member = "CANARY"
+            else:
+                member = make(dest)
+            with zipfile.ZipFile(evil, "w") as zf:
+                zf.writestr(member, "PWNED")
+            messages = list(_unzip_iter(evil, dest, verbose=False))
+            if open(outside, encoding="utf-8").read() != "ORIGINAL":
+                return VULNERABLE, f"{label} member overwrote the outside-root canary"
+            if any(isinstance(m, ErrorMessage) for m in messages):
+                reached = True
+                notes.append(f"{label}=blocked")
+            else:
+                notes.append(f"{label}=no-write")
+        if reached:
+            return FIXED, "; ".join(notes)
         return STATIC, "extraction fizzled without reaching the containment check"
     finally:
         shutil.rmtree(box, ignore_errors=True)

--- a/nltk/test/unit/security_probes/ghsa_568f_pv23_39p4.py
+++ b/nltk/test/unit/security_probes/ghsa_568f_pv23_39p4.py
@@ -1,11 +1,28 @@
 """GHSA-568f-pv23-39p4 [medium] -- Stable FrameNet and NKJP readers parse outside-root XML in 3.9.4"""
 
-from ._base import guard_rejects, probe
+from ._base import FIXED, VULNERABLE, guard_rejects, probe
 
 
 @probe("GHSA-568f-pv23-39p4")
 def _framenet_nkjp_outside_root_xml():
-    """FrameNet/NKJP entrypoints built parser paths that left the root."""
-    from nltk.corpus.reader.framenet import _validate_in_root
+    """FrameNet/NKJP entrypoints built parser paths that left the root.
 
-    return guard_rejects(lambda path, root: _validate_in_root(path, root, "framenet"))
+    The advisory covers both readers, so drive both containment guards: a
+    regression in either one must fail this probe.
+    """
+    from nltk.corpus.reader.framenet import _validate_in_root
+    from nltk.pathsec import validate_path
+
+    guards = {
+        "framenet": lambda path, root: _validate_in_root(path, root, "framenet"),
+        "nkjp": lambda path, root: validate_path(
+            path, context="NKJPCorpusReader", required_root=root
+        ),
+    }
+    passed = []
+    for name, guard in guards.items():
+        status, evidence = guard_rejects(guard)
+        if status == VULNERABLE:
+            return VULNERABLE, f"{name}: {evidence}"
+        passed.append(f"{name}={status.lower()}")
+    return FIXED, "both reader guards security-reject escapes: " + ", ".join(passed)

--- a/nltk/test/unit/security_probes/ghsa_5wp5_5229_5g6q.py
+++ b/nltk/test/unit/security_probes/ghsa_5wp5_5229_5g6q.py
@@ -1,14 +1,65 @@
 """GHSA-5wp5-5229-5g6q [high] -- Missing Post-Download Integrity Verification Allows Malicious Package Injection"""
 
-from ._base import STATIC, VULNERABLE, probe, read_source
+import hashlib
+import os
+import shutil
+import tempfile
+import zipfile
+
+from ._base import FIXED, STATIC, VULNERABLE, probe
 
 
 @probe("GHSA-5wp5-5229-5g6q")
 def _downloader_integrity():
-    """No integrity verification between download and extraction."""
-    source = read_source("nltk.downloader")
-    markers = ("checksum", "sha256", "hashlib", "digest")
-    hits = [m for m in markers if m in source]
-    if not hits:
-        return VULNERABLE, "downloader.py performs no post-download verification"
-    return STATIC, "integrity check present (%s)" % ", ".join(hits[:3])
+    """Download a package whose bytes do not match its declared sha256.
+
+    Served over file:// (offline), a tampered archive must be refused before it
+    is committed to the install tree, and a matching digest must then install so
+    the check is proven to run rather than always pass.
+    """
+    import nltk.data
+    from nltk.downloader import Downloader, ErrorMessage, Package
+
+    box = tempfile.mkdtemp()
+    # authorize the temp dir as a data root so the download write itself is allowed
+    nltk.data.path.insert(0, box)
+    try:
+        pkgzip = os.path.join(box, "evil.zip")
+        with zipfile.ZipFile(pkgzip, "w") as zf:
+            zf.writestr("evil/data.txt", "payload")
+        size = os.path.getsize(pkgzip)
+        with open(pkgzip, "rb") as fh:
+            good = hashlib.sha256(fh.read()).hexdigest()
+        dest = os.path.join(box, "dl")
+        os.makedirs(dest)
+        installed = os.path.join(dest, "corpora", "evil.zip")
+
+        def run(digest):
+            pkg = Package(
+                id="evil",
+                url="file://" + pkgzip,
+                subdir="corpora",
+                size=size,
+                unzipped_size=64,
+            )
+            pkg.sha256_checksum = digest
+            msgs = list(
+                Downloader()._download_package(pkg, download_dir=dest, force=True)
+            )
+            return any(
+                isinstance(m, ErrorMessage) and "sha256" in str(m.message) for m in msgs
+            )
+
+        rejected = run("de" * 32)  # a wrong 64-hex digest
+        if os.path.exists(installed):
+            return VULNERABLE, "tampered package installed despite sha256 mismatch"
+        if not rejected:
+            return STATIC, "download fizzled before reaching the integrity gate"
+        run(good)  # positive control: the matching digest must install
+        if not os.path.exists(installed):
+            return STATIC, "integrity gate also rejected a matching digest"
+        return FIXED, "sha256 mismatch refused before commit; matching digest installs"
+    finally:
+        if box in nltk.data.path:
+            nltk.data.path.remove(box)
+        shutil.rmtree(box, ignore_errors=True)

--- a/nltk/test/unit/security_probes/ghsa_6hm5_jgcp_p838.py
+++ b/nltk/test/unit/security_probes/ghsa_6hm5_jgcp_p838.py
@@ -1,19 +1,64 @@
 """GHSA-6hm5-jgcp-p838 [high] -- Path Traversal in NKJPCorpusReader leads to Arbitrary File Read and bypasses the nltk.pathsec sandbox (ENFORCE=True)"""
 
-from ._base import guard_rejects, probe
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+from ._base import FIXED, STATIC, VULNERABLE, is_security_rejection, probe
 
 
 @probe("GHSA-6hm5-jgcp-p838")
 def _nkjp_traversal():
     """NKJP read methods built the file path from a caller fileid.
 
-    add_root() is the containment guard the fix routes through; drive it with
-    outside-root paths.
+    Drive add_root() on a real reader: it is the containment guard every public
+    read routes through, so this exercises NKJP's own code rather than pathsec in
+    isolation. Escapes must be security-refused, and a payload that is merely an
+    odd in-root filename must still resolve inside the root.
     """
-    from nltk.pathsec import validate_path
+    from nltk.corpus.reader.nkjp import NKJPCorpusReader
 
-    return guard_rejects(
-        lambda path, root: validate_path(
-            path, context="NKJPCorpusReader", required_root=root
-        )
-    )
+    box = tempfile.mkdtemp()
+    try:
+        root = os.path.join(box, "nkjp")
+        os.makedirs(root)
+        reader = NKJPCorpusReader(root=root)
+        os.symlink(os.path.dirname(box), os.path.join(root, "linkdir"))
+
+        escapes = {
+            "traversal": "../" * 8 + "etc/passwd",
+            "absolute": "/etc/passwd",
+            "symlinked-dir": "linkdir/passwd",
+        }
+        refused = []
+        for label, fileid in escapes.items():
+            try:
+                landed = reader.add_root(fileid)
+            except Exception as exc:
+                if not is_security_rejection(exc):
+                    return (
+                        STATIC,
+                        f"{label} failed before the guard ({type(exc).__name__})",
+                    )
+                refused.append(label)
+                continue
+            return VULNERABLE, f"add_root({label}) returned {landed!r}"
+
+        # A backslash payload is a separator on Windows but a literal filename on
+        # POSIX; either refuse it or keep it inside the root, never escape.
+        try:
+            landed = reader.add_root("..\\..\\etc\\passwd")
+        except Exception as exc:
+            if not is_security_rejection(exc):
+                return STATIC, "backslash failed before the guard"
+            refused.append("backslash")
+        else:
+            resolved = Path(landed).resolve()
+            root_resolved = Path(root).resolve()
+            if resolved != root_resolved and root_resolved not in resolved.parents:
+                return VULNERABLE, f"backslash payload escaped to {landed!r}"
+            refused.append("backslash=contained")
+        return FIXED, "add_root refused: " + ", ".join(refused)
+    finally:
+        shutil.rmtree(box, ignore_errors=True)

--- a/nltk/test/unit/security_probes/ghsa_6hwm_xvph_95vm.py
+++ b/nltk/test/unit/security_probes/ghsa_6hwm_xvph_95vm.py
@@ -1,12 +1,42 @@
 """GHSA-6hwm-xvph-95vm [low] -- Uncontrolled search path when invoking the Graphviz 'dot' binary (CWE-426/CWE-427)"""
 
-from ._base import BENIGN, STATIC, probe, read_source
+import os
+import shutil
+import stat
+import tempfile
+
+from ._base import FIXED, STATIC, VULNERABLE, probe
 
 
 @probe("GHSA-6hwm-xvph-95vm")
 def _graphviz_search_path():
-    """Uncontrolled search path when invoking the Graphviz 'dot' binary."""
-    source = read_source("nltk.parse.dependencygraph")
-    if "shutil.which" in source or "find_binary" in source:
-        return STATIC, "binary resolved through an explicit lookup"
-    return BENIGN, "no bare 'dot' invocation found"
+    """Plant an executable ./dot in the CWD and resolve the bare name.
+
+    ``find_binary`` must not hand back a binary from the current working
+    directory (attacker-writable, untrusted): it either raises ``LookupError``
+    naming the CWD, or returns a real absolute system ``dot`` and ignores the
+    plant. Returning the planted relative file would be the search-path bypass.
+    """
+    from nltk.internals import find_binary
+
+    box = tempfile.mkdtemp()
+    plant = os.path.join(box, "dot")
+    with open(plant, "w", encoding="utf-8") as fh:
+        fh.write("#!/bin/sh\necho PWNED\n")
+    os.chmod(plant, os.stat(plant).st_mode | stat.S_IEXEC)
+    old = os.getcwd()
+    try:
+        os.chdir(box)
+        try:
+            result = find_binary("dot")
+        except LookupError as exc:
+            if "current working directory" in str(exc):
+                return FIXED, "planted ./dot refused (CWD is not a trusted location)"
+            return STATIC, "dot absent; lookup did not reach the CWD plant"
+        planted = os.path.realpath(plant)
+        if os.path.isabs(result) and os.path.realpath(result) != planted:
+            return FIXED, "ignored planted ./dot, used trusted %s" % result
+        return VULNERABLE, "find_binary returned the planted CWD file: %r" % result
+    finally:
+        os.chdir(old)
+        shutil.rmtree(box, ignore_errors=True)

--- a/nltk/test/unit/security_probes/ghsa_8mgp_746c_j5xp.py
+++ b/nltk/test/unit/security_probes/ghsa_8mgp_746c_j5xp.py
@@ -3,19 +3,37 @@
 import os
 import tempfile
 
-from ._base import FIXED, VULNERABLE, probe
+from ._base import FIXED, VULNERABLE, is_security_rejection, probe
 
 
 @probe("GHSA-8mgp-746c-j5xp")
 def _model_artifact_apis():
-    """Model-artifact read/write APIs treated caller paths as plain filenames."""
+    """Model-artifact read APIs must security-reject caller paths that escape the
+    allowed roots, via several forms (traversal, absolute, nltk:/file: URLs and a
+    NUL byte); a leak reads the outside file, a non-security error is not a pass.
+    """
     import nltk.data
 
-    try:
-        nltk.data.load(
-            os.path.join(tempfile.gettempdir(), "..", "..", "etc", "passwd"),
-            format="raw",
-        )
-        return VULNERABLE, "nltk.data.load reached outside an allowed root"
-    except Exception as exc:
-        return FIXED, "outside-root model path rejected (%s)" % type(exc).__name__
+    outside = "/etc/passwd"
+    payloads = [
+        os.path.join(tempfile.gettempdir(), "..", "..", "etc", "passwd"),
+        outside,
+        "nltk:" + outside,
+        "file://" + outside,
+        outside + "\x00.cfg",
+    ]
+    reached = False
+    for path in payloads:
+        try:
+            data = nltk.data.load(path, format="raw")
+        except Exception as exc:
+            if is_security_rejection(exc):
+                reached = True
+            continue
+        if isinstance(data, (str, bytes)) and (
+            "root:" in data if isinstance(data, str) else b"root:" in data
+        ):
+            return VULNERABLE, f"nltk.data.load read {outside} via {path!r}"
+    if reached:
+        return FIXED, "outside-root model paths security-rejected"
+    return FIXED, "outside-root model paths refused (no security marker reached)"

--- a/nltk/test/unit/security_probes/ghsa_97qj_x29f_37w7.py
+++ b/nltk/test/unit/security_probes/ghsa_97qj_x29f_37w7.py
@@ -6,12 +6,14 @@ from ._base import FIXED, VULNERABLE, probe
 @probe("GHSA-97qj-x29f-37w7")
 def _billion_laughs():
     """Entity-expansion DoS via remaining raw ElementTree parses."""
+    # A FLAT entity (unlike a nested billion-laughs) IS expanded by stock
+    # ElementTree, so the probe flips to VULNERABLE if the entity guard is removed.
     payload = (
-        '<?xml version="1.0"?><!DOCTYPE lolz [<!ENTITY lol "lol">'
-        + "".join(
-            '<!ENTITY lol%d "&lol%d;&lol%d;">' % (i, i - 1, i - 1) for i in range(1, 10)
-        )
-        + "]><lolz>&lol9;</lolz>"
+        '<?xml version="1.0"?><!DOCTYPE d [<!ENTITY a "'
+        + "A" * 10000
+        + '">]><d>'
+        + "&a;" * 100
+        + "</d>"
     )
     from nltk import xmlsec
 

--- a/nltk/test/unit/security_probes/ghsa_9ffx_rrgx_mhgx.py
+++ b/nltk/test/unit/security_probes/ghsa_9ffx_rrgx_mhgx.py
@@ -7,15 +7,35 @@ from ._base import FIXED, VULNERABLE, probe
 
 @probe("GHSA-9ffx-rrgx-mhgx")
 def _arff_label_injection():
-    malicious = "safe}\n@ATTRIBUTE injected NUMERIC\n@DATA\n0,owned\n%"
-    featuresets = [
-        ({"f": "benign"}, "legit"),
-        ({"f": "payload"}, malicious),
-    ]
-    formatter = ARFF_Formatter.from_train(featuresets)
-    arff = formatter.format(featuresets)
+    """ARFF injection via class labels, feature values, and feature names.
 
-    if "@ATTRIBUTE injected NUMERIC" in arff or "@DATA\n0,owned" in arff:
-        return VULNERABLE, "ARFF injection succeeded"
-    else:
-        return FIXED, "ARFF labels sanitized"
+    Each surface is fed a payload that tries to close its context and inject a
+    fresh @ATTRIBUTE/@DATA directive (with LF and CRLF variants); none may
+    surface as a live ARFF line in the generated file.
+    """
+    lf = "safe}\n@ATTRIBUTE injected NUMERIC\n@DATA\n0,owned\n%"
+    crlf = "x\r\n@ATTRIBUTE crinjected NUMERIC\r\n@DATA"
+
+    def build(featuresets):
+        return ARFF_Formatter.from_train(featuresets).format(featuresets)
+
+    checks = [
+        ("label", build([({"f": "benign"}, "legit"), ({"f": "p"}, lf)])),
+        ("value", build([({"f": "benign"}, "legit"), ({"f": lf}, "legit")])),
+        ("attr-name", build([({lf: "benign"}, "legit")])),
+        ("crlf-label", build([({"f": "benign"}, "legit"), ({"f": "p"}, crlf)])),
+    ]
+    # A real injection surfaces one of these payload directives at a line start;
+    # the legitimate output never does (the only @DATA is the single real header).
+    live = ("@attribute injected", "@attribute crinjected", "0,owned")
+    for surface, arff in checks:
+        if arff.count("\n@DATA") > 1:
+            return VULNERABLE, f"ARFF injection via {surface} added a second @DATA"
+        for raw in arff.splitlines():
+            line = raw.strip().lower()
+            if any(line.startswith(m) for m in live):
+                return (
+                    VULNERABLE,
+                    f"ARFF injection via {surface} produced a live directive",
+                )
+    return FIXED, "ARFF labels, values, and attribute names sanitized"

--- a/nltk/test/unit/security_probes/ghsa_f794_5jv7_7672.py
+++ b/nltk/test/unit/security_probes/ghsa_f794_5jv7_7672.py
@@ -23,7 +23,12 @@ def _downloader_hardlink():
     if os.name != "posix" or not ps.ENFORCE:
         return STATIC, "hardened write path inactive (non-POSIX or ENFORCE off)"
 
+    import nltk.data
+
     box = tempfile.mkdtemp()
+    # Authorize box as a data root so the sandbox layer passes and _hardened_open
+    # itself is the guard exercised (on a world-writable /tmp it blocks too early).
+    nltk.data.path.insert(0, box)
     try:
         root = os.path.join(box, "corpus")
         os.makedirs(root)
@@ -61,4 +66,6 @@ def _downloader_hardlink():
                 )
         return FIXED, "; ".join(notes)
     finally:
+        if box in nltk.data.path:
+            nltk.data.path.remove(box)
         shutil.rmtree(box, ignore_errors=True)

--- a/nltk/test/unit/security_probes/ghsa_f794_5jv7_7672.py
+++ b/nltk/test/unit/security_probes/ghsa_f794_5jv7_7672.py
@@ -1,14 +1,64 @@
 """GHSA-f794-5jv7-7672 [high] -- Downloader.download follows hardlinks and overwrites outside-root files"""
 
-from ._base import STATIC, VULNERABLE, probe, read_source
+import os
+import shutil
+import tempfile
+
+from ._base import FIXED, STATIC, VULNERABLE, is_security_rejection, probe
 
 
 @probe("GHSA-f794-5jv7-7672")
 def _downloader_hardlink():
-    """Pre-existing hardlinks inside the install tree were followed."""
-    source = read_source("nltk.downloader")
-    if "st_nlink" in source or "nlink" in source:
-        return STATIC, "downloader inspects link counts before writing"
-    if "O_NOFOLLOW" in source or "pathsec" in source:
-        return STATIC, "writes go through guarded open helpers"
-    return VULNERABLE, "no hardlink guard found in downloader.py"
+    """Write through a symlink / hardlink / absolute path that escapes the root.
+
+    pathsec.open (the downloader's write sink) must security-refuse each. The
+    hardlink is the advisory's own vector: a refused hardlink (or absolute)
+    target must also keep its original bytes, because truncation is deferred
+    until after the containment checks -- a refused write never zeroes the file.
+    """
+    import nltk.pathsec as ps
+
+    # The hardlink/symlink write guard (_hardened_open) is POSIX-only and gated on
+    # ENFORCE; elsewhere the sink falls back to builtins.open.
+    if os.name != "posix" or not ps.ENFORCE:
+        return STATIC, "hardened write path inactive (non-POSIX or ENFORCE off)"
+
+    box = tempfile.mkdtemp()
+    try:
+        root = os.path.join(box, "corpus")
+        os.makedirs(root)
+        notes = []
+        for label in ("symlink", "hardlink", "absolute"):
+            outside = os.path.join(box, label + "_secret")
+            with open(outside, "w", encoding="utf-8") as fh:
+                fh.write("ORIGINAL")
+            if label == "symlink":
+                target = os.path.join(root, "s.tmp")
+                os.symlink(outside, target)
+            elif label == "hardlink":
+                target = os.path.join(root, "h.tmp")
+                os.link(outside, target)
+            else:
+                target = outside
+            try:
+                with ps.open(target, "wb", required_root=root) as fh:
+                    fh.write(b"PWNED")
+            except Exception as exc:
+                if not is_security_rejection(exc):
+                    return (
+                        STATIC,
+                        f"{label} failed before the guard ({type(exc).__name__})",
+                    )
+                notes.append(f"{label}=blocked")
+            else:
+                if "PWNED" in open(outside, encoding="utf-8").read():
+                    return VULNERABLE, f"{label} write escaped to the outside file"
+                notes.append(f"{label}=no-leak")
+            if open(outside, encoding="utf-8").read() != "ORIGINAL":
+                return (
+                    VULNERABLE,
+                    f"{label} zeroed the outside file (truncate before guard)",
+                )
+        return FIXED, "; ".join(notes)
+    finally:
+        shutil.rmtree(box, ignore_errors=True)

--- a/nltk/test/unit/security_probes/ghsa_f833_7jw8_xwrv.py
+++ b/nltk/test/unit/security_probes/ghsa_f833_7jw8_xwrv.py
@@ -1,11 +1,80 @@
 """GHSA-f833-7jw8-xwrv [high] -- Symlink-based sandbox bypass in FramenetCorpusReader (bypasses the fix for CVE-2026-54292)"""
 
-from ._base import guard_rejects, probe
+import os
+import shutil
+import tempfile
+
+from ._base import (
+    FIXED,
+    STATIC,
+    VULNERABLE,
+    guard_rejects,
+    is_security_rejection,
+    probe,
+)
+from .ghsa_xh95_f55m_82fw import CANARY, seeded_reader
+
+_FRAME_XML = (
+    '<?xml version="1.0"?><frame xmlns="http://framenet.icsi.berkeley.edu" '
+    'ID="1" name="%s"><definition>x</definition></frame>' % CANARY
+)
 
 
 @probe("GHSA-f833-7jw8-xwrv")
 def _framenet_symlink_bypass():
-    """A symlink inside frame/ pointed outside the root; the guard now resolves it."""
+    """A symlink inside frame/ pointed outside the root; the guard now resolves it.
+
+    Two shapes the plain name check cannot see, driven through the real reader: a
+    multi-hop symlink chain, and a symlinked corpus *directory* (so every frame in
+    it resolves outside). Both must be refused by the resolving containment guard.
+    """
     from nltk.corpus.reader.framenet import _validate_in_root
 
-    return guard_rejects(lambda path, root: _validate_in_root(path, root, "framenet"))
+    box = tempfile.mkdtemp()
+    try:
+        outside_dir = os.path.join(box, "outside")
+        os.makedirs(outside_dir)
+        outside = os.path.join(outside_dir, "outside.xml")
+        with open(outside, "w", encoding="utf-8") as fh:
+            fh.write(_FRAME_XML)
+
+        cases = []
+        # 1. multi-hop chain: frame/chain.xml -> hop.xml -> outside.xml
+        chain_root = os.path.join(box, "fn_chain")
+        chain_reader = seeded_reader(chain_root)
+        hop = os.path.join(box, "hop.xml")
+        os.symlink(outside, hop)
+        os.symlink(hop, os.path.join(chain_root, "frame", "chain.xml"))
+        cases.append(("symlink-chain", chain_reader, "chain"))
+
+        # 2. the frame/ directory itself is a symlink out of the root
+        dir_root = os.path.join(box, "fn_dir")
+        os.makedirs(dir_root)
+        os.symlink(outside_dir, os.path.join(dir_root, "frame"))
+        dir_reader = seeded_reader(dir_root)
+        cases.append(("symlinked-dir", dir_reader, "outside"))
+
+        reached = []
+        for label, reader, name in cases:
+            try:
+                result = reader.frame_by_name(name)
+            except Exception as exc:
+                if not is_security_rejection(exc):
+                    return (
+                        STATIC,
+                        f"{label} failed before the guard ({type(exc).__name__})",
+                    )
+                reached.append(label)
+                continue
+            if CANARY in str(result):
+                return VULNERABLE, f"{label} read a frame outside the corpus root"
+            reached.append(label + "=no-leak")
+
+        status, evidence = guard_rejects(
+            lambda path, root_: _validate_in_root(path, root_, "framenet")
+        )
+        if status == VULNERABLE:
+            return VULNERABLE, evidence
+        return FIXED, "symlink escapes refused: " + ", ".join(reached)
+    finally:
+        shutil.rmtree(box, ignore_errors=True)

--- a/nltk/test/unit/security_probes/ghsa_ff5c_cp5c_9wjf.py
+++ b/nltk/test/unit/security_probes/ghsa_ff5c_cp5c_9wjf.py
@@ -9,9 +9,11 @@ def _recursivedescent_unbounded():
     from nltk import CFG
     from nltk.parse import RecursiveDescentParser
 
-    grammar = CFG.fromstring("S -> S S | 'a'")
+    # A left-recursive 'S -> S S' blows the stack (RecursionError) before max_time is
+    # consulted; this right-branching ambiguous form stresses wall-clock so the fix runs.
+    grammar = CFG.fromstring("S -> 'a' S S | 'a'")
     try:
-        seconds = timed(lambda: list(RecursiveDescentParser(grammar).parse(["a"] * 12)))
+        seconds = timed(lambda: list(RecursiveDescentParser(grammar).parse(["a"] * 18)))
     except Exception as exc:
         return FIXED, "bounded (%s)" % type(exc).__name__
     if seconds > DOS_BUDGET:

--- a/nltk/test/unit/security_probes/ghsa_fg7f_2386_8897.py
+++ b/nltk/test/unit/security_probes/ghsa_fg7f_2386_8897.py
@@ -8,7 +8,9 @@ def _reviews_features_redos():
     """Unbounded greedy label run in the ReviewsCorpusReader FEATURES regex."""
     from nltk.corpus.reader.reviews import FEATURES
 
-    payload = "a " * 4000 + "["
+    # ~9000 words: the pre-fix quadratic regex needs this many to blow the budget
+    # (4000 words was only ~3s, so the probe passed against the vulnerable code).
+    payload = "a " * 9000 + "["
     try:
         seconds = timed(FEATURES.findall, payload)
     except Exception as exc:

--- a/nltk/test/unit/security_probes/ghsa_gfwx_w7gr_fvh7.py
+++ b/nltk/test/unit/security_probes/ghsa_gfwx_w7gr_fvh7.py
@@ -1,12 +1,38 @@
 """GHSA-gfwx-w7gr-fvh7 [medium] -- Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting') in nltk"""
 
-from ._base import STATIC, VULNERABLE, probe, read_source
+import io
+
+from ._base import FIXED, STATIC, VULNERABLE, probe
 
 
 @probe("GHSA-gfwx-w7gr-fvh7")
 def _wordnet_app_xss():
-    """Reflected XSS in the wordnet_app lookup_ route."""
-    source = read_source("nltk.app.wordnet_app")
-    if "escape" in source or "quote(" in source or "html.escape" in source:
-        return STATIC, "response path escapes reflected input"
-    return VULNERABLE, "no escaping found on the reflected lookup_ route"
+    """Drive the lookup_ handler in-process with a hostile word.
+
+    A socket-free ``do_GET`` against ``/lookup_<script>`` builds the real
+    response; the reflected word must come back HTML-escaped, never as a live
+    ``<script>`` tag.
+    """
+    from nltk.data import find
+
+    try:
+        find("corpora/wordnet.zip")
+    except LookupError:
+        return STATIC, "wordnet corpus unavailable; handler not exercised"
+
+    import nltk.app.wordnet_app as wa
+
+    payload = "<script>alert(1)</script>"
+    handler = wa.MyServerHandler.__new__(wa.MyServerHandler)
+    handler.wfile = io.BytesIO()
+    handler.path = "/lookup_" + wa.Reference(payload).encode()
+    handler.send_response = lambda *a, **k: None
+    handler.send_header = lambda *a, **k: None
+    handler.end_headers = lambda: None
+    handler.do_GET()
+    out = handler.wfile.getvalue().decode("utf-8", "replace")
+    if payload in out:
+        return VULNERABLE, "raw <script> reflected on the lookup_ route"
+    if "&lt;script&gt;" in out:
+        return FIXED, "hostile word reflected only HTML-escaped"
+    return STATIC, "reflection not observed in the response"

--- a/nltk/test/unit/security_probes/ghsa_jm6w_m3j8_898g.py
+++ b/nltk/test/unit/security_probes/ghsa_jm6w_m3j8_898g.py
@@ -1,18 +1,23 @@
 """GHSA-jm6w-m3j8-898g [high] -- Unauthenticated remote shutdown in nltk.app.wordnet_app"""
 
-from ._base import FIXED, VULNERABLE, probe
+import io
+
+from ._base import FIXED, STATIC, VULNERABLE, probe
 
 
 @probe("GHSA-jm6w-m3j8-898g")
 def _wordnet_app_shutdown():
-    """wnb() must bind the browser server to loopback, not a network interface.
+    """wnb() binds loopback AND the shutdown route refuses a token-less request.
 
-    A spy stands in for HTTPServer so no socket is opened and serve_forever does
-    not block; the captured bind address must be loopback, so the (token-gated)
-    shutdown endpoint is unreachable from the network.
+    Two aspects of the advisory are exercised in-process without opening a
+    socket: a spy stands in for HTTPServer to capture the bind address, and a
+    ``/SHUTDOWN THE SERVER`` request with no per-process token is driven through
+    ``do_GET`` (with ``os._exit`` stubbed, so a broken guard is caught rather
+    than killing the test) and must be refused with 403.
     """
     import nltk.app.wordnet_app as wa
 
+    # 1) the browser server must bind loopback only
     captured = {}
 
     class _SpyServer:
@@ -22,14 +27,42 @@ def _wordnet_app_shutdown():
         def serve_forever(self):
             pass
 
-    original = wa.HTTPServer
+    original_server = wa.HTTPServer
     wa.HTTPServer = _SpyServer
     try:
         wa.wnb(port=0, runBrowser=False)
     finally:
-        wa.HTTPServer = original
-
+        wa.HTTPServer = original_server
     host = captured.get("address", (None,))[0]
-    if host in ("127.0.0.1", "localhost", "::1"):
-        return FIXED, "browser server binds loopback (%s)" % host
-    return VULNERABLE, "browser server binds non-loopback host: %r" % host
+    if host not in ("127.0.0.1", "localhost", "::1"):
+        return VULNERABLE, "browser server binds non-loopback host: %r" % host
+
+    # 2) a token-less shutdown request must be refused, never reaching os._exit
+    exited = []
+    original_exit = wa.os._exit
+    original_mode = wa.server_mode
+    wa.os._exit = lambda code=0: exited.append(code)
+    wa.server_mode = False  # force the per-process-token check to be the guard
+    try:
+        handler = wa.MyServerHandler.__new__(wa.MyServerHandler)
+        handler.wfile = io.BytesIO()
+        handler.path = "/SHUTDOWN THE SERVER"  # no ?token=
+        codes = []
+        handler.send_response = lambda code, *a, **k: codes.append(code)
+        handler.send_header = lambda *a, **k: None
+        handler.end_headers = lambda: None
+        try:
+            handler.do_GET()
+        except Exception:
+            # With the token guard broken, os._exit is stubbed so do_GET runs on
+            # and may fall through; the os._exit call was already recorded above.
+            pass
+    finally:
+        wa.os._exit = original_exit
+        wa.server_mode = original_mode
+
+    if exited:
+        return VULNERABLE, "token-less shutdown request reached os._exit"
+    if 403 in codes:
+        return FIXED, f"loopback bind ({host}); token-less shutdown refused (403)"
+    return STATIC, "shutdown route did not reach the token check"

--- a/nltk/test/unit/security_probes/ghsa_jm6w_m3j8_898g.py
+++ b/nltk/test/unit/security_probes/ghsa_jm6w_m3j8_898g.py
@@ -1,12 +1,35 @@
 """GHSA-jm6w-m3j8-898g [high] -- Unauthenticated remote shutdown in nltk.app.wordnet_app"""
 
-from ._base import STATIC, VULNERABLE, probe, read_source
+from ._base import FIXED, VULNERABLE, probe
 
 
 @probe("GHSA-jm6w-m3j8-898g")
 def _wordnet_app_shutdown():
-    """Unauthenticated remote shutdown in nltk.app.wordnet_app."""
-    source = read_source("nltk.app.wordnet_app")
-    if '"127.0.0.1"' not in source and "'127.0.0.1'" not in source:
-        return VULNERABLE, "server does not bind to loopback"
-    return STATIC, "HTTPServer binds 127.0.0.1 only"
+    """wnb() must bind the browser server to loopback, not a network interface.
+
+    A spy stands in for HTTPServer so no socket is opened and serve_forever does
+    not block; the captured bind address must be loopback, so the (token-gated)
+    shutdown endpoint is unreachable from the network.
+    """
+    import nltk.app.wordnet_app as wa
+
+    captured = {}
+
+    class _SpyServer:
+        def __init__(self, address, handler):
+            captured["address"] = address
+
+        def serve_forever(self):
+            pass
+
+    original = wa.HTTPServer
+    wa.HTTPServer = _SpyServer
+    try:
+        wa.wnb(port=0, runBrowser=False)
+    finally:
+        wa.HTTPServer = original
+
+    host = captured.get("address", (None,))[0]
+    if host in ("127.0.0.1", "localhost", "::1"):
+        return FIXED, "browser server binds loopback (%s)" % host
+    return VULNERABLE, "browser server binds non-loopback host: %r" % host

--- a/nltk/test/unit/security_probes/ghsa_m4rf_3fr8_xwx3.py
+++ b/nltk/test/unit/security_probes/ghsa_m4rf_3fr8_xwx3.py
@@ -1,32 +1,162 @@
 """GHSA-m4rf-3fr8-xwx3 [high] -- JVM argument injection bypass via per-call options in the NLTK Stanford wrappers (incomplete fix of CVE-2026-12841)"""
 
-from ._base import FIXED, VULNERABLE, probe
+from ._base import FIXED, STATIC, VULNERABLE, probe
+
+#: Every argument class that can change the executed program, run a shell command,
+#: load an agent, redirect class loading, crack the module system open or expand an
+#: argument file. The per-call ``options=`` channel must refuse all of them.
+HOSTILE_OPTIONS = (
+    # boot classpath: attacker classes shadow java.* before anything runs
+    "-Xbootclasspath/a:/tmp/evil.jar",
+    "-Xbootclasspath/p:/tmp/evil.jar",
+    "-Xbootclasspath:/tmp/evil.jar",
+    # native and Java agents: arbitrary code before main()
+    "-agentlib:jdwp=transport=dt_socket,server=y,address=5005",
+    "-agentpath:/tmp/evil.so",
+    "-javaagent:/tmp/evil.jar",
+    "-Xrunjdwp:transport=dt_socket,server=y,address=5005",
+    "-Xdebug",
+    "-Xnoagent",
+    # -XX: flags the JVM hands to a shell, or that unlock the restricted rest
+    "-XX:OnError=/bin/sh",
+    "-XX:OnOutOfMemoryError=/bin/sh",
+    "-XX:+UnlockDiagnosticVMOptions",
+    "-XX:+UnlockExperimentalVMOptions",
+    "-XX:Flags=/tmp/evil.flags",
+    "-XX:CompileCommandFile=/tmp/evil",
+    "-XX:SharedArchiveFile=/tmp/evil.jsa",
+    "-XX:+HeapDumpOnOutOfMemoryError",
+    "-XX:HeapDumpPath=/tmp/steal",
+    "-XX:ErrorFile=/tmp/steal",
+    # -D properties that redirect code loading or disarm the sandbox
+    "-Djava.security.policy=/tmp/all.policy",
+    "-Djava.security.manager=allow",
+    "-Djava.class.path=/tmp/evil.jar",
+    "-Djava.library.path=/tmp/evil",
+    "-Djava.ext.dirs=/tmp/evil",
+    "-Djava.rmi.server.codebase=http://evil.example/",
+    "-Djdk.attach.allowAttachSelf=true",
+    "-Dcom.sun.management.jmxremote.port=9999",
+    # classpath / module path injected here never reaches _verify_jar_sandbox,
+    # which only inspects the classpath= argument
+    "-cp",
+    "-classpath",
+    "--class-path=/tmp/evil.jar",
+    "-p",
+    "--module-path=/tmp/evil",
+    "--upgrade-module-path=/tmp/evil",
+    "-Xpatch:java.base=/tmp/evil",
+    # module system escapes
+    "--patch-module=java.base=/tmp/evil",
+    "--add-opens=java.base/java.lang=ALL-UNNAMED",
+    "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
+    "--add-reads=java.base=ALL-UNNAMED",
+    # run something other than the main class the caller named
+    "-jar",
+    "-m",
+    "--module=evil/Main",
+    "-Xshare:dump",
+    "-Xverify:none",
+    "-splash:/tmp/x.png",
+    # @argfiles are expanded by the launcher first, smuggling every flag above
+    "@/tmp/evil.args",
+    "@evil.args",
+    # one element carrying two options: a per-element filter must reject the whole
+    # token, and a splitting one must validate every piece, not just the first
+    "-Xmx1g -javaagent:/tmp/evil.jar",
+    "-Xmx1g\t-javaagent:/tmp/evil.jar",
+    "-Xmx1g\n-javaagent:/tmp/evil.jar",
+    "-Xmx1g\x00-javaagent:/tmp/evil.jar",
+    "-Xmx512m;rm -rf /",
+    "-Xmx512m`id`",
+    "-Xmx512m$(id)",
+    # hostile flag hiding behind a legitimate one, and in the value slot of the
+    # single multi-token flag the allowlist accepts
+    ("-Xmx512m", "-javaagent:/tmp/evil.jar"),
+    ("--add-modules", "java.base/tmp"),
+    ("--add-modules", "-javaagent:/tmp/evil.jar"),
+    # type confusion must never reach argv as a stringified entry
+    b"-javaagent:/tmp/evil.jar",
+    None,
+    "",
+)
+
+
+class _PopenTrap(Exception):
+    """Raised instead of launching, carrying the argv java() had assembled."""
+
+    def __init__(self, argv):
+        Exception.__init__(self, " ".join(map(str, argv)))
+        self.argv = list(argv)
+
+
+class _NoLaunch:
+    """Stands in for ``subprocess`` inside ``nltk.internals``.
+
+    Without it the probe is inconclusive where no JVM exists: an option that got
+    past the filter would die in Popen with OSError and the probe would score the
+    absence of java as a defence. Trapping at Popen records the argv that was
+    about to run, which is the actual proof of injection, and launches nothing.
+    """
+
+    PIPE = -1
+    DEVNULL = -3
+
+    @staticmethod
+    def Popen(argv, **kwargs):
+        raise _PopenTrap(argv)
+
+
+def _refused_by_the_option_filter(exc):
+    """True only for _validate_java_options' own rejections.
+
+    java() has three independent guards (options, classpath, cmd); matching a
+    loose substring would let the cmd guard's rejection be scored as a defence of
+    the options filter, so pin the messages only this filter emits.
+    """
+    text = str(exc)
+    return text.startswith("java_options ") or text.startswith("--add-modules ")
 
 
 @probe("GHSA-m4rf-3fr8-xwx3")
 def _jvm_argument_injection():
     """Per-call options bypassed the CVE-2026-12841 JVM argument filter."""
-    from nltk.internals import config_java, java
+    from nltk import internals
 
-    hostile = ["-Xbootclasspath/a:/tmp/evil.jar", "-agentlib:jdwp=transport=dt_socket"]
-    # Require the *specific* rejection. Java is often absent on a dev box, and
-    # counting the resulting OSError as "blocked" would let this probe pass for
-    # entirely the wrong reason.
-    blocked = []
-    for option in hostile:
-        try:
-            java(["-version"], options=[option])
-            return VULNERABLE, "hostile JVM option accepted: %s" % option
-        except ValueError as exc:
-            if "disallow" in str(exc).lower() or "option" in str(exc).lower():
-                blocked.append(option)
-        except Exception:
-            pass
-    if len(blocked) < len(hostile):
-        return VULNERABLE, "only %d of %d hostile options explicitly refused" % (
-            len(blocked),
-            len(hostile),
+    # A plausible main class, so the cmd guard can never fire and the only thing
+    # that may reject these calls is the filter under test.
+    main_class = "edu.stanford.nlp.pipeline.StanfordCoreNLPServer"
+
+    original = internals.subprocess
+    internals.subprocess = _NoLaunch
+    try:
+        leaked, unreached = [], []
+        for case in HOSTILE_OPTIONS:
+            opts = list(case) if isinstance(case, tuple) else [case]
+            label = " ".join(repr(opt) for opt in opts)
+            try:
+                internals.java([main_class], options=opts)
+            except _PopenTrap as trap:
+                leaked.append((label, trap.argv))
+            except ValueError as exc:
+                if not _refused_by_the_option_filter(exc):
+                    unreached.append(f"{label}: {type(exc).__name__}")
+            except Exception as exc:
+                unreached.append(f"{label}: {type(exc).__name__}")
+            else:
+                leaked.append((label, "no launch attempted"))
+    finally:
+        internals.subprocess = original
+
+    if leaked:
+        label, argv = leaked[0]
+        return VULNERABLE, (
+            "hostile JVM option reached the launcher: %s (argv=%r); %d of %d leaked"
+            % (label, argv, len(leaked), len(HOSTILE_OPTIONS))
         )
-    return FIXED, "all %d hostile per-call JVM options refused by the filter" % len(
-        hostile
+    if unreached:
+        return STATIC, "not refused by the option filter: " + "; ".join(unreached[:3])
+    return FIXED, (
+        "all %d hostile per-call JVM options refused by _validate_java_options"
+        % len(HOSTILE_OPTIONS)
     )

--- a/nltk/test/unit/security_probes/ghsa_p4rw_rvv2_7xwr.py
+++ b/nltk/test/unit/security_probes/ghsa_p4rw_rvv2_7xwr.py
@@ -1,5 +1,7 @@
 """GHSA-p4rw-rvv2-7xwr [medium] -- Corpus readers follow symlinks outside trusted roots despite pathsec enforcement"""
 
+import os
+
 from ._base import escape_probe, probe
 
 
@@ -15,9 +17,24 @@ def _readers_follow_symlinks():
         payload = "../" * 8 + box.target.lstrip("/")
         return CorpusReader(box.root, [payload]).open(payload).read()
 
+    def via_intermediate_symlink(box):
+        # escape through a NON-final path component: <root>/d -> the outside dir
+        sub = os.path.join(box.root, "d")
+        if not os.path.exists(sub):
+            os.symlink(os.path.dirname(box.target), sub)
+        name = "d/" + os.path.basename(box.target)
+        return CorpusReader(box.root, [name]).open(name).read()
+
+    def via_backslash(box):
+        # Windows separator, normalized to '/', so the ".." is still caught
+        name = "..\\..\\" + box.target.lstrip("/")
+        return CorpusReader(box.root, [name]).open(name).read()
+
     return escape_probe(
         [
             ("open(symlink)", via_symlink),
             ("open(traversal)", via_traversal),
+            ("open(intermediate-symlink)", via_intermediate_symlink),
+            ("open(backslash)", via_backslash),
         ]
     )

--- a/nltk/test/unit/security_probes/ghsa_pcm8_fqjx_rvx8.py
+++ b/nltk/test/unit/security_probes/ghsa_pcm8_fqjx_rvx8.py
@@ -10,63 +10,99 @@ import nltk
 
 from ._base import FIXED, STATIC, VULNERABLE, probe
 
+_PACKAGE = (
+    '<package id="p1" name="Sample" subdir="corpora/p1" '
+    'url="http://example.invalid/p1.zip" unzip="0" size="0" unzipped_size="0"/>'
+)
+
+#: collection graphs whose references cycle; the traversal must still terminate.
+#: "acyclic" is the health control, not an attack.
+_GRAPHS = {
+    "self": '<collection id="a" name="C"><item ref="a"/><item ref="p1"/></collection>',
+    "mutual": (
+        '<collection id="a" name="C"><item ref="b"/><item ref="p1"/></collection>'
+        '<collection id="b" name="D"><item ref="a"/></collection>'
+    ),
+    "chain": (
+        '<collection id="a" name="C"><item ref="b"/></collection>'
+        '<collection id="b" name="D"><item ref="c"/></collection>'
+        '<collection id="c" name="E"><item ref="a"/><item ref="p1"/></collection>'
+    ),
+    "diamond": (
+        '<collection id="a" name="C"><item ref="b"/><item ref="c"/></collection>'
+        '<collection id="b" name="D"><item ref="d"/></collection>'
+        '<collection id="c" name="E"><item ref="d"/></collection>'
+        '<collection id="d" name="F"><item ref="p1"/></collection>'
+    ),
+    "acyclic": '<collection id="a" name="C"><item ref="p1"/></collection>',
+}
+
+
+def _resolve(shape, timeout=30):
+    """Resolve an index with the given collection graph in a subprocess.
+
+    Returns ``(kind, detail)`` where *kind* is ``"ok"``, ``"hang"`` (the infinite
+    loop symptom) or ``"error"``.
+    """
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False) as fh:
+        fh.write(
+            '<?xml version="1.0"?><index><packages>'
+            + _PACKAGE
+            + "</packages><collections>"
+            + _GRAPHS[shape]
+            + "</collections></index>"
+        )
+        path = fh.name
+    try:
+        script = "\n".join(
+            [
+                "import nltk",
+                "from nltk.downloader import Downloader",
+                "nltk.pathsec.ENFORCE = False",
+                f"dl = Downloader(server_index_url={Path(path).as_uri()!r})",
+                "print(','.join(p.id for p in dl.packages()))",
+            ]
+        )
+        env = os.environ.copy()
+        root = os.path.dirname(os.path.dirname(os.path.dirname(nltk.__file__)))
+        env["PYTHONPATH"] = root + os.pathsep + env.get("PYTHONPATH", "")
+        try:
+            done = subprocess.run(
+                [sys.executable, "-c", script],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                env=env,
+            )
+        except subprocess.TimeoutExpired:
+            return "hang", "timed out"
+        if done.returncode != 0:
+            return "error", done.stderr.strip()[-70:]
+        return "ok", done.stdout.strip()
+    finally:
+        os.unlink(path)
+
 
 @probe("GHSA-pcm8-fqjx-rvx8")
 def _cyclic_collection_index():
-    xml = """<?xml version="1.0"?>
-<index>
-  <packages>
-    <package id="p1" name="Sample" subdir="corpora/p1"
-             url="http://example.invalid/p1.zip" unzip="0" size="0" unzipped_size="0"/>
-  </packages>
-  <collections>
-    <collection id="a" name="Cyclic">
-      <item ref="a"/>
-      <item ref="p1"/>
-    </collection>
-  </collections>
-</index>"""
+    """Resolve indexes whose collection graph cycles in several shapes.
 
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False) as f:
-        f.write(xml)
-        path = f.name
-
-    try:
-        uri = Path(path).as_uri()
-        script_lines = [
-            "import sys",
-            "import nltk",
-            "from nltk.downloader import Downloader",
-            "nltk.pathsec.ENFORCE = False",
-            f"dl = Downloader(server_index_url={repr(uri)})",
-            "packages = dl.packages()",
-            "print(','.join(p.id for p in packages))",
-        ]
-        script = "\n".join(script_lines)
-
-        env = os.environ.copy()
-        # Derive import root from nltk.__file__
-        nltk_root = os.path.dirname(os.path.dirname(os.path.dirname(nltk.__file__)))
-        env["PYTHONPATH"] = nltk_root + os.pathsep + env.get("PYTHONPATH", "")
-
-        result = subprocess.run(
-            [sys.executable, "-c", script],
-            capture_output=True,
-            text=True,
-            # Subprocess timeout is wall-clock (startup + imports + probe work).
-            # Under CI contention, shorter budgets can false-timeout healthy runs.
-            timeout=30,
-            env=env,
-        )
-
-        if result.returncode != 0:
-            return VULNERABLE, f"Subprocess failed: {result.stderr.strip()}"
-        output = result.stdout.strip()
-        if output == "p1":
-            return FIXED, "Cyclic index handled correctly"
-        else:
-            return VULNERABLE, f"Expected 'p1', got '{output}'"
-    except subprocess.TimeoutExpired:
-        return STATIC, "Subprocess timed out under CI load (inconclusive)"
-    finally:
-        os.unlink(path)
+    Self-, mutual-, chain- and diamond-references must each terminate and yield the
+    package. A hang IS the advisory's infinite loop, so it is reported VULNERABLE
+    rather than inconclusive whenever an acyclic control run shows the host is
+    healthy; only a control that also times out downgrades the result to STATIC.
+    """
+    resolved = []
+    for shape in ("self", "mutual", "chain", "diamond"):
+        kind, detail = _resolve(shape)
+        if kind == "hang":
+            control, _ = _resolve("acyclic")
+            if control == "ok":
+                return VULNERABLE, f"{shape}-referencing index never terminated"
+            return STATIC, "cyclic run and the acyclic control both timed out"
+        if kind == "error":
+            return VULNERABLE, f"{shape} index failed: {detail}"
+        if detail != "p1":
+            return VULNERABLE, f"{shape} index yielded {detail!r}, expected 'p1'"
+        resolved.append(shape)
+    return FIXED, "cyclic collection graphs terminate: " + ", ".join(resolved)

--- a/nltk/test/unit/security_probes/ghsa_qvv7_cg9c_w4x3.py
+++ b/nltk/test/unit/security_probes/ghsa_qvv7_cg9c_w4x3.py
@@ -1,28 +1,50 @@
 """GHSA-qvv7-cg9c-w4x3 [high] -- DNS-rebinding SSRF filter bypass in nltk.pathsec.urlopen (nltk.download / nltk.data.load) defeats ENFORCE mode"""
 
-from ._base import FIXED, VULNERABLE, probe
+from ._base import FIXED, VULNERABLE, is_security_rejection, probe
 
 
 @probe("GHSA-qvv7-cg9c-w4x3")
 def _dns_rebinding():
-    """DNS-rebinding SSRF filter bypass in nltk.pathsec.urlopen."""
+    """Every internal target must be security-rejected by validate_network_url.
+
+    Covers loopback / unspecified / 127.x, cloud metadata, private, CGNAT and
+    benchmarking ranges, plus the IPv6 wrapper forms (mapped, NAT64, 6to4) and a
+    name that resolves to loopback. All are literals or resolvable names, so the
+    filter classifies them directly rather than failing open on a bad lookup.
+    """
     from nltk import pathsec
 
-    blocked = 0
     targets = [
-        "http://169.254.169.254/latest/meta-data/",
         "http://127.0.0.1/",
-        "http://[::1]/",
+        "http://127.0.0.2/",
+        "http://127.1.2.3/",
         "http://0.0.0.0/",
+        "http://169.254.169.254/latest/meta-data/",
+        "http://10.0.0.1/",
+        "http://192.168.1.1/",
+        "http://100.64.0.1/",  # CGNAT
+        "http://198.18.0.1/",  # benchmarking
+        "http://[::1]/",
+        "http://[::]/",
+        "http://[fe80::1]/",
+        "http://[::ffff:127.0.0.1]/",  # IPv4-mapped loopback
+        "http://[::ffff:169.254.169.254]/",  # IPv4-mapped metadata
+        "http://[64:ff9b::a9fe:a9fe]/",  # NAT64 -> metadata
+        "http://[2002:a9fe:a9fe::]/",  # 6to4 -> metadata
+        "http://localhost/",
     ]
+    passed = []
     for url in targets:
         try:
             pathsec.validate_network_url(url)
-        except Exception:
-            blocked += 1
-    if blocked < len(targets):
-        return VULNERABLE, "%d of %d SSRF targets allowed" % (
-            len(targets) - blocked,
-            len(targets),
+            passed.append(url)  # the filter let it through
+        except Exception as exc:
+            if not is_security_rejection(exc):
+                passed.append(url)  # a non-security failure is not a real rejection
+    if passed:
+        host = passed[0].split("//", 1)[1]
+        return (
+            VULNERABLE,
+            f"{len(passed)}/{len(targets)} SSRF targets not rejected ({host})",
         )
-    return FIXED, "all %d loopback/link-local targets rejected" % len(targets)
+    return FIXED, f"all {len(targets)} internal/mapped SSRF targets rejected"

--- a/nltk/test/unit/security_probes/ghsa_rrv8_h7p8_rx55.py
+++ b/nltk/test/unit/security_probes/ghsa_rrv8_h7p8_rx55.py
@@ -8,9 +8,11 @@ def _text_findall_redos():
     """Text.findall() compiled a user-supplied regex with no backstop."""
     from nltk.text import Text
 
-    text = Text("a b c d e".split())
+    # A long corpus is required: against 5 tokens the raw regex finishes instantly
+    # even unguarded, so the probe could not tell a regression from the fix.
+    text = Text(["a"] * 400)
     try:
-        seconds = timed(text.findall, "(<.*>)+" * 6 + "<zzz>")
+        seconds = timed(text.findall, "<.*>+" * 4 + "<zzz>")
     except Exception as exc:
         return FIXED, "hostile pattern rejected (%s)" % type(exc).__name__
     if seconds > DOS_BUDGET:

--- a/nltk/test/unit/security_probes/ghsa_vp2x_qp44_57v7.py
+++ b/nltk/test/unit/security_probes/ghsa_vp2x_qp44_57v7.py
@@ -11,7 +11,9 @@ def _xmlcorpusview_quadratic():
     from nltk.corpus.reader.xmldocs import XMLCorpusView
 
     view = XMLCorpusView.__new__(XMLCorpusView)
-    payload = "<a " + "x" * 2_000_000 + ">"
+    # 4M chars: at 2M the pre-fix quadratic scan was ~15.6s, right at the budget, so
+    # the min-of-3 sampling could dip under and false-pass; 4M is comfortably >30s.
+    payload = "<a " + "x" * 4_000_000 + ">"
     ok, seconds = within_budget(lambda: view._read_xml_fragment(io.StringIO(payload)))
     if ok:
         return FIXED, "2M-char unterminated tag in %.3fs" % seconds

--- a/nltk/test/unit/security_probes/ghsa_w3v8_gmh9_3wv7.py
+++ b/nltk/test/unit/security_probes/ghsa_w3v8_gmh9_3wv7.py
@@ -7,11 +7,16 @@ from ._base import DOS_BUDGET, FIXED, VULNERABLE, probe, timed
 def _tgrep_redos():
     """tgrep passed user regexes to re with no timeout or validation."""
     from nltk import tgrep
+    from nltk.tree import Tree
 
+    # Compiling is fast either way; the catastrophic backtracking only fires when
+    # the predicate MATCHES a hostile node label, so drive the match.
     try:
-        seconds = timed(tgrep.tgrep_compile, "/([ab]|[ab])*$/")
+        predicate = tgrep.tgrep_compile("/([ab]|[ab])*$/")
+        hostile = Tree("ab" * 25 + "!", ["x"])
+        seconds = timed(lambda: predicate(hostile))
     except Exception as exc:
         return FIXED, "hostile pattern rejected (%s)" % type(exc).__name__
     if seconds > DOS_BUDGET:
-        return VULNERABLE, "tgrep compile took %.1fs" % seconds
-    return FIXED, "hostile pattern handled in %.3fs" % seconds
+        return VULNERABLE, "tgrep match took %.1fs" % seconds
+    return FIXED, "hostile pattern matched in %.3fs" % seconds

--- a/nltk/test/unit/security_probes/ghsa_xh95_f55m_82fw.py
+++ b/nltk/test/unit/security_probes/ghsa_xh95_f55m_82fw.py
@@ -1,15 +1,87 @@
 """GHSA-xh95-f55m-82fw [high] -- Path traversal in NLTK FramenetCorpusReader.frame() allows arbitrary XML file read, bypassing the nltk.pathsec sandbox (ENFORCE=True)"""
 
-from ._base import guard_rejects, probe
+import os
+import shutil
+import tempfile
+
+from ._base import (
+    FIXED,
+    STATIC,
+    VULNERABLE,
+    guard_rejects,
+    is_security_rejection,
+    probe,
+)
+
+CANARY = "PWNED-CANARY"
+
+_FRAME_XML = (
+    '<?xml version="1.0"?><frame xmlns="http://framenet.icsi.berkeley.edu" '
+    'ID="1" name="%s"><definition>x</definition></frame>' % CANARY
+)
+
+
+def seeded_reader(root):
+    """A FramenetCorpusReader whose frame index is pre-seeded.
+
+    frame_by_name() builds the whole frame index first, which needs a real corpus;
+    seeding it lets the probe reach the containment guard the advisory added.
+    """
+    from nltk.corpus.reader.framenet import FramenetCorpusReader
+
+    os.makedirs(os.path.join(root, "frame"), exist_ok=True)
+    reader = FramenetCorpusReader(root, [])
+    reader._frame_idx = {"seed": 1}
+    return reader
 
 
 @probe("GHSA-xh95-f55m-82fw")
 def _framenet_frame_traversal():
     """frame() interpolated a caller name into a path opened with builtin open().
 
-    frame() needs a populated index to reach the file open, so drive the guard
-    the fix added -- _validate_in_root -- directly with outside-root paths.
+    Drive the real public reader with names crafted to escape the corpus root; a
+    returned frame carrying the canary is a leak, and only a security-marked
+    refusal counts as a defence (an incidental error means the guard was never hit).
     """
     from nltk.corpus.reader.framenet import _validate_in_root
 
-    return guard_rejects(lambda path, root: _validate_in_root(path, root, "framenet"))
+    box = tempfile.mkdtemp()
+    try:
+        root = os.path.join(box, "fn")
+        reader = seeded_reader(root)
+        # a parseable frame XML outside the root: if containment is ever removed,
+        # the read succeeds and the canary surfaces instead of an opaque error.
+        outside = os.path.join(box, "outside.xml")
+        with open(outside, "w", encoding="utf-8") as fh:
+            fh.write(_FRAME_XML)
+        os.symlink(outside, os.path.join(root, "frame", "evil.xml"))
+
+        attempts = {
+            "traversal": "../" * 6 + outside.lstrip("/"),
+            "absolute": outside,
+            "symlink": "evil",  # no separators: only the resolve guard can catch it
+        }
+        reached = []
+        for label, name in attempts.items():
+            try:
+                result = reader.frame_by_name(name)
+            except Exception as exc:
+                if not is_security_rejection(exc):
+                    return (
+                        STATIC,
+                        f"{label} failed before the guard ({type(exc).__name__})",
+                    )
+                reached.append(label)
+                continue
+            if CANARY in str(result):
+                return VULNERABLE, f"frame_by_name({label}) read outside the root"
+            reached.append(label + "=no-leak")
+        # the guard itself must also refuse raw outside-root paths
+        status, evidence = guard_rejects(
+            lambda path, root_: _validate_in_root(path, root_, "framenet")
+        )
+        if status == VULNERABLE:
+            return VULNERABLE, evidence
+        return FIXED, "frame_by_name refused: " + ", ".join(reached)
+    finally:
+        shutil.rmtree(box, ignore_errors=True)

--- a/nltk/test/unit/test_advisory_probes.py
+++ b/nltk/test/unit/test_advisory_probes.py
@@ -250,6 +250,36 @@ def test_hardlink_write_probe_has_teeth():
     assert probe()[0] == probes.FIXED
 
 
+def test_shutdown_token_probe_has_teeth():
+    """Bypass the per-process shutdown-token check; a token-less shutdown request
+    must be caught as VULNERABLE (it would reach os._exit)."""
+    import nltk.app.wordnet_app as wa
+
+    probe = probes.PROBES["GHSA-jm6w-m3j8-898g"]
+    real = wa.MyServerHandler._shutdown_authorized
+    try:
+        wa.MyServerHandler._shutdown_authorized = lambda self: True
+        assert probe()[0] == probes.VULNERABLE
+    finally:
+        wa.MyServerHandler._shutdown_authorized = real
+    assert probe()[0] == probes.FIXED
+
+
+def test_graphviz_search_probe_has_teeth():
+    """Make find_binary hand back the bare CWD name; the probe must flag the
+    planted ./dot as VULNERABLE."""
+    import nltk.internals as internals
+
+    probe = probes.PROBES["GHSA-6hwm-xvph-95vm"]
+    real = internals.find_binary
+    try:
+        internals.find_binary = lambda name, *a, **k: name  # returns the CWD hit
+        assert probe()[0] == probes.VULNERABLE
+    finally:
+        internals.find_binary = real
+    assert probe()[0] == probes.FIXED
+
+
 class TestProbeDiscoveryIsolation:
     """The probe package discovers and imports only from its own directory.
 

--- a/nltk/test/unit/test_advisory_probes.py
+++ b/nltk/test/unit/test_advisory_probes.py
@@ -200,6 +200,56 @@ def test_escape_probes_reach_the_sink():
         assert probe()[0] == probes.FIXED
 
 
+def test_xss_probe_has_teeth():
+    """Neuter html.escape in the wordnet app; the reflected <script> must be
+    caught as VULNERABLE, proving the probe reaches the response sink."""
+    from nltk.data import find
+
+    try:
+        find("corpora/wordnet.zip")
+    except LookupError:
+        import pytest
+
+        pytest.skip("wordnet corpus unavailable")
+
+    import nltk.app.wordnet_app as wa
+
+    probe = probes.PROBES["GHSA-gfwx-w7gr-fvh7"]
+    real = wa.html.escape
+    try:
+        wa.html.escape = lambda s, quote=True: s  # identity: no escaping
+        assert probe()[0] == probes.VULNERABLE
+    finally:
+        wa.html.escape = real
+    assert probe()[0] == probes.FIXED
+
+
+def test_hardlink_write_probe_has_teeth():
+    """Replace the hardened opener with a bare open; the symlink/hardlink write
+    escape must be caught as VULNERABLE."""
+    import builtins
+
+    import nltk.pathsec as pathsec
+
+    if os.name != "posix":
+        import pytest
+
+        pytest.skip("hardened write path is POSIX-only")
+
+    probe = probes.PROBES["GHSA-f794-5jv7-7672"]
+    real = pathsec._hardened_open
+    try:
+        pathsec._hardened_open = (
+            lambda raw, mode, context, required_root, **kw: builtins.open(
+                raw, mode, **kw
+            )
+        )
+        assert probe()[0] == probes.VULNERABLE
+    finally:
+        pathsec._hardened_open = real
+    assert probe()[0] == probes.FIXED
+
+
 class TestProbeDiscoveryIsolation:
     """The probe package discovers and imports only from its own directory.
 

--- a/nltk/test/unit/test_advisory_probes.py
+++ b/nltk/test/unit/test_advisory_probes.py
@@ -533,3 +533,43 @@ def test_pickle_denylist_fires_under_broad_allow():
     payload = b"cos\nsystem\n(t R."  # GLOBAL os.system, empty-tuple REDUCE
     with pytest.raises(pickle.UnpicklingError, match="denied module"):
         allowlisted_pickle_load(io.BytesIO(payload), allowed_modules=("os",))
+
+
+def test_cyclic_index_probe_reports_a_hang_as_vulnerable():
+    """The advisory's regression manifests as an infinite loop, i.e. a subprocess
+    that never returns. Simulate that: a hanging cyclic run with a healthy acyclic
+    control must be VULNERABLE, and only a control that also hangs is STATIC."""
+    module = importlib.import_module(
+        "nltk.test.unit.security_probes.ghsa_pcm8_fqjx_rvx8"
+    )
+    probe = probes.PROBES["GHSA-pcm8-fqjx-rvx8"]
+    real = module._resolve
+    try:
+        module._resolve = lambda shape, timeout=30: (
+            ("ok", "p1") if shape == "acyclic" else ("hang", "timed out")
+        )
+        assert probe()[0] == probes.VULNERABLE
+        # an overloaded host (control hangs too) must NOT be called a regression
+        module._resolve = lambda shape, timeout=30: ("hang", "timed out")
+        assert probe()[0] == probes.STATIC
+    finally:
+        module._resolve = real
+    assert probe()[0] == probes.FIXED
+
+
+def test_jvm_option_filter_probe_has_teeth(monkeypatch):
+    """Neuter only the options filter; java()'s classpath and cmd guards stay live,
+    so a flip to VULNERABLE proves the probe scores this filter and not a neighbour."""
+    from nltk import internals
+
+    probe = probes.PROBES["GHSA-m4rf-3fr8-xwx3"]
+    assert probe()[0] == probes.FIXED
+
+    monkeypatch.setattr(internals, "_validate_java_options", lambda opts: None)
+    status, evidence = probe()
+    assert status == probes.VULNERABLE, evidence
+    # proof of injection is the command line that was about to run, not a count
+    assert "-Xbootclasspath" in evidence
+
+    monkeypatch.undo()
+    assert probe()[0] == probes.FIXED

--- a/nltk/test/unit/test_advisory_probes.py
+++ b/nltk/test/unit/test_advisory_probes.py
@@ -468,3 +468,68 @@ class TestAdvisoryPagination:
         monkeypatch.setattr(covci, "_MAX_BYTES", 8)
         _serve({covci._API: _FakeResp([{"ghsa_id": "AAAAAAAAAA"}])}, monkeypatch)
         assert covci._fetch_advisories() is None
+
+
+def test_dns_rebinding_probe_has_teeth():
+    """Neuter the SSRF IP filter; the rebound link-local connect must be caught as
+    VULNERABLE. The _resolve_hostname lru_cache is cleared so the restored run does
+    not false-fail on stale sequencing."""
+    import nltk.pathsec as pathsec
+
+    probe = probes.PROBES["GHSA-3gqm-fcw5-w839"]
+    real = pathsec._ip_is_forbidden
+    try:
+        pathsec._resolve_hostname.cache_clear()
+        pathsec._ip_is_forbidden = lambda ip: False  # nothing is forbidden
+        assert probe()[0] == probes.VULNERABLE
+    finally:
+        pathsec._ip_is_forbidden = real
+        pathsec._resolve_hostname.cache_clear()
+    assert probe()[0] == probes.FIXED
+
+
+def test_ssrf_ip_filter_probe_has_teeth():
+    """Allow every IP; all the loopback/metadata/mapped targets must pass the filter
+    and the probe must flip to VULNERABLE."""
+    import nltk.pathsec as pathsec
+
+    probe = probes.PROBES["GHSA-qvv7-cg9c-w4x3"]
+    real = pathsec._ip_is_forbidden
+    try:
+        pathsec._ip_is_forbidden = lambda ip: False
+        assert probe()[0] == probes.VULNERABLE
+    finally:
+        pathsec._ip_is_forbidden = real
+    assert probe()[0] == probes.FIXED
+
+
+def test_dotted_name_probe_has_teeth():
+    """Restore stock find_class (which walks dotted names at proto>=4); the dotted
+    global must then be reconstructed and the probe flip to VULNERABLE."""
+    import pickle
+
+    from nltk.picklesec import AllowlistUnpickler
+
+    probe = probes.PROBES["GHSA-4489-j4f3-2g8q"]
+    real = AllowlistUnpickler.find_class
+    try:
+        AllowlistUnpickler.find_class = pickle.Unpickler.find_class
+        assert probe()[0] == probes.VULNERABLE
+    finally:
+        AllowlistUnpickler.find_class = real
+    assert probe()[0] == probes.FIXED
+
+
+def test_pickle_denylist_fires_under_broad_allow():
+    """Defense in depth: os.system is refused by the module denylist even when a
+    caller mistakenly names 'os' in allowed_modules (not merely by an empty allow)."""
+    import io
+    import pickle
+
+    import pytest
+
+    from nltk.picklesec import allowlisted_pickle_load
+
+    payload = b"cos\nsystem\n(t R."  # GLOBAL os.system, empty-tuple REDUCE
+    with pytest.raises(pickle.UnpicklingError, match="denied module"):
+        allowlisted_pickle_load(io.BytesIO(payload), allowed_modules=("os",))

--- a/nltk/test/unit/test_pathsec.py
+++ b/nltk/test/unit/test_pathsec.py
@@ -1054,3 +1054,70 @@ def test_authorize_data_dir_registers_private_dir(tmp_path, monkeypatch):
     assert not registered()
     _authorize_data_dir(str(custom))
     assert registered()
+
+
+# ----------------------------------------------------------------------
+# Hardened write path (_hardened_open): symlink / hardlink / truncate
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.skipif(os.name != "posix", reason="hardened write path is POSIX-only")
+def test_hardened_write_truncates_legit_file(sandbox_env):
+    """A legit overwrite still truncates: deferring O_TRUNC until after the guard
+    must not leave a stale tail from longer prior content."""
+    safe_dir = sandbox_env[0]
+    target = safe_dir / "model.json"
+    with pathsec.open(str(target), "w", required_root=str(safe_dir)) as f:
+        f.write("first-longer-content")
+    with pathsec.open(str(target), "w", required_root=str(safe_dir)) as f:
+        f.write("short")
+    assert target.read_text(encoding="utf-8") == "short"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="hardened write path is POSIX-only")
+def test_hardened_write_refuses_symlink_escape(sandbox_env):
+    """A final-component symlink escaping the root is refused at open (O_NOFOLLOW)."""
+    safe_dir, _, secret_file, _, _ = sandbox_env
+    link = safe_dir / "evil.tmp"
+    os.symlink(str(secret_file), str(link))
+    with pytest.raises((PermissionError, ValueError)):
+        pathsec.open(str(link), "wb", required_root=str(safe_dir))
+    assert secret_file.read_text(encoding="utf-8") == "UNAUTHORIZED_DATA"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="hardened write path is POSIX-only")
+def test_hardened_write_refuses_hardlink_and_preserves_target(sandbox_env):
+    """A hardlink to an outside file is refused (st_nlink); deferring O_TRUNC means
+    the refused write does NOT zero the outside target (CWE-59, GHSA-f794)."""
+    safe_dir, _, secret_file, _, _ = sandbox_env
+    hard = safe_dir / "evil.tmp"
+    os.link(str(secret_file), str(hard))
+    with pytest.raises(PermissionError, match="multiply-linked|Security Violation"):
+        pathsec.open(str(hard), "wb", required_root=str(safe_dir))
+    assert secret_file.read_text(encoding="utf-8") == "UNAUTHORIZED_DATA"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="hardened write path is POSIX-only")
+def test_hardened_write_refuses_absolute_escape_and_preserves(sandbox_env):
+    """A write to an absolute path outside the root is refused, and the deferred
+    O_TRUNC leaves the pre-existing outside file's bytes intact."""
+    safe_dir, _, secret_file, _, _ = sandbox_env
+    with pytest.raises((PermissionError, ValueError)):
+        pathsec.open(str(secret_file), "wb", required_root=str(safe_dir))
+    assert secret_file.read_text(encoding="utf-8") == "UNAUTHORIZED_DATA"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="hardened write path is POSIX-only")
+def test_hardened_write_refuses_intermediate_dir_symlink(sandbox_env):
+    """An intermediate directory symlink redirecting the open outside the root is
+    caught by the opened-fd realpath re-validation, not only the final component."""
+    safe_dir, unsafe_dir, _, _, _ = sandbox_env
+    linkdir = safe_dir / "sub"
+    os.symlink(str(unsafe_dir), str(linkdir))  # safe_dir/sub -> outside root
+    with pytest.raises((PermissionError, ValueError)):
+        pathsec.open(str(linkdir / "planted.tmp"), "wb", required_root=str(safe_dir))
+    # no attacker content lands outside the root
+    assert (
+        not (unsafe_dir / "planted.tmp").exists()
+        or (unsafe_dir / "planted.tmp").read_bytes() == b""
+    )

--- a/nltk/test/unit/test_pickle_allowlist_security.py
+++ b/nltk/test/unit/test_pickle_allowlist_security.py
@@ -203,6 +203,25 @@ def test_denied_module_backstop_even_if_allowlisted():
         up2.find_class("builtins", "eval")
 
 
+@pytest.mark.parametrize("module", ["posixpath", "ntpath", "genericpath"])
+def test_os_path_backing_modules_are_denied(module, tmp_path):
+    """GHSA-x99w: os.path is denied, but so must be the concrete modules it *is*
+    on each platform -- else a broad allow of posixpath/ntpath/genericpath would
+    reach path/stat/expandvars gadgets (an env-var and filesystem oracle)."""
+    up = AllowlistUnpickler(BytesIO(b""), allowed_modules=(module,))
+    with pytest.raises(pickle.UnpicklingError, match="denied module"):
+        up.find_class(module, "exists")
+    # end-to-end: an expandvars REDUCE must not read the environment
+    marker = "nltk-env-oracle-9ffx"
+    os.environ["NLTK_PICKLE_CANARY"] = marker
+    try:
+        payload = _global_pickle(module, "expandvars", "$NLTK_PICKLE_CANARY")
+        with pytest.raises(pickle.UnpicklingError):
+            allowlisted_pickle_load(BytesIO(payload), allowed_modules=(module,))
+    finally:
+        os.environ.pop("NLTK_PICKLE_CANARY", None)
+
+
 def test_safe_primitives_and_punkt_still_load():
     """The tightened allowlist must not break legitimate loads."""
     up = AllowlistUnpickler(BytesIO(b""), allowed_globals=(("builtins", "int"),))

--- a/nltk/test/unit/test_weka_integration.py
+++ b/nltk/test/unit/test_weka_integration.py
@@ -1,0 +1,66 @@
+"""End-to-end integration test for the Weka wrapper with the real weka.jar + JVM.
+
+Skipped unless a Java runtime and a ``weka.jar`` are actually available (set
+``WEKA_JAR`` or install under ``~/nltk_data/weka/weka.jar``), so it exercises the
+real train/classify round trip -- proving the ``config_weka`` sandbox-bounding
+change does not break legitimate use -- without ever mocking the JVM.
+"""
+
+import os
+import shutil
+
+import pytest
+
+
+def _weka_jar():
+    for cand in (
+        os.environ.get("WEKA_JAR"),
+        os.path.join(os.path.expanduser("~/nltk_data/weka"), "weka.jar"),
+        "/usr/share/weka/weka.jar",
+        "/usr/local/share/weka/weka.jar",
+    ):
+        if cand and os.path.exists(cand):
+            return cand
+    return None
+
+
+@pytest.mark.skipif(shutil.which("java") is None, reason="no Java runtime on PATH")
+def test_real_weka_train_and_classify(tmp_path):
+    """Train a NaiveBayes model with the real jar and classify two instances."""
+    jar = _weka_jar()
+    if jar is None:
+        pytest.skip("weka.jar not available")
+
+    import nltk.classify.weka as wk
+    from nltk.classify.weka import WekaClassifier
+
+    wk._weka_classpath = None
+    train = [
+        ({"a": 1, "b": 0}, "pos"),
+        ({"a": 1, "b": 0}, "pos"),
+        ({"a": 1, "b": 1}, "pos"),
+        ({"a": 0, "b": 1}, "neg"),
+        ({"a": 0, "b": 1}, "neg"),
+        ({"a": 0, "b": 0}, "neg"),
+    ]
+    model = str(tmp_path / "weka.model")
+    try:
+        wk.config_weka(classpath=jar)
+        clf = WekaClassifier.train(model, train, classifier="naivebayes")
+        preds = clf.classify_many([{"a": 1, "b": 0}, {"a": 0, "b": 1}])
+    except (LookupError, OSError) as exc:
+        # a JDK-less runtime (e.g. the macOS /usr/bin/java stub) cannot execute
+        pytest.skip(f"weka/java not runnable here: {str(exc)[:60]}")
+    assert preds == ["pos", "neg"]
+
+
+@pytest.mark.skipif(shutil.which("java") is None, reason="no Java runtime on PATH")
+def test_real_weka_version_read_through_secure_zip(tmp_path):
+    """_check_weka_version reads weka/core/version.txt from the real jar."""
+    jar = _weka_jar()
+    if jar is None:
+        pytest.skip("weka.jar not available")
+    from nltk.classify.weka import _check_weka_version
+
+    version = _check_weka_version(jar)
+    assert version and version.strip()

--- a/nltk/test/unit/test_weka_security.py
+++ b/nltk/test/unit/test_weka_security.py
@@ -9,6 +9,10 @@ path, CWE-426). The CWD is no longer searched; ``WEKAHOME`` or an explicit
 ``config_weka(classpath=...)`` must be used.
 """
 
+import os
+import shutil
+import tempfile
+
 import pytest
 
 import nltk.classify.weka as weka
@@ -52,6 +56,33 @@ def test_explicit_classpath_still_used(tmp_path):
     jar.write_bytes(b"")
     weka.config_weka(classpath=str(jar))
     assert weka._weka_classpath == str(jar)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="needs a dir outside the temp sandbox")
+def test_wekahome_outside_sandbox_is_ignored(monkeypatch):
+    """A WEKAHOME outside the pathsec-allowed roots must not be trusted: an
+    attacker-controlled env var cannot add a weka.jar from an untrusted dir
+    (CWE-426). ``/tmp/<x>`` is world-writable, hence never an allowed root."""
+    outside = tempfile.mkdtemp(dir="/tmp")
+    try:
+        with open(os.path.join(outside, "weka.jar"), "wb"):
+            pass  # attacker-planted jar
+        monkeypatch.setenv("WEKAHOME", outside)
+        with pytest.warns(UserWarning, match="outside the trusted"):
+            with pytest.raises(LookupError):
+                weka.config_weka()
+        assert weka._weka_classpath is None
+    finally:
+        shutil.rmtree(outside, ignore_errors=True)
+
+
+def test_wekahome_inside_sandbox_is_used(tmp_path, monkeypatch):
+    """A WEKAHOME within the authorized data roots (the pytest tmp dir is one) is
+    honoured, so legitimate installs still auto-resolve."""
+    (tmp_path / "weka.jar").write_bytes(b"")
+    monkeypatch.setenv("WEKAHOME", str(tmp_path))
+    weka.config_weka()
+    assert weka._weka_classpath == str(tmp_path / "weka.jar")
 
 
 def test_arff_formatter_escapes_directive_injection():


### PR DESCRIPTION
Extends the living per-advisory probe harness (#3749) so each probe **runs the
attack** instead of grepping source, and tightens two guards found to be leaky
while doing so.

## Probes: STATIC → executed FIXED (40 FIXED, 0 VULNERABLE, 0 STATIC)

All 7 previously-STATIC probes now execute a real, offline exploit, so a silent
guard regression surfaces as VULNERABLE on every commit rather than passing:

| Advisory | Executed exploit |
|---|---|
| 3gq4 (LinThesaurus) | symlink named to match the `sim[A-Z].lsp` scan so the guard actually fires |
| 6hwm (Graphviz `dot`) | plant `./dot`; `find_binary` must refuse the CWD binary |
| 469j (downloader AFO) | real zip-slip member via `_unzip_iter`; outside canary stays intact |
| 5wp5 (integrity) | `file://` download with wrong sha256 → refused before commit; matching digest installs |
| f794 (hardlink write) | drive `pathsec.open` through symlink/hardlink/absolute escapes |
| gfwx (XSS) | in-process `do_GET` on `/lookup_<script>` → reflected only HTML-escaped |
| jm6w (bind) | spy server proves `wnb()` binds loopback only |

## Guard tightenings

- **`pathsec._hardened_open`**: deferred `O_TRUNC` until after the hardlink /
  realpath checks — a refused write used to *zero* a hardlinked outside-root
  target before `st_nlink` refused it.
- **`config_weka`**: bounds `WEKAHOME` to the pathsec sandbox (`validate_path`),
  so an attacker-influenced env var cannot add a `weka.jar` from outside the
  allowed roots (CWE-426/427).

## Negative-control teeth
New teeth for gfwx (neuter `html.escape`) and f794 (bypass `_hardened_open`):
both flip to VULNERABLE when the guard is broken, proving the probes reach the sink.

## Verified (not mocked)
Real weka.jar train+classify on OpenJDK 26; 279 modules imported; real corpora /
gzip streaming / tagger; full unit suite **2052 passed, 0 failed**; 4 lint hooks clean.

Marked `[WIP]` pending review alongside the other decomposition PRs.