### PR TITLE
[WIP] Make the GHSA-8mgp probe reach its sink and give it a negative control

### DIFF
--- a/nltk/classify/maxent.py
+++ b/nltk/classify/maxent.py
@@ -1441,7 +1441,9 @@ def train_maxent_classifier_with_megam(
     # Write a training file for megam.
     try:
         fd, trainfile_name = tempfile.mkstemp(prefix="nltk-")
-        with open(trainfile_name, "w") as trainfile:
+        with open(  # sandboxed-open ok: internal mkstemp name, not caller-supplied
+            trainfile_name, "w"
+        ) as trainfile:
             write_megam_file(
                 train_toks, encoding, trainfile, explicit=explicit, bernoulli=bernoulli
             )
@@ -1543,7 +1545,9 @@ class TadmMaxentClassifier(MaxentClassifier):
 
         call_tadm(options)
 
-        with open(weightfile_name) as weightfile:
+        with open(  # sandboxed-open ok: internal mkstemp name, not caller-supplied
+            weightfile_name
+        ) as weightfile:
             weights = parse_tadm_weights(weightfile)
 
         os.remove(trainfile_name)

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -145,8 +145,14 @@ def validate_path(path_input, context="NLTK", required_root=None):
     :param context: Diagnostic context for warnings/errors.
     :param required_root: If provided, enforces that the path is strictly
                           within this specific directory (scoped sandbox).
+
+    A whitespace-only path is NOT waved through: ``"   "`` is a legal relative
+    filename, so skipping it let a caller-supplied path reach ``os.open`` with no
+    containment check and create/truncate that file in the working directory,
+    outside every allowed root (GHSA-8mgp-746c-j5xp). Only an empty/absent path
+    (nothing to open) and a file descriptor short-circuit here.
     """
-    if isinstance(path_input, int) or not path_input or not str(path_input).strip():
+    if isinstance(path_input, int) or not path_input:
         return
     try:
         raw = path_input.path if hasattr(path_input, "path") else str(path_input)

--- a/nltk/tag/crf.py
+++ b/nltk/tag/crf.py
@@ -14,6 +14,7 @@ import re
 import unicodedata
 import warnings
 
+from nltk.pathsec import validate_path
 from nltk.tag.api import TaggerI
 
 try:
@@ -121,6 +122,16 @@ class CRFTagger(TaggerI):
         self._feature_cache = {}
 
     def set_model_file(self, model_file):
+        """Load a trained model from ``model_file``.
+
+        ``model_file`` is caller-supplied and pycrfsuite opens it natively, so
+        the path is validated against the NLTK data sandbox first: an
+        outside-root model is refused rather than handed to the native loader
+        (GHSA-8mgp-746c-j5xp). ``pathsec.open`` cannot be used here because the
+        C extension does its own open, so containment is the check that can be
+        applied; a symlink swapped in after it is not covered.
+        """
+        validate_path(model_file, context="CRFTagger.set_model_file")
         self._model_file = model_file
         self._tagger.open(self._model_file)
 
@@ -275,11 +286,19 @@ class CRFTagger(TaggerI):
 
         :param train_data: list of annotated sentences.
         :type train_data: list(list(tuple(str,str)))
-        :param model_file: path where the trained model will be written.
+        :param model_file: path where the trained model will be written. It must
+            be inside an allowed NLTK data root (see ``nltk.data.path``); use
+            ``nltk.data.make_staging_dir()`` for a private in-sandbox location.
         :type model_file: str
         """
         if pycrfsuite is None:
             raise ImportError("CRFTagger requires python-crfsuite to be installed.")
+
+        # Validate before any training work: the destination is caller-supplied
+        # and pycrfsuite writes it natively, so an outside-root path must be
+        # refused up front rather than after the model is built
+        # (GHSA-8mgp-746c-j5xp).
+        validate_path(model_file, context="CRFTagger.train")
 
         trainer = pycrfsuite.Trainer(verbose=self._verbose)
         trainer.set_params(self._training_options)

--- a/nltk/tag/perceptron.py
+++ b/nltk/tag/perceptron.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 from nltk import jsontags
 from nltk.data import FileSystemPathPointer, find, open_datafile
+from nltk.pathsec import _fd_realpath
 from nltk.pathsec import open as pathsec_open
 from nltk.pathsec import validate_path
 from nltk.tag.api import TaggerI
@@ -86,6 +87,11 @@ def _open_private_model_dir(loc):
                 f"Refusing non-private trained-model dir {loc!r}: not owned by "
                 "you or group-/world-writable (CWE-377/378)"
             )
+        landed = _fd_realpath(fd)
+        validate_path(
+            landed if landed is not None else os.path.realpath(loc),
+            context="PerceptronTagger.save_to_json",
+        )
     except BaseException:
         os.close(fd)
         raise

--- a/nltk/tag/perceptron.py
+++ b/nltk/tag/perceptron.py
@@ -15,37 +15,38 @@ import random
 from collections import defaultdict
 from os.path import join as path_join
 from pathlib import Path
-from tempfile import gettempdir
 
 from nltk import jsontags
 from nltk.data import FileSystemPathPointer, find, open_datafile
+from nltk.pathsec import open as pathsec_open
+from nltk.pathsec import validate_path
 from nltk.tag.api import TaggerI
 
 
-def _authorize_private_dir(directory):
-    """Register a private, user-owned trained-model directory on nltk.data.path
-    so the pathsec sandbox permits reading a saved model back from it.
+def _reject_path_structure(value, label):
+    """Refuse a value that would contribute path structure to a filename.
 
