### PR TITLE
Deserialize chat80 shelve values through the restricted unpickler (RCE fix)

### DIFF
--- a/nltk/sem/chat80.py
+++ b/nltk/sem/chat80.py
@@ -123,6 +123,7 @@ current directory.
 
 """
 
+import io
 import os
 import re
 import shelve
@@ -131,6 +132,57 @@ import sys
 import nltk.data
 from nltk.pathsec import open as pathsec_open
 from nltk.pathsec import validate_path
+from nltk.picklesec import RestrictedUnpickler
+
+
+def _restricted_shelve_open(db, flag="r"):
+    """Open a shelf whose values are read with a RESTRICTED unpickler.
+
+    ``shelve`` unpickles each stored value with the default, unrestricted
+    ``pickle.Unpickler``, so a ``.db`` file whose value bytes are a crafted
+    pickle gadget runs arbitrary code when read back, even though the file
+    PATH was validated (validate_path checks where the file is, not what is in
+    it). Chat-80 valuations are only sets and tuples of strings, which need no
+    globals, so :class:`nltk.picklesec.RestrictedUnpickler` (which blocks every
+    global while allowing plain containers) loads legitimate data and refuses
+    the gadget.
+    """
+    inner = shelve.open(db, flag)
+
+    class _RestrictedShelf:
+        """Delegates to a real shelf but reads values with RestrictedUnpickler.
+
+        Valuation() iterates the shelf as (key, value) pairs, which resolves
+        __getitem__ on the TYPE, so overriding it on an instance of shelve.Shelf
+        would not take effect. A wrapper whose own __getitem__ does the
+        restricted load is used instead.
+        """
+
+        def __iter__(self):
+            return iter(inner)
+
+        def keys(self):
+            return inner.keys()
+
+        def __len__(self):
+            return len(inner)
+
+        def __contains__(self, key):
+            return key in inner
+
+        def __getitem__(self, key):
+            raw = inner.dict[key.encode(inner.keyencoding)]
+            return RestrictedUnpickler(io.BytesIO(raw)).load()
+
+        def items(self):
+            for key in inner:
+                yield key, self[key]
+
+        def close(self):
+            inner.close()
+
+    return _RestrictedShelf()
+
 
 ###########################################################################
 # Chat-80 relation metadata bundles needed to build the valuation
@@ -647,10 +699,10 @@ def val_load(db):
     if not os.access(dbname, os.R_OK):
         sys.exit("Cannot read file: %s" % dbname)
     else:
-        db_in = shelve.open(db)
+        db_in = _restricted_shelve_open(db)
         from nltk.sem import Valuation
 
-        val = Valuation(db_in)
+        val = Valuation(db_in.items())
         #        val.read(db_in.items())
         return val
 

--- a/nltk/test/unit/test_chat80_shelve_rce.py
+++ b/nltk/test/unit/test_chat80_shelve_rce.py
@@ -1,0 +1,136 @@
+# Natural Language Toolkit: chat80 shelve deserialization
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""chat80.val_load must not run a pickle gadget from a hostile shelf.
+
+shelve unpickles each stored value with the default, unrestricted
+pickle.Unpickler. Validating the .db PATH (which chat80 does) checks WHERE the
+file is, not WHAT is in it, so a shelf whose value bytes are a crafted gadget
+ran arbitrary code when val_load read it back. The values are now read through
+nltk.picklesec.RestrictedUnpickler, which blocks every global while still
+loading the plain containers that real chat80 valuations use.
+
+Every shelf here is created and reopened through shelve.open(base), so the tests
+run on whatever dbm backend the platform selects (dbm.gnu, dbm.ndbm,
+dbm.sqlite3 or dbm.dumb) and never assume a particular on-disk filename.
+"""
+
+import os
+import pickle
+import shelve
+
+import pytest
+
+from nltk import pathsec
+
+
+class _Gadget:
+    """A value whose pickle references a module global (os.system).
+
+    RestrictedUnpickler refuses it at find_class before the reduce is applied;
+    the stock unpickler would instead run the command and create the marker.
+    """
+
+    def __init__(self, marker):
+        self._marker = marker
+
+    def __reduce__(self):
+        return (os.system, (f"touch {self._marker}",))
+
+
+def _make_shelf(base, values):
+    with shelve.open(base, "n") as shelf:
+        shelf.update(values)
+
+
+def _gate_shelf(base):
+    """Satisfy val_load's os.access(base + '.db') gate on any dbm backend.
+
+    Several backends name the file differently (dbm.gnu writes ``base``,
+    dbm.dumb writes ``base.dir`` / ``base.dat``), so hard-link the real backend
+    file to ``base + '.db'`` rather than assuming a suffix. Return the shelf keys
+    if the shelf still reopens on this backend, else None so the caller can skip.
+    """
+    gate = base + ".db"
+    try:
+        if not os.path.exists(gate):
+            directory, name = os.path.split(base)
+            for entry in sorted(os.listdir(directory or ".")):
+                full = os.path.join(directory, entry)
+                if (
+                    entry.startswith(name)
+                    and not entry.endswith(".db")
+                    and os.path.isfile(full)
+                ):
+                    os.link(full, gate)
+                    break
+        with shelve.open(base, "r") as shelf:
+            return set(shelf.keys())
+    except Exception:
+        return None
+
+
+def test_restricted_shelf_refuses_a_gadget_value(tmp_path):
+    """Core invariant: a value whose pickle needs a global is refused, not run."""
+    from nltk.sem.chat80 import _restricted_shelve_open
+
+    base = os.fspath(tmp_path / "hostile")
+    marker = os.fspath(tmp_path / "PWNED")
+    _make_shelf(base, {"ok": {("chile", "argentina")}, "bad": _Gadget(marker)})
+
+    restricted = _restricted_shelve_open(base)
+    try:
+        assert restricted["ok"] == {("chile", "argentina")}
+        with pytest.raises(pickle.UnpicklingError):
+            _ = restricted["bad"]
+    finally:
+        restricted.close()
+    assert not os.path.exists(marker), "reading the shelf executed a pickle gadget"
+
+
+def test_restricted_shelf_round_trips_benign_valuations(tmp_path):
+    """Over-block control: chat80 valuations are sets and tuples of strings,
+    which the restricted unpickler must still load."""
+    from nltk.sem.chat80 import _restricted_shelve_open
+
+    base = os.fspath(tmp_path / "good")
+    values = {
+        "adjacent": {("chile", "argentina"), ("uk", "france")},
+        "size": {("uk", "244820")},
+    }
+    _make_shelf(base, values)
+
+    restricted = _restricted_shelve_open(base)
+    try:
+        assert sorted(restricted.keys()) == ["adjacent", "size"]
+        assert restricted["adjacent"] == {("chile", "argentina"), ("uk", "france")}
+        assert dict(restricted.items()) == values
+    finally:
+        restricted.close()
+
+
+def test_val_load_end_to_end_does_not_execute_gadget(tmp_path, monkeypatch):
+    """val_load (path gate, restricted read and Valuation wiring) must refuse a
+    gadget rather than run it. Skips only on a backend whose files cannot satisfy
+    val_load's '.db' gate here; the invariant still holds via the direct tests.
+    """
+    monkeypatch.setattr(pathsec, "ENFORCE", False)
+    monkeypatch.setattr(pathsec, "_ALLOWED_ROOTS_CACHE", None, raising=False)
+    monkeypatch.setattr(pathsec, "_LAST_DATA_PATHS", None, raising=False)
+    from nltk.sem import chat80
+
+    base = os.fspath(tmp_path / "hostile")
+    marker = os.fspath(tmp_path / "PWNED")
+    _make_shelf(base, {"bad": _Gadget(marker)})
+
+    keys = _gate_shelf(base)
+    if keys is None or "bad" not in keys:
+        pytest.skip("dbm backend cannot satisfy val_load's .db gate portably here")
+
+    with pytest.raises(pickle.UnpicklingError):
+        valuation = chat80.val_load(base)
+        list(valuation.items())
+    assert not os.path.exists(marker), "chat80.val_load executed a pickle gadget"


