### PR TITLE
Bound re_show's caller-supplied regex against ReDoS (CWE-1333)

### DIFF
--- a/nltk/test/unit/test_redos_caller_patterns.py
+++ b/nltk/test/unit/test_redos_caller_patterns.py
@@ -1,0 +1,77 @@
+# Natural Language Toolkit: ReDoS on caller-supplied regexes
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""Any API that compiles a CALLER's regex must bound it.
+
+``nltk.redos.compile`` puts a wall-clock limit on matching. ``nltk.util.re_show``
+takes both a pattern and a string from the caller and previously compiled the
+pattern with a plain ``re.compile``, so a catastrophically backtracking pattern
+such as ``(a+)+$`` against a 34-character bait string hung the interpreter
+outright (CWE-1333). It now routes through ``nltk.redos.compile``.
+
+These run in a SUBPROCESS with a timeout. An in-process test cannot fail
+cleanly on catastrophic backtracking: the regex engine does not release the GIL,
+so a pytest timeout plugin cannot interrupt it and the whole run wedges. That is
+also why a hang must be asserted as a timeout rather than measured with a clock.
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+_EVIL = r"(a+)+$"
+_BAIT = "a" * 34 + "!"
+_LIMIT = 20
+
+
+def _run(code):
+    return subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import warnings;warnings.filterwarnings('ignore');" + code,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=_LIMIT,
+        env=dict(os.environ, PYTHONPATH=os.pathsep.join(sys.path)),
+    )
+
+
+def test_re_show_catastrophic_pattern_does_not_hang():
+    """Completing or raising are both fine. Hanging is not."""
+    code = f"from nltk.util import re_show; re_show({_EVIL!r}, {_BAIT!r})"
+    try:
+        _run(code)
+    except subprocess.TimeoutExpired:
+        pytest.fail("re_show hung on a catastrophic pattern (ReDoS)")
+
+
+def test_re_show_ordinary_pattern_still_produces_the_right_answer():
+    """Over-block control: bounding the engine must not change results."""
+    code = "from nltk.util import re_show; re_show('o+','foo')"
+    result = _run(code)
+    assert result.returncode == 0, result.stderr
+    assert "f{oo}" in result.stdout, result.stdout
+
+
+def test_util_routes_through_redos():
+    """Pin the mechanism, not just the timing.
+
+    A future edit could swap redos.compile back to re.compile and the timing
+    test would still pass on a fast machine with a smaller bait string.
+    """
+    import importlib
+    import inspect
+
+    # importlib, not "import nltk.util as util": the package star-imports
+    # nltk.stem, whose own util module shadows the nltk.util ATTRIBUTE.
+    module = importlib.import_module("nltk.util")
+    assert module.__name__ == "nltk.util", module.__name__
+    source = inspect.getsource(module)
+    assert "redos.compile" in source, "nltk.util no longer bounds its regex"

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -27,6 +27,7 @@ from urllib.request import (
     install_opener,
 )
 
+from nltk import redos
 from nltk.collections import *
 from nltk.internals import deprecated, raise_unorderable_types, slice_bounds
 from nltk.pathsec import open as _secure_open
@@ -214,7 +215,9 @@ def re_show(regexp, string, left="{", right="}"):
     :type right: str
     :rtype: str
     """
-    print(re.compile(regexp, re.M).sub(left + r"\g<0>" + right, string.rstrip()))
+    # regexp and string are both caller-supplied, so a catastrophically
+    # backtracking pattern hangs the process (CWE-1333). redos.compile bounds it.
+    print(redos.compile(regexp, re.M).sub(left + r"\g<0>" + right, string.rstrip()))
 
 
 ##########################################################################


### PR DESCRIPTION
This is a self-contained split from the larger GHSA-8mgp hardening, isolating only the change to the top-level `nltk/util.py`.

## What changed

`nltk.util.re_show(regexp, string)` compiled the caller-supplied `regexp` with a plain `re.compile` and then ran it against a caller-supplied `string`. A catastrophically backtracking pattern such as `(a+)+$` matched against a short bait string (e.g. `"a" * 34 + "!"`) hangs the interpreter outright (CWE-1333, catastrophic regex backtracking / ReDoS). Because the regex engine holds the GIL while backtracking, nothing in-process can interrupt it.

The compile now routes through `nltk.redos.compile`, which already exists on `develop` and applies a wall-clock bound to matching. This mirrors the guard already in place for `nltk.tokenize.RegexpTokenizer` and `nltk.tag.RegexpTagger`, which compile caller-supplied patterns through `redos` too.

The diff is small: one new import (`from nltk import redos`) and one line in `re_show` swapped from `re.compile(...)` to `redos.compile(...)`.

## Self-contained

The only new dependency is `nltk.redos`, which is already present on `develop` (unchanged by this PR). `import nltk.util` succeeds on a clean `develop` checkout plus this file alone.

## Tests

`nltk/test/unit/test_redos_caller_patterns.py` (a focused subset of the caller-regex probe from the larger effort, trimmed to only the `nltk.util` cases) asserts, each in a subprocess so a hang surfaces as a timeout rather than wedging the run:

- a catastrophic pattern no longer hangs `re_show`;
- an ordinary pattern still yields the correct bracketed output;
- `nltk.util` source still routes through `redos.compile` (pins the mechanism, not just the timing).

Runs green on Linux, macOS, and Windows: the tests use only a subprocess and `PYTHONPATH`, with no temp-dir fixtures or network resolution.