-    The default trained-tagger location is the system temp dir, which is shared
-    and world-writable on Linux. A directory that is private to the current user
-    (not group-/world-writable) cannot be tampered with by another local user, so
-    it is safe to trust; a world-writable one is deliberately NOT authorized and
-    stays refused (CWE-377/CWE-378).
+    A model-artifact filename is built by interpolation, so any separator,
+    ``..``, NUL or drive letter in the interpolated value turns one filename
+    into a path and lets the caller steer the open somewhere else (CWE-22).
+    Both separators are rejected regardless of platform, since a Windows-style
+    payload must not become live on a future port.
     """
-    import nltk.data
-    from nltk import pathsec
-
-    try:
-        real = os.path.realpath(str(directory))
-    except (OSError, ValueError):
-        return
-    if not pathsec.is_private_dir(real):
-        return
-    known = [os.path.realpath(str(p)) for p in nltk.data.path if isinstance(p, str)]
-    if real not in known:
-        nltk.data.path.append(real)
-        pathsec._ALLOWED_ROOTS_CACHE = None
-        pathsec._LAST_DATA_PATHS = None
+    text = str(value)
+    if (
+        not text
+        or text in (os.curdir, os.pardir)
+        or "/" in text
+        or "\\" in text
+        or "\x00" in text
+        or os.sep in text
+        or (os.altsep and os.altsep in text)
+    ):
+        raise ValueError(
+            f"Unsafe {label} {value!r}: must be a single path component with no "
+            "separator, traversal or NUL"
+        )
+    return text
 
 
 def _open_private_model_dir(loc):
@@ -174,13 +175,25 @@ class AveragedPerceptron:
             self.weights[feat] = new_feat_weights
 
     def save(self, path):
-        """Save the model weights as json"""
-        with open(path, "w") as fout:
+        """Save the model weights as json.
+
+        ``path`` is caller-supplied, so the write goes through the pathsec
+        sandbox: a destination outside the allowed NLTK data roots (or a symlink
+        planted at one) is refused before any bytes are written, instead of the
+        builtin ``open`` that made this an arbitrary-file write
+        (GHSA-8mgp-746c-j5xp).
+        """
+        with pathsec_open(path, "w", context="AveragedPerceptron.save") as fout:
             return json.dump(self.weights, fout)
 
     def load(self, path):
-        """Load the json model weights."""
-        with open(path) as fin:
+        """Load the json model weights.
+
+        The read is sandboxed for the same reason as :meth:`save`: a model path
+        outside the allowed roots is refused rather than read back to the caller
+        (GHSA-8mgp-746c-j5xp).
+        """
+        with pathsec_open(path, "r", context="AveragedPerceptron.load") as fin:
             self.weights = json.load(fin)
 
     def encode_json_obj(self):
@@ -243,16 +256,41 @@ class PerceptronTagger(TaggerI):
         self.tagdict = {}
         self.classes = set()
         self.lang = lang
-        # Save trained models in tmp directory by default:
-        self.TRAINED_TAGGER_PATH = gettempdir()
         self.TAGGER_NAME = "averaged_perceptron_tagger"
-        self.save_dir = path_join(
-            self.TRAINED_TAGGER_PATH, f"{self.TAGGER_NAME}_{self.lang}"
-        )
+        self._save_dir = None
         if load:
             self.load_from_json(lang, loc)
 
+    @property
+    def save_dir(self) -> str:
+        """This tagger's private directory for saved model artifacts.
+
+        Created lazily on first use under a data root, with an unpredictable name
+        and mode 0700, so (unlike the old guessable
+        ``<tempdir>/averaged_perceptron_tagger_<lang>``) another local user cannot
+        pre-create or symlink it to redirect or read the write (CWE-377/378), and
+        the saved model lands inside the pathsec sandbox so it can be read back
+        without widening the allowed roots (GHSA-8mgp-746c-j5xp).
+        """
+        from nltk.data import make_staging_dir
+
+        if self._save_dir is None:
+            self._save_dir = make_staging_dir(
+                prefix=f"nltk_{self.TAGGER_NAME}_{self.lang}_"
+            )
+        return self._save_dir
+
     def param_files(self, lang="eng"):
+        """The three json parameter filenames for *lang*.
+
+        ``lang`` is interpolated straight into a filename that both
+        :meth:`save_to_json` and :meth:`load_from_json` then open, so it is
+        pinned to a single path component here: a value carrying a separator, a
+        ``..`` or a NUL would otherwise contribute path structure and steer the
+        write/read out of the directory the caller authorized (CWE-22). One
+        choke point covers both directions.
+        """
+        _reject_path_structure(lang, "lang")
         return (
             f"{self.TAGGER_NAME}_{lang}.{attr}.json"
             for attr in ["weights", "tagdict", "classes"]
@@ -330,32 +368,40 @@ class PerceptronTagger(TaggerI):
             self.save_to_json(lang=self.lang, loc=save_loc)
 
     def save_to_json(self, lang="xxx", loc=None):
+        """Write the model's json parameter files into the directory ``loc``.
+
+        ``loc`` is caller-supplied, so it is validated against the NLTK data
+        sandbox before the directory is created or any file is written: an
+        outside-root destination is refused instead of being written through
+        (GHSA-8mgp-746c-j5xp). It defaults to :attr:`save_dir`, which is already
+        inside a data root.
+        """
         if not loc:
             loc = self.save_dir
-        # On POSIX the default TRAINED_TAGGER_PATH is a shared, world-writable
-        # temp dir (/tmp) and the save dir is a *guessable* name in it, so a
-        # local attacker can pre-plant or race a symlink at ``loc``. A plain
-        # ``islink`` pre-check is non-atomic (TOCTOU) and misses it once created;
+        validate_path(loc, context="PerceptronTagger.save_to_json")
+        # A ``loc`` inside an allowed root can still be a *guessable* name that a
+        # local attacker pre-plants or races a symlink at. A plain ``islink``
+        # pre-check is non-atomic (TOCTOU) and misses it once created;
         # ``_open_private_model_dir`` instead creates/re-opens the leaf atomically
         # with O_NOFOLLOW|O_DIRECTORY, verifies it is a real, user-owned,
         # non-world-writable directory, and returns a pinned fd we write relative
         # to (CWE-59/377/378).
         #
-        # On Windows ``%TEMP%`` is per-user and ACL-protected (no such squat), and
+        # On Windows the per-user profile is ACL-protected (no such squat), and
         # ``os.open`` cannot open a directory as a descriptor there, so use a
-        # plain create + write.
+        # plain create + sandboxed write.
         if os.name != "posix":
             os.makedirs(loc, exist_ok=True)
-            _authorize_private_dir(loc)
             for param, json_file in zip(self.encode_json_obj(), self.param_files(lang)):
-                with open(path_join(loc, json_file), "w") as fout:
+                target = path_join(loc, json_file)
+                with pathsec_open(
+                    target, "w", context="PerceptronTagger.save_to_json"
+                ) as fout:
                     json.dump(param, fout)
             return
 
         dir_fd = _open_private_model_dir(loc)
         try:
-            _authorize_private_dir(loc)
-
             # Write each model file relative to the pinned directory fd (where
             # supported) with O_NOFOLLOW (0600), so neither the dir nor the file
             # can be redirected outside the verified directory after the check.
@@ -367,9 +413,15 @@ class PerceptronTagger(TaggerI):
                     path, flags | getattr(os, "O_NOFOLLOW", 0), 0o600, **extra
                 )
 
+            # builtins.open with an explicit ``opener`` (not pathsec.open, which
+            # owns its own os.open and takes no opener): ``loc`` is already
+            # sandbox-validated above and the pinned dir_fd + O_NOFOLLOW is the
+            # stronger, race-free containment for the leaf write.
             for param, json_file in zip(self.encode_json_obj(), self.param_files(lang)):
                 target = json_file if use_dir_fd else path_join(loc, json_file)
-                with open(target, "w", opener=_no_follow_opener) as fout:
+                with open(  # sandboxed-open ok: dir_fd + O_NOFOLLOW opener
+                    target, "w", opener=_no_follow_opener
+                ) as fout:
                     json.dump(param, fout)
         finally:
             os.close(dir_fd)
@@ -392,13 +444,12 @@ class PerceptronTagger(TaggerI):
             loc = FileSystemPathPointer(str(loc))
         # else: assume loc is already a PathPointer (zip or filesystem)
 
-        # A trained model saved under the (private) system-temp trained-tagger
-        # dir lives outside nltk_data; authorize that specific private directory
-        # so it can be read back under the pathsec sandbox.
-        loc_path = getattr(loc, "path", None)
-        if loc_path and os.path.isdir(loc_path):
-            _authorize_private_dir(loc_path)
-
+        # No sandbox widening here: a trained model is saved under save_dir,
+        # which is already inside a data root, so the read below goes through
+        # open_datafile -> pathsec.open unaided. Appending a caller-supplied
+        # directory to nltk.data.path would make it an allowed root
+        # process-wide and disarm the containment check for every later read
+        # (GHSA-8mgp-746c-j5xp).
         def load_param(json_file):
             with open_datafile(loc, json_file) as fin:
                 return json.load(fin)

--- a/nltk/tbl/demo.py
+++ b/nltk/tbl/demo.py
@@ -13,6 +13,7 @@ import random
 import time
 
 from nltk.corpus import treebank
+from nltk.pathsec import open as pathsec_open
 from nltk.picklesec import pickle_load
 from nltk.tag import BrillTaggerTrainer, RegexpTagger, UnigramTagger
 from nltk.tag.brill import Pos, Word
@@ -246,14 +247,20 @@ def postag(
             baseline_tagger = UnigramTagger(
                 baseline_data, backoff=baseline_backoff_tagger
             )
-            with open(cache_baseline_tagger, "wb") as print_rules:
+            # ``cache_baseline_tagger`` is caller-supplied, so the model
+            # write/read goes through the pathsec sandbox (GHSA-8mgp-746c-j5xp).
+            with pathsec_open(
+                cache_baseline_tagger, "wb", context="tbl.demo.cache_baseline_tagger"
+            ) as print_rules:
                 pickle.dump(baseline_tagger, print_rules)
             print(
                 "Trained baseline tagger, pickled it to {}".format(
                     cache_baseline_tagger
                 )
             )
-        with open(cache_baseline_tagger, "rb") as print_rules:
+        with pathsec_open(
+            cache_baseline_tagger, "rb", context="tbl.demo.cache_baseline_tagger"
+        ) as print_rules:
             baseline_tagger = pickle_load(print_rules)
             print(f"Reloaded pickled tagger from {cache_baseline_tagger}")
     else:
@@ -314,18 +321,24 @@ def postag(
 
     # writing error analysis to file
     if error_output is not None:
-        with open(error_output, "w") as f:
+        with pathsec_open(
+            error_output, "w", context="tbl.demo.error_output", encoding="utf-8"
+        ) as f:
             f.write("Errors for Brill Tagger %r\n\n" % serialize_output)
-            f.write("\n".join(error_list(gold_data, taggedtest)).encode("utf-8") + "\n")
+            f.write("\n".join(error_list(gold_data, taggedtest)) + "\n")
         print(f"Wrote tagger errors including context to {error_output}")
 
     # serializing the tagger to a pickle file and reloading (just to see it works)
     if serialize_output is not None:
         taggedtest = brill_tagger.tag_sents(testing_data)
-        with open(serialize_output, "wb") as print_rules:
+        with pathsec_open(
+            serialize_output, "wb", context="tbl.demo.serialize_output"
+        ) as print_rules:
             pickle.dump(brill_tagger, print_rules)
         print(f"Wrote pickled tagger to {serialize_output}")
-        with open(serialize_output, "rb") as print_rules:
+        with pathsec_open(
+            serialize_output, "rb", context="tbl.demo.serialize_output"
+        ) as print_rules:
             brill_tagger_reloaded = pickle_load(print_rules)
         print(f"Reloaded pickled tagger from {serialize_output}")
         taggedtest_reloaded = brill_tagger_reloaded.tag_sents(testing_data)

--- a/nltk/tbl/demo.py
+++ b/nltk/tbl/demo.py
@@ -14,6 +14,7 @@ import time
 
 from nltk.corpus import treebank
 from nltk.pathsec import open as pathsec_open
+from nltk.pathsec import validate_path
 from nltk.picklesec import pickle_load
 from nltk.tag import BrillTaggerTrainer, RegexpTagger, UnigramTagger
 from nltk.tag.brill import Pos, Word
@@ -389,6 +390,13 @@ def _demo_prepare_data(
 
 
 def _demo_plot(learning_curve_output, teststats, trainstats=None, take=None):
+    """Write the learning-curve plot to ``learning_curve_output``.
+
+    The destination is caller-supplied and matplotlib writes it itself, so the
+    path is checked against the NLTK data sandbox before any work is done
+    (GHSA-8mgp-746c-j5xp); ``pathsec.open`` cannot wrap a ``savefig``.
+    """
+    validate_path(learning_curve_output, context="tbl.demo.learning_curve_output")
     testcurve = [teststats["initialerrors"]]
     for rulescore in teststats["rulescores"]:
         testcurve.append(testcurve[-1] - rulescore)

--- a/nltk/test/unit/security_probes/ghsa_8mgp_746c_j5xp.py
+++ b/nltk/test/unit/security_probes/ghsa_8mgp_746c_j5xp.py
@@ -1,42 +1,236 @@
 """GHSA-8mgp-746c-j5xp [high] -- Model-artifact APIs bypass pathsec and touch files outside allowed roots"""
 
+import contextlib
+import io
+import json
 import os
+import pathlib
+import shutil
 import tempfile
 
-from ._base import FIXED, VULNERABLE, is_security_rejection, probe
+from ._base import FIXED, STATIC, VULNERABLE, is_security_rejection, probe
+
+#: The canary an escaping read must hand back, and an escaping write must leave
+#: on disk outside the allowed roots.
+CANARY = "GHSA-8MGP-CANARY"
+
+#: ``lang`` for the throwaway tagger, so a probe run can never collide with a
+#: real ``averaged_perceptron_tagger_eng`` model.
+LANG = "probe8mgp"
+
+
+@contextlib.contextmanager
+def _outside_dir():
+    """A writable directory that is genuinely OUTSIDE every allowed pathsec root.
+
+    Not ``tempfile.mkdtemp()``: a *private* per-user system temp dir is itself an
+    allowed root on macOS/Windows, so an attack target staged there would be
+    correctly permitted and the probe would prove nothing. ``$HOME`` is not a
+    root (only ``~/nltk_data`` is), so a directory made there is a real escape
+    target. Yields ``None`` when it turns out to be inside a root anyway (an
+    operator may have put ``$HOME`` on ``nltk.data.path``), so the caller can
+    report STATIC instead of a bogus result.
+
+    Containment is compared against the allowed roots directly, never by calling
+    ``validate_path``: that answers "would this be refused", which is False once
+    ``ENFORCE`` is off, so the negative control would lose its escape target at
+    exactly the moment it needs one.
+    """
+    from nltk import pathsec
+
+    path = pathlib.Path(
+        tempfile.mkdtemp(prefix=".nltk_probe8mgp_", dir=str(pathlib.Path.home()))
+    )
+    try:
+        resolved = path.resolve()
+        inside = any(
+            resolved == root or resolved.is_relative_to(root)
+            for root in pathsec._get_allowed_roots()
+        )
+        yield None if inside else path
+    finally:
+        shutil.rmtree(path, ignore_errors=True)
+
+
+def _weights_files(loc, lang):
+    """Write the three json files ``PerceptronTagger.load_from_json`` reads.
+
+    Written with the stdlib writer on purpose: this is the *attacker's* plant,
+    staged outside the sandbox before the attack runs, not NLTK doing I/O.
+    """
+    payload = {
+        "weights": {CANARY: {"NN": 1.0}},
+        "tagdict": {},
+        "classes": ["NN"],
+    }
+    os.makedirs(loc, mode=0o700, exist_ok=True)
+    for attr, value in payload.items():
+        target = os.path.join(loc, f"averaged_perceptron_tagger_{lang}.{attr}.json")
+        pathlib.Path(target).write_text(json.dumps(value), encoding="utf-8")
+
+
+def _attempts(outside):
+    """(label, callable) for every API the advisory names, read and write.
+
+    Each callable must either be security-refused or leave evidence: a read
+    returns something containing ``CANARY``, a write returns the paths it
+    created outside the root. Returning a falsy value means "ran, escaped
+    nothing".
+    """
+    from nltk.parse.transitionparser import TransitionParser
+    from nltk.tag.perceptron import AveragedPerceptron, PerceptronTagger
+
+    def _tagger():
+        tagger = PerceptronTagger(load=False)
+        tagger.model.weights = {CANARY: {"NN": 1.0}}
+        tagger.tagdict = {}
+        tagger.classes = {"NN"}
+        return tagger
+
+    def perceptron_load():
+        target = os.path.join(outside, "weights.json")
+        pathlib.Path(target).write_text(
+            json.dumps({CANARY: {"NN": 1.0}}), encoding="utf-8"
+        )
+        model = AveragedPerceptron()
+        model.load(target)
+        return repr(model.weights)
+
+    def perceptron_save():
+        target = os.path.join(outside, "saved.json")
+        AveragedPerceptron({CANARY: {"NN": 1.0}}).save(target)
+        return pathlib.Path(target).read_text(encoding="utf-8")
+
+    def perceptron_save_symlink():
+        """A symlink inside a root pointing out of it must not carry the write."""
+        victim = os.path.join(outside, "victim.json")
+        pathlib.Path(victim).write_text("untouched", encoding="utf-8")
+        root = tempfile.mkdtemp(prefix="nltk_probe8mgp_root_")
+        link = os.path.join(root, "link.json")
+        try:
+            os.symlink(victim, link)
+        except OSError:
+            shutil.rmtree(root, ignore_errors=True)
+            return None
+        try:
+            AveragedPerceptron({CANARY: {"NN": 1.0}}).save(link)
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+        return pathlib.Path(victim).read_text(encoding="utf-8")
+
+    def tagger_save_to_json():
+        loc = os.path.join(outside, "tagger_save")
+        _tagger().save_to_json(lang=LANG, loc=loc)
+        return CANARY + " " + repr(sorted(os.listdir(loc)))
+
+    def tagger_load_from_json():
+        loc = os.path.join(outside, "tagger_load")
+        _weights_files(loc, LANG)
+        tagger = PerceptronTagger(load=False)
+        tagger.load_from_json(lang=LANG, loc=loc)
+        return repr(tagger.model.weights)
+
+    def tagger_ctor_loc():
+        loc = os.path.join(outside, "tagger_ctor")
+        _weights_files(loc, LANG)
+        return repr(PerceptronTagger(load=True, lang=LANG, loc=loc).model.weights)
+
+    def transition_parse():
+        target = os.path.join(outside, "model.pickle")
+        pathlib.Path(target).write_bytes(b"\x80\x04N.")
+        TransitionParser("arc-standard").parse([], target)
+        return CANARY + " read " + target
+
+    def maxent_save():
+        import numpy
+
+        from nltk.classify.maxent import save_maxent_params
+
+        loc = os.path.join(outside, "maxent_out")
+        save_maxent_params(
+            numpy.array([1.0]), {("a", "b"): 0}, ["L"], {"alwayson": 0}, tab_dir=loc
+        )
+        return CANARY + " " + repr(sorted(os.listdir(loc)))
+
+    def transition_train():
+        target = os.path.join(outside, "trained.pickle")
+        TransitionParser("arc-standard").train([], target, verbose=False)
+        return CANARY + " wrote " + target
+
+    def data_load_urls():
+        """The generic loader underneath the model APIs, in several path forms."""
+        import nltk.data
+
+        target = os.path.join(outside, "resource.txt")
+        pathlib.Path(target).write_text(CANARY, encoding="utf-8")
+        forms = [
+            target,
+            "nltk:" + target,
+            "file://" + target,
+            target + "\x00.cfg",
+            os.path.join(tempfile.gettempdir(), "..", "..", "etc", "passwd"),
+            "/etc/passwd",
+        ]
+        seen = []
+        for form in forms:
+            with contextlib.suppress(Exception):
+                # cache=False: nltk.data.load memoises by URL, so a read that
+                # succeeded in an earlier run would be replayed here and
+                # reported as a leak that is not there.
+                seen.append(str(nltk.data.load(form, format="raw", cache=False)))
+        return " ".join(seen)
+
+    return [
+        ("AveragedPerceptron.load", perceptron_load),
+        ("AveragedPerceptron.save", perceptron_save),
+        ("AveragedPerceptron.save/symlink", perceptron_save_symlink),
+        ("PerceptronTagger.save_to_json", tagger_save_to_json),
+        ("PerceptronTagger.load_from_json", tagger_load_from_json),
+        ("PerceptronTagger(loc=...)", tagger_ctor_loc),
+        ("TransitionParser.parse", transition_parse),
+        ("TransitionParser.train", transition_train),
+        ("save_maxent_params", maxent_save),
+        ("nltk.data.load", data_load_urls),
+    ]
 
 
 @probe("GHSA-8mgp-746c-j5xp")
 def _model_artifact_apis():
-    """Model-artifact read APIs must security-reject caller paths that escape the
-    allowed roots, via several forms (traversal, absolute, nltk:/file: URLs and a
-    NUL byte); a leak reads the outside file, a non-security error is not a pass.
+    """Every model-artifact API the advisory names must refuse an outside-root path.
 
-    Loads are uncached: nltk.data.load memoises by URL, so a successful read in
-    one run would be replayed to the next and report a leak that is not there.
+    The advisory is about ``TransitionParser.train``/``parse``,
+    ``AveragedPerceptron.save``/``load``, ``PerceptronTagger.save_to_json`` and
+    ``save_maxent_params`` treating a caller path as a plain filename, so the
+    probe drives those APIs, not only the generic loader underneath them: a
+    regression in any one of them is invisible to a probe that exercises
+    ``nltk.data.load`` alone.
+
+    A leak is evidence, not merely "the call returned": a read must hand back the
+    canary and a write must land outside the allowed roots. A refusal only counts
+    when it is security-marked, so an incidental ImportError/FileNotFoundError is
+    never scored as a defence.
     """
