### PR TITLE
Route corpus-reader scratch tempfiles through a data root and label framenet path refusals

### DIFF
--- a/nltk/corpus/reader/framenet.py
+++ b/nltk/corpus/reader/framenet.py
@@ -776,7 +776,9 @@ def _reject_unsafe_path_component(value, kind):
         or ".." in value
         or ntpath.splitdrive(value)[0]
     ):
-        raise FramenetError(f"Invalid {kind}: {value!r}")
+        # "Security violation" marks this as a containment decision, not an
+        # incidental lookup error, so callers and audits can tell them apart.
+        raise FramenetError(f"Security violation: Invalid {kind}: {value!r}")
 
 
 def _validate_in_root(locpath, root, context):

--- a/nltk/corpus/reader/nkjp.py
+++ b/nltk/corpus/reader/nkjp.py
@@ -277,7 +277,12 @@ class XML_Tool:
     def __init__(self, root, filename):
         self._root = root
         self.read_file = os.path.join(root, filename)
-        self.write_file = tempfile.NamedTemporaryFile(delete=False)
+        # Imported here: nltk.data imports the corpus package.
+        from nltk.data import staging_tempdir
+
+        self.write_file = tempfile.NamedTemporaryFile(
+            delete=False, dir=staging_tempdir()
+        )
 
     def build_preprocessed_file(self):
         try:

--- a/nltk/corpus/reader/timit.py
+++ b/nltk/corpus/reader/timit.py
@@ -395,7 +395,10 @@ class TimitCorpusReader(CorpusReader):
 
         # Open a new temporary file -- the wave module requires
         # an actual file, and won't work w/ stringio. :(
-        tf = tempfile.TemporaryFile()
+        # Imported here: nltk.data imports the corpus package.
+        from nltk.data import staging_tempdir
+
+        tf = tempfile.TemporaryFile(dir=staging_tempdir())
         out = wave.open(tf, "w")
 
         # Write the parameters & data to the new file.

