### PR TITLE
Harden path/resource/tool validation in nltk.pathsec

### DIFF
--- a/nltk/data.py
+++ b/nltk/data.py
@@ -668,6 +668,65 @@ def _check_zip_member_count(count, name="<archive>"):
         )
 
 
+def _check_zip_total_size(infolist, name="<archive>"):
+    """Reject an archive whose members SUM to a decompression bomb (CWE-409).
+
+    ``_check_decompression_bomb`` runs per member, so an archive of many members
+    each just under ``MAX_UNZIP_ACTIVATION`` (32 MiB) is never ratio-checked and
+    never individually refused, yet the members together expand from a tiny zip
+    to an arbitrarily large total: 40 members of 5 MiB came from a 400 KiB zip,
+    and at the ``MAX_UNZIP_MEMBERS`` limit the total reaches terabytes. Extraction
+    keeps no running byte total, so nothing caught it.
+
+    This applies the same activation-plus-ratio test at the whole-archive level:
+    a large total that expands by more than ``MAX_UNZIP_RATIO`` over the total
+    compressed size is refused. A legitimately large corpus has a modest overall
+    ratio and passes; only an aggregate that looks like a bomb is refused.
+    """
+    # A single real member is already fully covered by the per-member
+    # _check_decompression_bomb (declared size) and the bounded streaming reader
+    # (actual bytes). The aggregate gap this guards is specifically MANY members
+    # that each pass the per-member floor but sum to a bomb, so it only applies
+    # when there is more than one file member. Directory entries (size 0, name
+    # ending in "/") are not real members and are not counted, so a lone big file
+    # shipped with its parent directory entry stays on the per-member path.
+    files = [
+        info
+        for info in infolist
+        if not (getattr(info, "filename", "") or "").endswith("/")
+    ]
+    if len(files) <= 1:
+        return
+    total_uncompressed = 0
+    total_compressed = 0
+    for info in files:
+        total_uncompressed += getattr(info, "file_size", 0) or 0
+        total_compressed += getattr(info, "compress_size", 0) or 0
+    if MAX_UNZIP_SIZE is not None and total_uncompressed > MAX_UNZIP_SIZE:
+        raise ValueError(
+            "Refusing to read zip %r: its members total %d uncompressed bytes, "
+            "above nltk.data.MAX_UNZIP_SIZE=%d."
+            % (name, total_uncompressed, MAX_UNZIP_SIZE)
+        )
+    if (
+        total_uncompressed >= MAX_UNZIP_ACTIVATION
+        and total_compressed > 0
+        and total_uncompressed > MAX_UNZIP_RATIO * total_compressed
+    ):
+        raise ValueError(
+            "Refusing to read suspected zip bomb %r: its members expand %.1fx in "
+            "aggregate (%d -> %d bytes), above nltk.data.MAX_UNZIP_RATIO=%d. Raise "
+            "nltk.data.MAX_UNZIP_RATIO if this archive is trusted."
+            % (
+                name,
+                total_uncompressed / total_compressed,
+                total_compressed,
+                total_uncompressed,
+                MAX_UNZIP_RATIO,
+            )
+        )
+
+
 def _check_decompression_bomb(info):
     """
     Reject a zip member that looks like a decompression bomb (CWE-409).

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -9,6 +9,7 @@
 
 """Centralized I/O security sentinel for NLTK."""
 import builtins
+import errno
 import http.client
 import io
 import ipaddress
@@ -44,6 +45,14 @@ ALLOW_PROXIED_FETCH = False
 
 _ALLOWED_ROOTS_CACHE = None
 _LAST_DATA_PATHS = None
+
+# Reserved DOS device names. On Windows these resolve to a device rather than a
+# file in the current directory, whatever the surrounding path is.
+_WINDOWS_DEVICE_NAMES = frozenset(
+    ["CON", "PRN", "AUX", "NUL", "CONIN$", "CONOUT$"]
+    + [f"COM{i}" for i in range(1, 10)]
+    + [f"LPT{i}" for i in range(1, 10)]
+)
 
 
 def is_private_dir(path):
@@ -145,8 +154,16 @@ def validate_path(path_input, context="NLTK", required_root=None):
     :param context: Diagnostic context for warnings/errors.
     :param required_root: If provided, enforces that the path is strictly
                           within this specific directory (scoped sandbox).
+
+    A whitespace-only path is NOT waved through: ``"   "`` is a legal relative
+    filename, so skipping it let a caller-supplied path reach ``os.open`` with no
+    containment check and create/truncate that file in the working directory,
+    outside every allowed root (GHSA-8mgp-746c-j5xp). Only an empty/absent path
+    (nothing to open) and a file descriptor short-circuit here.
     """
-    if isinstance(path_input, int) or not path_input or not str(path_input).strip():
+    # An *empty* path is a no-op (nothing can open it), but a blank-but-non-empty
+    # one names a real file, so it must be validated like any other path.
+    if isinstance(path_input, int) or not path_input:
         return
     try:
         raw = path_input.path if hasattr(path_input, "path") else str(path_input)
@@ -174,13 +191,34 @@ def validate_path(path_input, context="NLTK", required_root=None):
                 )
             raw = unquote(parsed.path)
             if not raw:
-                return
+                # "file://evil" parses as netloc="evil" with an EMPTY path, so
+                # there is nothing to validate while the caller still holds the
+                # original string and opens it as the relative path "file:/evil".
+                raise PermissionError(
+                    f"Security Violation [{context}]: file URL {path_input!r} has "
+                    "no path component; it is not a usable filesystem path"
+                )
 
         # Resolve path to catch symlink escapes
         try:
             target = Path(raw).resolve()
         except (OSError, ValueError):
-            # Fallback for virtual paths inside ZIPs (e.g. corpora/foo.zip/file.txt)
+            # Fallback for virtual paths inside ZIPs (e.g. corpora/foo.zip/file.txt).
+            # This validates only the prefix up to ".zip", so it must never be
+            # reached by a path that can still traverse: resolve() also fails on a
+            # NUL (ValueError) and on an over-long component (ENAMETOOLONG), and
+            # "<root>/ok.zip/<5000 chars>/../../../etc/passwd" would then be
+            # approved on its harmless prefix while normpath() collapses the long
+            # component and leaves /etc/passwd for the caller to open.
+            if "\x00" in raw or ".." in raw.replace("\\", "/").split("/"):
+                msg = (
+                    f"Security Violation [{context}]: unresolvable path with a "
+                    f"traversal or NUL component: {raw!r}"
+                )
+                if ENFORCE:
+                    raise PermissionError(msg)
+                warnings.warn(msg, RuntimeWarning, stacklevel=3)
+                return
             lower_raw = raw.lower()
             if ".zip" in lower_raw:
                 zip_idx = lower_raw.find(".zip") + 4
@@ -242,6 +280,477 @@ def validate_path(path_input, context="NLTK", required_root=None):
             raise
 
 