-    import nltk.data
-
-    outside = "/etc/passwd"
-    payloads = [
-        os.path.join(tempfile.gettempdir(), "..", "..", "etc", "passwd"),
-        outside,
-        "nltk:" + outside,
-        "file://" + outside,
-        outside + "\x00.cfg",
-    ]
-    reached = False
-    for path in payloads:
-        try:
-            data = nltk.data.load(path, format="raw", cache=False)
-        except Exception as exc:
-            if is_security_rejection(exc):
-                reached = True
-            continue
-        if isinstance(data, (str, bytes)) and (
-            "root:" in data if isinstance(data, str) else b"root:" in data
-        ):
-            return VULNERABLE, f"nltk.data.load read {outside} via {path!r}"
-    if reached:
-        return FIXED, "outside-root model paths security-rejected"
-    return FIXED, "outside-root model paths refused (no security marker reached)"
+    with _outside_dir() as outside:
+        if outside is None:
+            return STATIC, "$HOME is inside an allowed root here; no escape target"
+        reached, notes = False, []
+        for label, run in _attempts(str(outside)):
+            try:
+                # Several of these APIs print progress; a probe reports through
+                # its return value, so keep the harness output clean.
+                with contextlib.redirect_stdout(io.StringIO()):
+                    result = run()
+            except Exception as exc:
+                if is_security_rejection(exc):
+                    reached = True
+                    notes.append(f"{label}=blocked")
+                else:
+                    notes.append(f"{label}=unreached({type(exc).__name__})")
+                continue
+            if result and CANARY in str(result):
+                return VULNERABLE, f"{label} escaped the sandbox: {str(result)[:120]}"
+            notes.append(f"{label}=no-escape")
+        detail = "; ".join(notes)
+        if reached:
+            return FIXED, detail
+        return STATIC, "attack never reached a security check: " + detail

--- a/nltk/test/unit/security_probes/ghsa_8mgp_746c_j5xp.py
+++ b/nltk/test/unit/security_probes/ghsa_8mgp_746c_j5xp.py
@@ -157,6 +157,24 @@ def _attempts(outside):
         TransitionParser("arc-standard").train([], target, verbose=False)
         return CANARY + " wrote " + target
 
+    def crf_train():
+        """A native (pycrfsuite) writer given a caller path."""
+        from nltk.tag.crf import CRFTagger
+
+        target = os.path.join(outside, "model.crf")
+        CRFTagger().train(
+            [[("the", "DT"), ("dog", "NN")], [("a", "DT"), ("cat", "NN")]], target
+        )
+        return CANARY + " wrote " + target if os.path.exists(target) else None
+
+    def crf_load():
+        from nltk.tag.crf import CRFTagger
+
+        target = os.path.join(outside, "planted.crf")
+        pathlib.Path(target).write_bytes(b"not-a-real-model")
+        CRFTagger().set_model_file(target)
+        return CANARY + " opened " + target
+
     def data_load_urls():
         """The generic loader underneath the model APIs, in several path forms."""
         import nltk.data
@@ -190,6 +208,8 @@ def _attempts(outside):
         ("TransitionParser.parse", transition_parse),
         ("TransitionParser.train", transition_train),
         ("save_maxent_params", maxent_save),
+        ("CRFTagger.train", crf_train),
+        ("CRFTagger.set_model_file", crf_load),
         ("nltk.data.load", data_load_urls),
     ]
 

--- a/nltk/test/unit/security_probes/ghsa_8mgp_746c_j5xp.py
+++ b/nltk/test/unit/security_probes/ghsa_8mgp_746c_j5xp.py
@@ -3,19 +3,40 @@
 import os
 import tempfile
 
-from ._base import FIXED, VULNERABLE, probe
+from ._base import FIXED, VULNERABLE, is_security_rejection, probe
 
 
 @probe("GHSA-8mgp-746c-j5xp")
 def _model_artifact_apis():
-    """Model-artifact read/write APIs treated caller paths as plain filenames."""
+    """Model-artifact read APIs must security-reject caller paths that escape the
+    allowed roots, via several forms (traversal, absolute, nltk:/file: URLs and a
+    NUL byte); a leak reads the outside file, a non-security error is not a pass.
+
+    Loads are uncached: nltk.data.load memoises by URL, so a successful read in
+    one run would be replayed to the next and report a leak that is not there.
+    """
     import nltk.data
 
-    try:
-        nltk.data.load(
-            os.path.join(tempfile.gettempdir(), "..", "..", "etc", "passwd"),
-            format="raw",
-        )
-        return VULNERABLE, "nltk.data.load reached outside an allowed root"
-    except Exception as exc:
-        return FIXED, "outside-root model path rejected (%s)" % type(exc).__name__
+    outside = "/etc/passwd"
+    payloads = [
+        os.path.join(tempfile.gettempdir(), "..", "..", "etc", "passwd"),
+        outside,
+        "nltk:" + outside,
+        "file://" + outside,
+        outside + "\x00.cfg",
+    ]
+    reached = False
+    for path in payloads:
+        try:
+            data = nltk.data.load(path, format="raw", cache=False)
+        except Exception as exc:
+            if is_security_rejection(exc):
+                reached = True
+            continue
+        if isinstance(data, (str, bytes)) and (
+            "root:" in data if isinstance(data, str) else b"root:" in data
+        ):
+            return VULNERABLE, f"nltk.data.load read {outside} via {path!r}"
+    if reached:
+        return FIXED, "outside-root model paths security-rejected"
+    return FIXED, "outside-root model paths refused (no security marker reached)"

--- a/nltk/test/unit/test_advisory_probes.py
+++ b/nltk/test/unit/test_advisory_probes.py
@@ -12,6 +12,8 @@ import os
 import pathlib
 import pkgutil
 import re
+import shutil
+import tempfile
 import warnings
 from collections import Counter
 
@@ -81,7 +83,7 @@ def test_pathsec_enforce_probe_has_teeth():
 
 
 def test_model_artifact_probe_has_teeth():
-    """Remove both containment layers and the probe must read /etc/passwd.
+    """Turn containment off and the probe must escape the sandbox.
 
     The payload has to genuinely reach the sink: a traversal that lands on a
     non-existent path errors out and would score FIXED no matter what the guards
@@ -99,6 +101,101 @@ def test_model_artifact_probe_has_teeth():
     finally:
         nltk.data._reject_unsafe_no_protocol, pathsec.ENFORCE = reject, enforce
     assert probe()[0] == probes.FIXED
+
+
+def test_model_artifact_probe_covers_every_api_the_advisory_names():
+    """The probe must drive the APIs the advisory lists, not only the loader.
+
+    The advisory names six model-artifact entry points. A probe that exercises
+    ``nltk.data.load`` alone reports FIXED while any one of them regresses, which
+    is the failure this list pins shut.
+    """
+    from nltk.test.unit.security_probes import ghsa_8mgp_746c_j5xp as mod
+
+    labels = {label for label, _ in mod._attempts(str(pathlib.Path.home()))}
+    for named in (
+        "TransitionParser.train",
+        "TransitionParser.parse",
+        "AveragedPerceptron.save",
+        "AveragedPerceptron.load",
+        "PerceptronTagger.save_to_json",
+        "save_maxent_params",
+    ):
+        assert named in labels, f"advisory API {named} is not probed"
+
+
+def test_perceptron_bare_open_probe_has_teeth():
+    """Restore the advisory's own bug and the probe must flip to VULNERABLE.
+
+    ``AveragedPerceptron.save``/``load`` used ``builtins.open`` on a caller path.
+    Putting that back is the exact regression this probe exists to catch, so it
+    must not stay FIXED through it.
+    """
+    import json as _json
+
+    from nltk.tag.perceptron import AveragedPerceptron
+
+    probe = probes.PROBES["GHSA-8mgp-746c-j5xp"]
+    saved, loaded = AveragedPerceptron.save, AveragedPerceptron.load
+
+    def bare_save(self, path):
+        with open(path, "w") as fout:
+            return _json.dump(self.weights, fout)
+
+    def bare_load(self, path):
+        with open(path) as fin:
+            self.weights = _json.load(fin)
+
+    try:
+        AveragedPerceptron.save, AveragedPerceptron.load = bare_save, bare_load
+        assert probe()[0] == probes.VULNERABLE
+    finally:
+        AveragedPerceptron.save, AveragedPerceptron.load = saved, loaded
+    assert probe()[0] == probes.FIXED
+
+
+def test_perceptron_save_to_json_validation_has_teeth():
+    """Drop the destination check and the tagger write must escape again."""
+    import nltk.pathsec as pathsec
+    import nltk.tag.perceptron as perceptron
+
+    probe = probes.PROBES["GHSA-8mgp-746c-j5xp"]
+    original = perceptron.validate_path
+    try:
+        # Only the tagger's own check is neutered; pathsec still guards
+        # AveragedPerceptron, so a flip proves save_to_json is what leaked.
+        perceptron.validate_path = lambda *args, **kwargs: None
+        assert probe()[0] == probes.VULNERABLE
+    finally:
+        perceptron.validate_path = original
+    assert probe()[0] == probes.FIXED
+    assert perceptron.validate_path is pathsec.validate_path
+
+
+def test_perceptron_load_does_not_widen_the_sandbox():
+    """A caller-supplied model dir must never become an allowed root.
+
+    ``load_from_json`` used to append a private caller directory to
+    ``nltk.data.path``, which turns the containment check off for that path (and
+    every later read under it) process-wide.
+    """
+    import nltk.data
+    from nltk.tag.perceptron import PerceptronTagger
+
+    before = list(nltk.data.path)
+    outside = pathlib.Path(
+        tempfile.mkdtemp(prefix=".nltk_widen_", dir=str(pathlib.Path.home()))
+    )
+    try:
+        (outside / "averaged_perceptron_tagger_xx.weights.json").write_text("{}")
+        try:
+            PerceptronTagger(load=False).load_from_json(lang="xx", loc=str(outside))
+        except Exception:
+            pass
+        assert list(nltk.data.path) == before, "caller dir was added to nltk.data.path"
+    finally:
+        nltk.data.path[:] = before
+        shutil.rmtree(outside, ignore_errors=True)
 
 
 def test_pickle_allowlist_probe_has_teeth():

--- a/nltk/test/unit/test_advisory_probes.py
+++ b/nltk/test/unit/test_advisory_probes.py
@@ -155,21 +155,31 @@ def test_perceptron_bare_open_probe_has_teeth():
 
 
 def test_perceptron_save_to_json_validation_has_teeth():
-    """Drop the destination check and the tagger write must escape again."""
+    """Restore the tagger's pre-fix destination handling and it must escape again.
+
+    Both of its guards go: the sandbox check on ``loc``, and (on the Windows
+    branch, where there is no pinned dir_fd to write through) the sandboxed
+    per-file open. Neutering only one leaves the other holding, which is the
+    point of having both -- and is why this control has to remove the pair.
+    """
+    import builtins
+
     import nltk.pathsec as pathsec
     import nltk.tag.perceptron as perceptron
 
     probe = probes.PROBES["GHSA-8mgp-746c-j5xp"]
-    original = perceptron.validate_path
+    validate, opener = perceptron.validate_path, perceptron.pathsec_open
     try:
-        # Only the tagger's own check is neutered; pathsec still guards
-        # AveragedPerceptron, so a flip proves save_to_json is what leaked.
         perceptron.validate_path = lambda *args, **kwargs: None
+        perceptron.pathsec_open = lambda path, mode="r", **kwargs: builtins.open(
+            path, mode
+        )
         assert probe()[0] == probes.VULNERABLE
     finally:
-        perceptron.validate_path = original
+        perceptron.validate_path, perceptron.pathsec_open = validate, opener
     assert probe()[0] == probes.FIXED
     assert perceptron.validate_path is pathsec.validate_path
+    assert perceptron.pathsec_open is pathsec.open
 
 
 def test_perceptron_load_does_not_widen_the_sandbox():

--- a/nltk/test/unit/test_advisory_probes.py
+++ b/nltk/test/unit/test_advisory_probes.py
@@ -80,6 +80,27 @@ def test_pathsec_enforce_probe_has_teeth():
     assert probe()[0] == probes.FIXED
 
 
+def test_model_artifact_probe_has_teeth():
+    """Remove both containment layers and the probe must read /etc/passwd.
+
+    The payload has to genuinely reach the sink: a traversal that lands on a
+    non-existent path errors out and would score FIXED no matter what the guards
+    do, which is how this probe used to pass with every guard disabled.
+    """
+    import nltk.data
+    import nltk.pathsec as pathsec
+
+    probe = probes.PROBES["GHSA-8mgp-746c-j5xp"]
+    reject, enforce = nltk.data._reject_unsafe_no_protocol, pathsec.ENFORCE
+    try:
+        nltk.data._reject_unsafe_no_protocol = lambda url: None
+        pathsec.ENFORCE = False
+        assert probe()[0] == probes.VULNERABLE
+    finally:
+        nltk.data._reject_unsafe_no_protocol, pathsec.ENFORCE = reject, enforce
+    assert probe()[0] == probes.FIXED
+
+
 def test_pickle_allowlist_probe_has_teeth():
     from nltk.picklesec import AllowlistUnpickler
 

