### PR TITLE
Harden the VERSION read in nltk package init with pathsec.open_package_resource

### DIFF
--- a/nltk/__init__.py
+++ b/nltk/__init__.py
@@ -32,7 +32,13 @@ import sys
 try:
     # If a VERSION file exists, use it!
     version_file = os.path.join(os.path.dirname(__file__), "VERSION")
-    with open(version_file) as infile:
+    from nltk.pathsec import open_package_resource
+
+    # Not an exemption: containment is enforced against the installed package
+    # directory, since VERSION ships beside the code and never in a data root.
+    with open_package_resource(
+        version_file, os.path.dirname(__file__), context="nltk.__version__"
+    ) as infile:
         __version__ = infile.read().strip()
 except NameError:
     __version__ = "unknown (running code interactively?)"

--- a/nltk/test/unit/test_init_exposure.py
+++ b/nltk/test/unit/test_init_exposure.py
@@ -1,0 +1,30 @@
+# Natural Language Toolkit: package-init import smoke test
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""Import-time smoke test for the hardened VERSION read in ``nltk/__init__``.
+
+The package initializer now reads its ``VERSION`` file through
+``nltk.pathsec.open_package_resource`` instead of a bare ``open``. That read runs
+at import time, so a wrong root or a too-strict guard would either raise or
+silently turn ``__version__`` into an error string, breaking the whole package.
+"""
+
+import nltk
+
+
+def test_import_nltk_and_version_is_clean():
+    """``import nltk`` must succeed and populate a real version string."""
+    assert nltk.__version__
+    assert "Security Violation" not in nltk.__version__
+    assert "unknown" not in nltk.__version__
+    assert nltk.__version__[0].isdigit()
+
+
+def test_pathsec_open_package_resource_is_reachable():
+    """The initializer depends on this symbol; it must import cleanly."""
+    from nltk.pathsec import open_package_resource
+
+    assert callable(open_package_resource)


### PR DESCRIPTION
## What this changes

`nltk/__init__.py` read its `VERSION` file at import time with a bare `open()`. This routes that read through `nltk.pathsec.open_package_resource`, which enforces containment against the installed package directory. `VERSION` ships beside the code and never lives in an NLTK data root, so `validate_path` refuses it and the caller was previously left with a bare `open`. `open_package_resource` is a second containment rule rather than an exemption from the first: symlinks, non-regular files, and names that escape the package are refused, and the caller-supplied root is itself bounded to the installed package (a caller passing `package_root="/"` would otherwise turn it into an arbitrary-read primitive).

The `__init__` diff is a single, surgical change to the version block. Nothing else in the file changes: no `__all__` entries, no version bump, no unrelated churn.

## Dependency status

The only module referenced is `nltk.pathsec`, and specifically `open_package_resource`, both already present on `develop` (merged in #3797). Nothing here references a module that is not yet on `develop`, so no wiring had to be deferred, and `import nltk` stays healthy on `develop` plus this change.

## Test

Adds a minimal import-time smoke test, `nltk/test/unit/test_init_exposure.py`:

- `import nltk` succeeds and `__version__` is populated, contains no `Security Violation` string, and starts with a digit (proving the hardened read succeeded at import).
- `nltk.pathsec.open_package_resource`, the symbol the initializer now depends on, is importable and callable.

Verified locally: `python3.13 -c "import nltk"` prints `3.10.3`, and the new test file passes (`2 passed`).

## Context

This is a self-contained split from the larger GHSA-8mgp hardening effort, isolated so the package-init change and its smoke test can be reviewed on their own.