### PR TITLE
Harden malt and stanford parser wrappers: validate binary/model/IO paths and argv

### DIFF
--- a/nltk/parse/malt.py
+++ b/nltk/parse/malt.py
@@ -12,7 +12,7 @@ import os
 import sys
 import tempfile
 
-from nltk.data import ZipFilePathPointer
+from nltk.data import ZipFilePathPointer, make_staging_dir
 from nltk.internals import (
     find_dir,
     find_file,
@@ -22,6 +22,12 @@ from nltk.internals import (
 from nltk.parse.api import ParserI
 from nltk.parse.dependencygraph import DependencyGraph
 from nltk.parse.util import taggedsents_to_conll
+from nltk.pathsec import open as pathsec_open
+from nltk.pathsec import (
+    validate_model_resource,
+    validate_path,
+    validate_tool_path,
+)
 
 
 def malt_regex_tagger():
@@ -160,10 +166,45 @@ class MaltParser(ParserI):
         # Initialize model.
         self.model = find_malt_model(model_filename)
         self._trained = self.model != "malt_temp.mco"
-        # Set the working_dir parameters i.e. `-w` from MaltParser's option.
-        self.working_dir = tempfile.gettempdir()
+        # `-w` is allocated lazily inside a data root; see the working_dir property.
+        self._working_dir = None
         # Initialize POS tagger.
         self.tagger = tagger if tagger is not None else malt_regex_tagger()
+
+    @property
+    def working_dir(self):
+        """MaltParser's ``-w`` directory, holding the temporary CoNLL files and,
+        for an untrained parser, the ``malt_temp.mco`` model that ``train()``
+        writes.
+
+        Allocated lazily by ``nltk.data.make_staging_dir`` INSIDE an allowed data
+        root, with an unpredictable name and mode 0700. The previous default was
+        the shared ``tempfile.gettempdir()``, which is world-writable on Linux and
+        gives a predictable, squattable path for both the CoNLL files and the model.
+        """
+        if self._working_dir is None:
+            # cleanup=True: the old shared tempdir was reaped by the OS, a dir
+            # under a data root is not, and the .mco it holds is temporary.
+            self._working_dir = make_staging_dir(prefix="nltk_malt_", cleanup=True)
+        return self._working_dir
+
+    @working_dir.setter
+    def working_dir(self, value):
+        # None restores the unset state, so the property allocates again on next
+        # access rather than raising.
+        if value is None:
+            self._working_dir = None
+            return
+        # A caller may still choose the directory, but only inside the sandbox.
+        # An empty value would reach MaltParser as `-w ""`, i.e. the CWD.
+        text = os.fspath(value)
+        if not text.strip():
+            raise ValueError(
+                "MaltParser.working_dir may not be empty; it would resolve to the "
+                "current working directory."
+            )
+        validate_path(text, context="MaltParser.working_dir")
+        self._working_dir = text
 
     def parse_tagged_sents(self, sentences, verbose=False, top_relation_label="null"):
         """
@@ -214,7 +255,9 @@ class MaltParser(ParserI):
                     )
 
                 # Must return iter(iter(Tree))
-                with open(output_file_name) as infile:
+                with pathsec_open(
+                    output_file_name, context="MaltParser.parse_tagged_sents"
+                ) as infile:
                     for tree_str in infile.read().split("\n\n"):
                         yield (
                             iter(
@@ -258,6 +301,12 @@ class MaltParser(ParserI):
         :type inputfilename: str
         :param outputfilename: path to the output file
         :type outputfilename: str
+
+        Both filenames are bounded to the NLTK data roots. ``-i`` is read by the
+        JVM and ``-o`` is *written* by it, so an unbounded value here is an
+        arbitrary file read and an arbitrary file write respectively. The
+        internal callers pass temporary files inside :attr:`working_dir`, which
+        is itself allocated inside a data root.
         """
 
         # Build only MaltParser's own arguments (main class + program args). The
@@ -270,13 +319,35 @@ class MaltParser(ParserI):
         # directory as the ``-w`` program argument rather than chdir-ing the JVM
         # process: no cwd is handed to java(), so there is no working-directory
         # class-injection surface (an empty/CWD -cp element, CWE-88).
-        model_dir, model_name = os.path.split(self.model)
-        workingdir = os.path.abspath(model_dir) if model_dir else os.getcwd()
+        # Rejects an empty / option-like / URL / traversing model name, and bounds
+        # it to the sandbox when it is a real path. Use the value it returns:
+        # __fspath__ may answer differently on every call, so re-reading
+        # self.model here would let the JVM open a file the guard never saw.
+        model = validate_model_resource(self.model, context="MaltParser model")
+        model_dir, model_name = os.path.split(model)
+        if model_dir:
+            # A model carrying a directory is a real path: bound the directory too,
+            # since in learn mode MaltParser WRITES the .mco into it.
+            validate_path(model, context="MaltParser model")
+            workingdir = os.path.abspath(model_dir)
+        else:
+            # A bare model name lives in the private dir that train() wrote it to.
+            workingdir = self.working_dir
         cmd += ["-w", workingdir, "-c", model_name]
 
-        cmd += ["-i", inputfilename]
+        # -i is read by the JVM and -o is written by it; train_from_file() and
+        # generate_malt_command() are both public, so neither may leave the roots.
+        cmd += ["-i", validate_tool_path(inputfilename, context="MaltParser input")]
         if mode == "parse":
-            cmd += ["-o", outputfilename]
+            cmd += [
+                "-o",
+                validate_tool_path(
+                    outputfilename,
+                    context="MaltParser output",
+                    for_write=True,
+                    must_exist=False,
+                ),
+            ]
         cmd += ["-m", mode]  # mode use to generate parses.
         return cmd
 

--- a/nltk/parse/stanford.py
+++ b/nltk/parse/stanford.py
@@ -11,9 +11,11 @@ import tempfile
 import warnings
 from subprocess import PIPE
 
+from nltk.data import staging_tempdir
 from nltk.internals import find_jar_iter, find_jars_within_path, java
 from nltk.parse.api import ParserI
 from nltk.parse.dependencygraph import DependencyGraph
+from nltk.pathsec import validate_model_resource
 from nltk.tree import Tree
 
 _stanford_url = "https://nlp.stanford.edu/software/lex-parser.shtml"
@@ -217,17 +219,64 @@ class GenericStanfordParser(ParserI):
             )
         )
 
