### PR TITLE
Restore pre-commit formatting and register the new probe id on develop

### DIFF
--- a/nltk/test/unit/security_probes/ghsa_8846_p9w9_5frf.py
+++ b/nltk/test/unit/security_probes/ghsa_8846_p9w9_5frf.py
@@ -1,18 +1,22 @@
-from ._base import FIXED, VULNERABLE, probe
 from nltk.util import acyclic_depth_first
+
+from ._base import FIXED, VULNERABLE, probe
+
 
 class MockNode:
     def __init__(self, name, children=None):
         self.name = name
         self._children = children or []
+
     def rel(self):
         return self._children
+
 
 @probe("GHSA-8846-p9w9-5frf")
 def test_wordnet_recursion():
     nodes = [MockNode(str(i)) for i in range(1500)]
     for i in range(1499):
-        nodes[i]._children = [nodes[i+1]]
+        nodes[i]._children = [nodes[i + 1]]
     try:
         list(acyclic_depth_first(nodes[0], lambda x: x.rel(), depth=-1))
         return (FIXED, "Depth cap prevents recursion overflow")

--- a/nltk/test/unit/test_advisory_coverage_ci.py
+++ b/nltk/test/unit/test_advisory_coverage_ci.py
@@ -55,7 +55,9 @@ _CLOSED_WITH_PROBE = {
     "GHSA-4489-j4f3-2g8q",
     "GHSA-9ffx-rrgx-mhgx",
     "GHSA-pcm8-fqjx-rvx8",
+    "GHSA-8846-p9w9-5frf",
 }
+
 
 def _next_url(link_header):
     """The *on-origin* rel="next" URL from a GitHub ``Link`` header, else None.

--- a/nltk/test/unit/test_wordnet_recursion.py
+++ b/nltk/test/unit/test_wordnet_recursion.py
@@ -78,11 +78,12 @@ def test_branches_same_behavior():
     depth = traversal_depth(result)
     assert depth <= MAX_RECURSION_DEPTH
 
+
 def test_dic2tree_short_chain():
     d = {}
     for i in range(5):
-        d[str(i)] = [str(i+1)] if i < 4 else []
-    result = acyclic_dic2tree('0', d)
+        d[str(i)] = [str(i + 1)] if i < 4 else []
+    result = acyclic_dic2tree("0", d)
     depth = 0
     current = result
     while isinstance(current, list) and len(current) > 1:
@@ -90,11 +91,12 @@ def test_dic2tree_short_chain():
         current = current[1]
     assert depth == 4
 
+
 def test_dic2tree_long_chain_capped():
     d = {}
     for i in range(1500):
-        d[str(i)] = [str(i+1)] if i < 1499 else []
-    result = acyclic_dic2tree('0', d)
+        d[str(i)] = [str(i + 1)] if i < 1499 else []
+    result = acyclic_dic2tree("0", d)
     depth = 0
     current = result
     while isinstance(current, list) and len(current) > 1:
@@ -102,11 +104,12 @@ def test_dic2tree_long_chain_capped():
         current = current[1]
     assert depth <= MAX_RECURSION_DEPTH
 
+
 def test_dic2tree_explicit_depth():
     d = {}
     for i in range(10):
-        d[str(i)] = [str(i+1)] if i < 9 else []
-    result = acyclic_dic2tree('0', d, depth=20)
+        d[str(i)] = [str(i + 1)] if i < 9 else []
+    result = acyclic_dic2tree("0", d, depth=20)
     depth = 0
     current = result
     while isinstance(current, list) and len(current) > 1:
@@ -114,14 +117,16 @@ def test_dic2tree_explicit_depth():
         current = current[1]
     assert depth == 9
 
+
 def test_dic2tree_negative_depth():
-    d = {'a': ['b']}
+    d = {"a": ["b"]}
     with pytest.raises(ValueError, match="depth must be >= -1"):
-        acyclic_dic2tree('a', d, depth=-2)
+        acyclic_dic2tree("a", d, depth=-2)
+
 
 def test_dic2tree_cycle():
     # Simple cycle: a -> b -> a
-    d = {'a': ['b'], 'b': ['a']}
-    result = acyclic_dic2tree('a', d, verbose=False)
+    d = {"a": ["b"], "b": ["a"]}
+    result = acyclic_dic2tree("a", d, verbose=False)
     # Should return ['a', ['b']] because the cycle is truncated
-    assert result == ['a', ['b']]
+    assert result == ["a", ["b"]]

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -640,6 +640,7 @@ def acyclic_branches_depth_first(
         out_tree += [cut_mark]
     return out_tree
 
+
 def acyclic_dic2tree(node, dic, depth=-1, traversed=None, verbose=False):
     """
     :param node: the root node


### PR DESCRIPTION
`develop` is currently red, and every open pull request inherits it. Two causes, both from the merge that added the GHSA-8846 probe.

**1. pre-commit was not run.** black and isort fail on four files:

```
reformatted nltk/test/unit/security_probes/ghsa_8846_p9w9_5frf.py
reformatted nltk/test/unit/test_advisory_coverage_ci.py
reformatted nltk/test/unit/test_wordnet_recursion.py
reformatted nltk/util.py
4 files reformatted, 514 files left unchanged.
```

Reformatting them is the whole of that part of the change. No logic moves.

**2. The new probe's id was never registered.** The merge added `nltk/test/unit/security_probes/ghsa_8846_p9w9_5frf.py` but did not add `GHSA-8846-p9w9-5frf` to `_CLOSED_WITH_PROBE`, so the *Advisory coverage (GitHub)* job fails:

```
AssertionError: probes for ids GitHub does not list: ['GHSA-8846-p9w9-5frf']
```

That set exists for precisely this case, a probe whose advisory GitHub does not list yet, so the id is added there rather than changing the assertion.

Verified locally: all pre-commit hooks pass, and `pytest nltk/test/unit` is 2119 passed, 45 skipped, 9 xfailed, 0 failed.

Separated from my other open work deliberately, since this is unrelated to any of it and unblocks everyone.