### PR DESCRIPTION
## Vulnerability

`nltk.sem.chat80.val_load` loaded its persistent valuation with `shelve.open()`. `shelve` reads every stored value with the default, unrestricted `pickle.Unpickler`, so a `.db` file whose value bytes are a crafted pickle gadget executes arbitrary code the moment `val_load` reads it back.

`val_load` already validates the `.db` path, but `validate_path` only checks WHERE the file is, not WHAT is inside it. A hostile shelf planted inside the data sandbox (for example shipped in a data package) therefore still ran on load.

## Fix

Add `_restricted_shelve_open()`, which wraps the real shelf in a `_RestrictedShelf` whose `__getitem__` deserializes the raw value bytes through `nltk.picklesec.RestrictedUnpickler` (which forbids every global at `find_class`). Chat-80 valuations are only sets and tuples of strings, which need no globals, so legitimate data still loads while the gadget is refused. `val_load` now reads its values through this wrapper (`Valuation(db_in.items())`).

`RestrictedUnpickler` is already on `develop` (merged via #3794), so this change is self-contained.

## Tests

`nltk/test/unit/test_chat80_shelve_rce.py`:

- `test_restricted_shelf_refuses_a_gadget_value` -- a value whose pickle references a module global raises `UnpicklingError` on read and never executes.
- `test_restricted_shelf_round_trips_benign_valuations` -- over-block control: sets and tuples of strings still load.
- `test_val_load_end_to_end_does_not_execute_gadget` -- drives `val_load` itself (path gate, restricted read and `Valuation` wiring).

### Cross-platform dbm handling

`shelve` sits on `dbm`, whose backend and on-disk filenames differ by platform (`dbm.gnu`, `dbm.ndbm`, `dbm.sqlite3`, `dbm.dumb`; a base path may become `base`, `base.db`, or `base.dir` / `base.dat`). Every shelf is created and reopened with `shelve.open(base)` so the tests run on whatever backend the platform selects, and no test hardcodes a `.db` suffix or a specific backend. The end-to-end test hard-links the real backend file to the `base + '.db'` name that `val_load`'s `os.access` gate expects and skips only if a backend cannot be gated portably, so the core invariant is always asserted on every OS.

Self-contained split from the larger GHSA-8mgp-746c-j5xp hardening effort.