--- a/nltk/test/unit/test_model_artifact_pathsec.py
+++ b/nltk/test/unit/test_model_artifact_pathsec.py
@@ -1,0 +1,714 @@
+"""Exploit matrix for the model-artifact read/write APIs (GHSA-8mgp-746c-j5xp).
+
+The advisory names six entry points that treated a caller-supplied model path as
+an ordinary filename: ``TransitionParser.train``/``parse``,
+``AveragedPerceptron.save``/``load``, ``PerceptronTagger.save_to_json`` and
+``save_maxent_params``. This file drives all of them, plus the sibling
+save/load helpers in the same family and the constructor/train routes that reach
+them, with every path form an attacker can supply.
+
+Three kinds of case are kept side by side on purpose:
+
+* **escapes** -- must be refused, and must leave nothing behind outside the root.
+* **benign / probable-but-harmless** -- pinned so that if a future change starts
+  expanding, decoding or following them, the pin turns into a failure.
+* **over-block controls** -- the legitimate in-sandbox flows must keep working,
+  so a fix cannot be "refuse everything".
+
+Plus negative controls: each guard is neutered in-process and the exploit must
+become reachable again, so none of these tests can pass by never reaching a sink.
+
+Staging note: an "outside" target is created under ``$HOME`` (the ``sandbox`` /
+``pathsec_sandbox`` fixtures in conftest.py), never in ``tempfile.mkdtemp()`` --
+a private per-user system temp dir IS an allowed root on macOS/Windows, so a
+target staged there would be correctly permitted and prove nothing.
+"""
+
+import json
+import os
+import pathlib
+import shutil
+import socket
+import stat
+import tempfile
+
+import pytest
+
+import nltk.data
+import nltk.pathsec as pathsec
+import nltk.tag.perceptron as perceptron
+from nltk.tag.perceptron import AveragedPerceptron, PerceptronTagger
+
+CANARY = "MODEL-ARTIFACT-CANARY"
+LANG = "probeartifact"
+
+POSIX_ONLY = pytest.mark.skipif(os.name != "posix", reason="POSIX-only path form")
+
+
+@pytest.fixture
+def outside_only(monkeypatch):
+    """An out-of-sandbox directory that leaves ``nltk.data.path`` alone.
+
+    The ``sandbox`` fixtures narrow the allowed roots to one empty directory,
+    which also hides the installed corpora; tests that must load a real corpus
+    (or a real shipped model) use this instead. ``$HOME`` is not an allowed root
+    on its own, so a directory made there is still a genuine escape target, and
+    that is asserted rather than assumed.
+    """
+    monkeypatch.setattr(pathsec, "ENFORCE", True)
+    path = pathlib.Path(
+        tempfile.mkdtemp(prefix=".nltk_artifact_outside_", dir=str(pathlib.Path.home()))
+    )
+    resolved = path.resolve()
+    inside = any(
+        resolved == root or resolved.is_relative_to(root)
+        for root in pathsec._get_allowed_roots()
+    )
+    try:
+        if inside:
+            pytest.skip("$HOME is inside an allowed root here; no escape target")
+        yield path
+    finally:
+        shutil.rmtree(path, ignore_errors=True)
+
+
+def _weights():
+    return {CANARY: {"NN": 1.0}}
+
+
+def _tagger():
+    tagger = PerceptronTagger(load=False)
+    tagger.model.weights = _weights()
+    tagger.tagdict = {}
+    tagger.classes = {"NN"}
+    return tagger
+
+
+def _plant_model_dir(loc, lang=LANG):
+    """Stage the three json files ``load_from_json`` reads, as an attacker would.
+
+    Written with the stdlib writer deliberately: this is the attacker's plant,
+    staged outside the sandbox before the attack runs, not NLTK doing the I/O.
+    """
+    os.makedirs(loc, mode=0o700, exist_ok=True)
+    for attr, value in (
+        ("weights", _weights()),
+        ("tagdict", {}),
+        ("classes", ["NN"]),
+    ):
+        target = os.path.join(loc, f"averaged_perceptron_tagger_{lang}.{attr}.json")
+        pathlib.Path(target).write_text(json.dumps(value), encoding="utf-8")
+
+
+def _refused(call, *args, **kwargs):
+    """Run *call*; return the security exception it raised, or fail loudly."""
+    with pytest.raises((PermissionError, ValueError, OSError)) as excinfo:
+        call(*args, **kwargs)
+    return excinfo.value
+
+
+# ==========================================================================
+# AveragedPerceptron.save / load -- the advisory's bare-open pair
+# ==========================================================================
+
+
+class TestAveragedPerceptronEscapes:
+    def test_load_outside_root_is_refused(self, sandbox):
+        target = sandbox / "weights.json"
+        target.write_text(json.dumps(_weights()), encoding="utf-8")
+        model = AveragedPerceptron()
+        _refused(model.load, str(target))
+        assert model.weights == {}, "outside-root weights reached the caller"
+
+    def test_save_outside_root_is_refused_and_writes_nothing(self, sandbox):
+        target = sandbox / "written.json"
+        _refused(AveragedPerceptron(_weights()).save, str(target))
+        assert not target.exists(), "refused write still created the file"
+
+    @POSIX_ONLY
+    def test_save_through_in_root_symlink_is_refused(self, pathsec_sandbox):
+        victim = pathsec_sandbox.outside / "victim.json"
+        victim.write_text("untouched", encoding="utf-8")
+        link = pathsec_sandbox.root / "link.json"
+        os.symlink(str(victim), str(link))
+        _refused(AveragedPerceptron(_weights()).save, str(link))
+        assert victim.read_text(encoding="utf-8") == "untouched"
+
+    @POSIX_ONLY
+    def test_save_through_symlinked_parent_is_refused(self, pathsec_sandbox):
+        victim_dir = pathsec_sandbox.outside / "parent"
+        victim_dir.mkdir()
+        link = pathsec_sandbox.root / "plink"
+        os.symlink(str(victim_dir), str(link))
+        _refused(AveragedPerceptron(_weights()).save, str(link / "w.json"))
+        assert not list(victim_dir.iterdir()), "write escaped via the parent symlink"
+
+    @POSIX_ONLY
+    def test_load_through_in_root_hardlink_is_refused(self, pathsec_sandbox):
+        secret = pathsec_sandbox.outside / "secret.json"
+        secret.write_text(json.dumps(_weights()), encoding="utf-8")
+        link = pathsec_sandbox.root / "hard.json"
+        try:
+            os.link(str(secret), str(link))
+        except OSError:
+            pytest.skip("cross-device hardlink not possible here")
+        model = AveragedPerceptron()
+        _refused(model.load, str(link))
+        assert model.weights == {}
+
+    def test_traversal_out_of_the_root_is_refused(self, pathsec_sandbox):
+        target = pathsec_sandbox.outside / "trav.json"
+        target.write_text(json.dumps(_weights()), encoding="utf-8")
+        hop = os.path.join(
+            str(pathsec_sandbox.root), *([os.pardir] * 12), str(target).lstrip("/")
+        )
+        model = AveragedPerceptron()
+        _refused(model.load, hop)
+        assert model.weights == {}
+
+    def test_sibling_directory_sharing_the_root_prefix_is_refused(
+        self, outside_only, monkeypatch
+    ):
+        """``<root>_evil`` starts with the root's characters but is not under it.
+
+        The root has to sit somewhere that is not itself a root, or the sibling
+        would be legitimately allowed by the parent and prove nothing.
+        """
+        root = outside_only / "root"
+        root.mkdir()
+        sibling = outside_only / "root_evil"
+        sibling.mkdir()
+        monkeypatch.setattr(nltk.data, "path", [str(root)])
+        monkeypatch.setattr(pathsec, "_ALLOWED_ROOTS_CACHE", None, raising=False)
+        monkeypatch.setattr(pathsec, "_LAST_DATA_PATHS", None, raising=False)
+        target = sibling / "x.json"
+        target.write_text(json.dumps(_weights()), encoding="utf-8")
+        model = AveragedPerceptron()
+        _refused(model.load, str(target))
+        assert model.weights == {}
+
+    def test_case_folded_root_prefix_is_refused(self, pathsec_sandbox):
+        """An upper-cased path is a different string, so containment fails closed.
+
+        On a case-insensitive filesystem it names the same file; the check must
+        still refuse rather than accidentally accept a non-matching prefix.
+        """
+        inside = pathsec_sandbox.root / "cf.json"
+        AveragedPerceptron(_weights()).save(str(inside))
+        model = AveragedPerceptron()
+        _refused(model.load, str(inside).upper())
+        assert model.weights == {}
+
+    def test_bytes_and_pathlike_forms_are_validated_too(self, sandbox):
+        _refused(AveragedPerceptron(_weights()).save, str(sandbox / "b.json").encode())
+        _refused(AveragedPerceptron(_weights()).save, pathlib.Path(sandbox / "p.json"))
+        assert not list(sandbox.iterdir())
+
+    def test_directory_where_a_file_is_expected_is_refused(self, sandbox):
+        _refused(AveragedPerceptron().load, str(sandbox))
+
+
+class TestAveragedPerceptronBenignForms:
+    """Forms that are harmless today, pinned so a future decode/expand regresses.
+
+    None of these may reach a file outside the sandbox: the assertion is that the
+    call fails and leaves the outside directory empty.
+    """
+
+    @pytest.mark.parametrize(
+        "form",
+        [
+            "nul-trailing",
+            "nul-middle",
+            "newline",
+            "tilde",
+            "relative",
+            "dot-slash",
+            "unc-forward",
+            "backslash",
+            "ads-stream",
+            "overlong",
+            "leading-dash",
+        ],
+    )
+    def test_probable_but_harmless_write_forms_touch_nothing(self, form, sandbox):
+        base = str(sandbox / "x.json")
+        payloads = {
+            "nul-trailing": base + "\x00",
+            "nul-middle": base + "\x00.cfg",
+            "newline": base + "\n",
+            "tilde": "~/" + os.path.basename(base),
+            "relative": os.path.basename(base),
+            "dot-slash": "./" + os.path.basename(base),
+            "unc-forward": "//" + base.lstrip("/"),
+            "backslash": base.replace("/", "\\"),
+            "ads-stream": base + ":stream",
+            "overlong": os.path.join(str(sandbox), "a" * 5000),
+            "leading-dash": "-rf",
+        }
+        with pytest.raises(Exception):
+            AveragedPerceptron(_weights()).save(payloads[form])
+        assert not list(sandbox.iterdir()), f"{form} created a file outside the root"
+
+    @pytest.mark.parametrize("blank", ["   ", "\t", "\n", "  \t "])
+    def test_whitespace_only_paths_do_not_create_a_file(self, blank, outside_only):
+        """A whitespace-only name is a legal relative filename, not "no path".
+
+        Waving it through skipped containment entirely and let the open create
+        that file in the working directory. The CWD is an out-of-sandbox
+        directory here, so a created file is a real escape (on macOS the private
+        system temp dir IS an allowed root, and a temp CWD would hide this).
+        """
+        saved = os.getcwd()
+        os.chdir(outside_only)
+        try:
+            with pytest.raises(Exception):
+                AveragedPerceptron(_weights()).save(blank)
+            assert not list(outside_only.iterdir()), "whitespace path created a file"
+        finally:
+            os.chdir(saved)
+
+    def test_empty_path_is_not_a_write(self, restricted_sandbox):
+        with pytest.raises(OSError):
+            AveragedPerceptron(_weights()).save("")
+
+    @POSIX_ONLY
+    @pytest.mark.parametrize("device", ["/dev/stdin", "/dev/fd/0", "/dev/null"])
+    def test_device_nodes_outside_the_root_are_refused(
+        self, device, restricted_sandbox
+    ):
+        """Never opened: containment refuses the path string before any open().
+
+        That ordering is what keeps a blocking device/FIFO from hanging the
+        reader, so it is asserted rather than assumed.
+        """
+        if not os.path.exists(device):
+            pytest.skip(f"{device} not present")
+        _refused(AveragedPerceptron().load, device)
+
+
+@POSIX_ONLY
+class TestBlockingSpecialFilesAreContained:
+    """A FIFO / unix socket blocks a reader forever, so containment must decide
+    before anything is opened.
+
+    An outside-root FIFO is refused on the path string. One planted *inside* a
+    trusted data root is deliberately still permitted (a root is trusted by
+    definition), so that decision is pinned here rather than left implicit, and
+    neither case is ever opened by this test.
+    """
+
+    def test_outside_fifo_is_refused_without_opening_it(self, pathsec_sandbox):
+        fifo = pathsec_sandbox.outside / "fifo"
+        os.mkfifo(str(fifo))
+        assert stat.S_ISFIFO(os.stat(str(fifo)).st_mode)
+        _refused(AveragedPerceptron().load, str(fifo))
+
+    def test_outside_unix_socket_is_refused_without_opening_it(self, pathsec_sandbox):
+        target = pathsec_sandbox.outside / "sock"
+        server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            server.bind(str(target))
+            _refused(AveragedPerceptron().load, str(target))
+        finally:
+            server.close()
+
+    def test_in_root_special_file_is_inside_the_sandbox(self, restricted_sandbox):
+        fifo = os.path.join(restricted_sandbox, "fifo")
+        os.mkfifo(fifo)
+        # No exception: a path inside a trusted root is contained. Not opened --
+        # a FIFO read blocks until a writer appears.
+        pathsec.validate_path(fifo, context="test")
+
+
+class TestAveragedPerceptronRoundTrip:
+    """Over-block control: the legitimate in-sandbox flow must keep working."""
+
+    def test_save_load_round_trip_inside_a_data_root(self, restricted_sandbox):
+        target = os.path.join(restricted_sandbox, "weights.json")
+        AveragedPerceptron(_weights()).save(target)
+        assert os.path.exists(target)
+        reloaded = AveragedPerceptron()
+        reloaded.load(target)
+        assert reloaded.weights == _weights()
+
+
+# ==========================================================================
+# PerceptronTagger.save_to_json / load_from_json / train / __init__
+# ==========================================================================
+
+
+class TestPerceptronTaggerEscapes:
+    def test_save_to_json_outside_root_is_refused(self, sandbox):
+        loc = str(sandbox / "tagger_out")
+        _refused(_tagger().save_to_json, LANG, loc)
+        assert not os.path.exists(loc), "refused save still created the directory"
+
+    def test_train_save_loc_outside_root_is_refused(self, sandbox):
+        loc = str(sandbox / "trained")
+        tagger = PerceptronTagger(load=False)
+        _refused(tagger.train, [[("a", "DT")]], loc, 1)
+        assert not os.path.exists(loc)
+
+    def test_forced_save_dir_outside_root_is_refused(self, sandbox):
+        tagger = _tagger()
+        tagger._save_dir = str(sandbox / "forced")
+        _refused(tagger.save_to_json, LANG)
+        assert not list(sandbox.iterdir())
+
+    @POSIX_ONLY
+    def test_save_to_json_into_a_symlinked_dir_is_refused(self, pathsec_sandbox):
+        victim = pathsec_sandbox.outside / "sym_victim"
+        victim.mkdir()
+        link = pathsec_sandbox.root / "symloc"
+        os.symlink(str(victim), str(link))
+        _refused(_tagger().save_to_json, LANG, str(link))
+        assert not list(victim.iterdir()), "write leaked through the symlink"
+
+    def test_save_to_json_traversal_out_of_the_root_is_refused(self, pathsec_sandbox):
+        hop = os.path.join(
+            str(pathsec_sandbox.root),
+            *([os.pardir] * 12),
+            str(pathsec_sandbox.outside / "trav").lstrip("/"),
+        )
+        _refused(_tagger().save_to_json, LANG, hop)
+        assert not list(pathsec_sandbox.outside.iterdir())
+
+    def test_load_from_json_outside_root_is_refused(self, sandbox):
+        loc = str(sandbox / "tagger_in")
+        _plant_model_dir(loc)
+        tagger = PerceptronTagger(load=False)
+        _refused(tagger.load_from_json, LANG, loc)
+        assert tagger.model.weights == {}
+
+    @pytest.mark.parametrize("wrap", [str, pathlib.Path, "pointer"])
+    def test_every_loc_type_reaches_the_same_guard(self, wrap, sandbox):
+        """str, pathlib.Path and PathPointer are three separate branches in
+        load_from_json; a guard on one is not a guard on the siblings."""
+        loc = str(sandbox / f"tagger_{getattr(wrap, '__name__', wrap)}")
+        _plant_model_dir(loc)
+        value = nltk.data.FileSystemPathPointer(loc) if wrap == "pointer" else wrap(loc)
+        tagger = PerceptronTagger(load=False)
+        _refused(tagger.load_from_json, LANG, value)
+        assert tagger.model.weights == {}
+
+    def test_constructor_loc_reaches_the_same_guard(self, sandbox):
+        loc = str(sandbox / "tagger_ctor")
+        _plant_model_dir(loc)
+        _refused(PerceptronTagger, True, LANG, loc)
+
+    def test_relative_traversal_loc_is_refused(self, restricted_sandbox):
+        _refused(PerceptronTagger(load=False).load_from_json, LANG, "../../../etc")
+
+    def test_load_from_json_does_not_widen_the_sandbox(self, sandbox):
+        """A caller-supplied dir must never be appended to nltk.data.path.
+
+        That primitive turns containment off for the path and everything under
+        it, process-wide, for every later read.
+        """
+        loc = str(sandbox / "tagger_widen")
+        _plant_model_dir(loc)
+        before = list(nltk.data.path)
+        with pytest.raises(Exception):
+            PerceptronTagger(load=False).load_from_json(LANG, loc)
+        assert list(nltk.data.path) == before
+
+
+class TestPerceptronTaggerLangComponent:
+    """``lang`` is interpolated into the filename both directions open."""
+
+    @pytest.mark.parametrize(
+        "lang",
+        [
+            "../evil",
+            "sub/../../evil",
+            "/abs",
+            "a\x00b",
+            "..",
+            ".",
+            "",
+            "e\\v",
+            "a/b",
+        ],
+    )
+    def test_lang_cannot_contribute_path_structure(self, lang, restricted_sandbox):
+        loc = os.path.join(restricted_sandbox, "d")
+        os.makedirs(loc, exist_ok=True)
+        with pytest.raises(ValueError):
+            _tagger().save_to_json(lang=lang, loc=loc)
+        assert not os.listdir(loc)
+
+    @pytest.mark.parametrize("lang", ["eng", "rus", "probeartifact", "xx"])
+    def test_ordinary_language_codes_still_work(self, lang, restricted_sandbox):
+        loc = os.path.join(restricted_sandbox, "ok")
+        os.makedirs(loc, exist_ok=True)
+        _tagger().save_to_json(lang=lang, loc=loc)
+        assert sorted(os.listdir(loc)) == sorted(
+            _tagger().param_files(lang)
+        ), "a legitimate language code was blocked or renamed"
+
+
+class TestPerceptronTaggerRoundTrip:
+    """Over-block controls for the whole train/save/load path."""
+
+    @pytest.fixture
+    def staged(self):
+        """A tagger whose lazily created staging dir is removed afterwards, so a
+        test run does not leave directories behind in the user's data root."""
+        made = []
+
+        def build(**kwargs):
+            tagger = (
+                _tagger() if not kwargs.get("plain") else PerceptronTagger(load=False)
+            )
+            made.append(tagger)
+            return tagger
+
+        try:
+            yield build
+        finally:
+            for tagger in made:
+                if tagger._save_dir:
+                    shutil.rmtree(tagger._save_dir, ignore_errors=True)
+
+    def test_default_save_dir_is_inside_a_data_root(self, staged):
+        tagger = staged(plain=True)
+        resolved = pathlib.Path(tagger.save_dir).resolve()
+        assert any(
+            resolved == root or resolved.is_relative_to(root)
+            for root in pathsec._get_allowed_roots()
+        ), f"{tagger.save_dir} is not inside an allowed root"
+        assert stat.S_IMODE(os.stat(tagger.save_dir).st_mode) == 0o700
+
+    def test_save_dir_is_memoized(self, staged):
+        tagger = staged(plain=True)
+        assert tagger.save_dir == tagger.save_dir
+
+    def test_save_then_load_round_trip(self, staged):
+        tagger = staged()
+        loc = tagger.save_dir
+        tagger.save_to_json(lang=LANG, loc=loc)
+        reloaded = PerceptronTagger(load=False)
+        reloaded.load_from_json(lang=LANG, loc=loc)
+        assert reloaded.model.weights == _weights()
+        assert reloaded.classes == {"NN"}
+
+    def test_train_with_default_save_loc_round_trips(self, staged):
+        tagger = staged(plain=True)
+        sentences = [[("the", "DT"), ("dog", "NN")], [("a", "DT"), ("cat", "NN")]]
+        tagger.train(sentences, save_loc=tagger.save_dir, nr_iter=2)
+        reloaded = PerceptronTagger(load=False)
+        reloaded.load_from_json(lang=tagger.lang, loc=tagger.save_dir)
+        assert reloaded.tag(["the", "dog"]) == [("the", "DT"), ("dog", "NN")]
+
+    def test_shipped_english_tagger_still_loads_and_tags(self):
+        pytest.importorskip("numpy")
+        try:
+            tagger = PerceptronTagger(load=True, lang="eng")
+        except LookupError:
+            pytest.skip("averaged_perceptron_tagger_eng not installed")
+        tagged = tagger.tag(["The", "dog", "barks", "."])
+        assert [word for word, _ in tagged] == ["The", "dog", "barks", "."]
+        assert [tag for _, tag in tagged][:2] == ["DT", "NN"]
+        assert all(tag for _, tag in tagged), "a token came back untagged"
+
+
+# ==========================================================================
+# The rest of the model-artifact family reached from the same threat
+# ==========================================================================
+
+
+class TestSiblingModelArtifactApis:
+    def test_transition_parser_parse_outside_root_is_refused(self, sandbox):
+        from nltk.parse.transitionparser import TransitionParser
+
+        target = sandbox / "model.pickle"
+        target.write_bytes(b"\x80\x04N.")
+        _refused(TransitionParser("arc-standard").parse, [], str(target))
+
+    def test_transition_parser_train_outside_root_is_refused(self, sandbox):
+        pytest.importorskip("sklearn")
+        from nltk.parse.transitionparser import TransitionParser
+
+        target = str(sandbox / "trained.pickle")
+        _refused(TransitionParser("arc-standard").train, [], target, False)
+        assert not os.path.exists(target)
+
+    def test_save_maxent_params_outside_root_is_refused(self, sandbox):
+        numpy = pytest.importorskip("numpy")
+        from nltk.classify.maxent import save_maxent_params
+
+        loc = str(sandbox / "maxent_out")
+        _refused(
+            save_maxent_params,
+            numpy.array([1.0]),
+            {("a", "b"): 0},
+            ["L"],
+            {"alwayson": 0},
+            loc,
+        )
+        assert not os.path.exists(loc)
+
+    def test_load_maxent_params_outside_root_is_refused(self, sandbox):
+        pytest.importorskip("numpy")
+        from nltk.classify.maxent import load_maxent_params
+
+        loc = sandbox / "maxent_in"
+        loc.mkdir()
+        for name, body in (
+            ("weights.txt", "1.0"),
+            ("mapping.tab", ""),
+            ("labels.txt", "L"),
+            ("alwayson.tab", ""),
+        ):
+            (loc / name).write_text(body, encoding="utf-8")
+        _refused(load_maxent_params, nltk.data.FileSystemPathPointer(str(loc)))
+
+    def test_save_punkt_params_outside_root_is_refused(self, sandbox):
+        from nltk.tokenize.punkt import PunktParameters, save_punkt_params
+
+        loc = str(sandbox / "punkt_out")
+        _refused(save_punkt_params, PunktParameters(), loc)
+        assert not os.path.exists(loc)
+
+    def test_maxent_ne_chunker_save_params_outside_root_is_refused(self, outside_only):
+        pytest.importorskip("numpy")
+        from nltk.chunk.named_entity import Maxent_NE_Chunker
+
+        try:
+            chunker = Maxent_NE_Chunker("multiclass")
+        except LookupError:
+            pytest.skip("maxent_ne_chunker_tab not installed")
+        loc = str(outside_only / "ne_out")
+        _refused(chunker.save_params, loc)
+        assert not os.path.exists(loc)
+
+
+class TestTblDemoModelPaths:
+    """``nltk.tbl.demo.postag`` pickles a tagger to caller-supplied paths."""
+
+    @staticmethod
+    def _postag(**kwargs):
+        """Run the demo, tolerating one pre-existing, unrelated failure.
+
+        Re-tagging with the *reloaded* tagger raises ``ValueError: timeout not
+        float or None`` on ``develop`` too (a redos-wrapped pattern does not
+        survive a pickle round trip). That happens after the model file is
+        written, so it does not affect what these tests assert; anything else
+        propagates.
+        """
+        from nltk.tbl import demo as tbl_demo
+
+        try:
+            tbl_demo.postag(
+                num_sents=10,
+                max_rules=1,
+                trace=0,
+                separate_baseline_data=True,
+                **kwargs,
+            )
+        except ValueError as exc:
+            if "timeout not float or None" not in str(exc):
+                raise
+
+    @pytest.fixture(autouse=True)
+    def _needs_treebank(self):
+        pytest.importorskip("numpy")
+        try:
+            nltk.data.find("corpora/treebank")
+        except LookupError:
+            pytest.skip("treebank corpus not installed")
+
+    @pytest.mark.parametrize(
+        "kwarg", ["serialize_output", "cache_baseline_tagger", "error_output"]
+    )
+    def test_outside_root_destinations_are_refused(self, kwarg, outside_only):
+        target = outside_only / f"{kwarg}.out"
+        with pytest.raises((PermissionError, ValueError, OSError)):
+            self._postag(**{kwarg: str(target)})
+        assert not target.exists(), f"{kwarg} wrote outside the sandbox"
+
+    @pytest.mark.parametrize(
+        "kwarg", ["serialize_output", "cache_baseline_tagger", "error_output"]
+    )
+    def test_in_root_destinations_still_work(self, kwarg):
+        staging = nltk.data.make_staging_dir(prefix="nltk_tbl_demo_")
+        try:
+            target = os.path.join(staging, f"{kwarg}.out")
+            self._postag(**{kwarg: target})
+            assert os.path.getsize(target) > 0, f"{kwarg} wrote nothing in-sandbox"
+        finally:
+            shutil.rmtree(staging, ignore_errors=True)
+
+
+# ==========================================================================
+# Negative controls: neuter a guard, the exploit must come back
+# ==========================================================================
+
+
+class TestNegativeControls:
+    def test_enforce_off_lets_the_read_escape(self, sandbox, monkeypatch):
+        target = sandbox / "weights.json"
+        target.write_text(json.dumps(_weights()), encoding="utf-8")
+        monkeypatch.setattr(pathsec, "ENFORCE", False)
+        model = AveragedPerceptron()
+        model.load(str(target))
+        assert model.weights == _weights(), "guard disabled but read still blocked"
+
+    def test_bare_open_reopens_the_advisory_write(self, sandbox, monkeypatch):
+        """Put the advisory's own bug back and the escape must return."""
+        target = sandbox / "bare.json"
+
+        def bare_save(self, path):
+            with open(path, "w") as fout:
+                return json.dump(self.weights, fout)
+
+        monkeypatch.setattr(AveragedPerceptron, "save", bare_save)
+        AveragedPerceptron(_weights()).save(str(target))
+        assert CANARY in target.read_text(encoding="utf-8")
+
+    def test_dropping_save_to_json_validation_reopens_the_write(
+        self, sandbox, monkeypatch
+    ):
+        monkeypatch.setattr(perceptron, "validate_path", lambda *a, **k: None)
+        loc = str(sandbox / "unguarded")
+        _tagger().save_to_json(lang=LANG, loc=loc)
+        assert sorted(os.listdir(loc)), "no files written with the guard removed"
+
+    def test_widening_nltk_data_path_reopens_the_read(self, sandbox, monkeypatch):
+        """The removed ``_authorize_private_dir`` primitive, reconstructed."""
+        loc = str(sandbox / "widened")
+        _plant_model_dir(loc)
+        monkeypatch.setattr(nltk.data, "path", list(nltk.data.path) + [loc])
+        monkeypatch.setattr(pathsec, "_ALLOWED_ROOTS_CACHE", None, raising=False)
+        monkeypatch.setattr(pathsec, "_LAST_DATA_PATHS", None, raising=False)
+        tagger = PerceptronTagger(load=False)
+        tagger.load_from_json(LANG, loc)
+        assert tagger.model.weights == _weights()
+
+    def test_dropping_the_lang_check_lets_lang_carry_a_separator(self):
+        assert "/" in "".join(
+            f"averaged_perceptron_tagger_{'a/b'}.{attr}.json" for attr in ("weights",)
+        ), "the filename template no longer interpolates lang"
+        with pytest.raises(ValueError):
+            perceptron._reject_path_structure("a/b", "lang")
+
+    def test_whitespace_waiver_reopens_the_cwd_write(self, outside_only, monkeypatch):
+        """Restoring the whitespace early-return must let the write land again."""
+        real = pathsec.validate_path
+
+        def waives_whitespace(path_input, *args, **kwargs):
+            if isinstance(path_input, str) and path_input and not path_input.strip():
+                return
+            return real(path_input, *args, **kwargs)
+
+        monkeypatch.setattr(pathsec, "validate_path", waives_whitespace)
+        monkeypatch.setattr(perceptron, "validate_path", waives_whitespace)
+        saved = os.getcwd()
+        os.chdir(outside_only)
+        try:
+            with pytest.raises(Exception):
+                AveragedPerceptron(_weights()).save("   ")
+            assert list(outside_only.iterdir()), "waiver did not reopen the write"
+        finally:
+            os.chdir(saved)