+# O_NOFOLLOW on a symlink, and O_RDONLY on a socket / write-only FIFO, fail with
+# these; they mean "refused by the hardening", not "this file is broken".
+_REFUSING_ERRNOS = frozenset(
+    e
+    for e in (
+        getattr(errno, "ELOOP", None),
+        getattr(errno, "EMLINK", None),
+        getattr(errno, "ENXIO", None),
+        getattr(errno, "EOPNOTSUPP", None),
+        getattr(errno, "ENOTSUP", None),
+    )
+    if e is not None
+)
+
+
+# On Windows these names are devices wherever they appear, so "<root>\NUL" is
+# the null device rather than a file inside the root, whatever the path says.
+_WINDOWS_RESERVED_NAMES = frozenset(
+    ["CON", "PRN", "AUX", "NUL"]
+    + [f"COM{n}" for n in range(1, 10)]
+    + [f"LPT{n}" for n in range(1, 10)]
+)
+
+
+def _is_windows_device_name(raw):
+    """True if the final component of *raw* names a Windows character device."""
+    if os.name == "posix":
+        return False
+    leaf = raw.replace("/", "\\").rsplit("\\", 1)[-1]
+    return leaf.split(".", 1)[0].strip().upper() in _WINDOWS_RESERVED_NAMES
+
+
+def _reject_colliding_members(members):
+    """Refuse an archive with two members that collide on a case-insensitive or
+    unicode-normalizing filesystem.
+
+    On macOS (APFS) and Windows, ``pkg/Weights.json`` and ``pkg/weights.json``,
+    or an NFC and an NFD spelling of the same name, map to ONE file: the second
+    member silently overwrites the first. A package could ship a benign-looking
+    ``Weights.json`` for a reviewer to read and a colliding ``weights.json`` that
+    replaces it with a poisoned model. A legitimate archive never contains such a
+    pair, so any collision is refused (CWE-22 / resource poisoning).
+    """
+    import unicodedata
+
+    seen = {}
+    for name in members:
+        text = name.filename if hasattr(name, "filename") else str(name)
+        key = unicodedata.normalize("NFC", text).casefold()
+        if key in seen and seen[key] != text:
+            raise ValueError(
+                "Refusing zip: members %r and %r collide on a case-insensitive "
+                "or normalizing filesystem, so one would silently overwrite the "
+                "other (resource poisoning)." % (seen[key], text)
+            )
+        seen[key] = text
+
+
+def _reject_url_shaped(raw, context):
+    """Refuse a URL where a model path is expected.
+
+    ``validate_path`` rewrites a ``file:`` URL to its path component before
+    checking it, but the caller still holds (and the tool still opens) the
+    original string. A model path is never a URL, so refusing the whole shape
+    here removes that validate-one-thing/open-another gap outright.
+    """
+    if _URL_SCHEME_RE.match(raw) or _FILE_SCHEME_RE.match(raw):
+        raise PermissionError(
+            f"Security Violation [{context}]: {raw!r} is a URL, not a model "
+            "path; the tool would open it verbatim as a relative path"
+        )
+
+
+def _as_path_string(path_input):
+    """Normalise a path-ish argument to the exact string a sink would use.
+
+    Mirrors :func:`validate_path`: a ``PathPointer`` exposes ``.path``, bytes are
+    decoded with the filesystem encoding, everything else goes through ``str``.
+    """
+    raw = path_input.path if hasattr(path_input, "path") else path_input
+    if isinstance(raw, bytes):
+        return os.fsdecode(raw)
+    return raw if isinstance(raw, str) else str(raw)
+
+
+def _as_path_text(value, context, error=ValueError):
+    """Resolve a caller value to a ``str`` path EXACTLY ONCE.
+
+    ``__fspath__`` is allowed to return a different answer on every call, so a
+    guard that calls it separately from the code that uses the path validates one
+    file while the tool opens another. Every caller must validate and then use
+    the single string returned here, never the original object.
+
+    Also turns a non-path (int, None, list) and a ``bytes`` path into a clean
+    security rejection instead of a TypeError that would escape a caller's
+    ``except (ValueError, PermissionError)``.
+    """
+    try:
+        text = os.fspath(value)
+    except TypeError as exc:
+        raise error(
+            f"Security Violation [{context}]: {value!r} is not a filesystem path."
+        ) from exc
+    if isinstance(text, bytes):
+        # A bytes path is a legal spelling on POSIX, so decode it rather than
+        # refusing; every check below then runs on the decoded characters.
+        try:
+            text = os.fsdecode(text)
+        except (UnicodeDecodeError, ValueError) as exc:
+            raise error(
+                f"Security Violation [{context}]: {text!r} is not decodable as a "
+                "filesystem path."
+            ) from exc
+    # os.fspath() hands back a str SUBCLASS unchanged, so every check below would
+    # run on attacker-controlled methods: a subclass overriding startswith,
+    # replace, split or __contains__ passes all of them while carrying a hostile
+    # value. str.__str__ is used rather than str(): it ignores a __str__ override
+    # and yields an exact str holding the real characters.
+    if type(text) is not str:
+        text = str.__str__(text)
+    return text
+
+
+def _reject_bad_name_syntax(text, context, error=ValueError):
+    """Syntactic checks shared by every caller-supplied model or tool path.
+
+    None of these can be a legitimate model, corpus or output file, so they are
+    refused before the value is treated as a path at all. ``..`` is checked after
+    folding ``\\`` to ``/``: a backslash is an ordinary filename character on
+    POSIX but a separator on Windows, so ``..\\..\\etc`` has to be rejected on both.
+    """
+
+    def _refuse(why):
+        # The exception type is the caller's convention: validate_model_resource
+        # reports a malformed value as ValueError, while the tool-path guards
+        # report every refusal as PermissionError.
+        raise error(f"Security Violation [{context}]: {text!r} {why}.")
+
+    if not text or not text.strip():
+        _refuse("is empty")
+    # A NUL truncates the path in a tool's native layer, so "good.ser.gz\0evil"
+    # can name a different file there than it does here.
+    if "\x00" in text:
+        _refuse("contains a NUL byte")
+    # Python 3.14's url2pathname follows the WHATWG rules and STRIPS tab, LF and
+    # CR, so ".\n./x" passes a '..' check here and becomes "../x" downstream.
+    if any(character in text for character in "\t\n\r\x0b\x0c"):
+        _refuse(
+            "contains a control character; these are stripped by URL-to-path "
+            "conversion on Python 3.14 and can turn into a '..' traversal"
+        )
+    # A leading '-' would be parsed as another option by the tool we hand it to.
+    if text.startswith("-"):
+        _refuse("looks like a command-line option (argument injection)")
+    # Stanford's loaders will fetch a URL; only local resources are permitted.
+    if "://" in text or text.lower().startswith(("file:", "jar:")):
+        _refuse("is a URL; only local resources are permitted")
+    # Nothing downstream expands '~', but a sink that did would reach $HOME.
+    if text.startswith("~"):
+        _refuse("starts with '~'; pass an already-expanded path")
+    # A Windows UNC path reaches a remote share.
+    if text.startswith("\\\\") or text.startswith("//"):
+        _refuse("is a UNC path; only local resources are permitted")
+    if ".." in text.replace("\\", "/").split("/"):
+        _refuse("contains a '..' component; it may not traverse out of the namespace")
+    # ':' names an NTFS alternate data stream, and "C:name" is drive-RELATIVE
+    # ("name in the current directory of drive C"), so it escapes the validated
+    # location. Both are Windows-only: on POSIX ':' is an ordinary filename
+    # character and refusing it would break legitimate names.
+    if os.name != "posix" and ":" in text and not re.match(r"^[A-Za-z]:[\\/]", text):
+        _refuse("contains ':', which names an NTFS alternate data stream")
+    # On Windows a leading separator with no drive is relative to the CURRENT
+    # drive, so it names a different file than the same string does on POSIX.
+    if os.name != "posix" and re.match(r"^[\\/]", text):
+        _refuse("is relative to the current drive; give a full path with a drive")
+    # Windows silently strips a trailing dot or space, so "evil.mco." is checked
+    # as one name and opened as another. Refused everywhere for determinism.
+    if text != text.rstrip(". "):
+        _refuse("ends with a dot or space, which Windows silently strips")
+    # On Windows these resolve to a device (a serial port, the null device) no
+    # matter which directory they appear in. On POSIX they are ordinary
+    # filenames, so refusing them there would be an over-block.
+    if os.name != "posix":
+        components = text.replace("\\", "/").split("/")
+        for component in components:
+            if not component:
+                continue
+            # A device name is reserved in ANY directory, and an 8.3 short name
+            # (PROGRA~1) aliases a different long name, so both must be checked on
+            # every component, not just the final one: "dir/PROGRA~1/x" traverses
+            # through the alias.
+            if (
+                component.split(".")[0].upper() in _WINDOWS_DEVICE_NAMES
+                or component.upper() in _WINDOWS_DEVICE_NAMES
+            ):
+                _refuse(f"contains a reserved Windows device ({component!r})")
+            if re.search(r"~[0-9]", component):
+                _refuse("contains an 8.3 short name, which aliases another file")
+
+
+def validate_model_resource(model_path, context="NLTK model"):
+    """Bound a caller-supplied model argument that may be a *resource name*.
+
+    Several JVM wrappers (Stanford parser/tagger/segmenter) accept the same
+    ``-model`` argument as either a filesystem path or a jar-internal classpath
+    resource, e.g. the default
+    ``edu/stanford/nlp/models/lexparser/englishPCFG.ser.gz``. Bounding every value
+    with :func:`validate_path` would break the jar-internal defaults, and skipping
+    validation entirely lets an attacker hand the JVM any file on disk.
+
+    So: a plain resource name is left alone, any real filesystem path is bounded to
+    the NLTK data roots, and a value that is neither (empty, an option-looking
+    token, a URL, or a ``..`` traversal) is refused outright so that a
+    resource-looking name cannot traverse out of the jar namespace.
+
+    ``..`` is checked after folding ``\\`` to ``/``: a backslash is an ordinary
+    filename character on POSIX but a separator on Windows, so ``..\\..\\etc`` has
+    to be rejected on both.
+
+    :param model_path: the model argument as supplied by the caller
+    :param context: label used in the security-violation message
+    :raises ValueError: if the value is empty, option-like, a URL, or traverses
+    :raises PermissionError: if it is a filesystem path outside the data roots
+    """
+    text = _as_path_text(model_path, context)
+    _reject_bad_name_syntax(text, context)
+
+    # Only a real filesystem path is sandboxed; a bare resource name is not a
+    # path. A bare name is deliberately NOT probed against the CWD: doing so made
+    # the default `malt_temp.mco` resolve to whatever happened to sit in the
+    # user's directory, which is exactly what older NLTK versions left there.
+    has_directory = bool(os.path.dirname(text.replace("\\", "/")))
+    if os.path.isabs(text) or (has_directory and os.path.exists(text)):
+        validate_path(text, context=context)
+        _reject_aliased_or_special(text, context)
+    return text
+
+
+def _reject_aliased_or_special(text, context, check_links=False):
+    """Physical checks on a path that already passed :func:`validate_path`.
+
+    A FIFO, socket or device planted in a data root would block the reader
+    forever, so only regular files and directories are accepted. Directories stay
+    legal, since corpora are passed as directories.
+
+    ``check_links`` additionally refuses a hardlinked file. ``realpath()`` cannot
+    see a hardlink, so an in-root alias of an outside file passes every
+    name-based check and the tool would overwrite the original. This is only
+    applied to paths the tool *writes*: for a read it is not an escalation (the
+    link can only be created by someone who can already write to the data root),
+    and rejecting ``st_nlink > 1`` outright would refuse ordinary
+    hardlink-deduplicated data such as ``cp -l`` or ``rsync --link-dest`` trees,
+    including the original file.
+
+    A path that does not exist yet (an output file) has nothing to check.
+    """
+    try:
+        info = os.stat(text)
+    except OSError:
+        return
+    if check_links and stat.S_ISREG(info.st_mode) and info.st_nlink > 1:
+        raise PermissionError(
+            f"Security Violation [{context}]: {text!r} has {info.st_nlink} hard "
+            "links, so writing it may overwrite a file outside the trusted NLTK "
+            "data roots."
+        )
+    if not (stat.S_ISREG(info.st_mode) or stat.S_ISDIR(info.st_mode)):
+        raise PermissionError(
+            f"Security Violation [{context}]: {text!r} is not a regular file or "
+            "directory; reading it could block indefinitely."
+        )
+
+
+def validate_tool_path(
+    path_input, context="NLTK tool", *, for_write=False, must_exist=True
+):
+    """Bound a filesystem path handed to an external tool to read or write.
+
+    Unlike :func:`validate_model_resource` this never accepts a bare resource
+    name: the value must be a real path inside the NLTK data roots. Use it for
+    arguments a tool opens directly, where an unbounded value is an arbitrary
+    file read and, for a write destination, an arbitrary file write.
+
+    :func:`validate_path` alone is not enough for these sinks, because it only
+    answers "does this NAME resolve inside a root". This additionally:
+
+    * runs the shared name checks (empty, NUL, control characters, option-shaped,
+      URL, ``~``, UNC, ``..``, NTFS stream, drive-relative, Windows device);
+    * refuses a hardlinked write target, whose inode may live outside the root;
+    * opens an existing path with ``O_NOFOLLOW|O_NONBLOCK`` and requires a
+      *regular* file with ``st_nlink == 1``, then re-validates the descriptor's
+      own kernel path, so a symlink or an intermediate directory swapped in after
+      the name check is refused (CWE-59);
+    * refuses a FIFO, socket, device or directory, whose open would block forever
+      or stream unbounded data (CWE-400).
+
+    A path-taking sink can never be fully race-free, since the callee re-resolves
+    the name, but every attack that does not require winning that race is
+    refused.
+
+    The resolved string is RETURNED and callers must build their argv from it:
+    ``__fspath__`` may answer differently on every call, so re-reading the
+    original would let the tool open a file the guard never saw.
+
+    :param path_input: the path about to be handed to the tool
+    :param context: diagnostic context for the raised error
+    :param for_write: True when the tool will write the path, which additionally
+        refuses a hardlinked file that could alias a target outside the roots
+    :param must_exist: when False a non-existent path is accepted after the
+        containment check, for a destination the tool will create
+    :raises ValueError: if the value is empty, option-like, a URL or traverses
+    :raises PermissionError: if the path is not usable safely
+    """
+    if isinstance(path_input, int):
+        return path_input
+    text = _as_path_text(path_input, context, error=PermissionError)
+    _reject_bad_name_syntax(text, context, error=PermissionError)
+    _reject_url_shaped(text, context)
+    validate_path(text, context=context)
+    _reject_aliased_or_special(text, context, check_links=for_write)
+    _reject_unsafe_open(text, context, must_exist)
+    return text
+
+
+def _reject_unsafe_open(raw, context, must_exist):
+    """Open-time hardening for a path already bounded by :func:`validate_path`.
+
+    Closes the window between the name check and the tool's own open: an
+    intermediate directory or the leaf itself may be swapped for a symlink in
+    between, which no name-based check can see.
+    """
+    if not ENFORCE:
+        return
+    if os.name != "posix":
+        # No O_NOFOLLOW/fstat here, so the symlink-swap race stays open on
+        # Windows, but a stat still refuses a directory or device.
+        try:
+            st = os.stat(raw)
+        except FileNotFoundError:
+            if must_exist:
+                raise
+            return
+        if not stat.S_ISREG(st.st_mode):
+            raise PermissionError(
+                f"Security Violation [{context}]: model path {raw!r} is not a "
+                "regular file"
+            )
+        return
+
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_NONBLOCK", 0)
+        | getattr(os, "O_CLOEXEC", 0)
+    )
+    try:
+        fd = os.open(raw, flags)
+    except FileNotFoundError:
+        if must_exist:
+            raise
+        return
+    except NotADirectoryError:
+        if must_exist:
+            raise
+        return
+    except OSError as e:
+        # Only the errnos the hardening flags produce are a security refusal;
+        # anything else (ENAMETOOLONG, EACCES, ...) is a plain OS error.
+        if e.errno in _REFUSING_ERRNOS:
+            raise PermissionError(
+                f"Security Violation [{context}]: refusing model path {raw!r}: "
+                f"{e.strerror} (symlink or non-regular file, CWE-59)"
+            ) from e
+        raise
+    try:
+        st = os.fstat(fd)
+        if not stat.S_ISREG(st.st_mode):
+            raise PermissionError(
+                f"Security Violation [{context}]: model path {raw!r} is not a "
+                "regular file (a FIFO/socket/device/directory can block the "
+                "loader forever or stream unbounded data, CWE-400)"
+            )
+        if st.st_nlink > 1:
+            raise PermissionError(
+                f"Security Violation [{context}]: refusing multiply-linked model "
+                f"{raw!r} (st_nlink={st.st_nlink}); a hardlink names an inode that "
+                "may live outside the sandbox (CWE-59)"
+            )
+        actual = _fd_realpath(fd)
+        validate_path(
+            actual if actual is not None else os.path.realpath(raw), context=context
+        )
+    finally:
+        os.close(fd)
+
+
+def validate_tool_dir(path_input, context="NLTK tool"):
+    """Validate a *directory* a tool or NLTK itself will write model files into.
+
+    The file-shaped checks in :func:`validate_tool_path` do not apply (the leaf
+    is a directory, and it may not exist yet), but the string-shaped ones do: a
+    blank or NUL-bearing destination silently becomes a directory in the current
+    working directory rather than anything the caller meant.
+    """
+    raw = _as_path_string(path_input)
+    if not raw or not raw.strip():
+        raise PermissionError(
+            f"Security Violation [{context}]: blank destination directory {raw!r}"
+        )
+    if "\x00" in raw:
+        raise PermissionError(
+            f"Security Violation [{context}]: NUL byte in destination {raw!r}"
+        )
+    _reject_url_shaped(raw, context)
+    validate_path(raw, context=context)
+    # Returned for the same reason as validate_tool_path: the caller must build
+    # from the checked string, not re-read a value that can resolve differently.
+    return raw
+
+
+def open_package_resource(
+    path, package_root, context="NLTK package data", mode="r", **kwargs
+):
+    """Open a file that ships INSIDE the installed package.
+
+    Package metadata such as ``VERSION`` lives beside the code, never in an
+    NLTK data root, so :func:`validate_path` refuses it and the caller is left
+    with a bare ``open``. This is not an exemption from the rule: containment is
+    still enforced, just against the package directory instead of the data
+    roots, and the same physical checks apply, so a symlink or a non-regular
+    file planted at the name is refused.
+
+    *package_root* is itself constrained to the installed NLTK package. Without
+    that this helper is a general arbitrary-read primitive: a caller passing
+    ``package_root="/"`` could read any file on the machine through it, which
+    would hand out exactly the sandbox bypass the rest of this module exists to
+    prevent.
+
+    :param path: the file to open, expected to live under *package_root*
+    :param package_root: the directory it must stay inside, itself required to
+        be within the installed NLTK package
+    :param context: label used in the security-violation message
+    :raises PermissionError: if *package_root* is outside the installed package,
+        if the path escapes it, or if it is not a plain file
+    """
+    text = _as_path_text(path, context, error=PermissionError)
+    _reject_bad_name_syntax(text, context, error=PermissionError)
+    root = Path(_as_path_text(package_root, context, error=PermissionError)).resolve()
+    # The root is caller-supplied, so bound IT too: this helper opens resources
+    # that ship inside NLTK, nothing else.
+    installed_package = Path(__file__).resolve().parent
+    if not (root == installed_package or root.is_relative_to(installed_package)):
+        raise PermissionError(
+            f"Security Violation [{context}]: package root {str(root)!r} is "
+            f"outside the installed NLTK package {str(installed_package)!r}."
+        )
+    try:
+        target = Path(text).resolve()
+    except (OSError, ValueError) as exc:
+        raise PermissionError(
+            f"Security Violation [{context}]: {text!r} is not resolvable."
+        ) from exc
+    if not (target == root or target.is_relative_to(root)):
+        raise PermissionError(
+            f"Security Violation [{context}]: {text!r} escapes the package "
+            f"directory {str(root)!r}."
+        )
+    _reject_aliased_or_special(str(target), context)
+    return builtins.open(target, mode, **kwargs)
+
+
 def _zip_member_is_unsafe(name_str):
     """True if a ZIP member is written somewhere other than where it is validated.
 
@@ -282,6 +791,7 @@ def validate_zip_archive(
                 _member_count_guard()(
                     len(members), getattr(zf, "filename", None) or "<archive>"
                 )
+                _reject_colliding_members(members)
             for name in members:
                 name_str = name.filename if hasattr(name, "filename") else str(name)
                 if "\0" in name_str:
@@ -304,7 +814,11 @@ def validate_zip_archive(
         if isinstance(zip_obj_or_path, zipfile.ZipFile):
             _audit(zip_obj_or_path)
         else:
-            with zipfile.ZipFile(zip_obj_or_path, "r") as zf:
+            # ZipFile here is pathsec's own subclass, not the stdlib one: its
+            # __init__ validates the path and applies the member-count guard,
+            # and it does NOT call back into this function, so there is no
+            # recursion. That makes the archive path checked before it is read.
+            with ZipFile(zip_obj_or_path, "r") as zf:
                 _audit(zf)
     except (PermissionError, ValueError):
         raise
@@ -749,13 +1263,15 @@ def _hardened_open(raw_path, mode, context, required_root, **kwargs):
     temp dir is not left group-/world-readable (CWE-377/378). POSIX only;
     callers fall back to :func:`builtins.open` elsewhere.
     """
