### PR TITLE
[WIP] Bound external-tool model paths to the pathsec sandbox

### DIFF
--- a/nltk/parse/malt.py
+++ b/nltk/parse/malt.py
@@ -12,7 +12,7 @@ import os
 import sys
 import tempfile
 
-from nltk.data import ZipFilePathPointer
+from nltk.data import ZipFilePathPointer, make_staging_dir
 from nltk.internals import (
     find_dir,
     find_file,
@@ -22,6 +22,7 @@ from nltk.internals import (
 from nltk.parse.api import ParserI
 from nltk.parse.dependencygraph import DependencyGraph
 from nltk.parse.util import taggedsents_to_conll
+from nltk.pathsec import validate_model_resource, validate_path
 
 
 def malt_regex_tagger():
@@ -160,10 +161,38 @@ class MaltParser(ParserI):
         # Initialize model.
         self.model = find_malt_model(model_filename)
         self._trained = self.model != "malt_temp.mco"
-        # Set the working_dir parameters i.e. `-w` from MaltParser's option.
-        self.working_dir = tempfile.gettempdir()
+        # `-w` is allocated lazily inside a data root; see the working_dir property.
+        self._working_dir = None
         # Initialize POS tagger.
         self.tagger = tagger if tagger is not None else malt_regex_tagger()
+
+    @property
+    def working_dir(self):
+        """MaltParser's ``-w`` directory, holding the temporary CoNLL files and,
+        for an untrained parser, the ``malt_temp.mco`` model that ``train()``
+        writes.
+
+        Allocated lazily by ``nltk.data.make_staging_dir`` INSIDE an allowed data
+        root, with an unpredictable name and mode 0700. The previous default was
+        the shared ``tempfile.gettempdir()``, which is world-writable on Linux and
+        gives a predictable, squattable path for both the CoNLL files and the model.
+        """
+        if self._working_dir is None:
+            self._working_dir = make_staging_dir(prefix="nltk_malt_")
+        return self._working_dir
+
+    @working_dir.setter
+    def working_dir(self, value):
+        # A caller may still choose the directory, but only inside the sandbox.
+        # An empty value would reach MaltParser as `-w ""`, i.e. the CWD.
+        text = os.fspath(value) if value is not None else ""
+        if not text.strip():
+            raise ValueError(
+                "MaltParser.working_dir may not be empty; it would resolve to the "
+                "current working directory."
+            )
+        validate_path(text, context="MaltParser.working_dir")
+        self._working_dir = text
 
     def parse_tagged_sents(self, sentences, verbose=False, top_relation_label="null"):
         """
@@ -270,8 +299,18 @@ class MaltParser(ParserI):
         # directory as the ``-w`` program argument rather than chdir-ing the JVM
         # process: no cwd is handed to java(), so there is no working-directory
         # class-injection surface (an empty/CWD -cp element, CWE-88).
+        # Rejects an empty / option-like / URL / traversing model name, and bounds
+        # it to the sandbox when it is a real path.
+        validate_model_resource(self.model, context="MaltParser model")
         model_dir, model_name = os.path.split(self.model)
-        workingdir = os.path.abspath(model_dir) if model_dir else os.getcwd()
+        if model_dir:
+            # A model carrying a directory is a real path: bound the directory too,
+            # since in learn mode MaltParser WRITES the .mco into it.
+            validate_path(self.model, context="MaltParser model")
+            workingdir = os.path.abspath(model_dir)
+        else:
+            # A bare model name lives in the private dir that train() wrote it to.
+            workingdir = self.working_dir
         cmd += ["-w", workingdir, "-c", model_name]
 
         cmd += ["-i", inputfilename]

--- a/nltk/parse/malt.py
+++ b/nltk/parse/malt.py
@@ -7,8 +7,10 @@
 # URL: <https://www.nltk.org/>
 # For license information, see LICENSE.TXT
 
+import atexit
 import inspect
 import os
+import shutil
 import sys
 import tempfile
 
@@ -178,14 +180,24 @@ class MaltParser(ParserI):
         gives a predictable, squattable path for both the CoNLL files and the model.
         """
         if self._working_dir is None:
-            self._working_dir = make_staging_dir(prefix="nltk_malt_")
+            staged = make_staging_dir(prefix="nltk_malt_")
+            # The old shared tempdir was reaped by the OS; a dir under a data
+            # root is not, so remove it ourselves rather than leaking one per
+            # parser (the .mco it holds is a temporary model by definition).
+            atexit.register(shutil.rmtree, staged, ignore_errors=True)
+            self._working_dir = staged
         return self._working_dir
 
     @working_dir.setter
     def working_dir(self, value):
+        # None restores the unset state, so the property allocates again on next
+        # access rather than raising.
+        if value is None:
+            self._working_dir = None
+            return
         # A caller may still choose the directory, but only inside the sandbox.
         # An empty value would reach MaltParser as `-w ""`, i.e. the CWD.
-        text = os.fspath(value) if value is not None else ""
+        text = os.fspath(value)
         if not text.strip():
             raise ValueError(
                 "MaltParser.working_dir may not be empty; it would resolve to the "
@@ -324,7 +336,9 @@ class MaltParser(ParserI):
         validate_tool_path(inputfilename, context="MaltParser input file")
         cmd += ["-i", inputfilename]
         if mode == "parse":
-            validate_tool_path(outputfilename, context="MaltParser output file")
+            validate_tool_path(
+                outputfilename, context="MaltParser output file", for_write=True
+            )
             cmd += ["-o", outputfilename]
         cmd += ["-m", mode]  # mode use to generate parses.
         return cmd

--- a/nltk/parse/malt.py
+++ b/nltk/parse/malt.py
@@ -22,7 +22,7 @@ from nltk.internals import (
 from nltk.parse.api import ParserI
 from nltk.parse.dependencygraph import DependencyGraph
 from nltk.parse.util import taggedsents_to_conll
-from nltk.pathsec import validate_model_resource, validate_path
+from nltk.pathsec import validate_model_resource, validate_path, validate_tool_path
 
 
 def malt_regex_tagger():
@@ -287,6 +287,12 @@ class MaltParser(ParserI):
         :type inputfilename: str
         :param outputfilename: path to the output file
         :type outputfilename: str
+
+        Both filenames are bounded to the NLTK data roots. ``-i`` is read by the
+        JVM and ``-o`` is *written* by it, so an unbounded value here is an
+        arbitrary file read and an arbitrary file write respectively. The
+        internal callers pass temporary files inside :attr:`working_dir`, which
+        is itself allocated inside a data root.
         """
 
         # Build only MaltParser's own arguments (main class + program args). The
@@ -313,8 +319,12 @@ class MaltParser(ParserI):
             workingdir = self.working_dir
         cmd += ["-w", workingdir, "-c", model_name]
 
+        # -i is read by the JVM and -o is written by it; train_from_file() and
+        # generate_malt_command() are both public, so neither may leave the roots.
+        validate_tool_path(inputfilename, context="MaltParser input file")
         cmd += ["-i", inputfilename]
         if mode == "parse":
+            validate_tool_path(outputfilename, context="MaltParser output file")
             cmd += ["-o", outputfilename]
         cmd += ["-m", mode]  # mode use to generate parses.
         return cmd

--- a/nltk/parse/malt.py
+++ b/nltk/parse/malt.py
@@ -318,13 +318,15 @@ class MaltParser(ParserI):
         # process: no cwd is handed to java(), so there is no working-directory
         # class-injection surface (an empty/CWD -cp element, CWE-88).
         # Rejects an empty / option-like / URL / traversing model name, and bounds
-        # it to the sandbox when it is a real path.
-        validate_model_resource(self.model, context="MaltParser model")
-        model_dir, model_name = os.path.split(self.model)
+        # it to the sandbox when it is a real path. Use the value it returns:
+        # __fspath__ may answer differently on every call, so re-reading
+        # self.model here would let the JVM open a file the guard never saw.
+        model = validate_model_resource(self.model, context="MaltParser model")
+        model_dir, model_name = os.path.split(model)
         if model_dir:
             # A model carrying a directory is a real path: bound the directory too,
             # since in learn mode MaltParser WRITES the .mco into it.
-            validate_path(self.model, context="MaltParser model")
+            validate_path(model, context="MaltParser model")
             workingdir = os.path.abspath(model_dir)
         else:
             # A bare model name lives in the private dir that train() wrote it to.
@@ -333,13 +335,14 @@ class MaltParser(ParserI):
 
         # -i is read by the JVM and -o is written by it; train_from_file() and
         # generate_malt_command() are both public, so neither may leave the roots.
-        validate_tool_path(inputfilename, context="MaltParser input file")
-        cmd += ["-i", inputfilename]
+        cmd += ["-i", validate_tool_path(inputfilename, context="MaltParser input")]
         if mode == "parse":
-            validate_tool_path(
-                outputfilename, context="MaltParser output file", for_write=True
-            )
-            cmd += ["-o", outputfilename]
+            cmd += [
+                "-o",
+                validate_tool_path(
+                    outputfilename, context="MaltParser output", for_write=True
+                ),
+            ]
         cmd += ["-m", mode]  # mode use to generate parses.
         return cmd
 

--- a/nltk/parse/stanford.py
+++ b/nltk/parse/stanford.py
@@ -14,6 +14,7 @@ from subprocess import PIPE
 from nltk.internals import find_jar_iter, find_jars_within_path, java
 from nltk.parse.api import ParserI
 from nltk.parse.dependencygraph import DependencyGraph
+from nltk.pathsec import validate_model_resource
 from nltk.tree import Tree
 
 _stanford_url = "https://nlp.stanford.edu/software/lex-parser.shtml"
@@ -218,6 +219,9 @@ class GenericStanfordParser(ParserI):
         )
 
     def _execute(self, cmd, input_, verbose=False):
+        # Bound `-model` here, at the single hand-off to the JVM, so all three
+        # callers are covered and a late reassignment cannot slip past.
+        validate_model_resource(self.model_path, context="StanfordParser model")
         encoding = self._encoding
         cmd.extend(["-encoding", encoding])
         if self.corenlp_options:

--- a/nltk/parse/stanford.py
+++ b/nltk/parse/stanford.py
@@ -220,8 +220,13 @@ class GenericStanfordParser(ParserI):
 
     def _execute(self, cmd, input_, verbose=False):
         # Bound `-model` here, at the single hand-off to the JVM, so all three
-        # callers are covered and a late reassignment cannot slip past.
-        validate_model_resource(self.model_path, context="StanfordParser model")
+        # callers are covered and a late reassignment cannot slip past. The argv
+        # entry is replaced with the validated string: __fspath__ may answer
+        # differently on every call, so the object the callers put in `cmd` could
+        # otherwise resolve to a file the guard never saw.
+        model = validate_model_resource(self.model_path, context="StanfordParser model")
+        if "-model" in cmd:
+            cmd[cmd.index("-model") + 1] = model
         encoding = self._encoding
         cmd.extend(["-encoding", encoding])
         if self.corenlp_options:

--- a/nltk/parse/stanford.py
+++ b/nltk/parse/stanford.py
@@ -218,6 +218,43 @@ class GenericStanfordParser(ParserI):
             )
         )
 
+    def _validated_extra_options(self, cmd):
+        """Bound the caller-supplied ``corenlp_options`` before it joins the argv.
+
+        The string is *split* into separate argv elements, so it can append a
+        second ``-model``. Stanford's ``LexicalizedParser`` honours the LAST
+        occurrence, which was verified directly against the JVM, so an injected
+        option silently replaced the model the guard above had just checked and
+        the parser deserialized an arbitrary file instead.
+
+        An option NLTK already set may therefore not be repeated here, and any
+        value that looks like a filesystem path is bounded to the data roots. A
+        value that is not a path (``xml``, ``key=value``) is left alone, since
+        this is a general passthrough for the tool's own settings.
+        """
+        already_set = {
+            argument
+            for argument in cmd
+            if isinstance(argument, str) and argument.startswith("-")
+        }
+        validated = []
+        for token in self.corenlp_options.split():
+            if token.startswith("-"):
+                if token in already_set:
+                    raise ValueError(
+                        f"Security Violation [StanfordParser corenlp_options]: "
+                        f"{token!r} is already set by NLTK and may not be "
+                        "overridden; the tool would honour the injected value."
+                    )
+                validated.append(token)
+                continue
+            if os.path.isabs(token) or "/" in token or "\\" in token:
+                token = validate_model_resource(
+                    token, context="StanfordParser corenlp_options"
+                )
+            validated.append(token)
+        return validated
+
     def _execute(self, cmd, input_, verbose=False):
         # Bound `-model` here, at the single hand-off to the JVM, so all three
         # callers are covered and a late reassignment cannot slip past. The argv
@@ -230,7 +267,7 @@ class GenericStanfordParser(ParserI):
         encoding = self._encoding
         cmd.extend(["-encoding", encoding])
         if self.corenlp_options:
-            cmd.extend(self.corenlp_options.split())
+            cmd.extend(self._validated_extra_options(cmd))
 
         # Windows is incompatible with NamedTemporaryFile() without passing in delete=False.
         input_file_name = None

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -272,6 +272,13 @@ def _as_path_text(value, context):
         raise ValueError(
             f"Security Violation [{context}]: {text!r} is bytes; pass a str path."
         )
+    # os.fspath() hands back a str SUBCLASS unchanged, so every check below would
+    # run on attacker-controlled methods: a subclass overriding startswith,
+    # replace, split or __contains__ passes all of them while carrying a hostile
+    # value. str.__str__ is used rather than str(): it ignores a __str__ override
+    # and yields an exact str holding the real characters.
+    if type(text) is not str:
+        text = str.__str__(text)
     return text
 
 

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -295,20 +295,31 @@ def validate_model_resource(model_path, context="NLTK model"):
     if ":" in text and not re.match(r"^[A-Za-z]:[\\/]", text):
         _refuse("contains ':', which names an NTFS alternate data stream")
 
-    # Only a real filesystem path is sandboxed; a bare resource name is not a path.
-    if os.path.isabs(text) or os.path.exists(text):
+    # Only a real filesystem path is sandboxed; a bare resource name is not a
+    # path. A bare name is deliberately NOT probed against the CWD: doing so made
+    # the default `malt_temp.mco` resolve to whatever happened to sit in the
+    # user's directory, which is exactly what older NLTK versions left there.
+    has_directory = bool(os.path.dirname(text.replace("\\", "/")))
+    if os.path.isabs(text) or (has_directory and os.path.exists(text)):
         validate_path(text, context=context)
         _reject_aliased_or_special(text, context)
 
 
-def _reject_aliased_or_special(text, context):
+def _reject_aliased_or_special(text, context, check_links=False):
     """Physical checks on a path that already passed :func:`validate_path`.
 
-    ``realpath()`` cannot see a hardlink, so an in-root alias of an outside file
-    passes every name-based check; the tool would then read, or overwrite, the
-    original. Mirrors the ``st_nlink`` guard in :func:`_hardened_open`. A FIFO,
-    socket or device planted in a data root would instead block the reader
-    forever. Directories stay legal, since corpora are passed as directories.
+    A FIFO, socket or device planted in a data root would block the reader
+    forever, so only regular files and directories are accepted. Directories stay
+    legal, since corpora are passed as directories.
+
+    ``check_links`` additionally refuses a hardlinked file. ``realpath()`` cannot
+    see a hardlink, so an in-root alias of an outside file passes every
+    name-based check and the tool would overwrite the original. This is only
+    applied to paths the tool *writes*: for a read it is not an escalation (the
+    link can only be created by someone who can already write to the data root),
+    and rejecting ``st_nlink > 1`` outright would refuse ordinary
+    hardlink-deduplicated data such as ``cp -l`` or ``rsync --link-dest`` trees,
+    including the original file.
 
     A path that does not exist yet (an output file) has nothing to check.
     """
@@ -316,10 +327,11 @@ def _reject_aliased_or_special(text, context):
         info = os.stat(text)
     except OSError:
         return
-    if stat.S_ISREG(info.st_mode) and info.st_nlink > 1:
+    if check_links and stat.S_ISREG(info.st_mode) and info.st_nlink > 1:
         raise PermissionError(
             f"Security Violation [{context}]: {text!r} has {info.st_nlink} hard "
-            "links, so it may alias a file outside the trusted NLTK data roots."
+            "links, so writing it may overwrite a file outside the trusted NLTK "
+            "data roots."
         )
     if not (stat.S_ISREG(info.st_mode) or stat.S_ISDIR(info.st_mode)):
         raise PermissionError(
@@ -328,7 +340,7 @@ def _reject_aliased_or_special(text, context):
         )
 
 
-def validate_tool_path(path_input, context="NLTK tool file"):
+def validate_tool_path(path_input, context="NLTK tool file", for_write=False):
     """Bound a filesystem path handed to an external tool to read or write.
 
     Unlike :func:`validate_model_resource` this never accepts a bare resource
@@ -339,9 +351,11 @@ def validate_tool_path(path_input, context="NLTK tool file"):
 
     :param path_input: the path as supplied by the caller
     :param context: label used in the security-violation message
+    :param for_write: True when the tool will write the path, which additionally
+        refuses a hardlinked file that could alias a target outside the roots
     :raises ValueError: if the value is empty or contains a NUL byte
-    :raises PermissionError: if it is outside the data roots, hardlinked, or a
-        non-regular file such as a FIFO
+    :raises PermissionError: if it is outside the data roots or is a non-regular
+        file such as a FIFO
     """
     text = os.fspath(path_input)
     if not text or not text.strip():
@@ -354,7 +368,7 @@ def validate_tool_path(path_input, context="NLTK tool file"):
             f"Security Violation [{context}]: path {text!r} contains a NUL byte."
         )
     validate_path(text, context=context)
-    _reject_aliased_or_special(text, context)
+    _reject_aliased_or_special(text, context, check_links=for_write)
 
 
 def _zip_member_is_unsafe(name_str):

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -250,6 +250,31 @@ def validate_path(path_input, context="NLTK", required_root=None):
             raise
 
 
+def _as_path_text(value, context):
+    """Resolve a caller value to a ``str`` path EXACTLY ONCE.
+
+    ``__fspath__`` is allowed to return a different answer on every call, so a
+    guard that calls it separately from the code that uses the path validates one
+    file while the tool opens another. Every caller must validate and then use
+    the single string returned here, never the original object.
+
+    Also turns a non-path (int, None, list) and a ``bytes`` path into a clean
+    security rejection instead of a TypeError that would escape a caller's
+    ``except (ValueError, PermissionError)``.
+    """
+    try:
+        text = os.fspath(value)
+    except TypeError as exc:
+        raise ValueError(
+            f"Security Violation [{context}]: {value!r} is not a filesystem path."
+        ) from exc
+    if isinstance(text, bytes):
+        raise ValueError(
+            f"Security Violation [{context}]: {text!r} is bytes; pass a str path."
+        )
+    return text
+
+
 def _reject_bad_name_syntax(text, context):
     """Syntactic checks shared by every caller-supplied model or tool path.
 
@@ -291,6 +316,10 @@ def _reject_bad_name_syntax(text, context):
     # drive, so it names a different file than the same string does on POSIX.
     if os.name != "posix" and re.match(r"^[\\/]", text):
         _refuse("is relative to the current drive; give a full path with a drive")
+    # Windows silently strips a trailing dot or space, so "evil.mco." is checked
+    # as one name and opened as another. Refused everywhere for determinism.
+    if text != text.rstrip(". "):
+        _refuse("ends with a dot or space, which Windows silently strips")
     # On Windows these resolve to devices (a serial port, the null device) no
     # matter which directory they appear in. Refused everywhere for determinism.
     stem = os.path.basename(text.replace("\\", "/")).split(".")[0].upper()
@@ -322,7 +351,7 @@ def validate_model_resource(model_path, context="NLTK model"):
     :raises ValueError: if the value is empty, option-like, a URL, or traverses
     :raises PermissionError: if it is a filesystem path outside the data roots
     """
-    text = os.fspath(model_path)
+    text = _as_path_text(model_path, context)
     _reject_bad_name_syntax(text, context)
 
     # Only a real filesystem path is sandboxed; a bare resource name is not a
@@ -333,6 +362,7 @@ def validate_model_resource(model_path, context="NLTK model"):
     if os.path.isabs(text) or (has_directory and os.path.exists(text)):
         validate_path(text, context=context)
         _reject_aliased_or_special(text, context)
+    return text
 
 
 def _reject_aliased_or_special(text, context, check_links=False):
@@ -387,10 +417,11 @@ def validate_tool_path(path_input, context="NLTK tool file", for_write=False):
     :raises PermissionError: if it is outside the data roots or is a non-regular
         file such as a FIFO
     """
-    text = os.fspath(path_input)
+    text = _as_path_text(path_input, context)
     _reject_bad_name_syntax(text, context)
     validate_path(text, context=context)
     _reject_aliased_or_special(text, context, check_links=for_write)
+    return text
 
 
 def _zip_member_is_unsafe(name_str):

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -188,7 +188,22 @@ def validate_path(path_input, context="NLTK", required_root=None):
         try:
             target = Path(raw).resolve()
         except (OSError, ValueError):
-            # Fallback for virtual paths inside ZIPs (e.g. corpora/foo.zip/file.txt)
+            # Fallback for virtual paths inside ZIPs (e.g. corpora/foo.zip/file.txt).
+            # This validates only the prefix up to ".zip", so it must never be
+            # reached by a path that can still traverse: resolve() also fails on a
+            # NUL (ValueError) and on an over-long component (ENAMETOOLONG), and
+            # "<root>/ok.zip/<5000 chars>/../../../etc/passwd" would then be
+            # approved on its harmless prefix while normpath() collapses the long
+            # component and leaves /etc/passwd for the caller to open.
+            if "\x00" in raw or ".." in raw.replace("\\", "/").split("/"):
+                msg = (
+                    f"Security Violation [{context}]: unresolvable path with a "
+                    f"traversal or NUL component: {raw!r}"
+                )
+                if ENFORCE:
+                    raise PermissionError(msg)
+                warnings.warn(msg, RuntimeWarning, stacklevel=3)
+                return
             lower_raw = raw.lower()
             if ".zip" in lower_raw:
                 zip_idx = lower_raw.find(".zip") + 4

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -242,6 +242,84 @@ def validate_path(path_input, context="NLTK", required_root=None):
             raise
 
 
+def validate_model_resource(model_path, context="NLTK model"):
+    """Bound a caller-supplied model argument that may be a *resource name*.
+
+    Several JVM wrappers (Stanford parser/tagger/segmenter) accept the same
+    ``-model`` argument as either a filesystem path or a jar-internal classpath
+    resource, e.g. the default
+    ``edu/stanford/nlp/models/lexparser/englishPCFG.ser.gz``. Bounding every value
+    with :func:`validate_path` would break the jar-internal defaults, and skipping
+    validation entirely lets an attacker hand the JVM any file on disk.
+
+    So: a plain resource name is left alone, any real filesystem path is bounded to
+    the NLTK data roots, and a value that is neither (empty, an option-looking
+    token, a URL, or a ``..`` traversal) is refused outright so that a
+    resource-looking name cannot traverse out of the jar namespace.
+
+    ``..`` is checked after folding ``\\`` to ``/``: a backslash is an ordinary
+    filename character on POSIX but a separator on Windows, so ``..\\..\\etc`` has
+    to be rejected on both.
+
+    :param model_path: the model argument as supplied by the caller
+    :param context: label used in the security-violation message
+    :raises ValueError: if the value is empty, option-like, a URL, or traverses
+    :raises PermissionError: if it is a filesystem path outside the data roots
+    """
+    text = os.fspath(model_path)
+
+    def _refuse(why):
+        raise ValueError(f"Security Violation [{context}]: model {text!r} {why}.")
+
+    if not text or not text.strip():
+        _refuse("is empty")
+    # A NUL truncates the path in the JVM's native layer, so "good.ser.gz\0evil"
+    # can name a different file there than it does here.
+    if "\x00" in text:
+        _refuse("contains a NUL byte")
+    # A leading '-' would be parsed as another option by the tool we hand it to.
+    if text.startswith("-"):
+        _refuse("looks like a command-line option (argument injection)")
+    # Stanford's loaders will fetch a URL; only local resources are permitted.
+    if "://" in text or text.lower().startswith(("file:", "jar:")):
+        _refuse("is a URL; only local model resources are permitted")
+    # Nothing downstream expands '~', but a sink that did would reach $HOME.
+    if text.startswith("~"):
+        _refuse("starts with '~'; pass an already-expanded path")
+    # A Windows UNC path reaches a remote share.
+    if text.startswith("\\\\") or text.startswith("//"):
+        _refuse("is a UNC path; only local model resources are permitted")
+    if ".." in text.replace("\\", "/").split("/"):
+        _refuse("contains a '..' component; it may not traverse out of the namespace")
+    # ':' names an NTFS alternate data stream, except in a drive prefix (C:\...).
+    if ":" in text and not re.match(r"^[A-Za-z]:[\\/]", text):
+        _refuse("contains ':', which names an NTFS alternate data stream")
+
+    # Only a real filesystem path is sandboxed; a bare resource name is not a path.
+    if os.path.isabs(text) or os.path.exists(text):
+        validate_path(text, context=context)
+        # realpath() cannot see a hardlink, so an in-root alias of an outside file
+        # passes the check above; the tool would then read (or overwrite) the
+        # original. Mirrors the st_nlink guard in _hardened_open.
+        try:
+            info = os.stat(text)
+        except OSError:
+            return
+        if stat.S_ISREG(info.st_mode) and info.st_nlink > 1:
+            raise PermissionError(
+                f"Security Violation [{context}]: model {text!r} has "
+                f"{info.st_nlink} hard links, so it may alias a file outside the "
+                "trusted NLTK data roots."
+            )
+        # A FIFO, socket or device planted in a data root would hang the reader
+        # forever. Directories stay legal: corpora are passed as directories.
+        if not (stat.S_ISREG(info.st_mode) or stat.S_ISDIR(info.st_mode)):
+            raise PermissionError(
+                f"Security Violation [{context}]: model {text!r} is not a regular "
+                "file or directory; reading it could block indefinitely."
+            )
+
+
 def _zip_member_is_unsafe(name_str):
     """True if a ZIP member is written somewhere other than where it is validated.
 
@@ -978,6 +1056,7 @@ class ZipFile(zipfile.ZipFile):
 
 __all__ = [
     "validate_path",
+    "validate_model_resource",
     "validate_network_url",
     "validate_zip_archive",
     "open",

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -298,26 +298,63 @@ def validate_model_resource(model_path, context="NLTK model"):
     # Only a real filesystem path is sandboxed; a bare resource name is not a path.
     if os.path.isabs(text) or os.path.exists(text):
         validate_path(text, context=context)
-        # realpath() cannot see a hardlink, so an in-root alias of an outside file
-        # passes the check above; the tool would then read (or overwrite) the
-        # original. Mirrors the st_nlink guard in _hardened_open.
-        try:
-            info = os.stat(text)
-        except OSError:
-            return
-        if stat.S_ISREG(info.st_mode) and info.st_nlink > 1:
-            raise PermissionError(
-                f"Security Violation [{context}]: model {text!r} has "
-                f"{info.st_nlink} hard links, so it may alias a file outside the "
-                "trusted NLTK data roots."
-            )
-        # A FIFO, socket or device planted in a data root would hang the reader
-        # forever. Directories stay legal: corpora are passed as directories.
-        if not (stat.S_ISREG(info.st_mode) or stat.S_ISDIR(info.st_mode)):
-            raise PermissionError(
-                f"Security Violation [{context}]: model {text!r} is not a regular "
-                "file or directory; reading it could block indefinitely."
-            )
+        _reject_aliased_or_special(text, context)
+
+
+def _reject_aliased_or_special(text, context):
+    """Physical checks on a path that already passed :func:`validate_path`.
+
+    ``realpath()`` cannot see a hardlink, so an in-root alias of an outside file
+    passes every name-based check; the tool would then read, or overwrite, the
+    original. Mirrors the ``st_nlink`` guard in :func:`_hardened_open`. A FIFO,
+    socket or device planted in a data root would instead block the reader
+    forever. Directories stay legal, since corpora are passed as directories.
+
+    A path that does not exist yet (an output file) has nothing to check.
+    """
+    try:
+        info = os.stat(text)
+    except OSError:
+        return
+    if stat.S_ISREG(info.st_mode) and info.st_nlink > 1:
+        raise PermissionError(
+            f"Security Violation [{context}]: {text!r} has {info.st_nlink} hard "
+            "links, so it may alias a file outside the trusted NLTK data roots."
+        )
+    if not (stat.S_ISREG(info.st_mode) or stat.S_ISDIR(info.st_mode)):
+        raise PermissionError(
+            f"Security Violation [{context}]: {text!r} is not a regular file or "
+            "directory; reading it could block indefinitely."
+        )
+
+
+def validate_tool_path(path_input, context="NLTK tool file"):
+    """Bound a filesystem path handed to an external tool to read or write.
+
+    Unlike :func:`validate_model_resource` this never accepts a bare resource
+    name: the value must be a real path inside the NLTK data roots. Use it for
+    arguments the tool opens directly, such as MaltParser's ``-i`` input and
+    ``-o`` output, where an unbounded value is an arbitrary file read and an
+    arbitrary file write respectively.
+
+    :param path_input: the path as supplied by the caller
+    :param context: label used in the security-violation message
+    :raises ValueError: if the value is empty or contains a NUL byte
+    :raises PermissionError: if it is outside the data roots, hardlinked, or a
+        non-regular file such as a FIFO
+    """
+    text = os.fspath(path_input)
+    if not text or not text.strip():
+        raise ValueError(
+            f"Security Violation [{context}]: path is empty; it would resolve to "
+            "the current working directory."
+        )
+    if "\x00" in text:
+        raise ValueError(
+            f"Security Violation [{context}]: path {text!r} contains a NUL byte."
+        )
+    validate_path(text, context=context)
+    _reject_aliased_or_special(text, context)
 
 
 def _zip_member_is_unsafe(name_str):
@@ -1057,6 +1094,7 @@ class ZipFile(zipfile.ZipFile):
 __all__ = [
     "validate_path",
     "validate_model_resource",
+    "validate_tool_path",
     "validate_network_url",
     "validate_zip_archive",
     "open",

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -250,6 +250,54 @@ def validate_path(path_input, context="NLTK", required_root=None):
             raise
 
 
+def _reject_bad_name_syntax(text, context):
+    """Syntactic checks shared by every caller-supplied model or tool path.
+
+    None of these can be a legitimate model, corpus or output file, so they are
+    refused before the value is treated as a path at all. ``..`` is checked after
+    folding ``\\`` to ``/``: a backslash is an ordinary filename character on
+    POSIX but a separator on Windows, so ``..\\..\\etc`` has to be rejected on both.
+    """
+
+    def _refuse(why):
+        raise ValueError(f"Security Violation [{context}]: {text!r} {why}.")
+
+    if not text or not text.strip():
+        _refuse("is empty")
+    # A NUL truncates the path in a tool's native layer, so "good.ser.gz\0evil"
+    # can name a different file there than it does here.
+    if "\x00" in text:
+        _refuse("contains a NUL byte")
+    # A leading '-' would be parsed as another option by the tool we hand it to.
+    if text.startswith("-"):
+        _refuse("looks like a command-line option (argument injection)")
+    # Stanford's loaders will fetch a URL; only local resources are permitted.
+    if "://" in text or text.lower().startswith(("file:", "jar:")):
+        _refuse("is a URL; only local resources are permitted")
+    # Nothing downstream expands '~', but a sink that did would reach $HOME.
+    if text.startswith("~"):
+        _refuse("starts with '~'; pass an already-expanded path")
+    # A Windows UNC path reaches a remote share.
+    if text.startswith("\\\\") or text.startswith("//"):
+        _refuse("is a UNC path; only local resources are permitted")
+    if ".." in text.replace("\\", "/").split("/"):
+        _refuse("contains a '..' component; it may not traverse out of the namespace")
+    # ':' names an NTFS alternate data stream, except in a drive prefix (C:\...).
+    # This also catches the drive-RELATIVE form "C:name", which means "name in
+    # the current directory of drive C" and so escapes the validated location.
+    if ":" in text and not re.match(r"^[A-Za-z]:[\\/]", text):
+        _refuse("contains ':', which names an NTFS alternate data stream")
+    # On Windows a leading separator with no drive is relative to the CURRENT
+    # drive, so it names a different file than the same string does on POSIX.
+    if os.name != "posix" and re.match(r"^[\\/]", text):
+        _refuse("is relative to the current drive; give a full path with a drive")
+    # On Windows these resolve to devices (a serial port, the null device) no
+    # matter which directory they appear in. Refused everywhere for determinism.
+    stem = os.path.basename(text.replace("\\", "/")).split(".")[0].upper()
+    if stem in _WINDOWS_DEVICE_NAMES:
+        _refuse(f"names the reserved Windows device {stem!r}")
+
+
 def validate_model_resource(model_path, context="NLTK model"):
     """Bound a caller-supplied model argument that may be a *resource name*.
 
@@ -275,38 +323,7 @@ def validate_model_resource(model_path, context="NLTK model"):
     :raises PermissionError: if it is a filesystem path outside the data roots
     """
     text = os.fspath(model_path)
-
-    def _refuse(why):
-        raise ValueError(f"Security Violation [{context}]: model {text!r} {why}.")
-
-    if not text or not text.strip():
-        _refuse("is empty")
-    # A NUL truncates the path in the JVM's native layer, so "good.ser.gz\0evil"
-    # can name a different file there than it does here.
-    if "\x00" in text:
-        _refuse("contains a NUL byte")
-    # A leading '-' would be parsed as another option by the tool we hand it to.
-    if text.startswith("-"):
-        _refuse("looks like a command-line option (argument injection)")
-    # Stanford's loaders will fetch a URL; only local resources are permitted.
-    if "://" in text or text.lower().startswith(("file:", "jar:")):
-        _refuse("is a URL; only local model resources are permitted")
-    # Nothing downstream expands '~', but a sink that did would reach $HOME.
-    if text.startswith("~"):
-        _refuse("starts with '~'; pass an already-expanded path")
-    # A Windows UNC path reaches a remote share.
-    if text.startswith("\\\\") or text.startswith("//"):
-        _refuse("is a UNC path; only local model resources are permitted")
-    if ".." in text.replace("\\", "/").split("/"):
-        _refuse("contains a '..' component; it may not traverse out of the namespace")
-    # ':' names an NTFS alternate data stream, except in a drive prefix (C:\...).
-    if ":" in text and not re.match(r"^[A-Za-z]:[\\/]", text):
-        _refuse("contains ':', which names an NTFS alternate data stream")
-    # On Windows these resolve to devices (a serial port, the null device) no
-    # matter which directory they appear in. Refused everywhere for determinism.
-    stem = os.path.basename(text.replace("\\", "/")).split(".")[0].upper()
-    if stem in _WINDOWS_DEVICE_NAMES:
-        _refuse(f"names the reserved Windows device {stem!r}")
+    _reject_bad_name_syntax(text, context)
 
     # Only a real filesystem path is sandboxed; a bare resource name is not a
     # path. A bare name is deliberately NOT probed against the CWD: doing so made
@@ -371,15 +388,7 @@ def validate_tool_path(path_input, context="NLTK tool file", for_write=False):
         file such as a FIFO
     """
     text = os.fspath(path_input)
-    if not text or not text.strip():
-        raise ValueError(
-            f"Security Violation [{context}]: path is empty; it would resolve to "
-            "the current working directory."
-        )
-    if "\x00" in text:
-        raise ValueError(
-            f"Security Violation [{context}]: path {text!r} contains a NUL byte."
-        )
+    _reject_bad_name_syntax(text, context)
     validate_path(text, context=context)
     _reject_aliased_or_special(text, context, check_links=for_write)
 

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -45,6 +45,14 @@ ALLOW_PROXIED_FETCH = False
 _ALLOWED_ROOTS_CACHE = None
 _LAST_DATA_PATHS = None
 
+# Reserved DOS device names. On Windows these resolve to a device rather than a
+# file in the current directory, whatever the surrounding path is.
+_WINDOWS_DEVICE_NAMES = frozenset(
+    ["CON", "PRN", "AUX", "NUL"]
+    + [f"COM{i}" for i in range(1, 10)]
+    + [f"LPT{i}" for i in range(1, 10)]
+)
+
 
 def is_private_dir(path):
     """Return True if *path* is a directory safe to trust as a data root: another
@@ -294,6 +302,11 @@ def validate_model_resource(model_path, context="NLTK model"):
     # ':' names an NTFS alternate data stream, except in a drive prefix (C:\...).
     if ":" in text and not re.match(r"^[A-Za-z]:[\\/]", text):
         _refuse("contains ':', which names an NTFS alternate data stream")
+    # On Windows these resolve to devices (a serial port, the null device) no
+    # matter which directory they appear in. Refused everywhere for determinism.
+    stem = os.path.basename(text.replace("\\", "/")).split(".")[0].upper()
+    if stem in _WINDOWS_DEVICE_NAMES:
+        _refuse(f"names the reserved Windows device {stem!r}")
 
     # Only a real filesystem path is sandboxed; a bare resource name is not a
     # path. A bare name is deliberately NOT probed against the CWD: doing so made

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -300,6 +300,13 @@ def _reject_bad_name_syntax(text, context):
     # can name a different file there than it does here.
     if "\x00" in text:
         _refuse("contains a NUL byte")
+    # Python 3.14's url2pathname follows the WHATWG rules and STRIPS tab, LF and
+    # CR, so ".\n./x" passes a '..' check here and becomes "../x" downstream.
+    if any(character in text for character in "\t\n\r\x0b\x0c"):
+        _refuse(
+            "contains a control character; these are stripped by URL-to-path "
+            "conversion on Python 3.14 and can turn into a '..' traversal"
+        )
     # A leading '-' would be parsed as another option by the tool we hand it to.
     if text.startswith("-"):
         _refuse("looks like a command-line option (argument injection)")

--- a/nltk/test/unit/test_java_injection_exploit.py
+++ b/nltk/test/unit/test_java_injection_exploit.py
@@ -187,6 +187,12 @@ def _malt_stub(jars, args, tmp_path):
     m.model = str(model)
     m._trained = True
     m._working_dir = None
+    # -i and -o are bounded to the data roots, so give the stub real in-root paths.
+    m._nltk_test_io = (
+        str(tmp_path / "nltk_data" / "in.conll"),
+        str(tmp_path / "nltk_data" / "out.conll"),
+    )
+    (tmp_path / "nltk_data" / "in.conll").touch()
     return m
 
 
@@ -202,7 +208,7 @@ def test_malt_untrusted_jar_is_blocked(tmp_path, monkeypatch):
     evil.parent.mkdir()
     evil.touch()
     m = _malt_stub([str(evil)], [], tmp_path)
-    cmd = m.generate_malt_command("in", "out", mode="parse")
+    cmd = m.generate_malt_command(*m._nltk_test_io, mode="parse")
     with pytest.raises(UntrustedJarError):  # java()'s classpath sandbox refuses it
         m._execute(cmd)
 
@@ -216,7 +222,7 @@ def test_malt_arg_injection_is_blocked(tmp_path, monkeypatch):
     monkeypatch.setattr("nltk.data.path", [str(data_dir)])
     monkeypatch.setattr("nltk.internals._java_bin", "/usr/bin/java")
     m = _malt_stub([str(good)], ["-XX:OnOutOfMemoryError=touch /tmp/x"], tmp_path)
-    cmd = m.generate_malt_command("in", "out", mode="parse")
+    cmd = m.generate_malt_command(*m._nltk_test_io, mode="parse")
     with pytest.raises(ValueError):  # java()'s option allowlist refuses it
         m._execute(cmd)
 
@@ -236,7 +242,7 @@ def test_malt_trusted_jar_and_safe_args_build_command(tmp_path, monkeypatch):
     monkeypatch.setattr("nltk.internals._java_bin", "java")
 
     m = _malt_stub([str(good)], ["-Xmx1024m"], tmp_path)
-    argv = m.generate_malt_command("in", "out", mode="parse")
+    argv = m.generate_malt_command(*m._nltk_test_io, mode="parse")
     # generate_malt_command now returns only the maltparser argv (no java/-cp/opts)
     assert argv[0] == "org.maltparser.Malt" and "-w" in argv
     assert "java" not in argv and "-Xmx1024m" not in argv

--- a/nltk/test/unit/test_java_injection_exploit.py
+++ b/nltk/test/unit/test_java_injection_exploit.py
@@ -180,8 +180,13 @@ def _malt_stub(jars, args, tmp_path):
     m = MaltParser.__new__(MaltParser)
     m.malt_jars = jars
     m.additional_java_args = args
-    m.model = "model.mco"
-    m.working_dir = str(tmp_path)
+    # The model must sit inside the allowed data root: generate_malt_command bounds
+    # it with validate_path before handing -w/-c to the JVM.
+    model = tmp_path / "nltk_data" / "model.mco"
+    model.touch()
+    m.model = str(model)
+    m._trained = True
+    m._working_dir = None
     return m
 
 

--- a/nltk/test/unit/test_module_import_and_functional_smoke.py
+++ b/nltk/test/unit/test_module_import_and_functional_smoke.py
@@ -1,0 +1,178 @@
+# Natural Language Toolkit: import + functional smoke test
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""Proof that the pathsec hardening did not break NLTK.
+
+The security work threads ``validate_path`` / ``validate_model_resource`` through
+loaders all over the tree. A guard that is slightly too strict does not fail the
+security tests, it fails *ordinary use*, and mocked tests cannot see that: they
+never load a real corpus or run a real model.
+
+So this module does two things that no other test file does:
+
+1. imports **every** module in the ``nltk`` package, and
+2. runs a battery of real operations against real corpora and real models.
+
+An ``ImportError`` is treated as a missing optional third-party dependency and a
+``LookupError`` as missing corpus data, since neither says anything about our
+code. Anything else is a hard failure and names the module that broke.
+"""
+
+import importlib
+import pkgutil
+
+import pytest
+
+import nltk
+
+# Loading these has side effects disproportionate to their value here: nltk.book
+# pulls in nine corpora and prints a banner, and nltk.app opens Tk toolkits.
+_SKIP_PREFIXES = ("nltk.test.", "nltk.book", "nltk.app")
+
+
+def _all_module_names():
+    names = []
+    for module in pkgutil.walk_packages(nltk.__path__, prefix="nltk."):
+        name = module.name
+        if name.startswith(_SKIP_PREFIXES) or name == "nltk.test":
+            continue
+        names.append(name)
+    return sorted(names)
+
+
+def test_every_nltk_module_imports():
+    """Every module must import. A guard that broke an import at module scope
+    shows up here as a named hard failure rather than as a mystery elsewhere."""
+    hard_failures = []
+    optional = []
+    imported = 0
+    for name in _all_module_names():
+        try:
+            importlib.import_module(name)
+        except ImportError as exc:
+            optional.append((name, str(exc)))
+        except LookupError as exc:
+            optional.append((name, str(exc)))
+        except Exception as exc:
+            hard_failures.append(f"{name}: {type(exc).__name__}: {exc}")
+        else:
+            imported += 1
+
+    assert hard_failures == [], "modules failed to import:\n" + "\n".join(hard_failures)
+    # A sanity floor: if the walk silently stopped finding modules the assertion
+    # above would pass vacuously.
+    assert imported > 200, f"only {imported} modules imported; the walk is broken"
+
+
+def _skip_without_data(func):
+    """Run ``func``, turning missing corpora into a skip rather than a failure."""
+    try:
+        return func()
+    except LookupError as exc:
+        pytest.skip(f"corpus data unavailable: {str(exc)[:80]}")
+
+
+# ---------------------------------------------------------------------------
+# Real operations. Nothing here is mocked: each one loads real data through the
+# hardened loaders and checks a real result.
+# ---------------------------------------------------------------------------
+
+
+def test_tokenizers_work():
+    from nltk.tokenize import sent_tokenize, word_tokenize
+
+    tokens = _skip_without_data(lambda: word_tokenize("Dr. Smith isn't here."))
+    assert "Dr." in tokens and "n't" in tokens
+    assert _skip_without_data(lambda: sent_tokenize("One. Two! Three?")) == [
+        "One.",
+        "Two!",
+        "Three?",
+    ]
+
+
+def test_pos_tagging_and_chunking_work():
+    from nltk.tokenize import word_tokenize
+
+    tagged = _skip_without_data(
+        lambda: nltk.pos_tag(word_tokenize("John lives in Paris"))
+    )
+    assert [word for word, _tag in tagged] == ["John", "lives", "in", "Paris"]
+    tree = _skip_without_data(lambda: nltk.ne_chunk(tagged))
+    assert tree.label() == "S"
+
+
+def test_perceptron_tagger_loads_its_pickled_model():
+    """The tagger reads a pickled model through the hardened loader, so a
+    too-strict path guard breaks it here first."""
+    from nltk.tag import PerceptronTagger
+
+    tagged = _skip_without_data(lambda: PerceptronTagger().tag(["The", "dog", "runs"]))
+    assert [word for word, _tag in tagged] == ["The", "dog", "runs"]
+
+
+def test_stemmers_and_lemmatizer_work():
+    from nltk.stem import PorterStemmer, SnowballStemmer, WordNetLemmatizer
+
+    assert PorterStemmer().stem("running") == "run"
+    assert SnowballStemmer("english").stem("generously") == "generous"
+    assert _skip_without_data(lambda: WordNetLemmatizer().lemmatize("geese")) == "goose"
+
+
+def test_zipped_corpora_load():
+    """wordnet and stopwords are read out of zip archives, which is exactly the
+    path the decompression guards sit on."""
+    from nltk.corpus import stopwords, wordnet
+
+    assert _skip_without_data(lambda: wordnet.synsets("dog")) != []
+    assert "the" in _skip_without_data(lambda: stopwords.words("english"))
+
+
+def test_tagged_and_parsed_corpora_load():
+    from nltk.corpus import brown, gutenberg, treebank
+
+    assert _skip_without_data(lambda: brown.tagged_words()[:3]) != []
+    assert _skip_without_data(lambda: gutenberg.words("austen-emma.txt")[:5]) != []
+    assert _skip_without_data(lambda: treebank.parsed_sents()[0]).label() == "S"
+
+
+def test_vader_sentiment_works():
+    from nltk.sentiment.vader import SentimentIntensityAnalyzer
+
+    scores = _skip_without_data(
+        lambda: SentimentIntensityAnalyzer().polarity_scores("NLTK is great!")
+    )
+    assert scores["compound"] > 0
+
+
+def test_grammar_parsing_works():
+    from nltk import CFG
+    from nltk.parse import RecursiveDescentParser
+
+    grammar = CFG.fromstring("S -> NP VP\nNP -> 'John'\nVP -> 'runs'")
+    trees = list(RecursiveDescentParser(grammar).parse(["John", "runs"]))
+    assert trees and trees[0].label() == "S"
+
+
+def test_classifier_training_works():
+    from nltk.classify import NaiveBayesClassifier
+
+    classifier = NaiveBayesClassifier.train([({"a": 1}, "x"), ({"a": 0}, "y")])
+    assert classifier.classify({"a": 1}) == "x"
+
+
+def test_metrics_and_translate_work():
+    from nltk.translate.bleu_score import sentence_bleu
+
+    assert nltk.edit_distance("kitten", "sitting") == 3
+    assert sentence_bleu([["a", "b", "c", "d"]], ["a", "b", "c", "d"]) == 1.0
+
+
+def test_collocations_and_freqdist_work():
+    from nltk.corpus import brown
+
+    words = _skip_without_data(lambda: list(brown.words()[:2000]))
+    assert nltk.FreqDist(words).most_common(1)[0][1] > 0
+    assert nltk.Text(words).collocation_list()[:1] != []

--- a/nltk/test/unit/test_pathsec_sweep_wrappers.py
+++ b/nltk/test/unit/test_pathsec_sweep_wrappers.py
@@ -96,7 +96,7 @@ def test_segmenter_model_paths_refuse_escape(pathsec_sandbox, monkeypatch, slot)
     evil = outside / "evil.ser.gz"
     evil.write_text("payload")
     inside = str(root / "in.txt")
-    with pathsec.open(inside, "w") as handle:
+    with pathsec.open(inside, "w", encoding="utf-8") as handle:
         handle.write("中文")
 
     tool = _segmenter(monkeypatch, str(root), **{slot: str(evil)})
@@ -127,7 +127,7 @@ def test_segmenter_in_sandbox_paths_reach_jvm(pathsec_sandbox, monkeypatch):
     with pathsec.open(model, "w") as handle:
         handle.write("m")
     inside = str(root / "in.txt")
-    with pathsec.open(inside, "w") as handle:
+    with pathsec.open(inside, "w", encoding="utf-8") as handle:
         handle.write("中文")
 
     tool = _segmenter(monkeypatch, str(root), model=model)
@@ -198,6 +198,7 @@ def test_malt_untrained_working_dir_is_staged_inside_root(pathsec_sandbox):
     assert cmd[cmd.index("-c") + 1] == "malt_temp.mco"
 
 
+@pytest.mark.skipif(os.name != "posix", reason="POSIX mode bits")
 def test_malt_working_dir_is_private():
     """The staging dir must not be group/world readable: it holds the CoNLL
     intermediates and the trained model."""
@@ -649,13 +650,14 @@ def _hostile_vectors(root, outside):
     secret = outside / "secret.mco"
     secret.write_text("SECRET")
 
+    system_file = "/etc/passwd" if os.name == "posix" else "C:\\Windows\\win.ini"
     vectors = [
         ("outside-abs", str(secret)),
-        ("etc-abs", "/etc/passwd"),
+        ("system-file-abs", system_file),
         ("traversal-from-root", os.path.join(str(root), "..", "..", "etc", "passwd")),
-        ("nul-byte", "/etc/pass\x00wd"),
+        ("nul-byte", system_file[:5] + "\x00" + system_file[5:]),
         ("leading-dash", "-Xmx99g"),
-        ("newline-injection", "/etc/passwd\n-serDictionary /etc/shadow"),
+        ("newline-injection", system_file + "\n-serDictionary " + system_file),
         ("backslash-traversal", "..\\..\\..\\etc\\passwd"),
         ("file-url", "file:///etc/passwd"),
         ("http-url", "http://evil.example/model.gz"),
@@ -676,14 +678,8 @@ def _hostile_vectors(root, outside):
     os.symlink(str(outside), symlinked_dir)
     vectors.append(("via-symlinked-dir", str(symlinked_dir / "secret.mco")))
 
-    hardlink = root / "hard.mco"
-    try:
-        os.link(str(secret), hardlink)
-    except OSError:  # pragma: no cover - cross-device or unsupported
-        pass
-    else:
-        vectors.append(("hardlink-to-outside", str(hardlink)))
-
+    # Hardlinks are deliberately NOT in this matrix: they are refused only for
+    # paths the tool writes. See the dedicated tests below.
     return vectors
 
 
@@ -735,10 +731,7 @@ def test_malt_working_dir_setter_refuses_every_hostile_vector(pathsec_sandbox):
     assert leaked == [], f"working_dir accepted these: {leaked}"
 
 
-def test_hardlinked_model_is_refused(pathsec_sandbox):
-    """realpath() cannot see a hardlink, so an in-root alias of an outside file
-    would otherwise pass every path check."""
-    root, outside = pathsec_sandbox
+def _hardlink_into(root, outside):
     secret = outside / "secret.mco"
     secret.write_text("SECRET")
     alias = root / "alias.mco"
@@ -746,8 +739,28 @@ def test_hardlinked_model_is_refused(pathsec_sandbox):
         os.link(str(secret), alias)
     except OSError:  # pragma: no cover - cross-device or unsupported
         pytest.skip("hard links unavailable between these directories")
+    return str(alias)
+
+
+def test_hardlinked_write_target_is_refused(pathsec_sandbox):
+    """realpath() cannot see a hardlink, so an in-root alias of an outside file
+    passes every path check and the tool would overwrite the original."""
+    root, outside = pathsec_sandbox
+    alias = _hardlink_into(root, outside)
     with pytest.raises(PermissionError):
-        validate_model_resource(str(alias), context="sweep")
+        validate_tool_path(alias, context="sweep", for_write=True)
+
+
+def test_hardlinked_read_target_is_allowed(pathsec_sandbox):
+    """Reading through a hardlink is not an escalation: creating the link already
+    requires write access to the data root. Rejecting st_nlink > 1 outright would
+    refuse ordinary deduplicated trees (cp -l, rsync --link-dest) and would also
+    refuse the ORIGINAL file, since both names share the link count.
+    """
+    root, outside = pathsec_sandbox
+    alias = _hardlink_into(root, outside)
+    validate_tool_path(alias, context="sweep")
+    validate_model_resource(alias, context="sweep")
 
 
 def test_single_linked_model_is_allowed(pathsec_sandbox):
@@ -756,6 +769,7 @@ def test_single_linked_model_is_allowed(pathsec_sandbox):
     model = root / "plain.mco"
     model.write_text("m")
     validate_model_resource(str(model), context="sweep")
+    validate_tool_path(str(model), context="sweep", for_write=True)
 
 
 def test_directory_model_is_not_hardlink_rejected(pathsec_sandbox):
@@ -788,21 +802,32 @@ def test_benign_resource_names_still_pass(value):
 
 def _exotic_vectors(root):
     vectors = [
-        ("dev-stdin", "/dev/stdin"),
-        ("dev-null", "/dev/null"),
-        ("proc-environ", "/proc/self/environ"),
-        ("case-folded-etc", "/ETC/PASSWD"),
         ("tilde-expansion", "~/.ssh/id_rsa"),
         ("ads-stream", "model.mco:evil"),
         ("unc-backslash", "\\\\server\\share\\evil.mco"),
         ("unc-slash", "//server/share/evil.mco"),
         ("nul-in-middle", "model\x00.mco"),
         ("jar-url", "jar:file:///etc/passwd!/x"),
-        ("overlong-name", "/" + ("A" * 300) + "/evil.mco"),
         ("double-slash", "//etc//passwd"),
-        ("root-only", "/"),
         ("dotdot-alone", ".."),
     ]
+    if os.name == "posix":
+        # Character devices and procfs exist only here; on Windows these are
+        # ordinary non-existent relative names and prove nothing.
+        vectors += [
+            ("dev-stdin", "/dev/stdin"),
+            ("dev-null", "/dev/null"),
+            ("proc-environ", "/proc/self/environ"),
+            ("case-folded-etc", "/ETC/PASSWD"),
+            ("overlong-name", "/" + ("A" * 300) + "/evil.mco"),
+            ("root-only", "/"),
+        ]
+    else:
+        vectors += [
+            ("windows-device", "NUL"),
+            ("windows-system-file", "C:\\Windows\\System32\\config\\SAM"),
+            ("drive-relative", "C:evil.mco"),
+        ]
 
     fifo = root / "fifo.mco"
     try:
@@ -1096,17 +1121,14 @@ def test_validate_tool_path_allows_in_sandbox_paths(pathsec_sandbox):
     validate_tool_path(str(root / "out.conll"), context="sweep")
 
 
-def test_validate_tool_path_refuses_hardlink(pathsec_sandbox):
+def test_malt_output_file_refuses_hardlink(pathsec_sandbox):
+    """-o is written by the JVM, so a hardlinked target would clobber the file
+    it aliases outside the roots."""
     root, outside = pathsec_sandbox
-    secret = outside / "secret.conll"
-    secret.write_text("SECRET")
-    alias = root / "alias.conll"
-    try:
-        os.link(str(secret), alias)
-    except OSError:  # pragma: no cover - cross-device or unsupported
-        pytest.skip("hard links unavailable between these directories")
+    alias = _hardlink_into(root, outside)
+    parser, infile = _malt_in_sandbox(root)
     with pytest.raises(PermissionError):
-        validate_tool_path(str(alias), context="sweep")
+        parser.generate_malt_command(infile, alias, mode="parse")
 
 
 def test_validate_tool_path_refuses_fifo(pathsec_sandbox):
@@ -1123,3 +1145,64 @@ def test_validate_tool_path_refuses_fifo(pathsec_sandbox):
 
 def test_validate_tool_path_is_exported():
     assert "validate_tool_path" in pathsec.__all__
+
+
+def test_regression_bare_model_name_is_not_probed_against_cwd(pathsec_sandbox):
+    """Regression: validate_model_resource decided "is this a real path?" with
+    os.path.exists(), which resolves relative to the CWD. A stray malt_temp.mco
+    in the user's directory therefore made the DEFAULT MaltParser() flow die with
+    a security violation. Older NLTK wrote exactly that file into the CWD, so an
+    upgrade would have tripped it.
+    """
+    root, _outside = pathsec_sandbox
+    os.chdir(str(root.parent))
+    decoy = root.parent / "malt_temp.mco"
+    decoy.write_text("decoy")
+    try:
+        validate_model_resource("malt_temp.mco", context="sweep")
+        parser, infile = _malt_in_sandbox(root)
+        parser.model = "malt_temp.mco"
+        cmd = parser.generate_malt_command(infile, None, mode="learn")
+        assert cmd[cmd.index("-c") + 1] == "malt_temp.mco"
+    finally:
+        decoy.unlink()
+
+
+def test_regression_staging_dirs_are_cleaned_up(tmp_path):
+    """Regression: every parser that touched working_dir left a directory under
+    the data root forever. The shared tempdir it replaced was OS-reaped, but a
+    data root is not, so the dir is now removed at interpreter exit.
+
+    Run in a real subprocess: atexit only fires when the process ends.
+    """
+    import subprocess
+    import sys
+
+    root = tmp_path / "nltk_data"
+    root.mkdir()
+    script = (
+        "import nltk.data, nltk.pathsec as ps;"
+        f"nltk.data.path[:] = [{str(root)!r}];"
+        "ps._ALLOWED_ROOTS_CACHE = None; ps._LAST_DATA_PATHS = None;"
+        "from nltk.parse.malt import MaltParser;"
+        "p = MaltParser.__new__(MaltParser); p._working_dir = None;"
+        "print(p.working_dir)"
+    )
+    env = dict(os.environ, PYTHONPATH=os.pathsep.join(sys.path))
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, env=env
+    )
+    assert result.returncode == 0, result.stderr
+    staged = result.stdout.strip()
+    assert staged.startswith(str(root))
+    assert not os.path.exists(staged), f"staging dir leaked after exit: {staged}"
+
+
+def test_working_dir_none_resets_to_lazy_allocation(pathsec_sandbox):
+    """Regression: assigning None used to raise; it now restores the unset state
+    so the property allocates again."""
+    root, _outside = pathsec_sandbox
+    parser = _malt("malt_temp.mco", trained=False)
+    first = parser.working_dir
+    parser.working_dir = None
+    assert parser.working_dir != first or os.path.isdir(parser.working_dir)

--- a/nltk/test/unit/test_pathsec_sweep_wrappers.py
+++ b/nltk/test/unit/test_pathsec_sweep_wrappers.py
@@ -1884,3 +1884,122 @@ def test_zip_member_paths_still_validate(pathsec_sandbox):
     for good in (archive, f"{archive}/member.txt", f"{archive}/sub/dir/member.txt"):
         pathsec.validate_path(good, context="sweep")
     assert ZipFilePathPointer(archive, "member.txt").open().read() == b"hello"
+
+
+# ---------------------------------------------------------------------------
+# Entry-point matrix. The recurring real bug in this PR was a guard placed on
+# ONE method while a sibling built its argv before validating. segment_file was
+# fixed first and segment_sents/segment still leaked. This drives the attack
+# through EVERY public entry point so a new method cannot reopen it quietly.
+# ---------------------------------------------------------------------------
+
+
+def _segmenter_entry_points():
+    return {
+        "segment_file": lambda tool, path: tool.segment_file(path),
+        "segment_sents": lambda tool, _path: tool.segment_sents([["中", "文"]]),
+        "segment": lambda tool, _path: tool.segment(["中", "文"]),
+    }
+
+
+@pytest.mark.parametrize("entry", sorted(_segmenter_entry_points()))
+@pytest.mark.parametrize("hostile", ["mutating", "dot-path", "plain-outside"])
+def test_every_segmenter_entry_point_refuses_hostile_models(
+    pathsec_sandbox, monkeypatch, entry, hostile
+):
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, outside = pathsec_sandbox
+    sink = _trap_java(monkeypatch, seg, {})
+    evil = str(outside / "evil.ser.gz")
+    (outside / "evil.ser.gz").write_text("x")
+    good = str(root / "ok.ser.gz")
+    with pathsec.open(good, "w", encoding="utf-8") as handle:
+        handle.write("m")
+    inside = str(root / "in.txt")
+    with pathsec.open(inside, "w", encoding="utf-8") as handle:
+        handle.write("x")
+
+    model = {
+        "mutating": _MutatingPath(good, evil),
+        "dot-path": _DotPathObject(good, evil),
+        "plain-outside": evil,
+    }[hostile]
+    tool = _segmenter(monkeypatch, str(root), model=model)
+
+    try:
+        _segmenter_entry_points()[entry](tool, inside)
+    except (PermissionError, ValueError):
+        return
+    except _ReachedJVM:
+        pass
+    # If it reached the JVM at all, the argv must hold the validated string.
+    handed = sink["cmd"][sink["cmd"].index("-loadClassifier") + 1]
+    resolved = _resolve(handed)
+    assert isinstance(handed, str), f"{entry} put a {type(handed).__name__} in argv"
+    assert os.path.realpath(str(resolved)).startswith(
+        os.path.realpath(str(root))
+    ), f"{entry} handed the JVM a path outside the roots: {resolved}"
+
+
+@pytest.mark.parametrize("entry", sorted(_segmenter_entry_points()))
+def test_every_segmenter_entry_point_still_works(pathsec_sandbox, monkeypatch, entry):
+    """Over-block control for the matrix above."""
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, _outside = pathsec_sandbox
+    sink = _trap_java(monkeypatch, seg, {})
+    good = str(root / "ok.ser.gz")
+    with pathsec.open(good, "w", encoding="utf-8") as handle:
+        handle.write("m")
+    inside = str(root / "in.txt")
+    with pathsec.open(inside, "w", encoding="utf-8") as handle:
+        handle.write("x")
+
+    tool = _segmenter(monkeypatch, str(root), model=good)
+    with pytest.raises(_ReachedJVM):
+        _segmenter_entry_points()[entry](tool, inside)
+    assert sink["cmd"][sink["cmd"].index("-loadClassifier") + 1] == good
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        "parse_sents",
+        "raw_parse_sents",
+        "tagged_parse_sents",
+        "raw_parse",
+        "tagged_parse",
+    ],
+)
+def test_every_parser_entry_point_refuses_a_mutating_model(
+    pathsec_sandbox, monkeypatch, entry
+):
+    """All five public parser methods funnel through _execute, which replaces the
+    -model argv entry with the validated string. This proves it for each."""
+    import nltk.parse.stanford as st
+
+    root, outside = pathsec_sandbox
+    sink = _trap_java(monkeypatch, st, {})
+    evil = outside / "evil.ser.gz"
+    evil.write_text("x")
+    good = root / "ok.ser.gz"
+    good.write_text("m")
+
+    parser = _stanford_parser(_MutatingPath(str(good), str(evil)))
+    calls = {
+        "parse_sents": lambda p: p.parse_sents([["hi", "there"]]),
+        "raw_parse_sents": lambda p: p.raw_parse_sents(["hi there"]),
+        "tagged_parse_sents": lambda p: p.tagged_parse_sents([[("hi", "UH")]]),
+        "raw_parse": lambda p: p.raw_parse("hi there"),
+        "tagged_parse": lambda p: p.tagged_parse([("hi", "UH")]),
+    }
+    try:
+        calls[entry](parser)
+    except (PermissionError, ValueError):
+        return
+    except _ReachedJVM:
+        pass
+    handed = sink["cmd"][sink["cmd"].index("-model") + 1]
+    assert isinstance(handed, str), f"{entry} put a {type(handed).__name__} in argv"
+    assert os.path.realpath(_resolve(handed)).startswith(os.path.realpath(str(root)))

--- a/nltk/test/unit/test_pathsec_sweep_wrappers.py
+++ b/nltk/test/unit/test_pathsec_sweep_wrappers.py
@@ -1459,3 +1459,104 @@ def test_dot_path_object_is_refused_by_both_guards(pathsec_sandbox):
     for guard in (validate_model_resource, validate_tool_path):
         with pytest.raises((PermissionError, ValueError)):
             guard(sneaky, context="sweep")
+
+
+class _LyingStr(str):
+    """A str subclass whose inspection methods lie.
+
+    os.fspath() returns a str subclass unchanged, so every syntactic check would
+    otherwise run on attacker-controlled methods while the value handed to the
+    tool still carries the real, hostile characters.
+    """
+
+    def __str__(self):
+        return "safe"
+
+    def startswith(self, *args, **kwargs):
+        return False
+
+    def strip(self, *args, **kwargs):
+        return "safe"
+
+    def rstrip(self, *args, **kwargs):
+        return self
+
+    def replace(self, *args, **kwargs):
+        return "safe/name.mco"
+
+    def split(self, *args, **kwargs):
+        return ["safe", "name.mco"]
+
+    def lower(self):
+        return "safe"
+
+    def __contains__(self, item):
+        return False
+
+
+class _LyingFsPath:
+    def __fspath__(self):
+        return _LyingStr("-Xmx99g")
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "-Xmx99g",
+        "../../../etc/passwd",
+        "file:///etc/passwd",
+        "model\x00.mco",
+        "NUL",
+        "evil.mco.",
+        "name:stream",
+    ],
+)
+def test_lying_str_subclass_is_refused(payload):
+    """Every check must see the real characters, not what the subclass claims."""
+    for guard in (validate_model_resource, validate_tool_path):
+        with pytest.raises((PermissionError, ValueError)):
+            guard(_LyingStr(payload), context="sweep")
+
+
+def test_lying_subclass_returned_by_fspath_is_refused():
+    for guard in (validate_model_resource, validate_tool_path):
+        with pytest.raises((PermissionError, ValueError)):
+            guard(_LyingFsPath(), context="sweep")
+
+
+def test_malt_argv_cannot_be_injected_via_str_subclass(pathsec_sandbox):
+    """The payload previously reached the JVM argv as "-c -Xmx99g"."""
+    root, _outside = pathsec_sandbox
+    parser = _malt(_LyingStr("-Xmx99g"))
+    infile, _outfile = _sandbox_io(parser)
+    with pytest.raises((PermissionError, ValueError)):
+        parser.generate_malt_command(infile, None, mode="learn")
+
+
+def test_guards_always_return_an_exact_str(pathsec_sandbox):
+    """The value callers put into argv must be a plain str, so that nothing can
+    re-resolve or re-inspect it differently later."""
+    root, _outside = pathsec_sandbox
+    model = root / "ok.mco"
+    model.write_text("m")
+
+    class _BenignSubclass(str):
+        pass
+
+    for value in (str(model), _BenignSubclass(str(model)), model, _DEFAULT_RESOURCE):
+        assert type(validate_model_resource(value, context="sweep")) is str
+    assert type(validate_tool_path(model, context="sweep")) is str
+
+
+def test_benign_str_subclass_still_works(pathsec_sandbox):
+    """Over-block control: subclassing str is legal, lying about it is not."""
+    root, _outside = pathsec_sandbox
+    model = root / "ok.mco"
+    model.write_text("m")
+
+    class _BenignSubclass(str):
+        pass
+
+    assert validate_model_resource(_BenignSubclass(str(model)), context="sweep") == str(
+        model
+    )

