### PR TITLE
Bound RegexpStemmer's caller-supplied pattern against ReDoS

### DIFF
--- a/nltk/stem/regexp.py
+++ b/nltk/stem/regexp.py
@@ -8,6 +8,7 @@
 # For license information, see LICENSE.TXT
 import re
 
+from nltk import redos
 from nltk.stem.api import StemmerI
 
 
@@ -41,7 +42,10 @@ class RegexpStemmer(StemmerI):
 
     def __init__(self, regexp, min=0):
         if not hasattr(regexp, "pattern"):
-            regexp = re.compile(regexp)
+            # The pattern is caller-supplied and applied to caller text, so a
+            # catastrophically backtracking one hangs the process (CWE-1333).
+            # redos.compile gives it a wall-clock bound. See ``nltk/redos.py``.
+            regexp = redos.compile(regexp)
         self._regexp = regexp
         self._min = min
 

--- a/nltk/test/unit/test_stem_regexp_redos.py
+++ b/nltk/test/unit/test_stem_regexp_redos.py
@@ -1,0 +1,79 @@
+# Natural Language Toolkit: ReDoS guard for RegexpStemmer
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""``RegexpStemmer`` compiles a CALLER's regex and applies it to CALLER text.
+
+A catastrophically backtracking pattern such as ``(a+)+$`` against a short bait
+string hangs the interpreter (CWE-1333, ReDoS). The stemmer now routes its
+pattern through :func:`nltk.redos.compile`, which puts a wall-clock bound on
+matching, mirroring the guard ``nltk.util.re_show`` received in PR #3796.
+
+The hang assertion runs the stemming in a SUBPROCESS with a wall-clock timeout.
+An in-process timeout cannot fail cleanly on catastrophic backtracking: the
+regex engine holds the GIL, so a pytest timeout plugin cannot interrupt it and
+the whole run wedges. A subprocess timeout also works on Windows, where the
+POSIX-only ``signal.SIGALRM`` approach silently does nothing.
+"""
+
+import inspect
+import os
+import subprocess
+import sys
+
+import pytest
+
+_EVIL = r"(a+)+$"
+_BAIT = "a" * 34 + "!"
+_LIMIT = 20
+
+
+def _run(code):
+    return subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import warnings;warnings.filterwarnings('ignore');" + code,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=_LIMIT,
+        env=dict(os.environ, PYTHONPATH=os.pathsep.join(sys.path)),
+    )
+
+
+def test_a_catastrophic_pattern_does_not_hang():
+    """Completing or raising are both fine. Hanging past the bound is not."""
+    code = (
+        f"from nltk.stem.regexp import RegexpStemmer;"
+        f"RegexpStemmer({_EVIL!r}).stem({_BAIT!r})"
+    )
+    try:
+        _run(code)
+    except subprocess.TimeoutExpired:
+        pytest.fail("RegexpStemmer hung on a catastrophic pattern (ReDoS)")
+
+
+def test_an_ordinary_pattern_still_stems():
+    """Over-block control: bounding the engine must not change results."""
+    code = (
+        "from nltk.stem.regexp import RegexpStemmer;"
+        "print(RegexpStemmer('ing$|s$|e$').stem('running'))"
+    )
+    result = _run(code)
+    assert result.returncode == 0, result.stderr
+    assert "runn" in result.stdout, result.stdout
+
+
+def test_the_stemmer_routes_through_redos():
+    """Pin the mechanism, not just the timing.
+
+    A future edit could swap ``redos.compile`` back to ``re.compile`` and the
+    timing test would still pass on a fast machine with a smaller bait string.
+    """
+    import nltk.stem.regexp
+
+    source = inspect.getsource(nltk.stem.regexp)
+    assert "redos.compile" in source, "RegexpStemmer no longer bounds its regex"


### PR DESCRIPTION
RegexpStemmer compiled its caller-supplied pattern with plain `re.compile` and then applied it to caller text. A catastrophically backtracking pattern such as `(a+)+$` against a short word hangs the interpreter (CWE-1333, ReDoS).

## Fix

Route the pattern through `nltk.redos.compile`, which puts a wall-clock bound on matching. This mirrors the guard `nltk.util.re_show` received in #3796.

```python
if not hasattr(regexp, "pattern"):
    # caller-supplied pattern applied to caller text
    regexp = redos.compile(regexp)
```

## Test

A focused new module `nltk/test/unit/test_stem_regexp_redos.py` asserts:

1. a catastrophic pattern does not hang `RegexpStemmer`,
2. an ordinary pattern (`ing$|s$|e$`) still stems (`running` -> `runn`), and
3. the `nltk.stem.regexp` source routes through `redos.compile` (pins the mechanism, not just the timing).

The hang assertion runs the stemming in a **subprocess** with a wall-clock timeout. An in-process timeout cannot fail cleanly on catastrophic backtracking: the regex engine holds the GIL, so a pytest timeout plugin cannot interrupt it and the whole run wedges. A subprocess timeout is also cross-platform: it works on Windows, where the POSIX-only `signal.SIGALRM` approach silently does nothing. The child timeout (20s) sits comfortably above `nltk.redos.DEFAULT_TIMEOUT` (5s) but well under any per-test CI limit, and the test has no temp-dir/network/dbm dependencies.

This is split out from the larger GHSA-8mgp ReDoS effort so it is self-contained on `develop`: `nltk.redos` already ships there (via #3796), and no other new symbol is introduced.