### PR TITLE
fix: traverse relation-mapped dependencies in cycle detection

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -319,6 +319,7 @@
 - Nicola <https://github.com/trinik15>
 - medisean <https://github.com/medisean>
 - tandede <https://github.com/tandede>
+- gry67673905 <https://github.com/gry67673905>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 

--- a/nltk/parse/dependencygraph.py
+++ b/nltk/parse/dependencygraph.py
@@ -470,6 +470,7 @@ class DependencyGraph:
         [1, 2, 4, 3]
 
         """
+
         # Detect a directed cycle with an iterative depth-first search in
         # O(V + E).  The previous implementation repeatedly recomputed a
         # transitive closure with a triple-nested loop over a ``distances``
@@ -480,10 +481,16 @@ class DependencyGraph:
         # let a single oversized graph exhaust CPU (CWE-407).
         #
         # ``deps`` may be a list of addresses or a relation->addresses
-        # mapping; iterating it yields the same edge targets the old code
-        # used.  The membership guard skips targets that are not nodes and
-        # avoids materialising spurious ``defaultdict`` entries in
-        # ``self.nodes``.
+        # mapping. Normalize mappings to their address values so the DFS does
+        # not mistake relation labels for graph nodes. The membership guard
+        # skips targets that are not nodes and avoids materialising spurious
+        # ``defaultdict`` entries in ``self.nodes``.
+        def iter_dependencies(node):
+            dependencies = node["deps"]
+            if isinstance(dependencies, dict):
+                return chain.from_iterable(dependencies.values())
+            return dependencies
+
         WHITE, GRAY, BLACK = 0, 1, 2
         color = defaultdict(int)  # int() == WHITE
 
@@ -492,7 +499,7 @@ class DependencyGraph:
                 continue
             color[start] = GRAY
             path = [start]
-            stack = [iter(self.nodes[start]["deps"])]
+            stack = [iter(iter_dependencies(self.nodes[start]))]
             while stack:
                 for dep in stack[-1]:
                     if dep not in self.nodes:
@@ -504,7 +511,7 @@ class DependencyGraph:
                     if color[dep] == WHITE:
                         color[dep] = GRAY
                         path.append(dep)
-                        stack.append(iter(self.nodes[dep]["deps"]))
+                        stack.append(iter(iter_dependencies(self.nodes[dep])))
                         break
                 else:
                     color[path.pop()] = BLACK

--- a/nltk/test/unit/test_dependencygraph_cycle.py
+++ b/nltk/test/unit/test_dependencygraph_cycle.py
@@ -1,0 +1,7 @@
+from nltk.parse.dependencygraph import DependencyGraph
+
+
+def test_contains_cycle_follows_relation_mapped_dependencies():
+    graph = DependencyGraph("a N 0 ROOT\n" "b N 3 dep\n" "c N 2 dep\n")
+
+    assert graph.contains_cycle() == [2, 3]


### PR DESCRIPTION
## Summary

- Traverse the child-address values of relation-keyed `deps` mappings in `DependencyGraph.contains_cycle`.
- Preserve support for legacy list-based dependency storage.
- Add a regression for a cycle created through normal CoNLL input parsing.

## Validation

- Focused regression plus existing DependencyGraph tests: `3 passed`
- Target `contains_cycle` doctest: `1 passed`
- Black, isort, Ruff, and `git diff --check`

The full module doctest still depends on an optional local Graphviz `dot` executable that is not installed; the focused cycle coverage does not require it.