--- a/nltk/test/unit/test_pathsec_sweep_wrappers.py
+++ b/nltk/test/unit/test_pathsec_sweep_wrappers.py
@@ -379,7 +379,8 @@ def test_teeth_segmenter_guard_is_load_bearing(pathsec_sandbox, monkeypatch):
 
     root, _outside = pathsec_sandbox
     _trap_java(monkeypatch, seg, {})
-    monkeypatch.setattr(seg, "validate_path", lambda *a, **k: None)
+    monkeypatch.setattr(seg, "validate_path", _passthrough)
+    monkeypatch.setattr(seg, "validate_tool_path", _passthrough)
     tool = _segmenter(monkeypatch, str(root))
     with pytest.raises(_ReachedJVM):
         tool.segment_file("/etc/passwd")
@@ -1379,3 +1380,82 @@ def test_trailing_dot_or_space_is_refused(name):
     that is opened."""
     with pytest.raises(ValueError):
         validate_model_resource(name, context="sweep")
+
+
+class _DotPathObject:
+    """validate_path reads a ``.path`` attribute in preference to __fspath__
+    (it supports NLTK's PathPointer objects). An object whose ``.path`` is
+    benign and whose __fspath__ is hostile therefore passes the check and is
+    resolved to the hostile value by whoever consumes it."""
+
+    def __init__(self, benign, hostile):
+        self.path = benign
+        self._hostile = hostile
+
+    def __fspath__(self):
+        return self._hostile
+
+    def __str__(self):
+        return self.path
+
+
+@pytest.mark.parametrize("slot", ["model", "input"])
+def test_segmenter_refuses_dot_path_objects(pathsec_sandbox, monkeypatch, slot):
+    """Both the model and the input file leaked this way: the guard read .path
+    and the JVM would have resolved __fspath__."""
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, outside = pathsec_sandbox
+    _trap_java(monkeypatch, seg, {})
+    evil = outside / "evil.ser.gz"
+    evil.write_text("x")
+    good = str(root / "ok.ser.gz")
+    with pathsec.open(good, "w", encoding="utf-8") as handle:
+        handle.write("m")
+    inside = str(root / "in.txt")
+    with pathsec.open(inside, "w", encoding="utf-8") as handle:
+        handle.write("x")
+
+    if slot == "model":
+        tool = _segmenter(monkeypatch, str(root), model=_DotPathObject(good, str(evil)))
+        target = inside
+    else:
+        tool = _segmenter(monkeypatch, str(root), model=good)
+        target = _DotPathObject(inside, "/etc/passwd")
+    with pytest.raises((PermissionError, ValueError)):
+        tool.segment_file(target)
+
+
+def test_segmenter_argv_carries_validated_strings(pathsec_sandbox, monkeypatch):
+    """Over-block control plus the positive invariant: what reaches the JVM is
+    the exact string the guard returned, as a str."""
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, _outside = pathsec_sandbox
+    sink = _trap_java(monkeypatch, seg, {})
+    model = str(root / "ok.ser.gz")
+    with pathsec.open(model, "w", encoding="utf-8") as handle:
+        handle.write("m")
+    inside = str(root / "in.txt")
+    with pathsec.open(inside, "w", encoding="utf-8") as handle:
+        handle.write("x")
+
+    tool = _segmenter(monkeypatch, str(root), model=model)
+    with pytest.raises(_ReachedJVM):
+        tool.segment_file(inside)
+    for flag in ("-loadClassifier", "-textFile"):
+        value = sink["cmd"][sink["cmd"].index(flag) + 1]
+        assert isinstance(value, str)
+        assert os.path.realpath(value).startswith(os.path.realpath(str(root)))
+
+
+def test_dot_path_object_is_refused_by_both_guards(pathsec_sandbox):
+    root, outside = pathsec_sandbox
+    evil = outside / "evil.mco"
+    evil.write_text("x")
+    good = root / "ok.mco"
+    good.write_text("m")
+    sneaky = _DotPathObject(str(good), str(evil))
+    for guard in (validate_model_resource, validate_tool_path):
+        with pytest.raises((PermissionError, ValueError)):
+            guard(sneaky, context="sweep")

--- a/nltk/test/unit/test_pathsec_sweep_wrappers.py
+++ b/nltk/test/unit/test_pathsec_sweep_wrappers.py
@@ -1792,3 +1792,95 @@ def test_segmenter_out_of_root_jar_is_refused_despite_approved_checksum(
     tool._jar_sha256_cache = {}
     with pytest.raises((PermissionError, ValueError)):
         tool._validate_classpath()
+
+
+# ---------------------------------------------------------------------------
+# Surfaces probed and found CLEAN. Pinned so a later change cannot open them
+# without a test noticing. Each was verified by execution, not by reading.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "java_class",
+    ["-jar", "-Xmx99g", "-javaagent:/tmp/evil.jar", "@/tmp/argfile"],
+)
+def test_segmenter_java_class_cannot_be_an_option(
+    pathsec_sandbox, monkeypatch, java_class
+):
+    """java_class is caller-supplied and lands in the JVM's MAIN CLASS slot, so
+    an option-shaped value would be read as a JVM option instead. internals.java
+    already refuses it; this pins that it keeps doing so."""
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, _outside = pathsec_sandbox
+    inside = str(root / "in.txt")
+    with pathsec.open(inside, "w", encoding="utf-8") as handle:
+        handle.write("x")
+    tool = _segmenter(monkeypatch, str(root))
+    tool._java_class = java_class
+    with pytest.raises((ValueError, PermissionError)):
+        tool.segment_file(inside)
+
+
+@pytest.mark.parametrize(
+    "option",
+    [
+        "-XX:OnOutOfMemoryError=touch /tmp/pwned",
+        "-javaagent:/tmp/evil.jar",
+        "@/tmp/argfile",
+        "-jar /tmp/evil.jar",
+    ],
+)
+def test_wrapper_java_options_hit_the_allowlist(pathsec_sandbox, monkeypatch, option):
+    """The JVM option allowlist lives in internals.java. This confirms it is
+    actually reached through THIS wrapper rather than assumed."""
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, _outside = pathsec_sandbox
+    inside = str(root / "in.txt")
+    with pathsec.open(inside, "w", encoding="utf-8") as handle:
+        handle.write("x")
+    tool = _segmenter(monkeypatch, str(root))
+    tool.java_options = option
+    with pytest.raises((ValueError, PermissionError)):
+        tool.segment_file(inside)
+
+
+def test_unresolvable_path_with_traversal_or_nul_is_refused(pathsec_sandbox):
+    """validate_path falls back to validating only the prefix up to ".zip" when
+    resolve() fails, and resolve() also fails on a NUL. Refusing an unresolvable
+    path that still contains a traversal or a NUL keeps that fallback from
+    approving a value on a harmless prefix.
+
+    No usable escape was found through this (a NUL path cannot be opened by
+    Python and truncates in a subprocess), so this is hardening rather than a
+    fixed vulnerability.
+    """
+    import zipfile as _zipfile
+
+    root, _outside = pathsec_sandbox
+    archive = str(root / "corpus.zip")
+    with _zipfile.ZipFile(archive, "w") as handle:
+        handle.writestr("member.txt", "hello")
+    for suspect in (
+        f"{archive}/\x00../../../etc/passwd",
+        f"{archive}/../../../../etc/passwd",
+    ):
+        with pytest.raises((PermissionError, ValueError)):
+            pathsec.validate_path(suspect, context="sweep")
+
+
+def test_zip_member_paths_still_validate(pathsec_sandbox):
+    """Over-block control for the change above: virtual zip member paths are the
+    reason that fallback exists and must keep working."""
+    import zipfile as _zipfile
+
+    from nltk.data import ZipFilePathPointer
+
+    root, _outside = pathsec_sandbox
+    archive = str(root / "corpus.zip")
+    with _zipfile.ZipFile(archive, "w") as handle:
+        handle.writestr("member.txt", "hello")
+    for good in (archive, f"{archive}/member.txt", f"{archive}/sub/dir/member.txt"):
+        pathsec.validate_path(good, context="sweep")
+    assert ZipFilePathPointer(archive, "member.txt").open().read() == b"hello"

--- a/nltk/test/unit/test_pathsec_sweep_wrappers.py
+++ b/nltk/test/unit/test_pathsec_sweep_wrappers.py
@@ -1560,3 +1560,116 @@ def test_benign_str_subclass_still_works(pathsec_sandbox):
     assert validate_model_resource(_BenignSubclass(str(model)), context="sweep") == str(
         model
     )
+
+
+# ---------------------------------------------------------------------------
+# corenlp_options is SPLIT into separate argv elements, so it can append a
+# second -model. Verified directly against the JVM that Stanford's
+# LexicalizedParser honours the LAST occurrence, so an injected option replaced
+# the model the guard had just checked and the parser deserialized that file.
+# ---------------------------------------------------------------------------
+
+
+def _stanford_with_options(model_path, options):
+    parser = _stanford_parser(model_path)
+    parser.corenlp_options = options
+    return parser
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        "-model /etc/passwd",
+        "-model ../../../etc/passwd",
+        "-loadClassifier /etc/passwd",
+        "-outputFormat xml",
+        "-encoding utf8",
+        "-sentences newline",
+    ],
+    ids=[
+        "second-model-abs",
+        "second-model-traversal",
+        "loadClassifier-abs",
+        "dup-outputFormat",
+        "dup-encoding",
+        "dup-sentences",
+    ],
+)
+def test_corenlp_options_cannot_override_guarded_flags(
+    pathsec_sandbox, monkeypatch, options
+):
+    import nltk.parse.stanford as st
+
+    root, _outside = pathsec_sandbox
+    _trap_java(monkeypatch, st, {})
+    model = str(root / "ok.ser.gz")
+    with pathsec.open(model, "w", encoding="utf-8") as handle:
+        handle.write("m")
+    with pytest.raises((PermissionError, ValueError)):
+        _stanford_with_options(model, options).parse_sents([["hi", "there"]])
+
+
+def test_corenlp_options_cannot_point_outside_the_roots(pathsec_sandbox, monkeypatch):
+    import nltk.parse.stanford as st
+
+    root, outside = pathsec_sandbox
+    _trap_java(monkeypatch, st, {})
+    evil = outside / "evil.ser.gz"
+    evil.write_text("x")
+    model = str(root / "ok.ser.gz")
+    with pathsec.open(model, "w", encoding="utf-8") as handle:
+        handle.write("m")
+    with pytest.raises((PermissionError, ValueError)):
+        _stanford_with_options(model, f"-serializedDict {evil}").parse_sents(
+            [["hi", "there"]]
+        )
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        "",
+        "-maxLength 40",
+        "-serializedDict edu/stanford/nlp/x.ser.gz",
+        "-retainTMPSubcategories",
+    ],
+    ids=["empty", "new-flag", "resource-value", "bare-flag"],
+)
+def test_corenlp_options_passthrough_still_works(pathsec_sandbox, monkeypatch, options):
+    """Over-block control: this is a general passthrough for the tool's own
+    settings, so anything that is neither a duplicate nor an out-of-root path
+    must still reach the JVM."""
+    import nltk.parse.stanford as st
+
+    root, _outside = pathsec_sandbox
+    sink = _trap_java(monkeypatch, st, {})
+    model = str(root / "ok.ser.gz")
+    with pathsec.open(model, "w", encoding="utf-8") as handle:
+        handle.write("m")
+    with pytest.raises(_ReachedJVM):
+        _stanford_with_options(model, options).parse_sents([["hi", "there"]])
+    assert sink["cmd"][sink["cmd"].index("-model") + 1] == model
+    for token in options.split():
+        assert token in sink["cmd"]
+
+
+def test_teeth_corenlp_options_guard_is_load_bearing(pathsec_sandbox, monkeypatch):
+    """Restore the raw split and the injected -model reaches the JVM again."""
+    import nltk.parse.stanford as st
+
+    root, outside = pathsec_sandbox
+    sink = _trap_java(monkeypatch, st, {})
+    evil = outside / "evil.ser.gz"
+    evil.write_text("x")
+    model = str(root / "ok.ser.gz")
+    with pathsec.open(model, "w", encoding="utf-8") as handle:
+        handle.write("m")
+    monkeypatch.setattr(
+        st.StanfordParser,
+        "_validated_extra_options",
+        lambda self, cmd: self.corenlp_options.split(),
+    )
+    with pytest.raises(_ReachedJVM):
+        _stanford_with_options(model, f"-model {evil}").parse_sents([["hi", "there"]])
+    models = [sink["cmd"][i + 1] for i, x in enumerate(sink["cmd"]) if x == "-model"]
+    assert str(evil) in models

--- a/nltk/test/unit/test_pathsec_sweep_wrappers.py
+++ b/nltk/test/unit/test_pathsec_sweep_wrappers.py
@@ -32,7 +32,7 @@ import pytest
 
 from nltk import pathsec
 from nltk.data import make_staging_dir
-from nltk.pathsec import validate_model_resource
+from nltk.pathsec import validate_model_resource, validate_tool_path
 
 
 class _ReachedJVM(Exception):
@@ -152,13 +152,25 @@ def _malt(model, trained=True):
     return parser
 
 
+def _sandbox_io(parser):
+    """Valid in-sandbox -i/-o paths for a test that targets some *other* guard.
+    Without these the input-file guard fires first and the test would pass for
+    the wrong reason."""
+    infile = os.path.join(parser.working_dir, "in.conll")
+    with pathsec.open(infile, "w") as handle:
+        handle.write("")
+    return infile, os.path.join(parser.working_dir, "out.conll")
+
+
 def test_malt_trained_model_refuses_escape(pathsec_sandbox):
     """A .mco outside the roots would make ``-w`` an arbitrary write target."""
     root, outside = pathsec_sandbox
     evil = outside / "evil.mco"
     evil.write_text("model")
+    parser = _malt(str(evil))
+    infile, _outfile = _sandbox_io(parser)
     with pytest.raises((PermissionError, ValueError)):
-        _malt(str(evil)).generate_malt_command("in.conll", "out.conll", mode="learn")
+        parser.generate_malt_command(infile, None, mode="learn")
 
 
 def test_malt_trained_model_in_sandbox_is_allowed(pathsec_sandbox):
@@ -166,7 +178,9 @@ def test_malt_trained_model_in_sandbox_is_allowed(pathsec_sandbox):
     root, _outside = pathsec_sandbox
     model = root / "engmalt.mco"
     model.write_text("model")
-    cmd = _malt(str(model)).generate_malt_command("in.conll", "out.conll", mode="parse")
+    parser = _malt(str(model))
+    infile, outfile = _sandbox_io(parser)
+    cmd = parser.generate_malt_command(infile, outfile, mode="parse")
     assert cmd[cmd.index("-w") + 1] == str(root)
     assert cmd[cmd.index("-c") + 1] == "engmalt.mco"
 
@@ -175,9 +189,9 @@ def test_malt_untrained_working_dir_is_staged_inside_root(pathsec_sandbox):
     """An untrained parser used to write malt_temp.mco into the CWD; it must now
     land in a private staging dir inside a data root."""
     root, _outside = pathsec_sandbox
-    cmd = _malt("malt_temp.mco", trained=False).generate_malt_command(
-        "in.conll", "out.conll", mode="learn"
-    )
+    parser = _malt("malt_temp.mco", trained=False)
+    infile, _outfile = _sandbox_io(parser)
+    cmd = parser.generate_malt_command(infile, None, mode="learn")
     workingdir = cmd[cmd.index("-w") + 1]
     assert os.path.realpath(workingdir).startswith(os.path.realpath(str(root)))
     assert os.path.realpath(workingdir) != os.path.realpath(os.getcwd())
@@ -372,6 +386,7 @@ def test_teeth_malt_guard_is_load_bearing(pathsec_sandbox, monkeypatch):
     _root, outside = pathsec_sandbox
     monkeypatch.setattr(malt, "validate_path", lambda *a, **k: None)
     monkeypatch.setattr(malt, "validate_model_resource", lambda *a, **k: None)
+    monkeypatch.setattr(malt, "validate_tool_path", lambda *a, **k: None)
     evil = outside / "evil.mco"
     evil.write_text("model")
     cmd = _malt(str(evil)).generate_malt_command("in.conll", "out.conll", mode="learn")
@@ -387,8 +402,10 @@ def test_teeth_malt_model_resource_guard_alone_blocks(pathsec_sandbox, monkeypat
     monkeypatch.setattr(malt, "validate_path", lambda *a, **k: None)
     evil = outside / "evil.mco"
     evil.write_text("model")
+    parser = _malt(str(evil))
+    infile, _outfile = _sandbox_io(parser)
     with pytest.raises((PermissionError, ValueError)):
-        _malt(str(evil)).generate_malt_command("in.conll", "out.conll", mode="learn")
+        parser.generate_malt_command(infile, None, mode="learn")
 
 
 # ---------------------------------------------------------------------------
@@ -480,12 +497,16 @@ def test_malt_command_shape_is_unchanged(pathsec_sandbox):
     root, _outside = pathsec_sandbox
     model = root / "engmalt.mco"
     model.write_text("model")
-    cmd = _malt(str(model)).generate_malt_command("in.conll", "out.conll", mode="parse")
+    parser = _malt(str(model))
+    infile, outfile = str(root / "in.conll"), str(root / "out.conll")
+    with pathsec.open(infile, "w") as handle:
+        handle.write("")
+    cmd = parser.generate_malt_command(infile, outfile, mode="parse")
     assert cmd[0] == "org.maltparser.Malt"
     for flag in ("-w", "-c", "-i", "-o", "-m"):
         assert flag in cmd
-    assert cmd[cmd.index("-i") + 1] == "in.conll"
-    assert cmd[cmd.index("-o") + 1] == "out.conll"
+    assert cmd[cmd.index("-i") + 1] == infile
+    assert cmd[cmd.index("-o") + 1] == outfile
     assert cmd[cmd.index("-m") + 1] == "parse"
 
 
@@ -688,7 +709,9 @@ def test_malt_model_refuses_every_hostile_vector(pathsec_sandbox):
     leaked = []
     for name, value in _hostile_vectors(root, outside):
         try:
-            _malt(value).generate_malt_command("in.conll", "out.conll", mode="learn")
+            parser = _malt(value)
+            infile, _outfile = _sandbox_io(parser)
+            parser.generate_malt_command(infile, None, mode="learn")
         except (PermissionError, ValueError, OSError):
             continue
         leaked.append(name)
@@ -871,7 +894,10 @@ def test_regression_generate_malt_command_needs_no_trained_attribute(pathsec_san
     parser.model = "malt_temp.mco"
     parser._working_dir = None
     parser.additional_java_args = []
-    cmd = parser.generate_malt_command("in.conll", "out.conll", mode="learn")
+    infile = os.path.join(parser.working_dir, "in.conll")
+    with pathsec.open(infile, "w") as handle:
+        handle.write("")
+    cmd = parser.generate_malt_command(infile, None, mode="learn")
     assert cmd[cmd.index("-c") + 1] == "malt_temp.mco"
 
 
@@ -881,7 +907,11 @@ def test_regression_trained_bare_model_resolves_to_working_dir(pathsec_sandbox):
     made every post-training parse fail with a security violation."""
     root, _outside = pathsec_sandbox
     parser = _malt("malt_temp.mco", trained=True)
-    cmd = parser.generate_malt_command("in.conll", "out.conll", mode="parse")
+    infile = os.path.join(parser.working_dir, "in.conll")
+    outfile = os.path.join(parser.working_dir, "out.conll")
+    with pathsec.open(infile, "w") as handle:
+        handle.write("")
+    cmd = parser.generate_malt_command(infile, outfile, mode="parse")
     workingdir = cmd[cmd.index("-w") + 1]
     assert os.path.realpath(workingdir).startswith(os.path.realpath(str(root)))
     assert os.path.realpath(workingdir) != os.path.realpath(os.getcwd())
@@ -911,3 +941,185 @@ def test_regression_has_java_probe_actually_executes():
             "java", env_vars=("JAVAHOME", "JAVA_HOME"), verbose=False, binary_names=None
         )
         assert subprocess.run([binary, "-version"], capture_output=True).returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# MaltParser -i / -o. Both are public: generate_malt_command() takes them
