### PR TITLE
Stage weka scratch files in a data root and validate the WEKAHOME jar path

### DIFF
--- a/nltk/classify/weka.py
+++ b/nltk/classify/weka.py
@@ -14,6 +14,7 @@ import re
 import subprocess
 import tempfile
 import time
+import warnings
 from sys import stdin
 
 from nltk.classify.api import ClassifierI
@@ -21,6 +22,7 @@ from nltk.data import make_staging_dir
 from nltk.internals import config_java, java
 from nltk.pathsec import ZipFile as SecureZipFile
 from nltk.pathsec import open as pathsec_open
+from nltk.pathsec import validate_path
 from nltk.probability import DictionaryProbDist
 
 _weka_classpath = None
@@ -51,7 +53,19 @@ def config_weka(classpath=None):
     if _weka_classpath is None:
         searchpath = list(_weka_search)  # copy; don't mutate the module global
         if "WEKAHOME" in os.environ:
-            searchpath.insert(0, os.environ["WEKAHOME"])
+            weka_home = os.environ["WEKAHOME"]
+            try:
+                # Bound the attacker-influenceable WEKAHOME to the pathsec sandbox so
+                # it cannot add a weka.jar from outside the trusted roots (CWE-426/427).
+                validate_path(
+                    os.path.join(weka_home, "weka.jar"), context="config_weka(WEKAHOME)"
+                )
+                searchpath.insert(0, weka_home)
+            except (PermissionError, ValueError):
+                warnings.warn(
+                    f"Ignoring WEKAHOME {weka_home!r}: outside the trusted NLTK data roots.",
+                    stacklevel=2,
+                )
 
         for path in searchpath:
             if os.path.exists(os.path.join(path, "weka.jar")):
@@ -105,7 +119,7 @@ class WekaClassifier(ClassifierI):
         # Make sure we can find java & weka.
         config_weka()
 
-        temp_dir = tempfile.mkdtemp()
+        temp_dir = make_staging_dir(prefix="nltk_weka_run_", cleanup=True)
         try:
             # Write the test data file.
             test_filename = os.path.join(temp_dir, "test.arff")
@@ -225,7 +239,7 @@ class WekaClassifier(ClassifierI):
         # Build an ARFF formatter.
         formatter = ARFF_Formatter.from_train(featuresets)
 
-        temp_dir = tempfile.mkdtemp()
+        temp_dir = make_staging_dir(prefix="nltk_weka_run_", cleanup=True)
         try:
             # Write the training data file.
             train_filename = os.path.join(temp_dir, "train.arff")

--- a/nltk/test/unit/test_weka_integration.py
+++ b/nltk/test/unit/test_weka_integration.py
@@ -1,0 +1,66 @@
+"""End-to-end integration test for the Weka wrapper with the real weka.jar + JVM.
+
+Skipped unless a Java runtime and a ``weka.jar`` are actually available (set
+``WEKA_JAR`` or install under ``~/nltk_data/weka/weka.jar``), so it exercises the
+real train/classify round trip (proving the ``config_weka`` sandbox-bounding
+change does not break legitimate use) without ever mocking the JVM.
+"""
+
+import os
+import shutil
+
+import pytest
+
+
+def _weka_jar():
+    for cand in (
+        os.environ.get("WEKA_JAR"),
+        os.path.join(os.path.expanduser("~/nltk_data/weka"), "weka.jar"),
+        "/usr/share/weka/weka.jar",
+        "/usr/local/share/weka/weka.jar",
+    ):
+        if cand and os.path.exists(cand):
+            return cand
+    return None
+
+
+@pytest.mark.skipif(shutil.which("java") is None, reason="no Java runtime on PATH")
+def test_real_weka_train_and_classify(tmp_path):
+    """Train a NaiveBayes model with the real jar and classify two instances."""
+    jar = _weka_jar()
+    if jar is None:
+        pytest.skip("weka.jar not available")
+
+    import nltk.classify.weka as wk
+    from nltk.classify.weka import WekaClassifier
+
+    wk._weka_classpath = None
+    train = [
+        ({"a": 1, "b": 0}, "pos"),
+        ({"a": 1, "b": 0}, "pos"),
+        ({"a": 1, "b": 1}, "pos"),
+        ({"a": 0, "b": 1}, "neg"),
+        ({"a": 0, "b": 1}, "neg"),
+        ({"a": 0, "b": 0}, "neg"),
+    ]
+    model = str(tmp_path / "weka.model")
+    try:
+        wk.config_weka(classpath=jar)
+        clf = WekaClassifier.train(model, train, classifier="naivebayes")
+        preds = clf.classify_many([{"a": 1, "b": 0}, {"a": 0, "b": 1}])
+    except (LookupError, OSError) as exc:
+        # a JDK-less runtime (e.g. the macOS /usr/bin/java stub) cannot execute
+        pytest.skip(f"weka/java not runnable here: {str(exc)[:60]}")
+    assert preds == ["pos", "neg"]
+
+
+@pytest.mark.skipif(shutil.which("java") is None, reason="no Java runtime on PATH")
+def test_real_weka_version_read_through_secure_zip(tmp_path):
+    """_check_weka_version reads weka/core/version.txt from the real jar."""
+    jar = _weka_jar()
+    if jar is None:
+        pytest.skip("weka.jar not available")
+    from nltk.classify.weka import _check_weka_version
+
+    version = _check_weka_version(jar)
+    assert version and version.strip()

