### PR TITLE
Add staging_tempdir and tighten data.py zip/staging guards

### DIFF
--- a/nltk/data.py
+++ b/nltk/data.py
@@ -32,11 +32,14 @@ adds it to a resource cache; and ``retrieve()`` copies a given resource
 to a local file.
 """
 
+import atexit
 import codecs
 import functools
 import os
 import pickle
 import re
+import shutil
+import stat
 import sys
 import tempfile
 import textwrap
@@ -88,6 +91,35 @@ def _assert_no_encoded_bypass(name, error_label=None):
     """
     decoded = unquote(name)
     if decoded != name and _UNSAFE_NO_PROTOCOL_RE.search(decoded):
+        label = name if error_label is None else error_label
+        raise ValueError(f"Unsafe resource path: {label!r}")
+
+
+# Python 3.14's url2pathname follows the WHATWG URL rules, so it silently strips
+# ASCII tab / LF / CR and truncates at "#" or "?". Earlier versions keep them.
+_URL_REWRITTEN_CHARS_RE = re.compile(r"[\t\n\r#?]")
+
+
+def _assert_no_normalized_bypass(name, error_label=None):
+    """
+    Reject *name* if :func:`url2pathname` would silently rewrite it.
+
+    Sibling of :func:`_assert_no_encoded_bypass`, for the same "the name that
+    was validated must be the name that is used" rule but a different rewriting
+    step. Python 3.14 made ``url2pathname`` follow the WHATWG URL rules: it
+    strips ASCII tab, LF and CR and truncates at ``#`` or ``?``. Stripping can
+    *create* a traversal that the raw-form check never saw, because ``".\\n./x"``
+    contains no ``../`` yet becomes ``"../x"`` once converted, which then joins
+    onto the data root and escapes it (CWE-22).
+
+    None of these characters belongs in an NLTK resource name, so refusing them
+    outright keeps the validated and the used name identical on every Python
+    version, rather than tracking what the standard library normalises next.
+
+    :param name: The resource string to validate.
+    :param error_label: Optional alternative string for the error message.
+    """
+    if _URL_REWRITTEN_CHARS_RE.search(name):
         label = name if error_label is None else error_label
         raise ValueError(f"Unsafe resource path: {label!r}")
 
@@ -176,7 +208,66 @@ else:
 ######################################################################
 
 
