### PR TITLE
Fix CI after merging from GHSA  fork

### DIFF
--- a/nltk/test/unit/security_probes/ghsa_8846_p9w9_5frf.py
+++ b/nltk/test/unit/security_probes/ghsa_8846_p9w9_5frf.py
@@ -1,18 +1,22 @@
-from ._base import FIXED, VULNERABLE, probe
 from nltk.util import acyclic_depth_first
+
+from ._base import FIXED, VULNERABLE, probe
+
 
 class MockNode:
     def __init__(self, name, children=None):
         self.name = name
         self._children = children or []
+
     def rel(self):
         return self._children
+
 
 @probe("GHSA-8846-p9w9-5frf")
 def test_wordnet_recursion():
     nodes = [MockNode(str(i)) for i in range(1500)]
     for i in range(1499):
-        nodes[i]._children = [nodes[i+1]]
+        nodes[i]._children = [nodes[i + 1]]
     try:
         list(acyclic_depth_first(nodes[0], lambda x: x.rel(), depth=-1))
         return (FIXED, "Depth cap prevents recursion overflow")

--- a/nltk/test/unit/test_advisory_coverage_ci.py
+++ b/nltk/test/unit/test_advisory_coverage_ci.py
@@ -55,6 +55,7 @@ _CLOSED_WITH_PROBE = {
     "GHSA-4489-j4f3-2g8q",
     "GHSA-9ffx-rrgx-mhgx",
     "GHSA-pcm8-fqjx-rvx8",
+    "GHSA-8846-p9w9-5frf",
 }
 
 

--- a/nltk/test/unit/test_advisory_coverage_ci.py
+++ b/nltk/test/unit/test_advisory_coverage_ci.py
@@ -57,6 +57,7 @@ _CLOSED_WITH_PROBE = {
     "GHSA-pcm8-fqjx-rvx8",
 }
 
+
 def _next_url(link_header):
     """The *on-origin* rel="next" URL from a GitHub ``Link`` header, else None.
 

--- a/nltk/test/unit/test_wordnet_recursion.py
+++ b/nltk/test/unit/test_wordnet_recursion.py
@@ -78,11 +78,12 @@ def test_branches_same_behavior():
     depth = traversal_depth(result)
     assert depth <= MAX_RECURSION_DEPTH
 
+
 def test_dic2tree_short_chain():
     d = {}
     for i in range(5):
-        d[str(i)] = [str(i+1)] if i < 4 else []
-    result = acyclic_dic2tree('0', d)
+        d[str(i)] = [str(i + 1)] if i < 4 else []
+    result = acyclic_dic2tree("0", d)
     depth = 0
     current = result
     while isinstance(current, list) and len(current) > 1:
@@ -90,11 +91,12 @@ def test_dic2tree_short_chain():
         current = current[1]
     assert depth == 4
 
+
 def test_dic2tree_long_chain_capped():
     d = {}
     for i in range(1500):
-        d[str(i)] = [str(i+1)] if i < 1499 else []
-    result = acyclic_dic2tree('0', d)
+        d[str(i)] = [str(i + 1)] if i < 1499 else []
+    result = acyclic_dic2tree("0", d)
     depth = 0
     current = result
     while isinstance(current, list) and len(current) > 1:
@@ -102,11 +104,12 @@ def test_dic2tree_long_chain_capped():
         current = current[1]
     assert depth <= MAX_RECURSION_DEPTH
 
+
 def test_dic2tree_explicit_depth():
     d = {}
     for i in range(10):
-        d[str(i)] = [str(i+1)] if i < 9 else []
-    result = acyclic_dic2tree('0', d, depth=20)
+        d[str(i)] = [str(i + 1)] if i < 9 else []
+    result = acyclic_dic2tree("0", d, depth=20)
     depth = 0
     current = result
     while isinstance(current, list) and len(current) > 1:
@@ -114,14 +117,16 @@ def test_dic2tree_explicit_depth():
         current = current[1]
     assert depth == 9
 
+
 def test_dic2tree_negative_depth():
-    d = {'a': ['b']}
+    d = {"a": ["b"]}
     with pytest.raises(ValueError, match="depth must be >= -1"):
-        acyclic_dic2tree('a', d, depth=-2)
+        acyclic_dic2tree("a", d, depth=-2)
+
 
 def test_dic2tree_cycle():
     # Simple cycle: a -> b -> a
-    d = {'a': ['b'], 'b': ['a']}
-    result = acyclic_dic2tree('a', d, verbose=False)
+    d = {"a": ["b"], "b": ["a"]}
+    result = acyclic_dic2tree("a", d, verbose=False)
     # Should return ['a', ['b']] because the cycle is truncated
-    assert result == ['a', ['b']]
+    assert result == ["a", ["b"]]

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -640,6 +640,7 @@ def acyclic_branches_depth_first(
         out_tree += [cut_mark]
     return out_tree
 
+
 def acyclic_dic2tree(node, dic, depth=-1, traversed=None, verbose=False):
     """
     :param node: the root node


### PR DESCRIPTION
CI fails after the latest merge a from a private GHSA fork. The present PR aims to make CI pass again. 