### PR TITLE
Refuse CWD-relative matches for bare names in find_file/find_dir (CWE-427)

### DIFF
--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -924,11 +924,48 @@ def find_file_iter(
         raise LookupError(f"\n\n{div}\n{msg}\n{div}")
 
 
+def _reject_cwd_relative_bare_match(filename, matches, kind):
+    """Filter out an untrusted CWD-relative match for a bare tool name.
+
+    ``find_file_iter`` probes the current working directory for a bare
+    ``filename`` before the configured env vars / searchpath, so a planted
+    ``./<name>`` or ``./<name>/<name>`` is returned first and, because a returned
+    relative path is later run or loaded relative to the CWD, an attacker who can
+    write to the CWD chooses the tool (CWE-426 / CWE-427). ``find_binary``
+    already refuses this; ``find_file`` / ``find_dir`` did not.
+
+    Only a *bare* name (no directory component) is filtered, and only when the
+    match is not absolute: a caller who passed ``tools/maltparser`` or an
+    absolute path made an explicit choice and is honoured. An env var or
+    searchpath hit is absolute, so it survives.
+    """
+    if os.path.dirname(filename) != "":
+        yield from matches
+        return
+    found_untrusted = False
+    for match in matches:
+        if not os.path.isabs(match):
+            found_untrusted = True
+            continue
+        yield match
+    if found_untrusted:
+        raise LookupError(
+            f"NLTK found {kind} {filename!r} only in the current working "
+            "directory, which is not a trusted location. Install it on a "
+            "configured search path, set the relevant environment variable, or "
+            "pass an absolute path."
+        )
+
+
 def find_file(
     filename, env_vars=(), searchpath=(), file_names=None, url=None, verbose=False
 ):
     return next(
-        find_file_iter(filename, env_vars, searchpath, file_names, url, verbose)
+        _reject_cwd_relative_bare_match(
+            filename,
+            find_file_iter(filename, env_vars, searchpath, file_names, url, verbose),
+            "file",
+        )
     )
 
 
@@ -936,8 +973,18 @@ def find_dir(
     filename, env_vars=(), searchpath=(), file_names=None, url=None, verbose=False
 ):
     return next(
-        find_file_iter(
-            filename, env_vars, searchpath, file_names, url, verbose, finding_dir=True
+        _reject_cwd_relative_bare_match(
+            filename,
+            find_file_iter(
+                filename,
+                env_vars,
+                searchpath,
+                file_names,
+                url,
+                verbose,
+                finding_dir=True,
+            ),
+            "directory",
         )
     )
 

--- a/nltk/test/unit/test_find_file_cwd_hardening.py
+++ b/nltk/test/unit/test_find_file_cwd_hardening.py
@@ -1,0 +1,79 @@
+# Natural Language Toolkit: find_file / find_dir CWD hardening
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""find_file / find_dir must not return a CWD-relative match for a bare name.
+
+find_file_iter probes the current working directory for a bare filename before
+the configured env vars and searchpath, so an attacker who can write to the CWD
+could plant a model, corpus dir or tool there and have NLTK pick it up
+(CWE-426 / CWE-427, issue #3624). find_binary already refused this; find_file
+and find_dir did not, so a bare find_file("maltparser") returned "maltparser"
+resolving against the CWD.
+
+Only a bare name is filtered, and only when the match is not absolute: an
+explicit path with a directory component, an absolute path, and an env-var /
+searchpath hit (which are absolute) all survive.
+"""
+
+import os
+import shutil
+import tempfile
+
+import pytest
+
+from nltk.internals import find_dir, find_file
+
+
+@pytest.fixture
+def hostile_cwd():
+    base = tempfile.mkdtemp(prefix=".nltk_cwd_", dir=os.path.expanduser("~"))
+    for name in ("maltparser", "evil.mco"):
+        with open(os.path.join(base, name), "w") as handle:
+            handle.write("x")
+    os.makedirs(os.path.join(base, "evildir"))
+    with open(os.path.join(base, "evildir", "x"), "w") as handle:
+        handle.write("y")
+    saved = os.getcwd()
+    os.chdir(base)
+    try:
+        yield base
+    finally:
+        os.chdir(saved)
+        shutil.rmtree(base, ignore_errors=True)
+
+
+@pytest.mark.parametrize("name", ["maltparser", "evil.mco"])
+def test_find_file_refuses_a_cwd_planted_bare_name(hostile_cwd, name):
+    with pytest.raises(LookupError):
+        find_file(name)
+
+
+def test_find_dir_refuses_a_cwd_planted_bare_name(hostile_cwd):
+    with pytest.raises(LookupError):
+        find_dir("evildir")
+
+
+def test_an_explicit_relative_path_is_still_honoured(hostile_cwd):
+    """A directory component means the caller chose it deliberately."""
+    assert find_file("evildir/x") == "evildir/x"
+
+
+def test_an_absolute_path_is_still_honoured(hostile_cwd):
+    absolute = os.path.join(hostile_cwd, "maltparser")
+    assert find_file(absolute) == absolute
+
+
+def test_an_env_var_match_survives_the_filter(hostile_cwd, monkeypatch):
+    """The legitimate discovery path: env var -> absolute -> allowed. A file of
+    the same bare name in the CWD must not shadow it."""
+    target_dir = os.path.join(hostile_cwd, "real")
+    os.makedirs(target_dir)
+    with open(os.path.join(target_dir, "maltparser"), "w") as handle:
+        handle.write("real")
+    monkeypatch.setenv("MALT_PARSER", target_dir)
+    found = find_file("maltparser", env_vars=("MALT_PARSER",))
+    assert os.path.isabs(found)
+    assert found.startswith(target_dir)


### PR DESCRIPTION
## What changed

`nltk.internals.find_file_iter` probes the current working directory for a bare
`filename` before consulting the configured environment variables and
searchpath. Because a returned bare relative path is later run or loaded
relative to the CWD, a match found only in the CWD lets an attacker who can
write to that directory choose the tool, model, or corpus directory that NLTK
picks up (CWE-426 untrusted search path / CWE-427 uncontrolled search element).
`find_binary` already refused a CWD-relative bare match; `find_file` and
`find_dir` did not, so e.g. `find_file("maltparser")` returned `"maltparser"`
resolving against the CWD.

This adds `_reject_cwd_relative_bare_match`, applied by `find_file` and
`find_dir`:

- When the requested name has **no directory component**, any non-absolute
  (CWD-relative) match is dropped, and if that was the only kind of match a
  `LookupError` is raised with guidance to install on a search path, set the
  env var, or pass an absolute path.
- A name **with** a directory component (`tools/maltparser`), an **absolute**
  path, and **env-var / searchpath** hits (which resolve to absolute paths) all
  survive, so legitimate discovery is unaffected.

## Vulnerability class

CWE-426 / CWE-427 binary/resource hijack via the current working directory for
bare tool/resource names.

## Tests

New `nltk/test/unit/test_find_file_cwd_hardening.py`:

- refuses a CWD-planted bare name for `find_file` and `find_dir`;
- an env-var match survives the filter and is not shadowed by a same-named file
  in the CWD;
- an explicit relative path (with a directory component) and an absolute path
  are still honoured.

Three of these fail on `develop` without the fix and pass with it; the rest
guard against regressing legitimate discovery.

## Cross-platform

Fixtures are staged under `$HOME` (not `/tmp`), and `find_file`/`find_dir` do
not route through the pathsec sandbox, so no data-root registration is needed on
any OS. Assertions are either `LookupError` expectations (OS-agnostic) or
identity / `startswith` comparisons against strings constructed the same way
they are returned, so there are no POSIX-only resolved-string assumptions. The
bare-name hijack case is constructed with a bare name (no path separators) and
is refused on Linux, macOS, and Windows alike.

## Scope

Self-contained split from the larger GHSA-8mgp hardening effort, limited to the
`nltk/internals.py` `find_file`/`find_dir` change and its focused tests. It
imports nothing beyond what `develop` already ships and does not modify
`nltk/test/internals.doctest`.