### PR TITLE
Prevent batch-boundary injection in StanfordParser

### DIFF
--- a/nltk/parse/stanford.py
+++ b/nltk/parse/stanford.py
@@ -113,6 +113,9 @@ class GenericStanfordParser(ParserI):
         :type sentences: list(list(str))
         :rtype: iter(iter(Tree))
         """
+        # Prevent generator exhaustion
+        sentences = list(sentences)
+
         # Security check: Validate individual tokens before joining
         for sentence in sentences:
             for token in sentence:
@@ -158,6 +161,8 @@ class GenericStanfordParser(ParserI):
         :type sentences: list(str)
         :rtype: iter(iter(Tree))
         """
+        # Prevent generator exhaustion
+        sentences = list(sentences)
         # Security check: Validate raw sentence strings
         for sentence in sentences:
             if "\n" in sentence or "\r" in sentence:
@@ -197,6 +202,17 @@ class GenericStanfordParser(ParserI):
         :type sentences: list(list(tuple(str, str)))
         :rtype: iter(iter(Tree))
         """
+        # 1. Prevent generator exhaustion
+        sentences = list(sentences)
+
+        # 2. Security check: Validate both words and tags for newline characters
+        for sentence in sentences:
+            for word, tag in sentence:
+                if "\n" in word or "\r" in word or "\n" in tag or "\r" in tag:
+                    raise ValueError(
+                        "Tokens and tags cannot contain newline characters."
+                    )
+
         tag_separator = "/"
         cmd = [
             self._MAIN_CLASS,

--- a/nltk/parse/stanford.py
+++ b/nltk/parse/stanford.py
@@ -113,6 +113,11 @@ class GenericStanfordParser(ParserI):
         :type sentences: list(list(str))
         :rtype: iter(iter(Tree))
         """
