### PR TITLE
Prevent IndexError in Hungarian stemmer on empty string

### DIFF
--- a/nltk/stem/snowball.py
+++ b/nltk/stem/snowball.py
@@ -2987,6 +2987,10 @@ class HungarianStemmer(_LanguageSpecificStemmer):
         """
         word = word.lower()
 
+        # Security fix for CVE-2026-14597: Guard against empty strings
+        if not word:
+            return word
+
         if word in self.stopwords:
             return word
 

--- a/nltk/test/unit/test_snowball.py
+++ b/nltk/test/unit/test_snowball.py
@@ -12,16 +12,10 @@ class TestSnowballStemmer(unittest.TestCase):
         crashing (CVE-2026-14597). Tests all supported Snowball languages.
         """
         for language in SnowballStemmer.languages:
-            stemmer = SnowballStemmer(language)
-
-            try:
-                result = stemmer.stem("")
+            with self.subTest(language=language):
+                stemmer = SnowballStemmer(language)
                 self.assertEqual(
-                    result,
+                    stemmer.stem(""),
                     "",
                     f"Stemmer for '{language}' failed to return empty string.",
-                )
-            except Exception as e:
-                self.fail(
-                    f"Stemmer for '{language}' raised {type(e).__name__} on empty string: {e}"
                 )

--- a/nltk/test/unit/test_snowball.py
+++ b/nltk/test/unit/test_snowball.py
@@ -1,0 +1,27 @@
+import unittest
+
+from nltk.stem.snowball import SnowballStemmer
+
+
+class TestSnowballStemmer(unittest.TestCase):
+    """Unit tests for the Snowball stemmer family."""
+
+    def test_empty_string_handling(self):
+        """
+        Verify that stemming an empty string returns an empty string without
+        crashing (CVE-2026-14597). Tests all supported Snowball languages.
+        """
+        for language in SnowballStemmer.languages:
+            stemmer = SnowballStemmer(language)
+
+            try:
+                result = stemmer.stem("")
+                self.assertEqual(
+                    result,
+                    "",
+                    f"Stemmer for '{language}' failed to return empty string.",
+                )
+            except Exception as e:
+                self.fail(
+                    f"Stemmer for '{language}' raised {type(e).__name__} on empty string: {e}"
+                )


### PR DESCRIPTION
### **Description**

This PR addresses **CVE-2026-14597** (CWE-248), a robustness issue where the Hungarian Snowball stemmer crashes with an `IndexError` when attempting to stem an empty token.

Because the `__r1_hungarian` helper method indexes the first character of the input word without verifying its length, passing an empty string (which can naturally arise from tokenizing untrusted or anomalous text) resulted in an uncaught exception. This crashed the stemming worker, leading to a localized Denial of Service (DoS).

**Changes Made:**

* Added a standard empty-string guard (`if not word: return word`) to the top of the Hungarian `stem()` method.
* This brings the Hungarian stemmer in line with the empty-string safety guards already present in the other Snowball language implementations.
* Added a unit test to ensure all Snowball stemmers safely handle empty strings without raising exceptions.