-    import errno
-
     flags = (
         _os_open_flags(mode)
         | getattr(os, "O_NOFOLLOW", 0)
         | getattr(os, "O_CLOEXEC", 0)
     )
+    # Defer O_TRUNC until after the hardlink/realpath checks: truncating at open
+    # time would zero a hardlinked outside-root target before st_nlink refuses it.
+    truncate_after = bool(flags & os.O_TRUNC)
+    flags &= ~os.O_TRUNC
     try:
         # 0o600 is only consulted when O_CREAT is in flags (write/append/x modes).
         fd = os.open(raw_path, flags, 0o600)
@@ -782,6 +1298,9 @@ def _hardened_open(raw_path, mode, context, required_root, **kwargs):
             context=context,
             required_root=required_root,
         )
+        # Safe now: the fd is confirmed single-linked and inside the root.
+        if truncate_after:
+            os.ftruncate(fd, 0)
     except BaseException:
         os.close(fd)
         raise
@@ -867,6 +1386,13 @@ def _member_count_guard():
     return _check_zip_member_count
 
 
+def _total_size_guard():
+    """Deferred import of the aggregate-decompression-bomb check (see above)."""
+    from nltk.data import _check_zip_total_size
+
+    return _check_zip_total_size
+
+
 class _BoundedZipExtFile(io.RawIOBase):
     """Wraps zipfile's streaming member reader and refuses a decompression bomb
     (CWE-409) as the member is consumed: it accumulates the ACTUAL decompressed
@@ -936,17 +1462,91 @@ class ZipFile(zipfile.ZipFile):
         # Refuse a central-directory bomb here, the earliest point the entry count
         # is known, so no consumer pays to list, validate or extract its members.
         if getattr(self, "mode", "r") == "r":
-            _member_count_guard()(
-                len(self.filelist), getattr(self, "filename", None) or "<archive>"
-            )
+            archive_name = getattr(self, "filename", None) or "<archive>"
+            _member_count_guard()(len(self.filelist), archive_name)
+            _total_size_guard()(self.filelist, archive_name)
 
     def extract(self, member, path=None, pwd=None):
         validate_zip_archive(self, path or os.getcwd(), specific_member=member)
+        self._extract_root = os.path.abspath(path or os.getcwd())
         return super().extract(member, path, pwd)
 
     def extractall(self, path=None, members=None, pwd=None):
         validate_zip_archive(self, path or os.getcwd())
+        self._extract_root = os.path.abspath(path or os.getcwd())
         super().extractall(path, members, pwd)
+
+    def _extract_member(self, member, targetpath, pwd):
+        """Write each member by walking its path with O_NOFOLLOW at every step.
+
+        validate_zip_archive resolves each member and refuses one that escapes,
+        but between that resolution and the write there is a TOCTOU window: a
+        local attacker who can write inside the extraction root can swap a
+        DIRECTORY component for a symlink pointing outside, and the stdlib
+        extractor's plain ``open(targetpath, "wb")`` follows it. O_NOFOLLOW on the
+        leaf alone does not help, since it only guards the final component.
+
+        So the target is opened relative to the extraction root by walking each
+        component with ``openat(dir_fd, name, O_NOFOLLOW | O_DIRECTORY)``: a
+        symlink swapped in at any component fails with ELOOP instead of being
+        followed, and the leaf is created with O_EXCL so a raced or pre-planted
+        file/symlink at the target is refused too. On a platform without dir_fd
+        support this falls back to the stdlib extractor.
+        """
+        import shutil as _shutil
+
+        if (
+            getattr(member, "filename", None) is None
+            or member.is_dir()
+            or os.open not in os.supports_dir_fd
+            or not getattr(os, "O_NOFOLLOW", 0)
+        ):
+            return super()._extract_member(member, targetpath, pwd)
+
+        # _extract_root is set by extract()/extractall(); when _extract_member is
+        # called directly, anchor at the target's parent.
+        root = getattr(self, "_extract_root", None) or os.path.dirname(targetpath)
+        rel = os.path.relpath(os.path.normpath(targetpath), os.path.normpath(root))
+        parts = [p for p in rel.split(os.sep) if p not in ("", os.curdir)]
+        if not parts or os.pardir in parts:
+            raise PermissionError(
+                f"Security Violation [pathsec.ZipFile]: refusing member path "
+                f"{rel!r}"
+            )
+        *dirs, leaf = parts
+
+        dir_fd = os.open(root, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+        try:
+            for component in dirs:
+                try:
+                    os.mkdir(component, 0o755, dir_fd=dir_fd)
+                except FileExistsError:
+                    pass
+                nxt = os.open(
+                    component,
+                    os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_DIRECTORY", 0),
+                    dir_fd=dir_fd,
+                )
+                os.close(dir_fd)
+                dir_fd = nxt
+            flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW
+            try:
+                leaf_fd = os.open(leaf, flags, 0o644, dir_fd=dir_fd)
+            except FileExistsError:
+                info = os.lstat(leaf, dir_fd=dir_fd)
+                if not stat.S_ISREG(info.st_mode):
+                    raise PermissionError(
+                        f"Security Violation [pathsec.ZipFile]: refusing to "
+                        f"extract onto non-regular file {leaf!r}"
+                    )
+                leaf_fd = os.open(
+                    leaf, os.O_WRONLY | os.O_TRUNC | os.O_NOFOLLOW, dir_fd=dir_fd
+                )
+        finally:
+            os.close(dir_fd)
+        with os.fdopen(leaf_fd, "wb") as sink, self.open(member, pwd=pwd) as source:
+            _shutil.copyfileobj(source, sink)
+        return targetpath
 
     def read(self, name, pwd=None):
         # Not the raw one-shot super().read() (bounded only by the attacker-declared
@@ -978,6 +1578,10 @@ class ZipFile(zipfile.ZipFile):
 
 __all__ = [
     "validate_path",
+    "validate_model_resource",
+    "validate_tool_path",
+    "validate_tool_dir",
+    "open_package_resource",
     "validate_network_url",
     "validate_zip_archive",
     "open",

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -339,30 +339,18 @@ def _reject_colliding_members(members):
 
 
 def _reject_url_shaped(raw, context):
-    """Refuse a URL where a model path is expected.
+    """Refuse a URL where a filesystem path is expected.
 
     ``validate_path`` rewrites a ``file:`` URL to its path component before
     checking it, but the caller still holds (and the tool still opens) the
-    original string. A model path is never a URL, so refusing the whole shape
-    here removes that validate-one-thing/open-another gap outright.
+    original string. A filesystem path is never a URL, so refusing the whole
+    shape here removes that validate-one-thing/open-another gap outright.
     """
     if _URL_SCHEME_RE.match(raw) or _FILE_SCHEME_RE.match(raw):
         raise PermissionError(
-            f"Security Violation [{context}]: {raw!r} is a URL, not a model "
+            f"Security Violation [{context}]: {raw!r} is a URL, not a filesystem "
             "path; the tool would open it verbatim as a relative path"
         )
