### PR TITLE
Harden nltk.tbl.demo model load/save through picklesec and pathsec

### DIFF
--- a/nltk/tbl/demo.py
+++ b/nltk/tbl/demo.py
@@ -13,6 +13,8 @@ import random
 import time
 
 from nltk.corpus import treebank
+from nltk.pathsec import open as pathsec_open
+from nltk.pathsec import validate_path
 from nltk.picklesec import pickle_load
 from nltk.tag import BrillTaggerTrainer, RegexpTagger, UnigramTagger
 from nltk.tag.brill import Pos, Word
@@ -246,14 +248,20 @@ def postag(
             baseline_tagger = UnigramTagger(
                 baseline_data, backoff=baseline_backoff_tagger
             )
-            with open(cache_baseline_tagger, "wb") as print_rules:
+            # ``cache_baseline_tagger`` is caller-supplied, so the model
+            # write/read goes through the pathsec sandbox (GHSA-8mgp-746c-j5xp).
+            with pathsec_open(
+                cache_baseline_tagger, "wb", context="tbl.demo.cache_baseline_tagger"
+            ) as print_rules:
                 pickle.dump(baseline_tagger, print_rules)
             print(
                 "Trained baseline tagger, pickled it to {}".format(
                     cache_baseline_tagger
                 )
             )
-        with open(cache_baseline_tagger, "rb") as print_rules:
+        with pathsec_open(
+            cache_baseline_tagger, "rb", context="tbl.demo.cache_baseline_tagger"
+        ) as print_rules:
             baseline_tagger = pickle_load(print_rules)
             print(f"Reloaded pickled tagger from {cache_baseline_tagger}")
     else:
@@ -314,18 +322,24 @@ def postag(
 
     # writing error analysis to file
     if error_output is not None:
-        with open(error_output, "w") as f:
+        with pathsec_open(
+            error_output, "w", context="tbl.demo.error_output", encoding="utf-8"
+        ) as f:
             f.write("Errors for Brill Tagger %r\n\n" % serialize_output)
-            f.write("\n".join(error_list(gold_data, taggedtest)).encode("utf-8") + "\n")
+            f.write("\n".join(error_list(gold_data, taggedtest)) + "\n")
         print(f"Wrote tagger errors including context to {error_output}")
 
     # serializing the tagger to a pickle file and reloading (just to see it works)
     if serialize_output is not None:
         taggedtest = brill_tagger.tag_sents(testing_data)
-        with open(serialize_output, "wb") as print_rules:
+        with pathsec_open(
+            serialize_output, "wb", context="tbl.demo.serialize_output"
+        ) as print_rules:
             pickle.dump(brill_tagger, print_rules)
         print(f"Wrote pickled tagger to {serialize_output}")
-        with open(serialize_output, "rb") as print_rules:
+        with pathsec_open(
+            serialize_output, "rb", context="tbl.demo.serialize_output"
+        ) as print_rules:
             brill_tagger_reloaded = pickle_load(print_rules)
         print(f"Reloaded pickled tagger from {serialize_output}")
         taggedtest_reloaded = brill_tagger_reloaded.tag_sents(testing_data)
@@ -376,6 +390,13 @@ def _demo_prepare_data(
 
 
 def _demo_plot(learning_curve_output, teststats, trainstats=None, take=None):
+    """Write the learning-curve plot to ``learning_curve_output``.
+
+    The destination is caller-supplied and matplotlib writes it itself, so the
+    path is checked against the NLTK data sandbox before any work is done
+    (GHSA-8mgp-746c-j5xp); ``pathsec.open`` cannot wrap a ``savefig``.
+    """
+    validate_path(learning_curve_output, context="tbl.demo.learning_curve_output")
     testcurve = [teststats["initialerrors"]]
     for rulescore in teststats["rulescores"]:
         testcurve.append(testcurve[-1] - rulescore)

--- a/nltk/test/unit/test_pathsec_sweep_tbl.py
+++ b/nltk/test/unit/test_pathsec_sweep_tbl.py
@@ -1,0 +1,194 @@
+# Natural Language Toolkit: pathsec sweep attack tests (tbl.demo)
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""Path-traversal attack tests for the caller-controlled file sinks hardened in
+``nltk.tbl.demo`` (GHSA-8mgp-746c-j5xp).
+
+``nltk.tbl.demo.postag`` pickles a trained Brill/baseline tagger, writes an
+error-analysis text file, and plots a learning curve, each to a caller-supplied
+path. The hardening routes the pickle and text sinks through ``pathsec.open``
+and validates the plot path (which matplotlib writes itself) with
+``pathsec.validate_path``. Every one of those destinations must refuse a path
+outside the NLTK data sandbox and leave nothing behind, while an in-root
+destination must still be accepted.
+
+The generic ``pathsec.open`` negative control and the chat80/agreement sinks this
+module once also covered now live in their own suites on ``develop``
+(``test_chat80_pathsec.py``, ``test_agreement_pathsec.py`` and the
+``test_pathsec_sweep_sem_util.py`` negative control), so they are not repeated
+here.
+"""
+
+import os
+
+import pytest
+
+import nltk.pathsec as pathsec
+
+# A tiny synthetic tagged corpus so tbl.demo.postag() never needs the treebank
+# corpus (postag skips corpus loading when tagged_data is supplied).
+TINY_TAGGED = [
+    [("the", "AT"), ("dog", "NN"), ("runs", "VBZ")],
+    [("a", "AT"), ("cat", "NN"), ("sleeps", "VBZ")],
+] * 10
+
+
+# The pathsec sandbox fixtures (sandbox / pathsec_sandbox) are provided by
+# nltk/test/unit/conftest.py.
+
+
+def test_tbl_demo_cache_baseline_refuses_outside(sandbox):
+    from nltk.tbl import demo
+
+    target = sandbox / "evil_baseline.pcl"
+    with pytest.raises(PermissionError):
+        demo.postag(
+            tagged_data=list(TINY_TAGGED),
+            num_sents=20,
+            trace=0,
+            cache_baseline_tagger=str(target),
+        )
+    assert not target.exists()
+
+
+def test_tbl_demo_serialize_output_refuses_outside(sandbox):
+    from nltk.tbl import demo
+
+    target = sandbox / "evil_tagger.pcl"
+    with pytest.raises(PermissionError):
+        demo.postag(
+            tagged_data=list(TINY_TAGGED),
+            num_sents=20,
+            trace=0,
+            max_rules=5,
+            serialize_output=str(target),
+        )
+    assert not target.exists()
+
+
+def test_tbl_demo_error_output_refuses_outside(sandbox):
+    from nltk.tbl import demo
+
+    target = sandbox / "evil_errors.txt"
+    with pytest.raises(PermissionError):
+        demo.postag(
+            tagged_data=list(TINY_TAGGED),
+            num_sents=20,
+            trace=0,
+            max_rules=5,
+            error_output=str(target),
+        )
+    assert not target.exists()
+
+
+def test_tbl_demo_plot_refuses_outside(sandbox):
+    from nltk.tbl import demo
+
+    target = sandbox / "evil_curve.png"
+    stats = {"initialerrors": 0, "rulescores": [], "tokencount": 1}
+    with pytest.raises(PermissionError):
+        demo._demo_plot(str(target), stats, stats)
+    assert not target.exists()
+
+
+# In-root acceptance (the other half of the teeth): a destination inside the
+# sandbox must still be written. These stay corpus-free by supplying
+# tagged_data / synthetic stats, so they run on any platform.
+
+
+def test_tbl_demo_error_output_in_root_accepted(pathsec_sandbox):
+    """The error-analysis text sink goes through pathsec.open; an in-root path
+    is accepted and written (no pickle round trip is involved)."""
+    from nltk.tbl import demo
+
+    target = pathsec_sandbox.root / "errors_ok.txt"
+    demo.postag(
+        tagged_data=list(TINY_TAGGED),
+        num_sents=20,
+        trace=0,
+        max_rules=5,
+        error_output=str(target),
+    )
+    assert target.exists()
+    assert target.stat().st_size > 0
+
+
+def test_tbl_demo_plot_in_root_accepted(pathsec_sandbox):
+    """The learning-curve path is validate_path()-checked, then written by
+    matplotlib; an in-root destination is accepted."""
+    pytest.importorskip("matplotlib")
+    from nltk.tbl import demo
+
+    target = pathsec_sandbox.root / "curve_ok.png"
+    stats = {"initialerrors": 2, "rulescores": [1, 1], "tokencount": 10}
+    demo._demo_plot(str(target), stats, stats)
+    assert target.exists()
+    assert target.stat().st_size > 0
+
+
+# postag()'s caller-supplied output paths, exercised through the real treebank
+# corpus. These deliberately do NOT use the pathsec_sandbox fixture: it narrows
+# nltk.data.path to one empty temp root, so the treebank corpus cannot load and
+# postag raises LookupError long before reaching any write. The real roots stay
+# in place and the attack target is staged outside them instead.
+
+
+@pytest.fixture
+def corpus_backed_sandbox(monkeypatch, tmp_path_factory):
+    """ENFORCE on, the real data roots intact, plus an out-of-root target."""
+    import pathlib as _pathlib
+    import shutil as _shutil
+    import tempfile as _tempfile
+
+    import nltk.data
+
+    pytest.importorskip("numpy")
+    try:
+        nltk.data.find("corpora/treebank")
+    except LookupError:
+        pytest.skip("treebank corpus unavailable")
+
+    outside = _pathlib.Path(
+        _tempfile.mkdtemp(prefix=".nltk_tbl_outside_", dir=str(_pathlib.Path.home()))
+    )
+    monkeypatch.setattr(pathsec, "ENFORCE", True)
+    monkeypatch.setattr(pathsec, "_ALLOWED_ROOTS_CACHE", None, raising=False)
+    monkeypatch.setattr(pathsec, "_LAST_DATA_PATHS", None, raising=False)
+    try:
+        yield outside
+    finally:
+        _shutil.rmtree(outside, ignore_errors=True)
+
+
+@pytest.mark.parametrize(
+    "kwarg",
+    [
+        "serialize_output",
+        "error_output",
+        "cache_baseline_tagger",
+        "learning_curve_output",
+    ],
+)
+def test_postag_output_paths_refuse_escape(corpus_backed_sandbox, kwarg):
+    """Every destination postag() writes is caller-supplied, so none may leave
+    the data roots. learning_curve_output reaches savefig, which pathsec.open
+    cannot wrap, so it is validated rather than opened through the sentinel."""
+    import nltk.tbl.demo as demo
+
+    for target in (str(corpus_backed_sandbox / "pwned.out"), "/etc/nltk_pwned.out"):
+        with pytest.raises((PermissionError, ValueError)):
+            demo.postag(num_sents=1, max_rules=1, **{kwarg: target})
+        assert not os.path.exists(target)
+
+
+@pytest.mark.parametrize(
+    "target", ["../../../tmp/evil.pcl", "ok.pcl\x00.evil", "-Xmx99g", ""]
+)
+def test_postag_serialize_output_refuses_malformed_paths(corpus_backed_sandbox, target):
+    import nltk.tbl.demo as demo
+
+    with pytest.raises((PermissionError, ValueError)):
+        demo.postag(num_sents=1, max_rules=1, serialize_output=target)


### PR DESCRIPTION
## Summary

`nltk.tbl.demo.postag()` serializes a trained Brill/baseline tagger, writes an error-analysis text file, and plots a learning curve, each to a **caller-supplied** path. On `develop` those sinks used bare `open()`, so a caller-controlled destination could be written anywhere on disk (path traversal / arbitrary write, GHSA-8mgp-746c-j5xp), and the reloaded pickles are the RCE surface that `picklesec` already guards.

This routes every caller-controlled sink in the module through the `nltk.pathsec` sandbox.

## Vulnerability classes

- **Path traversal / arbitrary write** on `cache_baseline_tagger`, `serialize_output`, `error_output`, and `learning_curve_output` (all caller-supplied).
- **Pickle RCE on model load** for the two tagger pickles; loads already go through `nltk.picklesec.pickle_load` on `develop`, and the writes/reads are now also confined to the data sandbox.
- **Scratch placement**: model/plot/error artifacts must land inside an allowed NLTK data root, not at an attacker-named location.

## The fix (`nltk/tbl/demo.py`)

- `from nltk.pathsec import open as pathsec_open` and `validate_path`.
- `cache_baseline_tagger` pickle dump/load, `serialize_output` pickle dump/load, and the `error_output` text write now use `pathsec_open(..., context="tbl.demo.*")`.
- The `error_output` change also fixes a pre-existing bug: the payload is a `str` written in text mode, so the stray `.encode("utf-8")` (which raised `TypeError: can't concat str to bytes`) is dropped and `encoding="utf-8"` is set on the sandboxed open.
- `_demo_plot()` validates `learning_curve_output` with `validate_path()` up front, because matplotlib writes the plot itself and `pathsec.open()` cannot wrap a `savefig()`.
- Pickle loads continue through `nltk.picklesec.pickle_load` (already on `develop`).

## Tests (`nltk/test/unit/test_pathsec_sweep_tbl.py`)

- **Refusal teeth**, corpus-free (a tiny synthetic tagged corpus, so no downloaded model/corpus is required): each of the four sinks refuses an out-of-root destination with `PermissionError` and leaves nothing behind. Each of these fails against the un-hardened `demo.py` (the pickle sinks write outside then error; `error_output` hits the old `str`+`bytes` bug; `_demo_plot` does not raise at all), proving the guard.
- **In-root acceptance teeth**, corpus-free: the `pathsec.open` text sink and the `validate_path` plot sink both accept an in-root destination and write it.
- **Corpus-backed pins**: escape and malformed-path (`../../../`, NUL byte, `-Xmx99g`, empty) cases that skip cleanly when the treebank corpus / numpy is unavailable.

## Cross-platform

Green on Linux, macOS, and Windows. Out-of-root targets are staged under `$HOME` (never `/tmp`, which is a valid root on some CI images), pickles use `"rb"`/`"wb"`, text uses `encoding="utf-8"`, and the matplotlib acceptance test `importorskip`s matplotlib. No POSIX-only assertions are used, so nothing is skipped spuriously.

## Self-contained split

This is split out to stand alone on `develop`: it depends only on symbols already present there (`nltk.picklesec.pickle_load`/`RestrictedUnpickler` #3794, `nltk.pathsec.open`/`validate_path`/`validate_model_resource` #3797, `nltk.data.staging_tempdir`/`make_staging_dir` #3808) and the shared `nltk/test/unit/conftest.py` sandbox fixtures. `python3.13 -m pytest nltk/test/unit/test_pathsec_sweep_tbl.py` is 14 passed on `origin/develop` + this `demo.py` alone.

## No duplication

The tbl cases in the shared `test_model_artifact_pathsec.py` are shipped here as a focused, tbl-only module instead. The generic `pathsec.open` negative control and the maxent (#3807) and perceptron/crf tagger (#3813, `test_pathsec_sweep_tag.py`) cases already on `develop` are **not** re-shipped; every test function name in this file was checked against `develop` and none collides.
