### PR TITLE
Harden stanford tokenizer/segmenter wrappers: validate jar/model paths and argv

### DIFF
--- a/nltk/test/unit/test_tokenize_stanford_pathsec.py
+++ b/nltk/test/unit/test_tokenize_stanford_pathsec.py
@@ -1,0 +1,255 @@
+# Natural Language Toolkit: pathsec guards for the Stanford tokenizer wrappers
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""Security guards for ``nltk.tokenize.stanford`` and
+``nltk.tokenize.stanford_segmenter``.
+
+Both wrappers hand caller-supplied model, dictionary, corpus and input-file
+paths straight into a child JVM's argv (``-loadClassifier`` /
+``-serDictionary`` / ``-sighanCorporaDict`` / ``-textFile``), which
+``pathsec.open`` cannot wrap. An unbounded value there is an arbitrary file read
+(GHSA-8mgp-746c-j5xp). These tests drive the real code path with only the
+``java`` hand-off replaced, so a probe cannot pass merely because the test
+assembled the argv itself. Each guard assertion runs WITHOUT the real Stanford
+jars: the crafted attack is refused before the JVM is reached, and the benign
+control stops at a trapped ``java`` rather than launching one.
+
+SSRF is not in scope here: these wrappers invoke a local Java jar, they never
+fetch a URL.
+"""
+
+import hashlib
+import os
+
+import pytest
+
+import nltk.data
+from nltk import pathsec
+
+
+class _ReachedJVM(Exception):
+    """Raised by the trapped ``java`` so a test can tell "the argv was built and
+    handed off" apart from "a guard refused first"."""
+
+
+class _MutatingPath:
+    """A ``PathLike`` that answers one path the first time and another after.
+
+    Models the ``__fspath__`` TOCTOU: a guard that validates the object and then
+    lets the caller re-read it would check one file and hand a different one to
+    the JVM. The wrapper must freeze the value the guard returned.
+    """
+
+    def __init__(self, first, rest):
+        self._calls = 0
+        self._first = first
+        self._rest = rest
+
+    def __fspath__(self):
+        self._calls += 1
+        return self._first if self._calls == 1 else self._rest
+
+
+def _trap_java(monkeypatch, module, sink):
+    """Replace ``module.java`` with a trap that records argv and stops before
+    launching a JVM."""
+
+    def fake_java(cmd, *args, **kwargs):
+        sink["cmd"] = list(cmd)
+        raise _ReachedJVM
+
+    monkeypatch.setattr(module, "java", fake_java)
+    return sink
+
+
+def _segmenter(monkeypatch, root, model=None, dictionary=None, sihan=None):
+    """A StanfordSegmenter whose jar passes the sha256 allowlist, so a benign
+    call reaches the model-path handling rather than stopping at the jar check."""
+    import nltk.tokenize.stanford_segmenter as seg
+
+    jar = os.path.join(root, "seg.jar")
+    with pathsec.open(jar, "wb") as handle:
+        handle.write(b"PK\x05\x06" + b"\0" * 18)
+    with pathsec.open(jar, "rb") as handle:
+        digest = hashlib.sha256(handle.read()).hexdigest()
+    monkeypatch.setenv("NLTK_SEGMENTER_ALLOW_SHA256", digest)
+
+    tool = object.__new__(seg.StanfordSegmenter)
+    tool._stanford_jar = jar
+    tool._encoding = "utf8"
+    tool.java_options = "-mx1g"
+    tool._jar_sha256_cache = {}
+    tool._java_class = "edu.stanford.nlp.ie.crf.CRFClassifier"
+    tool._model = model
+    tool._dict = dictionary
+    tool._sihan_corpora_dict = sihan
+    tool._sihan_post_processing = "true"
+    tool._keep_whitespaces = "false"
+    tool._options_cmd = ""
+    return tool
+
+
+# ---------------------------------------------------------------------------
+# StanfordSegmenter: model / dictionary / sihan / input-file argv paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("slot", ["model", "dictionary", "sihan"])
+def test_segmenter_model_paths_refuse_escape(pathsec_sandbox, monkeypatch, slot):
+    """A model, dictionary or Sihan corpus dir outside the roots is refused
+    before the JVM sees it."""
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, outside = pathsec_sandbox
+    _trap_java(monkeypatch, seg, {})
+    evil = outside / "evil.ser.gz"
+    evil.write_text("payload", encoding="utf-8")
+    inside = str(root / "in.txt")
+    with pathsec.open(inside, "w", encoding="utf-8") as handle:
+        handle.write("中文")
+
+    tool = _segmenter(monkeypatch, str(root), **{slot: str(evil)})
+    with pytest.raises((PermissionError, ValueError)):
+        tool.segment_file(inside)
+
+
+def test_segmenter_input_file_refuses_escape(pathsec_sandbox, monkeypatch):
+    """``segment_file`` is an arbitrary-file-read primitive without a guard on
+    its own argument."""
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, outside = pathsec_sandbox
+    _trap_java(monkeypatch, seg, {})
+    tool = _segmenter(monkeypatch, str(root))
+    with pytest.raises((PermissionError, ValueError)):
+        tool.segment_file(str(outside / "passwd"))
+
+
+def test_segmenter_segment_sents_model_refuses_escape(pathsec_sandbox, monkeypatch):
+    """The second argv-building path (``segment_sents``) stages its input under a
+    data root and must reject an out-of-sandbox model just the same."""
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, outside = pathsec_sandbox
+    monkeypatch.setattr(nltk.data, "_STAGING_TEMPDIR", None, raising=False)
+    _trap_java(monkeypatch, seg, {})
+    evil = outside / "evil.ser.gz"
+    evil.write_text("payload", encoding="utf-8")
+
+    tool = _segmenter(monkeypatch, str(root), model=str(evil))
+    with pytest.raises((PermissionError, ValueError)):
+        tool.segment_sents([["中文"]])
+
+
+def test_segmenter_in_sandbox_paths_reach_jvm(pathsec_sandbox, monkeypatch):
+    """Over-block control: legitimate in-sandbox paths must still be handed to
+    the JVM, otherwise the guard has broken the feature."""
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, _outside = pathsec_sandbox
+    sink = _trap_java(monkeypatch, seg, {})
+    model = str(root / "model.ser.gz")
+    with pathsec.open(model, "w", encoding="utf-8") as handle:
+        handle.write("m")
+    inside = str(root / "in.txt")
+    with pathsec.open(inside, "w", encoding="utf-8") as handle:
+        handle.write("中文")
+
+    tool = _segmenter(monkeypatch, str(root), model=model)
+    with pytest.raises(_ReachedJVM):
+        tool.segment_file(inside)
+    assert model in sink["cmd"]
+
+
+def test_segmenter_model_fspath_frozen_once(pathsec_sandbox, monkeypatch):
+    """A mutating ``__fspath__`` must not swap the model between the check and
+    the argv: the JVM sees the validated string, coerced to a real ``str``."""
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, outside = pathsec_sandbox
+    sink = _trap_java(monkeypatch, seg, {})
+    good = str(root / "model.ser.gz")
+    with pathsec.open(good, "w", encoding="utf-8") as handle:
+        handle.write("m")
+    evil = outside / "evil.ser.gz"
+    evil.write_text("payload", encoding="utf-8")
+    inside = str(root / "in.txt")
+    with pathsec.open(inside, "w", encoding="utf-8") as handle:
+        handle.write("中文")
+
+    tool = _segmenter(monkeypatch, str(root), model=_MutatingPath(good, str(evil)))
+    with pytest.raises(_ReachedJVM):
+        tool.segment_file(inside)
+    idx = sink["cmd"].index("-loadClassifier") + 1
+    assert sink["cmd"][idx] == good
+    assert type(sink["cmd"][idx]) is str
+    assert str(evil) not in sink["cmd"]
+
+
+# ---------------------------------------------------------------------------
+# StanfordSegmenter: -options is one comma-joined argv element
+# ---------------------------------------------------------------------------
+
+
+def test_segmenter_options_reject_separator_injection():
+    """An option NAME holding a separator would inject extra option pairs into
+    the single comma-joined ``-options`` element."""
+    from nltk.tokenize.stanford_segmenter import _validated_options
+
+    with pytest.raises(ValueError):
+        _validated_options({"normalize=true,serDictionary": "value"})
+
+
+def test_segmenter_options_reject_empty_name():
+    from nltk.tokenize.stanford_segmenter import _validated_options
+
+    with pytest.raises(ValueError):
+        _validated_options({"   ": "value"})
+
+
+def test_segmenter_options_path_value_bounded(pathsec_sandbox):
+    """An option VALUE that names a file is bounded to the data roots."""
+    from nltk.tokenize.stanford_segmenter import _validated_options
+
+    _root, outside = pathsec_sandbox
+    with pytest.raises((PermissionError, ValueError)):
+        _validated_options({"serDictionary": str(outside / "passwd")})
+
+
+def test_segmenter_options_benign_pass():
+    """Over-block control: ordinary options pass through unchanged."""
+    from nltk.tokenize.stanford_segmenter import _validated_options
+
+    out = _validated_options({"normalizeSpace": True, "americanize": "false"})
+    assert out == {"normalizeSpace": True, "americanize": "false"}
+
+
+# ---------------------------------------------------------------------------
+# StanfordTokenizer: the staged input file must land inside a data root
+# ---------------------------------------------------------------------------
+
+
+def test_stanford_tokenizer_input_file_staged_in_data_root(
+    pathsec_sandbox, monkeypatch
+):
+    """The temp input file is created with ``dir=staging_tempdir()``, so it lands
+    inside a data root rather than the shared system temp dir."""
+    import nltk.tokenize.stanford as st
+
+    root, _outside = pathsec_sandbox
+    monkeypatch.setattr(nltk.data, "_STAGING_TEMPDIR", None, raising=False)
+    sink = _trap_java(monkeypatch, st, {})
+    tool = object.__new__(st.StanfordTokenizer)
+    tool._stanford_jar = str(root / "postagger.jar")
+    tool._encoding = "utf8"
+    tool.java_options = "-mx1g"
+    tool._options_cmd = ""
+
+    with pytest.raises(_ReachedJVM):
+        tool._execute(["edu.stanford.nlp.process.PTBTokenizer"], "hello world")
+
+    staged = os.path.realpath(sink["cmd"][-1])
+    assert staged.startswith(os.path.realpath(str(root)) + os.sep)

