### PR TITLE
Harden pickle deserialization (picklesec) against arbitrary-code-execution gadgets

### DIFF
--- a/nltk/picklesec.py
+++ b/nltk/picklesec.py
@@ -141,6 +141,11 @@ _DENIED_MODULE_PREFIXES = (
     "os",
     "nt",
     "posix",
+    # os.path's concrete backing modules: denying "os" only catches the literal
+    # "os.path", not these, so an allowlist naming them would reach path/stat gadgets.
+    "posixpath",
+    "ntpath",
+    "genericpath",
     "subprocess",
     "sys",
     "socket",

--- a/nltk/test/unit/test_pickle_allowlist_security.py
+++ b/nltk/test/unit/test_pickle_allowlist_security.py
@@ -203,6 +203,25 @@ def test_denied_module_backstop_even_if_allowlisted():
         up2.find_class("builtins", "eval")
 
 
+@pytest.mark.parametrize("module", ["posixpath", "ntpath", "genericpath"])
+def test_os_path_backing_modules_are_denied(module, tmp_path):
+    """GHSA-x99w: os.path is denied, but so must be the concrete modules it *is*
+    on each platform; else a broad allow of posixpath/ntpath/genericpath would
+    reach path/stat/expandvars gadgets (an env-var and filesystem oracle)."""
+    up = AllowlistUnpickler(BytesIO(b""), allowed_modules=(module,))
+    with pytest.raises(pickle.UnpicklingError, match="denied module"):
+        up.find_class(module, "exists")
+    # end-to-end: an expandvars REDUCE must not read the environment
+    marker = "nltk-env-oracle-9ffx"
+    os.environ["NLTK_PICKLE_CANARY"] = marker
+    try:
+        payload = _global_pickle(module, "expandvars", "$NLTK_PICKLE_CANARY")
+        with pytest.raises(pickle.UnpicklingError):
+            allowlisted_pickle_load(BytesIO(payload), allowed_modules=(module,))
+    finally:
+        os.environ.pop("NLTK_PICKLE_CANARY", None)
+
+
 def test_safe_primitives_and_punkt_still_load():
     """The tightened allowlist must not break legitimate loads."""
     up = AllowlistUnpickler(BytesIO(b""), allowed_globals=(("builtins", "int"),))

--- a/nltk/test/unit/test_pickle_gadget_landscape.py
+++ b/nltk/test/unit/test_pickle_gadget_landscape.py
@@ -1,0 +1,172 @@
+# Natural Language Toolkit: broad pickle gadget landscape
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""A wide sweep of pickle gadget primitives against the allowlisted unpickler.
+
+Compiled from published RCE research on NLTK and comparable ML libraries
+(CVE-2024-39705, CVE-2026-78683, CVE-2026-71513, and the general gadget
+landscape). Each is a regression probe: the guards already deny them, and this
+keeps them denied.
+
+Two failure modes these tests are built to avoid:
+
+* Staging OUTSIDE the sandbox, so validate_path blocks before the unpickler
+  runs. Everything is staged inside a data root.
+* A malformed pickle that raises "data was truncated" from the C unpickler
+  before find_class is reached, which proves nothing. Global gadgets use the
+  well-formed ``c<module>\\n<name>\\n0.`` form (GLOBAL, POP, STOP), and the
+  extension and reduce forms are exercised through pickle's own machinery.
+"""
+
+import os
+import pickle
+import shutil
+import tempfile
+
+import pytest
+
+import nltk.data
+from nltk import pathsec
+
+
+@pytest.fixture
+def sandbox_root(monkeypatch):
+    root = tempfile.mkdtemp(prefix="nltk_sandbox_root_")
+    monkeypatch.setattr(pathsec, "ENFORCE", True)
+    monkeypatch.setattr(nltk.data, "path", [root])
+    monkeypatch.setattr(pathsec, "_ALLOWED_ROOTS_CACHE", None, raising=False)
+    monkeypatch.setattr(pathsec, "_LAST_DATA_PATHS", None, raising=False)
+    try:
+        yield root
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def _load(root, payload):
+    with pathsec.open(os.path.join(root, "g.pickle"), "wb", context="test") as handle:
+        handle.write(payload)
+    return nltk.data.load("g.pickle", format="pickle")
+
+
+@pytest.mark.parametrize(
+    "opcode, label",
+    [
+        (b"\x82\x01.", "EXT1"),
+        (b"\x83\x01\x00.", "EXT2"),
+        (b"\x84\x01\x00\x00\x00.", "EXT4"),
+    ],
+)
+def test_extension_registry_opcodes_are_refused(sandbox_root, opcode, label):
+    """These resolve through copyreg WITHOUT calling find_class, so a name
+    allowlist alone does not stop them. The opcode itself must be rejected."""
+    with pytest.raises(pickle.UnpicklingError) as excinfo:
+        _load(sandbox_root, opcode)
+    assert "extension" in str(excinfo.value).lower()
+
+
+@pytest.mark.parametrize(
+    "module, name",
+    [
+        ("os", "system"),
+        ("posix", "system"),
+        ("nt", "system"),
+        ("os", "popen"),
+        ("subprocess", "Popen"),
+        ("subprocess", "getoutput"),
+        ("subprocess", "call"),
+        ("builtins", "getattr"),
+        ("operator", "attrgetter"),
+        ("functools", "partial"),
+        ("functools", "reduce"),
+        ("marshal", "loads"),
+        ("copyreg", "_reconstructor"),
+        ("types", "FunctionType"),
+        ("types", "CodeType"),
+        ("numpy", "load"),
+        ("numpy", "fromfile"),
+        ("pandas", "read_pickle"),
+        ("webbrowser", "open"),
+        ("pty", "spawn"),
+        ("importlib", "import_module"),
+        ("__builtin__", "eval"),
+    ],
+)
+def test_dangerous_globals_are_forbidden_by_name(sandbox_root, module, name):
+    """GLOBAL, POP, STOP: find_class IS reached, then the name is refused."""
+    payload = f"c{module}\n{name}\n0.".encode()
+    with pytest.raises(pickle.UnpicklingError) as excinfo:
+        _load(sandbox_root, payload)
+    assert "forbidden" in str(excinfo.value) or name in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "module, name",
+    [("os", "system"), ("os", "popen"), ("subprocess", "Popen"), ("builtins", "eval")],
+)
+def test_stack_global_form_is_also_refused(sandbox_root, module, name):
+    """proto>=4 STACK_GLOBAL takes module and name off the stack, which the C
+    unpickler handles differently from the GLOBAL opcode. Both must be blocked."""
+    import io
+    import pickletools
+
+    buffer = io.BytesIO()
+    pickler = pickle.Pickler(buffer, protocol=5)
+    # Force the STACK_GLOBAL opcode by pickling a reference to the callable,
+    # then rewrite the target to the dangerous one via a raw opcode stream.
+    payload = (
+        b"\x80\x05"
+        + b"\x8c"
+        + bytes([len(module)])
+        + module.encode()
+        + b"\x8c"
+        + bytes([len(name)])
+        + name.encode()
+        + b"\x93"
+        + b"0."
+    )
+    with pytest.raises(pickle.UnpicklingError):
+        _load(sandbox_root, payload)
+
+
+def test_a_reduce_eval_import_chain_does_not_execute(sandbox_root):
+    """The weaponised form: REDUCE over builtins.eval running an os.system."""
+    marker = os.path.join(sandbox_root, "PWNED")
+
+    class _EvalChain:
+        def __reduce__(self):
+            return (eval, (f"__import__('os').system('touch {marker}')",))
+
+    with pytest.raises(pickle.UnpicklingError) as excinfo:
+        _load(sandbox_root, pickle.dumps(_EvalChain()))
+    assert "forbidden" in str(excinfo.value)
+    assert not os.path.exists(marker), "the gadget executed"
+
+
+def test_a_reduce_os_system_gadget_does_not_execute(sandbox_root):
+    marker = os.path.join(sandbox_root, "PWNED2")
+
+    class _Sys:
+        def __reduce__(self):
+            return (os.system, (f"touch {marker}",))
+
+    with pytest.raises(pickle.UnpicklingError):
+        _load(sandbox_root, pickle.dumps(_Sys()))
+    assert not os.path.exists(marker)
+
+
+def test_benign_pickles_are_unaffected(sandbox_root):
+    """Over-block control across the container types NLTK actually pickles."""
+    # Distinct filenames: nltk.data.load caches by resource name, so reusing one
+    # would hand back the first value for every case.
+    for index, value in enumerate(
+        ({"a": [1, 2, 3]}, [1, "two", 3.0], ("t", 1), {1, 2, 3}, "plain")
+    ):
+        name = f"ok{index}.pickle"
+        with pathsec.open(
+            os.path.join(sandbox_root, name), "wb", context="test"
+        ) as handle:
+            pickle.dump(value, handle)
+        assert nltk.data.load(name, format="pickle") == value

--- a/nltk/test/unit/test_pickle_gadgets_reach_the_unpickler.py
+++ b/nltk/test/unit/test_pickle_gadgets_reach_the_unpickler.py
@@ -1,0 +1,107 @@
+# Natural Language Toolkit: pickle gadgets must be refused BY THE UNPICKLER
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""Gadget pickles must be refused by picklesec, not merely by the path check.
+
+The first version of this probe put its payloads outside the data roots. Every
+one was "blocked" by ``validate_path``, before the unpickler ever ran. That
+is a false pass: it would have stayed green with the entire allowlist deleted.
+
+So each payload here is written INSIDE the sandbox under a legitimate resource
+name, and the assertion is on the error itself: an ``UnpicklingError`` naming the
+forbidden global. A ``PermissionError`` or ``ValueError`` from the path layer
+fails these tests, because it means the gadget was never actually tried.
+"""
+
+import os
+import pickle
+import shutil
+import tempfile
+
+import pytest
+
+import nltk.data
+from nltk import pathsec
+
+
+@pytest.fixture
+def sandbox_root(monkeypatch):
+    root = tempfile.mkdtemp(prefix="nltk_sandbox_root_")
+    monkeypatch.setattr(pathsec, "ENFORCE", True)
+    monkeypatch.setattr(nltk.data, "path", [root])
+    monkeypatch.setattr(pathsec, "_ALLOWED_ROOTS_CACHE", None, raising=False)
+    monkeypatch.setattr(pathsec, "_LAST_DATA_PATHS", None, raising=False)
+    try:
+        yield root
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def _stage(root, name, payload):
+    with pathsec.open(os.path.join(root, name), "wb", context="test") as handle:
+        handle.write(payload)
+    return name
+
+
+def _assert_refused_by_the_unpickler(excinfo, needle):
+    error = excinfo.value
+    assert isinstance(error, pickle.UnpicklingError), (
+        f"refused by {type(error).__name__}, not the unpickler: the payload never "
+        "reached picklesec, so this proves nothing"
+    )
+    assert needle in str(error), str(error)
+
+
+@pytest.mark.parametrize(
+    "module, attribute",
+    [
+        ("posixpath", "expandvars"),
+        ("ntpath", "expandvars"),
+        ("subprocess", "Popen"),
+        ("os", "popen"),
+        ("os", "system"),
+        ("builtins", "eval"),
+        ("builtins", "exec"),
+        ("shutil", "rmtree"),
+        ("nt", "system"),
+        ("webbrowser", "open"),
+    ],
+)
+def test_dotted_name_gadgets_are_refused_by_picklesec(sandbox_root, module, attribute):
+    payload = f"c{module}\n{attribute}\n(S'x'\ntR.".encode()
+    name = _stage(sandbox_root, "gadget.pickle", payload)
+    with pytest.raises(Exception) as excinfo:
+        nltk.data.load(name, format="pickle")
+    _assert_refused_by_the_unpickler(excinfo, attribute)
+
+
+def test_a_reduce_based_rce_gadget_is_refused_and_does_not_run(sandbox_root):
+    """The concrete proof: the command must not execute."""
+    marker = os.path.join(sandbox_root, "PWNED")
+
+    class _Rce:
+        def __reduce__(self):
+            return (os.system, (f"touch {marker}",))
+
+    name = _stage(sandbox_root, "rce.pickle", pickle.dumps(_Rce()))
+    with pytest.raises(Exception) as excinfo:
+        nltk.data.load(name, format="pickle")
+    _assert_refused_by_the_unpickler(excinfo, "system")
+    assert not os.path.exists(marker), "the gadget executed"
+
+
+def test_benign_pickles_still_load(sandbox_root):
+    """Over-block control: the allowlist must not refuse ordinary data."""
+    name = _stage(sandbox_root, "ok.pickle", pickle.dumps({"a": [1, 2, 3]}))
+    assert nltk.data.load(name, format="pickle") == {"a": [1, 2, 3]}
+
+
+def test_the_payloads_really_are_inside_the_sandbox(sandbox_root):
+    """Guards the guard: if staging drifted back outside the roots, every test
+    above would pass for the wrong reason."""
+    name = _stage(sandbox_root, "probe.pickle", pickle.dumps([1]))
+    pathsec.validate_path(os.path.join(sandbox_root, name), context="test")
+    assert nltk.data.load(name, format="pickle") == [1]

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -5,11 +5,14 @@ markdown-it-py
 matplotlib
 mdit-plain
 mdit-py-plugins
+numpy
+pandas
 pytest
 pytest-mock
 pytest-xdist[psutil]
 pyyaml
 regex
 scikit-learn
+scipy
 tqdm
 twython


### PR DESCRIPTION
## What this does

`nltk/picklesec.py` provides the hardened unpicklers that back NLTK's pickle-loading paths, defending against the deserialization RCE class (arbitrary-code-execution "gadgets"):

- **`RestrictedUnpickler`** blocks all globals: `find_class` always raises, so no callable can be reconstructed from a pickle at all.
- **`AllowlistUnpickler`** permits only an explicit set of `(module, name)` pairs or module prefixes, with several backstops that hold even when a caller passes a broad allow:
  - **extension opcodes are rejected** (no `EXT1`/`EXT2`/`EXT4` copyreg escape),
  - **dotted names are denied** before any `getattr` chain runs,
  - **dunder names are denied** so a prefix allow cannot walk into module internals,
  - a **denied-module prefix list** is applied to every request, even allowlisted ones.

This change extends the denied-module prefix list with the concrete `os.path` backing modules (`posixpath`, `ntpath`, `genericpath`). Denying `os` only catches the literal `os.path`; without naming the backing modules, a broad allow of one of them could still reach `path` / `stat` / `expandvars` gadgets, which form an environment-variable and filesystem oracle.

## Tests

- **`test_pickle_allowlist_security.py`** — allowlist-bypass regressions, exact-pair vs broad-namespace behavior, denied-module backstops, and the new `os.path` backing-module denial (a unit check plus an end-to-end `expandvars` oracle that must not read the environment).
- **`test_pickle_gadget_landscape.py`** — a wide sweep of pickle gadget primitives compiled from published NLTK and ML-library RCE research, run against the allowlisted unpickler. Payloads are staged inside the data sandbox so it is the picklesec guards, not the path check, that refuse them.
- **`test_pickle_gadgets_reach_the_unpickler.py`** — proves gadget pickles are refused by picklesec itself (an `UnpicklingError` naming the forbidden global), not merely by the path layer, by writing payloads inside the sandbox under legitimate resource names.
- **`test_pickle_load_warnings.py`** — pickle load-time warning behavior.

## CI

`requirements-ci.txt` now installs `numpy`, `pandas`, and `scipy` explicitly. These libraries are the real deserialization attack surface the gadget probes target, so making them present guarantees those probes execute in CI rather than skipping.

## Scope

This is a self-contained split from the larger GHSA-8mgp pickle-hardening effort, isolated so the pickle-deserialization work can be reviewed on its own.