-
-
-def _as_path_string(path_input):
-    """Normalise a path-ish argument to the exact string a sink would use.
-
-    Mirrors :func:`validate_path`: a ``PathPointer`` exposes ``.path``, bytes are
-    decoded with the filesystem encoding, everything else goes through ``str``.
-    """
-    raw = path_input.path if hasattr(path_input, "path") else path_input
-    if isinstance(raw, bytes):
-        return os.fsdecode(raw)
-    return raw if isinstance(raw, str) else str(raw)
 
 
 def _as_path_text(value, context, error=ValueError):
@@ -624,8 +612,7 @@ def _reject_unsafe_open(raw, context, must_exist):
             return
         if not stat.S_ISREG(st.st_mode):
             raise PermissionError(
-                f"Security Violation [{context}]: model path {raw!r} is not a "
-                "regular file"
+                f"Security Violation [{context}]: path {raw!r} is not a " "regular file"
             )
         return
 
@@ -650,7 +637,7 @@ def _reject_unsafe_open(raw, context, must_exist):
         # anything else (ENAMETOOLONG, EACCES, ...) is a plain OS error.
         if e.errno in _REFUSING_ERRNOS:
             raise PermissionError(
-                f"Security Violation [{context}]: refusing model path {raw!r}: "
+                f"Security Violation [{context}]: refusing path {raw!r}: "
                 f"{e.strerror} (symlink or non-regular file, CWE-59)"
             ) from e
         raise
