### PR TITLE
Add tests covering already-merged pathsec/security guards

### DIFF
--- a/nltk/test/unit/test_aggregate_zip_bomb.py
+++ b/nltk/test/unit/test_aggregate_zip_bomb.py
@@ -1,0 +1,91 @@
+# Natural Language Toolkit: aggregate decompression-bomb guard
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""A zip whose members SUM to a bomb must be refused, not only per-member.
+
+_check_decompression_bomb runs per member and only ratio-checks a member above
+32 MiB (MAX_UNZIP_ACTIVATION). So an archive of many members each just under the
+floor is never individually refused, yet the members together expand from a tiny
+zip to an arbitrarily large total, and extraction kept no running byte total.
+_check_zip_total_size applies the same activation-plus-ratio test at the whole
+archive level.
+"""
+
+import os
+import shutil
+import tempfile
+import zipfile
+
+import pytest
+
+import nltk.data
+from nltk import pathsec
+
+
+@pytest.fixture
+def sandbox_root(monkeypatch):
+    root = tempfile.mkdtemp(prefix="nltk_sandbox_root_")
+    monkeypatch.setattr(pathsec, "ENFORCE", True)
+    monkeypatch.setattr(nltk.data, "path", [root])
+    monkeypatch.setattr(pathsec, "_ALLOWED_ROOTS_CACHE", None, raising=False)
+    monkeypatch.setattr(pathsec, "_LAST_DATA_PATHS", None, raising=False)
+    try:
+        yield root
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def test_members_below_the_floor_that_aggregate_to_a_bomb_are_refused(sandbox_root):
+    """Each member is below MAX_UNZIP_ACTIVATION so the per-member guard passes;
+    together they are a ratio-1000+ bomb."""
+    archive = os.path.join(sandbox_root, "bomb.zip")
+    zeros = b"\0" * (20 * 1024 * 1024)  # 20 MiB, below the 32 MiB floor
+    with zipfile.ZipFile(archive, "w", zipfile.ZIP_DEFLATED) as handle:
+        for index in range(20):  # 400 MiB total from a sub-MB zip
+            handle.writestr(f"z{index}.dat", zeros)
+
+    # Confirm the per-member guard alone would NOT catch these.
+    from nltk.data import _check_decompression_bomb
+
+    for info in zipfile.ZipFile(archive).infolist():
+        _check_decompression_bomb(info)  # must not raise
+
+    with pytest.raises((PermissionError, ValueError)):
+        with pathsec.ZipFile(archive):
+            pass
+
+
+def test_a_small_legitimate_zip_is_allowed(sandbox_root):
+    archive = os.path.join(sandbox_root, "ok.zip")
+    with zipfile.ZipFile(archive, "w", zipfile.ZIP_DEFLATED) as handle:
+        handle.writestr("a.txt", "hello")
+        handle.writestr("b/c.txt", "world")
+    with pathsec.ZipFile(archive) as handle:
+        assert handle.namelist() == ["a.txt", "b/c.txt"]
+
+
+def test_a_large_but_honest_corpus_is_allowed(sandbox_root):
+    """A real corpus is large but has a modest overall ratio, so it must pass:
+    the guard refuses bombs, not size."""
+    archive = os.path.join(sandbox_root, "big.zip")
+    incompressible = os.urandom(1024 * 1024)  # ratio ~1
+    with zipfile.ZipFile(archive, "w", zipfile.ZIP_DEFLATED) as handle:
+        for index in range(60):  # ~60 MiB, ratio ~1
+            handle.writestr(f"f{index}", incompressible)
+    with pathsec.ZipFile(archive) as handle:
+        assert len(handle.namelist()) == 60
+
+
+def test_a_moderate_ratio_archive_below_the_threshold_is_allowed(sandbox_root):
+    """Ratio ~500 is under MAX_UNZIP_RATIO=1000, so it is not a bomb even though
+    it compresses well. Pins that the aggregate check uses the same threshold."""
+    archive = os.path.join(sandbox_root, "mid.zip")
+    block = b"NLTKPADDINGBLOCK" * 128  # ~500:1 compressible
+    with zipfile.ZipFile(archive, "w", zipfile.ZIP_DEFLATED) as handle:
+        for index in range(40):
+            handle.writestr(f"m{index}.dat", block * 2560)
+    with pathsec.ZipFile(archive) as handle:
+        assert len(handle.namelist()) == 40

--- a/nltk/test/unit/test_chat80_pathsec.py
+++ b/nltk/test/unit/test_chat80_pathsec.py
@@ -66,3 +66,35 @@ def test_chat80_label_indivs_refuses_outside_cwd(sandbox):
     with pytest.raises(PermissionError):
         chat80.label_indivs(Valuation([]), lexicon=True)
     assert not (sandbox / "chat_pnames.cfg").exists()
+
+
+@pytest.mark.parametrize(
+    "target",
+    ["<outside>/evil", "/etc/nltk_pwned", "<outside>/e\x00vil"],
+    ids=["outside", "etc", "nul"],
+)
+def test_shelve_backed_valuation_paths_refuse_escape(pathsec_sandbox, target):
+    """val_dump/val_load hand a caller path straight to shelve.open, which
+    creates its own backing files, so pathsec.open cannot wrap it. The path is
+    validated first instead, before any corpus work happens."""
+    from nltk.sem import chat80
+
+    root, outside = pathsec_sandbox
+    resolved = target.replace("<outside>", str(outside))
+    with pytest.raises((PermissionError, ValueError)):
+        chat80.val_dump({}, resolved)
+    with pytest.raises((PermissionError, ValueError)):
+        chat80.val_load(resolved)
+
+
+def test_shelve_valuation_path_inside_the_root_is_allowed(pathsec_sandbox):
+    """Over-block control: an in-root destination passes validation."""
+    from nltk.sem import chat80
+
+    root, _outside = pathsec_sandbox
+    try:
+        chat80.val_dump({}, str(root / "ok"))
+    except (PermissionError, ValueError) as exc:
+        pytest.fail(f"in-root shelve destination was refused: {exc}")
+    except Exception:
+        pass  # past validation; whatever shelve/corpus does next is not our concern

--- a/nltk/test/unit/test_enforce_does_not_break_normal_use.py
+++ b/nltk/test/unit/test_enforce_does_not_break_normal_use.py
@@ -1,0 +1,134 @@
+# Natural Language Toolkit: the sandbox must not break ordinary NLTK use
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""With ENFORCE on and the real data roots, ordinary NLTK must still work.
+
+Most security tests narrow ``nltk.data.path`` to a single throwaway root so an
+attack target can be staged outside it. That is deliberate, but it also means
+those tests say nothing about whether a NORMAL installation still functions:
+under a narrowed path a corpus is simply absent, which is a very different
+thing from the sandbox refusing it.
+
+This file pins both halves of that distinction:
+
+* with the real roots in place and ``ENFORCE`` on, the standard entry points
+  load real data and produce real output;
+* when a corpus genuinely is not on the path, the failure is ``LookupError``
+  ("not found"), never ``PermissionError`` ("refused"). If the sandbox ever
+  starts refusing legitimate in-root data, that difference is what catches it.
+"""
+
+import os
+import tempfile
+
+import pytest
+
+import nltk
+import nltk.data
+from nltk import pathsec
+
+
+@pytest.fixture
+def enforced_real_roots(monkeypatch):
+    """ENFORCE on, with the machine's real data roots left in place."""
+    monkeypatch.setattr(pathsec, "ENFORCE", True)
+    monkeypatch.setattr(pathsec, "_ALLOWED_ROOTS_CACHE", None, raising=False)
+    monkeypatch.setattr(pathsec, "_LAST_DATA_PATHS", None, raising=False)
+    return nltk.data.path
+
+
+def _run_or_skip(call):
+    """Run the real call; skip only if the DATA is genuinely absent.
+
+    The check is the call itself rather than a guessed nltk.data.find() name:
+    several corpora resolve through a zip or a lazy loader, so find("corpora/x")
+    can raise for a corpus that loads perfectly well, which produced skips for
+    data that was actually present.
+    """
+    try:
+        return call()
+    except LookupError:
+        pytest.skip("data unavailable on this machine")
+
+
+@pytest.mark.parametrize(
+    "call, check",
+    [
+        (
+            lambda: __import__("nltk").tokenize.word_tokenize("The dog barks."),
+            lambda r: "dog" in r,
+        ),
+        (lambda: nltk.pos_tag(["The", "dog"]), lambda r: len(r) == 2),
+        (
+            lambda: __import__("nltk.corpus", fromlist=["wordnet"])
+            .wordnet.synsets("dog")[0]
+            .name(),
+            lambda r: r.startswith("dog."),
+        ),
+        (
+            lambda: __import__("nltk.corpus", fromlist=["stopwords"]).stopwords.words(
+                "english"
+            ),
+            lambda r: "the" in r,
+        ),
+        (
+            lambda: __import__("nltk.corpus", fromlist=["brown"]).brown.tagged_words()[
+                :1
+            ],
+            lambda r: len(r) == 1,
+        ),
+        (
+            lambda: __import__("nltk.corpus", fromlist=["treebank"])
+            .treebank.parsed_sents()[0]
+            .label(),
+            lambda r: r == "S",
+        ),
+        (
+            lambda: __import__("nltk.tag", fromlist=["PerceptronTagger"])
+            .PerceptronTagger()
+            .tag(["dog"]),
+            lambda r: r[0][0] == "dog",
+        ),
+    ],
+    ids=[
+        "word_tokenize",
+        "pos_tag",
+        "wordnet",
+        "stopwords",
+        "brown",
+        "treebank",
+        "perceptron_tagger",
+    ],
+)
+def test_real_data_still_loads_under_enforce(enforced_real_roots, call, check):
+    """The sandbox must never refuse data that legitimately lives in a root."""
+    assert pathsec.ENFORCE is True
+    assert check(_run_or_skip(call)), "loaded, but not the result the caller expects"
+
+
+def test_missing_data_is_lookuperror_not_permissionerror(monkeypatch):
+    """Absence and refusal must stay distinguishable.
+
+    A narrowed data path means the corpus is not there to find, which is a
+    LookupError. A PermissionError here would mean the sandbox had started
+    rejecting a legitimate read, which is the failure this whole guard set is
+    supposed to avoid.
+    """
+    empty_root = tempfile.mkdtemp(prefix="nltk_empty_root_")
+    monkeypatch.setattr(pathsec, "ENFORCE", True)
+    monkeypatch.setattr(nltk.data, "path", [empty_root])
+    monkeypatch.setattr(pathsec, "_ALLOWED_ROOTS_CACHE", None, raising=False)
+    monkeypatch.setattr(pathsec, "_LAST_DATA_PATHS", None, raising=False)
+    nltk.data.clear_cache()
+
+    with pytest.raises(LookupError) as caught:
+        nltk.data.find("corpora/definitely_not_a_real_corpus")
+    assert not isinstance(caught.value, PermissionError)
+
+
+def test_enforce_is_actually_on_by_default():
+    """A guard set that ships with ENFORCE off would test nothing in production."""
+    assert pathsec.ENFORCE is True

