### PR TITLE
Canonicalize obfuscated numeric IPv4 in the SSRF guard (CWE-918)

### DIFF
--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -887,6 +887,51 @@ def _ip_is_forbidden(ip):
     return ip.is_multicast or not ip.is_global
 
 
+def _numeric_ipv4(host):
+    """Canonical ``inet_aton`` parse of a numeric IPv4 literal, or None.
+
+    Follows the classic ``inet_aton`` rules: 1 to 4 dot parts, each decimal, a
+    ``0x`` hex value, or a leading-zero octal value, with the final part
+    absorbing the remaining low-order bytes. glibc and BSD fold these obfuscated
+    forms (``2130706433``, ``0x7f000001``, ``127.1``, ``0177.0.0.1``) to their
+    real address at resolution time, but the Windows resolver does not, so the
+    SSRF guard must canonicalize them itself to refuse loopback on every
+    platform (CWE-918).
+    """
+    if not host:
+        return None
+    parts = host.split(".")
+    if not 1 <= len(parts) <= 4:
+        return None
+    values = []
+    for part in parts:
+        if not part:
+            return None
+        try:
+            if part[:2].lower() == "0x":
+                value = int(part, 16)
+            elif part[0] == "0" and len(part) > 1:
+                value = int(part, 8)
+            else:
+                value = int(part, 10)
+        except ValueError:
+            return None
+        values.append(value)
+    for leading in values[:-1]:
+        if not 0 <= leading <= 0xFF:
+            return None
+    last = values[-1]
+    if not 0 <= last <= (1 << (8 * (5 - len(values)))) - 1:
+        return None
+    packed = last
+    for index, leading in enumerate(values[:-1]):
+        packed |= leading << (8 * (3 - index))
+    try:
+        return ipaddress.IPv4Address(packed)
+    except ipaddress.AddressValueError:
+        return None
+
+
 def validate_network_url(url_input, context="NetworkIO"):
     """Hardened URL validation with SSRF protection."""
     if not url_input or not str(url_input).strip():
@@ -929,7 +974,22 @@ def validate_network_url(url_input, context="NetworkIO"):
                 warnings.warn(msg, RuntimeWarning, stacklevel=3)
             return
 
-        for result in _resolve_hostname(parsed.hostname or ""):
+        host = parsed.hostname or ""
+
+        # Canonicalize obfuscated numeric IPv4 forms ourselves before trusting
+        # the resolver: the Windows resolver does not fold decimal/hex/octal
+        # inet_aton spellings, so a loopback disguised as 2130706433 would
+        # otherwise reach the network there (CWE-918).
+        numeric = _numeric_ipv4(host)
+        if numeric is not None and _ip_is_forbidden(numeric):
+            msg = f"Security Violation [{context}]: SSRF attempt to restricted IP {numeric}"
+            if ENFORCE:
+                raise PermissionError(msg)
+            else:
+                warnings.warn(msg, RuntimeWarning, stacklevel=3)
+            return
+
+        for result in _resolve_hostname(host):
             ip = ipaddress.ip_address(result[4][0])
             if _ip_is_forbidden(ip):
                 msg = f"Security Violation [{context}]: SSRF attempt to restricted IP {ip}"

--- a/nltk/test/unit/security_probes/ghsa_6ww7_3frv_cqxh.py
+++ b/nltk/test/unit/security_probes/ghsa_6ww7_3frv_cqxh.py
@@ -23,6 +23,7 @@ def _proxy_ssrf_bypass():
         pathsec.ENFORCE,
         pathsec.ALLOW_PROXIED_FETCH,
         getattr(pathsec, "_resolve_hostname", None),
+        getattr(pathsec, "_numeric_ipv4", None),
     )
     try:
         urllib.request.getproxies = lambda: {"http": "http://attacker-proxy:8080"}
@@ -37,6 +38,10 @@ def _proxy_ssrf_bypass():
         pathsec.ENFORCE = True
         pathsec.ALLOW_PROXIED_FETCH = False
         pathsec._resolve_hostname = lambda host: []