+    def _validated_extra_options(self, cmd):
+        """Bound the caller-supplied ``corenlp_options`` before it joins the argv.
+
+        The string is *split* into separate argv elements, so it can append a
+        second ``-model``. Stanford's ``LexicalizedParser`` honours the LAST
+        occurrence, which was verified directly against the JVM, so an injected
+        option silently replaced the model the guard above had just checked and
+        the parser deserialized an arbitrary file instead.
+
+        An option NLTK already set may therefore not be repeated here, and any
+        value that looks like a filesystem path is bounded to the data roots. A
+        value that is not a path (``xml``, ``key=value``) is left alone, since
+        this is a general passthrough for the tool's own settings.
+        """
+        already_set = {
+            argument
+            for argument in cmd
+            if isinstance(argument, str) and argument.startswith("-")
+        }
+        validated = []
+        for token in self.corenlp_options.split():
+            if token.startswith("-"):
+                if token in already_set:
+                    raise ValueError(
+                        f"Security Violation [StanfordParser corenlp_options]: "
+                        f"{token!r} is already set by NLTK and may not be "
+                        "overridden; the tool would honour the injected value."
+                    )
+                validated.append(token)
+                continue
+            if os.path.isabs(token) or "/" in token or "\\" in token:
+                token = validate_model_resource(
+                    token, context="StanfordParser corenlp_options"
+                )
+            validated.append(token)
+        return validated
+
     def _execute(self, cmd, input_, verbose=False):
+        # Bound `-model` here, at the single hand-off to the JVM, so all three
+        # callers are covered and a late reassignment cannot slip past. The argv
+        # entry is replaced with the validated string: __fspath__ may answer
+        # differently on every call, so the object the callers put in `cmd` could
+        # otherwise resolve to a file the guard never saw.
+        model = validate_model_resource(self.model_path, context="StanfordParser model")
+        if "-model" in cmd:
+            cmd[cmd.index("-model") + 1] = model
         encoding = self._encoding
         cmd.extend(["-encoding", encoding])
         if self.corenlp_options:
-            cmd.extend(self.corenlp_options.split())
+            cmd.extend(self._validated_extra_options(cmd))
 
         # Windows is incompatible with NamedTemporaryFile() without passing in delete=False.
         input_file_name = None
         java_succeeded = False
         try:
-            with tempfile.NamedTemporaryFile(mode="wb", delete=False) as input_file:
+            with tempfile.NamedTemporaryFile(
+                mode="wb", delete=False, dir=staging_tempdir()
+            ) as input_file:
                 input_file_name = input_file.name
                 # Write the actual sentences to the temporary input file
                 if isinstance(input_, str) and encoding:

--- a/nltk/test/unit/test_malt_stanford_pathsec.py
+++ b/nltk/test/unit/test_malt_stanford_pathsec.py
@@ -1,0 +1,666 @@
+# Natural Language Toolkit: MaltParser / StanfordParser pathsec regressions
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""Path and argv hardening for the two JVM parser wrappers.
+
+``nltk.parse.malt`` and ``nltk.parse.stanford`` take caller-supplied model,
+corpus and IO paths and pass them straight into a child JVM's argv. Those are
+*data* paths, so they must stay inside the NLTK data roots; a value outside the
+sandbox lets the tool read (and, for MaltParser's ``-w`` in learn mode, WRITE)
+anywhere on disk.
+
+Vulnerability classes covered here:
+
+* MaltParser ``-i`` arbitrary read / ``-o`` arbitrary write, ``-c`` model
+  traversal, and the ``-w`` working directory, which used to default to the
+  shared world-writable ``tempfile.gettempdir()`` and now stages a private dir
+  inside a data root.
+* StanfordParser ``-model`` traversal and the ``corenlp_options`` string, which
+  is split into argv and could append a second ``-model`` (the JVM honours the
+  last one, verified against a real ``LexicalizedParser``).
+* A ``__fspath__`` time-of-check/time-of-use gap and a lying ``str`` subclass,
+  both closed by the guards returning the resolved plain string the callers use.
+
+Every guard test drives the real wrapper with only the ``java`` hand-off
+replaced, so a probe cannot pass merely because the argv was assembled by the
+test itself. The teeth tests neuter a guard and assert the attack reappears, so
+each refusal is known to fail against the un-hardened code.
+"""
+
+import os
+
+import pytest
+
+from nltk import pathsec
+from nltk.data import make_staging_dir
+from nltk.pathsec import validate_model_resource, validate_tool_path
+
+_DEFAULT_RESOURCE = "edu/stanford/nlp/models/lexparser/englishPCFG.ser.gz"
+
+
+class _ReachedJVM(Exception):
+    """Raised by the trapped ``java`` so a test can tell "the argv was built and
+    handed off" apart from "a guard refused first"."""
+
+
+def _passthrough(value, *args, **kwargs):
+    """A neutered guard: performs no checks but still returns the path, since the
+    callers now use the value the guard hands back."""
+    return os.fspath(value)
+
+
+def _trap_java(monkeypatch, module, sink):
+    """Replace ``module.java`` with a trap that records argv and stops before
+    launching a JVM."""
+
+    def fake_java(cmd, *args, **kwargs):
+        sink["cmd"] = list(cmd)
+        raise _ReachedJVM
+
+    monkeypatch.setattr(module, "java", fake_java)
+    return sink
+
+
+class _MutatingPath:
+    """A legal os.PathLike whose __fspath__ answers differently each call."""
+
+    def __init__(self, first, rest):
+        self._calls = 0
+        self._first = first
+        self._rest = rest
+
+    def __fspath__(self):
+        self._calls += 1
+        return self._first if self._calls == 1 else self._rest
+
+    def __str__(self):
+        return self._first
+
+
+def _resolve(value):
+    return os.fspath(value) if hasattr(value, "__fspath__") else value
+
+
+class _LyingStr(str):
+    """A str subclass whose inspection methods lie.
+
+    os.fspath() returns a str subclass unchanged, so every syntactic check would
+    otherwise run on attacker-controlled methods while the value handed to the
+    tool still carries the real, hostile characters.
+    """
+
+    def __str__(self):
+        return "safe"
+
+    def startswith(self, *args, **kwargs):
+        return False
+
+    def strip(self, *args, **kwargs):
+        return "safe"
+
+    def rstrip(self, *args, **kwargs):
+        return self
+
+    def replace(self, *args, **kwargs):
+        return "safe/name.mco"
+
+    def split(self, *args, **kwargs):
+        return ["safe", "name.mco"]
+
+    def lower(self):
+        return "safe"
+
+    def __contains__(self, item):
+        return False
+
+
+# MaltParser: the -c model and the -w working directory (WRITTEN in learn mode).
+
+
+def _malt(model, trained=True):
+    import nltk.parse.malt as malt
+
+    parser = object.__new__(malt.MaltParser)
+    parser.model = model
+    parser._trained = trained
+    parser._working_dir = None
+    parser.additional_java_args = []
+    return parser
+
+
+def _sandbox_io(parser):
+    """Valid in-sandbox -i/-o paths for a test that targets some *other* guard.
+    Without these the input-file guard fires first and the test would pass for
+    the wrong reason."""
+    infile = os.path.join(parser.working_dir, "in.conll")
+    with pathsec.open(infile, "w", encoding="utf-8") as handle:
+        handle.write("")
+    return infile, os.path.join(parser.working_dir, "out.conll")
+
+
+def test_malt_trained_model_refuses_escape(pathsec_sandbox):
+    """A .mco outside the roots would make ``-w`` an arbitrary write target."""
+    root, outside = pathsec_sandbox
+    evil = outside / "evil.mco"
+    evil.write_text("model", encoding="utf-8")
+    parser = _malt(str(evil))
+    infile, _outfile = _sandbox_io(parser)
+    with pytest.raises((PermissionError, ValueError)):
+        parser.generate_malt_command(infile, None, mode="learn")
+
+
+def test_malt_trained_model_in_sandbox_is_allowed(pathsec_sandbox):
+    """Over-block control for the trained path."""
+    root, _outside = pathsec_sandbox
+    model = root / "engmalt.mco"
+    model.write_text("model", encoding="utf-8")
+    parser = _malt(str(model))
+    infile, outfile = _sandbox_io(parser)
+    cmd = parser.generate_malt_command(infile, outfile, mode="parse")
+    assert cmd[cmd.index("-w") + 1] == str(root)
+    assert cmd[cmd.index("-c") + 1] == "engmalt.mco"
+
+
+def test_malt_untrained_working_dir_is_staged_inside_root(pathsec_sandbox):
+    """An untrained parser used to write malt_temp.mco into the CWD; it must now
+    land in a private staging dir inside a data root."""
+    root, _outside = pathsec_sandbox
+    parser = _malt("malt_temp.mco", trained=False)
+    infile, _outfile = _sandbox_io(parser)
+    cmd = parser.generate_malt_command(infile, None, mode="learn")
+    workingdir = cmd[cmd.index("-w") + 1]
+    assert os.path.realpath(workingdir).startswith(os.path.realpath(str(root)))
+    assert os.path.realpath(workingdir) != os.path.realpath(os.getcwd())
+    assert cmd[cmd.index("-c") + 1] == "malt_temp.mco"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX mode bits")
+def test_malt_working_dir_is_private():
+    """The staging dir must not be group/world readable: it holds the CoNLL
+    intermediates and the trained model."""
+    staged = make_staging_dir(prefix="nltk_malt_test_")
+    assert os.stat(staged).st_mode & 0o077 == 0
+
+
+def test_malt_working_dir_setter_refuses_escape(pathsec_sandbox):
+    """A caller may still choose the directory, but only inside the sandbox."""
+    _root, outside = pathsec_sandbox
+    parser = _malt("malt_temp.mco", trained=False)
+    with pytest.raises((PermissionError, ValueError)):
+        parser.working_dir = str(outside)
+
+
+def test_malt_working_dir_setter_accepts_in_sandbox(pathsec_sandbox):
+    """Over-block control for the setter."""
+    root, _outside = pathsec_sandbox
+    parser = _malt("malt_temp.mco", trained=False)
+    parser.working_dir = str(root)
+    assert parser.working_dir == str(root)
+
+
+def test_malt_working_dir_is_not_shared_tempdir(pathsec_sandbox):
+    """Regression: the default was ``tempfile.gettempdir()``, which is
+    world-writable on Linux and gives a predictable, squattable path."""
+    import tempfile as _tempfile
+
+    root, _outside = pathsec_sandbox
+    parser = _malt("malt_temp.mco", trained=False)
+    assert os.path.realpath(parser.working_dir) != os.path.realpath(
+        _tempfile.gettempdir()
+    )
+
+
+def test_malt_command_shape_is_unchanged(pathsec_sandbox):
+    """The guard must not reorder or drop MaltParser's arguments."""
+    root, _outside = pathsec_sandbox
+    model = root / "engmalt.mco"
+    model.write_text("model", encoding="utf-8")
+    parser = _malt(str(model))
+    infile, outfile = str(root / "in.conll"), str(root / "out.conll")
+    with pathsec.open(infile, "w", encoding="utf-8") as handle:
+        handle.write("")
+    cmd = parser.generate_malt_command(infile, outfile, mode="parse")
+    assert cmd[0] == "org.maltparser.Malt"
+    for flag in ("-w", "-c", "-i", "-o", "-m"):
+        assert flag in cmd
+    assert cmd[cmd.index("-i") + 1] == infile
+    assert cmd[cmd.index("-o") + 1] == outfile
+    assert cmd[cmd.index("-m") + 1] == "parse"
+
+
+def test_malt_working_dir_is_stable_across_calls(pathsec_sandbox):
+    """The lazy property must allocate once, not a fresh dir per access, or the
+    CoNLL intermediates and the model would land in different directories."""
+    parser = _malt("malt_temp.mco", trained=False)
+    assert parser.working_dir == parser.working_dir
+
+
+def test_malt_working_dir_none_resets_to_lazy_allocation(pathsec_sandbox):
+    """Regression: assigning None used to raise; it now restores the unset state
+    so the property allocates again."""
+    root, _outside = pathsec_sandbox
+    parser = _malt("malt_temp.mco", trained=False)
+    first = parser.working_dir
+    parser.working_dir = None
+    assert parser.working_dir != first or os.path.isdir(parser.working_dir)
+
+
+def test_teeth_malt_guard_is_load_bearing(pathsec_sandbox, monkeypatch):
+    """Both guards have to go before the escape reappears, which is the point:
+    validate_model_resource still catches the model when validate_path is gone."""
+    import nltk.parse.malt as malt
+
+    _root, outside = pathsec_sandbox
+    monkeypatch.setattr(malt, "validate_path", lambda *a, **k: None)
+    monkeypatch.setattr(malt, "validate_model_resource", _passthrough)
+    monkeypatch.setattr(malt, "validate_tool_path", _passthrough)
+    evil = outside / "evil.mco"
+    evil.write_text("model", encoding="utf-8")
+    cmd = _malt(str(evil)).generate_malt_command("in.conll", "out.conll", mode="learn")
+    assert cmd[cmd.index("-w") + 1] == str(outside)
+
+
+def test_teeth_malt_model_resource_guard_alone_blocks(pathsec_sandbox, monkeypatch):
+    """Removing only validate_path must NOT reopen the escape: the second guard
+    is independently load-bearing."""
+    import nltk.parse.malt as malt
+
+    _root, outside = pathsec_sandbox
+    monkeypatch.setattr(malt, "validate_path", lambda *a, **k: None)
+    evil = outside / "evil.mco"
+    evil.write_text("model", encoding="utf-8")
+    parser = _malt(str(evil))
+    infile, _outfile = _sandbox_io(parser)
+    with pytest.raises((PermissionError, ValueError)):
+        parser.generate_malt_command(infile, None, mode="learn")
+
+
+def test_malt_working_dir_uses_the_validated_model_string(pathsec_sandbox):
+    """A mutating __fspath__ must not resolve to a file the guard never saw."""
+    root, outside = pathsec_sandbox
+    evil = outside / "evil.mco"
+    evil.write_text("x", encoding="utf-8")
+    good = root / "ok.mco"
+    good.write_text("m", encoding="utf-8")
+
+    parser = _malt(_MutatingPath(str(good), str(evil)))
+    infile, _outfile = _sandbox_io(parser)
+    cmd = parser.generate_malt_command(infile, None, mode="learn")
+    workingdir = cmd[cmd.index("-w") + 1]
+    assert os.path.realpath(str(workingdir)).startswith(os.path.realpath(str(root)))
+
+
+def test_malt_argv_cannot_be_injected_via_str_subclass(pathsec_sandbox):
+    """The payload previously reached the JVM argv as "-c -Xmx99g"."""
+    root, _outside = pathsec_sandbox
+    parser = _malt(_LyingStr("-Xmx99g"))
+    infile, _outfile = _sandbox_io(parser)
+    with pytest.raises((PermissionError, ValueError)):
+        parser.generate_malt_command(infile, None, mode="learn")
+
+
+def test_malt_working_dir_is_cleaned_up(tmp_path):
+    """Reclaimed malt cleanup regression: every parser that touched working_dir
+    left a directory under the data root forever. The shared tempdir it replaced
+    was OS-reaped, but a data root is not, so the dir is now removed at
+    interpreter exit.
+
+    Run in a real subprocess: atexit only fires when the process ends.
+    """
+    import subprocess
+    import sys
+
+    root = tmp_path / "nltk_data"
+    root.mkdir()
+    script = (
+        "import nltk.data, nltk.pathsec as ps;"
+        f"nltk.data.path[:] = [{str(root)!r}];"
+        "ps._ALLOWED_ROOTS_CACHE = None; ps._LAST_DATA_PATHS = None;"
+        "from nltk.parse.malt import MaltParser;"
+        "p = MaltParser.__new__(MaltParser); p._working_dir = None;"
+        "print(p.working_dir)"
+    )
+    env = dict(os.environ, PYTHONPATH=os.pathsep.join(sys.path))
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, env=env
+    )
+    assert result.returncode == 0, result.stderr
+    staged = result.stdout.strip()
+    assert staged.startswith(str(root))
+    assert not os.path.exists(staged), f"staging dir leaked after exit: {staged}"
+
+
+# StanfordParser: -model may be a filesystem path OR a jar-internal resource.
+
+
+def _stanford_parser(model_path):
+    import nltk.parse.stanford as st
+
+    parser = object.__new__(st.StanfordParser)
+    parser.model_path = model_path
+    parser._classpath = ()
+    parser.java_options = "-mx1g"
+    parser._encoding = "utf8"
+    parser.corenlp_options = ""
+    parser._USE_STDIN = False
+    return parser
+
+
+def _stanford_with_options(model_path, options):
+    parser = _stanford_parser(model_path)
+    parser.corenlp_options = options
+    return parser
+
+
+@pytest.mark.parametrize(
+    "model_path",
+    ["/etc/passwd", "edu/stanford/../../../../etc/passwd"],
+    ids=["etc-abs", "traversal"],
+)
+def test_stanford_parser_model_refuses_escape(pathsec_sandbox, monkeypatch, model_path):
+    import nltk.parse.stanford as st
+
+    _trap_java(monkeypatch, st, {})
+    with pytest.raises((PermissionError, ValueError)):
+        _stanford_parser(model_path).parse_sents([["hello", "world"]])
+
+
+def test_stanford_parser_outside_model_refuses_escape(pathsec_sandbox, monkeypatch):
+    import nltk.parse.stanford as st
+
+    _root, outside = pathsec_sandbox
+    _trap_java(monkeypatch, st, {})
+    evil = outside / "evil.ser.gz"
+    evil.write_text("model", encoding="utf-8")
+    with pytest.raises((PermissionError, ValueError)):
+        _stanford_parser(str(evil)).parse_sents([["hello", "world"]])
+
+
+def test_stanford_parser_default_resource_still_works(pathsec_sandbox, monkeypatch):
+    """Over-block control: the shipped default is a jar-internal resource, not a
+    file on disk, and must not be treated as a path."""
+    import nltk.parse.stanford as st
+
+    sink = _trap_java(monkeypatch, st, {})
+    with pytest.raises(_ReachedJVM):
+        _stanford_parser(_DEFAULT_RESOURCE).parse_sents([["hello", "world"]])
+    assert sink["cmd"][sink["cmd"].index("-model") + 1] == _DEFAULT_RESOURCE
+
+
+def test_stanford_parser_in_sandbox_model_still_works(pathsec_sandbox, monkeypatch):
+    """Over-block control: a real model inside a data root must still load."""
+    import nltk.parse.stanford as st
+
+    root, _outside = pathsec_sandbox
+    sink = _trap_java(monkeypatch, st, {})
+    model = root / "englishPCFG.ser.gz"
+    model.write_text("model", encoding="utf-8")
+    with pytest.raises(_ReachedJVM):
+        _stanford_parser(str(model)).parse_sents([["hello", "world"]])
+    assert sink["cmd"][sink["cmd"].index("-model") + 1] == str(model)
+
+
+def test_teeth_stanford_parser_guard_is_load_bearing(pathsec_sandbox, monkeypatch):
+    import nltk.parse.stanford as st
+
+    _trap_java(monkeypatch, st, {})
+    monkeypatch.setattr(st, "validate_model_resource", _passthrough)
+    with pytest.raises(_ReachedJVM):
+        _stanford_parser("/etc/passwd").parse_sents([["hello", "world"]])
+
+
+def test_stanford_model_argv_carries_the_validated_string(pathsec_sandbox, monkeypatch):
+    """The argv entry must be the exact string the guard checked, not an object
+    that can resolve to something else when the child process reads it."""
+    import nltk.parse.stanford as st
+
+    root, outside = pathsec_sandbox
+    sink = _trap_java(monkeypatch, st, {})
+    evil = outside / "evil.ser.gz"
+    evil.write_text("x", encoding="utf-8")
+    good = root / "ok.ser.gz"
+    good.write_text("m", encoding="utf-8")
+
+    parser = _stanford_parser(_MutatingPath(str(good), str(evil)))
+    with pytest.raises(_ReachedJVM):
+        parser.parse_sents([["hello", "world"]])
+    handed_over = sink["cmd"][sink["cmd"].index("-model") + 1]
+    assert isinstance(handed_over, str)
+    assert os.path.realpath(_resolve(handed_over)).startswith(
+        os.path.realpath(str(root))
+    )
+
+
+# StanfordParser corenlp_options: split into argv, so it can append a 2nd -model.
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        "-model /etc/passwd",
+        "-model ../../../etc/passwd",
+        "-loadClassifier /etc/passwd",
+        "-outputFormat xml",
+        "-encoding utf8",
+        "-sentences newline",
+    ],
+    ids=[
+        "second-model-abs",
+        "second-model-traversal",
+        "loadClassifier-abs",
+        "dup-outputFormat",
+        "dup-encoding",
+        "dup-sentences",
+    ],
+)
+def test_corenlp_options_cannot_override_guarded_flags(
+    pathsec_sandbox, monkeypatch, options
+):
+    import nltk.parse.stanford as st
+
+    root, _outside = pathsec_sandbox
+    _trap_java(monkeypatch, st, {})
+    model = str(root / "ok.ser.gz")
+    with pathsec.open(model, "w", encoding="utf-8") as handle:
+        handle.write("m")
+    with pytest.raises((PermissionError, ValueError)):
+        _stanford_with_options(model, options).parse_sents([["hi", "there"]])
+
+
+def test_corenlp_options_cannot_point_outside_the_roots(pathsec_sandbox, monkeypatch):
+    import nltk.parse.stanford as st
+
+    root, outside = pathsec_sandbox
+    _trap_java(monkeypatch, st, {})
+    evil = outside / "evil.ser.gz"
+    evil.write_text("x", encoding="utf-8")
+    model = str(root / "ok.ser.gz")
+    with pathsec.open(model, "w", encoding="utf-8") as handle:
+        handle.write("m")
+    with pytest.raises((PermissionError, ValueError)):
+        _stanford_with_options(model, f"-serializedDict {evil}").parse_sents(
+            [["hi", "there"]]
+        )
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        "",
+        "-maxLength 40",
+        "-serializedDict edu/stanford/nlp/x.ser.gz",
+        "-retainTMPSubcategories",
+    ],
+    ids=["empty", "new-flag", "resource-value", "bare-flag"],
+)
+def test_corenlp_options_passthrough_still_works(pathsec_sandbox, monkeypatch, options):
+    """Over-block control: this is a general passthrough for the tool's own
+    settings, so anything that is neither a duplicate nor an out-of-root path
+    must still reach the JVM."""
+    import nltk.parse.stanford as st
+
+    root, _outside = pathsec_sandbox
+    sink = _trap_java(monkeypatch, st, {})
+    model = str(root / "ok.ser.gz")
+    with pathsec.open(model, "w", encoding="utf-8") as handle:
+        handle.write("m")
+    with pytest.raises(_ReachedJVM):
+        _stanford_with_options(model, options).parse_sents([["hi", "there"]])
+    assert sink["cmd"][sink["cmd"].index("-model") + 1] == model
+    for token in options.split():
+        assert token in sink["cmd"]
+
+
+def test_teeth_corenlp_options_guard_is_load_bearing(pathsec_sandbox, monkeypatch):
+    """Restore the raw split and the injected -model reaches the JVM again."""
+    import nltk.parse.stanford as st
+
+    root, outside = pathsec_sandbox
+    sink = _trap_java(monkeypatch, st, {})
+    evil = outside / "evil.ser.gz"
+    evil.write_text("x", encoding="utf-8")
+    model = str(root / "ok.ser.gz")
+    with pathsec.open(model, "w", encoding="utf-8") as handle:
+        handle.write("m")
+    monkeypatch.setattr(
+        st.StanfordParser,
+        "_validated_extra_options",
+        lambda self, cmd: self.corenlp_options.split(),
+    )
+    with pytest.raises(_ReachedJVM):
+        _stanford_with_options(model, f"-model {evil}").parse_sents([["hi", "there"]])
+    models = [sink["cmd"][i + 1] for i, x in enumerate(sink["cmd"]) if x == "-model"]
+    assert str(evil) in models
+
+
+# Functional: the patched wrappers must still import with no new import cycle.
+
+
+def test_wrapper_modules_still_import():
+    """Both wrappers touched by this change import cleanly, with no import cycle
+    introduced by the new pathsec dependency."""
+    import importlib
+
+    for name in ("nltk.parse.malt", "nltk.parse.stanford"):
+        assert importlib.import_module(name) is not None
+
+
+# Real end-to-end runs. These launch an actual JVM against a real MaltParser /
+# Stanford parser install; they skip when the external tool is genuinely absent.
+
+
+def _has_java():
+    """True only if a JVM actually *runs*.
+
+    Merely finding a ``java`` on PATH is not enough: macOS ships a
+    ``/usr/bin/java`` stub that resolves fine and then fails at exec time with
+    "Unable to locate a Java Runtime", which would turn these into hard failures
+    on a machine with no JDK instead of skips.
+    """
+    import subprocess
+
+    from nltk.internals import find_binary
+
+    try:
+        binary = find_binary(
+            "java", env_vars=("JAVAHOME", "JAVA_HOME"), verbose=False, binary_names=None
+        )
+    except LookupError:
+        return False
+    try:
+        return (
+            subprocess.run(
+                [binary, "-version"], capture_output=True, timeout=60
+            ).returncode
+            == 0
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+def _find_tool_dir(*names):
+    """Absolute path of an external tool directory inside a data root, or None."""
+    import nltk.data
+
+    for root in nltk.data.path:
+        for name in names:
+            candidate = os.path.join(root, name)
+            if os.path.isdir(candidate):
+                return candidate
+    return None
+
+
+requires_java = pytest.mark.skipif(not _has_java(), reason="no JVM on this machine")
+
+
+@requires_java
+def test_real_malt_train_writes_model_inside_sandbox(tmp_path):
+    """End-to-end: a real MaltParser JVM must write malt_temp.mco into the private
+    staging dir, and must NOT pollute the current working directory as it did when
+    ``-w`` defaulted to ``os.getcwd()``."""
+    import nltk.data
+    from nltk.parse.dependencygraph import DependencyGraph
+    from nltk.parse.malt import MaltParser
+
+    malt_dir = _find_tool_dir("maltparser-1.9.2", "maltparser-1.9.1")
+    if malt_dir is None:
+        pytest.skip("maltparser is not installed under nltk.data.path")
+
+    parser = MaltParser(parser_dirname=malt_dir)
+    assert os.stat(parser.working_dir).st_mode & 0o077 == 0
+    assert any(
+        os.path.realpath(parser.working_dir).startswith(os.path.realpath(root))
+        for root in nltk.data.path
+    )
+
+    rows = "1\tJohn\t_\tNNP\t_\t_\t2\tSUBJ\t_\t_\n2\tsees\t_\tVB\t_\t_\t0\tROOT\t_\t_\n"
+    parser.train([DependencyGraph(rows), DependencyGraph(rows)], verbose=False)
+
+    model = os.path.join(parser.working_dir, "malt_temp.mco")
+    assert os.path.exists(model) and os.path.getsize(model) > 0
+    assert not os.path.exists(os.path.join(os.getcwd(), "malt_temp.mco"))
+
+
+@requires_java
+def test_real_stanford_parser_default_resource_parses(monkeypatch):
+    """End-to-end: the shipped jar-internal default model must still parse. If the
+    guard treated it as a filesystem path this raises instead."""
+    from nltk.parse.stanford import StanfordParser
+
+    parser_dir = _find_tool_dir("stanford-parser-full-2020-11-17")
+    if parser_dir is None:
+        pytest.skip("stanford-parser is not installed under nltk.data.path")
+    monkeypatch.setenv("STANFORD_PARSER", parser_dir)
+    monkeypatch.setenv("STANFORD_MODELS", parser_dir)
+
+    trees = list(StanfordParser().raw_parse("John sees a dog."))
+    assert trees and trees[0].label() == "ROOT"
+
+
+@requires_java
+@pytest.mark.parametrize(
+    "model_path",
+    [
+        "/etc/passwd" if os.name == "posix" else "C:\\Windows\\win.ini",
+        "edu/stanford/../../../../etc/passwd",
+    ],
+    ids=["system-file-abs", "traversal"],
+)
+def test_real_stanford_parser_refuses_escape_with_jvm_present(monkeypatch, model_path):
+    """End-to-end negative: with a working JVM and real jars, a hostile -model is
+    refused before launch, so the block is the guard and not a missing JVM."""
+    from nltk.parse.stanford import StanfordParser
+
+    parser_dir = _find_tool_dir("stanford-parser-full-2020-11-17")
+    if parser_dir is None:
+        pytest.skip("stanford-parser is not installed under nltk.data.path")
+    monkeypatch.setenv("STANFORD_PARSER", parser_dir)
+    monkeypatch.setenv("STANFORD_MODELS", parser_dir)
+
+    parser = StanfordParser()
+    parser.model_path = model_path
+    with pytest.raises((PermissionError, ValueError)):
+        list(parser.raw_parse("John sees a dog."))


### PR DESCRIPTION
Both JVM parser wrappers hand caller-supplied model, corpus and IO paths straight to a child process's argv without bounding them to the NLTK data roots. This splits the malt/stanford portion of the wrapper hardening into a standalone change against `develop`; every guard symbol it relies on (`nltk.pathsec.validate_tool_path`/`validate_model_resource`/`validate_path`, `nltk.data.make_staging_dir`/`staging_tempdir`) is already on `develop`.

## Vulnerability classes

**nltk/parse/malt.py**
- **Arbitrary read/write via `-i`/`-o`.** `generate_malt_command`'s `-i` is read by the JVM and `-o` is written by it. Both are public entry points (`generate_malt_command`, `train_from_file`), so an unbounded value is an arbitrary file read and an arbitrary file write.
- **Model path traversal (`-c`/`-w`).** The trained-model path was used unchecked; in learn mode MaltParser writes the `.mco` into the model's directory.
- **World-writable working dir.** `working_dir` defaulted to the shared `tempfile.gettempdir()`, a predictable, squattable location on Linux for the CoNLL intermediates and, for an untrained parser, `malt_temp.mco`.
- **`__fspath__` TOCTOU / lying `str` subclass.** A `PathLike` whose `__fspath__` mutates between the check and the JVM call, or a `str` subclass whose inspection methods lie, could smuggle a different value into argv.

**nltk/parse/stanford.py**
- **`-model` traversal / TOCTOU.** `self.model_path` reached the JVM unchecked and could mutate between check and use.
- **Argument injection via `corenlp_options`.** The string is split into separate argv elements, so it could append a second `-model`; `LexicalizedParser` honours the last occurrence (verified against a real JVM), silently replacing the model the guard had just checked.

## The fix
- malt: `-i`/`-o` bounded with `validate_tool_path` (`-o` with `for_write=True`); model bounded with `validate_model_resource` and, when it carries a directory, `validate_path`; `working_dir` is now a lazily allocated private dir via `nltk.data.make_staging_dir(cleanup=True)` (mode 0700, inside a data root, removed at exit) with a setter that refuses empty/out-of-root values; the model string is frozen once and coerced to a real `str`; `parse_tagged_sents` reads output through `pathsec.open`.
- stanford: `_execute` validates `model_path` at the single JVM hand-off and replaces the `-model` argv entry with the resolved string (covers all three callers); `_validated_extra_options` refuses re-setting an option NLTK already set and bounds any path-like `corenlp_options` value to the roots; the JVM input file is staged in `nltk.data.staging_tempdir()`.

## Tests
New focused module `nltk/test/unit/test_malt_stanford_pathsec.py` drives the real wrappers with only the `java` hand-off trapped, so a probe cannot pass because the test assembled the argv itself. It proves crafted `-i`/`-o`/model/`corenlp_options` values are refused, while benign in-root paths and jar-internal resource names still reach the JVM; the teeth tests neuter each guard and assert the attack reappears, so every refusal is known to fail against the un-hardened code. It also includes the reclaimed malt working-dir cleanup regression (`test_malt_working_dir_is_cleaned_up`, kept with the malt wrapper rather than in the data.py staging test file) and real end-to-end JVM runs that skip cleanly when the external tool is absent.

## Cross-platform
POSIX-only checks (mode bits) and JVM/tool-dependent runs are gated with `skipif`, and Windows-specific payloads are only used on Windows, so the module is green on Linux, macOS and Windows.

## Self-contained split note
The security guards this depends on are already on `develop`. The two source files apply cleanly with no other changes; one pair of dead imports (`atexit`, `shutil`, now unused because the cleanup registration lives in `nltk.data.make_staging_dir`) was dropped to satisfy the unused-import check.