+# directly and train_from_file() is the public route to -i. -i is READ by the
+# JVM and -o is WRITTEN by it, so an unbounded value is an arbitrary file read
+# and an arbitrary file write.
+# ---------------------------------------------------------------------------
+
+
+def _malt_in_sandbox(root):
+    parser = _malt("malt_temp.mco", trained=False)
+    parser.malt_jars = []
+    infile = os.path.join(parser.working_dir, "in.conll")
+    with pathsec.open(infile, "w") as handle:
+        handle.write("")
+    return parser, infile
+
+
+def test_malt_input_file_refuses_every_hostile_vector(pathsec_sandbox):
+    """-i is an arbitrary-file-read primitive without a guard."""
+    root, outside = pathsec_sandbox
+    parser, _infile = _malt_in_sandbox(root)
+    leaked = []
+    for name, value in _hostile_vectors(root, outside):
+        try:
+            parser.generate_malt_command(value, None, mode="learn")
+        except (PermissionError, ValueError, OSError):
+            continue
+        leaked.append(name)
+    assert leaked == [], f"MaltParser -i accepted: {leaked}"
+
+
+def test_malt_output_file_refuses_every_hostile_vector(pathsec_sandbox):
+    """-o is an arbitrary-file-WRITE primitive without a guard."""
+    root, outside = pathsec_sandbox
+    parser, infile = _malt_in_sandbox(root)
+    leaked = []
+    for name, value in _hostile_vectors(root, outside):
+        try:
+            parser.generate_malt_command(infile, value, mode="parse")
+        except (PermissionError, ValueError, OSError):
+            continue
+        leaked.append(name)
+    assert leaked == [], f"MaltParser -o accepted: {leaked}"
+
+
+def test_malt_train_from_file_refuses_outside_corpus(pathsec_sandbox):
+    """train_from_file is the public route to -i."""
+    root, outside = pathsec_sandbox
+    parser, _infile = _malt_in_sandbox(root)
+    corpus = outside / "steal.conll"
+    corpus.write_text("1\ta\t_\tNN\t_\t_\t0\tROOT\t_\t_\n")
+    for target in ("/etc/passwd", str(corpus)):
+        with pytest.raises((PermissionError, ValueError)):
+            parser.train_from_file(target)
+
+
+def test_malt_in_sandbox_input_and_output_are_allowed(pathsec_sandbox):
+    """Over-block control: the internal callers pass temp files inside
+    working_dir, which must keep working."""
+    root, _outside = pathsec_sandbox
+    parser, infile = _malt_in_sandbox(root)
+    outfile = os.path.join(parser.working_dir, "out.conll")
+    cmd = parser.generate_malt_command(infile, outfile, mode="parse")
+    assert cmd[cmd.index("-i") + 1] == infile
+    assert cmd[cmd.index("-o") + 1] == outfile
+
+
+def test_teeth_malt_io_guard_is_load_bearing(pathsec_sandbox, monkeypatch):
+    """Neuter the guard and -o reaches the JVM again."""
+    import nltk.parse.malt as malt
+
+    root, outside = pathsec_sandbox
+    parser, infile = _malt_in_sandbox(root)
+    monkeypatch.setattr(malt, "validate_tool_path", lambda *a, **k: None)
+    target = str(outside / "pwned.conll")
+    cmd = parser.generate_malt_command(infile, target, mode="parse")
+    assert cmd[cmd.index("-o") + 1] == target
+
+
+def test_malt_revalidates_on_every_call(pathsec_sandbox):
+    """No cached verdict: a model swapped after a successful call is re-checked,
+    so an attacker cannot 'warm up' the parser with a benign value first."""
+    root, outside = pathsec_sandbox
+    parser, infile = _malt_in_sandbox(root)
+    parser.generate_malt_command(infile, None, mode="learn")
+    evil = outside / "evil.mco"
+    evil.write_text("x")
+    parser.model = str(evil)
+    with pytest.raises((PermissionError, ValueError)):
+        parser.generate_malt_command(infile, None, mode="learn")
+
+
+def test_edited_wrappers_never_widen_the_sandbox(pathsec_sandbox):
+    """Regression guard for the worst bug class in this audit: a loader that
+    appends its target to nltk.data.path and clears the pathsec root cache
+    disarms validate_path process-wide. None of the modules touched here may do
+    that, whatever else they change.
+    """
+    import nltk.data
+
+    before = list(nltk.data.path)
+    root, outside = pathsec_sandbox
+    parser, infile = _malt_in_sandbox(root)
+    for target in ("/etc/passwd", str(outside / "evil.mco")):
+        for call in (
+            lambda t=target: parser.generate_malt_command(t, None, mode="learn"),
+            lambda t=target: setattr(parser, "working_dir", t),
+            lambda t=target: validate_model_resource(t, context="widen"),
+        ):
+            try:
+                call()
+            except (PermissionError, ValueError, OSError):
+                pass
+    assert list(nltk.data.path) == before
+    with pytest.raises(PermissionError):
+        pathsec.validate_path("/etc/passwd", context="widen-check")
+
+
+# ---------------------------------------------------------------------------
+# validate_tool_path. Contract differs from validate_model_resource: this one
+# never accepts a bare resource name, because the tool opens the value directly.
+# ---------------------------------------------------------------------------
+
+
+def test_validate_tool_path_refuses_every_hostile_vector(pathsec_sandbox):
+    root, outside = pathsec_sandbox
+    leaked = []
+    for name, value in _hostile_vectors(root, outside) + _exotic_vectors(root):
+        try:
+            validate_tool_path(value, context="sweep")
+        except (PermissionError, ValueError, OSError):
+            continue
+        leaked.append(name)
+    assert leaked == [], f"validate_tool_path let these through: {leaked}"
+
+
+def test_validate_tool_path_rejects_bare_resource_names(pathsec_sandbox):
+    """Unlike a model argument, an -i/-o value is never a classpath resource: a
+    bare name would resolve against the current working directory."""
+    for value in ("in.conll", "malt_temp.mco", _DEFAULT_RESOURCE):
+        with pytest.raises((PermissionError, ValueError)):
+            validate_tool_path(value, context="sweep")
+
+
+def test_validate_tool_path_allows_in_sandbox_paths(pathsec_sandbox):
+    """Over-block control, including a not-yet-created output file."""
+    root, _outside = pathsec_sandbox
+    existing = root / "in.conll"
+    existing.write_text("")
+    validate_tool_path(str(existing), context="sweep")
+    validate_tool_path(str(root / "out.conll"), context="sweep")
+
+
+def test_validate_tool_path_refuses_hardlink(pathsec_sandbox):
+    root, outside = pathsec_sandbox
+    secret = outside / "secret.conll"
+    secret.write_text("SECRET")
+    alias = root / "alias.conll"
+    try:
+        os.link(str(secret), alias)
+    except OSError:  # pragma: no cover - cross-device or unsupported
+        pytest.skip("hard links unavailable between these directories")
+    with pytest.raises(PermissionError):
+        validate_tool_path(str(alias), context="sweep")
+
+
+def test_validate_tool_path_refuses_fifo(pathsec_sandbox):
+    """An output path that is a FIFO would block the JVM forever."""
+    root, _outside = pathsec_sandbox
+    fifo = root / "out.fifo"
+    try:
+        os.mkfifo(fifo)
+    except (AttributeError, OSError):  # pragma: no cover - not on Windows
+        pytest.skip("mkfifo unavailable")
+    with pytest.raises(PermissionError):
+        validate_tool_path(str(fifo), context="sweep")
+
+
+def test_validate_tool_path_is_exported():
+    assert "validate_tool_path" in pathsec.__all__

