### PR TITLE
Fix internals.doctest to match the hardened _validate_java_options allowlist

### DIFF
--- a/nltk/test/internals.doctest
+++ b/nltk/test/internals.doctest
@@ -178,12 +178,32 @@ wrappers pass are equivalent and also permitted:
 >>> _validate_java_options(["-mx2g"])
 >>> _validate_java_options(["-ms128m"])
 >>> _validate_java_options(["-ss4m"])
->>> _validate_java_options(["-XX:+UseG1GC"])
 >>> _validate_java_options(["-verbose:gc"])
 >>> _validate_java_options(["-server"])
 >>> _validate_java_options(["-client"])
->>> _validate_java_options(["-Dsome.property=value"])
->>> _validate_java_options(["-Xmx1g", "-Dsome.key=val", "-server"])
+>>> _validate_java_options(["-Xmx1g", "-server"])
+
+The filter is an allowlist, so ``-XX:`` and ``-D`` flags are refused even though
+they look innocuous: ``-XX:`` can name a file the JVM executes on error and
+``-D`` can redirect class loading or disarm the security manager. Pass a genuinely
+needed one through ``java(trusted_raw_options=...)``:
+
+>>> _validate_java_options(["-XX:+UseG1GC"])  # doctest: +ELLIPSIS
+Traceback (most recent call last):
+    ...
+ValueError: java_options contains a disallowed JVM/launcher flag: '-XX:+UseG1GC'...
+
+>>> _validate_java_options(["-Dsome.property=value"])  # doctest: +ELLIPSIS
+Traceback (most recent call last):
+    ...
+ValueError: java_options contains a disallowed JVM/launcher flag: '-Dsome.property=value'...
+
+A single bad flag rejects the whole list, even mixed with permitted ones:
+
+>>> _validate_java_options(["-Xmx1g", "-Dsome.key=val", "-server"])  # doctest: +ELLIPSIS
+Traceback (most recent call last):
+    ...
+ValueError: java_options contains a disallowed JVM/launcher flag: '-Dsome.key=val'...
 
 Agent-loading and JDWP flags are blocked:
 


### PR DESCRIPTION
## What this fixes

`nltk/internals.py` already validates `java_options` against an allowlist: only JVM memory/stack tuning, `-verbose`, `-server`/`-client`, and `--add-modules` are permitted. Anything else (including `-XX:` and `-D` flags) must be passed explicitly through `java(trusted_raw_options=...)`, since `-XX:OnError=`/`-XX:OnOutOfMemoryError=` execute a command and `-D` system properties can redirect class loading. That guard closes CVE-2026-12841 (CWE-88).

`nltk/test/internals.doctest` was not updated when that allowlist landed, so it still asserted the older permissive behavior:

```
>>> _validate_java_options(["-XX:+UseG1GC"])
>>> _validate_java_options(["-Dsome.property=value"])
>>> _validate_java_options(["-Xmx1g", "-Dsome.key=val", "-server"])
```

Against the current code those calls raise `ValueError: java_options contains a disallowed JVM/launcher flag: ...`, so the doctest fails under `make doctest` / `pytest --doctest-glob='*.doctest' nltk/test/internals.doctest`. (The main CI pytest gate runs `--doctest-modules`, which collects only `.py` docstrings, so it does not surface this.)

## Change

- Flips the three affected `_validate_java_options` examples to expect the `ValueError` (via `# doctest: +ELLIPSIS`).
- Adds a short note that the filter is an allowlist and how to pass a genuinely needed flag through `trusted_raw_options`.

Before: `1 failed`. After: `1 passed`, with `nltk/internals.py` unchanged.

Documentation/test only, no source change. This is a small self-contained fix split out from the larger GHSA-8mgp hardening effort; the `_validate_java_options` allowlist it documents is already on `develop`.