@@ -658,13 +645,13 @@ def _reject_unsafe_open(raw, context, must_exist):
         st = os.fstat(fd)
         if not stat.S_ISREG(st.st_mode):
             raise PermissionError(
-                f"Security Violation [{context}]: model path {raw!r} is not a "
+                f"Security Violation [{context}]: path {raw!r} is not a "
                 "regular file (a FIFO/socket/device/directory can block the "
                 "loader forever or stream unbounded data, CWE-400)"
             )
         if st.st_nlink > 1:
             raise PermissionError(
-                f"Security Violation [{context}]: refusing multiply-linked model "
+                f"Security Violation [{context}]: refusing multiply-linked file "
                 f"{raw!r} (st_nlink={st.st_nlink}); a hardlink names an inode that "
                 "may live outside the sandbox (CWE-59)"
             )
@@ -679,25 +666,21 @@ def _reject_unsafe_open(raw, context, must_exist):
 def validate_tool_dir(path_input, context="NLTK tool"):
     """Validate a *directory* a tool or NLTK itself will write model files into.
 
-    The file-shaped checks in :func:`validate_tool_path` do not apply (the leaf
-    is a directory, and it may not exist yet), but the string-shaped ones do: a
-    blank or NUL-bearing destination silently becomes a directory in the current
-    working directory rather than anything the caller meant.
+    The file-shaped physical checks in :func:`validate_tool_path` do not apply
+    (the leaf is a directory and may not exist yet), but the string-shaped ones
+    do. It shares :func:`_as_path_text` and :func:`_reject_bad_name_syntax` with
+    that guard, so a caller value resolves to a plain ``str`` exactly once (a
+    frozen ``__fspath__``, never a re-read one) and the same name refusals (blank,
+    NUL, option-shaped, URL, ``..``, NTFS stream, drive-relative, Windows device)
+    run before containment.
     """