--- a/nltk/test/unit/test_pathsec_sweep_wrappers.py
+++ b/nltk/test/unit/test_pathsec_sweep_wrappers.py
@@ -2003,3 +2003,89 @@ def test_every_parser_entry_point_refuses_a_mutating_model(
     handed = sink["cmd"][sink["cmd"].index("-model") + 1]
     assert isinstance(handed, str), f"{entry} put a {type(handed).__name__} in argv"
     assert os.path.realpath(_resolve(handed)).startswith(os.path.realpath(str(root)))
+
+
+def test_validate_model_paths_returns_the_validated_strings(
+    pathsec_sandbox, monkeypatch
+):
+    """The contract the segmenter's argv builders rely on: the guard hands back
+    what it checked, so nothing has to re-read shared mutable state."""
+    root, _outside = pathsec_sandbox
+    model = str(root / "m.ser.gz")
+    dictionary = str(root / "d.ser.gz")
+    sihan = str(root / "sihan")
+    for path in (model, dictionary):
+        with pathsec.open(path, "w", encoding="utf-8") as handle:
+            handle.write("x")
+    os.mkdir(sihan)
+
+    tool = _segmenter(monkeypatch, str(root), model=model)
+    tool._dict = dictionary
+    tool._sihan_corpora_dict = sihan
+    assert tool._validate_model_paths() == (model, dictionary, sihan)
+
+    unset = _segmenter(monkeypatch, str(root))
+    assert unset._validate_model_paths() == (None, None, None)
+
+
+def test_segmenter_argv_survives_a_concurrent_model_swap(pathsec_sandbox, monkeypatch):
+    """A background thread rewriting self._model must never land an out-of-root
+    path in the argv. The builders take the guard's return value rather than
+    re-reading the attribute, so the checked value and the used value are the
+    same object.
+
+    No leak was observed here before the change either, so this documents the
+    property rather than reproducing a past failure.
+    """
+    import threading
+
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, outside = pathsec_sandbox
+    evil = str(outside / "evil.ser.gz")
+    (outside / "evil.ser.gz").write_text("x")
+    good = str(root / "ok.ser.gz")
+    with pathsec.open(good, "w", encoding="utf-8") as handle:
+        handle.write("m")
+    inside = str(root / "in.txt")
+    with pathsec.open(inside, "w", encoding="utf-8") as handle:
+        handle.write("x")
+
+    handed = []
+
+    def fake_java(cmd, *args, **kwargs):
+        handed.append(cmd[cmd.index("-loadClassifier") + 1])
+        raise _ReachedJVM
+
+    monkeypatch.setattr(seg, "java", fake_java)
+    tool = _segmenter(monkeypatch, str(root), model=good)
+
+    stop = threading.Event()
+
+    def flipper():
+        while not stop.is_set():
+            tool._model = evil
+            tool._model = good
+
+    thread = threading.Thread(target=flipper, daemon=True)
+    thread.start()
+    try:
+        for _ in range(200):
+            for call in (
+                lambda: tool.segment_file(inside),
+                lambda: tool.segment_sents([["中", "文"]]),
+            ):
+                try:
+                    call()
+                except (_ReachedJVM, PermissionError, ValueError):
+                    pass
+    finally:
+        stop.set()
+        thread.join(timeout=5)
+
+    escaped = [
+        value
+        for value in handed
+        if not os.path.realpath(str(value)).startswith(os.path.realpath(str(root)))
+    ]
+    assert escaped == [], f"a concurrent write reached the JVM argv: {escaped[:3]}"

--- a/nltk/test/unit/test_pathsec_sweep_wrappers.py
+++ b/nltk/test/unit/test_pathsec_sweep_wrappers.py
@@ -851,6 +851,7 @@ def test_validate_model_resource_refuses_exotic_vectors(pathsec_sandbox):
     assert leaked == [], f"validate_model_resource let these through: {leaked}"
 
 
+@pytest.mark.skipif(not hasattr(__import__("socket"), "AF_UNIX"), reason="no AF_UNIX")
 def test_unix_socket_model_is_refused(pathsec_sandbox):
     """A socket planted in a data root is not a model; reading it would block."""
     import socket
@@ -901,6 +902,10 @@ def test_windows_drive_path_is_not_stream_rejected():
         _vmr("C:\\models\\english.ser.gz", context="sweep")
     except ValueError as exc:
         assert "alternate data stream" not in str(exc), exc
+    except PermissionError:
+        # On Windows this IS an absolute path, so it is (correctly) refused for
+        # being outside the data roots. That is not the stream rejection.
+        pass
     assert _re.match(r"^[A-Za-z]:[\\/]", "C:\\models\\english.ser.gz")
 
 
@@ -1206,3 +1211,21 @@ def test_working_dir_none_resets_to_lazy_allocation(pathsec_sandbox):
     first = parser.working_dir
     parser.working_dir = None
     assert parser.working_dir != first or os.path.isdir(parser.working_dir)
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["NUL", "CON", "COM1", "LPT1", "nul.ser.gz", "models/COM9.mco", "AUX"],
+)
+def test_reserved_windows_device_names_are_refused(value):
+    """On Windows these resolve to a device (a serial port, the null device) no
+    matter which directory they appear in, so a bare resource name must not be
+    allowed to name one."""
+    with pytest.raises(ValueError):
+        validate_model_resource(value, context="sweep")
+
+
+@pytest.mark.parametrize("value", ["CONTEXT.mco", "console.ser.gz", "nulls.mco"])
+def test_names_merely_starting_like_a_device_are_allowed(value):
+    """Over-block control: the check is on the whole stem, not a prefix."""
+    validate_model_resource(value, context="sweep")

