### PR TITLE
Pin maxent scratch files to a data root and validate scratch IO

### DIFF
--- a/nltk/classify/maxent.py
+++ b/nltk/classify/maxent.py
@@ -58,6 +58,7 @@ except ImportError:
     pass
 
 import os
+import shutil
 import tempfile
 from collections import defaultdict
 
@@ -1439,14 +1440,20 @@ def train_maxent_classifier_with_megam(
         raise ValueError("Specify encoding or labels, not both")
 
     # Write a training file for megam.
+    # make_staging_dir stages inside a data root (a private 0700 dir), so the
+    # scratch file lands in the sandbox and pathsec_open accepts its path.
+    stagedir = make_staging_dir(prefix="nltk_megam_")
     try:
-        fd, trainfile_name = tempfile.mkstemp(prefix="nltk-")
-        with open(trainfile_name, "w") as trainfile:
+        fd, trainfile_name = tempfile.mkstemp(prefix="nltk-", dir=stagedir)
+        with pathsec_open(
+            trainfile_name, "w", context="maxent.call_megam"
+        ) as trainfile:
             write_megam_file(
                 train_toks, encoding, trainfile, explicit=explicit, bernoulli=bernoulli
             )
         os.close(fd)
     except (OSError, ValueError) as e:
+        shutil.rmtree(stagedir, ignore_errors=True)
         raise ValueError("Error while creating megam training file: %s" % e) from e
 
     # Run megam on the training file.
@@ -1482,6 +1489,8 @@ def train_maxent_classifier_with_megam(
         os.remove(trainfile_name)
     except OSError as e:
         print(f"Warning: unable to delete {trainfile_name}: {e}")
+    # Remove the private staging directory so it does not leak per call.
+    shutil.rmtree(stagedir, ignore_errors=True)
 
     # Parse the generated weight vector.
     weights = parse_megam_weights(stdout, encoding.length(), explicit)
@@ -1516,10 +1525,15 @@ class TadmMaxentClassifier(MaxentClassifier):
                 train_toks, count_cutoff, labels=labels
             )
 
+        # make_staging_dir stages inside a data root (a private 0700 dir), so
+        # both scratch files land in the sandbox instead of the shared temp dir.
+        stagedir = make_staging_dir(prefix="nltk_tadm_")
         trainfile_fd, trainfile_name = tempfile.mkstemp(
-            prefix="nltk-tadm-events-", suffix=".gz"
+            prefix="nltk-tadm-events-", suffix=".gz", dir=stagedir
         )
-        weightfile_fd, weightfile_name = tempfile.mkstemp(prefix="nltk-tadm-weights-")
+        weightfile_fd, weightfile_name = tempfile.mkstemp(
+            prefix="nltk-tadm-weights-", dir=stagedir
+        )
 
         trainfile = gzip_open_unicode(trainfile_name, "w")
         write_tadm_file(train_toks, encoding, trainfile)
@@ -1543,11 +1557,15 @@ class TadmMaxentClassifier(MaxentClassifier):
 
         call_tadm(options)
 
-        with open(weightfile_name) as weightfile:
+        with pathsec_open(  # staged inside a data root by mkstemp above
+            weightfile_name
+        ) as weightfile:
             weights = parse_tadm_weights(weightfile)
 
         os.remove(trainfile_name)
         os.remove(weightfile_name)
+        # Remove the private staging directory so it does not leak per call.
+        shutil.rmtree(stagedir, ignore_errors=True)
 
         # Convert from base-e to base-2 weights.
         weights *= numpy.log2(numpy.e)

--- a/nltk/test/unit/test_maxent_scratch_staging_security.py
+++ b/nltk/test/unit/test_maxent_scratch_staging_security.py
@@ -1,0 +1,130 @@
+"""
+Regression tests for the scratch-file hardening in ``nltk.classify.maxent``
+(GHSA-8mgp-746c-j5xp, CWE-377/378).
+
+The external-trainer wrappers ``train_maxent_classifier_with_megam`` and
+``TadmMaxentClassifier.train`` used to stage their training / weight files with a
+bare ``tempfile.mkstemp`` (no ``dir=``), which lands in the shared, world-writable
+system temp on Linux, and they read the tadm weights back through the plain
+builtin ``open``. Both now stage inside a private (mode 0700) directory under an
+allowed data root via ``nltk.data.make_staging_dir`` and route the read/write
+through ``nltk.pathsec.open`` so a path outside the sandbox is refused.
+
+These tests never invoke the real megam / tadm binaries: the external call is
+patched out after the scratch file has been created, which is exactly the point
+at which the file's location matters.
+
+The "outside" target is a fresh directory under the real ``$HOME`` supplied by the
+``pathsec_sandbox`` fixture; never a temp dir, because a private system temp
+directory is itself an allowed pathsec root on macOS, which would make a temp
+target a false "outside".
+"""
+
+import os
+
+import pytest
+
+numpy = pytest.importorskip("numpy")
+
+from nltk.classify import maxent
+
+TRAIN = [
+    (dict(a=1, b=1, c=1), "y"),
+    (dict(a=1, b=1, c=1), "x"),
+    (dict(a=1, b=1, c=0), "y"),
+    (dict(a=0, b=1, c=1), "x"),
+    (dict(a=0, b=1, c=1), "y"),
+    (dict(a=0, b=0, c=1), "y"),
+    (dict(a=0, b=1, c=0), "x"),
+    (dict(a=0, b=0, c=0), "x"),
+    (dict(a=0, b=1, c=1), "y"),
+]
+
+
+def _is_inside(path, root):
+    """True iff *path* resolves to a location within *root*."""
+    path = os.path.normcase(os.path.realpath(path))
+    root = os.path.normcase(os.path.realpath(root))
+    try:
+        return os.path.commonpath([path, root]) == root
+    except ValueError:
+        # Different drives on Windows raise; that is genuinely "not inside".
+        return False
+
+
+class _StopBeforeExternalCall(Exception):
+    """Raised by the patched trainer to abort once the scratch path is captured."""
+
+
+def test_megam_training_file_is_staged_inside_a_data_root(
+    monkeypatch, restricted_sandbox
+):
+    """The megam training file must be created inside the enforced data root, not
+    on the shared system temp. The un-hardened bare ``mkstemp`` places it in the
+    system temp, so this assertion fails against it."""
+    data_root = restricted_sandbox
+    captured = {}
+
+    def fake_call_megam(options):
+        trainfile_name = options[-1]
+        captured["path"] = trainfile_name
+        captured["exists"] = os.path.exists(trainfile_name)
+        raise _StopBeforeExternalCall
+
+    monkeypatch.setattr(maxent, "call_megam", fake_call_megam)
+
+    with pytest.raises(_StopBeforeExternalCall):
+        maxent.train_maxent_classifier_with_megam(TRAIN, trace=0)
+
+    assert captured.get("exists"), "megam training file was not created"
+    assert _is_inside(
+        captured["path"], data_root
+    ), f"megam scratch file {captured['path']!r} escaped data root {data_root!r}"
+
+
+def test_tadm_scratch_files_are_staged_inside_a_data_root(
+    monkeypatch, restricted_sandbox
+):
+    """Both tadm scratch files (events and weights) must be created inside the
+    enforced data root. The un-hardened bare ``mkstemp`` calls place them in the
+    system temp, so these assertions fail against it."""
+    data_root = restricted_sandbox
+    captured = {}
+
+    def fake_call_tadm(options):
+        captured["events"] = options[options.index("-events_in") + 1]
+        captured["params"] = options[options.index("-params_out") + 1]
+        raise _StopBeforeExternalCall
+
+    monkeypatch.setattr(maxent, "call_tadm", fake_call_tadm)
+
+    with pytest.raises(_StopBeforeExternalCall):
+        maxent.TadmMaxentClassifier.train(TRAIN, trace=0)
+
+    for kind in ("events", "params"):
+        assert _is_inside(
+            captured[kind], data_root
+        ), f"tadm {kind} file {captured[kind]!r} escaped data root {data_root!r}"
+
+
+def test_megam_write_outside_data_root_is_refused(monkeypatch, pathsec_sandbox):
+    """If the scratch file somehow lands outside the sandbox, the pathsec-guarded
+    write must refuse it and the external binary must never run. The un-hardened
+    plain ``open`` writes it and reaches ``call_megam``, so this test fails
+    against it."""
+    real_mkstemp = maxent.tempfile.mkstemp
+
+    def fake_mkstemp(*args, **kwargs):
+        # Force the scratch file outside every allowed root, ignoring the
+        # in-root dir the hardened code asked for.
+        return real_mkstemp(prefix="nltk-evil-", dir=str(pathsec_sandbox.outside))
+
+    monkeypatch.setattr(maxent.tempfile, "mkstemp", fake_mkstemp)
+    monkeypatch.setattr(
+        maxent,
+        "call_megam",
+        lambda options: pytest.fail("megam ran with an out-of-root scratch file"),
+    )
+
+    with pytest.raises(ValueError, match="megam training file"):
+        maxent.train_maxent_classifier_with_megam(TRAIN, trace=0)


### PR DESCRIPTION
## What

`nltk.classify.maxent`'s external-trainer wrappers staged their scratch files with a bare `tempfile.mkstemp` (no `dir=`). On Linux that places them in the shared, world-writable system temp, where the name is guessable and another local user can pre-create or symlink the path to read or redirect the write (CWE-377 / CWE-378):

- `train_maxent_classifier_with_megam` wrote the megam training file there.
- `TadmMaxentClassifier.train` wrote both the tadm events file and the weights file there, then read the weights back through the plain builtin `open`.

## Fix

Both wrappers now allocate a private (mode 0700) directory inside an allowed data root with `nltk.data.make_staging_dir` and pass it as `dir=` to `mkstemp`, so the scratch files land inside the pathsec sandbox on every platform (Linux included, where `/tmp` is deliberately not an allowed root). The megam write and the tadm weights read are routed through `nltk.pathsec.open`, which refuses a path outside the sandbox. The staging directory is removed after use so it does not leak per call.

## Dependencies

Self-contained on `develop`. It relies only on `make_staging_dir` and `pathsec.open`, both already present on `develop`. It deliberately does **not** use the process-wide `staging_tempdir` helper introduced by the companion `nltk.data` split, so this PR carries no cross-PR ordering dependency.

## Test

`nltk/test/unit/test_maxent_scratch_staging_security.py` exercises the delta without the real megam/tadm binaries by patching the external call out once the scratch file exists:

- the megam training file is created inside the enforced data root, not the system temp;
- both tadm scratch files are created inside the enforced data root;
- a scratch path forced outside the sandbox is refused by the pathsec-guarded write before the binary runs.

All three tests fail against the un-hardened code and pass with the fix. They reuse the existing `nltk/test/unit/conftest.py` sandbox fixtures, skip cleanly if numpy is absent, and avoid POSIX-only assumptions, so they run on Linux, macOS and Windows.

This is a self-contained split from the larger GHSA-8mgp-746c-j5xp hardening effort.