--- a/nltk/test/unit/test_module_import_and_functional_smoke.py
+++ b/nltk/test/unit/test_module_import_and_functional_smoke.py
@@ -1,0 +1,178 @@
+# Natural Language Toolkit: import + functional smoke test
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""Proof that the pathsec hardening did not break NLTK.
+
+The security work threads ``validate_path`` / ``validate_model_resource`` through
+loaders all over the tree. A guard that is slightly too strict does not fail the
+security tests, it fails *ordinary use*, and mocked tests cannot see that: they
+never load a real corpus or run a real model.
+
+So this module does two things that no other test file does:
+
+1. imports **every** module in the ``nltk`` package, and
+2. runs a battery of real operations against real corpora and real models.
+
+An ``ImportError`` is treated as a missing optional third-party dependency and a
+``LookupError`` as missing corpus data, since neither says anything about our
+code. Anything else is a hard failure and names the module that broke.
+"""
+
+import importlib
+import pkgutil
+
+import pytest
+
+import nltk
+
+# Loading these has side effects disproportionate to their value here: nltk.book
+# pulls in nine corpora and prints a banner, and nltk.app opens Tk toolkits.
+_SKIP_PREFIXES = ("nltk.test.", "nltk.book", "nltk.app")
+
+
+def _all_module_names():
+    names = []
+    for module in pkgutil.walk_packages(nltk.__path__, prefix="nltk."):
+        name = module.name
+        if name.startswith(_SKIP_PREFIXES) or name == "nltk.test":
+            continue
+        names.append(name)
+    return sorted(names)
+
+
+def test_every_nltk_module_imports():
+    """Every module must import. A guard that broke an import at module scope
+    shows up here as a named hard failure rather than as a mystery elsewhere."""
+    hard_failures = []
+    optional = []
+    imported = 0
+    for name in _all_module_names():
+        try:
+            importlib.import_module(name)
+        except ImportError as exc:
+            optional.append((name, str(exc)))
+        except LookupError as exc:
+            optional.append((name, str(exc)))
+        except Exception as exc:
+            hard_failures.append(f"{name}: {type(exc).__name__}: {exc}")
+        else:
+            imported += 1
+
+    assert hard_failures == [], "modules failed to import:\n" + "\n".join(hard_failures)
+    # A sanity floor: if the walk silently stopped finding modules the assertion
+    # above would pass vacuously.
+    assert imported > 200, f"only {imported} modules imported; the walk is broken"
+
+
+def _skip_without_data(func):
+    """Run ``func``, turning missing corpora into a skip rather than a failure."""
+    try:
+        return func()
+    except LookupError as exc:
+        pytest.skip(f"corpus data unavailable: {str(exc)[:80]}")
+
+
+# ---------------------------------------------------------------------------
+# Real operations. Nothing here is mocked: each one loads real data through the
+# hardened loaders and checks a real result.
+# ---------------------------------------------------------------------------
+
+
+def test_tokenizers_work():
+    from nltk.tokenize import sent_tokenize, word_tokenize
+
+    tokens = _skip_without_data(lambda: word_tokenize("Dr. Smith isn't here."))
+    assert "Dr." in tokens and "n't" in tokens
+    assert _skip_without_data(lambda: sent_tokenize("One. Two! Three?")) == [
+        "One.",
+        "Two!",
+        "Three?",
+    ]
+
+
+def test_pos_tagging_and_chunking_work():
+    from nltk.tokenize import word_tokenize
+
+    tagged = _skip_without_data(
+        lambda: nltk.pos_tag(word_tokenize("John lives in Paris"))
+    )
+    assert [word for word, _tag in tagged] == ["John", "lives", "in", "Paris"]
+    tree = _skip_without_data(lambda: nltk.ne_chunk(tagged))
+    assert tree.label() == "S"
+
+
+def test_perceptron_tagger_loads_its_pickled_model():
+    """The tagger reads a pickled model through the hardened loader, so a
+    too-strict path guard breaks it here first."""
+    from nltk.tag import PerceptronTagger
+
+    tagged = _skip_without_data(lambda: PerceptronTagger().tag(["The", "dog", "runs"]))
+    assert [word for word, _tag in tagged] == ["The", "dog", "runs"]
+
+
+def test_stemmers_and_lemmatizer_work():
+    from nltk.stem import PorterStemmer, SnowballStemmer, WordNetLemmatizer
+
+    assert PorterStemmer().stem("running") == "run"
+    assert SnowballStemmer("english").stem("generously") == "generous"
+    assert _skip_without_data(lambda: WordNetLemmatizer().lemmatize("geese")) == "goose"
+
+
+def test_zipped_corpora_load():
+    """wordnet and stopwords are read out of zip archives, which is exactly the
+    path the decompression guards sit on."""
+    from nltk.corpus import stopwords, wordnet
+
+    assert _skip_without_data(lambda: wordnet.synsets("dog")) != []
+    assert "the" in _skip_without_data(lambda: stopwords.words("english"))
+
+
+def test_tagged_and_parsed_corpora_load():
+    from nltk.corpus import brown, gutenberg, treebank
+
+    assert _skip_without_data(lambda: brown.tagged_words()[:3]) != []
+    assert _skip_without_data(lambda: gutenberg.words("austen-emma.txt")[:5]) != []
+    assert _skip_without_data(lambda: treebank.parsed_sents()[0]).label() == "S"
+
+
+def test_vader_sentiment_works():
+    from nltk.sentiment.vader import SentimentIntensityAnalyzer
+
+    scores = _skip_without_data(
+        lambda: SentimentIntensityAnalyzer().polarity_scores("NLTK is great!")
+    )
+    assert scores["compound"] > 0
+
+
+def test_grammar_parsing_works():
+    from nltk import CFG
+    from nltk.parse import RecursiveDescentParser
+
+    grammar = CFG.fromstring("S -> NP VP\nNP -> 'John'\nVP -> 'runs'")
+    trees = list(RecursiveDescentParser(grammar).parse(["John", "runs"]))
+    assert trees and trees[0].label() == "S"
+
+
+def test_classifier_training_works():
+    from nltk.classify import NaiveBayesClassifier
+
+    classifier = NaiveBayesClassifier.train([({"a": 1}, "x"), ({"a": 0}, "y")])
+    assert classifier.classify({"a": 1}) == "x"
+
+
+def test_metrics_and_translate_work():
+    from nltk.translate.bleu_score import sentence_bleu
+
+    assert nltk.edit_distance("kitten", "sitting") == 3
+    assert sentence_bleu([["a", "b", "c", "d"]], ["a", "b", "c", "d"]) == 1.0
+
+
+def test_collocations_and_freqdist_work():
+    from nltk.corpus import brown
+
+    words = _skip_without_data(lambda: list(brown.words()[:2000]))
+    assert nltk.FreqDist(words).most_common(1)[0][1] > 0
+    assert nltk.Text(words).collocation_list()[:1] != []

--- a/nltk/test/unit/test_zip_extraction_toctou.py
+++ b/nltk/test/unit/test_zip_extraction_toctou.py
@@ -1,0 +1,109 @@
+# Natural Language Toolkit: zip extraction TOCTOU hardening
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""Zip extraction must not follow a symlink at the write target.
+
+validate_zip_archive resolves each member and refuses one that escapes, but
+between that resolution and the write there is a TOCTOU window: a local attacker
+who can write inside the extraction root can swap a directory component for a
+symlink pointing outside, and the stdlib extractor's plain open(target, "wb")
+follows it. pathsec.ZipFile._extract_member writes the leaf through an
+O_NOFOLLOW | O_EXCL opener, so a symlink at the final component (raced in or
+pre-planted) is refused rather than followed.
+"""
+
+import os
+import shutil
+import tempfile
+import zipfile
+
+import pytest
+
+import nltk.data
+from nltk import pathsec
+
+
+@pytest.fixture
+def sandbox(monkeypatch):
+    base = tempfile.mkdtemp(prefix=".nltk_toctou_", dir=os.path.expanduser("~"))
+    root = os.path.join(base, "root")
+    outside = os.path.join(base, "outside")
+    os.makedirs(root)
+    os.makedirs(outside)
+    monkeypatch.setattr(pathsec, "ENFORCE", True)
+    monkeypatch.setattr(nltk.data, "path", [root])
+    monkeypatch.setattr(pathsec, "_ALLOWED_ROOTS_CACHE", None, raising=False)
+    monkeypatch.setattr(pathsec, "_LAST_DATA_PATHS", None, raising=False)
+    try:
+        yield root, outside
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+
+
+@pytest.mark.skipif(not hasattr(os, "O_NOFOLLOW"), reason="requires O_NOFOLLOW")
+def test_raw_zipfile_would_follow_a_symlinked_parent(sandbox):
+    """Establishes the primitive the guard defends against: the stdlib extractor
+    writes through a symlinked parent directory."""
+    root, outside = sandbox
+    archive = os.path.join(root, "a.zip")
+    with zipfile.ZipFile(archive, "w") as handle:
+        handle.writestr("pkg/sub/PWNED.txt", "PWNED")
+    os.makedirs(os.path.join(root, "pkg"))
+    os.symlink(outside, os.path.join(root, "pkg", "sub"))
+    with zipfile.ZipFile(archive) as handle:  # raw stdlib
+        handle.extract("pkg/sub/PWNED.txt", root)
+    assert os.path.exists(os.path.join(outside, "PWNED.txt"))
+
+
+@pytest.mark.skipif(not hasattr(os, "O_NOFOLLOW"), reason="requires O_NOFOLLOW")
+def test_pathsec_extract_refuses_a_symlinked_leaf_parent(sandbox):
+    root, outside = sandbox
+    archive = os.path.join(root, "a.zip")
+    with zipfile.ZipFile(archive, "w") as handle:
+        handle.writestr("pkg/sub/PWNED.txt", "PWNED")
+    os.makedirs(os.path.join(root, "pkg"))
+    os.symlink(outside, os.path.join(root, "pkg", "sub"))
+    with pytest.raises((PermissionError, OSError, ValueError)):
+        with pathsec.ZipFile(archive) as handle:
+            handle.extract("pkg/sub/PWNED.txt", root)
+    assert not os.path.exists(os.path.join(outside, "PWNED.txt"))
+
+
+@pytest.mark.skipif(not hasattr(os, "O_NOFOLLOW"), reason="requires O_NOFOLLOW")
+def test_pathsec_extract_refuses_a_pre_planted_symlink_leaf(sandbox):
+    root, outside = sandbox
+    archive = os.path.join(root, "a.zip")
+    with zipfile.ZipFile(archive, "w") as handle:
+        handle.writestr("x", "PWNED")
+    os.makedirs(os.path.join(root, "p"))
+    victim = os.path.join(outside, "victim")
+    # archive member p/leaf will target the pre-planted symlink at <root>/p/leaf
+    archive2 = os.path.join(root, "b.zip")
+    with zipfile.ZipFile(archive2, "w") as handle:
+        handle.writestr("p/leaf", "PWNED")
+    os.symlink(victim, os.path.join(root, "p", "leaf"))
+    with pytest.raises((PermissionError, OSError, ValueError)):
+        with pathsec.ZipFile(archive2) as handle:
+            handle.extract("p/leaf", root)
+    assert not os.path.exists(victim)
+
+
+def test_ordinary_extraction_still_works(sandbox):
+    """Over-block control: nested dirs, top-level files, and a benign re-extract
+    onto existing files."""
+    root, _outside = sandbox
+    archive = os.path.join(root, "g.zip")
+    with zipfile.ZipFile(archive, "w") as handle:
+        handle.writestr("a/b/c.txt", "hello")
+        handle.writestr("top.txt", "x")
+    destination = os.path.join(root, "out")
+    with pathsec.ZipFile(archive) as handle:
+        handle.extractall(destination)
+    with open(os.path.join(destination, "a", "b", "c.txt")) as fh:
+        assert fh.read() == "hello"
+    # re-extract must not fail on the now-existing regular files
+    with pathsec.ZipFile(archive) as handle:
+        handle.extractall(destination)