--- a/nltk/test/unit/test_pathsec_sweep_wrappers.py
+++ b/nltk/test/unit/test_pathsec_sweep_wrappers.py
@@ -1673,3 +1673,33 @@ def test_teeth_corenlp_options_guard_is_load_bearing(pathsec_sandbox, monkeypatc
         _stanford_with_options(model, f"-model {evil}").parse_sents([["hi", "there"]])
     models = [sink["cmd"][i + 1] for i, x in enumerate(sink["cmd"]) if x == "-model"]
     assert str(evil) in models
+
+
+@pytest.mark.parametrize(
+    "name",
+    [".\n./TARGET", ".\t./TARGET", ".\r./TARGET", ".\x0b./TARGET", "model\x0c.mco"],
+    ids=["lf", "tab", "cr", "vtab", "formfeed"],
+)
+def test_control_characters_are_refused(name):
+    """Python 3.14's url2pathname follows the WHATWG rules and STRIPS tab, LF and
+    CR, so a name containing them passes a '..' check here and then BECOMES a
+    traversal downstream. Verified against a real 3.14.4 interpreter:
+
+        url2pathname('.\\n./TARGET') -> '../TARGET'
+
+    A legitimate model or corpus filename never contains a control character, so
+    they are refused outright rather than normalised.
+    """
+    for guard in (validate_model_resource, validate_tool_path):
+        with pytest.raises((PermissionError, ValueError)):
+            guard(name, context="sweep")
+
+
+def test_control_character_guard_does_not_block_ordinary_names(pathsec_sandbox):
+    """Over-block control: spaces are legal in a filename, control characters
+    are not."""
+    root, _outside = pathsec_sandbox
+    spaced = root / "my model.ser.gz"
+    spaced.write_text("m")
+    validate_model_resource(str(spaced), context="sweep")
+    validate_model_resource(_DEFAULT_RESOURCE, context="sweep")

--- a/nltk/test/unit/test_pathsec_sweep_wrappers.py
+++ b/nltk/test/unit/test_pathsec_sweep_wrappers.py
@@ -40,6 +40,12 @@ class _ReachedJVM(Exception):
     handed off" apart from "a guard refused first"."""
 
 
+def _passthrough(value, *args, **kwargs):
+    """A neutered guard: performs no checks but still returns the path, since
+    the callers now use the value the guard hands back."""
+    return os.fspath(value)
+
+
 def _trap_java(monkeypatch, module, sink):
     """Replace ``module.java`` with a trap that records argv and stops before
     launching a JVM."""
@@ -363,7 +369,7 @@ def test_teeth_stanford_parser_guard_is_load_bearing(pathsec_sandbox, monkeypatc
     import nltk.parse.stanford as st
 
     _trap_java(monkeypatch, st, {})
-    monkeypatch.setattr(st, "validate_model_resource", lambda *a, **k: None)
+    monkeypatch.setattr(st, "validate_model_resource", _passthrough)
     with pytest.raises(_ReachedJVM):
         _stanford_parser("/etc/passwd").parse_sents([["hello", "world"]])
 
@@ -386,8 +392,8 @@ def test_teeth_malt_guard_is_load_bearing(pathsec_sandbox, monkeypatch):
 
     _root, outside = pathsec_sandbox
     monkeypatch.setattr(malt, "validate_path", lambda *a, **k: None)
-    monkeypatch.setattr(malt, "validate_model_resource", lambda *a, **k: None)
-    monkeypatch.setattr(malt, "validate_tool_path", lambda *a, **k: None)
+    monkeypatch.setattr(malt, "validate_model_resource", _passthrough)
+    monkeypatch.setattr(malt, "validate_tool_path", _passthrough)
     evil = outside / "evil.mco"
     evil.write_text("model")
     cmd = _malt(str(evil)).generate_malt_command("in.conll", "out.conll", mode="learn")
@@ -1049,7 +1055,7 @@ def test_teeth_malt_io_guard_is_load_bearing(pathsec_sandbox, monkeypatch):
 
     root, outside = pathsec_sandbox
     parser, infile = _malt_in_sandbox(root)
-    monkeypatch.setattr(malt, "validate_tool_path", lambda *a, **k: None)
+    monkeypatch.setattr(malt, "validate_tool_path", _passthrough)
     target = str(outside / "pwned.conll")
     cmd = parser.generate_malt_command(infile, target, mode="parse")
     assert cmd[cmd.index("-o") + 1] == target
@@ -1263,3 +1269,113 @@ def test_both_guards_share_one_syntax_gate(pathsec_sandbox):
         if verdicts[0] == "refused" and verdicts[1] == "allowed":
             disagreements.append(name)
     assert disagreements == [], f"tool_path weaker than model_resource: {disagreements}"
+
+
+# ---------------------------------------------------------------------------
+# Time-of-check/time-of-use at the API boundary. __fspath__ is allowed to
+# return a different answer on every call, so a guard that resolves the path
+# separately from the code that uses it validates one file while the tool opens
+# another. Both parsers leaked this way until the guards started returning the
+# resolved string for the caller to use.
+# ---------------------------------------------------------------------------
+
+
+class _MutatingPath:
+    """A legal os.PathLike whose __fspath__ answers differently each call."""
+
+    def __init__(self, first, rest):
+        self._calls = 0
+        self._first = first
+        self._rest = rest
+
+    def __fspath__(self):
+        self._calls += 1
+        return self._first if self._calls == 1 else self._rest
+
+    def __str__(self):
+        return self._first
+
+
+def _resolve(value):
+    return os.fspath(value) if hasattr(value, "__fspath__") else value
+
+
+def test_stanford_model_argv_carries_the_validated_string(pathsec_sandbox, monkeypatch):
+    """The argv entry must be the exact string the guard checked, not an object
+    that can resolve to something else when the child process reads it."""
+    import nltk.parse.stanford as st
+
+    root, outside = pathsec_sandbox
+    sink = _trap_java(monkeypatch, st, {})
+    evil = outside / "evil.ser.gz"
+    evil.write_text("x")
+    good = root / "ok.ser.gz"
+    good.write_text("m")
+
+    parser = _stanford_parser(_MutatingPath(str(good), str(evil)))
+    with pytest.raises(_ReachedJVM):
+        parser.parse_sents([["hello", "world"]])
+    handed_over = sink["cmd"][sink["cmd"].index("-model") + 1]
+    assert isinstance(handed_over, str)
+    assert os.path.realpath(_resolve(handed_over)).startswith(
+        os.path.realpath(str(root))
+    )
+
+
+def test_malt_working_dir_uses_the_validated_model_string(pathsec_sandbox):
+    root, outside = pathsec_sandbox
+    evil = outside / "evil.mco"
+    evil.write_text("x")
+    good = root / "ok.mco"
+    good.write_text("m")
+
+    parser = _malt(_MutatingPath(str(good), str(evil)))
+    infile, _outfile = _sandbox_io(parser)
+    cmd = parser.generate_malt_command(infile, None, mode="learn")
+    workingdir = cmd[cmd.index("-w") + 1]
+    assert os.path.realpath(str(workingdir)).startswith(os.path.realpath(str(root)))
+
+
+def test_mutating_path_that_starts_hostile_is_refused(pathsec_sandbox):
+    """The other ordering: hostile on the guard's call. Must still be refused."""
+    root, outside = pathsec_sandbox
+    evil = outside / "evil.mco"
+    evil.write_text("x")
+    good = root / "ok.mco"
+    good.write_text("m")
+    with pytest.raises((PermissionError, ValueError)):
+        validate_model_resource(_MutatingPath(str(evil), str(good)), context="sweep")
+
+
+def test_guards_return_the_resolved_string(pathsec_sandbox):
+    """The contract callers rely on: use the return value, never the original."""
+    root, _outside = pathsec_sandbox
+    model = root / "m.mco"
+    model.write_text("m")
+    assert validate_model_resource(model, context="sweep") == str(model)
+    assert validate_tool_path(model, context="sweep") == str(model)
+    assert validate_model_resource(_DEFAULT_RESOURCE, context="sweep") == (
+        _DEFAULT_RESOURCE
+    )
+
+
+@pytest.mark.parametrize(
+    "value", [b"/etc/passwd", b"model.mco", 0, None, ["/etc/passwd"], 12345]
+)
+def test_non_path_inputs_are_a_clean_security_rejection(value):
+    """A TypeError would escape a caller's except (ValueError, PermissionError)
+    and surface as a crash rather than a refusal. bytes paths are refused too:
+    they pass os.fspath but then break every str check."""
+    for guard in (validate_model_resource, validate_tool_path):
+        with pytest.raises(ValueError):
+            guard(value, context="sweep")
+
+
+@pytest.mark.parametrize(
+    "name", ["evil.mco.", "evil.mco ", "evil.mco...", "evil.mco. "]
+)
+def test_trailing_dot_or_space_is_refused(name):
+    """Windows silently strips these, so the name that is checked is not the name
+    that is opened."""
+    with pytest.raises(ValueError):
+        validate_model_resource(name, context="sweep")

--- a/nltk/test/unit/test_pathsec_sweep_wrappers.py
+++ b/nltk/test/unit/test_pathsec_sweep_wrappers.py
@@ -1,0 +1,913 @@
+# Natural Language Toolkit: pathsec sweep over the external-tool wrappers
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""Escape matrix for the model/data paths handed to external tools.
+
+The JVM wrappers take caller-supplied model and corpus paths and pass them
+straight into the child process's argv. Those are *data* paths, so they must be
+bounded to the NLTK data roots; a path outside the sandbox means the wrapper will
+read (and, for MaltParser's ``-w`` in learn mode, WRITE) anywhere on disk.
+
+Two classes of path are deliberately treated differently:
+
+* **model / corpus paths** (this file) are bounded with ``pathsec.validate_path``
+  or ``pathsec.validate_model_resource``.
+* **install / binary directories** (``candc``/``boxer``'s ``bin_dir``, REPP's
+  tokenizer dir) are NOT: ``validate_path`` permits only NLTK *data* roots, so
+  bounding them would break every real installation. They get an absolute-path
+  (CWE-426) check instead, and the tests at the end of this file pin that
+  distinction so a later refactor cannot quietly collapse the two.
+
+Every test drives the real code path with only the ``java`` hand-off replaced, so
+a probe cannot pass merely because the argv was assembled by the test itself.
+"""
+
+import hashlib
+import os
+
+import pytest
+
+from nltk import pathsec
+from nltk.data import make_staging_dir
+from nltk.pathsec import validate_model_resource
+
+
+class _ReachedJVM(Exception):
+    """Raised by the trapped ``java`` so a test can tell "the argv was built and
+    handed off" apart from "a guard refused first"."""
+
+
+def _trap_java(monkeypatch, module, sink):
+    """Replace ``module.java`` with a trap that records argv and stops before
+    launching a JVM."""
+
+    def fake_java(cmd, *args, **kwargs):
+        sink["cmd"] = list(cmd)
+        raise _ReachedJVM
+
+    monkeypatch.setattr(module, "java", fake_java)
+    return sink
+
+
+# ---------------------------------------------------------------------------
+# StanfordSegmenter: -loadClassifier / -serDictionary / -sighanCorporaDict /
+# -textFile all reach the JVM argv.
+# ---------------------------------------------------------------------------
+
+
+def _segmenter(monkeypatch, root, model=None, dictionary=None, sihan=None):
+    """A StanfordSegmenter whose jar passes the sha256 allowlist, so the test
+    reaches the model-path handling rather than stopping at the jar check."""
+    import nltk.tokenize.stanford_segmenter as seg
+
+    jar = os.path.join(root, "seg.jar")
+    with pathsec.open(jar, "wb") as handle:
+        handle.write(b"PK\x05\x06" + b"\0" * 18)
+    with pathsec.open(jar, "rb") as handle:
+        digest = hashlib.sha256(handle.read()).hexdigest()
+    monkeypatch.setenv("NLTK_SEGMENTER_ALLOW_SHA256", digest)
+
+    tool = object.__new__(seg.StanfordSegmenter)
+    tool._stanford_jar = jar
+    tool._encoding = "utf8"
+    tool.java_options = "-mx1g"
+    tool._jar_sha256_cache = {}
+    tool._java_class = "edu.stanford.nlp.ie.crf.CRFClassifier"
+    tool._model = model
+    tool._dict = dictionary
+    tool._sihan_corpora_dict = sihan
+    tool._sihan_post_processing = "true"
+    tool._keep_whitespaces = "false"
+    tool._options_cmd = ""
+    return tool
+
+
+@pytest.mark.parametrize("slot", ["model", "dictionary", "sihan"])
+def test_segmenter_model_paths_refuse_escape(pathsec_sandbox, monkeypatch, slot):
+    """A model, dictionary or Sihan corpus dir outside the roots is refused
+    before the JVM sees it."""
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, outside = pathsec_sandbox
+    _trap_java(monkeypatch, seg, {})
+    evil = outside / "evil.ser.gz"
+    evil.write_text("payload")
+    inside = str(root / "in.txt")
+    with pathsec.open(inside, "w") as handle:
+        handle.write("中文")
+
+    tool = _segmenter(monkeypatch, str(root), **{slot: str(evil)})
+    with pytest.raises((PermissionError, ValueError)):
+        tool.segment_file(inside)
+
+
+def test_segmenter_input_file_refuses_escape(pathsec_sandbox, monkeypatch):
+    """``segment_file`` is an arbitrary-file-read primitive without a guard on
+    its own argument."""
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, outside = pathsec_sandbox
+    _trap_java(monkeypatch, seg, {})
+    tool = _segmenter(monkeypatch, str(root))
+    with pytest.raises((PermissionError, ValueError)):
+        tool.segment_file("/etc/passwd")
+
+
+def test_segmenter_in_sandbox_paths_reach_jvm(pathsec_sandbox, monkeypatch):
+    """Over-block control: legitimate in-sandbox paths must still be handed to
+    the JVM, otherwise the guard has broken the feature."""
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, _outside = pathsec_sandbox
+    sink = _trap_java(monkeypatch, seg, {})
+    model = str(root / "model.ser.gz")
+    with pathsec.open(model, "w") as handle:
+        handle.write("m")
+    inside = str(root / "in.txt")
+    with pathsec.open(inside, "w") as handle:
+        handle.write("中文")
+
+    tool = _segmenter(monkeypatch, str(root), model=model)
+    with pytest.raises(_ReachedJVM):
+        tool.segment_file(inside)
+    assert model in sink["cmd"]
+
+
+# ---------------------------------------------------------------------------
+# MaltParser: -c model and the -w working directory (WRITTEN to in learn mode).
+# ---------------------------------------------------------------------------
+
+
+def _malt(model, trained=True):
+    import nltk.parse.malt as malt
+
+    parser = object.__new__(malt.MaltParser)
+    parser.model = model
+    parser._trained = trained
+    parser._working_dir = None
+    parser.additional_java_args = []
+    return parser
+
+
+def test_malt_trained_model_refuses_escape(pathsec_sandbox):
+    """A .mco outside the roots would make ``-w`` an arbitrary write target."""
+    root, outside = pathsec_sandbox
+    evil = outside / "evil.mco"
+    evil.write_text("model")
+    with pytest.raises((PermissionError, ValueError)):
+        _malt(str(evil)).generate_malt_command("in.conll", "out.conll", mode="learn")
+
+
+def test_malt_trained_model_in_sandbox_is_allowed(pathsec_sandbox):
+    """Over-block control for the trained path."""
+    root, _outside = pathsec_sandbox
+    model = root / "engmalt.mco"
+    model.write_text("model")
+    cmd = _malt(str(model)).generate_malt_command("in.conll", "out.conll", mode="parse")
+    assert cmd[cmd.index("-w") + 1] == str(root)
+    assert cmd[cmd.index("-c") + 1] == "engmalt.mco"
+
+
+def test_malt_untrained_working_dir_is_staged_inside_root(pathsec_sandbox):
+    """An untrained parser used to write malt_temp.mco into the CWD; it must now
+    land in a private staging dir inside a data root."""
+    root, _outside = pathsec_sandbox
+    cmd = _malt("malt_temp.mco", trained=False).generate_malt_command(
+        "in.conll", "out.conll", mode="learn"
+    )
+    workingdir = cmd[cmd.index("-w") + 1]
+    assert os.path.realpath(workingdir).startswith(os.path.realpath(str(root)))
+    assert os.path.realpath(workingdir) != os.path.realpath(os.getcwd())
+    assert cmd[cmd.index("-c") + 1] == "malt_temp.mco"
+
+
+def test_malt_working_dir_is_private():
+    """The staging dir must not be group/world readable: it holds the CoNLL
+    intermediates and the trained model."""
+    staged = make_staging_dir(prefix="nltk_malt_test_")
+    assert os.stat(staged).st_mode & 0o077 == 0
+
+
+def test_malt_working_dir_setter_refuses_escape(pathsec_sandbox):
+    """A caller may still choose the directory, but only inside the sandbox."""
+    _root, outside = pathsec_sandbox
+    parser = _malt("malt_temp.mco", trained=False)
+    with pytest.raises((PermissionError, ValueError)):
+        parser.working_dir = str(outside)
+
+
+def test_malt_working_dir_setter_accepts_in_sandbox(pathsec_sandbox):
+    """Over-block control for the setter."""
+    root, _outside = pathsec_sandbox
+    parser = _malt("malt_temp.mco", trained=False)
+    parser.working_dir = str(root)
+    assert parser.working_dir == str(root)
+
+
+def test_malt_working_dir_is_not_shared_tempdir(pathsec_sandbox):
+    """Regression: the default was ``tempfile.gettempdir()``, which is
+    world-writable on Linux and gives a predictable, squattable path."""
+    import tempfile as _tempfile
+
+    root, _outside = pathsec_sandbox
+    parser = _malt("malt_temp.mco", trained=False)
+    assert os.path.realpath(parser.working_dir) != os.path.realpath(
+        _tempfile.gettempdir()
+    )
+
+
+# ---------------------------------------------------------------------------
+# StanfordParser: -model may be a filesystem path OR a jar-internal resource.
+# ---------------------------------------------------------------------------
+
+_DEFAULT_RESOURCE = "edu/stanford/nlp/models/lexparser/englishPCFG.ser.gz"
+
+
+def _stanford_parser(model_path):
+    import nltk.parse.stanford as st
+
+    parser = object.__new__(st.StanfordParser)
+    parser.model_path = model_path
+    parser._classpath = ()
+    parser.java_options = "-mx1g"
+    parser._encoding = "utf8"
+    parser.corenlp_options = ""
+    parser._USE_STDIN = False
+    return parser
+
+
+@pytest.mark.parametrize(
+    "model_path",
+    ["/etc/passwd", "edu/stanford/../../../../etc/passwd"],
+    ids=["etc-abs", "traversal"],
+)
+def test_stanford_parser_model_refuses_escape(pathsec_sandbox, monkeypatch, model_path):
+    import nltk.parse.stanford as st
+
+    _trap_java(monkeypatch, st, {})
+    with pytest.raises((PermissionError, ValueError)):
+        _stanford_parser(model_path).parse_sents([["hello", "world"]])
+
+
+def test_stanford_parser_outside_model_refuses_escape(pathsec_sandbox, monkeypatch):
+    import nltk.parse.stanford as st
+
+    _root, outside = pathsec_sandbox
+    _trap_java(monkeypatch, st, {})
+    evil = outside / "evil.ser.gz"
+    evil.write_text("model")
+    with pytest.raises((PermissionError, ValueError)):
+        _stanford_parser(str(evil)).parse_sents([["hello", "world"]])
+
+
+def test_stanford_parser_default_resource_still_works(pathsec_sandbox, monkeypatch):
+    """Over-block control: the shipped default is a jar-internal resource, not a
+    file on disk, and must not be treated as a path."""
+    import nltk.parse.stanford as st
+
+    sink = _trap_java(monkeypatch, st, {})
+    with pytest.raises(_ReachedJVM):
+        _stanford_parser(_DEFAULT_RESOURCE).parse_sents([["hello", "world"]])
+    assert sink["cmd"][sink["cmd"].index("-model") + 1] == _DEFAULT_RESOURCE
+
+
+def test_stanford_parser_in_sandbox_model_still_works(pathsec_sandbox, monkeypatch):
+    """Over-block control: a real model inside a data root must still load."""
+    import nltk.parse.stanford as st
+
+    root, _outside = pathsec_sandbox
+    sink = _trap_java(monkeypatch, st, {})
+    model = root / "englishPCFG.ser.gz"
+    model.write_text("model")
+    with pytest.raises(_ReachedJVM):
+        _stanford_parser(str(model)).parse_sents([["hello", "world"]])
+    assert sink["cmd"][sink["cmd"].index("-model") + 1] == str(model)
+
+
+# ---------------------------------------------------------------------------
+# validate_model_resource itself.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "edu/stanford/../nlp/x.ser.gz",
+        "../x.ser.gz",
+        "a/b/../../../etc/passwd",
+        "edu\\stanford\\..\\x.ser.gz",
+    ],
+)
+def test_validate_model_resource_rejects_traversal(value):
+    """``..`` is refused whether or not the value looks like a real path, so a
+    resource name cannot escape the jar namespace."""
+    with pytest.raises(ValueError):
+        validate_model_resource(value, context="test")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [_DEFAULT_RESOURCE, "edu/stanford/nlp/models/pos-tagger/english-left3words.tagger"],
+)
+def test_validate_model_resource_allows_resource_names(value):
+    """A bare classpath resource is not a filesystem path and is left alone."""
+    validate_model_resource(value, context="test")
+
+
+def test_validate_model_resource_bounds_real_paths(pathsec_sandbox):
+    root, outside = pathsec_sandbox
+    inside = root / "m.ser.gz"
+    inside.write_text("m")
+    validate_model_resource(str(inside), context="test")
+    with pytest.raises((PermissionError, ValueError)):
+        validate_model_resource(str(outside / "m.ser.gz"), context="test")
+
+
+def test_validate_model_resource_accepts_pathlike(pathsec_sandbox):
+    """os.PathLike must not blow up on ``.replace``."""
+    root, _outside = pathsec_sandbox
+    inside = root / "m.ser.gz"
+    inside.write_text("m")
+    validate_model_resource(inside, context="test")
+
+
+def test_validate_model_resource_is_exported():
+    assert "validate_model_resource" in pathsec.__all__
+
+
+# ---------------------------------------------------------------------------
+# Teeth: neuter each guard and assert the attack becomes reachable again. A
+# probe that passes with the guard removed is not testing the guard.
+# ---------------------------------------------------------------------------
+
+
+def test_teeth_stanford_parser_guard_is_load_bearing(pathsec_sandbox, monkeypatch):
+    import nltk.parse.stanford as st
+
+    _trap_java(monkeypatch, st, {})
+    monkeypatch.setattr(st, "validate_model_resource", lambda *a, **k: None)
+    with pytest.raises(_ReachedJVM):
+        _stanford_parser("/etc/passwd").parse_sents([["hello", "world"]])
+
+
+def test_teeth_segmenter_guard_is_load_bearing(pathsec_sandbox, monkeypatch):
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, _outside = pathsec_sandbox
+    _trap_java(monkeypatch, seg, {})
+    monkeypatch.setattr(seg, "validate_path", lambda *a, **k: None)
+    tool = _segmenter(monkeypatch, str(root))
+    with pytest.raises(_ReachedJVM):
+        tool.segment_file("/etc/passwd")
+
+
+def test_teeth_malt_guard_is_load_bearing(pathsec_sandbox, monkeypatch):
+    """Both guards have to go before the escape reappears, which is the point:
+    validate_model_resource still catches the model when validate_path is gone."""
+    import nltk.parse.malt as malt
+
+    _root, outside = pathsec_sandbox
+    monkeypatch.setattr(malt, "validate_path", lambda *a, **k: None)
+    monkeypatch.setattr(malt, "validate_model_resource", lambda *a, **k: None)
+    evil = outside / "evil.mco"
+    evil.write_text("model")
+    cmd = _malt(str(evil)).generate_malt_command("in.conll", "out.conll", mode="learn")
+    assert cmd[cmd.index("-w") + 1] == str(outside)
+
+
+def test_teeth_malt_model_resource_guard_alone_blocks(pathsec_sandbox, monkeypatch):
+    """Removing only validate_path must NOT reopen the escape: the second guard
+    is independently load-bearing."""
+    import nltk.parse.malt as malt
+
+    _root, outside = pathsec_sandbox
+    monkeypatch.setattr(malt, "validate_path", lambda *a, **k: None)
+    evil = outside / "evil.mco"
+    evil.write_text("model")
+    with pytest.raises((PermissionError, ValueError)):
+        _malt(str(evil)).generate_malt_command("in.conll", "out.conll", mode="learn")
+
+
+# ---------------------------------------------------------------------------
+# Install-directory wrappers: pinned as a DIFFERENT class. These must keep the
+# CWE-426 absolute-path check and must NOT gain validate_path, which permits
+# only NLTK data roots and would break every real installation.
+# ---------------------------------------------------------------------------
+
+
+def test_boxer_bin_dir_rejects_relative_and_cwd(pathsec_sandbox):
+    """A relative or CWD bin_dir is a binary-planting vector (CWE-426)."""
+    import nltk.sem.boxer as boxer
+
+    _root, outside = pathsec_sandbox
+    bindir = outside / "candcbin"
+    bindir.mkdir()
+    for name in ("candc", "boxer"):
+        target = bindir / name
+        target.write_text("#!/bin/sh\n")
+        target.chmod(0o755)
+    os.chdir(str(outside))
+
+    tool = object.__new__(boxer.Boxer)
+    for bad in ("candcbin", "."):
+        with pytest.raises(LookupError):
+            tool.set_bin_dir(bad)
+
+
+def test_boxer_models_path_is_derived_not_caller_supplied(pathsec_sandbox):
+    """``--models`` has no independent input: it is derived from the absolute
+    candc binary, so bounding bin_dir bounds the models dir too."""
+    import nltk.sem.boxer as boxer
+
+    _root, outside = pathsec_sandbox
+    bindir = outside / "candcbin"
+    bindir.mkdir()
+    for name in ("candc", "boxer"):
+        target = bindir / name
+        target.write_text("#!/bin/sh\n")
+        target.chmod(0o755)
+
+    tool = object.__new__(boxer.Boxer)
+    tool.set_bin_dir(str(bindir))
+    assert tool._candc_models_path == os.path.normpath(str(outside / "models"))
+
+
+def test_repp_dir_must_resolve_absolute(pathsec_sandbox):
+    """REPP executes ``<dir>/src/repp``; a CWD-relative dir would let an
+    attacker plant that binary."""
+    import nltk.tokenize.repp as repp
+
+    _root, outside = pathsec_sandbox
+    tree = outside / "evil_repp"
+    (tree / "src").mkdir(parents=True)
+    (tree / "erg").mkdir()
+    (tree / "src" / "repp").write_text("#!/bin/sh\n")
+    (tree / "erg" / "repp.set").write_text("")
+    os.environ.pop("REPP_TOKENIZER", None)
+    os.chdir(str(outside))
+
+    tokenizer = object.__new__(repp.ReppTokenizer)
+    with pytest.raises(LookupError):
+        tokenizer.find_repptokenizer("evil_repp")
+
+
+# ---------------------------------------------------------------------------
+# Functional: the patched modules must still import and behave. These exercise
+# the real objects rather than asserting on mocks.
+# ---------------------------------------------------------------------------
+
+
+def test_wrapper_modules_still_import():
+    """Every module touched by this PR imports cleanly, with no import cycle
+    introduced by the new pathsec dependency."""
+    import importlib
+
+    for name in (
+        "nltk.parse.malt",
+        "nltk.parse.stanford",
+        "nltk.sem.boxer",
+        "nltk.tokenize.repp",
+        "nltk.tokenize.stanford_segmenter",
+    ):
+        assert importlib.import_module(name) is not None
+
+
+def test_malt_command_shape_is_unchanged(pathsec_sandbox):
+    """The guard must not reorder or drop MaltParser's arguments."""
+    root, _outside = pathsec_sandbox
+    model = root / "engmalt.mco"
+    model.write_text("model")
+    cmd = _malt(str(model)).generate_malt_command("in.conll", "out.conll", mode="parse")
+    assert cmd[0] == "org.maltparser.Malt"
+    for flag in ("-w", "-c", "-i", "-o", "-m"):
+        assert flag in cmd
+    assert cmd[cmd.index("-i") + 1] == "in.conll"
+    assert cmd[cmd.index("-o") + 1] == "out.conll"
+    assert cmd[cmd.index("-m") + 1] == "parse"
+
+
+def test_malt_working_dir_is_stable_across_calls(pathsec_sandbox):
+    """The lazy property must allocate once, not a fresh dir per access, or the
+    CoNLL intermediates and the model would land in different directories."""
+    parser = _malt("malt_temp.mco", trained=False)
+    assert parser.working_dir == parser.working_dir
+
+
+# ---------------------------------------------------------------------------
+# Real end-to-end runs. These launch an actual JVM against a real MaltParser /
+# Stanford parser install, so they prove the guards neither break the feature
+# nor "pass" merely because no JVM was reachable. They skip when the external
+# tool is genuinely absent (CI has no JVM or model jars); every other test in
+# this file runs unconditionally.
+# ---------------------------------------------------------------------------
+
+
+def _has_java():
+    """True only if a JVM actually *runs*.
+
+    Merely finding a ``java`` on PATH is not enough: macOS ships a
+    ``/usr/bin/java`` stub that resolves fine and then fails at exec time with
+    "Unable to locate a Java Runtime", which would turn these into hard failures
+    on a machine with no JDK instead of skips.
+    """
+    import subprocess
+
+    from nltk.internals import find_binary
+
+    try:
+        binary = find_binary(
+            "java", env_vars=("JAVAHOME", "JAVA_HOME"), verbose=False, binary_names=None
+        )
+    except LookupError:
+        return False
+    try:
+        return (
+            subprocess.run(
+                [binary, "-version"], capture_output=True, timeout=60
+            ).returncode
+            == 0
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+def _find_tool_dir(*names):
+    """Absolute path of an external tool directory inside a data root, or None."""
+    import nltk.data
+
+    for root in nltk.data.path:
+        for name in names:
+            candidate = os.path.join(root, name)
+            if os.path.isdir(candidate):
+                return candidate
+    return None
+
+
+requires_java = pytest.mark.skipif(not _has_java(), reason="no JVM on this machine")
+
+
+@requires_java
+def test_real_malt_train_writes_model_inside_sandbox(tmp_path):
+    """End-to-end: a real MaltParser JVM must write malt_temp.mco into the private
+    staging dir, and must NOT pollute the current working directory as it did when
+    ``-w`` defaulted to ``os.getcwd()``."""
+    import nltk.data
+    from nltk.parse.dependencygraph import DependencyGraph
+    from nltk.parse.malt import MaltParser
+
+    malt_dir = _find_tool_dir("maltparser-1.9.2", "maltparser-1.9.1")
+    if malt_dir is None:
+        pytest.skip("maltparser is not installed under nltk.data.path")
+
+    parser = MaltParser(parser_dirname=malt_dir)
+    assert os.stat(parser.working_dir).st_mode & 0o077 == 0
+    assert any(
+        os.path.realpath(parser.working_dir).startswith(os.path.realpath(root))
+        for root in nltk.data.path
+    )
+
+    rows = "1\tJohn\t_\tNNP\t_\t_\t2\tSUBJ\t_\t_\n2\tsees\t_\tVB\t_\t_\t0\tROOT\t_\t_\n"
+    parser.train([DependencyGraph(rows), DependencyGraph(rows)], verbose=False)
+
+    model = os.path.join(parser.working_dir, "malt_temp.mco")
+    assert os.path.exists(model) and os.path.getsize(model) > 0
+    assert not os.path.exists(os.path.join(os.getcwd(), "malt_temp.mco"))
+
+
+@requires_java
+def test_real_stanford_parser_default_resource_parses(monkeypatch):
+    """End-to-end: the shipped jar-internal default model must still parse. If the
+    guard treated it as a filesystem path this raises instead."""
+    from nltk.parse.stanford import StanfordParser
+
+    parser_dir = _find_tool_dir("stanford-parser-full-2020-11-17")
+    if parser_dir is None:
+        pytest.skip("stanford-parser is not installed under nltk.data.path")
+    monkeypatch.setenv("STANFORD_PARSER", parser_dir)
+    monkeypatch.setenv("STANFORD_MODELS", parser_dir)
+
+    trees = list(StanfordParser().raw_parse("John sees a dog."))
+    assert trees and trees[0].label() == "ROOT"
+
+
+@requires_java
+@pytest.mark.parametrize(
+    "model_path",
+    ["/etc/passwd", "edu/stanford/../../../../etc/passwd"],
+    ids=["etc-abs", "traversal"],
+)
+def test_real_stanford_parser_refuses_escape_with_jvm_present(monkeypatch, model_path):
+    """End-to-end negative: with a working JVM and real jars, a hostile -model is
+    refused before launch, so the block is the guard and not a missing JVM."""
+    from nltk.parse.stanford import StanfordParser
+
+    parser_dir = _find_tool_dir("stanford-parser-full-2020-11-17")
+    if parser_dir is None:
+        pytest.skip("stanford-parser is not installed under nltk.data.path")
+    monkeypatch.setenv("STANFORD_PARSER", parser_dir)
+    monkeypatch.setenv("STANFORD_MODELS", parser_dir)
+
+    parser = StanfordParser()
+    parser.model_path = model_path
+    with pytest.raises((PermissionError, ValueError)):
+        list(parser.raw_parse("John sees a dog."))
+
+
+# ---------------------------------------------------------------------------
+# Expanded vector matrix. Every entry below was run against the live sinks; the
+# ones that leaked drove the hardening in validate_model_resource. Benign and
+# merely-suspicious candidates are kept so a regression shows up as a new leak.
+# ---------------------------------------------------------------------------
+
+
+def _hostile_vectors(root, outside):
+    """(id, value) pairs that must never reach an external tool."""
+    secret = outside / "secret.mco"
+    secret.write_text("SECRET")
+
+    vectors = [
+        ("outside-abs", str(secret)),
+        ("etc-abs", "/etc/passwd"),
+        ("traversal-from-root", os.path.join(str(root), "..", "..", "etc", "passwd")),
+        ("nul-byte", "/etc/pass\x00wd"),
+        ("leading-dash", "-Xmx99g"),
+        ("newline-injection", "/etc/passwd\n-serDictionary /etc/shadow"),
+        ("backslash-traversal", "..\\..\\..\\etc\\passwd"),
+        ("file-url", "file:///etc/passwd"),
+        ("http-url", "http://evil.example/model.gz"),
+        ("empty", ""),
+        ("whitespace-only", "   "),
+        ("dir-not-file", str(outside)),
+    ]
+
+    symlink = root / "sym.mco"
+    os.symlink(str(secret), symlink)
+    vectors.append(("symlink-to-outside", str(symlink)))
+
+    symlink_etc = root / "symetc"
+    os.symlink("/etc/passwd", symlink_etc)
+    vectors.append(("symlink-to-etc", str(symlink_etc)))
+
+    symlinked_dir = root / "symdir"
+    os.symlink(str(outside), symlinked_dir)
+    vectors.append(("via-symlinked-dir", str(symlinked_dir / "secret.mco")))
+
+    hardlink = root / "hard.mco"
+    try:
+        os.link(str(secret), hardlink)
+    except OSError:  # pragma: no cover - cross-device or unsupported
+        pass
+    else:
+        vectors.append(("hardlink-to-outside", str(hardlink)))
+
+    return vectors
+
+
+def _vector_ids(vectors):
+    return [name for name, _ in vectors]
+
+
+def test_validate_model_resource_refuses_every_hostile_vector(pathsec_sandbox):
+    """The whole matrix at once, so a new leak names itself in the failure."""
+    root, outside = pathsec_sandbox
+    leaked = []
+    for name, value in _hostile_vectors(root, outside):
+        try:
+            validate_model_resource(value, context="sweep")
+        except (PermissionError, ValueError, OSError):
+            continue
+        leaked.append(name)
+    assert leaked == [], f"validate_model_resource let these through: {leaked}"
+
+
+def test_malt_model_refuses_every_hostile_vector(pathsec_sandbox):
+    root, outside = pathsec_sandbox
+    leaked = []
+    for name, value in _hostile_vectors(root, outside):
+        try:
+            _malt(value).generate_malt_command("in.conll", "out.conll", mode="learn")
+        except (PermissionError, ValueError, OSError):
+            continue
+        leaked.append(name)
+    assert leaked == [], f"MaltParser passed these to the JVM: {leaked}"
+
+
+def test_malt_working_dir_setter_refuses_every_hostile_vector(pathsec_sandbox):
+    root, outside = pathsec_sandbox
+    leaked = []
+    for name, value in _hostile_vectors(root, outside):
+        parser = _malt("malt_temp.mco", trained=False)
+        try:
+            parser.working_dir = value
+        except (PermissionError, ValueError, OSError):
+            continue
+        # An in-root staging dir is the only acceptable outcome.
+        if not os.path.realpath(parser.working_dir).startswith(
+            os.path.realpath(str(root))
+        ):
+            leaked.append(name)
+    assert leaked == [], f"working_dir accepted these: {leaked}"
+
+
+def test_hardlinked_model_is_refused(pathsec_sandbox):
+    """realpath() cannot see a hardlink, so an in-root alias of an outside file
+    would otherwise pass every path check."""
+    root, outside = pathsec_sandbox
+    secret = outside / "secret.mco"
+    secret.write_text("SECRET")
+    alias = root / "alias.mco"
+    try:
+        os.link(str(secret), alias)
+    except OSError:  # pragma: no cover - cross-device or unsupported
+        pytest.skip("hard links unavailable between these directories")
+    with pytest.raises(PermissionError):
+        validate_model_resource(str(alias), context="sweep")
+
+
+def test_single_linked_model_is_allowed(pathsec_sandbox):
+    """Over-block control for the hardlink guard: an ordinary file has one link."""
+    root, _outside = pathsec_sandbox
+    model = root / "plain.mco"
+    model.write_text("m")
+    validate_model_resource(str(model), context="sweep")
+
+
+def test_directory_model_is_not_hardlink_rejected(pathsec_sandbox):
+    """Directories always have st_nlink >= 2, so the guard must apply to regular
+    files only or every corpus directory would be refused."""
+    root, _outside = pathsec_sandbox
+    corpus = root / "sihan"
+    corpus.mkdir()
+    validate_model_resource(str(corpus), context="sweep")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "malt_temp.mco",
+        _DEFAULT_RESOURCE,
+        "edu/stanford/nlp/models/pos-tagger/english-left3words.tagger",
+    ],
+)
+def test_benign_resource_names_still_pass(value):
+    """The values NLTK itself uses must survive every check added above."""
+    validate_model_resource(value, context="sweep")
+
+
+# ---------------------------------------------------------------------------
+# Exotic vectors: NUL truncation, '~', NTFS streams, UNC shares and blocking
+# device nodes. Each of these leaked when first run and drove a guard.
+# ---------------------------------------------------------------------------
+
+
+def _exotic_vectors(root):
+    vectors = [
+        ("dev-stdin", "/dev/stdin"),
+        ("dev-null", "/dev/null"),
+        ("proc-environ", "/proc/self/environ"),
+        ("case-folded-etc", "/ETC/PASSWD"),
+        ("tilde-expansion", "~/.ssh/id_rsa"),
+        ("ads-stream", "model.mco:evil"),
+        ("unc-backslash", "\\\\server\\share\\evil.mco"),
+        ("unc-slash", "//server/share/evil.mco"),
+        ("nul-in-middle", "model\x00.mco"),
+        ("jar-url", "jar:file:///etc/passwd!/x"),
+        ("overlong-name", "/" + ("A" * 300) + "/evil.mco"),
+        ("double-slash", "//etc//passwd"),
+        ("root-only", "/"),
+        ("dotdot-alone", ".."),
+    ]
+
+    fifo = root / "fifo.mco"
+    try:
+        os.mkfifo(fifo)
+    except (AttributeError, OSError):  # pragma: no cover - not on Windows
+        pass
+    else:
+        vectors.append(("fifo-in-root", str(fifo)))
+    return vectors
+
+
+def test_validate_model_resource_refuses_exotic_vectors(pathsec_sandbox):
+    root, _outside = pathsec_sandbox
+    leaked = []
+    for name, value in _exotic_vectors(root):
+        try:
+            validate_model_resource(value, context="sweep")
+        except (PermissionError, ValueError, OSError):
+            continue
+        leaked.append(name)
+    assert leaked == [], f"validate_model_resource let these through: {leaked}"
+
+
+def test_unix_socket_model_is_refused(pathsec_sandbox):
+    """A socket planted in a data root is not a model; reading it would block."""
+    import socket
+
+    root, _outside = pathsec_sandbox
+    path = str(root / "s.sock")
+    sock = socket.socket(socket.AF_UNIX)
+    try:
+        sock.bind(path)
+        with pytest.raises(PermissionError):
+            validate_model_resource(path, context="sweep")
+    finally:
+        sock.close()
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "$EVIL_HOME/passwd",
+        "..\uff0f..\uff0fetc\uff0fpasswd",
+        "%2e%2e/%2e%2e/etc/passwd",
+    ],
+    ids=["env-var", "fullwidth-solidus", "percent-encoded"],
+)
+def test_benign_lookalikes_stay_literal(pathsec_sandbox, value):
+    """These are permitted because nothing downstream expands or decodes them:
+    they stay literal filenames. The test pins that assumption, so if a sink ever
+    starts expanding them this fails instead of silently reading /etc.
+    """
+    validate_model_resource(value, context="sweep")
+    assert not os.path.exists(value)
+    assert not os.path.realpath(os.path.expandvars(value)).startswith("/etc/")
+
+
+def test_java_inner_class_resource_is_allowed():
+    """Over-block control: '$' is legal in a JVM resource name, so the option and
+    stream checks must not reject it."""
+    validate_model_resource("edu/stanford/Foo$Bar.ser.gz", context="sweep")
+
+
+def test_windows_drive_path_is_not_stream_rejected():
+    """Over-block control: 'C:\\...' is a drive prefix, not an NTFS stream."""
+    import re as _re
+
+    from nltk.pathsec import validate_model_resource as _vmr
+
+    try:
+        _vmr("C:\\models\\english.ser.gz", context="sweep")
+    except ValueError as exc:
+        assert "alternate data stream" not in str(exc), exc
+    assert _re.match(r"^[A-Za-z]:[\\/]", "C:\\models\\english.ser.gz")
+
+
+# ---------------------------------------------------------------------------
+# Regressions found while building this PR. Each one shipped a bug that the
+# mocked tests missed, so they are pinned here permanently.
+# ---------------------------------------------------------------------------
+
+
+def test_regression_generate_malt_command_needs_no_trained_attribute(pathsec_sandbox):
+    """Regression: generate_malt_command briefly branched on a private ``_trained``
+    attribute, which broke every caller that built a parser without it."""
+    import nltk.parse.malt as malt
+
+    parser = object.__new__(malt.MaltParser)
+    parser.model = "malt_temp.mco"
+    parser._working_dir = None
+    parser.additional_java_args = []
+    cmd = parser.generate_malt_command("in.conll", "out.conll", mode="learn")
+    assert cmd[cmd.index("-c") + 1] == "malt_temp.mco"
+
+
+def test_regression_trained_bare_model_resolves_to_working_dir(pathsec_sandbox):
+    """Regression: after train(), ``self.model`` is still the bare name
+    ``malt_temp.mco`` while ``_trained`` is True. Resolving that against the CWD
+    made every post-training parse fail with a security violation."""
+    root, _outside = pathsec_sandbox
+    parser = _malt("malt_temp.mco", trained=True)
+    cmd = parser.generate_malt_command("in.conll", "out.conll", mode="parse")
+    workingdir = cmd[cmd.index("-w") + 1]
+    assert os.path.realpath(workingdir).startswith(os.path.realpath(str(root)))
+    assert os.path.realpath(workingdir) != os.path.realpath(os.getcwd())
+
+
+def test_regression_working_dir_setter_rejects_empty(pathsec_sandbox):
+    """Regression: an empty working_dir passed validate_path and reached
+    MaltParser as ``-w ""``, i.e. the current working directory."""
+    parser = _malt("malt_temp.mco", trained=False)
+    for value in ("", "   "):
+        with pytest.raises(ValueError):
+            parser.working_dir = value
+
+
+def test_regression_has_java_probe_actually_executes():
+    """Regression: the JVM probe used to accept any ``java`` on PATH. macOS ships
+    a /usr/bin/java stub that resolves fine and then fails at exec, which turned
+    the end-to-end tests into hard failures instead of skips."""
+    import subprocess
+
+    result = _has_java()
+    assert isinstance(result, bool)
+    if result:
+        from nltk.internals import find_binary
+
+        binary = find_binary(
+            "java", env_vars=("JAVAHOME", "JAVA_HOME"), verbose=False, binary_names=None
+        )
+        assert subprocess.run([binary, "-version"], capture_output=True).returncode == 0