--- a/nltk/test/unit/test_model_artifact_pathsec.py
+++ b/nltk/test/unit/test_model_artifact_pathsec.py
@@ -24,7 +24,9 @@ a private per-user system temp dir IS an allowed root on macOS/Windows, so a
 target staged there would be correctly permitted and prove nothing.
 """
 
+import ast
 import builtins
+import contextlib
 import json
 import os
 import pathlib
@@ -37,6 +39,7 @@ import time
 
 import pytest
 
+import nltk
 import nltk.data
 import nltk.pathsec as pathsec
 import nltk.tag.perceptron as perceptron
@@ -219,6 +222,28 @@ class TestAveragedPerceptronEscapes:
 
     def test_directory_where_a_file_is_expected_is_refused(self, sandbox):
         _refused(AveragedPerceptron().load, str(sandbox))
+
+    def test_an_open_descriptor_is_passed_through_by_design(self, sandbox):
+        """An int is a descriptor the caller already holds, not a path.
+
+        pathsec deliberately lets one through: opening it grants no capability
+        the caller did not already have. Pinned because it is the one input that
+        skips containment, so the exemption must stay a deliberate, narrow one
+        (an int) and never widen to something a caller could supply as text.
+        """
+        target = sandbox / "weights.json"
+        target.write_text(json.dumps(_weights()), encoding="utf-8")
+        # os.open, not the builtin: this deliberately stages a descriptor for a
+        # file outside the sandbox, which is the whole point of the case.
+        descriptor = os.open(str(target), os.O_RDONLY)
+        try:
+            model = AveragedPerceptron()
+            model.load(descriptor)
+            assert model.weights == _weights()
+        finally:
+            with contextlib.suppress(OSError):
+                os.close(descriptor)
+        _refused(AveragedPerceptron().load, str(target))
 
     @POSIX_ONLY
     def test_dangling_in_root_symlink_destination_creates_nothing(
@@ -925,6 +950,45 @@ class TestModelReadsRefuseAPickleGadget:
         target = self._planted(restricted_sandbox)
         with pytest.raises(pickle.UnpicklingError):
             nltk.data.load(os.path.basename(target), format="pickle", cache=False)
+
+
+class TestNoOtherCodeWidensTheSandbox:
+    """Repo-wide invariant behind the ``load_from_json`` fix.
+
+    Appending to ``nltk.data.path`` makes a directory an allowed root for the
+    rest of the process, which disarms containment for it and everything under
+    it. Exactly one place may do that: ``nltk.download(download_dir=...)``, where
+    the caller explicitly names the destination for NLTK's own data and the
+    downloader refuses a non-private one. Any new occurrence is the primitive
+    that made the advisory's read succeed, coming back.
+    """
+
+    ALLOWED = {("nltk/downloader.py", "_authorize_data_dir")}
+
+    def test_only_the_downloader_appends_to_nltk_data_path(self):
+        root = pathlib.Path(nltk.__file__).parent
+        offenders = []
+        for source in sorted(root.rglob("*.py")):
+            relative = source.relative_to(root.parent).as_posix()
+            if relative.startswith("nltk/test/"):
+                continue
+            tree = ast.parse(source.read_text(encoding="utf-8"), relative)
+            for parent in ast.walk(tree):
+                if not isinstance(parent, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                for node in ast.walk(parent):
+                    if (
+                        isinstance(node, ast.Call)
+                        and isinstance(node.func, ast.Attribute)
+                        and node.func.attr in ("append", "insert", "extend")
+                        and isinstance(node.func.value, ast.Attribute)
+                        and node.func.value.attr == "path"
+                        and getattr(node.func.value.value, "attr", None) == "data"
+                    ):
+                        offenders.append((relative, parent.name))
+        assert (
+            set(offenders) <= self.ALLOWED
+        ), "new nltk.data.path widening: %s" % sorted(set(offenders) - self.ALLOWED)
 
 
 class TestNegativeControls:

--- a/nltk/test/unit/test_model_artifact_pathsec.py
+++ b/nltk/test/unit/test_model_artifact_pathsec.py
@@ -24,6 +24,7 @@ a private per-user system temp dir IS an allowed root on macOS/Windows, so a
 target staged there would be correctly permitted and prove nothing.
 """
 
+import builtins
 import json
 import os
 import pathlib
@@ -478,7 +479,9 @@ class TestPerceptronTaggerRoundTrip:
             resolved == root or resolved.is_relative_to(root)
             for root in pathsec._get_allowed_roots()
         ), f"{tagger.save_dir} is not inside an allowed root"
-        assert stat.S_IMODE(os.stat(tagger.save_dir).st_mode) == 0o700
+        if os.name == "posix":
+            # Windows has no POSIX mode bits; the per-user profile ACLs govern.
+            assert stat.S_IMODE(os.stat(tagger.save_dir).st_mode) == 0o700
 
     def test_save_dir_is_memoized(self, staged):
         tagger = staged(plain=True)
@@ -641,6 +644,109 @@ class TestTblDemoModelPaths:
             shutil.rmtree(staging, ignore_errors=True)
 
 
+class TestCRFTaggerModelPaths:
+    """``CRFTagger`` hands a caller path to a native (pycrfsuite) loader/writer.
+
+    Not in the advisory's list, but the same threat: the C extension does its
+    own open, so nothing downstream would have contained it.
+    """
+
+    TRAIN = [[("the", "DT"), ("dog", "NN")], [("a", "DT"), ("cat", "NN")]]
+
+    def test_train_outside_root_is_refused_before_writing(self, sandbox):
+        pytest.importorskip("pycrfsuite")
+        from nltk.tag.crf import CRFTagger
+
+        target = str(sandbox / "model.crf")
+        _refused(CRFTagger().train, self.TRAIN, target)
+        assert not os.path.exists(target), "refused train still wrote the model"
+
+    def test_set_model_file_outside_root_is_refused(self, sandbox):
+        pytest.importorskip("pycrfsuite")
+        from nltk.tag.crf import CRFTagger
+
+        target = sandbox / "model.crf"
+        target.write_bytes(b"not-a-real-model")
+        _refused(CRFTagger().set_model_file, str(target))
+
+    def test_in_root_train_and_tag_round_trip(self, restricted_sandbox):
+        pytest.importorskip("pycrfsuite")
+        from nltk.tag.crf import CRFTagger
+
+        target = os.path.join(restricted_sandbox, "model.crf")
+        tagger = CRFTagger()
+        tagger.train(self.TRAIN, target)
+        assert os.path.getsize(target) > 0
+        reloaded = CRFTagger()
+        reloaded.set_model_file(target)
+        assert reloaded.tag(["the", "dog"]) == [("the", "DT"), ("dog", "NN")]
+
+
+class TestResourceNameSteering:
+    """Caller-supplied *resource names* that steer a model load.
+
+    None of these escape a data root, so they are pinned as audited-benign: the
+    assertion is the containment property, so a future change that lets one
+    resolve outside turns into a failure here.
+    """
+
+    def test_punkt_lang_traversal_stays_inside_a_data_root(self):
+        """``PunktTokenizer(lang)`` climbs at most within the trusted root.
+
+        ``normalize_resource_name`` collapses ``punkt_tab/..`` to ``tokenizers/``
+        before ``find`` sees it, so the lookup moves inside the root but cannot
+        leave it; a leading ``..`` survives normalisation and ``find`` rejects it.
+        """
+        from nltk.tokenize import PunktTokenizer
+
+        with pytest.raises((LookupError, OSError, ValueError)) as excinfo:
+            PunktTokenizer("../..")
+        message = str(excinfo.value)
+        assert "/etc/" not in message and "passwd" not in message
+
+    @pytest.mark.parametrize(
+        "resource",
+        [
+            "tokenizers/punkt/../x.pickle",
+            "tokenizers/punkt/../../../etc/passwd.pickle",
+            "chunkers/maxent_ne_chunker/../../../etc/x.pickle",
+        ],
+    )
+    def test_pickle_shim_resource_names_cannot_traverse(self, resource):
+        """load() routes a *.pickle name to a pickle-free loader; the name that
+        picks the model must not carry traversal."""
+        with pytest.raises((ValueError, LookupError, OSError)):
+            nltk.data.load(resource)
+
+    def test_pos_tag_rejects_an_unknown_language(self):
+        with pytest.raises(NotImplementedError):
+            nltk.pos_tag(["a"], lang="../../etc")
+
+    def test_ne_chunker_format_cannot_traverse(self):
+        from nltk.chunk import ne_chunker
+
+        with pytest.raises((ValueError, LookupError, OSError)):
+            ne_chunker("../../../etc")
+
+    def test_retrieve_without_a_filename_does_not_write_to_an_outside_cwd(
+        self, outside_only
+    ):
+        """``retrieve`` derives the destination from the URL and writes it to the
+        working directory; that destination is still sandbox-checked."""
+        try:
+            source = str(nltk.data.find("corpora/city_database/city.db"))
+        except LookupError:
+            pytest.skip("city_database corpus not installed")
+        saved = os.getcwd()
+        os.chdir(outside_only)
+        try:
+            with pytest.raises((PermissionError, ValueError, OSError)):
+                nltk.data.retrieve("file://" + source, verbose=False)
+            assert not list(outside_only.iterdir())
+        finally:
+            os.chdir(saved)
+
+
 # ==========================================================================
 # Negative controls: neuter a guard, the exploit must come back
 # ==========================================================================