--- a/nltk/test/unit/test_zip_member_collision.py
+++ b/nltk/test/unit/test_zip_member_collision.py
@@ -1,0 +1,79 @@
+# Natural Language Toolkit: zip member name-collision guard
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""Refuse archives whose members collide on a case/normalization-folding FS.
+
+On macOS (APFS) and Windows, ``pkg/Weights.json`` and ``pkg/weights.json``, or an
+NFC and NFD spelling of the same name, map to one file: the second silently
+overwrites the first. A package could ship a benign ``Weights.json`` for a
+reviewer and a colliding ``weights.json`` that replaces it with a poisoned model.
+A legitimate archive never contains such a pair, so any collision is refused.
+"""
+
+import os
+import shutil
+import tempfile
+import unicodedata
+import zipfile
+
+import pytest
+
+import nltk.data
+from nltk import pathsec
+
+
+@pytest.fixture
+def sandbox_root(monkeypatch):
+    root = tempfile.mkdtemp(prefix="nltk_sandbox_root_")
+    monkeypatch.setattr(pathsec, "ENFORCE", True)
+    monkeypatch.setattr(nltk.data, "path", [root])
+    monkeypatch.setattr(pathsec, "_ALLOWED_ROOTS_CACHE", None, raising=False)
+    monkeypatch.setattr(pathsec, "_LAST_DATA_PATHS", None, raising=False)
+    try:
+        yield root
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def _extract(root, members, name):
+    archive = os.path.join(root, name + ".zip")
+    with zipfile.ZipFile(archive, "w") as handle:
+        for member, content in members:
+            handle.writestr(member, content)
+    with pathsec.ZipFile(archive) as handle:
+        handle.extractall(os.path.join(root, name))
+
+
+@pytest.mark.parametrize(
+    "members, label",
+    [
+        ([("pkg/Weights.json", "B"), ("pkg/weights.json", "M")], "case"),
+        (
+            [
+                ("pkg/" + unicodedata.normalize("NFC", "café.json"), "N"),
+                ("pkg/" + unicodedata.normalize("NFD", "café.json"), "D"),
+            ],
+            "nfc-nfd",
+        ),
+        ([("pkg/file.txt", "x"), ("pkg/ﬁle.txt", "y")], "ligature"),
+        ([("a/x.json", "1"), ("A/x.json", "2")], "case-dir"),
+    ],
+)
+def test_colliding_members_are_refused(sandbox_root, members, label):
+    with pytest.raises((PermissionError, ValueError)):
+        _extract(sandbox_root, members, label)
+
+
+def test_distinct_members_including_nested_dirs_are_allowed(sandbox_root):
+    """Over-block control: same basename in different real directories is fine."""
+    _extract(
+        sandbox_root,
+        [("pkg/a.json", "1"), ("pkg/b.json", "2"), ("pkg/sub/a.json", "3")],
+        "ok",
+    )
+    extracted = os.path.join(sandbox_root, "ok", "pkg")
+    assert sorted(os.listdir(extracted)) == ["a.json", "b.json", "sub"]
+    assert os.path.exists(os.path.join(extracted, "sub", "a.json"))

--- a/nltk/test/unit/test_zip_member_platform_rules.py
+++ b/nltk/test/unit/test_zip_member_platform_rules.py
@@ -1,0 +1,103 @@
+# Natural Language Toolkit: zip member safety under both platforms' rules
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""A zip member's safety depends on whose separator rules apply.
+
+``..\\..\\x`` is a single ordinary filename on POSIX and cannot traverse, but on
+Windows the backslash IS a separator and the same member escapes. ``C:/x`` is
+likewise a plain relative name on POSIX and an absolute path on Windows.
+
+``_zip_member_is_unsafe`` therefore normalises only when ``os.path.altsep`` is
+set, which is ``'/'`` on Windows and ``None`` on POSIX. That is easy to read as
+a bug ("why isn't it always normalising?") and easy to 'fix' into an over-block
+that refuses legitimate POSIX filenames, so this pins BOTH answers by swapping
+in each platform's path module. It means a Linux CI run still checks the Windows
+behaviour, which no single-platform test can.
+"""
+
+import ntpath
+import os
+import posixpath
+
+import pytest
+
+from nltk import pathsec
+
+# (member, unsafe-on-posix, unsafe-on-windows)
+_MEMBERS = [
+    ("plain.txt", False, False),
+    ("good/sub/file.txt", False, False),
+    ("../../outside/PWNED.txt", True, True),
+    ("/abs/PWNED.txt", True, True),
+    ("ok\x00/../../P.txt", True, True),
+    ("..\\..\\outside\\PWNED.txt", False, True),
+    ("C:/PWNED.txt", False, True),
+    ("C:\\PWNED.txt", False, True),
+]
+
+
+def _verdict_under(module, member):
+    """Run the check with a given platform's path semantics."""
+    saved_altsep, saved_splitdrive = os.path.altsep, os.path.splitdrive
+    os.path.altsep, os.path.splitdrive = module.altsep, module.splitdrive
+    try:
+        return pathsec._zip_member_is_unsafe(member)
+    finally:
+        os.path.altsep, os.path.splitdrive = saved_altsep, saved_splitdrive
+
+
+@pytest.mark.parametrize(
+    "member, unsafe_posix, unsafe_windows",
+    _MEMBERS,
+    ids=[m.replace("\\", "bs").replace("/", "_")[:24] for m, _, _ in _MEMBERS],
+)
+def test_member_safety_matches_each_platforms_rules(
+    member, unsafe_posix, unsafe_windows
+):
+    assert _verdict_under(posixpath, member) is unsafe_posix
+    assert _verdict_under(ntpath, member) is unsafe_windows
+
+
+def test_backslash_members_are_only_dangerous_on_windows():
+    """Stated explicitly because it is the counter-intuitive half.
+
+    Refusing these on POSIX would be an over-block: a file really can be named
+    ``..\\..\\x`` there, and extracting it creates that one file.
+    """
+    member = "..\\..\\outside\\PWNED.txt"
+    assert _verdict_under(ntpath, member) is True
+    assert _verdict_under(posixpath, member) is False
+
+
+def test_extraction_refuses_traversing_members_end_to_end(pathsec_sandbox):
+    """The real extractor, not just the predicate."""
+    import zipfile
+
+    root, outside = pathsec_sandbox
+    archive = str(root / "evil.zip")
+    for member in ("../../outside/PWNED.txt", "/tmp/PWNED_ABS.txt", ".."):
+        with zipfile.ZipFile(archive, "w") as handle:
+            handle.writestr(member, "PWNED")
+        destination = str(root / "unpacked")
+        with pytest.raises((PermissionError, ValueError)):
+            with pathsec.ZipFile(archive) as handle:
+                handle.extractall(destination)
+        assert not (outside / "PWNED.txt").exists()
+        assert not os.path.exists("/tmp/PWNED_ABS.txt")
+
+
+def test_extraction_still_works_for_ordinary_members(pathsec_sandbox):
+    """Over-block control."""
+    import zipfile
+
+    root, _outside = pathsec_sandbox
+    archive = str(root / "good.zip")
+    with zipfile.ZipFile(archive, "w") as handle:
+        handle.writestr("sub/dir/file.txt", "fine")
+    destination = str(root / "unpacked")
+    with pathsec.ZipFile(archive) as handle:
+        handle.extractall(destination)
+    assert (root / "unpacked" / "sub" / "dir" / "file.txt").read_text() == "fine"