--- a/nltk/test/unit/test_weka_security.py
+++ b/nltk/test/unit/test_weka_security.py
@@ -9,6 +9,8 @@ path, CWE-426). The CWD is no longer searched; ``WEKAHOME`` or an explicit
 ``config_weka(classpath=...)`` must be used.
 """
 
+import os
+
 import pytest
 
 import nltk.classify.weka as weka
@@ -52,6 +54,60 @@ def test_explicit_classpath_still_used(tmp_path):
     jar.write_bytes(b"")
     weka.config_weka(classpath=str(jar))
     assert weka._weka_classpath == str(jar)
+
+
+def test_wekahome_outside_sandbox_is_ignored(pathsec_sandbox, monkeypatch):
+    """A WEKAHOME outside the pathsec-allowed roots must not be trusted: an
+    attacker-controlled env var cannot add a weka.jar from an untrusted dir
+    (CWE-426/CWE-427). The pathsec_sandbox fixture enforces a single data root,
+    so ``outside`` is guaranteed to be outside it on every platform."""
+    outside = pathsec_sandbox.outside
+    (outside / "weka.jar").write_bytes(b"")  # attacker-planted jar
+    monkeypatch.setenv("WEKAHOME", str(outside))
+    with pytest.warns(UserWarning, match="outside the trusted"):
+        with pytest.raises(LookupError):
+            weka.config_weka()
+    assert weka._weka_classpath is None
+
+
+def test_wekahome_inside_sandbox_is_used(pathsec_sandbox, monkeypatch):
+    """A WEKAHOME within the authorized data roots is honoured, so a legitimate
+    install still auto-resolves. The fixture makes ``root`` the one allowed
+    data root on every platform, so this does not depend on a host temp dir
+    happening to be trusted."""
+    root = pathsec_sandbox.root
+    (root / "weka.jar").write_bytes(b"")
+    monkeypatch.setenv("WEKAHOME", str(root))
+    weka.config_weka()
+    assert weka._weka_classpath == os.path.join(str(root), "weka.jar")
+
+
+def test_train_scratch_arff_staged_inside_data_root(restricted_sandbox, monkeypatch):
+    """The scratch ARFF that train() feeds to weka must be staged INSIDE an
+    NLTK data root, not the shared system temp dir (CWE-377). The external java
+    call is mocked, so this needs neither a JVM nor a real weka.jar; the mock
+    captures the ``-t <train.arff>`` path and confirms it exists at call time."""
+    data_root = restricted_sandbox
+    captured = {}
+
+    def fake_java(cmd, **kwargs):
+        train_file = cmd[cmd.index("-t") + 1]
+        captured["train"] = train_file
+        assert os.path.exists(train_file)  # staged before weka is invoked
+        return ("", "")
+
+    monkeypatch.setattr(weka, "config_weka", lambda *a, **k: None)
+    monkeypatch.setattr(weka, "java", fake_java)
+
+    model = os.path.join(data_root, "name.model")
+    featuresets = [({"a": 1, "b": 0}, "pos"), ({"a": 0, "b": 1}, "neg")]
+    weka.WekaClassifier.train(model, featuresets)
+
+    staged = os.path.realpath(captured["train"])
+    root = os.path.realpath(data_root)
+    # Inside-root via commonpath (Windows-drive-safe); un-hardened develop staged
+    # under tempfile.gettempdir() instead, so this assertion fails against it.
+    assert os.path.commonpath([staged, root]) == root
 
 
 def test_arff_formatter_escapes_directive_injection():


### PR DESCRIPTION
The Weka wrapper (`nltk/classify/weka.py`) drives an external `weka.jar` through a subprocess. Two path-handling issues are fixed here.

## Vulnerability classes

**Scratch ARFF on the shared system temp dir (CWE-377).** `WekaClassifier.train()` and `_classify_many()` wrote their `train.arff` / `test.arff` to `tempfile.mkdtemp()`, which lands in the world-writable system temp dir on Linux and is deliberately *not* an NLTK data root. A local user could observe or race the scratch file another process is about to feed to weka.

**Unbounded `WEKAHOME` search path (CWE-426 / CWE-427).** `config_weka()` inserted `os.environ["WEKAHOME"]` at the front of the jar search path with no validation, so anyone able to set that environment variable could point NLTK at a `weka.jar` outside the trusted roots and have it loaded and executed.

## The fix

- Both scratch files now stage under `nltk.data.make_staging_dir(prefix="nltk_weka_run_", cleanup=True)` — a private `0700` directory inside an allowed data root, removed at interpreter exit.
- `WEKAHOME` is validated with `nltk.pathsec.validate_path` before it is trusted: an out-of-root value is ignored with a `UserWarning`, while a legitimate in-root install still resolves.

## Tests

- `nltk/test/unit/test_weka_security.py` gains three cases: an out-of-root `WEKAHOME` is refused (warning + `LookupError`), an in-root `WEKAHOME` still resolves, and `train()`s scratch ARFF is proven to land inside the data root rather than the system temp dir. The refusal and placement assertions fail against the un-hardened code; the external `java` call is mocked, so none of these need a JVM or a real `weka.jar`.
- `nltk/test/unit/test_weka_integration.py` is a new end-to-end round trip that runs only when a real java runtime and `weka.jar` are present, and skips cleanly otherwise.

## Cross-platform

The refusal/placement tests use the shared `pathsec_sandbox` / `restricted_sandbox` conftest fixtures (a single enforced data root plus an out-of-root dir under `$HOME`) instead of a hard-coded `/tmp` path, inside-root checks use `os.path.commonpath` on `realpath`ed paths, and the JVM-dependent tests skip when no `java` is on `PATH`. The suite is green on Linux, macOS and Windows.

## Notes

This change is split out of a larger hardening effort so it stands alone: it applies cleanly on top of `develop` (all guard symbols it uses — `make_staging_dir`, `validate_path` — are already on `develop`) and its tests pass against `develop` plus this `weka.py` alone.

SSRF is not applicable to this wrapper: it only invokes a local `weka.jar` and never fetches a URL.