-    raw = _as_path_string(path_input)
-    if not raw or not raw.strip():
-        raise PermissionError(
-            f"Security Violation [{context}]: blank destination directory {raw!r}"
-        )
-    if "\x00" in raw:
-        raise PermissionError(
-            f"Security Violation [{context}]: NUL byte in destination {raw!r}"
-        )
-    _reject_url_shaped(raw, context)
-    validate_path(raw, context=context)
+    text = _as_path_text(path_input, context, error=PermissionError)
+    _reject_bad_name_syntax(text, context, error=PermissionError)
+    _reject_url_shaped(text, context)
+    validate_path(text, context=context)
     # Returned for the same reason as validate_tool_path: the caller must build
     # from the checked string, not re-read a value that can resolve differently.
-    return raw
+    return text
 
 
 def open_package_resource(

--- a/nltk/test/unit/conftest.py
+++ b/nltk/test/unit/conftest.py
@@ -45,7 +45,9 @@ def _enforce_single_root(monkeypatch):
     """Turn ENFORCE on, restrict the allowed roots to one fresh data root, and
     invalidate the cached roots. Returns the data-root path. monkeypatch restores
     every mutated global at teardown."""
-    data_root = tempfile.mkdtemp(prefix="nltk_sandbox_root_")
+    # realpath folds an 8.3 short component (a Windows runner's temp under
+    # RUNNER~1) to long form, so an in-root path clears the short-name guard.
+    data_root = os.path.realpath(tempfile.mkdtemp(prefix="nltk_sandbox_root_"))
     monkeypatch.setattr(pathsec, "ENFORCE", True)
     monkeypatch.setattr(nltk.data, "path", [data_root])
     monkeypatch.setattr(pathsec, "_ALLOWED_ROOTS_CACHE", None, raising=False)

--- a/nltk/test/unit/test_package_resource_guard.py
+++ b/nltk/test/unit/test_package_resource_guard.py
@@ -1,0 +1,122 @@
+# Natural Language Toolkit: package-resource opener
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""``pathsec.open_package_resource`` must not become a general read primitive.
+
+It exists for one narrow case: files that ship INSIDE the installed package,
+such as ``VERSION``, which sit beside the code and are never in an NLTK data
+root, so :func:`validate_path` refuses them.
+
+That makes it a second containment rule rather than an exemption from the
+first, and the danger is obvious once stated: it takes the root to contain
+against as an argument. A caller passing ``package_root="/"`` would turn it into
+"read any file on the machine", which is exactly the bypass the rest of pathsec
+exists to prevent, and it is exported, so any caller could do it. The root is
+therefore itself bounded to the installed package.
+"""
+
+import os
+import pathlib
+import tempfile
+
+import pytest
+
+import nltk
+from nltk.pathsec import open_package_resource
+
+_PACKAGE = pathlib.Path(nltk.__file__).resolve().parent
+
+
+@pytest.fixture
+def outside_secret():
+    base = pathlib.Path(
+        tempfile.mkdtemp(prefix=".nltk_pkgres_", dir=str(pathlib.Path.home()))
+    )
+    secret = base / "SECRET"
+    secret.write_text("TOP-SECRET")
+    try:
+        yield secret
+    finally:
+        import shutil
+
+        shutil.rmtree(base, ignore_errors=True)
+
+
+@pytest.mark.parametrize(
+    "root",
+    ["/", "/etc", os.path.join(str(_PACKAGE), ".."), str(pathlib.Path.home())],
+    ids=["filesystem-root", "etc", "package-parent", "home"],
+)
+def test_a_caller_chosen_root_outside_the_package_is_refused(root):
+    """The regression this file exists for: an unbounded root read anything."""
+    with pytest.raises((PermissionError, ValueError)):
+        open_package_resource("/etc/passwd", root, context="test")
+
+
+def test_the_secret_is_not_readable_through_any_root(outside_secret):
+    for root in ("/", str(outside_secret.parent), str(pathlib.Path.home())):
+        with pytest.raises((PermissionError, ValueError)):
+            open_package_resource(str(outside_secret), root, context="test")
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/etc/passwd",
+        os.path.join(str(_PACKAGE), "..", "..", "etc", "passwd"),
+        os.path.join(str(_PACKAGE), "..", "setup.py"),
+    ],
+    ids=["absolute", "traversal", "parent-file"],
+)
+def test_paths_escaping_the_package_are_refused(path):
+    """Even with a legitimate root, the path itself may not climb out."""
+    with pytest.raises((PermissionError, ValueError)):
+        open_package_resource(path, str(_PACKAGE), context="test")
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="requires symlinks")
+def test_a_symlink_planted_in_the_package_is_refused(outside_secret):
+    """Containment resolves symlinks, so a link inside the package that points
+    out of it does not become a read primitive either."""
+    link = _PACKAGE / "_pkgres_test_link"
+    try:
+        os.symlink(str(outside_secret), link)
+    except OSError:  # pragma: no cover - read-only install
+        pytest.skip("cannot write into the installed package")
+    try:
+        with pytest.raises((PermissionError, ValueError)):
+            open_package_resource(str(link), str(_PACKAGE), context="test")
+    finally:
+        if link.is_symlink():
+            link.unlink()
+
+
+@pytest.mark.parametrize("payload", ["", "   ", "VERSION\x00.evil", "-VERSION", "~/x"])
+def test_malformed_resource_names_are_refused(payload):
+    with pytest.raises((PermissionError, ValueError)):
+        open_package_resource(payload, str(_PACKAGE), context="test")
+
+
+def test_the_legitimate_case_still_works():
+    """Over-block control, and the reason the helper exists at all."""
+    version_file = _PACKAGE / "VERSION"
+    if not version_file.exists():
+        pytest.skip("no VERSION file in this checkout")
+    with open_package_resource(
+        str(version_file), str(_PACKAGE), context="test"
+    ) as handle:
+        assert handle.read().strip()
+
+
+def test_nltk_version_is_populated():
+    """The guard must not break __version__, which reads VERSION at import.
+
+    A previous attempt used plain pathsec.open here; the data-root check refused
+    the package directory and __version__ silently became an error string.
+    """
+    assert nltk.__version__
+    assert "Security Violation" not in nltk.__version__
+    assert nltk.__version__[0].isdigit()

--- a/nltk/test/unit/test_pathsec_tool_resources.py
+++ b/nltk/test/unit/test_pathsec_tool_resources.py
@@ -30,6 +30,7 @@ import pytest
 
 from nltk.pathsec import (
     validate_model_resource,
+    validate_path,
     validate_tool_dir,
     validate_tool_path,
 )
@@ -127,3 +128,69 @@ def test_validate_model_resource_refuses_an_absolute_outside_path(sandbox):
 def test_validate_model_resource_refuses_option_traversal_and_url(bad):
     with pytest.raises((PermissionError, ValueError)):
         validate_model_resource(bad, context="test")
+
+
+# Review regression locks: the URL-scheme bypass (GHSA-8mgp) and the hardlink
+# alias (CWE-59 / GHSA-f794) must stay refused; reworded messages must not weaken them.
+
+
+@pytest.mark.parametrize(
+    "evil",
+    [
+        "http://../../../../etc/passwd",
+        "https://../../../../etc/passwd",
+        "ftp://../../etc/passwd",
+        "HTTP://../../etc/passwd",
+        "  http://../../etc/passwd",
+        "file:///etc/passwd",
+        "file://../../etc/passwd",
+    ],
+)
+def test_validate_path_rejects_url_scheme_traversal(restricted_sandbox, evil):
+    """GHSA-8mgp-746c-j5xp: a scheme prefix must never authorize a kernel
+    traversal. validate_path once returned (authorized) for any '://' http/https/
+    ftp string, but 'http://..' is the directory 'http:' then '..', escaping every
+    allowed root. restricted_sandbox pins ENFORCE on so the refusal is exercised.
+    """
+    with pytest.raises((ValueError, PermissionError)):
+        validate_path(evil, context="test")
+
+
+@pytest.mark.parametrize(
+    "guard", [validate_model_resource, validate_tool_path, validate_tool_dir]
+)
+@pytest.mark.parametrize(
+    "evil",
+    [
+        "http://../../etc/passwd",
+        "https://evil/x",
+        "ftp://evil/x",
+        "file:///etc",
+        "HTTP://evil/x",
+    ],
+)
+def test_all_caller_guards_reject_url_shapes(guard, evil):
+    """Every caller-supplied guard refuses a URL shape whatever the error wording:
+    the value is never a filesystem path and the tool would open it verbatim as a
+    relative path. Locks the shared URL rejection after the message rewording."""
+    with pytest.raises((ValueError, PermissionError)):
+        guard(evil, context="test")
+
+
+@pytest.mark.skipif(
+    os.name != "posix", reason="the st_nlink hardlink guard is POSIX-only"
+)
+def test_validate_tool_path_refuses_a_hardlinked_file(restricted_sandbox):
+    """CWE-59 / GHSA-f794 class: a hardlink names an inode that may live outside
+    the roots, so a multiply-linked in-root file is refused for a read (the
+    open-time st_nlink>1 guard) and a write (the aliased-write guard). Removing
+    either check would resurface the hardlink-overwrite bypass."""
+    real = os.path.join(restricted_sandbox, "real.bin")
+    with open(real, "w", encoding="utf-8") as handle:
+        handle.write("weights")
+    alias = os.path.join(restricted_sandbox, "alias.bin")
+    os.link(real, alias)
+    with pytest.raises(PermissionError):
+        validate_tool_path(alias, context="test")
+    with pytest.raises(PermissionError):
+        validate_tool_path(alias, context="test", for_write=True)

--- a/nltk/test/unit/test_pathsec_tool_resources.py
+++ b/nltk/test/unit/test_pathsec_tool_resources.py
@@ -1,0 +1,129 @@
+# Natural Language Toolkit: pathsec tool/resource guard tests
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""Focused tests for the four caller-supplied path guards in :mod:`nltk.pathsec`.
+
+These guards bound the values NLTK hands to external tools (Stanford, MaltParser,
+CRF) and reads from the installed package:
+
+* :func:`validate_tool_dir` bounds a directory a tool writes model files into.
+* :func:`validate_tool_path` bounds a single file a tool opens to read or write.
+* :func:`validate_model_resource` bounds a value that may be a real path OR a
+  jar-internal resource name.
+
+Refusals of blank, NUL and URL-shaped values are checked directly, since they
+raise before any containment check. Containment (outside a data root, a ``..``
+traversal) is checked through the shared ``sandbox`` / ``restricted_sandbox``
+fixtures in ``nltk/test/unit/conftest.py``, which turn enforcement on and pin
+``nltk.data.path`` to one throwaway data root. That matters for portability: on
+Linux ``tempfile.mkdtemp()`` lands under world-writable ``/tmp``, which pathsec
+refuses to trust, so a fixture that registers its own root is the only way these
+containment tests pass on Linux, macOS and Windows alike.
+"""
+
+import os
+
+import pytest
+
+from nltk.pathsec import (
+    validate_model_resource,
+    validate_tool_dir,
+    validate_tool_path,
+)
+
+# validate_tool_dir
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\t"])
+def test_validate_tool_dir_refuses_blank_destination(blank):
+    """A blank destination silently becomes a directory in the working dir."""
+    with pytest.raises(PermissionError):
+        validate_tool_dir(blank, context="test")
+
+
+def test_validate_tool_dir_refuses_nul_byte():
+    with pytest.raises(PermissionError):
+        validate_tool_dir("models\x00evil", context="test")
+
+
+@pytest.mark.parametrize(
+    "url", ["http://evil/dir", "https://evil/dir", "ftp://evil/dir", "file:///etc"]
+)
+def test_validate_tool_dir_refuses_url_shaped(url):
+    with pytest.raises(PermissionError):
+        validate_tool_dir(url, context="test")
+
+
+def test_validate_tool_dir_refuses_a_directory_outside_the_roots(sandbox):
+    with pytest.raises((PermissionError, ValueError)):
+        validate_tool_dir(str(sandbox), context="test")
+
+
+def test_validate_tool_dir_refuses_a_traversal_out_of_the_root(restricted_sandbox):
+    escape = os.path.join(restricted_sandbox, "..", "..", "etc")
+    with pytest.raises((PermissionError, ValueError)):
+        validate_tool_dir(escape, context="test")
+
+
+def test_validate_tool_dir_allows_a_directory_inside_the_root(restricted_sandbox):
+    """Over-block control: a destination inside a data root is returned as-is,
+    and it need not exist yet (a tool creates it)."""
+    dest = os.path.join(restricted_sandbox, "model_out")
+    assert validate_tool_dir(dest, context="test") == dest
+
+
+# validate_tool_path
+
+
+def test_validate_tool_path_allows_an_in_root_file(restricted_sandbox):
+    target = os.path.join(restricted_sandbox, "model.bin")
+    with open(target, "w", encoding="utf-8") as handle:
+        handle.write("weights")
+    assert validate_tool_path(target, context="test") == target
+
+
+def test_validate_tool_path_refuses_an_outside_file(sandbox):
+    target = sandbox / "model.bin"
+    target.write_text("weights")
+    with pytest.raises((PermissionError, ValueError)):
+        validate_tool_path(str(target), context="test")
+
+
+def test_validate_tool_path_accepts_a_nonexistent_write_target_in_root(
+    restricted_sandbox,
+):
+    dest = os.path.join(restricted_sandbox, "new_model.bin")
+    assert validate_tool_path(dest, context="test", must_exist=False) == dest
+
+
+@pytest.mark.parametrize("bad", ["-loadClassifier", "../escape", "ok\x00.bin"])
+def test_validate_tool_path_refuses_option_traversal_and_nul(bad):
+    with pytest.raises((PermissionError, ValueError)):
+        validate_tool_path(bad, context="test")
+
+
+# validate_model_resource
+
+
+@pytest.mark.parametrize(
+    "resource",
+    ["edu/stanford/nlp/models/lexparser/englishPCFG.ser.gz", "englishPCFG.ser.gz"],
+)
+def test_validate_model_resource_passes_bare_resource_names(resource):
+    """A jar-internal resource name is neither absolute nor an existing file, so
+    it is left untouched rather than bounded to a data root."""
+    assert validate_model_resource(resource, context="test") == resource
+
+
+def test_validate_model_resource_refuses_an_absolute_outside_path(sandbox):
+    with pytest.raises((PermissionError, ValueError)):
+        validate_model_resource("/etc/passwd", context="test")
+
+
+@pytest.mark.parametrize("bad", ["-props", "../../etc/passwd", "http://evil/model"])
+def test_validate_model_resource_refuses_option_traversal_and_url(bad):
+    with pytest.raises((PermissionError, ValueError)):
+        validate_model_resource(bad, context="test")

--- a/nltk/test/unit/test_windows_path_syntax_gaps.py
+++ b/nltk/test/unit/test_windows_path_syntax_gaps.py
@@ -6,9 +6,10 @@
 
 """Windows path forms that name a different file than they appear to.
 
-These only matter under Windows semantics, so every case is run with ``os.name``
-and ``os.path`` swapped for Windows' -- a Linux CI run then covers the Windows
-behaviour, which no single-platform test can. Security research on this class
+These only matter under Windows semantics, so ``_verdict`` runs each case with
+``os.name`` set to ``nt`` and the syntax-relevant ``os.path`` hooks (``altsep``,
+``splitdrive``) swapped for Windows', so a Linux or macOS CI run covers the
+Windows behaviour that no single-platform test can. Security research on this class
 (``\\?\\`` extended-length, ``\\.\\`` device namespace, ``CONIN$``/``CONOUT$``
 console devices, 8.3 short names like ``PROGRA~1``) drove the additions here.
 

--- a/nltk/test/unit/test_windows_path_syntax_gaps.py
+++ b/nltk/test/unit/test_windows_path_syntax_gaps.py
@@ -19,6 +19,7 @@ through the alias just as a final one does.
 
 import ntpath
 import os
+import posixpath
 
 import pytest
 
@@ -30,6 +31,9 @@ def _verdict(guard, value, windows=True):
     if windows:
         os.name = "nt"
         os.path.altsep, os.path.splitdrive = ntpath.altsep, ntpath.splitdrive
+    else:
+        os.name = "posix"
+        os.path.altsep, os.path.splitdrive = posixpath.altsep, posixpath.splitdrive
     try:
         guard(value, context="test")
         return "allowed"

--- a/nltk/test/unit/test_windows_path_syntax_gaps.py
+++ b/nltk/test/unit/test_windows_path_syntax_gaps.py
@@ -1,0 +1,97 @@
+# Natural Language Toolkit: Windows-specific path-syntax gaps
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""Windows path forms that name a different file than they appear to.
+
+These only matter under Windows semantics, so every case is run with ``os.name``
+and ``os.path`` swapped for Windows' -- a Linux CI run then covers the Windows
+behaviour, which no single-platform test can. Security research on this class
+(``\\?\\`` extended-length, ``\\.\\`` device namespace, ``CONIN$``/``CONOUT$``
+console devices, 8.3 short names like ``PROGRA~1``) drove the additions here.
+
+The 8.3 and device checks run on EVERY path component, not just the last: a
+short name or a device in a middle segment (``dir/PROGRA~1/x``) traverses
+through the alias just as a final one does.
+"""
+
+import ntpath
+import os
+
+import pytest
+
+from nltk.pathsec import validate_model_resource, validate_tool_path
+
+
+def _verdict(guard, value, windows=True):
+    saved = (os.name, os.path.altsep, os.path.splitdrive)
+    if windows:
+        os.name = "nt"
+        os.path.altsep, os.path.splitdrive = ntpath.altsep, ntpath.splitdrive
+    try:
+        guard(value, context="test")
+        return "allowed"
+    except (PermissionError, ValueError):
+        return "blocked"
+    finally:
+        os.name, os.path.altsep, os.path.splitdrive = saved
+
+
+_WINDOWS_HOSTILE = [
+    "\\\\?\\C:\\Windows\\x",
+    "\\\\?\\UNC\\server\\share\\x",
+    "\\\\.\\C:\\x",
+    "\\\\.\\PhysicalDrive0",
+    "CONIN$",
+    "CONOUT$",
+    "PROGRA~1",
+    "EVILFI~1.EXE",
+    "dir/PROGRA~1/x",
+    "a/CON/b",
+    "x/CONIN$/y",
+    "model.ser.gz::$DATA",
+    "model.ser.gz:hidden",
+    "C:model.mco",
+    "\\model",
+    "model.mco.",
+    "model.mco ",
+    "CON",
+    "NUL",
+    "COM1",
+    "LPT1",
+    "AUX",
+    "PRN",
+]
+
+
+@pytest.mark.parametrize("value", _WINDOWS_HOSTILE)
+def test_hostile_windows_forms_are_refused_by_both_guards(value):
+    assert _verdict(validate_model_resource, value) == "blocked", value
+    assert _verdict(validate_tool_path, value) == "blocked", value
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "model~backup.mco",
+        "file~.txt",
+        "CONTEXT.mco",
+        "console.gz",
+        "edu/stanford/x.ser.gz",
+    ],
+)
+def test_lookalikes_are_still_allowed(value):
+    """Over-block control. A '~' without a trailing digit is not an 8.3 name, and
+    a name that merely starts like a device (CONTEXT, console) is a real file."""
+    assert _verdict(validate_model_resource, value) == "allowed", value
+
+
+@pytest.mark.parametrize(
+    "value", ["CON", "NUL", "CONIN$", "PROGRA~1", "dir/EVILFI~1/x"]
+)
+def test_these_are_ordinary_filenames_on_posix(value):
+    """The whole point of the os.name guard: on POSIX these are legal filenames
+    and refusing them would break real usage."""
+    assert _verdict(validate_model_resource, value, windows=False) == "allowed", value


