### PR TITLE
Prevent combinatorial DoS in skipgrams

### DIFF
--- a/nltk/test/unit/test_skipgrams.py
+++ b/nltk/test/unit/test_skipgrams.py
@@ -1,0 +1,40 @@
+import unittest
+
+from nltk.util import skipgrams
+
+
+class TestSkipgrams(unittest.TestCase):
+    """Unit tests for nltk.util.skipgrams, including CVE-2026-14595 mitigation."""
+
+    def test_skipgrams_basic(self):
+        """Test standard skipgram generation with benign inputs."""
+        tokens = ["Insurgents", "killed", "in", "ongoing", "fighting"]
+        result = list(skipgrams(tokens, 2, 2))
+        expected = [
+            ("Insurgents", "killed"),
+            ("Insurgents", "in"),
+            ("Insurgents", "ongoing"),
+            ("killed", "in"),
+            ("killed", "ongoing"),
+            ("killed", "fighting"),
+            ("in", "ongoing"),
+            ("in", "fighting"),
+            ("ongoing", "fighting"),
+        ]
+        self.assertEqual(result, expected)
+
+    def test_skipgrams_combinatorial_dos_mitigation(self):
+        """Verify that explosive (n, k) parameters raise ValueError (CVE-2026-14595)."""
+        tokens = [f"t{i}" for i in range(60)]
+
+        # n=7, k=30 yields math.comb(36, 6) = 1,947,792 combinations per window (> 1,000,000 limit)
+        gen = skipgrams(tokens, n=7, k=30)
+
+        with self.assertRaises(ValueError) as ctx:
+            # Use next() instead of list().
+            # If the fix is missing, this yields the first item instantly and fails the test.
+            # If the fix is present, it instantly raises our ValueError.
+            # This prevents the CI pipeline from hanging if a regression occurs!
+            next(gen)
+
+        self.assertIn("exceed the maximum allowed combinations", str(ctx.exception))

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -1047,6 +1047,8 @@ def trigrams(sequence, **kwargs):
 #: only affects the default; an explicitly supplied ``max_len`` is never capped.
 MAX_EVERYGRAMS_DEFAULT_LEN = 256
 
+MAX_SKIPGRAMS_COMBINATIONS_PER_WINDOW = 1_000_000
+
 
 def everygrams(
     sequence, min_len=1, max_len=-1, pad_left=False, pad_right=False, **kwargs
@@ -1146,14 +1148,32 @@ def skipgrams(sequence, n, k, **kwargs):
     :type  k: int
     :rtype: iter(tuple)
     """
+    if n < 1:
+        raise ValueError("n must be greater than or equal to 1")
+    if k < 0:
+        raise ValueError("k must be greater than or equal to 0")
 
-    MAX_COMBINATIONS_PER_WINDOW = 1_000_000
+    # Fast-path / safety check for n == 1 (no skip-tail combinations needed)
+    if n == 1:
+        if "pad_left" in kwargs or "pad_right" in kwargs:
+            sequence = pad_sequence(sequence, n, **kwargs)
+        for ngram in ngrams(sequence, 1 + k, pad_right=True, right_pad_symbol=object()):
+            if ngram[0] is not object():
+                yield (ngram[0],)
+        return
 
-    if n > 0 and (n + k - 1) >= (n - 1):
-        if math.comb(n + k - 1, n - 1) > MAX_COMBINATIONS_PER_WINDOW:
+    # Pre-check bounds before math.comb to prevent big-integer performance spikes on huge inputs
+    if (
+        n > MAX_SKIPGRAMS_COMBINATIONS_PER_WINDOW
+        or k > MAX_SKIPGRAMS_COMBINATIONS_PER_WINDOW
+    ):
+        raise ValueError(f"Skipgram parameters n={n} and k={k} are excessively large.")
+
+    if (n + k - 1) >= (n - 1):
+        if math.comb(n + k - 1, n - 1) > MAX_SKIPGRAMS_COMBINATIONS_PER_WINDOW:
             raise ValueError(
                 f"Skipgram parameters n={n} and k={k} exceed the maximum allowed "
-                f"combinations per window ({MAX_COMBINATIONS_PER_WINDOW})."
+                f"combinations per window ({MAX_SKIPGRAMS_COMBINATIONS_PER_WINDOW})."
             )
 
     # Pads the sequence as desired by **kwargs.

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -7,6 +7,7 @@
 # For license information, see LICENSE.TXT
 import inspect
 import locale
+import math
 import os
 import pydoc
 import re
@@ -1145,6 +1146,15 @@ def skipgrams(sequence, n, k, **kwargs):
     :type  k: int
     :rtype: iter(tuple)
     """
+
+    MAX_COMBINATIONS_PER_WINDOW = 1_000_000
+
+    if n > 0 and (n + k - 1) >= (n - 1):
+        if math.comb(n + k - 1, n - 1) > MAX_COMBINATIONS_PER_WINDOW:
+            raise ValueError(
+                f"Skipgram parameters n={n} and k={k} exceed the maximum allowed "
+                f"combinations per window ({MAX_COMBINATIONS_PER_WINDOW})."
+            )
 
     # Pads the sequence as desired by **kwargs.
     if "pad_left" in kwargs or "pad_right" in kwargs:


### PR DESCRIPTION
### **Description**

This PR addresses **CVE-2026-14595** (CWE-770), a resource exhaustion vulnerability where the `skipgrams` generator could be forced to allocate unbounded CPU and memory resources.

Because the generator enumerates all combinations for every sliding window, passing large values for the gram size (`n`) and skip distance (`k`) results in explosive combinatorial growth. A tiny sequence could previously generate millions or billions of tuples, leading to resource exhaustion and potential Denial of Service (DoS) in downstream applications accepting untrusted skipgram parameters.

**Changes Made:**

* **Mathematical Bounds Checking:** Introduced a pre-calculation check using `math.comb` to determine the exact number of combinations per window before allocating resources to the generator logic.
* **Hard Throttling:** The generator now raises a `ValueError` if the requested parameters exceed a safe threshold (capped at 1,000,000 combinations per window), effectively neutralizing the DoS vector while preserving legitimate natural language processing workloads.
* **Unit Testing:** Added `test_skipgrams.py` to ensure standard skipgram generation remains unaffected and to explicitly verify that abusive parameters trigger the `ValueError` when the generator is consumed.


### **Checklist**

* [x] Mitigates CVE-2026-14595 by bounding combinations.
* [x] Added `test_skipgrams_combinatorial_dos_mitigation` to the unit test suite.
* [x] Verified backward compatibility for benign NLP workloads.