--- a/nltk/tokenize/stanford.py
+++ b/nltk/tokenize/stanford.py
@@ -12,6 +12,7 @@ import tempfile
 import warnings
 from subprocess import PIPE
 
+from nltk.data import staging_tempdir
 from nltk.internals import find_jar, java
 from nltk.parse.corenlp import CoreNLPParser
 from nltk.tokenize.api import TokenizerI
@@ -90,7 +91,9 @@ class StanfordTokenizer(TokenizerI):
         input_file_name = None
         java_succeeded = False
         try:
-            with tempfile.NamedTemporaryFile(mode="wb", delete=False) as input_file:
+            with tempfile.NamedTemporaryFile(
+                mode="wb", delete=False, dir=staging_tempdir()
+            ) as input_file:
                 input_file_name = input_file.name
                 # Write the actual sentences to the temporary input file
                 if isinstance(input_, str) and encoding:

--- a/nltk/tokenize/stanford_segmenter.py
+++ b/nltk/tokenize/stanford_segmenter.py
@@ -17,6 +17,7 @@ import tempfile
 import warnings
 from subprocess import PIPE
 
+from nltk.data import staging_tempdir
 from nltk.internals import (
     find_dir,
     find_file,
@@ -24,10 +25,46 @@ from nltk.internals import (
     java,
 )
 from nltk.pathsec import open as pathsec_open
-from nltk.pathsec import validate_path
+from nltk.pathsec import validate_path, validate_tool_dir, validate_tool_path
 from nltk.tokenize.api import TokenizerI
 
 _stanford_url = "https://nlp.stanford.edu/software"
+
+
+def _validated_options(options):
+    """Bound the caller-supplied ``options`` dict before it becomes ``-options``.
+
+    The pairs are joined into ONE comma-separated argv element, so a key holding
+    a ``,`` or an ``=`` silently injects extra option pairs that the wrapper
+    never intended. This is the same class as the parser's ``corenlp_options``:
+
+        {"normalize=true,serDictionary": "/etc/passwd"}
+        -> normalize=true,serDictionary="/etc/passwd"
+
+    Values are JSON-encoded, so they cannot break out of their own pair, but one
+    that names a file is still bounded to the data roots.
+    """
+    validated = {}
+    for key, value in options.items():
+        name = str(key)
+        if not name.strip():
+            raise ValueError(
+                "Security Violation [StanfordSegmenter options]: empty option name."
+            )
+        if any(character in name for character in ",=\t\n\r\x00 "):
+            raise ValueError(
+                f"Security Violation [StanfordSegmenter options]: option name "
+                f"{name!r} contains a separator, so it would inject extra "
+                "option pairs into the argument list."
+            )
+        if isinstance(value, str) and (
+            os.path.isabs(value) or "/" in value or "\\" in value
+        ):
+            value = validate_tool_path(
+                value, context=f"StanfordSegmenter options[{name}]"
+            )
+        validated[name] = value
+    return validated
 
 
 class StanfordSegmenter(TokenizerI):
@@ -119,7 +156,8 @@ class StanfordSegmenter(TokenizerI):
         self.java_options = java_options
         options = {} if options is None else options
         self._options_cmd = ",".join(
-            f"{key}={json.dumps(val)}" for key, val in options.items()
+            f"{key}={json.dumps(val)}"
+            for key, val in _validated_options(options).items()
         )
         self._jar_sha256_cache = {}
 
@@ -201,22 +239,30 @@ class StanfordSegmenter(TokenizerI):
 
     def segment_file(self, input_file_path):
         """ """
+        # Caller-supplied and handed to the JVM as -textFile, which pathsec.open
+        # cannot wrap; validate before the spawn (GHSA-8mgp-746c-j5xp). Build the
+        # argv from the returned string, never the original object: a PathLike can
+        # answer one way here and another way when the child resolves it.
+        input_file_path = validate_tool_path(
+            input_file_path, context="StanfordSegmenter.segment_file"
+        )
+        model, dictionary, sihan = self._validate_model_paths()
         cmd = [
             self._java_class,
             "-loadClassifier",
-            self._model,
+            model,
             "-keepAllWhitespaces",
             self._keep_whitespaces,
             "-textFile",
             input_file_path,
         ]
-        if self._sihan_corpora_dict is not None:
+        if sihan is not None:
             cmd.extend(
                 [
                     "-serDictionary",
-                    self._dict,
+                    dictionary,
                     "-sighanCorporaDict",
-                    self._sihan_corpora_dict,
+                    sihan,
                     "-sighanPostProcessing",
                     self._sihan_post_processing,
                 ]
@@ -236,7 +282,9 @@ class StanfordSegmenter(TokenizerI):
         java_succeeded = False
         try:
             # Create a temporary input file
-            _input_fh, input_file_path = tempfile.mkstemp(text=True)
+            _input_fh, input_file_path = tempfile.mkstemp(
+                text=True, dir=staging_tempdir()
+            )
             self._input_file_path = input_file_path
 
             # Write the actual sentences to the temporary input file
@@ -246,22 +294,27 @@ class StanfordSegmenter(TokenizerI):
                     _input = _input.encode(encoding)
                 input_fh.write(_input)
 
+            # Validate BEFORE building the command, and build it from the
+            # attributes the guard replaced. Capturing self._model into cmd first
+            # would put the original object there, and a PathLike may resolve to
+            # something else when the child process reads it.
+            model, dictionary, sihan = self._validate_model_paths()
             cmd = [
                 self._java_class,
                 "-loadClassifier",
-                self._model,
+                model,
                 "-keepAllWhitespaces",
                 self._keep_whitespaces,
                 "-textFile",
                 self._input_file_path,
             ]
-            if self._sihan_corpora_dict is not None:
+            if sihan is not None:
                 cmd.extend(
                     [
                         "-serDictionary",
-                        self._dict,
+                        dictionary,
                         "-sighanCorporaDict",
-                        self._sihan_corpora_dict,
+                        sihan,
                         "-sighanPostProcessing",
                         self._sihan_post_processing,
                     ]
@@ -328,6 +381,44 @@ class StanfordSegmenter(TokenizerI):
                     "Multiple approved checksums may be supplied as a comma-separated list."
                 )
 
+    def _validate_model_paths(self):
+        """Refuse model/dictionary paths that escape the NLTK data sandbox.
+
+        These are embedded in the JVM argv (-loadClassifier / -serDictionary /
+        -sighanCorporaDict), which pathsec.open cannot wrap, so they are checked
+        here before the process is spawned (GHSA-8mgp-746c-j5xp).
+
+        Each attribute is replaced with the string the guard returned, and the
+        same strings are RETURNED for the caller to build its argv from. A
+        PathLike may answer differently on every call, and ``validate_path``
+        reads a ``.path`` attribute in preference to ``__fspath__``, so
+        validating the object and then handing the same object to the JVM
+        checked one file and opened another.
+
+        Returning them matters beyond that: a caller that re-reads
+        ``self._model`` after this returns is reading shared mutable state again,
+        so a concurrent write could still swap the value between the check and
+        the argv. Building from the return value keeps the checked value and the
+        used value the same object.
+
+        :return: the validated (model, dictionary, sihan corpora dict) strings,
+            each None when it was unset
+        """
+        validated = []
+        for attribute, label, guard in (
+            ("_model", "model", validate_tool_path),
+            ("_dict", "dictionary", validate_tool_path),
+            # The Sihan corpora dict is a DIRECTORY, so it needs the directory
+            # guard: validate_tool_path requires a regular file.
+            ("_sihan_corpora_dict", "sihan corpora dict", validate_tool_dir),
+        ):
+            value = getattr(self, attribute)
+            if value:
+                value = guard(value, context=f"StanfordSegmenter {label}")
+                setattr(self, attribute, value)
+            validated.append(value)
+        return tuple(validated)
+
     def _execute(self, cmd, verbose=False):
         encoding = self._encoding
         cmd.extend(["-inputEncoding", encoding])
@@ -335,6 +426,7 @@ class StanfordSegmenter(TokenizerI):
         if _options_cmd:
             cmd.extend(["-options", self._options_cmd])
 
+        self._validate_model_paths()
         self._validate_classpath()
 
         stdout, _stderr = java(


### PR DESCRIPTION
The Stanford tokenizer and segmenter wrappers hand caller-supplied model, dictionary, corpus and input-file paths straight into a child JVM's argv (`-loadClassifier` / `-serDictionary` / `-sighanCorporaDict` / `-textFile`), which `pathsec.open` cannot wrap. Left unbounded, those are arbitrary-file-read primitives (GHSA-8mgp-746c-j5xp). This is one file-scoped split out of a larger hardening branch, covering only the two `nltk/tokenize` Stanford wrappers.

## Vulnerability classes and fixes

**`nltk/tokenize/stanford_segmenter.py`**
- Model / dictionary / Sihan-dir path traversal: `-loadClassifier`, `-serDictionary` and `-sighanCorporaDict` reached the JVM unbounded. New `_validate_model_paths()` bounds the model and dictionary files with `validate_tool_path` and the Sihan corpora directory with `validate_tool_dir` before the process is spawned.
- Input-file path traversal: `segment_file` validates its `-textFile` argument with `validate_tool_path`.
- `__fspath__` TOCTOU: each guarded attribute is replaced with, and the argv is built from, the string the guard returned, never the original object. A `PathLike` whose `__fspath__` answers differently on a later call can no longer have one file checked and another handed to the JVM.
- Argv injection through `-options`: the options dict is joined into one comma-separated `-options` element, so an option name holding a `,`/`=`/whitespace/NUL separator would inject extra option pairs. New `_validated_options()` refuses such names and bounds any value that names a file.
- Temp input file is staged under a data root via `staging_tempdir()` instead of the shared system temp dir.

**`nltk/tokenize/stanford.py`**
- Temp input file is staged under a data root via `staging_tempdir()` instead of the shared system temp dir.

## Tests

New `nltk/test/unit/test_tokenize_stanford_pathsec.py` drives the real code path with only the `java` hand-off trapped, so a probe cannot pass merely because the test assembled the argv itself. It proves an out-of-sandbox model, dictionary, Sihan dir, input file or option value is refused; a mutating `__fspath__` is frozen to the validated string; an option name carrying a separator is rejected; benign in-root paths still reach the JVM; and the tokenizer's staged input lands inside a data root. Every guard assertion runs without the real Stanford jars and each fails against the un-hardened code, so the tests have teeth.

## Cross-platform

`pathsec` containment is OS-agnostic and `java` is never launched, so the suite is green on Linux, macOS and Windows with no external tool. It reuses the existing `pathsec_sandbox` conftest fixture (which folds Windows 8.3 short names and treats a private per-user temp dir correctly), stages fixtures under `$HOME`/the data root rather than `/tmp`, and reads text as UTF-8.

## Self-contained split

Depends only on symbols already on `develop`: `validate_tool_path` / `validate_tool_dir` from #3797 and `staging_tempdir` from #3808. `import nltk.tokenize.stanford` and `import nltk.tokenize.stanford_segmenter` both succeed on `develop`.

SSRF is not applicable to these wrappers: they invoke a local Java jar, they never fetch a URL.