### PR TITLE
Sanitize SFM markers in ToolboxData

### DIFF
--- a/nltk/test/unit/test_toolbox_xss.py
+++ b/nltk/test/unit/test_toolbox_xss.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from xml.etree.ElementTree import tostring
+
+import nltk.pathsec
+from nltk.corpus.reader.toolbox import ToolboxCorpusReader
+
+
+def test_toolbox_xss_mitigation():
+    malicious_corpus = r"""\_sh v3.0  400  Rotokas Dictionary
+\lx kaa
+\script globalThis.XSS=1337;
+\123_invalid_start
+"""
+    with TemporaryDirectory() as d:
+        root = Path(d)
+        corpus_path = root / "malicious.txt"
+        corpus_path.write_text(malicious_corpus, encoding="utf-8")
+
+        # Register temporary root with pathsec so the corpus reader accepts it
+        nltk.data.path.append(str(root))
+
+        try:
+            reader = ToolboxCorpusReader(str(root), ["malicious.txt"])
+            xml_tree = reader.xml(["malicious.txt"])
+            xml_str = tostring(xml_tree).decode("utf-8")
+
+            # Validate hazardous HTML tags are neutralized with a safe prefix
+            assert "<script>" not in xml_str
+            assert "<tb_script>" in xml_str
+            assert "globalThis.XSS=1337;" in xml_str
+
+            # Validate XML compliance (tags cannot start with numbers)
+            assert "<123_invalid_start>" not in xml_str
+            assert "<_123_invalid_start" in xml_str
+        finally:
+            if str(root) in nltk.data.path:
+                nltk.data.path.remove(str(root))

--- a/nltk/toolbox.py
+++ b/nltk/toolbox.py
@@ -145,6 +145,20 @@ class StandardFormat:
             pass
 
 
+def _sanitize_marker(mkr):
+    if not mkr:
+        return "empty"
+    # Replace non-word characters with underscores, preserving letters, numbers, hyphens, and dots
+    safe = re.sub(r"[^\w\-.]", "_", mkr)
+    # XML element names cannot start with a digit, hyphen, or dot
+    if re.match(r"^[\d\-.]", safe):
+        safe = "_" + safe
+    # Mitigate HTML element injection for web viewers / XSS
+    if safe.lower() in {"script", "style", "iframe", "object", "embed", "link", "meta"}:
+        safe = "tb_" + safe
+    return safe
+
+
 class ToolboxData(StandardFormat):
     def parse(self, grammar=None, **kwargs):
         if grammar:
@@ -209,18 +223,19 @@ class ToolboxData(StandardFormat):
         builder.start("header", {})
         in_records = False
         for mkr, value in self.fields(**kwargs):
-            if key is None and not in_records and mkr[0] != "_":
-                key = mkr
-            if mkr == key:
+            safe_mkr = _sanitize_marker(mkr)
+            if key is None and not in_records and safe_mkr[0] != "_":
+                key = safe_mkr
+            if safe_mkr == key:
                 if in_records:
                     builder.end("record")
                 else:
                     builder.end("header")
                     in_records = True
                 builder.start("record", {})
-            builder.start(mkr, {})
+            builder.start(safe_mkr, {})
             builder.data(value)
-            builder.end(mkr)
+            builder.end(safe_mkr)
         if in_records:
             builder.end("record")
         else:
@@ -348,23 +363,23 @@ class ToolboxSettings(StandardFormat):
         """
         builder = TreeBuilder()
         for mkr, value in self.fields(encoding=encoding, errors=errors, **kwargs):
-            # Check whether the first char of the field marker
-            # indicates a block start (+) or end (-)
-            block = mkr[0]
+            block = mkr[0] if mkr else None
             if block in ("+", "-"):
                 mkr = mkr[1:]
             else:
                 block = None
-            # Build tree on the basis of block char
+
+            safe_mkr = _sanitize_marker(mkr)
+
             if block == "+":
-                builder.start(mkr, {})
+                builder.start(safe_mkr, {})
                 builder.data(value)
             elif block == "-":
-                builder.end(mkr)
+                builder.end(safe_mkr)
             else:
-                builder.start(mkr, {})
+                builder.start(safe_mkr, {})
                 builder.data(value)
-                builder.end(mkr)
+                builder.end(safe_mkr)
         return builder.close()
 
 

--- a/nltk/toolbox.py
+++ b/nltk/toolbox.py
@@ -223,19 +223,23 @@ class ToolboxData(StandardFormat):
         builder.start("header", {})
         in_records = False
         for mkr, value in self.fields(**kwargs):
-            safe_mkr = _sanitize_marker(mkr)
-            if key is None and not in_records and safe_mkr[0] != "_":
-                key = safe_mkr
-            if safe_mkr == key:
+            # 1. Structural Logic: Use the ORIGINAL `mkr` and `key`
+            if key is None and not in_records and mkr and mkr[0] != "_":
+                key = mkr
+            if mkr == key:
                 if in_records:
                     builder.end("record")
                 else:
                     builder.end("header")
                     in_records = True
                 builder.start("record", {})
+
+            # 2. Emission Logic: Use `safe_mkr` STRICTLY for XML tags
+            safe_mkr = _sanitize_marker(mkr)
             builder.start(safe_mkr, {})
             builder.data(value)
             builder.end(safe_mkr)
+
         if in_records:
             builder.end("record")
         else:


### PR DESCRIPTION
#### Overview

This pull request resolves **CVE-2026-14718** by implementing strict marker name sanitization in `ToolboxData` before constructing XML element trees, preventing attackers from injecting arbitrary or executable markup (such as `<script>` tags) via Standard Format Marker (SFM) corpora.

This fixes one of the 20 remaining vulnerabilities in https://github.com/nltk/nltk/issues/3793.

#### Root Cause

`ToolboxCorpusReader.xml()` parses SFM records into an ElementTree via `ToolboxData._record_parse()`, which historically used marker strings directly as XML element tags (`builder.start(mkr, {})`). Because attacker-controlled corpora could supply arbitrary markers (e.g., `\script`), NLTK converted them into real markup elements in the returned XML tree, leading to stored cross-site scripting (XSS) if serialized and rendered in web-based notebook previews, dashboards, or review interfaces.

#### Changes Made

* Added a robust `_sanitize_marker()` helper function in `nltk/toolbox.py` that:
* Replaces non-alphanumeric characters (except dots and hyphens) with underscores.
* Ensures XML element names do not start with a digit, dot, or hyphen.
* Prefixes hazardous HTML tag names (`script`, `style`, `iframe`, `object`, `embed`, `link`, `meta`) with `tb_` to neutralize downstream browser-side execution.


* Updated `ToolboxData._record_parse()` and settings parsers to sanitize marker names before passing them to `TreeBuilder`.
* Added a dedicated unit test suite under `nltk/test/unit/` (`test_toolbox_xss.py`) verifying proper marker sanitization and XML compliance.