### PR TITLE
Harden downloader Package attributes and extraction against traversal/Zip-Slip

### DIFF
--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -161,7 +161,9 @@ default: unzip or not?
 """
 import functools
 import itertools
+import ntpath
 import os
+import posixpath
 import subprocess
 import sys
 import textwrap
@@ -262,8 +264,18 @@ class Package:
         self.name = name or id
         """A string name for this package."""
 
-        # Validate subdir to prevent path traversal from malicious XML index
-        if os.path.isabs(subdir) or ".." in subdir.replace("\\", "/").split("/"):
+        # Validate subdir to prevent path traversal from malicious XML index.
+        # Check absoluteness under both posix and windows rules, plus a drive
+        # prefix: Python 3.13's ntpath.isabs no longer treats a bare "/tmp" as
+        # absolute, so os.path.isabs alone lets a rooted subdir through on Windows.
+        _norm_subdir = subdir.replace("\\", "/")
+        if (
+            os.path.isabs(subdir)
+            or posixpath.isabs(_norm_subdir)
+            or ntpath.isabs(subdir)
+            or ntpath.splitdrive(subdir)[0]
+            or ".." in _norm_subdir.split("/")
+        ):
             raise ValueError(
                 f"Invalid package subdir {subdir!r}: must be a relative path "
                 f"without parent directory references"
@@ -886,6 +898,10 @@ class Downloader:
                 return
 
             try:
+                # The lock lives under the caller-chosen download dir, so bound
+                # it before creating it. O_EXCL already refuses an existing file
+                # or symlink; this stops the path leaving the sandbox at all.
+                validate_path(lock_filepath, context="downloader.lock")
                 fd = os.open(lock_filepath, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
                 os.close(fd)
                 break
@@ -2574,7 +2590,7 @@ def md5_hexdigest(file):
     ``file`` may either be a filename or an open stream.
     """
     if isinstance(file, str):
-        with open(file, "rb") as infile:
+        with pathsec_open(file, "rb", context="downloader.checksum") as infile:
             return _md5_hexdigest(infile)
     return _md5_hexdigest(file)
 
@@ -2595,7 +2611,7 @@ def sha256_hexdigest(file):
     ``file`` may either be a filename or an open stream.
     """
     if isinstance(file, str):
-        with open(file, "rb") as infile:
+        with pathsec_open(file, "rb", context="downloader.checksum") as infile:
             return _sha256_hexdigest(infile)
     return _sha256_hexdigest(file)
 

--- a/nltk/test/unit/test_downloader_package_traversal.py
+++ b/nltk/test/unit/test_downloader_package_traversal.py
@@ -1,0 +1,66 @@
+# Natural Language Toolkit: downloader package-attribute traversal
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""A malicious download index must not write outside the download directory.
+
+CVE-2026-33236: the ``subdir`` and ``id`` attributes in the remote index.xml
+were joined into the install path (``os.path.join(subdir, id + ext)``). A
+``subdir`` of ``../../../../tmp`` or an ``id`` of ``../../evil`` escaped the
+download dir. Both are validated at Package construction now; this pins that a
+crafted index cannot build an escaping filename.
+
+The ``subdir`` check rejects absoluteness under posix and windows rules and a
+bare drive prefix, because Python 3.13's ``ntpath.isabs`` no longer treats a
+rooted ``/tmp`` as absolute and ``os.path.isabs`` sees no drive on posix.
+"""
+
+import os
+
+import pytest
+
+from nltk.downloader import Package
+
+_REQUIRED = dict(url="http://example/x.zip", size=1, unzipped_size=1, checksum="a")
+
+
+@pytest.mark.parametrize(
+    "attributes",
+    [
+        {"id": "x", "subdir": "../../../../tmp"},
+        {"id": "x", "subdir": "/tmp"},
+        {"id": "x", "subdir": "..\\..\\tmp"},
+        {"id": "x", "subdir": "C:\\evil"},
+        {"id": "../../../../tmp/evil", "subdir": "corpora"},
+        {"id": "/tmp/evil", "subdir": "corpora"},
+        {"id": "..\\..\\..\\tmp\\evil", "subdir": "corpora"},
+        {"id": "ok\x00/../evil", "subdir": "corpora"},
+        {"id": "a/b", "subdir": "corpora"},
+    ],
+    ids=[
+        "subdir-traversal",
+        "subdir-absolute",
+        "subdir-backslash",
+        "subdir-drive",
+        "id-traversal",
+        "id-absolute",
+        "id-backslash",
+        "id-nul",
+        "id-with-slash",
+    ],
+)
+def test_malicious_package_attributes_are_refused(attributes):
+    with pytest.raises((PermissionError, ValueError)):
+        Package(**_REQUIRED, **attributes)
+
+
+def test_a_benign_package_builds_a_contained_filename():
+    """Over-block control, and the shape a real index uses."""
+    package = Package(id="punkt", subdir="tokenizers", **_REQUIRED)
+    assert package.filename == os.path.join("tokenizers", "punkt.zip")
+    # the join with any download dir stays inside it
+    download_dir = os.path.join("home", "user", "nltk_data")
+    full = os.path.normpath(os.path.join(download_dir, package.filename))
+    assert full.startswith(os.path.normpath(download_dir))


### PR DESCRIPTION
## Summary

A malicious remote `index.xml` could set a package's `subdir` or `id` to escape the download directory (CVE-2026-33236, a Zip-Slip / path-traversal class). Because both attributes are joined into the install path (`os.path.join(subdir, id + ext)`), a `subdir` of `../../../../tmp`, a rooted `/tmp`, a drive-prefixed `C:\evil`, or an `id` of `../../evil` (or one containing a path separator or NUL) wrote files outside the download dir.

This is a self-contained split from the larger GHSA-8mgp hardening effort, touching only `nltk/downloader.py` and adding one focused test. It depends only on `nltk.pathsec` / `nltk.data` symbols already on `develop`.

## Vulnerability classes addressed

- **Absolute / rooted / drive-letter subdir.** `Package` now rejects a `subdir` that is absolute under posix rules (`posixpath.isabs`), under windows rules (`ntpath.isabs`), or that carries a drive prefix (`ntpath.splitdrive`). Python 3.13's `ntpath.isabs` no longer treats a bare `/tmp` as absolute, so `os.path.isabs` alone let a rooted subdir through on Windows; the posix/windows/drive combination closes that gap on every platform.
- **Parent-reference traversal.** A `subdir` containing `..` in either slash style is rejected, and an `id` containing a path separator, a NUL, or `..` is rejected.
- **Zip-Slip / extraction confinement + integrity.** The download lock path is bounded with `validate_path` before `O_EXCL` creation, and the md5/sha256 integrity helpers read through the pathsec sandbox, so a checksum can no longer be computed over a file outside the download dir.

## Windows-specific fix

The recent change adds `import ntpath` / `import posixpath` and checks absoluteness under both rule sets plus a drive prefix. Without it, `os.path.isabs('/tmp')` returns `False` on Windows under Python 3.13 and a rooted subdir would be accepted.

## Tests

`nltk/test/unit/test_downloader_package_traversal.py` pins that crafted `subdir` / `id` attributes are refused across posix-traversal, windows-backslash, drive-letter, absolute, and NUL forms, while benign relative subdirs (`''`, `tokenizers`, `a/b`) build a contained filename. The refusals hold cross-platform with no platform gating: the drive-letter case is refused via `ntpath` even where `os.path.isabs` is `False`, which is what makes the delta observable outside Windows too.

Verified against `develop` + this `downloader.py` alone; the existing `test_downloader_atomic.py` and `test_downloader_unzip.py` continue to pass unchanged.