### PR DESCRIPTION
## Test-only additions for hardening already on develop

These are test-only changes. Every guard they exercise is already merged
on `develop`; each test file was run unchanged against `develop` (no
source/module change) and passes, so this only adds coverage for
hardening that shipped without a focused test.

### Added, grouped by the guard they cover

- **Zip member platform rules** (`test_zip_member_platform_rules.py`) --
  `pathsec._zip_member_is_unsafe` under both POSIX and Windows separator
  rules. A `..\..\x` / `C:\x` member is unsafe on Windows but a legal
  filename on POSIX; the test swaps in each platform's path module so a
  Linux CI run also checks the Windows verdict, and adds an end-to-end
  extraction refusal plus an over-block control. The predicate had no
  test on develop.
- **Zip member collision** (`test_zip_member_collision.py`) --
  `pathsec._reject_colliding_members` refuses archives whose members
  collide on a case-folding or unicode-normalizing filesystem (case,
  NFC/NFD, ligature, case-differing directory), with a control that
  distinct members still extract.
- **Aggregate decompression bomb** (`test_aggregate_zip_bomb.py`) --
  `nltk.data._check_zip_total_size` refuses an archive whose members each
  pass the per-member floor but sum to a bomb, with controls for a
  legitimately large corpus and a below-threshold ratio. The aggregate
  guard had no test on develop.