-def make_staging_dir(prefix="nltk_"):
+_STAGING_TEMPDIR = None
+
+
+def staging_tempdir():
+    """A process-wide scratch directory INSIDE an allowed data root.
+
+    ``tempfile.mkstemp()`` and ``NamedTemporaryFile()`` default to the system
+    temp dir, which on Linux is the shared, world-writable ``/tmp`` and is
+    deliberately NOT a pathsec root. Wrappers that stage an input file for an
+    external tool therefore wrote outside the sandbox. Pass this as ``dir=`` so
+    the scratch file lands inside a root instead.
+
+    Allocated once per process and removed at exit, so callers do not leak a
+    directory per invocation the way a per-call ``make_staging_dir`` would.
+    """
+    global _STAGING_TEMPDIR
+    if _STAGING_TEMPDIR is not None and not _staging_dir_is_still_safe(
+        _STAGING_TEMPDIR
+    ):
+        _STAGING_TEMPDIR = None
+    if _STAGING_TEMPDIR is None:
+        staged = make_staging_dir(prefix="nltk_scratch_")
+        atexit.register(shutil.rmtree, staged, ignore_errors=True)
+        _STAGING_TEMPDIR = staged
+    return _STAGING_TEMPDIR
+
+
+def _staging_dir_is_still_safe(path):
+    """Re-check a cached scratch directory before handing it out again.
+
+    The cache is a module global, so it is only as trustworthy as the directory
+    it names. ``os.path.isdir`` FOLLOWS symlinks, so an attacker who removes the
+    directory and drops a symlink in its place passes that check and every later
+    scratch file lands wherever the link points. ``lstat`` is used instead, and
+    containment is re-verified, so a swapped or poisoned value is discarded and
+    a fresh directory allocated.
+    """
+    from nltk import pathsec
+
+    try:
+        info = os.lstat(path)
+    except OSError:
+        return False
+    # Not stat(): a symlink must be rejected, not followed.
+    if not stat.S_ISDIR(info.st_mode):
+        return False
+    try:
+        pathsec.validate_path(path, context="nltk.data.staging_tempdir")
+    except (PermissionError, ValueError):
+        return False
+    # A scratch dir that has become group- or world-writable is squattable:
+    # another local user can replace a file between the moment this process
+    # creates it and the moment it reads it back (CWE-377/CWE-378). Discard it
+    # and allocate a fresh 0700 one rather than reusing it.
+    if not pathsec.is_private_dir(path):
+        return False
+    return True
+
+
+def make_staging_dir(prefix="nltk_", cleanup=False):
     """Create a fresh private directory for NLTK's own output, inside a data root.
 
     NLTK's save helpers default here so their output lands within the security
@@ -185,13 +276,41 @@ def make_staging_dir(prefix="nltk_"):
     directory is created with ``tempfile.mkdtemp`` (mode 0700, unpredictable name)
     under the first ``nltk.data.path`` entry that can be written to.
 
-    :param prefix: filename prefix for the created directory.
+    :param prefix: filename prefix for the created directory. It is a *name*
+        fragment, not a path: callers build it from values such as a tagger's
+        language code, and ``tempfile.mkdtemp`` simply concatenates it onto
+        *dir*, so a ``..`` inside it would place the directory outside the data
+        root (CWE-22). Path separators and NUL are therefore refused.
     :type prefix: str
+    :param cleanup: remove the directory when the interpreter exits. Use it for
+        scratch output nobody will look for again; leave it False for a saved
+        model, where deleting the user's artifact would be surprising. Without
+        it every call leaks a directory under the data root, since the name is
+        unpredictable and no caller can find it again to clean up.
     :return: the absolute path of the created directory.
+
+    See also :func:`staging_tempdir`, which is this function memoised: one
+    shared scratch directory for the whole process, for callers that need a
+    *place* to put a throwaway file rather than a directory of their own.
+    Allocating a fresh directory per throwaway file is what leaked 70 of them on
+    a development machine.
     :rtype: str
+    :raises ValueError: if *prefix* is not a plain filename fragment.
     :raises PermissionError: if no ``nltk.data.path`` entry is a writable allowed
         root, in which case the caller should pass an explicit destination.
     """
+    prefix = str(prefix)
+    if (
+        "\x00" in prefix
+        or "/" in prefix
+        or "\\" in prefix
+        or os.sep in prefix
+        or (os.altsep and os.altsep in prefix)
+    ):
+        raise ValueError(
+            f"Invalid staging-dir prefix {prefix!r}: a prefix is a filename "
+            "fragment, not a path (no separators or NUL)"
+        )
     for root in path:
         base = os.path.expanduser(str(root.path if hasattr(root, "path") else root))
         try:
@@ -203,7 +322,17 @@ def make_staging_dir(prefix="nltk_"):
             # the sandbox does.
             _validate_path(base, context="nltk.data.make_staging_dir")
             os.makedirs(base, exist_ok=True)