+        # Also disable the numeric IPv4 canonicalizer: it is an independent
+        # direct-IP guard that would otherwise refuse the link-local literal
+        # first, hiding whether the proxy-specific guard fires.
+        pathsec._numeric_ipv4 = lambda host: None
         try:
             pathsec.urlopen("http://169.254.169.254/latest/meta-data/", timeout=2)
         except PermissionError as exc:
@@ -61,4 +66,5 @@ def _proxy_ssrf_bypass():
             pathsec.ENFORCE,
             pathsec.ALLOW_PROXIED_FETCH,
             pathsec._resolve_hostname,
+            pathsec._numeric_ipv4,
         ) = saved

--- a/nltk/test/unit/test_pathsec.py
+++ b/nltk/test/unit/test_pathsec.py
@@ -443,6 +443,7 @@ def _capture_urlopen_handlers(monkeypatch, url="http://safe.example.com/x"):
 
     monkeypatch.setattr(urllib.request, "_opener", None)
     monkeypatch.setattr(pathsec, "_resolve_hostname", lambda h: [])
+    monkeypatch.setattr(pathsec, "_numeric_ipv4", lambda h: None)
     monkeypatch.setattr(urllib.request, "build_opener", spy_build_opener)
     pathsec.urlopen(url)
     return captured
@@ -470,6 +471,7 @@ def test_env_proxy_fails_closed_under_enforce(monkeypatch):
     )
     monkeypatch.setattr(urllib.request, "_opener", None)
     monkeypatch.setattr(pathsec, "_resolve_hostname", lambda h: [])
+    monkeypatch.setattr(pathsec, "_numeric_ipv4", lambda h: None)
     monkeypatch.setattr(pathsec, "ENFORCE", True)
     monkeypatch.setattr(pathsec, "ALLOW_PROXIED_FETCH", False)
 
