### PR TITLE
Stage boxer scratch input inside an nltk.data root

### DIFF
--- a/nltk/sem/boxer.py
+++ b/nltk/sem/boxer.py
@@ -31,6 +31,7 @@ For example::
 import operator
 import os
 import re
+import shutil
 import subprocess
 import tempfile
 from functools import reduce
@@ -204,10 +205,17 @@ class Boxer:
         :param candc_out: str output from C&C parser
         :return: stdout
         """
+        # Imported here, not at module scope: nltk.data's import graph pulls in
+        # nltk.sem, so a top level import can see a half built nltk.data module.
+        from nltk.data import make_staging_dir
+
         f = None
+        # Stage the scratch input inside an allowed nltk.data root, never the
+        # shared system temp dir (world writable, not a pathsec root; CWE-377).
+        staging_dir = make_staging_dir(prefix="boxer-")
         try:
             fd, temp_filename = tempfile.mkstemp(
-                prefix="boxer-", suffix=".in", text=True
+                prefix="boxer-", suffix=".in", text=True, dir=staging_dir
             )
             f = os.fdopen(fd, "w")
             f.write(candc_out.decode("utf-8"))
@@ -233,7 +241,7 @@ class Boxer:
             temp_filename,
         ]
         stdout = self._call(None, self._boxer_bin, args, verbose)
-        os.remove(temp_filename)
+        shutil.rmtree(staging_dir, ignore_errors=True)
         return stdout
 
     def _find_binary(self, name, bin_dir, verbose=False):

--- a/nltk/test/unit/test_boxer_security.py
+++ b/nltk/test/unit/test_boxer_security.py
@@ -19,9 +19,13 @@ a ``$PATH`` lookup) keeps working.
 """
 
 import os
+import shutil
+import tempfile
 
 import pytest
 
+import nltk.data
+from nltk import pathsec
 from nltk.sem.boxer import Boxer
 
 _BIN_NAMES = ("candc", "boxer")
@@ -89,3 +93,47 @@ def test_absolute_bin_dir_is_accepted(tmp_path, monkeypatch):
     assert os.path.realpath(boxer._candc_bin) == os.path.realpath(
         os.path.join(abs_dir, "candc")
     )
+
+
+def test_boxer_scratch_file_staged_in_data_root(monkeypatch):
+    """The scratch input handed to boxer must be staged inside an allowed
+    nltk.data root, never the shared system temp dir (world writable and not a
+    pathsec root; CWE-377/CWE-378).
+
+    Teeth: an unhardened wrapper calls ``tempfile.mkstemp`` with no ``dir=``, so
+    the file lands in the system temp dir and the containment check below fails.
+    This needs neither the ``boxer`` nor the ``candc`` binary: ``_call`` is faked.
+    """
+    # Stage the data root under $HOME so it is inside the pathsec sandbox on
+    # every OS; the system temp dir is deliberately not an allowed data root.
+    home = os.path.expanduser("~")
+    root = tempfile.mkdtemp(prefix="nltk_boxer_test_", dir=home)
+    monkeypatch.setattr(nltk.data, "path", [root, *nltk.data.path])
+
+    boxer = Boxer.__new__(Boxer)
+    boxer._resolve = True
+    boxer._elimeq = False
+    boxer._boxer_bin = os.path.join(root, "boxer")  # never executed; _call is faked
+
+    captured = {}
+
+    def fake_call(input_str, binary, args=(), verbose=False):
+        temp_path = args[args.index("--input") + 1]
+        captured["path"] = temp_path
+        with open(temp_path, encoding="utf-8") as handle:
+            captured["contents"] = handle.read()
+        return b""
+
+    monkeypatch.setattr(boxer, "_call", fake_call)
+    try:
+        boxer._call_boxer(b"ccg(1, t).")
+
+        staged = os.path.realpath(captured["path"])
+        assert staged.startswith(
+            os.path.realpath(root) + os.sep
+        ), "boxer scratch file was staged outside the nltk.data root"
+        # Exercise the guard itself: the staged path validates as in-sandbox.
+        pathsec.validate_path(captured["path"], required_root=root)
+        assert captured["contents"] == "ccg(1, t)."
+    finally:
+        shutil.rmtree(root, ignore_errors=True)


### PR DESCRIPTION
## What

`Boxer` writes the C&C parser output to a scratch file and hands that file's
path to the external `boxer` binary. It created the file with
`tempfile.mkstemp()` and no `dir=`, so the scratch input landed in the shared
system temp directory rather than inside the NLTK data sandbox.

## Why it matters

The system temp directory is not an allowed `nltk.data` root. On Linux it is the
world-writable `/tmp`, so the boxer input file was staged outside the pathsec
sandbox and was exposed to a local squatting/replacement race between the moment
this process created it and the moment the external tool read it back
(CWE-377 / CWE-378, insecure temp file placement).

## Fix

`_call_boxer` now allocates a private, in-sandbox scratch directory with
`nltk.data.make_staging_dir(prefix="boxer-")` and stages the input file inside it
via `mkstemp(dir=...)`. The staging directory and its file are removed with
`shutil.rmtree` after the boxer call, so nothing leaks. `make_staging_dir` is
imported inside the method because `nltk.data`'s import graph reaches back into
`nltk.sem`, and a module-level import can otherwise observe a partially
initialised `nltk.data`.

The candc/boxer binary-path hardening (untrusted search path, CWE-426 / CWE-427)
already landed on `develop` and is unchanged here.

## Relationship to the larger effort

This is a self-contained split from the larger GHSA-8mgp hardening work. That
wider effort also introduces a cached, process-wide `nltk.data.staging_tempdir()`
helper, which ships in a separate `nltk.data` change. To keep this PR standalone
and importable on `develop` today, it deliberately uses the already-present
`make_staging_dir` primitive instead. There is no dependency on the in-flight
`data.py` split.

## Test

`nltk/test/unit/test_boxer_security.py` gains
`test_boxer_scratch_file_staged_in_data_root`. It fakes `Boxer._call`, so it
needs neither the `boxer` nor the `candc` binary, and asserts the staged scratch
path is contained inside an allowed `nltk.data` root (staged under `$HOME`). The
test has teeth: it fails against the unhardened wrapper because the scratch file
then lands in the system temp directory. It is cross-platform (no POSIX-only path
shapes, reads with `encoding="utf-8"`), so it runs cleanly on Linux, macOS, and
Windows. The four existing binary-path regression tests are unchanged.

Full boxer security suite: `5 passed`.