+        # Security check: Validate individual tokens before joining
+        for sentence in sentences:
+            for token in sentence:
+                if "\n" in token or "\r" in token:
+                    raise ValueError("Tokens cannot contain newline characters.")
         cmd = [
             self._MAIN_CLASS,
             "-model",
@@ -153,6 +158,10 @@ class GenericStanfordParser(ParserI):
         :type sentences: list(str)
         :rtype: iter(iter(Tree))
         """
+        # Security check: Validate raw sentence strings
+        for sentence in sentences:
+            if "\n" in sentence or "\r" in sentence:
+                raise ValueError("Sentences cannot contain newline characters.")
         cmd = [
             self._MAIN_CLASS,
             "-model",

--- a/nltk/test/unit/test_stanford_parser.py
+++ b/nltk/test/unit/test_stanford_parser.py
@@ -1,0 +1,55 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from nltk.parse.stanford import StanfordParser
+
+
+class TestStanfordParserSecurity(unittest.TestCase):
+    def setUp(self):
+        # Create temporary dummy files so os.path.isfile() passes during initialization
+        self.tmp_dir = tempfile.TemporaryDirectory()
+        tmp_path = Path(self.tmp_dir.name)
+
+        self.fake_parser_jar = tmp_path / "stanford-parser.jar"
+        self.fake_models_jar = tmp_path / "stanford-parser-models.jar"
+
+        self.fake_parser_jar.write_text("dummy jar", encoding="utf-8")
+        self.fake_models_jar.write_text("dummy jar", encoding="utf-8")
+
+    def tearDown(self):
+        self.tmp_dir.cleanup()
+
+    def test_parse_sents_rejects_newlines_in_tokens(self):
+        """
+        Verify that StanfordParser.parse_sents() raises a ValueError
+        when a token contains embedded newlines, preventing batch-boundary injection.
+        """
+        parser = StanfordParser(
+            path_to_jar=str(self.fake_parser_jar),
+            path_to_models_jar=str(self.fake_models_jar),
+        )
+
+        # Mock execution to avoid requiring an external Java / Stanford installation
+        parser._execute = lambda cmd, input_data, verbose: "(ROOT (S (NN dummy)))\n\n"
+
+        # Malicious input: token containing an embedded newline
+        malicious_batch = [["ATTACKER", "safe\nINJECTED"]]
+
+        with self.assertRaises(ValueError):
+            list(parser.parse_sents(malicious_batch))
+
+    def test_raw_parse_sents_rejects_newlines(self):
+        """
+        Verify that raw_parse_sents also rejects newline-bearing sentences.
+        """
+        parser = StanfordParser(
+            path_to_jar=str(self.fake_parser_jar),
+            path_to_models_jar=str(self.fake_models_jar),
+        )
+        parser._execute = lambda cmd, input_data, verbose: "(ROOT (S (NN dummy)))\n\n"
+
+        malicious_sentences = ["ATTACKER safe\nINJECTED"]
+
+        with self.assertRaises(ValueError):
+            list(parser.raw_parse_sents(malicious_sentences))

--- a/nltk/test/unit/test_stanford_parser.py
+++ b/nltk/test/unit/test_stanford_parser.py
@@ -7,7 +7,6 @@ from nltk.parse.stanford import StanfordParser
 
 class TestStanfordParserSecurity(unittest.TestCase):
     def setUp(self):
-        # Create temporary dummy files so os.path.isfile() passes during initialization
         self.tmp_dir = tempfile.TemporaryDirectory()
         tmp_path = Path(self.tmp_dir.name)
 
@@ -23,25 +22,26 @@ class TestStanfordParserSecurity(unittest.TestCase):
     def test_parse_sents_rejects_newlines_in_tokens(self):
         """
         Verify that StanfordParser.parse_sents() raises a ValueError
-        when a token contains embedded newlines, preventing batch-boundary injection.
+        when a token contains embedded newlines or carriage returns.
         """
         parser = StanfordParser(
             path_to_jar=str(self.fake_parser_jar),
             path_to_models_jar=str(self.fake_models_jar),
         )
-
-        # Mock execution to avoid requiring an external Java / Stanford installation
         parser._execute = lambda cmd, input_data, verbose: "(ROOT (S (NN dummy)))\n\n"
 
-        # Malicious input: token containing an embedded newline
-        malicious_batch = [["ATTACKER", "safe\nINJECTED"]]
+        for malicious_char in ["\n", "\r"]:
+            # Testing both \n and \r
+            malicious_batch = [["ATTACKER", f"safe{malicious_char}INJECTED"]]
+            # Also verify it works with generators
+            malicious_gen = (sent for sent in malicious_batch)
 
-        with self.assertRaises(ValueError):
-            list(parser.parse_sents(malicious_batch))
+            with self.assertRaises(ValueError):
+                list(parser.parse_sents(malicious_gen))
 
     def test_raw_parse_sents_rejects_newlines(self):
         """
-        Verify that raw_parse_sents also rejects newline-bearing sentences.
+        Verify that raw_parse_sents also rejects newline/CR-bearing sentences.
         """
         parser = StanfordParser(
             path_to_jar=str(self.fake_parser_jar),
@@ -49,7 +49,28 @@ class TestStanfordParserSecurity(unittest.TestCase):
         )
         parser._execute = lambda cmd, input_data, verbose: "(ROOT (S (NN dummy)))\n\n"
 
-        malicious_sentences = ["ATTACKER safe\nINJECTED"]
+        for malicious_char in ["\n", "\r"]:
+            malicious_sentences = [f"ATTACKER safe{malicious_char}INJECTED"]
+            malicious_gen = (sent for sent in malicious_sentences)
 
-        with self.assertRaises(ValueError):
-            list(parser.raw_parse_sents(malicious_sentences))
+            with self.assertRaises(ValueError):
+                list(parser.raw_parse_sents(malicious_gen))
+
+    def test_tagged_parse_sents_rejects_newlines(self):
+        """
+        Verify that tagged_parse_sents rejects newline/CR-bearing words or tags.
+        """
+        parser = StanfordParser(
+            path_to_jar=str(self.fake_parser_jar),
+            path_to_models_jar=str(self.fake_models_jar),
+        )
+        parser._execute = lambda cmd, input_data, verbose: "(ROOT (S (NN dummy)))\n\n"
+
+        for malicious_char in ["\n", "\r"]:
+            malicious_batch = [
+                [("ATTACKER", "NN"), (f"safe{malicious_char}INJECTED", "NN")]
+            ]
+            malicious_gen = (sent for sent in malicious_batch)
+
+            with self.assertRaises(ValueError):
+                list(parser.tagged_parse_sents(malicious_gen))


### PR DESCRIPTION
### Description

#### Summary

This PR fixes **CVE-2026-14729** (Trust Boundary Violation / Batch-Boundary Injection in `StanfordParser.parse_sents()`).

Previously, `StanfordParser` concatenated token lists and sentences using newlines before invoking the underlying Stanford parser with `-sentences newline`. Because individual tokens or sentences containing embedded newline characters (`\n` or `\r`) were not validated or escaped, malicious inputs could inject extra downstream sentence boundaries, desynchronizing batch order and shifting parse results.

#### Changes Made

* **Input Validation in `parse_sents()`:** Added strict checks to verify that individual tokens in input sequences do not contain newline or carriage return characters, raising a `ValueError` if invalid characters are detected.
* **Input Validation in `raw_parse_sents()`:** Added corresponding security checks for raw sentence strings.

#### Testing

* Added dedicated unit tests in `nltk/test/unit/test_stanford_parser.py` covering:
* Token-level newline injection attempts via `parse_sents()`.
* Sentence-level newline injection attempts via `raw_parse_sents()`.


* The tests use temporary mock jar files and mock the `_execute` method, ensuring they run cleanly in CI environments without requiring an external Java or Stanford Parser installation.