@@ -587,6 +589,7 @@ def test_proxied_fetch_refused_for_every_target_even_with_no_proxy_present(
     monkeypatch.setattr(urllib.request, "proxy_bypass", lambda host: False)
     monkeypatch.setattr(urllib.request, "_opener", None)
     monkeypatch.setattr(pathsec, "_resolve_hostname", lambda h: [])
+    monkeypatch.setattr(pathsec, "_numeric_ipv4", lambda h: None)
     monkeypatch.setattr(pathsec, "ENFORCE", True)
     monkeypatch.setattr(pathsec, "ALLOW_PROXIED_FETCH", False)
 
@@ -625,6 +628,7 @@ def test_proxy_with_unbypassed_target_still_fails_closed(monkeypatch):
     monkeypatch.setattr(urllib.request, "proxy_bypass", lambda host: False)
     monkeypatch.setattr(urllib.request, "_opener", None)
     monkeypatch.setattr(pathsec, "_resolve_hostname", lambda h: [])
+    monkeypatch.setattr(pathsec, "_numeric_ipv4", lambda h: None)
     monkeypatch.setattr(pathsec, "ALLOW_PROXIED_FETCH", False)
 
     with pytest.raises(PermissionError, match="proxied fetch"):

--- a/nltk/test/unit/test_ssrf_url_encodings.py
+++ b/nltk/test/unit/test_ssrf_url_encodings.py
@@ -1,0 +1,150 @@
+# Natural Language Toolkit: SSRF encoding matrix for the downloader
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""``validate_network_url`` must refuse every spelling of an internal target.
+
+Attackers disguise loopback, link-local and private addresses as decimal, hex,
+octal, IPv4-mapped IPv6, and NAT64/6to4 tunnels. The cloud-metadata address
+(169.254.169.254) is the highest-value SSRF target.
+
+A subtlety the tests encode rather than gloss over: a spelling like
+``0177.0.0.1`` is interpreted differently per platform. The BSD/macOS resolver
+reads ``0177`` as decimal 177, resolving to the public 177.0.0.1; glibc on Linux
+reads it as octal, resolving to loopback 127.0.0.1. ``0x7f.0.0.1`` really is
+127.0.0.1 everywhere and is refused. The guard follows whatever getaddrinfo
+actually returns, so the test below pins its verdict to the live resolution
+rather than to a single platform's guess.
+"""
+
+import socket
+
+import pytest
+
+from nltk import pathsec
+
+
+def _verdict(url):
+    try:
+        pathsec.validate_network_url(url, context="test")
+        return "allowed"
+    except (PermissionError, ValueError, OSError):
+        return "blocked"
+
+
+@pytest.fixture(autouse=True)
+def enforce_on(monkeypatch):
+    monkeypatch.setattr(pathsec, "ENFORCE", True)
+
+
+_INTERNAL = [
+    "http://127.0.0.1/",
+    "http://2130706433/",
+    "http://0x7f000001/",
+    "http://0x7f.0.0.1/",
+    "http://127.1/",
+    "http://0/",
+    "http://0.0.0.0/",
+    "http://[::1]/",
+    "http://[::ffff:127.0.0.1]/",
+    "http://[::ffff:7f00:1]/",
+    "http://[64:ff9b::7f00:1]/",
+    "http://[2002:7f00:1::]/",
+    "http://169.254.169.254/latest/meta-data/",
+    "http://[fd00:ec2::254]/",
+    "http://100.64.0.1/",
+    "http://10.0.0.1/",
+    "http://192.168.1.1/",
+    "http://172.16.0.1/",
+    "http://[::]/",
+    "http://[fe80::1]/",
+]
+
+
+@pytest.mark.parametrize("url", _INTERNAL)
+def test_internal_addresses_are_refused(url):
+    assert _verdict(url) == "blocked", f"{url} reached the network"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "file:///etc/passwd",
+        "file://attacker.com/x",
+        "gopher://127.0.0.1/",
+        "ftp://127.0.0.1/",
+        "dict://127.0.0.1:11211/",
+        "nltk://x",
+    ],
+)
+def test_non_http_schemes_are_refused(url):
+    assert _verdict(url) == "blocked", f"{url} was accepted"
+
+
+def test_leading_zero_octal_loopback_is_always_refused():
+    """0177.0.0.1 is octal-obfuscated loopback (0177 == 127). glibc reads it as
+    octal, BSD/macOS as decimal, and the Windows resolver folds neither. The
+    guard canonicalizes numeric IPv4 forms itself, so it refuses this on every
+    platform rather than deferring to the resolver's inconsistent reading."""
+    assert _verdict("http://0177.0.0.1/") == "blocked"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://2130706433/",
+        "http://0x7f000001/",
+        "http://0x7f.0.0.1/",
+        "http://127.1/",
+        "http://0177.0.0.1/",
+        "http://0/",
+    ],
+)
+def test_obfuscated_numeric_ip_refused_even_when_resolver_returns_nothing(
+    url, monkeypatch
+):
+    """Regression teeth for the Windows non-folding resolver. glibc and BSD fold
+    obfuscated numeric IPv4 spellings to loopback at resolution time, but the
+    Windows resolver returns nothing for them, so before the canonicalizer these
+    reached the network there. With the resolver stubbed empty (the Windows
+    behavior), the guard must still refuse every spelling on its own."""
+    monkeypatch.setattr(pathsec, "_resolve_hostname", lambda host: [])
+    assert _verdict(url) == "blocked", f"{url} reached the network"
+
+
+def test_public_numeric_ip_still_allowed(monkeypatch):
+    """Over-block control for the canonicalizer: a public numeric spelling
+    (0x08080808 == 8.8.8.8) must not be refused by the numeric guard."""
+    monkeypatch.setattr(
+        pathsec,
+        "_resolve_hostname",
+        lambda host: [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", 80))],
+    )
+    assert _verdict("http://0x08080808/") == "allowed"
+
+
+def test_a_hostname_resolving_to_loopback_is_refused(monkeypatch):
+    """DNS names are only as safe as what they resolve to. A name pointing at
+    127.0.0.1 must be refused as if the literal IP were given."""
+
+    def fake_getaddrinfo(host, *args, **kwargs):
+        if host == "evil.internal.test":
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 80))]
+        return socket.getaddrinfo(host, *args, **kwargs)
+
+    monkeypatch.setattr(pathsec.socket, "getaddrinfo", fake_getaddrinfo)
+    assert _verdict("http://evil.internal.test/") == "blocked"
+
+
+def test_a_public_index_url_is_allowed(monkeypatch):
+    """Over-block control: the real download source must not be refused."""
+
+    def fake_getaddrinfo(host, *args, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("185.199.108.133", 443))]
+
+    monkeypatch.setattr(pathsec.socket, "getaddrinfo", fake_getaddrinfo)
+    assert _verdict("https://raw.githubusercontent.com/nltk/nltk_data/index.xml") == (
+        "allowed"
+    )