### PR DESCRIPTION
This is a self-contained split from the larger GHSA-8mgp-746c-j5xp hardening effort. It carries only `nltk/pathsec.py` and a minimal set of tests for four caller-supplied path guards, so it can be reviewed and merged on its own.

## What pathsec.py adds

`nltk.pathsec` is the centralized I/O security sentinel: it decides whether a caller-supplied path may be opened, and against which roots. This PR brings four guards used at the boundary where NLTK hands a value to an external tool or reads a file that ships inside the package.

- **`validate_model_resource`** bounds a value that may be *either* a real filesystem path or a jar-internal classpath resource (the Stanford wrappers accept both for `-model`). A bare resource name such as `edu/stanford/nlp/models/lexparser/englishPCFG.ser.gz` is left untouched; a real filesystem path is contained to the NLTK data roots; and an option-shaped token, a URL, or a `..` traversal is refused outright, so a resource-looking name cannot climb out of the jar namespace.
- **`validate_tool_path`** bounds a single file a tool opens to read or write. Beyond name containment it opens an existing path with `O_NOFOLLOW` and requires a regular, single-link file, then re-validates the descriptor's own kernel path. That closes the swap-after-check symlink race (CWE-59) and refuses a FIFO, socket, device, or directory whose open would block forever or stream unbounded data (CWE-400). The resolved string is returned so the caller builds its argv from the exact value that was checked.
- **`validate_tool_dir`** bounds a *directory* a tool writes model files into. A blank, whitespace-only, NUL-bearing, or URL-shaped destination would silently become a directory in the current working directory; each is refused, and the destination is then contained to the data roots.
- **`open_package_resource`** opens files that ship inside the installed package (`VERSION` and friends), which live beside the code and never in a data root. It contains both the path *and* the caller-supplied package root to the installed NLTK package, so it cannot be turned into an arbitrary-read primitive by passing `package_root="/"`.