-            return tempfile.mkdtemp(prefix=prefix, dir=base)
+            staged = tempfile.mkdtemp(prefix=prefix, dir=base)
+            try:
+                # Defence in depth: confirm what was actually created is inside
+                # the root just validated, not merely that the base was.
+                _validate_path(staged, context="nltk.data.make_staging_dir")
+            except BaseException:
+                os.rmdir(staged)
+                raise
+            if cleanup:
+                atexit.register(shutil.rmtree, staged, ignore_errors=True)
+            return staged
         except (OSError, ValueError, PermissionError):
             continue
     raise PermissionError(
@@ -994,6 +1123,7 @@ def find(resource_name, paths=None):
     if _UNSAFE_NO_PROTOCOL_RE.search(resource_name):
         raise ValueError(f"Unsafe resource path: {resource_name!r}")
     _assert_no_encoded_bypass(resource_name)
+    _assert_no_normalized_bypass(resource_name)
 
     # Resolve default paths at runtime in-case the user overrides
     # nltk.data.path
@@ -1001,7 +1131,10 @@ def find(resource_name, paths=None):
         paths = path
 
     # Check if the resource name includes a zipfile name
-    m = re.match(r"(.*?\.zip)/?(.*)$", resource_name)
+    # DOTALL matters for termination, not just matching: without it a name
+    # containing a newline never looks like a zip, so the ".zip/" fallback below
+    # recurses on an ever-growing name instead of stopping (CWE-407 / CWE-1333).
+    m = re.match(r"(.*?\.zip)/?(.*)$", resource_name, re.DOTALL)
     if m:
         zipfile, zipentry = m.groups()
     else:

--- a/nltk/test/unit/test_data_name_guards.py
+++ b/nltk/test/unit/test_data_name_guards.py
@@ -1,0 +1,77 @@
+# Natural Language Toolkit: resource-name and staging-prefix guards
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""Two small input guards added to ``nltk.data`` for the same "the name that was
+validated must be the name that is used" rule.
+
+``find`` refuses a resource name holding an ASCII tab, LF, CR, ``#`` or ``?``.
+Python 3.14 made ``url2pathname`` follow the WHATWG URL rules, so it strips those
+control characters and truncates at ``#`` / ``?``; the stripping can turn a name
+with no ``..`` component into a traversal after validation has already run
+(CWE-22). ``make_staging_dir`` refuses a prefix that is a path rather than a
+plain filename fragment, so a caller-built prefix cannot place the directory
+outside the data root.
+"""
+
+import os
+
+import pytest
+
+import nltk.data as data
+
+# find(): characters url2pathname would silently rewrite
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "corpora\tbrown",
+        "corpora\nbrown",
+        "corpora\rbrown",
+        "corpora#brown",
+        "corpora?brown",
+    ],
+    ids=["tab", "lf", "cr", "hash", "question"],
+)
+def test_find_rejects_url_rewritten_characters(name, tmp_path):
+    """None of these reaches the raw-form traversal check, so before this guard
+    they passed validation and were only rewritten later inside url2pathname."""
+    with pytest.raises(ValueError):
+        data.find(name, paths=[str(tmp_path)])
+
+
+def test_find_rejects_traversal_created_by_newline_stripping(tmp_path):
+    """The headline case: ".\\n./x" holds no ".." run, yet stripping the LF joins
+    the dots into "../x", which then escapes the data root (CWE-22)."""
+    with pytest.raises(ValueError):
+        data.find(".\n./x", paths=[str(tmp_path)])
+
+
+def test_assert_no_normalized_bypass_allows_a_plain_name():
+    """A normal posix-style resource name must pass the guard untouched."""
+    assert data._assert_no_normalized_bypass("corpora/brown") is None
+
+
+# make_staging_dir(): a prefix is a filename fragment, not a path
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    ["nltk_/evil", "nltk_\\evil", "nltk_\x00", "../evil"],
+    ids=["slash", "backslash", "nul", "dotdot_slash"],
+)
+def test_make_staging_dir_rejects_path_like_prefix(prefix):
+    """A separator or NUL in the prefix could steer the created directory out of
+    the data root, so the fragment is refused before any directory is made."""
+    with pytest.raises(ValueError):
+        data.make_staging_dir(prefix=prefix)
+
+
+def test_make_staging_dir_accepts_a_plain_prefix(restricted_sandbox):
+    """A plain fragment still yields a fresh directory inside the data root."""
+    staged = data.make_staging_dir(prefix="nltk_plain_")
+    assert os.path.isdir(staged)
+    assert os.path.realpath(staged).startswith(os.path.realpath(restricted_sandbox))

--- a/nltk/test/unit/test_staging_tempdir_security.py
+++ b/nltk/test/unit/test_staging_tempdir_security.py
@@ -1,0 +1,212 @@
+# Natural Language Toolkit: staging scratch directory security
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""``nltk.data.staging_tempdir`` must stay inside a data root for its whole life.
+
+The wrappers that shell out to an external tool stage an input file first.
+Those used to go to the system temp dir, which on Linux is the shared,
+world-writable ``/tmp`` and is deliberately not a pathsec root, so the scratch
+file landed outside the sandbox. ``staging_tempdir`` fixes that by allocating a
+0700 directory inside a data root.
+
+Because it caches that directory in a module global, the cache is only as
+trustworthy as the directory it names, which is what these tests attack.
+"""
+
+import os
+import shutil
+import stat
+
+import pytest
+
+import nltk.data
+from nltk import pathsec
+
+
+@pytest.fixture
+def fresh_staging(pathsec_sandbox, monkeypatch):
+    """A sandbox with no staging dir carried over from another test."""
+    monkeypatch.setattr(nltk.data, "_STAGING_TEMPDIR", None, raising=False)
+    yield pathsec_sandbox
+    monkeypatch.setattr(nltk.data, "_STAGING_TEMPDIR", None, raising=False)
+
+
+def _inside(path, root):
+    return os.path.realpath(str(path)).startswith(os.path.realpath(str(root)))
+
+
+def test_staging_dir_is_inside_a_root_and_private(fresh_staging):
+    root, _outside = fresh_staging
+    staged = nltk.data.staging_tempdir()
+    assert _inside(staged, root)
+    if os.name == "posix":
+        assert os.stat(staged).st_mode & 0o077 == 0
+
+
+def test_staging_dir_is_stable_across_calls(fresh_staging):
+    """One directory per process, or every call would leak another."""
+    assert nltk.data.staging_tempdir() == nltk.data.staging_tempdir()
+
+
+@pytest.mark.skipif(os.name != "posix", reason="symlink swap is a POSIX concern")
+def test_cached_dir_swapped_for_a_symlink_is_discarded(fresh_staging):
+    """The regression this file exists for.
+
+    os.path.isdir FOLLOWS symlinks, so removing the cached directory and
+    dropping a symlink in its place passed the cache check, and every later
+    scratch file landed wherever the link pointed.
+    """
+    root, outside = fresh_staging
+    staged = nltk.data.staging_tempdir()
+    shutil.rmtree(staged)
+    os.symlink(str(outside), staged)
+    assert _inside(nltk.data.staging_tempdir(), root)
+
+
+def test_poisoned_cache_value_is_discarded(fresh_staging, monkeypatch):
+    """A global set to an out-of-root path must not be handed back."""
+    root, outside = fresh_staging
+    monkeypatch.setattr(nltk.data, "_STAGING_TEMPDIR", str(outside), raising=False)
+    assert _inside(nltk.data.staging_tempdir(), root)
+
+
+def test_deleted_cached_dir_is_reallocated(fresh_staging):
+    root, _outside = fresh_staging
+    staged = nltk.data.staging_tempdir()
+    shutil.rmtree(staged)
+    assert _inside(nltk.data.staging_tempdir(), root)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="symlink swap is a POSIX concern")
+def test_a_real_scratch_file_cannot_escape_after_a_swap(fresh_staging):
+    """End of the chain: what a wrapper actually writes must stay in the root."""
+    import tempfile as _tempfile
+
+    root, outside = fresh_staging
+    staged = nltk.data.staging_tempdir()
+    shutil.rmtree(staged)
+    os.symlink(str(outside), staged)
+    handle, path = _tempfile.mkstemp(text=True, dir=nltk.data.staging_tempdir())
+    os.close(handle)
+    assert _inside(path, root), f"scratch file escaped to {path}"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="symlink swap is a POSIX concern")
+def test_teeth_isdir_check_alone_would_reopen_the_swap(fresh_staging, monkeypatch):
+    """Negative control: restore the old ``os.path.isdir`` test and the swapped
+    symlink is accepted again, which is exactly the bug."""
+    root, outside = fresh_staging
+    staged = nltk.data.staging_tempdir()
+    shutil.rmtree(staged)
+    os.symlink(str(outside), staged)
+    monkeypatch.setattr(
+        nltk.data, "_staging_dir_is_still_safe", lambda path: os.path.isdir(path)
+    )
+    assert not _inside(nltk.data.staging_tempdir(), root)
+
+
+def test_a_regular_file_in_the_cache_slot_is_discarded(fresh_staging):
+    root, _outside = fresh_staging
+    staged = nltk.data.staging_tempdir()
+    shutil.rmtree(staged)
+    with pathsec.open(staged, "w", context="test") as handle:
+        handle.write("not a directory")
+    assert _inside(nltk.data.staging_tempdir(), root)
+    assert stat.S_ISDIR(os.lstat(nltk.data.staging_tempdir()).st_mode)
+
+
+class TestStagingDirLifetime:
+    """make_staging_dir leaked a directory per call for every caller but one.
+
+    The name is unpredictable, so nothing can find it again to clean up: 70 had
+    accumulated under the data root on a development machine. Cleanup is opt-in
+    rather than automatic because some callers stage a *saved model* there, and
+    deleting the user's artifact at exit would be surprising.
+    """
+
+    def _run(self, script):
+        import subprocess
+        import sys
+
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            env=dict(os.environ, PYTHONPATH=os.pathsep.join(sys.path)),
+        )
+        assert result.returncode == 0, result.stderr
+        return dict(
+            line.split("=", 1)
+            for line in result.stdout.strip().splitlines()
+            if line.startswith("D")
+        )
+
+    def test_cleanup_true_removes_the_dir_at_exit(self):
+        paths = self._run(
+            "import nltk.data;"
+            "print('D=' + nltk.data.make_staging_dir("
+            "prefix='nltk_cleanup_t_', cleanup=True))"
+        )
+        assert not os.path.exists(paths["D"])
+
+    def test_cleanup_defaults_to_keeping_the_dir(self):
+        """A saved model must survive the interpreter exiting."""
+        paths = self._run(
+            "import nltk.data;"
+            "print('D=' + nltk.data.make_staging_dir(prefix='nltk_cleanup_f_'))"
+        )
+        try:
+            assert os.path.exists(paths["D"])
+        finally:
+            shutil.rmtree(paths["D"], ignore_errors=True)
+
+    def test_staging_tempdir_always_cleans_up(self):
+        """The shared scratch dir holds only throwaway files."""
+        paths = self._run("import nltk.data; print('D=' + nltk.data.staging_tempdir())")
+        assert not os.path.exists(paths["D"])
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX mode bits")
+@pytest.mark.parametrize("mode", [0o777, 0o770, 0o707], ids=["world", "group", "other"])
+def test_a_writable_scratch_dir_is_not_reused(fresh_staging, mode):
+    """A scratch dir that has become group- or world-writable is squattable.
+
+    Another local user can replace a file between this process creating it and
+    reading it back (CWE-377/CWE-378), so the cache must discard it and
+    allocate a fresh 0700 one rather than handing it out again.
+    """
+    root, _outside = fresh_staging
+    staged = nltk.data.staging_tempdir()
+    os.chmod(staged, mode)
+    replacement = nltk.data.staging_tempdir()
+    assert replacement != staged, "reused a writable scratch directory"
+    assert _inside(replacement, root)
+    assert os.stat(replacement).st_mode & 0o077 == 0
+
+
+@pytest.mark.skipif(
+    os.name != "posix",
+    reason="chmod 0o500 does not block directory writes on Windows",
+)
+def test_no_writable_root_refuses_rather_than_falling_back(fresh_staging, monkeypatch):
+    """With no writable root the correct answer is to refuse.
+
+    Silently falling back to the system temp dir would put scratch output on
+    Linux's shared /tmp, which is exactly what pinning dir= was meant to stop.
+    """
+    import tempfile as _tempfile
+
+    read_only = _tempfile.mkdtemp(prefix="nltk_ro_root_")
+    os.chmod(read_only, 0o500)
+    monkeypatch.setattr(nltk.data, "path", [read_only])
+    monkeypatch.setattr(pathsec, "_ALLOWED_ROOTS_CACHE", None, raising=False)
+    monkeypatch.setattr(pathsec, "_LAST_DATA_PATHS", None, raising=False)
+    try:
+        with pytest.raises((PermissionError, OSError)):
+            nltk.data.staging_tempdir()
+    finally:
+        os.chmod(read_only, 0o700)
+        shutil.rmtree(read_only, ignore_errors=True)


