### PR TITLE
Harden nltk.xmlsec.parse: read filename sources through pathsec.open

### DIFF
--- a/nltk/test/unit/test_xml_attack_matrix.py
+++ b/nltk/test/unit/test_xml_attack_matrix.py
@@ -1,0 +1,161 @@
+# Natural Language Toolkit: XML attack matrix
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""XML entity attacks against ``nltk.xmlsec``, the parser the readers use.
+
+Several corpus readers parse XML that a user supplies, so the classic entity
+attacks all apply: file disclosure through an external entity, exponential
+expansion, and an external DTD that turns the parser into an SSRF client.
+
+Every case runs against both back ends: ``defusedxml`` when it is installed, and
+the standard-library fallback used when it is not.  The two must agree, because
+either may be the one protecting a given install, and only the fallback exercises
+the pathsec-guarded file read that :func:`nltk.xmlsec.parse` uses for a filename
+source.
+
+The external-DTD case is checked against a REAL listening socket rather than by
+reading the parsed text. A document whose DTD was fetched still parses to the
+same text, so text alone cannot tell "ignored" from "fetched and discarded", and
+the second of those is a live outbound request.
+"""
+
+import importlib
+import os
+import shutil
+import socket
+import sys
+import tempfile
+import threading
+
+import pytest
+
+import nltk.data
+from nltk import pathsec
+
+xmlsec = pytest.importorskip("nltk.xmlsec")
+
+_XXE = (
+    '<?xml version="1.0"?>'
+    '<!DOCTYPE r [<!ENTITY x SYSTEM "file:///etc/passwd">]><r>&x;</r>'
+)
+_BILLION = (
+    '<?xml version="1.0"?><!DOCTYPE l ['
+    '<!ENTITY a "aa">'
+    '<!ENTITY b "&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;">'
+    '<!ENTITY c "&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;">'
+    '<!ENTITY d "&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;">'
+    '<!ENTITY e "&d;&d;&d;&d;&d;&d;&d;&d;&d;&d;">'
+    "]><l>&e;</l>"
+)
+_PARAM = (
+    '<?xml version="1.0"?>'
+    '<!DOCTYPE r [<!ENTITY % p SYSTEM "file:///etc/passwd">%p;]><r/>'
+)
+
+
+@pytest.fixture(params=["defusedxml", "fallback"])
+def backend(request, monkeypatch):
+    """``nltk.xmlsec`` with each back end forced.
+
+    The fallback path is the one whose filename read goes through
+    ``nltk.pathsec.open``; forcing it here makes the attack matrix cover that
+    guard even where ``defusedxml`` is installed.
+    """
+    if request.param == "defusedxml":
+        pytest.importorskip("defusedxml")
+        module = importlib.reload(xmlsec)
+        assert module.HAVE_DEFUSEDXML
+    else:
+        # Hiding the module makes ``import defusedxml`` raise ImportError, so
+        # reloading selects the standard-library path.
+        monkeypatch.setitem(sys.modules, "defusedxml", None)
+        module = importlib.reload(xmlsec)
+        assert not module.HAVE_DEFUSEDXML
+    yield module
+    # Undo the patch before reloading so the module is left on its real back end.
+    monkeypatch.undo()
+    importlib.reload(xmlsec)
+
+
+@pytest.fixture
+def sandbox_root(monkeypatch):
+    root = tempfile.mkdtemp(prefix="nltk_sandbox_root_")
+    monkeypatch.setattr(pathsec, "ENFORCE", True)
+    monkeypatch.setattr(nltk.data, "path", [root])
+    monkeypatch.setattr(pathsec, "_ALLOWED_ROOTS_CACHE", None, raising=False)
+    monkeypatch.setattr(pathsec, "_LAST_DATA_PATHS", None, raising=False)
+    try:
+        yield root
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def _write(root, document):
+    path = os.path.join(root, "doc.xml")
+    with pathsec.open(path, "w", context="test", encoding="utf-8") as handle:
+        handle.write(document)
+    return path
+
+
+@pytest.mark.parametrize(
+    "document, label",
+    [
+        (_XXE, "external entity"),
+        (_BILLION, "billion laughs"),
+        (_PARAM, "parameter entity"),
+    ],
+    ids=["xxe", "billion-laughs", "param-entity"],
+)
+def test_entity_attacks_are_refused(backend, sandbox_root, document, label):
+    path = _write(sandbox_root, document)
+    with pytest.raises(Exception) as excinfo:
+        tree = backend.parse(path)
+        text = "".join(tree.getroot().itertext())
+        assert "root:" not in text, f"{label} disclosed /etc/passwd"
+    assert "Forbidden" in type(excinfo.value).__name__ or "Entit" in str(excinfo.value)
+
+
+def test_an_external_dtd_is_not_fetched(backend, sandbox_root):
+    """SSRF check against a real socket.
+
+    The document parses either way, so the only honest test is whether anything
+    connected.
+    """
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(1)
+    listener.settimeout(4)
+    port = listener.getsockname()[1]
+    connections = []
+
+    def accept_one():
+        try:
+            connection, _ = listener.accept()
+            connections.append(connection.recv(64))
+            connection.close()
+        except Exception:
+            pass
+
+    thread = threading.Thread(target=accept_one, daemon=True)
+    thread.start()
+    path = _write(
+        sandbox_root,
+        f'<?xml version="1.0"?><!DOCTYPE r SYSTEM '
+        f'"http://127.0.0.1:{port}/evil.dtd"><r>x</r>',
+    )
+    try:
+        backend.parse(path)
+    except Exception:
+        pass
+    thread.join(timeout=5)
+    listener.close()
+    assert connections == [], "the parser fetched the external DTD (SSRF)"
+
+
+def test_ordinary_xml_still_parses(backend, sandbox_root):
+    """Over-block control: the readers depend on this working."""
+    path = _write(sandbox_root, "<r><a>hi</a></r>")
+    assert backend.parse(path).getroot().find("a").text == "hi"

--- a/nltk/xmlsec.py
+++ b/nltk/xmlsec.py
@@ -54,6 +54,7 @@ import io
 from xml.etree import ElementTree
 from xml.parsers import expat
 
+from nltk.pathsec import open as pathsec_open
 from nltk.pathsec import validate_path
 
 __all__ = ["HAVE_DEFUSEDXML", "EntitiesForbidden", "fromstring", "parse"]
@@ -138,7 +139,7 @@ def parse(source):
     if hasattr(source, "read"):
         data = source.read()
     else:
-        with open(source, "rb") as stream:
+        with pathsec_open(source, "rb", context="xmlsec.parse") as stream:
             data = stream.read()
 
     _reject_entities(data)


### PR DESCRIPTION
## What

`nltk.xmlsec.parse()` accepts a caller-controlled filename. In the standard-library fallback path (used when `defusedxml` is not installed) it read that file with a bare builtin `open()` after `validate_path()`. This routes the read through `nltk.pathsec.open()` instead, so the open is covered by the same sandbox as the rest of `nltk.data`: path containment plus symlink/hardlink TOCTOU hardening (CWE-22 / CWE-59). The `defusedxml` fast path and the entity-expansion refusal (CWE-776) are unchanged.

The diff to `nltk/xmlsec.py` is two lines: import `nltk.pathsec.open` and use it for the filename read.

## Vulnerability classes closed / reinforced

- **XXE / external-entity file disclosure** and **billion-laughs / entity-expansion DoS (CWE-776)** are refused on both back ends (already the module's contract; covered here by an end-to-end test through a file source).
- **External-DTD SSRF**: the parser never fetches an external DTD; verified against a real listening socket.
- **Path traversal / symlink TOCTOU (CWE-22 / CWE-59)** on the filename read: now goes through the pathsec sandbox rather than a bare `open()`.

## Design

`nltk.xmlsec` uses `defusedxml` when installed and falls back to an equivalent standard-library implementation (an expat pre-scan that rejects any entity declaration or external reference) otherwise, so protection holds either way and `defusedxml` stays optional. The bare-`open` swap only affects the fallback path; the `defusedxml` path opens through its own reader.

## Tests

Adds `nltk/test/unit/test_xml_attack_matrix.py`:

- external-entity file disclosure, billion-laughs expansion, and parameter-entity payloads fed to `xmlsec.parse()` from a **file source** are refused;
- a real-socket check that an external DTD is never fetched (SSRF);
- a benign-document control that must still parse.

Every case runs against **both back ends** (`defusedxml` and the stdlib fallback); the fallback is the one that exercises the pathsec-guarded read introduced here. The existing `nltk/test/unit/test_xmlsec.py` continues to pass unchanged.

Teeth: the same billion-laughs payload expands to 20000 characters under the raw stdlib `ElementTree` parser, and is refused (`EntitiesForbidden`) by `xmlsec` on both back ends, so the assertions exercise the guard rather than a tautology.

## Cross-platform

XML parsing is platform-independent. The payloads reference `file:///etc/passwd` only as bait: the entity declaration is refused before any read, and the assertions check the raised exception, not file contents, so there is no POSIX path dependency. Documents are staged under a registered nltk data root (not a hard-coded `/tmp`) so the pathsec-guarded open resolves them on POSIX and Windows alike, and the SSRF check uses `127.0.0.1` with an ephemeral port.

Self-contained split from the larger GHSA-8mgp hardening effort.