### PR DESCRIPTION
## Vulnerability

`validate_network_url` is the SSRF guard for the downloader network path. It resolves the URL host and refuses the request when any resolved address is loopback, link-local, private, or otherwise non-global. Before this change it trusted the platform resolver to first fold obfuscated numeric IPv4 spellings to their real address:

- `http://2130706433/` (decimal)
- `http://0x7f000001/`, `http://0x7f.0.0.1/` (hex)
- `http://127.1/` (short form, last part absorbs the low bytes)
- `http://0177.0.0.1/` (leading-zero octal)

glibc and BSD `getaddrinfo`/`inet_aton` do fold these to 127.0.0.1, so the guard blocked them there. The Windows resolver does not: it returns nothing for these numeric literals, so the forbidden-IP loop saw no addresses to reject and the request reached the network. A loopback or cloud-metadata target disguised as a numeric literal therefore bypassed the SSRF guard on Windows (CWE-918).

## Fix

Add `_numeric_ipv4(host)`, a classic `inet_aton` parse: 1 to 4 dot-separated parts, each decimal, `0x` hex, or leading-zero octal, with the final part absorbing the remaining low-order bytes. `validate_network_url` now canonicalizes the host itself and, before the `getaddrinfo` loop, refuses the request when the parsed numeric IPv4 is forbidden. The verdict no longer depends on whether the platform resolver folds the spelling, so loopback/link-local/private numeric forms are refused on every platform. Octal loopback such as `0177.0.0.1` is refused unconditionally. Public numeric forms (e.g. `0x08080808` = 8.8.8.8) stay allowed. Hostnames return `None` from the parser and fall through to normal resolution. The helper uses only the `ipaddress` module already imported in `pathsec.py`; no new dependency.

## Why the proxy probe and proxied-fetch tests were updated

`_numeric_ipv4` is a second, independent direct-IP guard alongside `_resolve_hostname`. The proxy-SSRF probe (`security_probes/ghsa_6ww7_3frv_cqxh.py`) and the proxied-fetch tests in `test_pathsec.py` deliberately neuter `_resolve_hostname` so that the proxy-specific guard is what gets exercised rather than the direct-IP resolution path. With the new canonicalizer in place, the link-local literal `169.254.169.254` would now be refused by `_numeric_ipv4` first, hiding whether the proxy guard fires; without neutering it the probe reports VULNERABLE against the new guard. Those tests now also neuter `_numeric_ipv4` in their save/patch/restore so the proxy path remains the thing under test.

## Tests

- `nltk/test/unit/test_ssrf_url_encodings.py` — refusal cases for the obfuscated numeric spellings; a renamed test asserting `0177.0.0.1` is always refused; a regression test that pins `_resolve_hostname` to empty (the Windows non-folding behavior) and proves the guard blocks every numeric spelling on its own; and an over-block control keeping a public numeric form allowed.
- `nltk/test/unit/security_probes/ghsa_6ww7_3frv_cqxh.py` — neuters `_numeric_ipv4` alongside `_resolve_hostname` so the proxy guard stays under test.
- `nltk/test/unit/test_pathsec.py` — the four proxied-fetch tests that neuter `_resolve_hostname` now also neuter `_numeric_ipv4`.

Verified locally (Python 3.13): the full `test_ssrf_url_encodings.py`, `test_pathsec.py`, and `test_advisory_probes.py` suites pass, and a direct comparison against the current `develop` `pathsec.py` under a stubbed empty resolver shows the pre-patch guard allows `http://2130706433/` while the patched guard blocks it.

## Scope

Self-contained split from the larger GHSA-8mgp effort: this PR is only the SSRF numeric-IPv4 canonicalization guard and the tests that prove it.