### PR DESCRIPTION
This is a self-contained split from the larger GHSA-8mgp hardening effort: the changes to `nltk/data.py` plus a minimal set of tests for exactly the new behaviour, so it can be reviewed and merged on its own. Every helper it relies on (`pathsec.validate_path`, `pathsec.is_private_dir`, `make_staging_dir`) is already on `develop` (the aggregate zip-bomb helper and base decompression-bomb guards landed in #3797), and importing `nltk.data` and its dependents stays healthy.

## What changes in `nltk/data.py`

- **`staging_tempdir()`** (new): a process-wide 0700 scratch directory *inside* an allowed data root, allocated once per process and removed at exit. Wrappers that stage an input file for an external tool previously fell back to the system temp dir, which on Linux is the shared, world-writable `/tmp` and is deliberately not a pathsec root, so the scratch file landed outside the sandbox. Passing this as `dir=` keeps it inside a root. Backed by a module global `_STAGING_TEMPDIR`.
- **`_staging_dir_is_still_safe()`** (new): re-validates the cached scratch directory before handing it out again. `os.path.isdir` follows symlinks, so an attacker who removes the directory and drops a symlink in its place would pass a naive check and every later scratch file would land wherever the link points. This uses `lstat` (a symlink is rejected, not followed), re-verifies containment via `validate_path`, and requires a private (0700) directory, discarding a swapped, poisoned, or world/group-writable value and allocating a fresh one. Guards CWE-377 / CWE-378.
- **`make_staging_dir()`**: gains an opt-in `cleanup` flag (a *saved model* must survive interpreter exit; throwaway scratch should not), a defence-in-depth re-validation that the directory actually created is inside the root just validated, and rejection of a `prefix` that is a path rather than a plain filename fragment. Callers build the prefix from values such as a tagger's language code, and `mkdtemp` concatenates it onto `dir`, so a separator or NUL in the prefix could place the directory outside the data root (CWE-22).
- **`_assert_no_normalized_bypass()`** (new) wired into `find()`: refuses a resource name holding an ASCII tab, LF, CR, `#` or `?`. Python 3.14 made `url2pathname` follow the WHATWG URL rules, stripping those control characters and truncating at `#` / `?`. The stripping can turn a name with no `..` run (for example `".\n./x"`) into a traversal *after* the raw-form check has already passed, which then escapes the data root (CWE-22). Refusing the characters outright keeps the validated name and the used name identical on every Python version.
- **`find()` zip-split** gains `re.DOTALL` so a newline-bearing name cannot drive the `".zip/"` fallback into unbounded recursion (CWE-407 / CWE-1333). This sits behind the new character guard as defence in depth.

## Vulnerability classes

CWE-22 (path traversal via a control-character-normalised name and via a path-like staging prefix), CWE-377 / CWE-378 (insecure/squattable temporary directory reused from a poisoned or symlink-swapped cache), CWE-407 / CWE-1333 (unbounded recursion / ReDoS on a newline-bearing resource name).

## Tests

- `nltk/test/unit/test_staging_tempdir_security.py` (new): containment and privacy of the scratch dir, the symlink-swap and poisoned-cache regressions, an end-to-end scratch file that must not escape after a swap, a negative control showing the old `os.path.isdir` check reopens the bug, cleanup lifetime (opt-in vs default), and refusal of a writable or unwritable root.
- `nltk/test/unit/test_data_name_guards.py` (new): `find()` rejecting each `url2pathname`-rewritten character and the newline-created traversal, plus `make_staging_dir` refusing a path-like prefix and accepting a plain one.

## Cross-platform handling

The tests are green on Linux, macOS and Windows. Checks that are genuinely POSIX-only skip cleanly elsewhere:

- Symlink-swap tests (`test_cached_dir_swapped_for_a_symlink_is_discarded`, `test_a_real_scratch_file_cannot_escape_after_a_swap`, `test_teeth_isdir_check_alone_would_reopen_the_swap`) are gated `os.name != "posix"`, matching the existing `symlink squat is a POSIX concern` gating on `develop`.
- POSIX mode-bit tests (`test_a_writable_scratch_dir_is_not_reused` for world/group/other, and the `chmod 0o500` unwritable-root case) skip on non-POSIX, since Windows uses ACLs and `chmod` does not block directory writes there.
- The `make_staging_dir` prefix guards and the `find()` character guards are pure input validation and run on every platform.