--- a/nltk/test/unit/test_pathsec_sweep_wrappers.py
+++ b/nltk/test/unit/test_pathsec_sweep_wrappers.py
@@ -1703,3 +1703,92 @@ def test_control_character_guard_does_not_block_ordinary_names(pathsec_sandbox):
     spaced.write_text("m")
     validate_model_resource(str(spaced), context="sweep")
     validate_model_resource(_DEFAULT_RESOURCE, context="sweep")
+
+
+# ---------------------------------------------------------------------------
+# StanfordSegmenter's options dict is joined into ONE comma-separated -options
+# argv element, so a key containing ',' or '=' injects extra option pairs. Same
+# class as the parser's corenlp_options, in the sibling wrapper.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "key",
+    ["normalize=true,serDictionary", "a,b", "a=b", "a b", "a\nb", "a\tb", "", "   "],
+    ids=[
+        "comma-and-equals",
+        "comma",
+        "equals",
+        "space",
+        "newline",
+        "tab",
+        "empty",
+        "whitespace",
+    ],
+)
+def test_segmenter_option_keys_cannot_inject_pairs(key):
+    from nltk.tokenize.stanford_segmenter import _validated_options
+
+    with pytest.raises(ValueError):
+        _validated_options({key: "1"})
+
+
+def test_segmenter_option_values_are_bounded(pathsec_sandbox):
+    """A value that names a file must stay inside the data roots."""
+    from nltk.tokenize.stanford_segmenter import _validated_options
+
+    root, outside = pathsec_sandbox
+    evil = outside / "evil.gz"
+    evil.write_text("x")
+    for value in ("/etc/passwd", str(evil)):
+        with pytest.raises((PermissionError, ValueError)):
+            _validated_options({"serDictionary": value})
+
+
+def test_segmenter_benign_options_still_work(pathsec_sandbox):
+    """Over-block control: ordinary settings, numbers and in-root paths pass."""
+    from nltk.tokenize.stanford_segmenter import _validated_options
+
+    root, _outside = pathsec_sandbox
+    good = root / "ok.gz"
+    good.write_text("m")
+    assert _validated_options({"normalize": "true", "keepAll": "false"}) == {
+        "normalize": "true",
+        "keepAll": "false",
+    }
+    assert _validated_options({"maxLen": 40}) == {"maxLen": 40}
+    assert _validated_options({"serDictionary": str(good)}) == {
+        "serDictionary": str(good)
+    }
+    assert _validated_options({}) == {}
+
+
+def test_teeth_segmenter_options_guard_is_load_bearing():
+    """Without the guard the injected pair lands in the built option string."""
+    import json as _json
+
+    options = {"normalize=true,serDictionary": "/etc/passwd"}
+    unguarded = ",".join(f"{k}={_json.dumps(v)}" for k, v in options.items())
+    assert "serDictionary" in unguarded.split(",")[1]
+
+
+def test_segmenter_out_of_root_jar_is_refused_despite_approved_checksum(
+    pathsec_sandbox, monkeypatch
+):
+    """The checksum allowlist is not a location check. A jar outside the roots
+    must still be refused, even when its sha256 has been approved."""
+    import hashlib as _hashlib
+
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, outside = pathsec_sandbox
+    evil_jar = outside / "evil.jar"
+    evil_jar.write_bytes(b"PK\x05\x06" + b"\0" * 18)
+    digest = _hashlib.sha256(evil_jar.read_bytes()).hexdigest()
+    monkeypatch.setenv("NLTK_SEGMENTER_ALLOW_SHA256", digest)
+
+    tool = object.__new__(seg.StanfordSegmenter)
+    tool._stanford_jar = str(evil_jar)
+    tool._jar_sha256_cache = {}
+    with pytest.raises((PermissionError, ValueError)):
+        tool._validate_classpath()