--- a/nltk/test/unit/test_corpus_reader_hardening.py
+++ b/nltk/test/unit/test_corpus_reader_hardening.py
@@ -1,0 +1,165 @@
+# Natural Language Toolkit: corpus-reader file-IO hardening tests
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""File-IO hardening for three corpus readers.
+
+This is the corpus-reader slice of the larger GHSA-8mgp effort. It covers only
+what those readers changed:
+
+* ``framenet``: ``_reject_unsafe_path_component`` now labels its refusal as a
+  "Security violation" so a containment decision is distinguishable from an
+  incidental lookup miss (the resolving choke point ``_validate_in_root`` is
+  exercised too as an over-block control).
+* ``nkjp`` and ``timit``: their scratch tempfiles used to default to the system
+  temp dir, which on Linux is the shared, world-writable ``/tmp`` and is
+  deliberately not a pathsec data root. They are now pinned to
+  ``nltk.data.staging_tempdir()`` so the scratch file lands inside a data root.
+
+The ``restricted_sandbox`` / ``pathsec_sandbox`` fixtures (see the shared
+``conftest.py``) enforce pathsec against one throwaway data root registered on
+``nltk.data.path``. That registration is what lets these tests run on Linux and
+Windows, where a bare temp dir is not a data root, as well as on macOS.
+"""
+
+import os
+
+import pytest
+
+from nltk.data import staging_tempdir
+
+POSIX_ONLY = pytest.mark.skipif(
+    os.name != "posix", reason="requires POSIX symlink semantics"
+)
+
+_SECRET = "root:x:0:0:SECRET"
+
+
+# ----------------------------------------------------------------------------
+# framenet: the refusal is labelled, and the resolving choke point still holds
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["../evil", "a/b", "..", r"sub\evil", "C:evil", r"\\host\share"],
+)
+def test_framenet_reject_unsafe_component_flags_security_violation(bad):
+    from nltk.corpus.reader.framenet import FramenetError, _reject_unsafe_path_component
+
+    with pytest.raises(FramenetError, match="Security violation"):
+        _reject_unsafe_path_component(bad, "frame name")
+
+
+def test_framenet_reject_unsafe_component_accepts_a_plain_name():
+    # Over-block control: a name with no separator, "..", or drive is allowed.
+    from nltk.corpus.reader.framenet import _reject_unsafe_path_component
+
+    assert _reject_unsafe_path_component("Communication", "frame name") is None
+
+
+def test_framenet_validate_in_root_refuses_traversal_and_absolute(pathsec_sandbox):
+    from nltk.corpus.reader.framenet import _validate_in_root
+
+    root = str(pathsec_sandbox.root)
+    outside_secret = os.path.join(str(pathsec_sandbox.outside), "SECRET")
+    for locpath in (
+        os.path.join(root, "frame", "..", "..", "outside", "SECRET"),
+        outside_secret,
+    ):
+        with pytest.raises((PermissionError, ValueError)):
+            _validate_in_root(locpath, root, "test")
+
+
+@POSIX_ONLY
+def test_framenet_validate_in_root_refuses_symlink_escape(pathsec_sandbox):
+    from nltk.corpus.reader.framenet import _validate_in_root
+
+    root = str(pathsec_sandbox.root)
+    outside = str(pathsec_sandbox.outside)
+    with open(os.path.join(outside, "SECRET"), "w", encoding="utf-8") as handle:
+        handle.write(_SECRET)
+    frame_dir = os.path.join(root, "frame")
+    os.makedirs(frame_dir, exist_ok=True)
+    symlink = os.path.join(frame_dir, "evil.xml")
+    os.symlink(os.path.join(outside, "SECRET"), symlink)
+    with pytest.raises((PermissionError, ValueError)):
+        _validate_in_root(symlink, root, "test")
+
+
+def test_framenet_validate_in_root_accepts_an_in_root_path(pathsec_sandbox):
+    # Over-block control: a legitimate in-root path must not be refused.
+    from nltk.corpus.reader.framenet import _validate_in_root
+
+    root = str(pathsec_sandbox.root)
+    frame_dir = os.path.join(root, "frame")
+    os.makedirs(frame_dir, exist_ok=True)
+    good = os.path.join(frame_dir, "good.xml")
+    with open(good, "w", encoding="utf-8") as handle:
+        handle.write("<frame/>")
+    _validate_in_root(good, root, "test")
+
+
+# ----------------------------------------------------------------------------
+# nkjp: XML_Tool's scratch tempfile is pinned inside a data root
+# ----------------------------------------------------------------------------
+
+
+def test_nkjp_xml_tool_tempfile_is_pinned_to_a_data_root(restricted_sandbox):
+    from nltk.corpus.reader.nkjp import XML_Tool
+
+    root = restricted_sandbox
+    tool = XML_Tool(root, "header.xml")
+    try:
+        scratch_dir = os.path.realpath(os.path.dirname(tool.write_file.name))
+        assert scratch_dir == os.path.realpath(staging_tempdir())
+        assert scratch_dir.startswith(os.path.realpath(root))
+    finally:
+        tool.write_file.close()
+        if os.path.exists(tool.write_file.name):
+            os.remove(tool.write_file.name)
+
+
+# ----------------------------------------------------------------------------
+# timit: the wav() scratch tempfile is pinned inside a data root
+# ----------------------------------------------------------------------------
+
+
+def _write_minimal_wav(path):
+    import wave
+
+    with wave.open(str(path), "wb") as handle:
+        handle.setnchannels(1)
+        handle.setsampwidth(2)
+        handle.setframerate(8000)
+        handle.writeframes(b"\x00\x00" * 100)
+
+
+def test_timit_wav_tempfile_is_pinned_to_a_data_root(restricted_sandbox, monkeypatch):
+    import tempfile
+
+    from nltk.corpus.reader import timit as timit_module
+    from nltk.corpus.reader.timit import TimitCorpusReader
+    from nltk.data import FileSystemPathPointer
+
+    root = restricted_sandbox
+    speaker_dir = os.path.join(root, "dr1-fabc0")
+    os.makedirs(speaker_dir, exist_ok=True)
+    _write_minimal_wav(os.path.join(speaker_dir, "sa1.wav"))
+
+    recorded = {}
+    real_temporaryfile = tempfile.TemporaryFile
+
+    def recording_temporaryfile(*args, **kwargs):
+        recorded["dir"] = kwargs.get("dir")
+        return real_temporaryfile(*args, **kwargs)
+
+    monkeypatch.setattr(timit_module.tempfile, "TemporaryFile", recording_temporaryfile)
+
+    reader = TimitCorpusReader(FileSystemPathPointer(root))
+    reader.wav("dr1-fabc0/sa1")
+
+    assert recorded["dir"] == staging_tempdir()
+    assert os.path.realpath(recorded["dir"]).startswith(os.path.realpath(root))


### PR DESCRIPTION
## What

A self-contained split from the larger GHSA-8mgp file-IO hardening effort, covering only the three corpus readers that touch scratch tempfiles or path-containment messages.

### Readers changed

- **`nltk/corpus/reader/nkjp.py`** (`XML_Tool.__init__`): the preprocessing scratch file, previously `tempfile.NamedTemporaryFile(delete=False)`, is now pinned with `dir=staging_tempdir()`.
- **`nltk/corpus/reader/timit.py`** (`TimitCorpusReader.wav`): the wave scratch file, previously `tempfile.TemporaryFile()`, is now pinned with `dir=staging_tempdir()`.
- **`nltk/corpus/reader/framenet.py`** (`_reject_unsafe_path_component`): the refusal message is prefixed with `Security violation:` so a containment decision reads differently from an incidental lookup miss. Behaviour is otherwise unchanged; the resolving choke point `_validate_in_root` is untouched.

### Vulnerability classes

- **Unpinned scratch tempfiles on shared `/tmp` (CWE-377 / CWE-378).** `tempfile.NamedTemporaryFile()` / `TemporaryFile()` default to the system temp dir. On Linux that is the shared, world-writable `/tmp`, which is deliberately *not* a pathsec data root, so NKJP and TIMIT staged scratch data outside the sandbox where another local user could observe or race it. `nltk.data.staging_tempdir()` (already on `develop`) returns a private directory inside an allowed data root on every platform; passing it as `dir=` moves the scratch file back inside the sandbox.
- **Path-containment message labelling.** Framenet frame/lu/doc loads funnel caller- and corpus-supplied names through `_reject_unsafe_path_component`; the refusal is now explicitly labelled so callers and audits can tell a security refusal apart from a plain lookup error.

## Tests

Adds `nltk/test/unit/test_corpus_reader_hardening.py`, scoped to exactly this delta:

- framenet refusal is labelled `Security violation` (across separator, `..`, and Windows drive/UNC names), plus over-block controls: a plain frame name is accepted, and `_validate_in_root` still refuses a traversal / absolute / symlink escape while accepting an in-root path.
- the NKJP and TIMIT scratch tempfiles land inside a registered data root (equal to `staging_tempdir()`), verified behaviourally.

Each tempfile-pinning and message assertion fails against the current un-hardened `develop` readers (verified by reverting each file), so the tests have teeth.

## Cross-platform handling

The tests use the shared `conftest.py` sandbox fixtures (`restricted_sandbox`, `pathsec_sandbox`), which enforce pathsec against one throwaway data root and register it on `nltk.data.path`. That registration is what lets a `CorpusReader` construct against a fixture root and lets `staging_tempdir()` allocate inside it on Linux and Windows, where a bare temp dir is not a data root, as well as on macOS. Fixture files are read `encoding="utf-8"` and audio is written binary; the symlink-escape check is skipped off POSIX.

This split is self-contained on `develop` (it depends only on `nltk.data.staging_tempdir` and `nltk.pathsec`, both already merged) and lets the deferred temp-file-factory guard be re-enabled later.