- **Zip extraction symlink TOCTOU** (`test_zip_extraction_toctou.py`) --
  `pathsec.ZipFile` extraction refuses a symlinked-parent leaf so a member
  write cannot escape through it.
- **Enforce does not break normal use**
  (`test_enforce_does_not_break_normal_use.py`) -- with `pathsec.ENFORCE`
  on by default, real tokenizers/taggers/corpora still load and a missing
  resource surfaces as `LookupError`, not `PermissionError`.
- **Module import + functional smoke**
  (`test_module_import_and_functional_smoke.py`) -- every `nltk` module
  imports and the common pipelines run under the hardened defaults.
- **chat80 shelve-backed valuation sinks** (`test_chat80_pathsec.py`) --
  two added tests: `val_dump`/`val_load` validate the caller path before
  `shelve.open` creates its backing files (outside, `/etc`, NUL are
  refused; an in-root destination passes). The five existing tests in
  that file are unchanged.

### Deliberately excluded to avoid duplication

- The monster sweep modules (`test_pathsec_sweep_wrappers.py`,
  `test_model_artifact_pathsec.py`, `test_pathsec_sweep_tbl.py`) -- their
  assertions were already lifted into focused modules on develop.
- `test_stanford_arg_injection.py` -- every guard it exercises (per-call
  java option allowlist, `_java_child_env()` env stripping, `cmd[0]`/
  `@argfile` rejection, bounded model path) is already covered by
  `test_java_per_call_options_security.py` and `test_malt_stanford_pathsec.py`.
- `test_corpus_reader_traversal.py` -- its Framenet `_validate_in_root`
  choke-point test duplicates `test_corpus_reader_hardening.py`, and
  reader-root / symlink containment is covered by
  `test_corpus_reader_pathsec.py`.
- `test_archive_extraction_hardening.py` -- its high-entry-count and
  gzip-pointer bomb tests duplicate `test_zipbomb_security.py`.

### Deferred (would need an unsplit source change)

- `test_file_io_guard_coverage.py` -- asserts the `tools/check_no_unsandboxed_open.py`
  guard scans the whole package rather than a shortlist; that broader
  guard is not on develop, so the file fails there and does not belong in
  a test-only PR.

Non-vacuousness was verified by neutering each new guard and confirming
the corresponding refusal tests fail (collision, platform-rule and
aggregate-bomb tests all fail with the guard removed), while the
over-block controls keep passing.