--- a/nltk/test/unit/test_pathsec_sweep_wrappers.py
+++ b/nltk/test/unit/test_pathsec_sweep_wrappers.py
@@ -618,8 +618,11 @@ def test_real_stanford_parser_default_resource_parses(monkeypatch):
 @requires_java
 @pytest.mark.parametrize(
     "model_path",
-    ["/etc/passwd", "edu/stanford/../../../../etc/passwd"],
-    ids=["etc-abs", "traversal"],
+    [
+        "/etc/passwd" if os.name == "posix" else "C:\\Windows\\win.ini",
+        "edu/stanford/../../../../etc/passwd",
+    ],
+    ids=["system-file-abs", "traversal"],
 )
 def test_real_stanford_parser_refuses_escape_with_jvm_present(monkeypatch, model_path):
     """End-to-end negative: with a working JVM and real jars, a hostile -model is
@@ -1229,3 +1232,34 @@ def test_reserved_windows_device_names_are_refused(value):
 def test_names_merely_starting_like_a_device_are_allowed(value):
     """Over-block control: the check is on the whole stem, not a prefix."""
     validate_model_resource(value, context="sweep")
+
+
+@pytest.mark.parametrize("value", ["C:evil.mco", "C:models\\evil.mco", "D:x.ser.gz"])
+def test_drive_relative_paths_are_refused(value):
+    """Windows CI found this: "C:name" is drive-RELATIVE, meaning "name in the
+    current directory of drive C", so it escapes the location that was validated.
+    It is not the same as the absolute "C:\\name"."""
+    for guard in (validate_model_resource, validate_tool_path):
+        with pytest.raises(ValueError):
+            guard(value, context="sweep")
+
+
+def test_both_guards_share_one_syntax_gate(pathsec_sandbox):
+    """Windows CI found that validate_tool_path skipped the name checks that
+    validate_model_resource applied, so a value refused by one was accepted by
+    the other. They must stay in agreement on syntax."""
+    root, outside = pathsec_sandbox
+    disagreements = []
+    for name, value in _hostile_vectors(root, outside) + _exotic_vectors(root):
+        verdicts = []
+        for guard in (validate_model_resource, validate_tool_path):
+            try:
+                guard(value, context="sweep")
+                verdicts.append("allowed")
+            except (PermissionError, ValueError, OSError):
+                verdicts.append("refused")
+        # validate_tool_path is strictly stricter: it may refuse where the model
+        # guard allows a bare resource name, but never the reverse.
+        if verdicts[0] == "refused" and verdicts[1] == "allowed":
+            disagreements.append(name)
+    assert disagreements == [], f"tool_path weaker than model_resource: {disagreements}"

--- a/nltk/test/unit/test_platform_detection.py
+++ b/nltk/test/unit/test_platform_detection.py
@@ -58,7 +58,12 @@ def test_maltparser_command_uses_os_pathsep(monkeypatch, tmp_path):
     parser = MaltParser.__new__(MaltParser)
     parser.additional_java_args = []
     parser.malt_jars = [str(jar_a), str(jar_b)]
-    parser.model = "model.mco"
+    # Inside the allowed data root: generate_malt_command bounds the model path.
+    model = data_root / "model.mco"
+    model.touch()
+    parser.model = str(model)
+    parser._trained = True
+    parser._working_dir = None
 
     captured = {}
 

--- a/nltk/test/unit/test_platform_detection.py
+++ b/nltk/test/unit/test_platform_detection.py
@@ -82,7 +82,9 @@ def test_maltparser_command_uses_os_pathsep(monkeypatch, tmp_path):
 
     # MaltParser hands its jars to internals.java(), which joins the classpath with
     # os.pathsep; the launcher command's -cp value must use it.
-    argv = parser.generate_malt_command("input.conll", mode="learn")
+    conll = data_root / "input.conll"
+    conll.touch()
+    argv = parser.generate_malt_command(str(conll), mode="learn")
     parser._execute(argv)
     cmd = captured["cmd"]
     assert cmd[cmd.index("-cp") + 1] == f"{jar_a};{jar_b}"

--- a/nltk/tokenize/stanford_segmenter.py
+++ b/nltk/tokenize/stanford_segmenter.py
@@ -201,6 +201,9 @@ class StanfordSegmenter(TokenizerI):
 
     def segment_file(self, input_file_path):
         """ """
+        # Caller-supplied and handed to the JVM as -textFile, which pathsec.open
+        # cannot wrap; validate before the spawn (GHSA-8mgp-746c-j5xp).
+        validate_path(input_file_path, context="StanfordSegmenter.segment_file")
         cmd = [
             self._java_class,
             "-loadClassifier",
@@ -328,6 +331,21 @@ class StanfordSegmenter(TokenizerI):
                     "Multiple approved checksums may be supplied as a comma-separated list."
                 )
 
+    def _validate_model_paths(self):
+        """Refuse model/dictionary paths that escape the NLTK data sandbox.
+
+        These are embedded in the JVM argv (-loadClassifier / -serDictionary /
+        -sighanCorporaDict), which pathsec.open cannot wrap, so they are checked
+        here before the process is spawned (GHSA-8mgp-746c-j5xp).
+        """
+        for label, value in (
+            ("model", self._model),
+            ("dictionary", self._dict),
+            ("sihan corpora dict", self._sihan_corpora_dict),
+        ):
+            if value:
+                validate_path(value, context=f"StanfordSegmenter {label}")
+
     def _execute(self, cmd, verbose=False):
         encoding = self._encoding
         cmd.extend(["-inputEncoding", encoding])
@@ -335,6 +353,7 @@ class StanfordSegmenter(TokenizerI):
         if _options_cmd:
             cmd.extend(["-options", self._options_cmd])
 
+        self._validate_model_paths()
         self._validate_classpath()
 
         stdout, _stderr = java(

--- a/nltk/tokenize/stanford_segmenter.py
+++ b/nltk/tokenize/stanford_segmenter.py
@@ -245,23 +245,23 @@ class StanfordSegmenter(TokenizerI):
         input_file_path = validate_tool_path(
             input_file_path, context="StanfordSegmenter.segment_file"
         )
-        self._validate_model_paths()
+        model, dictionary, sihan = self._validate_model_paths()
         cmd = [
             self._java_class,
             "-loadClassifier",
-            self._model,
+            model,
             "-keepAllWhitespaces",
             self._keep_whitespaces,
             "-textFile",
             input_file_path,
         ]
-        if self._sihan_corpora_dict is not None:
+        if sihan is not None:
             cmd.extend(
                 [
                     "-serDictionary",
-                    self._dict,
+                    dictionary,
                     "-sighanCorporaDict",
-                    self._sihan_corpora_dict,
+                    sihan,
                     "-sighanPostProcessing",
                     self._sihan_post_processing,
                 ]
@@ -295,23 +295,23 @@ class StanfordSegmenter(TokenizerI):
             # attributes the guard replaced. Capturing self._model into cmd first
             # would put the original object there, and a PathLike may resolve to
             # something else when the child process reads it.
-            self._validate_model_paths()
+            model, dictionary, sihan = self._validate_model_paths()
             cmd = [
                 self._java_class,
                 "-loadClassifier",
-                self._model,
+                model,
                 "-keepAllWhitespaces",
                 self._keep_whitespaces,
                 "-textFile",
                 self._input_file_path,
             ]
-            if self._sihan_corpora_dict is not None:
+            if sihan is not None:
                 cmd.extend(
                     [
                         "-serDictionary",
-                        self._dict,
+                        dictionary,
                         "-sighanCorporaDict",
-                        self._sihan_corpora_dict,
+                        sihan,
                         "-sighanPostProcessing",
                         self._sihan_post_processing,
                     ]
@@ -385,12 +385,23 @@ class StanfordSegmenter(TokenizerI):
         -sighanCorporaDict), which pathsec.open cannot wrap, so they are checked
         here before the process is spawned (GHSA-8mgp-746c-j5xp).
 
-        Each attribute is replaced with the string the guard returned. A PathLike
-        may answer differently on every call, and ``validate_path`` reads a
-        ``.path`` attribute in preference to ``__fspath__``, so validating the
-        object and then handing the same object to the JVM checked one file and
-        opened another.
+        Each attribute is replaced with the string the guard returned, and the
+        same strings are RETURNED for the caller to build its argv from. A
+        PathLike may answer differently on every call, and ``validate_path``
+        reads a ``.path`` attribute in preference to ``__fspath__``, so
+        validating the object and then handing the same object to the JVM
+        checked one file and opened another.
+
+        Returning them matters beyond that: a caller that re-reads
+        ``self._model`` after this returns is reading shared mutable state again,
+        so a concurrent write could still swap the value between the check and
+        the argv. Building from the return value keeps the checked value and the
+        used value the same object.
+
+        :return: the validated (model, dictionary, sihan corpora dict) strings,
+            each None when it was unset
         """