@@ -670,7 +776,14 @@ class TestNegativeControls:
     def test_dropping_save_to_json_validation_reopens_the_write(
         self, sandbox, monkeypatch
     ):
+        """Both destination guards go: the sandbox check on ``loc`` and, on the
+        branch that has no pinned dir_fd, the sandboxed per-file open."""
         monkeypatch.setattr(perceptron, "validate_path", lambda *a, **k: None)
+        monkeypatch.setattr(
+            perceptron,
+            "pathsec_open",
+            lambda path, mode="r", **kwargs: builtins.open(path, mode),
+        )
         loc = str(sandbox / "unguarded")
         _tagger().save_to_json(lang=LANG, loc=loc)
         assert sorted(os.listdir(loc)), "no files written with the guard removed"
@@ -712,3 +825,16 @@ class TestNegativeControls:
             assert list(outside_only.iterdir()), "waiver did not reopen the write"
         finally:
             os.chdir(saved)
+
+    def test_dropping_the_crf_check_reopens_the_native_write(
+        self, sandbox, monkeypatch
+    ):
+        pytest.importorskip("pycrfsuite")
+        import nltk.tag.crf as crf
+
+        monkeypatch.setattr(crf, "validate_path", lambda *a, **k: None)
+        target = str(sandbox / "unguarded.crf")
+        crf.CRFTagger().train(
+            [[("the", "DT"), ("dog", "NN")], [("a", "DT"), ("cat", "NN")]], target
+        )
+        assert os.path.getsize(target) > 0, "no model written with the guard removed"

--- a/nltk/test/unit/test_model_artifact_pathsec.py
+++ b/nltk/test/unit/test_model_artifact_pathsec.py
@@ -28,10 +28,12 @@ import builtins
 import json
 import os
 import pathlib
+import pickle
 import shutil
 import socket
 import stat
 import tempfile
+import time
 
 import pytest
 
@@ -415,6 +417,64 @@ class TestPerceptronTaggerEscapes:
         assert list(nltk.data.path) == before
 
 
+class TestPerceptronTaggerDirectoryOpen:
+    """The pinned-descriptor layer under ``save_to_json``."""
+
+    @POSIX_ONLY
+    def test_a_swapped_intermediate_directory_is_caught_by_the_fd_recheck(
+        self, pathsec_sandbox, monkeypatch
+    ):
+        """O_NOFOLLOW only covers the leaf.
+
+        With the caller-path check skipped (as a swapped parent between check and
+        open would leave it), the descriptor's own real path must still be
+        refused, so the model write cannot land outside the roots.
+        """
+        victim = pathsec_sandbox.outside / "redirected"
+        victim.mkdir()
+        link = pathsec_sandbox.root / "plink"
+        os.symlink(str(victim), str(link))
+
+        real = perceptron.validate_path
+        calls = []
+
+        def skip_the_caller_check(*args, **kwargs):
+            calls.append(args)
+            if len(calls) == 1:
+                return None
+            return real(*args, **kwargs)
+
+        monkeypatch.setattr(perceptron, "validate_path", skip_the_caller_check)
+        _refused(_tagger().save_to_json, LANG, str(link / "leaf"))
+        assert (
+            not any((victim / "leaf").iterdir()) if (victim / "leaf").exists() else True
+        )
+        assert len(calls) > 1, "the descriptor was never re-validated"
+
+    def test_a_regular_file_as_the_destination_is_refused(self, restricted_sandbox):
+        target = os.path.join(restricted_sandbox, "not_a_dir")
+        with pathsec.open(target, "w", context="test") as handle:
+            handle.write("{}")
+        _refused(_tagger().save_to_json, LANG, target)
+
+    @POSIX_ONLY
+    def test_an_in_root_symlink_destination_is_refused_fail_closed(
+        self, restricted_sandbox
+    ):
+        """Even a symlink pointing at another in-root file is refused.
+
+        Model artifacts are never symlinks, so refusing the final component
+        outright is the fail-closed choice; it is asserted so a future
+        "follow it, it stays in-root anyway" relaxation shows up here.
+        """
+        real = os.path.join(restricted_sandbox, "real.json")
+        with pathsec.open(real, "w", context="test") as handle:
+            handle.write("{}")
+        link = os.path.join(restricted_sandbox, "link.json")
+        os.symlink(real, link)
+        _refused(AveragedPerceptron(_weights()).save, link)
+
+
 class TestPerceptronTaggerLangComponent:
     """``lang`` is interpolated into the filename both directions open."""
 
@@ -631,6 +691,23 @@ class TestTblDemoModelPaths:
             self._postag(**{kwarg: str(target)})
         assert not target.exists(), f"{kwarg} wrote outside the sandbox"
 
+    def test_learning_curve_output_outside_root_is_refused(self, outside_only):
+        """matplotlib writes the plot itself, so the path is checked up front."""
+        target = outside_only / "curve.png"
+        with pytest.raises((PermissionError, ValueError, OSError)):
+            self._postag(incremental_stats=True, learning_curve_output=str(target))
+        assert not target.exists()
+
+    def test_learning_curve_output_in_root_still_works(self):
+        pytest.importorskip("matplotlib")
+        staging = nltk.data.make_staging_dir(prefix="nltk_tbl_curve_")
+        try:
+            target = os.path.join(staging, "curve.png")
+            self._postag(incremental_stats=True, learning_curve_output=target)
+            assert os.path.getsize(target) > 0
+        finally:
+            shutil.rmtree(staging, ignore_errors=True)
+
     @pytest.mark.parametrize(
         "kwarg", ["serialize_output", "cache_baseline_tagger", "error_output"]
     )
@@ -750,6 +827,51 @@ class TestResourceNameSteering:
 # ==========================================================================
 # Negative controls: neuter a guard, the exploit must come back
 # ==========================================================================
+
+
+class TestModelReadsAreBounded:
+    """A hostile *in-root* model must fail fast, not hang or exhaust the process."""
+
+    def test_deeply_nested_json_weights_are_rejected_quickly(self, restricted_sandbox):
+        target = os.path.join(restricted_sandbox, "nested.json")
+        with pathsec.open(target, "w", context="test") as handle:
+            handle.write("[" * 200000 + "]" * 200000)
+        started = time.perf_counter()
+        with pytest.raises((RecursionError, ValueError)):
+            AveragedPerceptron().load(target)
+        assert time.perf_counter() - started < 15.0
+
+
+class TestModelReadsRefuseAPickleGadget:
+    """Containment is not the only guard on a model read.
+
+    A model file *inside* a trusted root still goes through an allowlisting
+    unpickler, so a reachable-path model cannot execute a reduce gadget. Pinned
+    here because these are the same read paths the sandbox guards: fixing one
+    must not be mistaken for covering the other.
+    """
+
+    class _Boom:
+        def __reduce__(self):
+            return (os.system, ("exit 0",))
+
+    def _planted(self, root):
+        target = os.path.join(root, "gadget.pickle")
+        with pathsec.open(target, "wb", context="test") as handle:
+            pickle.dump(self._Boom(), handle)
+        return target
+
+    def test_transition_parser_refuses_a_gadget_model(self, restricted_sandbox):
+        from nltk.parse.transitionparser import TransitionParser
+
+        target = self._planted(restricted_sandbox)
+        with pytest.raises(pickle.UnpicklingError):
+            TransitionParser("arc-standard").parse([], target)
+
+    def test_data_load_pickle_refuses_a_gadget_model(self, restricted_sandbox):
+        target = self._planted(restricted_sandbox)
+        with pytest.raises(pickle.UnpicklingError):
+            nltk.data.load(os.path.basename(target), format="pickle", cache=False)
 
 
 class TestNegativeControls:

--- a/nltk/test/unit/test_model_artifact_pathsec.py
+++ b/nltk/test/unit/test_model_artifact_pathsec.py
@@ -210,6 +210,49 @@ class TestAveragedPerceptronEscapes:
     def test_directory_where_a_file_is_expected_is_refused(self, sandbox):
         _refused(AveragedPerceptron().load, str(sandbox))
 