Together these refuse path traversal, CWD-relative binary hijack, jar-internal resource escape, and arbitrary file reads through a caller-supplied root.

## Tests included

- `nltk/test/unit/test_windows_path_syntax_gaps.py` (moved as-is) exercises `validate_model_resource` and `validate_tool_path` against Windows-only path forms that name a different file than they appear to (reserved device names, 8.3 short names, `\\?\` extended-length and `\\.\` device-namespace prefixes, NTFS `::$DATA` streams, drive-relative and trailing dot/space spellings), driven under emulated Windows semantics so a single-platform CI run still covers them, plus POSIX and lookalike over-block controls.
- `nltk/test/unit/test_package_resource_guard.py` (moved, trimmed) pins `open_package_resource`: a caller-chosen root outside the package is refused, paths escaping the package are refused, a planted symlink is refused, malformed resource names are refused, and the legitimate `VERSION` read still works. The unrelated `validate_path(required_root=...)` class from the source file was dropped to keep this split scoped to the four functions.
- `nltk/test/unit/test_pathsec_tool_resources.py` (new, focused) covers `validate_tool_dir`, `validate_tool_path`, and `validate_model_resource`: blank/NUL/URL refusals, outside-root and traversal refusals, and in-root over-block controls. Containment tests use the shared `sandbox` / `restricted_sandbox` fixtures from `nltk/test/unit/conftest.py`, which register their own throwaway data root, so they pass on Linux, macOS, and Windows rather than depending on the system temp dir being a trusted root.

All three files pass under `pytest -p no:randomly`.