+        validated = []
         for attribute, label in (
             ("_model", "model"),
             ("_dict", "dictionary"),
@@ -398,11 +409,10 @@ class StanfordSegmenter(TokenizerI):
         ):
             value = getattr(self, attribute)
             if value:
-                setattr(
-                    self,
-                    attribute,
-                    validate_tool_path(value, context=f"StanfordSegmenter {label}"),
-                )
+                value = validate_tool_path(value, context=f"StanfordSegmenter {label}")
+                setattr(self, attribute, value)
+            validated.append(value)
+        return tuple(validated)
 
     def _execute(self, cmd, verbose=False):
         encoding = self._encoding

--- a/nltk/tokenize/stanford_segmenter.py
+++ b/nltk/tokenize/stanford_segmenter.py
@@ -24,7 +24,7 @@ from nltk.internals import (
     java,
 )
 from nltk.pathsec import open as pathsec_open
-from nltk.pathsec import validate_path
+from nltk.pathsec import validate_path, validate_tool_path
 from nltk.tokenize.api import TokenizerI
 
 _stanford_url = "https://nlp.stanford.edu/software"
@@ -202,8 +202,13 @@ class StanfordSegmenter(TokenizerI):
     def segment_file(self, input_file_path):
         """ """
         # Caller-supplied and handed to the JVM as -textFile, which pathsec.open
-        # cannot wrap; validate before the spawn (GHSA-8mgp-746c-j5xp).
-        validate_path(input_file_path, context="StanfordSegmenter.segment_file")
+        # cannot wrap; validate before the spawn (GHSA-8mgp-746c-j5xp). Build the
+        # argv from the returned string, never the original object: a PathLike can
+        # answer one way here and another way when the child resolves it.
+        input_file_path = validate_tool_path(
+            input_file_path, context="StanfordSegmenter.segment_file"
+        )
+        self._validate_model_paths()
         cmd = [
             self._java_class,
             "-loadClassifier",
@@ -337,14 +342,25 @@ class StanfordSegmenter(TokenizerI):
         These are embedded in the JVM argv (-loadClassifier / -serDictionary /
         -sighanCorporaDict), which pathsec.open cannot wrap, so they are checked
         here before the process is spawned (GHSA-8mgp-746c-j5xp).
+
+        Each attribute is replaced with the string the guard returned. A PathLike
+        may answer differently on every call, and ``validate_path`` reads a
+        ``.path`` attribute in preference to ``__fspath__``, so validating the
+        object and then handing the same object to the JVM checked one file and
+        opened another.
         """
-        for label, value in (
-            ("model", self._model),
-            ("dictionary", self._dict),
-            ("sihan corpora dict", self._sihan_corpora_dict),
+        for attribute, label in (
+            ("_model", "model"),
+            ("_dict", "dictionary"),
+            ("_sihan_corpora_dict", "sihan corpora dict"),
         ):
+            value = getattr(self, attribute)
             if value:
-                validate_path(value, context=f"StanfordSegmenter {label}")
+                setattr(
+                    self,
+                    attribute,
+                    validate_tool_path(value, context=f"StanfordSegmenter {label}"),
+                )
 
     def _execute(self, cmd, verbose=False):
         encoding = self._encoding

--- a/nltk/tokenize/stanford_segmenter.py
+++ b/nltk/tokenize/stanford_segmenter.py
@@ -291,6 +291,11 @@ class StanfordSegmenter(TokenizerI):
                     _input = _input.encode(encoding)
                 input_fh.write(_input)
 
+            # Validate BEFORE building the command, and build it from the
+            # attributes the guard replaced. Capturing self._model into cmd first
+            # would put the original object there, and a PathLike may resolve to
+            # something else when the child process reads it.
+            self._validate_model_paths()
             cmd = [
                 self._java_class,
                 "-loadClassifier",

--- a/nltk/tokenize/stanford_segmenter.py
+++ b/nltk/tokenize/stanford_segmenter.py
@@ -30,6 +30,42 @@ from nltk.tokenize.api import TokenizerI
 _stanford_url = "https://nlp.stanford.edu/software"
 
 
+def _validated_options(options):
+    """Bound the caller-supplied ``options`` dict before it becomes ``-options``.
+
+    The pairs are joined into ONE comma-separated argv element, so a key holding
+    a ``,`` or an ``=`` silently injects extra option pairs that the wrapper
+    never intended. This is the same class as the parser's ``corenlp_options``:
+
+        {"normalize=true,serDictionary": "/etc/passwd"}
+        -> normalize=true,serDictionary="/etc/passwd"
+
+    Values are JSON-encoded, so they cannot break out of their own pair, but one
+    that names a file is still bounded to the data roots.
+    """
+    validated = {}
+    for key, value in options.items():
+        name = str(key)
+        if not name.strip():
+            raise ValueError(
+                "Security Violation [StanfordSegmenter options]: empty option name."
+            )
+        if any(character in name for character in ",=\t\n\r\x00 "):
+            raise ValueError(
+                f"Security Violation [StanfordSegmenter options]: option name "
+                f"{name!r} contains a separator, so it would inject extra "
+                "option pairs into the argument list."
+            )
+        if isinstance(value, str) and (
+            os.path.isabs(value) or "/" in value or "\\" in value
+        ):
+            value = validate_tool_path(
+                value, context=f"StanfordSegmenter options[{name}]"
+            )
+        validated[name] = value
+    return validated
+
+
 class StanfordSegmenter(TokenizerI):
     """Interface to the Stanford Segmenter
 
@@ -119,7 +155,8 @@ class StanfordSegmenter(TokenizerI):
         self.java_options = java_options
         options = {} if options is None else options
         self._options_cmd = ",".join(
-            f"{key}={json.dumps(val)}" for key, val in options.items()
+            f"{key}={json.dumps(val)}"
+            for key, val in _validated_options(options).items()
         )
         self._jar_sha256_cache = {}
 


### PR DESCRIPTION
Part of the #3753 decomposition. Covers the external-tool wrappers, which pass caller-supplied model and corpus paths straight into the child process argv.

## The leak

With a checksum-approved jar (the jar allowlist gates before `java()`), all four caller-controlled `StanfordSegmenter` paths reached the JVM unvalidated:

```
LEAKED -loadClassifier   -> ~/.nltk_out_xxx/evil.ser.gz
LEAKED -serDictionary    -> /etc/passwd
LEAKED -sighanCorporaDict-> ~/.nltk_out_xxx
LEAKED -textFile         -> /etc/shadow
```

`MaltParser` was worse than a read: `-w` is where MaltParser *writes* the `.mco` in learn mode, and it defaulted to `os.getcwd()` for an untrained model and `tempfile.gettempdir()` (world-writable on Linux, predictable) for the CoNLL intermediates.

`StanfordParser` passed `-model` through unchecked, including `edu/stanford/../../../../etc/passwd`.

## The fix

- **Segmenter** validates all four paths before the `java()` hand-off.
- **MaltParser** allocates `-w` lazily via `nltk.data.make_staging_dir` — inside a data root, mode 0700, unpredictable name. Same pattern already used by `PerceptronTagger` and the named-entity chunker. A model with a directory component is bounded with `validate_path`; `working_dir` gained a validating setter.
- **StanfordParser** bounds `-model` at `_execute`, the single choke point for all three callers.
- **New `pathsec.validate_model_resource`** for arguments that may be *either* a filesystem path or a jar-internal classpath resource (the shipped `englishPCFG.ser.gz` default). Resource names pass, real paths are sandboxed, and empty / option-like / URL / `..` / NUL / `~` / UNC / NTFS-stream values are refused. It also rejects a **hardlinked** model (realpath cannot distinguish it from an ordinary in-root file) and **non-regular files** such as a planted FIFO, which would block the reader forever.

## Deliberately NOT changed

`candc`/`boxer`'s `bin_dir` and REPP's tokenizer dir are **install directories**, not data paths. `validate_path` permits only NLTK data roots, so bounding them would break every real installation. I verified their existing absolute-path (CWE-426) checks still refuse relative and CWD-relative values, and added tests pinning that distinction so a later refactor cannot collapse the two classes.

## Verification

Not mocked. Every escape test drives the real code path with only the `java` hand-off replaced, so a probe cannot pass because the test assembled the argv itself.

- Escape matrix per sink: 16 hostile vectors (symlink, hardlink, traversal, NUL, argv injection, newline, URL, empty, ...) plus 14 exotic ones (device nodes, FIFO, `~`, UNC, NTFS stream, fullwidth solidus, percent-encoding, case-folding). All refused.
- Over-block controls: the jar-internal default, in-sandbox models, corpus directories and Java inner-class `$` names all still work.
- Negative-control teeth tests: neuter a guard, the probe flips to reachable.
- **Real end-to-end against an actual JVM**: trains a real MaltParser model (lands in the staging dir, CWD stays clean) and parses with the real Stanford parser. These skip cleanly where no JVM is installed — the probe runs `java -version` rather than trusting a `java` on PATH, because macOS ships a stub that resolves and then fails at exec.
- New import sweep over **every** nltk module plus a functional battery against real corpora and models, so a too-strict guard fails visibly instead of only breaking ordinary use.

Full suite: 2166 passed, 0 failed. Advisory probe gate: 24 passed, 0 VULNERABLE. The 5 failing doctest files in the wider tree (`wordnet`, `wsd`, `sentiwordnet`, `treeprettyprinter`, `internals`) fail identically on pristine develop — pre-existing, not from this branch.

Marked WIP pending review of the remaining wrapper cluster.