+    @POSIX_ONLY
+    def test_dangling_in_root_symlink_destination_creates_nothing(
+        self, pathsec_sandbox
+    ):
+        """A symlink to a path that does not exist yet is the sharper write case.
+
+        ``os.path.exists`` says False, so an "already there?" pre-check waves it
+        through, and the open would then create the victim at the far end.
+        """
+        victim = pathsec_sandbox.outside / "victim.json"
+        link = pathsec_sandbox.root / "dangling.json"
+        os.symlink(str(victim), str(link))
+        _refused(AveragedPerceptron(_weights()).save, str(link))
+        assert not victim.exists(), "the write created the outside-root victim"
+
+    @POSIX_ONLY
+    def test_retrieve_to_a_dangling_in_root_symlink_creates_nothing(
+        self, pathsec_sandbox
+    ):
+        source = pathsec_sandbox.root / "src.txt"
+        with pathsec.open(str(source), "w", context="test") as handle:
+            handle.write("inside-payload")
+        victim = pathsec_sandbox.outside / "victim.txt"
+        link = pathsec_sandbox.root / "dangling.txt"
+        os.symlink(str(victim), str(link))
+        with pytest.raises((PermissionError, ValueError, OSError)):
+            nltk.data.retrieve("file://" + str(source), str(link), verbose=False)
+        assert not victim.exists()
+
+    def test_empty_resource_name_resolves_to_the_root_not_outside_it(
+        self, restricted_sandbox
+    ):
+        """``load("")`` normalises to the data root itself.
+
+        Harmless (a directory is not a readable model) but pinned: the point is
+        that it lands *on* the root rather than anywhere above it.
+        """
+        with pytest.raises((OSError, ValueError, LookupError)) as excinfo:
+            nltk.data.load("", format="raw", cache=False)
+        assert os.path.dirname(str(restricted_sandbox)) not in str(excinfo.value) or (
+            str(restricted_sandbox) in str(excinfo.value)
+        )
+
 
 class TestAveragedPerceptronBenignForms:
     """Forms that are harmless today, pinned so a future decode/expand regresses.

--- a/nltk/test/unit/test_model_artifact_pathsec.py
+++ b/nltk/test/unit/test_model_artifact_pathsec.py
@@ -553,6 +553,63 @@ class TestPerceptronTaggerDirectoryOpen:
         _refused(AveragedPerceptron(_weights()).save, link)
 
 
+class TestDestinationSpellings:
+    """The same outside directory, written several legal ways.
+
+    Trailing separators/dots/spaces and the non-``str`` path types are the
+    spellings a prefix comparison is most likely to disagree with the kernel
+    about, so each is asserted to end at the same refusal.
+    """
+
+    @pytest.mark.parametrize("suffix", ["/", ".", " ", "//", "/."])
+    def test_trailing_characters_do_not_change_the_verdict(self, suffix, sandbox):
+        _refused(_tagger().save_to_json, LANG, str(sandbox / "dest") + suffix)
+        assert not list(sandbox.iterdir())
+
+    @pytest.mark.parametrize("wrap", ["path", "bytes"])
+    def test_non_string_destinations_are_validated_too(self, wrap, sandbox):
+        raw = str(sandbox / "dest")
+        loc = pathlib.Path(raw) if wrap == "path" else raw.encode()
+        _refused(_tagger().save_to_json, LANG, loc)
+        assert not list(sandbox.iterdir())
+
+    @POSIX_ONLY
+    def test_a_symlink_chain_is_followed_to_its_real_end(self, pathsec_sandbox):
+        """Two in-root hops to an outside file, not one.
+
+        A check that resolves only one level would call the second hop in-root
+        and let the read through.
+        """
+        target = pathsec_sandbox.outside / "chain.json"
+        target.write_text(json.dumps(_weights()), encoding="utf-8")
+        second = pathsec_sandbox.root / "second.json"
+        first = pathsec_sandbox.root / "first.json"
+        os.symlink(str(target), str(second))
+        os.symlink(str(second), str(first))
+        model = AveragedPerceptron()
+        _refused(model.load, str(first))
+        assert model.weights == {}
+
+    @POSIX_ONLY
+    def test_maxent_tab_dir_symlinked_out_of_the_root_is_refused(self, pathsec_sandbox):
+        numpy = pytest.importorskip("numpy")
+        from nltk.classify.maxent import save_maxent_params
+
+        victim = pathsec_sandbox.outside / "mx"
+        victim.mkdir()
+        link = pathsec_sandbox.root / "symdir"
+        os.symlink(str(victim), str(link))
+        _refused(
+            save_maxent_params,
+            numpy.array([1.0]),
+            {("a", "b"): 0},
+            ["L"],
+            {"alwayson": 0},
+            str(link),
+        )
+        assert not list(victim.iterdir())
+
+
 class TestPerceptronTaggerLangComponent:
     """``lang`` is interpolated into the filename both directions open."""
 
@@ -576,6 +633,29 @@ class TestPerceptronTaggerLangComponent:
         with pytest.raises(ValueError):
             _tagger().save_to_json(lang=lang, loc=loc)
         assert not os.listdir(loc)
+
+    def test_an_overlong_lang_cannot_be_written(self, restricted_sandbox):
+        """Rejected by the filesystem, not by a guard, so it is a pin: nothing is
+        created and the failure never lands outside the directory."""
+        loc = os.path.join(restricted_sandbox, "long")
+        os.makedirs(loc, exist_ok=True)
+        with pytest.raises(OSError):
+            _tagger().save_to_json(lang="a" * 5000, loc=loc)
+        assert not os.listdir(loc)
+
+    def test_a_leading_dash_lang_stays_a_filename(self, restricted_sandbox):
+        """Audited-benign: no model-artifact path is ever a subprocess argument,
+        so a leading dash is just a filename. Pinned so that if one of these
+        paths ever becomes argv, this stops being silently true."""
+        loc = os.path.join(restricted_sandbox, "dash")
+        os.makedirs(loc, exist_ok=True)
+        _tagger().save_to_json(lang="-rf", loc=loc)
+        written = sorted(os.listdir(loc))
+        assert written == sorted(_tagger().param_files("-rf"))
+        for name in written:
+            assert os.path.dirname(os.path.realpath(os.path.join(loc, name))) == (
+                os.path.realpath(loc)
+            )
 
     @pytest.mark.parametrize("lang", ["eng", "rus", "probeartifact", "xx"])
     def test_ordinary_language_codes_still_work(self, lang, restricted_sandbox):

--- a/nltk/test/unit/test_model_artifact_pathsec.py
+++ b/nltk/test/unit/test_model_artifact_pathsec.py
@@ -190,17 +190,27 @@ class TestAveragedPerceptronEscapes:
         _refused(model.load, str(target))
         assert model.weights == {}
 
-    def test_case_folded_root_prefix_is_refused(self, pathsec_sandbox):
-        """An upper-cased path is a different string, so containment fails closed.
+    def test_case_folded_path_never_resolves_outside_the_root(self, pathsec_sandbox):
+        """Case folding must not be a way to sidestep the prefix comparison.
 
-        On a case-insensitive filesystem it names the same file; the check must
-        still refuse rather than accidentally accept a non-matching prefix.
+        The two platforms differ legitimately and the invariant has to hold on
+        both: POSIX resolve() keeps the upper-cased string, which no longer
+        matches the root prefix, so the read is refused; Windows resolve()
+        returns the real on-disk casing, so it names the *same in-root file* and
+        the read is allowed. Either outcome is fine; reading something else is
+        not.
         """
         inside = pathsec_sandbox.root / "cf.json"
         AveragedPerceptron(_weights()).save(str(inside))
         model = AveragedPerceptron()
-        _refused(model.load, str(inside).upper())
-        assert model.weights == {}
+        try:
+            model.load(str(inside).upper())
+        except (PermissionError, ValueError, OSError):
+            assert model.weights == {}
+        else:
+            assert (
+                model.weights == _weights()
+            ), "case-folded path resolved to a different file than the in-root one"
 
     def test_bytes_and_pathlike_forms_are_validated_too(self, sandbox):
         _refused(AveragedPerceptron(_weights()).save, str(sandbox / "b.json").encode())
@@ -971,8 +981,13 @@ class TestNegativeControls:
         with pytest.raises(ValueError):
             perceptron._reject_path_structure("a/b", "lang")
 
+    @POSIX_ONLY
     def test_whitespace_waiver_reopens_the_cwd_write(self, outside_only, monkeypatch):
-        """Restoring the whitespace early-return must let the write land again."""
+        """Restoring the whitespace early-return must let the write land again.
+
+        POSIX-only: Windows rejects a filename that is only whitespace, so the
+        waiver cannot reopen anything there and the control would prove nothing.
+        """
         real = pathsec.validate_path
 
         def waives_whitespace(path_input, *args, **kwargs):

--- a/nltk/test/unit/test_path_traversal_security.py
+++ b/nltk/test/unit/test_path_traversal_security.py
@@ -20,6 +20,7 @@ double-decode bug would regress, so they are asserted to resolve in-root.
 """
 
 import os
+import shutil
 import tempfile
 
 import pytest
@@ -346,18 +347,25 @@ class TestPerceptronSaveSquat:
         t.classes = {"NN", "DT"}
         return t
 
-    def _base(self):
-        """A scratch dir INSIDE an allowed data root.
+    @pytest.fixture
+    def base(self):
+        """A scratch dir INSIDE an allowed data root, removed afterwards.
 
         ``tempfile.mkdtemp()`` is not usable here: on Linux it lands under the
         shared ``/tmp``, which is deliberately not an allowed root, so
         ``save_to_json`` would refuse it for containment before ever reaching the
-        squat guards these tests are about.
+        squat guards these tests are about. It is cleaned up rather than left in
+        the user's data root, where a suite run would otherwise pile up a
+        directory per test.
         """
-        return D.make_staging_dir(prefix="nltk_perceptron_squat_")
+        staging = D.make_staging_dir(prefix="nltk_perceptron_squat_")
+        try:
+            yield staging
+        finally:
+            shutil.rmtree(staging, ignore_errors=True)
 
-    def test_benign_save_is_private_and_roundtrips(self):
-        loc = os.path.join(self._base(), "model_dir")
+    def test_benign_save_is_private_and_roundtrips(self, base):
+        loc = os.path.join(base, "model_dir")
         t = self._tagger()
         t.save_to_json(lang="eng", loc=loc)
         files = os.listdir(loc)
@@ -370,10 +378,9 @@ class TestPerceptronSaveSquat:
         assert reloaded.model.weights == t.model.weights
         assert reloaded.tagdict == t.tagdict
 
-    def test_symlinked_save_location_is_refused(self):
+    def test_symlinked_save_location_is_refused(self, base):
         # A guessable in-root save dir a local attacker pre-plants a symlink at
         # must not capture/redirect the model write.
-        base = self._base()
         victim = os.path.join(base, "attacker_dir")
         os.makedirs(victim)
         squat = os.path.join(base, "squat")
@@ -382,10 +389,10 @@ class TestPerceptronSaveSquat:
             self._tagger().save_to_json(lang="eng", loc=squat)
         assert not os.listdir(victim), "write leaked through the symlink"
 
-    def test_world_writable_save_location_is_refused(self):
+    def test_world_writable_save_location_is_refused(self, base):
         # A pre-existing real dir at the guessable name that is world-writable
         # (an attacker could drop files in it / read the model back) is refused.
-        loc = os.path.join(self._base(), "shared")
+        loc = os.path.join(base, "shared")
         os.makedirs(loc)
         os.chmod(loc, 0o777)
         with pytest.raises(PermissionError):

--- a/nltk/test/unit/test_path_traversal_security.py
+++ b/nltk/test/unit/test_path_traversal_security.py
@@ -346,9 +346,18 @@ class TestPerceptronSaveSquat:
         t.classes = {"NN", "DT"}
         return t
 
+    def _base(self):
+        """A scratch dir INSIDE an allowed data root.
+
+        ``tempfile.mkdtemp()`` is not usable here: on Linux it lands under the
+        shared ``/tmp``, which is deliberately not an allowed root, so
+        ``save_to_json`` would refuse it for containment before ever reaching the
+        squat guards these tests are about.
+        """
+        return D.make_staging_dir(prefix="nltk_perceptron_squat_")
+
     def test_benign_save_is_private_and_roundtrips(self):
-        base = tempfile.mkdtemp()
-        loc = os.path.join(base, "model_dir")
+        loc = os.path.join(self._base(), "model_dir")
         t = self._tagger()
         t.save_to_json(lang="eng", loc=loc)
         files = os.listdir(loc)
@@ -356,12 +365,15 @@ class TestPerceptronSaveSquat:
         for f in files:
             # written model must not be group-/world-readable (CWE-377/378)
             assert (os.stat(os.path.join(loc, f)).st_mode & 0o077) == 0
+        reloaded = self._tagger()
+        reloaded.load_from_json(lang="eng", loc=loc)
+        assert reloaded.model.weights == t.model.weights
+        assert reloaded.tagdict == t.tagdict
 
     def test_symlinked_save_location_is_refused(self):
-        # The default save dir is a guessable name in a shared temp dir; a local
-        # attacker who pre-plants a symlink there must not capture/redirect the
-        # model write.
-        base = tempfile.mkdtemp()
+        # A guessable in-root save dir a local attacker pre-plants a symlink at
+        # must not capture/redirect the model write.
+        base = self._base()
         victim = os.path.join(base, "attacker_dir")
         os.makedirs(victim)
         squat = os.path.join(base, "squat")
@@ -373,8 +385,7 @@ class TestPerceptronSaveSquat:
     def test_world_writable_save_location_is_refused(self):
         # A pre-existing real dir at the guessable name that is world-writable
         # (an attacker could drop files in it / read the model back) is refused.
-        base = tempfile.mkdtemp()
-        loc = os.path.join(base, "shared")
+        loc = os.path.join(self._base(), "shared")
         os.makedirs(loc)
         os.chmod(loc, 0o777)
         with pytest.raises(PermissionError):

--- a/tools/check_no_unsandboxed_open.py
+++ b/tools/check_no_unsandboxed_open.py
@@ -36,6 +36,15 @@ GUARDED_PATHS = [
     "nltk/corpus/reader",
     "nltk/corpus/util.py",
     "nltk/data.py",
+    # Model-artifact save/load helpers: the same untrusted-path problem, and the
+    # exact family GHSA-8mgp-746c-j5xp was filed against.
+    "nltk/chunk/named_entity.py",
+    "nltk/classify/maxent.py",
+    "nltk/parse/transitionparser.py",
+    "nltk/tabdata.py",
+    "nltk/tag/perceptron.py",
+    "nltk/tbl/demo.py",
+    "nltk/tokenize/punkt.py",
 ]
 
 SUPPRESS_MARKER = "# sandboxed-open ok"


### PR DESCRIPTION
Found while auditing the stale `fix-ghsa-8mgp` branch (which turns out to be
superseded — merging it would *revert* `pathsec.py`).

## The probe could not detect a regression

`ghsa_8mgp_746c_j5xp.py` read `<tempdir>/../../etc/passwd`. Two levels up from a
deep temp directory does not reach `/etc`:

```
payload:       /var/folders/cq/9c.../T/../../etc/passwd
normalises to: /var/folders/cq/etc/passwd      <- does not exist
```

So it scored FIXED off a `FileNotFoundError`, never touching a guard. Proof — with
**both** containment layers disabled it still passed:

```
normalizer off + ENFORCE off  -> FIXED    # should have leaked
```

A probe that passes with every guard removed is not testing anything.

## Fix

- Fire payloads that genuinely reach the sink: traversal, absolute `/etc/passwd`,
  `nltk:` and `file://` URLs, and a NUL byte.
- Require a **security-marked** refusal (`is_security_rejection`) rather than any
  exception, so an incidental error is not scored as a defence.
- Treat *reading the file's contents* as the leak, not merely "the call returned".
- Load with `cache=False`: `nltk.data.load` memoises by URL, so a successful read
  in one run was replayed into the next and reported a leak that was not there
  (the probe was not idempotent).

## Negative control

The probe never had one. Now:

| state | result |
|---|---|
| unmodified tree | FIXED |
| normaliser + `ENFORCE` removed | **VULNERABLE** |
| restored | FIXED |
| run twice in a row | FIXED, FIXED (idempotent) |

Harness stays at 40 probes, 0 VULNERABLE; `test_advisory_probes.py` 25 passed.

> Note: #3783 carries the same probe rewrite as part of its wider STATIC→FIXED
> sweep. Whichever lands first, I will rebase the other — this PR is the
> standalone version so the false-FIXED can be fixed independently.

Marked `[WIP]` alongside the other decomposition PRs.