### PR TITLE
Fix newline in ellipsis tokens in TweetTokenizer

### DIFF
--- a/nltk/test/unit/test_tokenize.py
+++ b/nltk/test/unit/test_tokenize.py
@@ -71,6 +71,20 @@ class TestTokenize:
         ]
         assert tokens == expected
 
+    def test_tweet_tokenizer_ellipsis_newline(self):
+        """
+        Ellipsis tokens must not span newlines (#1954).
+        """
+        tokenizer = TweetTokenizer()
+        assert tokenizer.tokenize("hello...\n...world") == [
+            "hello",
+            "...",
+            "...",
+            "world",
+        ]
+        # spaces between ellipsis dots are still allowed
+        assert tokenizer.tokenize("a.. .b") == ["a", ".. .", "b"]
+
     @pytest.mark.parametrize(
         "test_input, expecteds",
         [

--- a/nltk/tokenize/casual.py
+++ b/nltk/tokenize/casual.py
@@ -199,7 +199,7 @@ REGEXPS = (
     |
     (?:[\w_]+)                     # Words without apostrophes or dashes.
     |
-    (?:\.(?:\s*\.){1,})            # Ellipsis dots.
+    (?:\.(?:[^\S\r\n]*\.){1,})            # Ellipsis dots.
     |
     (?:\S)                         # Everything else that isn't whitespace.
     """,


### PR DESCRIPTION
## Summary

Fixes #1954.

The ellipsis regex in `TweetTokenizer` used `\s*` between dots, so a newline between ellipsis dots got swallowed into a single token (e.g. `...\n...` became one token `...\n...`).

This PR replaces `\s` with `[^\S\r\n]` in the ellipsis regex, so ellipsis tokens no longer span newlines while spaces between dots are still allowed (e.g. `.. .` remains a single token).

## Changes

- `nltk/tokenize/casual.py`: ellipsis regex `\s* → [^\S\r\n]*`.
- `nltk/test/unit/test_tokenize.py`: added `test_tweet_tokenizer_ellipsis_newline`.

## Test

`pytest nltk/test/unit/test_tokenize.py::TestTokenize::test_tweet_tokenizer_ellipsis_newline` — passed.