### PR TITLE
Add remaining GHSA-8mgp security regression tests (pathsec/java/redos/archive/corpus)

### DIFF
--- a/nltk/test/unit/test_archive_extraction_hardening.py
+++ b/nltk/test/unit/test_archive_extraction_hardening.py
@@ -1,0 +1,115 @@
+# Natural Language Toolkit: archive extraction hardening
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""Archive attacks beyond a plain ``..`` member.
+
+Covers the write/read-through, entry-count and decompression-bomb classes. One
+result is worth stating rather than assuming: Python's ``zipfile`` never creates
+a symlink on extract; a symlink member is written as a regular file whose
+content is the link-target string. So the zip symlink-write-through attack is
+structurally impossible through ``extractall``, and the test pins that behaviour
+so a future move to a symlink-honouring extractor would surface here.
+"""
+
+import gzip
+import os
+import shutil
+import tempfile
+import zipfile
+
+import pytest
+
+import nltk.data
+from nltk import pathsec
+
+
+@pytest.fixture
+def sandbox(monkeypatch):
+    base = tempfile.mkdtemp(prefix=".nltk_arc_", dir=os.path.expanduser("~"))
+    root = os.path.join(base, "nltk_data")
+    outside = os.path.join(base, "outside")
+    os.makedirs(root)
+    os.makedirs(outside)
+    monkeypatch.setattr(pathsec, "ENFORCE", True)
+    monkeypatch.setattr(nltk.data, "path", [root])
+    monkeypatch.setattr(pathsec, "_ALLOWED_ROOTS_CACHE", None, raising=False)
+    monkeypatch.setattr(pathsec, "_LAST_DATA_PATHS", None, raising=False)
+    try:
+        yield root, outside
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+
+
+def test_a_symlink_member_is_written_as_a_regular_file(sandbox):
+    root, _outside = sandbox
+    archive = os.path.join(root, "sym.zip")
+    with zipfile.ZipFile(archive, "w") as handle:
+        info = zipfile.ZipInfo("passwd_link")
+        info.external_attr = 0o120777 << 16  # S_IFLNK
+        handle.writestr(info, "/etc/passwd")
+    destination = os.path.join(root, "unpacked")
+    with pathsec.ZipFile(archive) as handle:
+        handle.extractall(destination)
+    extracted = os.path.join(destination, "passwd_link")
+    assert not os.path.islink(extracted), "extractall created a symlink"
+    with open(extracted) as fh:
+        assert fh.read() == "/etc/passwd"
+
+
+def test_symlink_write_through_cannot_escape(sandbox):
+    """Two-member layout: a symlink then a file written through it. zipfile
+    writes the symlink as a plain file, so the second member cannot descend into
+    it and the write stays contained (or raises)."""
+    root, outside = sandbox
+    archive = os.path.join(root, "wt.zip")
+    with zipfile.ZipFile(archive, "w") as handle:
+        info = zipfile.ZipInfo("sub")
+        info.external_attr = 0o120777 << 16
+        handle.writestr(info, outside)
+        handle.writestr("sub/PWNED.txt", "PWNED")
+    destination = os.path.join(root, "wt_out")
+    try:
+        with pathsec.ZipFile(archive) as handle:
+            handle.extractall(destination)
+    except (OSError, PermissionError, ValueError):
+        pass  # NotADirectoryError etc. -- the escape simply cannot happen
+    assert not os.path.exists(os.path.join(outside, "PWNED.txt"))
+
+
+def test_a_high_entry_count_zip_is_refused(sandbox):
+    root, _outside = sandbox
+    archive = os.path.join(root, "many.zip")
+    with zipfile.ZipFile(archive, "w") as handle:
+        for index in range(150000):
+            handle.writestr(f"f{index}", "")
+    with pytest.raises((PermissionError, ValueError)):
+        with pathsec.ZipFile(archive):
+            pass
+
+
+def test_a_gzip_decompression_bomb_is_refused(sandbox):
+    root, _outside = sandbox
+    bomb = os.path.join(root, "bomb.gz")
+    with gzip.open(bomb, "wb") as handle:
+        handle.write(b"\0" * (200 * 1024 * 1024))
+    assert os.path.getsize(bomb) < 1_000_000  # tiny on disk
+    from nltk.data import GzipFileSystemPathPointer
+
+    with pytest.raises((PermissionError, ValueError)):
+        GzipFileSystemPathPointer(bomb).open().read()
+
+
+def test_ordinary_archives_still_extract(sandbox):
+    """Over-block control."""
+    root, _outside = sandbox
+    archive = os.path.join(root, "good.zip")
+    with zipfile.ZipFile(archive, "w") as handle:
+        handle.writestr("sub/dir/file.txt", "fine")
+    destination = os.path.join(root, "good_out")
+    with pathsec.ZipFile(archive) as handle:
+        handle.extractall(destination)
+    with open(os.path.join(destination, "sub", "dir", "file.txt")) as fh:
+        assert fh.read() == "fine"

--- a/nltk/test/unit/test_corpus_reader_traversal.py
+++ b/nltk/test/unit/test_corpus_reader_traversal.py
@@ -1,0 +1,134 @@
+# Natural Language Toolkit: corpus-reader path traversal / symlink escape
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""Corpus readers must not read outside their own root.
+
+This maps to a cluster of published advisories: CVE-2026-0847 (WordList /
+Tagged / Bracket readers concatenating fileids), CVE-2026-12072 (NKJP header /
+raw), CVE-2026-12074 / -62384 (Framenet frame files via traversal and symlink),
+and CVE-2026-70626 (CorpusReader.open symlink). A caller-supplied fileid must
+stay inside the corpus whether it is a ``..`` path, an absolute path, or a
+symlink planted inside the corpus that points out of it.
+"""
+
+import os
+import shutil
+import tempfile
+
+import pytest
+
+import nltk.data
+from nltk import pathsec
+
+_SECRET = "root:x:0:0:SECRET"
+
+
+@pytest.fixture
+def corpus_and_outside(monkeypatch):
+    base = tempfile.mkdtemp(prefix=".nltk_corpus_", dir=os.path.expanduser("~"))
+    corpus = os.path.join(base, "corpus")
+    outside = os.path.join(base, "outside")
+    os.makedirs(corpus)
+    os.makedirs(outside)
+    with open(os.path.join(outside, "SECRET"), "w") as handle:
+        handle.write(_SECRET)
+    with open(os.path.join(corpus, "real.txt"), "w") as handle:
+        handle.write("hello world")
+    monkeypatch.setattr(pathsec, "ENFORCE", True)
+    monkeypatch.setattr(nltk.data, "path", [base])
+    monkeypatch.setattr(pathsec, "_ALLOWED_ROOTS_CACHE", None, raising=False)
+    monkeypatch.setattr(pathsec, "_LAST_DATA_PATHS", None, raising=False)
+    try:
+        yield corpus, outside
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+
+
+@pytest.mark.parametrize(
+    "reader_name, method",
+    [
+        ("WordListCorpusReader", "words"),
+        ("PlaintextCorpusReader", "raw"),
+        ("TaggedCorpusReader", "words"),
+    ],
+)
+@pytest.mark.parametrize(
+    "fileid",
+    ["../../outside/SECRET", "/etc/passwd", "../../../etc/passwd"],
+    ids=["traversal", "absolute", "deep-traversal"],
+)
+def test_reader_fileid_cannot_escape(corpus_and_outside, reader_name, method, fileid):
+    from nltk.corpus import reader as reader_module
+
+    corpus, _outside = corpus_and_outside
+    reader_cls = getattr(reader_module, reader_name)
+    reader = reader_cls(corpus, r".*\.txt")
+    with pytest.raises((PermissionError, ValueError)):
+        result = getattr(reader, method)(fileid)
+        text = "".join(result) if hasattr(result, "__iter__") else str(result)
+        assert _SECRET not in text
+
+
+def test_a_symlink_fileid_cannot_escape(corpus_and_outside):
+    from nltk.corpus import WordListCorpusReader
+
+    corpus, outside = corpus_and_outside
+    os.symlink(os.path.join(outside, "SECRET"), os.path.join(corpus, "evil.txt"))
+    reader = WordListCorpusReader(corpus, r".*\.txt")
+    with pytest.raises((PermissionError, ValueError)):
+        text = "".join(reader.words("evil.txt"))
+        assert _SECRET not in text
+
+
+def test_corpusreader_open_refuses_a_symlink_out(corpus_and_outside):
+    from nltk.corpus.reader.api import CorpusReader
+
+    corpus, outside = corpus_and_outside
+    os.symlink(os.path.join(outside, "SECRET"), os.path.join(corpus, "link.txt"))
+    reader = CorpusReader(corpus, [r".*"])
+    with pytest.raises((PermissionError, ValueError)):
+        reader.open("link.txt").read()
+
+
+def test_nkjp_header_and_raw_cannot_escape(corpus_and_outside):
+    from nltk.corpus.reader.nkjp import NKJPCorpusReader
+
+    corpus, _outside = corpus_and_outside
+    for fileid in ("../../outside/SECRET", "/etc/passwd"):
+        with pytest.raises((PermissionError, ValueError)):
+            reader = NKJPCorpusReader(corpus, fileids=fileid)
+            reader.header()
+
+
+def test_framenet_validate_in_root_is_the_choke_point(corpus_and_outside):
+    """Every Framenet frame/lu/doc load funnels through _validate_in_root; it
+    must refuse a symlink out, a traversal and an absolute path."""
+    from nltk.corpus.reader.framenet import _validate_in_root
+
+    corpus, outside = corpus_and_outside
+    os.makedirs(os.path.join(corpus, "frame"))
+    symlink = os.path.join(corpus, "frame", "evil.xml")
+    os.symlink(os.path.join(outside, "SECRET"), symlink)
+    for path in (
+        symlink,
+        os.path.join(corpus, "frame", "..", "..", "outside", "SECRET"),
+        os.path.join(outside, "SECRET"),
+    ):
+        with pytest.raises((PermissionError, ValueError)):
+            _validate_in_root(path, corpus, "test")
+    # over-block control: an in-root path is accepted
+    good = os.path.join(corpus, "frame", "good.xml")
+    _validate_in_root(good, corpus, "test")
+
+
+def test_the_real_file_still_reads(corpus_and_outside):
+    """Over-block control: the whole reader is useless if it refuses its own
+    files."""
+    from nltk.corpus import WordListCorpusReader
+
+    corpus, _outside = corpus_and_outside
+    # WordListCorpusReader.words() yields whole lines, one per entry.
+    assert WordListCorpusReader(corpus, r".*\.txt").words("real.txt") == ["hello world"]

--- a/nltk/test/unit/test_model_artifact_pathsec.py
+++ b/nltk/test/unit/test_model_artifact_pathsec.py
@@ -1,0 +1,1228 @@
+"""Exploit matrix for the model-artifact read/write APIs (GHSA-8mgp-746c-j5xp).
+
+The advisory names six entry points that treated a caller-supplied model path as
+an ordinary filename: ``TransitionParser.train``/``parse``,
+``AveragedPerceptron.save``/``load``, ``PerceptronTagger.save_to_json`` and
+``save_maxent_params``. This file drives all of them, plus the sibling
+save/load helpers in the same family and the constructor/train routes that reach
+them, with every path form an attacker can supply.
+
+Three kinds of case are kept side by side on purpose:
+
+* **escapes** -- must be refused, and must leave nothing behind outside the root.
+* **benign / probable-but-harmless** -- pinned so that if a future change starts
+  expanding, decoding or following them, the pin turns into a failure.
+* **over-block controls** -- the legitimate in-sandbox flows must keep working,
+  so a fix cannot be "refuse everything".
+
+Plus negative controls: each guard is neutered in-process and the exploit must
+become reachable again, so none of these tests can pass by never reaching a sink.
+
+Staging note: an "outside" target is created under ``$HOME`` (the ``sandbox`` /
+``pathsec_sandbox`` fixtures in conftest.py), never in ``tempfile.mkdtemp()`` --
+a private per-user system temp dir IS an allowed root on macOS/Windows, so a
+target staged there would be correctly permitted and prove nothing.
+"""
+
+import ast
+import builtins
+import contextlib
+import json
+import os
+import pathlib
+import pickle
+import shutil
+import socket
+import stat
+import sys
+import tempfile
+import time
+
+import pytest
+
+import nltk
+import nltk.data
+import nltk.pathsec as pathsec
+import nltk.tag.perceptron as perceptron
+from nltk.tag.perceptron import AveragedPerceptron, PerceptronTagger
+
+CANARY = "MODEL-ARTIFACT-CANARY"
+LANG = "probeartifact"
+
+POSIX_ONLY = pytest.mark.skipif(os.name != "posix", reason="POSIX-only path form")
+
+
+@pytest.fixture
+def outside_only(monkeypatch):
+    """An out-of-sandbox directory that leaves ``nltk.data.path`` alone.
+
+    The ``sandbox`` fixtures narrow the allowed roots to one empty directory,
+    which also hides the installed corpora; tests that must load a real corpus
+    (or a real shipped model) use this instead. ``$HOME`` is not an allowed root
+    on its own, so a directory made there is still a genuine escape target, and
+    that is asserted rather than assumed.
+    """
+    monkeypatch.setattr(pathsec, "ENFORCE", True)
+    path = pathlib.Path(
+        tempfile.mkdtemp(prefix=".nltk_artifact_outside_", dir=str(pathlib.Path.home()))
+    )
+    resolved = path.resolve()
+    inside = any(
+        resolved == root or resolved.is_relative_to(root)
+        for root in pathsec._get_allowed_roots()
+    )
+    try:
+        if inside:
+            pytest.skip("$HOME is inside an allowed root here; no escape target")
+        yield path
+    finally:
+        shutil.rmtree(path, ignore_errors=True)
+
+
+def _weights():
+    return {CANARY: {"NN": 1.0}}
+
+
+def _tagger():
+    tagger = PerceptronTagger(load=False)
+    tagger.model.weights = _weights()
+    tagger.tagdict = {}
+    tagger.classes = {"NN"}
+    return tagger
+
+
+def _plant_model_dir(loc, lang=LANG):
+    """Stage the three json files ``load_from_json`` reads, as an attacker would.
+
+    Written with the stdlib writer deliberately: this is the attacker's plant,
+    staged outside the sandbox before the attack runs, not NLTK doing the I/O.
+    """
+    os.makedirs(loc, mode=0o700, exist_ok=True)
+    for attr, value in (
+        ("weights", _weights()),
+        ("tagdict", {}),
+        ("classes", ["NN"]),
+    ):
+        target = os.path.join(loc, f"averaged_perceptron_tagger_{lang}.{attr}.json")
+        pathlib.Path(target).write_text(json.dumps(value), encoding="utf-8")
+
+
+def _refused(call, *args, **kwargs):
+    """Run *call*; return the security exception it raised, or fail loudly."""
+    with pytest.raises((PermissionError, ValueError, OSError)) as excinfo:
+        call(*args, **kwargs)
+    return excinfo.value
+
+
+# ==========================================================================
+# AveragedPerceptron.save / load -- the advisory's bare-open pair
+# ==========================================================================
+
+
+class TestAveragedPerceptronEscapes:
+    def test_load_outside_root_is_refused(self, sandbox):
+        target = sandbox / "weights.json"
+        target.write_text(json.dumps(_weights()), encoding="utf-8")
+        model = AveragedPerceptron()
+        _refused(model.load, str(target))
+        assert model.weights == {}, "outside-root weights reached the caller"
+
+    def test_save_outside_root_is_refused_and_writes_nothing(self, sandbox):
+        target = sandbox / "written.json"
+        _refused(AveragedPerceptron(_weights()).save, str(target))
+        assert not target.exists(), "refused write still created the file"
+
+    @POSIX_ONLY
+    def test_save_through_in_root_symlink_is_refused(self, pathsec_sandbox):
+        victim = pathsec_sandbox.outside / "victim.json"
+        victim.write_text("untouched", encoding="utf-8")
+        link = pathsec_sandbox.root / "link.json"
+        os.symlink(str(victim), str(link))
+        _refused(AveragedPerceptron(_weights()).save, str(link))
+        assert victim.read_text(encoding="utf-8") == "untouched"
+
+    @POSIX_ONLY
+    def test_save_through_symlinked_parent_is_refused(self, pathsec_sandbox):
+        victim_dir = pathsec_sandbox.outside / "parent"
+        victim_dir.mkdir()
+        link = pathsec_sandbox.root / "plink"
+        os.symlink(str(victim_dir), str(link))
+        _refused(AveragedPerceptron(_weights()).save, str(link / "w.json"))
+        assert not list(victim_dir.iterdir()), "write escaped via the parent symlink"
+
+    @POSIX_ONLY
+    def test_load_through_in_root_hardlink_is_refused(self, pathsec_sandbox):
+        secret = pathsec_sandbox.outside / "secret.json"
+        secret.write_text(json.dumps(_weights()), encoding="utf-8")
+        link = pathsec_sandbox.root / "hard.json"
+        try:
+            os.link(str(secret), str(link))
+        except OSError:
+            pytest.skip("cross-device hardlink not possible here")
+        model = AveragedPerceptron()
+        _refused(model.load, str(link))
+        assert model.weights == {}
+
+    def test_traversal_out_of_the_root_is_refused(self, pathsec_sandbox):
+        target = pathsec_sandbox.outside / "trav.json"
+        target.write_text(json.dumps(_weights()), encoding="utf-8")
+        hop = os.path.join(
+            str(pathsec_sandbox.root), *([os.pardir] * 12), str(target).lstrip("/")
+        )
+        model = AveragedPerceptron()
+        _refused(model.load, hop)
+        assert model.weights == {}
+
+    def test_sibling_directory_sharing_the_root_prefix_is_refused(
+        self, outside_only, monkeypatch
+    ):
+        """``<root>_evil`` starts with the root's characters but is not under it.
+
+        The root has to sit somewhere that is not itself a root, or the sibling
+        would be legitimately allowed by the parent and prove nothing.
+        """
+        root = outside_only / "root"
+        root.mkdir()
+        sibling = outside_only / "root_evil"
+        sibling.mkdir()
+        monkeypatch.setattr(nltk.data, "path", [str(root)])
+        monkeypatch.setattr(pathsec, "_ALLOWED_ROOTS_CACHE", None, raising=False)
+        monkeypatch.setattr(pathsec, "_LAST_DATA_PATHS", None, raising=False)
+        target = sibling / "x.json"
+        target.write_text(json.dumps(_weights()), encoding="utf-8")
+        model = AveragedPerceptron()
+        _refused(model.load, str(target))
+        assert model.weights == {}
+
+    def test_case_folded_path_never_resolves_outside_the_root(self, pathsec_sandbox):
+        """Case folding must not be a way to sidestep the prefix comparison.
+
+        The two platforms differ legitimately and the invariant has to hold on
+        both: POSIX resolve() keeps the upper-cased string, which no longer
+        matches the root prefix, so the read is refused; Windows resolve()
+        returns the real on-disk casing, so it names the *same in-root file* and
+        the read is allowed. Either outcome is fine; reading something else is
+        not.
+        """
+        inside = pathsec_sandbox.root / "cf.json"
+        AveragedPerceptron(_weights()).save(str(inside))
+        model = AveragedPerceptron()
+        try:
+            model.load(str(inside).upper())
+        except (PermissionError, ValueError, OSError):
+            assert model.weights == {}
+        else:
+            assert (
+                model.weights == _weights()
+            ), "case-folded path resolved to a different file than the in-root one"
+
+    def test_bytes_and_pathlike_forms_are_validated_too(self, sandbox):
+        _refused(AveragedPerceptron(_weights()).save, str(sandbox / "b.json").encode())
+        _refused(AveragedPerceptron(_weights()).save, pathlib.Path(sandbox / "p.json"))
+        assert not list(sandbox.iterdir())
+
+    def test_directory_where_a_file_is_expected_is_refused(self, sandbox):
+        _refused(AveragedPerceptron().load, str(sandbox))
+
+    def test_an_open_descriptor_is_passed_through_by_design(self, sandbox):
+        """An int is a descriptor the caller already holds, not a path.
+
+        pathsec deliberately lets one through: opening it grants no capability
+        the caller did not already have. Pinned because it is the one input that
+        skips containment, so the exemption must stay a deliberate, narrow one
+        (an int) and never widen to something a caller could supply as text.
+        """
+        target = sandbox / "weights.json"
+        target.write_text(json.dumps(_weights()), encoding="utf-8")
+        # os.open, not the builtin: this deliberately stages a descriptor for a
+        # file outside the sandbox, which is the whole point of the case.
+        descriptor = os.open(str(target), os.O_RDONLY)
+        try:
+            model = AveragedPerceptron()
+            model.load(descriptor)
+            assert model.weights == _weights()
+        finally:
+            with contextlib.suppress(OSError):
+                os.close(descriptor)
+        _refused(AveragedPerceptron().load, str(target))
+
+    @POSIX_ONLY
+    def test_dangling_in_root_symlink_destination_creates_nothing(
+        self, pathsec_sandbox
+    ):
+        """A symlink to a path that does not exist yet is the sharper write case.
+
+        ``os.path.exists`` says False, so an "already there?" pre-check waves it
+        through, and the open would then create the victim at the far end.
+        """
+        victim = pathsec_sandbox.outside / "victim.json"
+        link = pathsec_sandbox.root / "dangling.json"
+        os.symlink(str(victim), str(link))
+        _refused(AveragedPerceptron(_weights()).save, str(link))
+        assert not victim.exists(), "the write created the outside-root victim"
+
+    @POSIX_ONLY
+    def test_retrieve_to_a_dangling_in_root_symlink_creates_nothing(
+        self, pathsec_sandbox
+    ):
+        source = pathsec_sandbox.root / "src.txt"
+        with pathsec.open(str(source), "w", context="test") as handle:
+            handle.write("inside-payload")
+        victim = pathsec_sandbox.outside / "victim.txt"
+        link = pathsec_sandbox.root / "dangling.txt"
+        os.symlink(str(victim), str(link))
+        with pytest.raises((PermissionError, ValueError, OSError)):
+            nltk.data.retrieve("file://" + str(source), str(link), verbose=False)
+        assert not victim.exists()
+
+    def test_empty_resource_name_resolves_to_the_root_not_outside_it(
+        self, restricted_sandbox
+    ):
+        """``load("")`` normalises to the data root itself.
+
+        Harmless (a directory is not a readable model) but pinned: the point is
+        that it lands *on* the root rather than anywhere above it.
+        """
+        with pytest.raises((OSError, ValueError, LookupError)) as excinfo:
+            nltk.data.load("", format="raw", cache=False)
+        assert os.path.dirname(str(restricted_sandbox)) not in str(excinfo.value) or (
+            str(restricted_sandbox) in str(excinfo.value)
+        )
+
+
+class TestAveragedPerceptronBenignForms:
+    """Forms that are harmless today, pinned so a future decode/expand regresses.
+
+    None of these may reach a file outside the sandbox: the assertion is that the
+    call fails and leaves the outside directory empty.
+    """
+
+    @pytest.mark.parametrize(
+        "form",
+        [
+            "nul-trailing",
+            "nul-middle",
+            "newline",
+            "tilde",
+            "relative",
+            "dot-slash",
+            "unc-forward",
+            "backslash",
+            "ads-stream",
+            "overlong",
+            "leading-dash",
+        ],
+    )
+    def test_probable_but_harmless_write_forms_touch_nothing(self, form, sandbox):
+        base = str(sandbox / "x.json")
+        payloads = {
+            "nul-trailing": base + "\x00",
+            "nul-middle": base + "\x00.cfg",
+            "newline": base + "\n",
+            "tilde": "~/" + os.path.basename(base),
+            "relative": os.path.basename(base),
+            "dot-slash": "./" + os.path.basename(base),
+            "unc-forward": "//" + base.lstrip("/"),
+            "backslash": base.replace("/", "\\"),
+            "ads-stream": base + ":stream",
+            "overlong": os.path.join(str(sandbox), "a" * 5000),
+            "leading-dash": "-rf",
+        }
+        with pytest.raises(Exception):
+            AveragedPerceptron(_weights()).save(payloads[form])
+        assert not list(sandbox.iterdir()), f"{form} created a file outside the root"
+
+    @pytest.mark.parametrize("blank", ["   ", "\t", "\n", "  \t "])
+    def test_whitespace_only_paths_do_not_create_a_file(self, blank, outside_only):
+        """A whitespace-only name is a legal relative filename, not "no path".
+
+        Waving it through skipped containment entirely and let the open create
+        that file in the working directory. The CWD is an out-of-sandbox
+        directory here, so a created file is a real escape (on macOS the private
+        system temp dir IS an allowed root, and a temp CWD would hide this).
+        """
+        saved = os.getcwd()
+        os.chdir(outside_only)
+        try:
+            with pytest.raises(Exception):
+                AveragedPerceptron(_weights()).save(blank)
+            assert not list(outside_only.iterdir()), "whitespace path created a file"
+        finally:
+            os.chdir(saved)
+
+    def test_empty_path_is_not_a_write(self, restricted_sandbox):
+        with pytest.raises(OSError):
+            AveragedPerceptron(_weights()).save("")
+
+    @POSIX_ONLY
+    @pytest.mark.parametrize("device", ["/dev/stdin", "/dev/fd/0", "/dev/null"])
+    def test_device_nodes_outside_the_root_are_refused(
+        self, device, restricted_sandbox
+    ):
+        """Never opened: containment refuses the path string before any open().
+
+        That ordering is what keeps a blocking device/FIFO from hanging the
+        reader, so it is asserted rather than assumed.
+        """
+        if not os.path.exists(device):
+            pytest.skip(f"{device} not present")
+        _refused(AveragedPerceptron().load, device)
+
+
+@POSIX_ONLY
+class TestBlockingSpecialFilesAreContained:
+    """A FIFO / unix socket blocks a reader forever, so containment must decide
+    before anything is opened.
+
+    An outside-root FIFO is refused on the path string. One planted *inside* a
+    trusted data root is deliberately still permitted (a root is trusted by
+    definition), so that decision is pinned here rather than left implicit, and
+    neither case is ever opened by this test.
+    """
+
+    def test_outside_fifo_is_refused_without_opening_it(self, pathsec_sandbox):
+        fifo = pathsec_sandbox.outside / "fifo"
+        os.mkfifo(str(fifo))
+        assert stat.S_ISFIFO(os.stat(str(fifo)).st_mode)
+        _refused(AveragedPerceptron().load, str(fifo))
+
+    def test_outside_unix_socket_is_refused_without_opening_it(self, pathsec_sandbox):
+        target = pathsec_sandbox.outside / "sock"
+        server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            server.bind(str(target))
+            _refused(AveragedPerceptron().load, str(target))
+        finally:
+            server.close()
+
+    def test_in_root_special_file_is_inside_the_sandbox(self, restricted_sandbox):
+        fifo = os.path.join(restricted_sandbox, "fifo")
+        os.mkfifo(fifo)
+        # No exception: a path inside a trusted root is contained. Not opened --
+        # a FIFO read blocks until a writer appears.
+        pathsec.validate_path(fifo, context="test")
+
+
+class TestAveragedPerceptronRoundTrip:
+    """Over-block control: the legitimate in-sandbox flow must keep working."""
+
+    def test_save_load_round_trip_inside_a_data_root(self, restricted_sandbox):
+        target = os.path.join(restricted_sandbox, "weights.json")
+        AveragedPerceptron(_weights()).save(target)
+        assert os.path.exists(target)
+        reloaded = AveragedPerceptron()
+        reloaded.load(target)
+        assert reloaded.weights == _weights()
+
+
+# ==========================================================================
+# PerceptronTagger.save_to_json / load_from_json / train / __init__
+# ==========================================================================
+
+
+class TestPerceptronTaggerEscapes:
+    def test_save_to_json_outside_root_is_refused(self, sandbox):
+        loc = str(sandbox / "tagger_out")
+        _refused(_tagger().save_to_json, LANG, loc)
+        assert not os.path.exists(loc), "refused save still created the directory"
+
+    def test_train_save_loc_outside_root_is_refused(self, sandbox):
+        loc = str(sandbox / "trained")
+        tagger = PerceptronTagger(load=False)
+        _refused(tagger.train, [[("a", "DT")]], loc, 1)
+        assert not os.path.exists(loc)
+
+    def test_forced_save_dir_outside_root_is_refused(self, sandbox):
+        tagger = _tagger()
+        tagger._save_dir = str(sandbox / "forced")
+        _refused(tagger.save_to_json, LANG)
+        assert not list(sandbox.iterdir())
+
+    @POSIX_ONLY
+    def test_save_to_json_into_a_symlinked_dir_is_refused(self, pathsec_sandbox):
+        victim = pathsec_sandbox.outside / "sym_victim"
+        victim.mkdir()
+        link = pathsec_sandbox.root / "symloc"
+        os.symlink(str(victim), str(link))
+        _refused(_tagger().save_to_json, LANG, str(link))
+        assert not list(victim.iterdir()), "write leaked through the symlink"
+
+    def test_save_to_json_traversal_out_of_the_root_is_refused(self, pathsec_sandbox):
+        hop = os.path.join(
+            str(pathsec_sandbox.root),
+            *([os.pardir] * 12),
+            str(pathsec_sandbox.outside / "trav").lstrip("/"),
+        )
+        _refused(_tagger().save_to_json, LANG, hop)
+        assert not list(pathsec_sandbox.outside.iterdir())
+
+    def test_load_from_json_outside_root_is_refused(self, sandbox):
+        loc = str(sandbox / "tagger_in")
+        _plant_model_dir(loc)
+        tagger = PerceptronTagger(load=False)
+        _refused(tagger.load_from_json, LANG, loc)
+        assert tagger.model.weights == {}
+
+    @pytest.mark.parametrize("wrap", [str, pathlib.Path, "pointer"])
+    def test_every_loc_type_reaches_the_same_guard(self, wrap, sandbox):
+        """str, pathlib.Path and PathPointer are three separate branches in
+        load_from_json; a guard on one is not a guard on the siblings."""
+        loc = str(sandbox / f"tagger_{getattr(wrap, '__name__', wrap)}")
+        _plant_model_dir(loc)
+        value = nltk.data.FileSystemPathPointer(loc) if wrap == "pointer" else wrap(loc)
+        tagger = PerceptronTagger(load=False)
+        _refused(tagger.load_from_json, LANG, value)
+        assert tagger.model.weights == {}
+
+    def test_constructor_loc_reaches_the_same_guard(self, sandbox):
+        loc = str(sandbox / "tagger_ctor")
+        _plant_model_dir(loc)
+        _refused(PerceptronTagger, True, LANG, loc)
+
+    def test_relative_traversal_loc_is_refused(self, restricted_sandbox):
+        _refused(PerceptronTagger(load=False).load_from_json, LANG, "../../../etc")
+
+    def test_load_from_json_does_not_widen_the_sandbox(self, sandbox):
+        """A caller-supplied dir must never be appended to nltk.data.path.
+
+        That primitive turns containment off for the path and everything under
+        it, process-wide, for every later read.
+        """
+        loc = str(sandbox / "tagger_widen")
+        _plant_model_dir(loc)
+        before = list(nltk.data.path)
+        with pytest.raises(Exception):
+            PerceptronTagger(load=False).load_from_json(LANG, loc)
+        assert list(nltk.data.path) == before
+
+
+class TestPerceptronTaggerDirectoryOpen:
+    """The pinned-descriptor layer under ``save_to_json``."""
+
+    @POSIX_ONLY
+    def test_a_swapped_intermediate_directory_is_caught_by_the_fd_recheck(
+        self, pathsec_sandbox, monkeypatch
+    ):
+        """O_NOFOLLOW only covers the leaf.
+
+        With the caller-path check skipped (as a swapped parent between check and
+        open would leave it), the descriptor's own real path must still be
+        refused, so the model write cannot land outside the roots.
+        """
+        victim = pathsec_sandbox.outside / "redirected"
+        victim.mkdir()
+        link = pathsec_sandbox.root / "plink"
+        os.symlink(str(victim), str(link))
+
+        real = perceptron.validate_path
+        calls = []
+
+        def count_the_recheck(*args, **kwargs):
+            calls.append(args)
+            return real(*args, **kwargs)
+
+        # The caller-path check is validate_tool_dir since the merge, so that is
+        # the layer to bypass here (as a parent directory swapped in between the
+        # check and the open would leave it). validate_path is left LIVE and only
+        # counted: the descriptor re-check inside _open_private_model_dir is the
+        # thing under test, so skipping a call to it would disable it.
+        monkeypatch.setattr(perceptron, "validate_path", count_the_recheck)
+        monkeypatch.setattr(
+            perceptron, "validate_tool_dir", lambda value, *a, **k: os.fspath(value)
+        )
+        _refused(_tagger().save_to_json, LANG, str(link / "leaf"))
+        assert (
+            not any((victim / "leaf").iterdir()) if (victim / "leaf").exists() else True
+        )
+        assert calls, "the descriptor was never re-validated"
+
+    def test_a_regular_file_as_the_destination_is_refused(self, restricted_sandbox):
+        target = os.path.join(restricted_sandbox, "not_a_dir")
+        with pathsec.open(target, "w", context="test") as handle:
+            handle.write("{}")
+        _refused(_tagger().save_to_json, LANG, target)
+
+    @POSIX_ONLY
+    def test_an_in_root_symlink_destination_is_refused_fail_closed(
+        self, restricted_sandbox
+    ):
+        """Even a symlink pointing at another in-root file is refused.
+
+        Model artifacts are never symlinks, so refusing the final component
+        outright is the fail-closed choice; it is asserted so a future
+        "follow it, it stays in-root anyway" relaxation shows up here.
+        """
+        real = os.path.join(restricted_sandbox, "real.json")
+        with pathsec.open(real, "w", context="test") as handle:
+            handle.write("{}")
+        link = os.path.join(restricted_sandbox, "link.json")
+        os.symlink(real, link)
+        _refused(AveragedPerceptron(_weights()).save, link)
+
+
+class TestDestinationSpellings:
+    """The same outside directory, written several legal ways.
+
+    Trailing separators/dots/spaces and the non-``str`` path types are the
+    spellings a prefix comparison is most likely to disagree with the kernel
+    about, so each is asserted to end at the same refusal.
+    """
+
+    @pytest.mark.parametrize("suffix", ["/", ".", " ", "//", "/."])
+    def test_trailing_characters_do_not_change_the_verdict(self, suffix, sandbox):
+        _refused(_tagger().save_to_json, LANG, str(sandbox / "dest") + suffix)
+        assert not list(sandbox.iterdir())
+
+    @pytest.mark.parametrize("wrap", ["path", "bytes"])
+    def test_non_string_destinations_are_validated_too(self, wrap, sandbox):
+        raw = str(sandbox / "dest")
+        loc = pathlib.Path(raw) if wrap == "path" else raw.encode()
+        _refused(_tagger().save_to_json, LANG, loc)
+        assert not list(sandbox.iterdir())
+
+    @POSIX_ONLY
+    def test_a_symlink_chain_is_followed_to_its_real_end(self, pathsec_sandbox):
+        """Two in-root hops to an outside file, not one.
+
+        A check that resolves only one level would call the second hop in-root
+        and let the read through.
+        """
+        target = pathsec_sandbox.outside / "chain.json"
+        target.write_text(json.dumps(_weights()), encoding="utf-8")
+        second = pathsec_sandbox.root / "second.json"
+        first = pathsec_sandbox.root / "first.json"
+        os.symlink(str(target), str(second))
+        os.symlink(str(second), str(first))
+        model = AveragedPerceptron()
+        _refused(model.load, str(first))
+        assert model.weights == {}
+
+    @POSIX_ONLY
+    def test_maxent_tab_dir_symlinked_out_of_the_root_is_refused(self, pathsec_sandbox):
+        numpy = pytest.importorskip("numpy")
+        from nltk.classify.maxent import save_maxent_params
+
+        victim = pathsec_sandbox.outside / "mx"
+        victim.mkdir()
+        link = pathsec_sandbox.root / "symdir"
+        os.symlink(str(victim), str(link))
+        _refused(
+            save_maxent_params,
+            numpy.array([1.0]),
+            {("a", "b"): 0},
+            ["L"],
+            {"alwayson": 0},
+            str(link),
+        )
+        assert not list(victim.iterdir())
+
+
+class TestPerceptronTaggerLangComponent:
+    """``lang`` is interpolated into the filename both directions open."""
+
+    @pytest.mark.parametrize(
+        "lang",
+        [
+            "../evil",
+            "sub/../../evil",
+            "/abs",
+            "a\x00b",
+            "..",
+            ".",
+            "",
+            "e\\v",
+            "a/b",
+        ],
+    )
+    def test_lang_cannot_contribute_path_structure(self, lang, restricted_sandbox):
+        loc = os.path.join(restricted_sandbox, "d")
+        os.makedirs(loc, exist_ok=True)
+        with pytest.raises(ValueError):
+            _tagger().save_to_json(lang=lang, loc=loc)
+        assert not os.listdir(loc)
+
+    def test_an_overlong_lang_cannot_be_written(self, restricted_sandbox):
+        """Rejected by the filesystem, not by a guard, so it is a pin: nothing is
+        created and the failure never lands outside the directory."""
+        loc = os.path.join(restricted_sandbox, "long")
+        os.makedirs(loc, exist_ok=True)
+        with pytest.raises(OSError):
+            _tagger().save_to_json(lang="a" * 5000, loc=loc)
+        assert not os.listdir(loc)
+
+    def test_a_leading_dash_lang_stays_a_filename(self, restricted_sandbox):
+        """Audited-benign: no model-artifact path is ever a subprocess argument,
+        so a leading dash is just a filename. Pinned so that if one of these
+        paths ever becomes argv, this stops being silently true."""
+        loc = os.path.join(restricted_sandbox, "dash")
+        os.makedirs(loc, exist_ok=True)
+        _tagger().save_to_json(lang="-rf", loc=loc)
+        written = sorted(os.listdir(loc))
+        assert written == sorted(_tagger().param_files("-rf"))
+        for name in written:
+            assert os.path.dirname(os.path.realpath(os.path.join(loc, name))) == (
+                os.path.realpath(loc)
+            )
+
+
+class TestPerceptronTaggerRoundTrip:
+    """Over-block controls for the whole train/save/load path."""
+
+    @pytest.fixture
+    def staged(self):
+        """A tagger whose lazily created staging dir is removed afterwards, so a
+        test run does not leave directories behind in the user's data root."""
+        made = []
+
+        def build(**kwargs):
+            tagger = (
+                _tagger() if not kwargs.get("plain") else PerceptronTagger(load=False)
+            )
+            made.append(tagger)
+            return tagger
+
+        try:
+            yield build
+        finally:
+            for tagger in made:
+                if tagger._save_dir:
+                    shutil.rmtree(tagger._save_dir, ignore_errors=True)
+
+    def test_default_save_dir_is_inside_a_data_root(self, staged):
+        tagger = staged(plain=True)
+        resolved = pathlib.Path(tagger.save_dir).resolve()
+        assert any(
+            resolved == root or resolved.is_relative_to(root)
+            for root in pathsec._get_allowed_roots()
+        ), f"{tagger.save_dir} is not inside an allowed root"
+        if os.name == "posix":
+            # Windows has no POSIX mode bits; the per-user profile ACLs govern.
+            assert stat.S_IMODE(os.stat(tagger.save_dir).st_mode) == 0o700
+
+    def test_save_dir_is_memoized(self, staged):
+        tagger = staged(plain=True)
+        assert tagger.save_dir == tagger.save_dir
+
+    def test_save_then_load_round_trip(self, staged):
+        tagger = staged()
+        loc = tagger.save_dir
+        tagger.save_to_json(lang=LANG, loc=loc)
+        reloaded = PerceptronTagger(load=False)
+        reloaded.load_from_json(lang=LANG, loc=loc)
+        assert reloaded.model.weights == _weights()
+        assert reloaded.classes == {"NN"}
+
+    def test_train_with_default_save_loc_round_trips(self, staged):
+        tagger = staged(plain=True)
+        sentences = [[("the", "DT"), ("dog", "NN")], [("a", "DT"), ("cat", "NN")]]
+        tagger.train(sentences, save_loc=tagger.save_dir, nr_iter=2)
+        reloaded = PerceptronTagger(load=False)
+        reloaded.load_from_json(lang=tagger.lang, loc=tagger.save_dir)
+        assert reloaded.tag(["the", "dog"]) == [("the", "DT"), ("dog", "NN")]
+
+    def test_shipped_english_tagger_still_loads_and_tags(self):
+        pytest.importorskip("numpy")
+        try:
+            tagger = PerceptronTagger(load=True, lang="eng")
+        except LookupError:
+            pytest.skip("averaged_perceptron_tagger_eng not installed")
+        tagged = tagger.tag(["The", "dog", "barks", "."])
+        assert [word for word, _ in tagged] == ["The", "dog", "barks", "."]
+        assert [tag for _, tag in tagged][:2] == ["DT", "NN"]
+        assert all(tag for _, tag in tagged), "a token came back untagged"
+
+
+# ==========================================================================
+# The rest of the model-artifact family reached from the same threat
+# ==========================================================================
+
+
+class TestSiblingModelArtifactApis:
+    def test_transition_parser_parse_outside_root_is_refused(self, sandbox):
+        from nltk.parse.transitionparser import TransitionParser
+
+        target = sandbox / "model.pickle"
+        target.write_bytes(b"\x80\x04N.")
+        _refused(TransitionParser("arc-standard").parse, [], str(target))
+
+    def test_transition_parser_train_outside_root_is_refused(self, sandbox):
+        pytest.importorskip("sklearn")
+        from nltk.parse.transitionparser import TransitionParser
+
+        target = str(sandbox / "trained.pickle")
+        _refused(TransitionParser("arc-standard").train, [], target, False)
+        assert not os.path.exists(target)
+
+    def test_save_maxent_params_outside_root_is_refused(self, sandbox):
+        numpy = pytest.importorskip("numpy")
+        from nltk.classify.maxent import save_maxent_params
+
+        loc = str(sandbox / "maxent_out")
+        _refused(
+            save_maxent_params,
+            numpy.array([1.0]),
+            {("a", "b"): 0},
+            ["L"],
+            {"alwayson": 0},
+            loc,
+        )
+        assert not os.path.exists(loc)
+
+    def test_load_maxent_params_outside_root_is_refused(self, sandbox):
+        pytest.importorskip("numpy")
+        from nltk.classify.maxent import load_maxent_params
+
+        loc = sandbox / "maxent_in"
+        loc.mkdir()
+        for name, body in (
+            ("weights.txt", "1.0"),
+            ("mapping.tab", ""),
+            ("labels.txt", "L"),
+            ("alwayson.tab", ""),
+        ):
+            (loc / name).write_text(body, encoding="utf-8")
+        _refused(load_maxent_params, nltk.data.FileSystemPathPointer(str(loc)))
+
+    def test_save_punkt_params_outside_root_is_refused(self, sandbox):
+        from nltk.tokenize.punkt import PunktParameters, save_punkt_params
+
+        loc = str(sandbox / "punkt_out")
+        _refused(save_punkt_params, PunktParameters(), loc)
+        assert not os.path.exists(loc)
+
+    def test_maxent_ne_chunker_save_params_outside_root_is_refused(self, outside_only):
+        pytest.importorskip("numpy")
+        from nltk.chunk.named_entity import Maxent_NE_Chunker
+
+        try:
+            chunker = Maxent_NE_Chunker("multiclass")
+        except LookupError:
+            pytest.skip("maxent_ne_chunker_tab not installed")
+        loc = str(outside_only / "ne_out")
+        _refused(chunker.save_params, loc)
+        assert not os.path.exists(loc)
+
+
+class TestTblDemoModelPaths:
+    """``nltk.tbl.demo.postag`` pickles a tagger to caller-supplied paths."""
+
+    @staticmethod
+    def _postag(**kwargs):
+        """Run the demo, tolerating one pre-existing, unrelated failure.
+
+        Re-tagging with the *reloaded* tagger raises ``ValueError: timeout not
+        float or None`` on ``develop`` too (a redos-wrapped pattern does not
+        survive a pickle round trip). That happens after the model file is
+        written, so it does not affect what these tests assert; anything else
+        propagates.
+        """
+        from nltk.tbl import demo as tbl_demo
+
+        try:
+            tbl_demo.postag(
+                num_sents=10,
+                max_rules=1,
+                trace=0,
+                separate_baseline_data=True,
+                **kwargs,
+            )
+        except ValueError as exc:
+            if "timeout not float or None" not in str(exc):
+                raise
+
+    @pytest.fixture(autouse=True)
+    def _needs_treebank(self):
+        pytest.importorskip("numpy")
+        try:
+            nltk.data.find("corpora/treebank")
+        except LookupError:
+            pytest.skip("treebank corpus not installed")
+
+    @pytest.mark.parametrize(
+        "kwarg", ["serialize_output", "cache_baseline_tagger", "error_output"]
+    )
+    def test_outside_root_destinations_are_refused(self, kwarg, outside_only):
+        target = outside_only / f"{kwarg}.out"
+        with pytest.raises((PermissionError, ValueError, OSError)):
+            self._postag(**{kwarg: str(target)})
+        assert not target.exists(), f"{kwarg} wrote outside the sandbox"
+
+    def test_learning_curve_output_outside_root_is_refused(self, outside_only):
+        """matplotlib writes the plot itself, so the path is checked up front."""
+        target = outside_only / "curve.png"
+        with pytest.raises((PermissionError, ValueError, OSError)):
+            self._postag(incremental_stats=True, learning_curve_output=str(target))
+        assert not target.exists()
+
+    def test_learning_curve_output_in_root_still_works(self):
+        pytest.importorskip("matplotlib")
+        staging = nltk.data.make_staging_dir(prefix="nltk_tbl_curve_")
+        try:
+            target = os.path.join(staging, "curve.png")
+            self._postag(incremental_stats=True, learning_curve_output=target)
+            assert os.path.getsize(target) > 0
+        finally:
+            shutil.rmtree(staging, ignore_errors=True)
+
+    @pytest.mark.parametrize(
+        "kwarg", ["serialize_output", "cache_baseline_tagger", "error_output"]
+    )
+    def test_in_root_destinations_still_work(self, kwarg):
+        staging = nltk.data.make_staging_dir(prefix="nltk_tbl_demo_")
+        try:
+            target = os.path.join(staging, f"{kwarg}.out")
+            self._postag(**{kwarg: target})
+            assert os.path.getsize(target) > 0, f"{kwarg} wrote nothing in-sandbox"
+        finally:
+            shutil.rmtree(staging, ignore_errors=True)
+
+
+class TestCRFTaggerModelPaths:
+    """``CRFTagger`` hands a caller path to a native (pycrfsuite) loader/writer.
+
+    Not in the advisory's list, but the same threat: the C extension does its
+    own open, so nothing downstream would have contained it.
+    """
+
+    TRAIN = [[("the", "DT"), ("dog", "NN")], [("a", "DT"), ("cat", "NN")]]
+
+    def test_train_outside_root_is_refused_before_writing(self, sandbox):
+        pytest.importorskip("pycrfsuite")
+        from nltk.tag.crf import CRFTagger
+
+        target = str(sandbox / "model.crf")
+        _refused(CRFTagger().train, self.TRAIN, target)
+        assert not os.path.exists(target), "refused train still wrote the model"
+
+    def test_set_model_file_outside_root_is_refused(self, sandbox):
+        pytest.importorskip("pycrfsuite")
+        from nltk.tag.crf import CRFTagger
+
+        target = sandbox / "model.crf"
+        target.write_bytes(b"not-a-real-model")
+        _refused(CRFTagger().set_model_file, str(target))
+
+    def test_in_root_train_and_tag_round_trip(self, restricted_sandbox):
+        pytest.importorskip("pycrfsuite")
+        from nltk.tag.crf import CRFTagger
+
+        target = os.path.join(restricted_sandbox, "model.crf")
+        tagger = CRFTagger()
+        tagger.train(self.TRAIN, target)
+        assert os.path.getsize(target) > 0
+        reloaded = CRFTagger()
+        reloaded.set_model_file(target)
+        assert reloaded.tag(["the", "dog"]) == [("the", "DT"), ("dog", "NN")]
+
+
+class TestResourceNameSteering:
+    """Caller-supplied *resource names* that steer a model load.
+
+    None of these escape a data root, so they are pinned as audited-benign: the
+    assertion is the containment property, so a future change that lets one
+    resolve outside turns into a failure here.
+    """
+
+    def test_punkt_lang_traversal_stays_inside_a_data_root(self):
+        """``PunktTokenizer(lang)`` climbs at most within the trusted root.
+
+        ``normalize_resource_name`` collapses ``punkt_tab/..`` to ``tokenizers/``
+        before ``find`` sees it, so the lookup moves inside the root but cannot
+        leave it; a leading ``..`` survives normalisation and ``find`` rejects it.
+        """
+        from nltk.tokenize import PunktTokenizer
+
+        with pytest.raises((LookupError, OSError, ValueError)) as excinfo:
+            PunktTokenizer("../..")
+        message = str(excinfo.value)
+        assert "/etc/" not in message and "passwd" not in message
+
+    @pytest.mark.parametrize(
+        "resource",
+        [
+            "tokenizers/punkt/../x.pickle",
+            "tokenizers/punkt/../../../etc/passwd.pickle",
+            "chunkers/maxent_ne_chunker/../../../etc/x.pickle",
+        ],
+    )
+    def test_pickle_shim_resource_names_cannot_traverse(self, resource):
+        """load() routes a *.pickle name to a pickle-free loader; the name that
+        picks the model must not carry traversal."""
+        with pytest.raises((ValueError, LookupError, OSError)):
+            nltk.data.load(resource)
+
+    def test_pos_tag_rejects_an_unknown_language(self):
+        with pytest.raises(NotImplementedError):
+            nltk.pos_tag(["a"], lang="../../etc")
+
+    def test_ne_chunker_format_cannot_traverse(self):
+        from nltk.chunk import ne_chunker
+
+        with pytest.raises((ValueError, LookupError, OSError)):
+            ne_chunker("../../../etc")
+
+    def test_retrieve_without_a_filename_does_not_write_to_an_outside_cwd(
+        self, outside_only
+    ):
+        """``retrieve`` derives the destination from the URL and writes it to the
+        working directory; that destination is still sandbox-checked."""
+        try:
+            source = str(nltk.data.find("corpora/city_database/city.db"))
+        except LookupError:
+            pytest.skip("city_database corpus not installed")
+        saved = os.getcwd()
+        os.chdir(outside_only)
+        try:
+            with pytest.raises((PermissionError, ValueError, OSError)):
+                nltk.data.retrieve("file://" + source, verbose=False)
+            assert not list(outside_only.iterdir())
+        finally:
+            os.chdir(saved)
+
+
+# ==========================================================================
+# Negative controls: neuter a guard, the exploit must come back
+# ==========================================================================
+
+
+class TestModelReadsAreBounded:
+    """A hostile *in-root* model must fail fast, not hang or exhaust the process."""
+
+    def test_deeply_nested_json_weights_are_rejected_quickly(self, restricted_sandbox):
+        target = os.path.join(restricted_sandbox, "nested.json")
+        with pathsec.open(target, "w", context="test") as handle:
+            handle.write("[" * 200000 + "]" * 200000)
+        started = time.perf_counter()
+        with pytest.raises((RecursionError, ValueError)):
+            AveragedPerceptron().load(target)
+        assert time.perf_counter() - started < 15.0
+
+
+class TestModelReadsRefuseAPickleGadget:
+    """Containment is not the only guard on a model read.
+
+    A model file *inside* a trusted root still goes through an allowlisting
+    unpickler, so a reachable-path model cannot execute a reduce gadget. Pinned
+    here because these are the same read paths the sandbox guards: fixing one
+    must not be mistaken for covering the other.
+    """
+
+    class _Boom:
+        def __reduce__(self):
+            return (os.system, ("exit 0",))
+
+    def _planted(self, root):
+        target = os.path.join(root, "gadget.pickle")
+        with pathsec.open(target, "wb", context="test") as handle:
+            pickle.dump(self._Boom(), handle)
+        return target
+
+    def test_transition_parser_refuses_a_gadget_model(self, restricted_sandbox):
+        from nltk.parse.transitionparser import TransitionParser
+
+        target = self._planted(restricted_sandbox)
+        with pytest.raises(pickle.UnpicklingError):
+            TransitionParser("arc-standard").parse([], target)
+
+    def test_data_load_pickle_refuses_a_gadget_model(self, restricted_sandbox):
+        target = self._planted(restricted_sandbox)
+        with pytest.raises(pickle.UnpicklingError):
+            nltk.data.load(os.path.basename(target), format="pickle", cache=False)
+
+
+class TestNoOtherCodeWidensTheSandbox:
+    """Repo-wide invariant behind the ``load_from_json`` fix.
+
+    Appending to ``nltk.data.path`` makes a directory an allowed root for the
+    rest of the process, which disarms containment for it and everything under
+    it. Exactly one place may do that: ``nltk.download(download_dir=...)``, where
+    the caller explicitly names the destination for NLTK's own data and the
+    downloader refuses a non-private one. Any new occurrence is the primitive
+    that made the advisory's read succeed, coming back.
+    """
+
+    ALLOWED = {("nltk/downloader.py", "_authorize_data_dir")}
+
+    def test_only_the_downloader_appends_to_nltk_data_path(self):
+        root = pathlib.Path(nltk.__file__).parent
+        offenders = []
+        for source in sorted(root.rglob("*.py")):
+            relative = source.relative_to(root.parent).as_posix()
+            if relative.startswith("nltk/test/"):
+                continue
+            tree = ast.parse(source.read_text(encoding="utf-8"), relative)
+            for parent in ast.walk(tree):
+                if not isinstance(parent, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                for node in ast.walk(parent):
+                    if (
+                        isinstance(node, ast.Call)
+                        and isinstance(node.func, ast.Attribute)
+                        and node.func.attr in ("append", "insert", "extend")
+                        and isinstance(node.func.value, ast.Attribute)
+                        and node.func.value.attr == "path"
+                        and getattr(node.func.value.value, "attr", None) == "data"
+                    ):
+                        offenders.append((relative, parent.name))
+        assert (
+            set(offenders) <= self.ALLOWED
+        ), "new nltk.data.path widening: %s" % sorted(set(offenders) - self.ALLOWED)
+
+
+# Two branches merged here, so several sinks now carry TWO independent guards.
+# A negative control must therefore neuter BOTH layers: neutering one and finding
+# the exploit still blocked proves defence in depth, not a missing guard.
+
+
+def _neuter_tool_guards(monkeypatch):
+    """Disable the tool-path guards as well as validate_path.
+
+    The merge gave these sinks a second, independent layer (validate_tool_path /
+    validate_tool_dir). A negative control has to remove every layer it is
+    testing, otherwise it proves only that some OTHER guard still holds.
+    """
+    passthrough = lambda value, *args, **kwargs: (  # noqa: E731
+        os.fspath(value)
+        if hasattr(value, "__fspath__") or isinstance(value, str)
+        else value
+    )
+    modules = [perceptron, pathsec]
+    crf_module = sys.modules.get("nltk.tag.crf")
+    if crf_module is not None:
+        modules.append(crf_module)
+    for module in modules:
+        for name in ("validate_tool_path", "validate_tool_dir"):
+            if hasattr(module, name):
+                monkeypatch.setattr(module, name, passthrough)
+
+
+class TestNegativeControls:
+    def test_enforce_off_lets_the_read_escape(self, sandbox, monkeypatch):
+        target = sandbox / "weights.json"
+        target.write_text(json.dumps(_weights()), encoding="utf-8")
+        monkeypatch.setattr(pathsec, "ENFORCE", False)
+        model = AveragedPerceptron()
+        model.load(str(target))
+        assert model.weights == _weights(), "guard disabled but read still blocked"
+
+    def test_bare_open_reopens_the_advisory_write(self, sandbox, monkeypatch):
+        """Put the advisory's own bug back and the escape must return."""
+        target = sandbox / "bare.json"
+
+        def bare_save(self, path):
+            with open(path, "w") as fout:
+                return json.dump(self.weights, fout)
+
+        monkeypatch.setattr(AveragedPerceptron, "save", bare_save)
+        AveragedPerceptron(_weights()).save(str(target))
+        assert CANARY in target.read_text(encoding="utf-8")
+
+    def test_dropping_save_to_json_validation_reopens_the_write(
+        self, sandbox, monkeypatch
+    ):
+        """Both destination guards go: the sandbox check on ``loc`` and, on the
+        branch that has no pinned dir_fd, the sandboxed per-file open."""
+        monkeypatch.setattr(perceptron, "validate_path", lambda *a, **k: None)
+        _neuter_tool_guards(monkeypatch)
+        monkeypatch.setattr(
+            perceptron,
+            "pathsec_open",
+            lambda path, mode="r", **kwargs: builtins.open(path, mode),
+        )
+        loc = str(sandbox / "unguarded")
+        _tagger().save_to_json(lang=LANG, loc=loc)
+        assert sorted(os.listdir(loc)), "no files written with the guard removed"
+
+    def test_widening_nltk_data_path_reopens_the_read(self, sandbox, monkeypatch):
+        """The removed ``_authorize_private_dir`` primitive, reconstructed."""
+        loc = str(sandbox / "widened")
+        _plant_model_dir(loc)
+        monkeypatch.setattr(nltk.data, "path", list(nltk.data.path) + [loc])
+        monkeypatch.setattr(pathsec, "_ALLOWED_ROOTS_CACHE", None, raising=False)
+        monkeypatch.setattr(pathsec, "_LAST_DATA_PATHS", None, raising=False)
+        tagger = PerceptronTagger(load=False)
+        tagger.load_from_json(LANG, loc)
+        assert tagger.model.weights == _weights()
+
+    def test_dropping_the_lang_check_lets_lang_carry_a_separator(self):
+        assert "/" in "".join(
+            f"averaged_perceptron_tagger_{'a/b'}.{attr}.json" for attr in ("weights",)
+        ), "the filename template no longer interpolates lang"
+        with pytest.raises(ValueError):
+            perceptron._validate_name_component("a/b", "lang")
+
+    @POSIX_ONLY
+    def test_whitespace_waiver_reopens_the_cwd_write(self, outside_only, monkeypatch):
+        """Restoring the whitespace early-return must let the write land again.
+
+        POSIX-only: Windows rejects a filename that is only whitespace, so the
+        waiver cannot reopen anything there and the control would prove nothing.
+        """
+        real = pathsec.validate_path
+
+        def waives_whitespace(path_input, *args, **kwargs):
+            if isinstance(path_input, str) and path_input and not path_input.strip():
+                return
+            return real(path_input, *args, **kwargs)
+
+        monkeypatch.setattr(pathsec, "validate_path", waives_whitespace)
+        monkeypatch.setattr(perceptron, "validate_path", waives_whitespace)
+        _neuter_tool_guards(monkeypatch)
+        saved = os.getcwd()
+        os.chdir(outside_only)
+        try:
+            with pytest.raises(Exception):
+                AveragedPerceptron(_weights()).save("   ")
+            assert list(outside_only.iterdir()), "waiver did not reopen the write"
+        finally:
+            os.chdir(saved)
+
+    def test_dropping_the_crf_check_reopens_the_native_write(
+        self, sandbox, monkeypatch
+    ):
+        pytest.importorskip("pycrfsuite")
+        import nltk.tag.crf as crf
+
+        monkeypatch.setattr(crf, "validate_tool_path", lambda *a, **k: None)
+        target = str(sandbox / "unguarded.crf")
+        crf.CRFTagger().train(
+            [[("the", "DT"), ("dog", "NN")], [("a", "DT"), ("cat", "NN")]], target
+        )
+        assert os.path.getsize(target) > 0, "no model written with the guard removed"
+
+
+class TestLoaderPathSweep:
+    """``nltk.data.load`` must security-reject caller paths that escape the roots.
+
+    Carried over from the tagger branch, which had added these payloads to the
+    GHSA-8mgp probe. They live here rather than in the probe because the advisory
+    names the model-artifact APIs, not this loader, and because running them
+    inside the probe made its verdict depend on test order.
+    """
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            os.path.join(tempfile.gettempdir(), "..", "..", "etc", "passwd"),
+            "/etc/passwd",
+            "nltk:/etc/passwd",
+            "file:///etc/passwd",
+            "/etc/passwd\x00.cfg",
+        ],
+        ids=["traversal", "absolute", "nltk-url", "file-url", "nul-suffix"],
+    )
+    def test_outside_root_loader_paths_are_refused(self, payload, pathsec_sandbox):
+        """The sandbox fixture matters: without a known set of roots and ENFORCE
+        on, the result depends on whatever earlier tests left in nltk.data.path.
+
+        The resource cache is cleared first for the same reason: nltk.data.load
+        memoises by resource name, so a value another test loaded while the roots
+        differed would be handed back here without being re-validated.
+        """
+        nltk.data.clear_cache()
+        try:
+            data = nltk.data.load(payload, format="raw")
+        except (PermissionError, ValueError, OSError, LookupError):
+            return
+        marker = "root:" in data if isinstance(data, str) else b"root:" in data
+        assert not marker, f"nltk.data.load read /etc/passwd via {payload!r}"

--- a/nltk/test/unit/test_package_resource_guard.py
+++ b/nltk/test/unit/test_package_resource_guard.py
@@ -120,3 +120,81 @@ def test_nltk_version_is_populated():
     assert nltk.__version__
     assert "Security Violation" not in nltk.__version__
     assert nltk.__version__[0].isdigit()
+
+
+class TestRequiredRootOnlyNarrows:
+    """``validate_path(required_root=...)`` is the other caller-supplied root.
+
+    Thirty-odd call sites pass one, so if it could WIDEN access it would be a
+    bypass available almost everywhere. It is additive by design: Layer 1 is the
+    scoped root, Layer 2 is the data roots, and a path must satisfy both. These
+    pin that, since making it authoritative would look like a tidy
+    simplification to a future reader.
+    """
+
+    @pytest.mark.parametrize(
+        "target, root",
+        [
+            ("/etc/passwd", "/etc"),
+            ("/etc/passwd", "/"),
+        ],
+        ids=["etc", "filesystem-root"],
+    )
+    def test_it_cannot_widen_beyond_the_data_roots(self, pathsec_sandbox, target, root):
+        from nltk import pathsec
+
+        with pytest.raises((PermissionError, ValueError)):
+            pathsec.validate_path(target, context="test", required_root=root)
+
+    def test_it_still_narrows_within_a_data_root(self, pathsec_sandbox):
+        from nltk import pathsec
+
+        root, _outside = pathsec_sandbox
+        (root / "sub").mkdir()
+        (root / "other").mkdir()
+        (root / "other" / "f.txt").write_text("x")
+        with pytest.raises((PermissionError, ValueError)):
+            pathsec.validate_path(
+                str(root / "other" / "f.txt"),
+                context="test",
+                required_root=str(root / "sub"),
+            )
+
+    def test_a_lying_root_object_cannot_widen(self, pathsec_sandbox):
+        """validate_path reads .path in preference to __fspath__, so a root whose
+        two answers differ must not be usable to smuggle access."""
+        from nltk import pathsec
+
+        root, outside = pathsec_sandbox
+        secret = outside / "SECRET"
+        secret.write_text("S")
+
+        class _LyingRoot:
+            def __init__(self, shown, real):
+                self.path = shown
+                self._real = real
+
+            def __fspath__(self):
+                return self._real
+
+            def __str__(self):
+                return self.path
+
+        with pytest.raises((PermissionError, ValueError)):
+            pathsec.validate_path(
+                str(secret),
+                context="test",
+                required_root=_LyingRoot(str(root), str(outside)),
+            )
+
+    @pytest.mark.skipif(not hasattr(os, "symlink"), reason="requires symlinks")
+    def test_a_symlinked_root_cannot_widen(self, pathsec_sandbox):
+        from nltk import pathsec
+
+        root, outside = pathsec_sandbox
+        secret = outside / "SECRET"
+        secret.write_text("S")
+        link = root / "rrlink"
+        os.symlink(str(outside), link)
+        with pytest.raises((PermissionError, ValueError)):
+            pathsec.validate_path(str(secret), context="test", required_root=str(link))

--- a/nltk/test/unit/test_path_traversal_security.py
+++ b/nltk/test/unit/test_path_traversal_security.py
@@ -380,6 +380,15 @@ class TestPerceptronSaveSquat:
         with pytest.raises(PermissionError):
             self._tagger().save_to_json(lang="eng", loc=loc)
 
+    def test_out_of_sandbox_save_location_is_refused(self, sandbox):
+        # A caller-supplied destination outside every data root is refused before
+        # anything is created: save_to_json used to os.makedirs() a whole chain
+        # anywhere the process could write (GHSA-8mgp-746c-j5xp).
+        loc = sandbox / "planted" / "model_dir"
+        with pytest.raises(PermissionError):
+            self._tagger().save_to_json(lang="eng", loc=str(loc))
+        assert not loc.exists() and not loc.parent.exists()
+
 
 # ==========================================================================
 # 4. Entity-expansion (billion-laughs) in the bcp47 XML corpus reader (CWE-776)

--- a/nltk/test/unit/test_pathsec.py
+++ b/nltk/test/unit/test_pathsec.py
@@ -1058,3 +1058,224 @@ def test_authorize_data_dir_registers_private_dir(tmp_path, monkeypatch):
     assert not registered()
     _authorize_data_dir(str(custom))
     assert registered()
+
+
+# ----------------------------------------------------------------------
+# Hardened write path (_hardened_open): symlink / hardlink / truncate
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.skipif(os.name != "posix", reason="hardened write path is POSIX-only")
+def test_hardened_write_truncates_legit_file(sandbox_env):
+    """A legit overwrite still truncates: deferring O_TRUNC until after the guard
+    must not leave a stale tail from longer prior content."""
+    safe_dir = sandbox_env[0]
+    target = safe_dir / "model.json"
+    with pathsec.open(str(target), "w", required_root=str(safe_dir)) as f:
+        f.write("first-longer-content")
+    with pathsec.open(str(target), "w", required_root=str(safe_dir)) as f:
+        f.write("short")
+    assert target.read_text(encoding="utf-8") == "short"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="hardened write path is POSIX-only")
+def test_hardened_write_refuses_symlink_escape(sandbox_env):
+    """A final-component symlink escaping the root is refused at open (O_NOFOLLOW)."""
+    safe_dir, _, secret_file, _, _ = sandbox_env
+    link = safe_dir / "evil.tmp"
+    os.symlink(str(secret_file), str(link))
+    with pytest.raises((PermissionError, ValueError)):
+        pathsec.open(str(link), "wb", required_root=str(safe_dir))
+    assert secret_file.read_text(encoding="utf-8") == "UNAUTHORIZED_DATA"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="hardened write path is POSIX-only")
+def test_hardened_write_refuses_hardlink_and_preserves_target(sandbox_env):
+    """A hardlink to an outside file is refused (st_nlink); deferring O_TRUNC means
+    the refused write does NOT zero the outside target (CWE-59, GHSA-f794)."""
+    safe_dir, _, secret_file, _, _ = sandbox_env
+    hard = safe_dir / "evil.tmp"
+    os.link(str(secret_file), str(hard))
+    with pytest.raises(PermissionError, match="multiply-linked|Security Violation"):
+        pathsec.open(str(hard), "wb", required_root=str(safe_dir))
+    assert secret_file.read_text(encoding="utf-8") == "UNAUTHORIZED_DATA"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="hardened write path is POSIX-only")
+def test_hardened_write_refuses_absolute_escape_and_preserves(sandbox_env):
+    """A write to an absolute path outside the root is refused, and the deferred
+    O_TRUNC leaves the pre-existing outside file's bytes intact."""
+    safe_dir, _, secret_file, _, _ = sandbox_env
+    with pytest.raises((PermissionError, ValueError)):
+        pathsec.open(str(secret_file), "wb", required_root=str(safe_dir))
+    assert secret_file.read_text(encoding="utf-8") == "UNAUTHORIZED_DATA"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="hardened write path is POSIX-only")
+def test_hardened_write_refuses_intermediate_dir_symlink(sandbox_env):
+    """An intermediate directory symlink redirecting the open outside the root is
+    caught by the opened-fd realpath re-validation, not only the final component."""
+    safe_dir, unsafe_dir, _, _, _ = sandbox_env
+    linkdir = safe_dir / "sub"
+    os.symlink(str(unsafe_dir), str(linkdir))  # safe_dir/sub -> outside root
+    with pytest.raises((PermissionError, ValueError)):
+        pathsec.open(str(linkdir / "planted.tmp"), "wb", required_root=str(safe_dir))
+    # no attacker content lands outside the root
+    assert (
+        not (unsafe_dir / "planted.tmp").exists()
+        or (unsafe_dir / "planted.tmp").read_bytes() == b""
+    )
+
+
+# Carried over from the umbrella branch: these cover cases the tagger branch
+# did not, so the merge keeps both sets rather than the newer file alone.
+
+
+class TestUrlSchemePathBypass:
+    """GHSA-8mgp-746c-j5xp: validate_path() must not authorize URL-shaped paths.
+
+    The old check did ``if "://" in raw: return``; unconditional authorization
+    for anything with an http/https/ftp scheme. To the kernel ``http://../x`` is
+    the directory ``http:`` then ``..``, so this waved a traversal straight
+    through every allowed root and defeated every downstream path check.
+    """
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "http://../../../../etc/passwd",
+            "https://../../x",
+            "ftp://../../y",
+            "HTTP://../../etc/passwd",  # case
+            "  https://../../etc/passwd",  # leading whitespace
+        ],
+    )
+    def test_url_prefix_is_not_an_authorization_bypass(self, path):
+        # The single most important regression: if this ever passes silently,
+        # GHSA-8mgp is back.
+        with pytest.raises(PermissionError):
+            pathsec.validate_path(path)
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "file:///tmp/x?y/../../etc/passwd",  # query
+            "file:///etc/passwd#frag",  # fragment
+            "file:///tmp/x;/../../etc/passwd",  # params
+        ],
+    )
+    def test_ambiguous_file_url_is_rejected(self, path):
+        # urllib opens Request.selector (keeps ?/#/;), urlparse().path drops them,
+        # so a file: URL with those would validate a different target than opens.
+        with pytest.raises(PermissionError):
+            pathsec.validate_path(path)
+
+    def test_plain_in_root_path_still_validates(self, tmp_path, monkeypatch):
+        # No false positive: a normal filesystem path inside an allowed root must
+        # still pass after the URL rejection is added.
+        import nltk.data as _nltk_data
+
+        root = tmp_path / "nltk_data"
+        (root / "corpora").mkdir(parents=True)
+        monkeypatch.setattr(_nltk_data, "path", [str(root)])
+        pathsec._ALLOWED_ROOTS_CACHE = None
+        pathsec._LAST_DATA_PATHS = None
+        pathsec.validate_path(str(root / "corpora" / "x.txt"))  # must not raise
+
+
+class TestModelArtifactSaveContainment:
+    """GHSA-8mgp: low-level model save/load must not open outside allowed roots."""
+
+    def test_averaged_perceptron_save_load_refuse_outside_root(
+        self, tmp_path, monkeypatch
+    ):
+        import pathlib
+        import shutil
+
+        import nltk.data as _nltk_data
+        from nltk.tag.perceptron import AveragedPerceptron
+
+        sandbox = tmp_path / "nltk_data"
+        sandbox.mkdir()
+        # A genuinely-outside target: a fresh $HOME dir. NOT tmp_path; the
+        # private system temp is an allowed pathsec root on macOS, so a temp
+        # target would not actually be outside the sandbox.
+        outside_dir = pathlib.Path.home() / (".ghsa8mgp_pathsec_test_%s" % os.getpid())
+        outside = outside_dir / "model.json"
+        monkeypatch.setattr(_nltk_data, "path", [str(sandbox)])
+        pathsec._ALLOWED_ROOTS_CACHE = None
+        pathsec._LAST_DATA_PATHS = None
+        outside_dir.mkdir(exist_ok=True)
+        try:
+            # Guard the test: the target must be genuinely outside the sandbox.
+            with pytest.raises(PermissionError):
+                with pathsec.open(str(outside), "w"):
+                    pass
+
+            ap = AveragedPerceptron()
+            ap.weights = {"f": {"t": 1.0}}
+            with pytest.raises(PermissionError):
+                ap.save(str(outside))
+            assert not outside.exists(), "refused save must not have written the file"
+            with pytest.raises(PermissionError):
+                ap.load(str(outside))
+        finally:
+            shutil.rmtree(outside_dir, ignore_errors=True)
+
+
+class TestStagingUnderDataRoot:
+    """``nltk.data.make_staging_dir`` stages NLTK's own output inside a data root,
+    so the default save destination is within the pathsec sandbox on every
+    platform (including Linux, where the shared ``/tmp`` is not a root). When no
+    data root is writable it refuses rather than falling back to an untrusted
+    temp dir, forcing the caller to pass an explicit destination.
+    """
+
+    def test_staging_dir_is_inside_a_data_root_and_passes_sandbox(
+        self, tmp_path, monkeypatch
+    ):
+        """The staged dir is created under a data root, is private (0700), and its
+        contents pass validate_path without any temp-dir trust."""
+        import nltk.data as _data
+
+        root = tmp_path / "nltk_data"
+        root.mkdir()
+        monkeypatch.setattr(_data, "path", [str(root)])
+        pathsec._ALLOWED_ROOTS_CACHE = None
+        pathsec._LAST_DATA_PATHS = None
+
+        d = _data.make_staging_dir(prefix="nltk_probe_")
+        assert os.path.realpath(d).startswith(os.path.realpath(str(root)))
+        assert pathsec.is_private_dir(d)
+        pathsec.validate_path(os.path.join(d, "out.tab"), context="test")
+
+    def test_refuses_when_no_writable_data_root(self, tmp_path, monkeypatch):
+        """With no writable data root, staging refuses (PermissionError) instead of
+        writing to an out-of-sandbox temp dir."""
+        import nltk.data as _data
+
+        blocker = tmp_path / "not_a_dir"
+        blocker.write_text("x")
+        monkeypatch.setattr(_data, "path", [str(blocker / "sub")])
+        with pytest.raises(PermissionError):
+            _data.make_staging_dir(prefix="nltk_probe_")
+
+    def test_refuses_writable_path_entry_outside_the_sandbox(
+        self, tmp_path, monkeypatch
+    ):
+        """Defensive guard: a writable nltk.data.path entry that is not an allowed
+        root (data path and sandbox disagree) is refused, so make_staging_dir
+        never creates or stages output outside what pathsec accepts."""
+        from pathlib import Path
+
+        import nltk.data as _data
+
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        sandbox = tmp_path / "sandbox"
+        sandbox.mkdir()
+        monkeypatch.setattr(_data, "path", [str(outside)])
+        monkeypatch.setattr(pathsec, "_get_allowed_roots", lambda: {Path(sandbox)})
+        with pytest.raises(PermissionError):
+            _data.make_staging_dir(prefix="nltk_probe_")
+        assert list(outside.iterdir()) == [], "nothing may be staged out of sandbox"

--- a/nltk/test/unit/test_pathsec_sweep_wrappers.py
+++ b/nltk/test/unit/test_pathsec_sweep_wrappers.py
@@ -1,0 +1,1669 @@
+# Natural Language Toolkit: pathsec sweep over the external-tool wrappers
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""Escape matrix for the model/data paths handed to external tools.
+
+The JVM wrappers take caller-supplied model and corpus paths and pass them
+straight into the child process's argv. Those are *data* paths, so they must be
+bounded to the NLTK data roots; a path outside the sandbox means the wrapper will
+read (and, for MaltParser's ``-w`` in learn mode, WRITE) anywhere on disk.
+
+Two classes of path are deliberately treated differently:
+
+* **model / corpus paths** (this file) are bounded with ``pathsec.validate_path``
+  or ``pathsec.validate_model_resource``.
+* **install / binary directories** (``candc``/``boxer``'s ``bin_dir``, REPP's
+  tokenizer dir) are NOT: ``validate_path`` permits only NLTK *data* roots, so
+  bounding them would break every real installation. They get an absolute-path
+  (CWE-426) check instead, and the tests at the end of this file pin that
+  distinction so a later refactor cannot quietly collapse the two.
+
+Every test drives the real code path with only the ``java`` hand-off replaced, so
+a probe cannot pass merely because the argv was assembled by the test itself.
+"""
+
+import hashlib
+import os
+
+import pytest
+
+from nltk import pathsec
+from nltk.data import make_staging_dir
+from nltk.pathsec import validate_model_resource, validate_tool_path
+
+
+class _ReachedJVM(Exception):
+    """Raised by the trapped ``java`` so a test can tell "the argv was built and
+    handed off" apart from "a guard refused first"."""
+
+
+def _passthrough(value, *args, **kwargs):
+    """A neutered guard: performs no checks but still returns the path, since
+    the callers now use the value the guard hands back."""
+    return os.fspath(value)
+
+
+def _trap_java(monkeypatch, module, sink):
+    """Replace ``module.java`` with a trap that records argv and stops before
+    launching a JVM."""
+
+    def fake_java(cmd, *args, **kwargs):
+        sink["cmd"] = list(cmd)
+        raise _ReachedJVM
+
+    monkeypatch.setattr(module, "java", fake_java)
+    return sink
+
+
+# ---------------------------------------------------------------------------
+# StanfordSegmenter: -loadClassifier / -serDictionary / -sighanCorporaDict /
+# -textFile all reach the JVM argv.
+# ---------------------------------------------------------------------------
+
+
+def _segmenter(monkeypatch, root, model=None, dictionary=None, sihan=None):
+    """A StanfordSegmenter whose jar passes the sha256 allowlist, so the test
+    reaches the model-path handling rather than stopping at the jar check."""
+    import nltk.tokenize.stanford_segmenter as seg
+
+    jar = os.path.join(root, "seg.jar")
+    with pathsec.open(jar, "wb") as handle:
+        handle.write(b"PK\x05\x06" + b"\0" * 18)
+    with pathsec.open(jar, "rb") as handle:
+        digest = hashlib.sha256(handle.read()).hexdigest()
+    monkeypatch.setenv("NLTK_SEGMENTER_ALLOW_SHA256", digest)
+
+    tool = object.__new__(seg.StanfordSegmenter)
+    tool._stanford_jar = jar
+    tool._encoding = "utf8"
+    tool.java_options = "-mx1g"
+    tool._jar_sha256_cache = {}
+    tool._java_class = "edu.stanford.nlp.ie.crf.CRFClassifier"
+    tool._model = model
+    tool._dict = dictionary
+    tool._sihan_corpora_dict = sihan
+    tool._sihan_post_processing = "true"
+    tool._keep_whitespaces = "false"
+    tool._options_cmd = ""
+    return tool
+
+
+# ---------------------------------------------------------------------------
+# MaltParser: -c model and the -w working directory (WRITTEN to in learn mode).
+# ---------------------------------------------------------------------------
+
+
+def _malt(model, trained=True):
+    import nltk.parse.malt as malt
+
+    parser = object.__new__(malt.MaltParser)
+    parser.model = model
+    parser._trained = trained
+    parser._working_dir = None
+    parser.additional_java_args = []
+    return parser
+
+
+def _sandbox_io(parser):
+    """Valid in-sandbox -i/-o paths for a test that targets some *other* guard.
+    Without these the input-file guard fires first and the test would pass for
+    the wrong reason."""
+    infile = os.path.join(parser.working_dir, "in.conll")
+    with pathsec.open(infile, "w") as handle:
+        handle.write("")
+    return infile, os.path.join(parser.working_dir, "out.conll")
+
+
+# ---------------------------------------------------------------------------
+# StanfordParser: -model may be a filesystem path OR a jar-internal resource.
+# ---------------------------------------------------------------------------
+
+_DEFAULT_RESOURCE = "edu/stanford/nlp/models/lexparser/englishPCFG.ser.gz"
+
+
+def _stanford_parser(model_path):
+    import nltk.parse.stanford as st
+
+    parser = object.__new__(st.StanfordParser)
+    parser.model_path = model_path
+    parser._classpath = ()
+    parser.java_options = "-mx1g"
+    parser._encoding = "utf8"
+    parser.corenlp_options = ""
+    parser._USE_STDIN = False
+    return parser
+
+
+# ---------------------------------------------------------------------------
+# validate_model_resource itself.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "edu/stanford/../nlp/x.ser.gz",
+        "../x.ser.gz",
+        "a/b/../../../etc/passwd",
+        "edu\\stanford\\..\\x.ser.gz",
+    ],
+)
+def test_validate_model_resource_rejects_traversal(value):
+    """``..`` is refused whether or not the value looks like a real path, so a
+    resource name cannot escape the jar namespace."""
+    with pytest.raises(ValueError):
+        validate_model_resource(value, context="test")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [_DEFAULT_RESOURCE, "edu/stanford/nlp/models/pos-tagger/english-left3words.tagger"],
+)
+def test_validate_model_resource_allows_resource_names(value):
+    """A bare classpath resource is not a filesystem path and is left alone."""
+    validate_model_resource(value, context="test")
+
+
+def test_validate_model_resource_bounds_real_paths(pathsec_sandbox):
+    root, outside = pathsec_sandbox
+    inside = root / "m.ser.gz"
+    inside.write_text("m")
+    validate_model_resource(str(inside), context="test")
+    with pytest.raises((PermissionError, ValueError)):
+        validate_model_resource(str(outside / "m.ser.gz"), context="test")
+
+
+def test_validate_model_resource_accepts_pathlike(pathsec_sandbox):
+    """os.PathLike must not blow up on ``.replace``."""
+    root, _outside = pathsec_sandbox
+    inside = root / "m.ser.gz"
+    inside.write_text("m")
+    validate_model_resource(inside, context="test")
+
+
+def test_validate_model_resource_is_exported():
+    assert "validate_model_resource" in pathsec.__all__
+
+
+# ---------------------------------------------------------------------------
+# Teeth: neuter each guard and assert the attack becomes reachable again. A
+# probe that passes with the guard removed is not testing the guard.
+# ---------------------------------------------------------------------------
+
+
+def test_teeth_segmenter_guard_is_load_bearing(pathsec_sandbox, monkeypatch):
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, _outside = pathsec_sandbox
+    _trap_java(monkeypatch, seg, {})
+    monkeypatch.setattr(seg, "validate_path", _passthrough)
+    monkeypatch.setattr(seg, "validate_tool_path", _passthrough)
+    tool = _segmenter(monkeypatch, str(root))
+    with pytest.raises(_ReachedJVM):
+        tool.segment_file("/etc/passwd")
+
+
+# ---------------------------------------------------------------------------
+# Install-directory wrappers: pinned as a DIFFERENT class. These must keep the
+# CWE-426 absolute-path check and must NOT gain validate_path, which permits
+# only NLTK data roots and would break every real installation.
+# ---------------------------------------------------------------------------
+
+
+def test_boxer_bin_dir_rejects_relative_and_cwd(pathsec_sandbox):
+    """A relative or CWD bin_dir is a binary-planting vector (CWE-426)."""
+    import nltk.sem.boxer as boxer
+
+    _root, outside = pathsec_sandbox
+    bindir = outside / "candcbin"
+    bindir.mkdir()
+    for name in ("candc", "boxer"):
+        target = bindir / name
+        target.write_text("#!/bin/sh\n")
+        target.chmod(0o755)
+    os.chdir(str(outside))
+
+    tool = object.__new__(boxer.Boxer)
+    for bad in ("candcbin", "."):
+        with pytest.raises(LookupError):
+            tool.set_bin_dir(bad)
+
+
+def test_boxer_models_path_is_derived_not_caller_supplied(pathsec_sandbox):
+    """``--models`` has no independent input: it is derived from the absolute
+    candc binary, so bounding bin_dir bounds the models dir too."""
+    import nltk.sem.boxer as boxer
+
+    _root, outside = pathsec_sandbox
+    bindir = outside / "candcbin"
+    bindir.mkdir()
+    for name in ("candc", "boxer"):
+        target = bindir / name
+        target.write_text("#!/bin/sh\n")
+        target.chmod(0o755)
+
+    tool = object.__new__(boxer.Boxer)
+    tool.set_bin_dir(str(bindir))
+    assert tool._candc_models_path == os.path.normpath(str(outside / "models"))
+
+
+def test_repp_dir_must_resolve_absolute(pathsec_sandbox):
+    """REPP executes ``<dir>/src/repp``; a CWD-relative dir would let an
+    attacker plant that binary."""
+    import nltk.tokenize.repp as repp
+
+    _root, outside = pathsec_sandbox
+    tree = outside / "evil_repp"
+    (tree / "src").mkdir(parents=True)
+    (tree / "erg").mkdir()
+    (tree / "src" / "repp").write_text("#!/bin/sh\n")
+    (tree / "erg" / "repp.set").write_text("")
+    os.environ.pop("REPP_TOKENIZER", None)
+    os.chdir(str(outside))
+
+    tokenizer = object.__new__(repp.ReppTokenizer)
+    with pytest.raises(LookupError):
+        tokenizer.find_repptokenizer("evil_repp")
+
+
+# ---------------------------------------------------------------------------
+# Functional: the patched modules must still import and behave. These exercise
+# the real objects rather than asserting on mocks.
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Real end-to-end runs. These launch an actual JVM against a real MaltParser /
+# Stanford parser install, so they prove the guards neither break the feature
+# nor "pass" merely because no JVM was reachable. They skip when the external
+# tool is genuinely absent (CI has no JVM or model jars); every other test in
+# this file runs unconditionally.
+# ---------------------------------------------------------------------------
+
+
+def _has_java():
+    """True only if a JVM actually *runs*.
+
+    Merely finding a ``java`` on PATH is not enough: macOS ships a
+    ``/usr/bin/java`` stub that resolves fine and then fails at exec time with
+    "Unable to locate a Java Runtime", which would turn these into hard failures
+    on a machine with no JDK instead of skips.
+    """
+    import subprocess
+
+    from nltk.internals import find_binary
+
+    try:
+        binary = find_binary(
+            "java", env_vars=("JAVAHOME", "JAVA_HOME"), verbose=False, binary_names=None
+        )
+    except LookupError:
+        return False
+    try:
+        return (
+            subprocess.run(
+                [binary, "-version"], capture_output=True, timeout=60
+            ).returncode
+            == 0
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+def _find_tool_dir(*names):
+    """Absolute path of an external tool directory inside a data root, or None."""
+    import nltk.data
+
+    for root in nltk.data.path:
+        for name in names:
+            candidate = os.path.join(root, name)
+            if os.path.isdir(candidate):
+                return candidate
+    return None
+
+
+requires_java = pytest.mark.skipif(not _has_java(), reason="no JVM on this machine")
+
+
+# ---------------------------------------------------------------------------
+# Expanded vector matrix. Every entry below was run against the live sinks; the
+# ones that leaked drove the hardening in validate_model_resource. Benign and
+# merely-suspicious candidates are kept so a regression shows up as a new leak.
+# ---------------------------------------------------------------------------
+
+
+def _hostile_vectors(root, outside):
+    """(id, value) pairs that must never reach an external tool."""
+    secret = outside / "secret.mco"
+    secret.write_text("SECRET")
+
+    system_file = "/etc/passwd" if os.name == "posix" else "C:\\Windows\\win.ini"
+    vectors = [
+        ("outside-abs", str(secret)),
+        ("system-file-abs", system_file),
+        ("traversal-from-root", os.path.join(str(root), "..", "..", "etc", "passwd")),
+        ("nul-byte", system_file[:5] + "\x00" + system_file[5:]),
+        ("leading-dash", "-Xmx99g"),
+        ("newline-injection", system_file + "\n-serDictionary " + system_file),
+        ("backslash-traversal", "..\\..\\..\\etc\\passwd"),
+        ("file-url", "file:///etc/passwd"),
+        ("http-url", "http://evil.example/model.gz"),
+        ("empty", ""),
+        ("whitespace-only", "   "),
+        ("dir-not-file", str(outside)),
+    ]
+
+    symlink = root / "sym.mco"
+    os.symlink(str(secret), symlink)
+    vectors.append(("symlink-to-outside", str(symlink)))
+
+    symlink_etc = root / "symetc"
+    os.symlink("/etc/passwd", symlink_etc)
+    vectors.append(("symlink-to-etc", str(symlink_etc)))
+
+    symlinked_dir = root / "symdir"
+    os.symlink(str(outside), symlinked_dir)
+    vectors.append(("via-symlinked-dir", str(symlinked_dir / "secret.mco")))
+
+    # Hardlinks are deliberately NOT in this matrix: they are refused only for
+    # paths the tool writes. See the dedicated tests below.
+    return vectors
+
+
+def _vector_ids(vectors):
+    return [name for name, _ in vectors]
+
+
+def test_validate_model_resource_refuses_every_hostile_vector(pathsec_sandbox):
+    """The whole matrix at once, so a new leak names itself in the failure."""
+    root, outside = pathsec_sandbox
+    leaked = []
+    for name, value in _hostile_vectors(root, outside):
+        try:
+            validate_model_resource(value, context="sweep")
+        except (PermissionError, ValueError, OSError):
+            continue
+        leaked.append(name)
+    assert leaked == [], f"validate_model_resource let these through: {leaked}"
+
+
+def test_malt_model_refuses_every_hostile_vector(pathsec_sandbox):
+    root, outside = pathsec_sandbox
+    leaked = []
+    for name, value in _hostile_vectors(root, outside):
+        try:
+            parser = _malt(value)
+            infile, _outfile = _sandbox_io(parser)
+            parser.generate_malt_command(infile, None, mode="learn")
+        except (PermissionError, ValueError, OSError):
+            continue
+        leaked.append(name)
+    assert leaked == [], f"MaltParser passed these to the JVM: {leaked}"
+
+
+def test_malt_working_dir_setter_refuses_every_hostile_vector(pathsec_sandbox):
+    root, outside = pathsec_sandbox
+    leaked = []
+    for name, value in _hostile_vectors(root, outside):
+        parser = _malt("malt_temp.mco", trained=False)
+        try:
+            parser.working_dir = value
+        except (PermissionError, ValueError, OSError):
+            continue
+        # An in-root staging dir is the only acceptable outcome.
+        if not os.path.realpath(parser.working_dir).startswith(
+            os.path.realpath(str(root))
+        ):
+            leaked.append(name)
+    assert leaked == [], f"working_dir accepted these: {leaked}"
+
+
+def _hardlink_into(root, outside):
+    secret = outside / "secret.mco"
+    secret.write_text("SECRET")
+    alias = root / "alias.mco"
+    try:
+        os.link(str(secret), alias)
+    except OSError:  # pragma: no cover - cross-device or unsupported
+        pytest.skip("hard links unavailable between these directories")
+    return str(alias)
+
+
+def test_hardlinked_write_target_is_refused(pathsec_sandbox):
+    """realpath() cannot see a hardlink, so an in-root alias of an outside file
+    passes every path check and the tool would overwrite the original."""
+    root, outside = pathsec_sandbox
+    alias = _hardlink_into(root, outside)
+    with pytest.raises(PermissionError):
+        validate_tool_path(alias, context="sweep", for_write=True)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="st_nlink hardlink guard is POSIX-only")
+def test_hardlinked_read_target_is_refused_by_the_tool_guard(pathsec_sandbox):
+    """validate_tool_path refuses a multiply-linked file for READS as well.
+
+    The two branches merged here disagreed. The wrapper work allowed it, on the
+    grounds that creating the link already needs write access to the data root
+    and that refusing st_nlink > 1 also refuses ordinary deduplicated trees
+    (cp -l, rsync --link-dest) and the ORIGINAL file, since both names share the
+    count. The tagger work refused it, because a hardlink names an inode that may
+    live outside the sandbox and no path resolution can see that (CWE-59).
+
+    The stricter reading wins for the sinks that open a file directly. The
+    trade-off is recorded here rather than dropped: a user whose models live in a
+    hardlink-deduplicated tree will need a plain copy.
+    """
+    root, outside = pathsec_sandbox
+    alias = _hardlink_into(root, outside)
+    with pytest.raises(PermissionError):
+        validate_tool_path(alias, context="sweep")
+    # validate_model_resource keeps the laxer rule: it also serves values that
+    # are classpath resources rather than files the guard is about to open.
+    validate_model_resource(alias, context="sweep")
+
+
+def test_single_linked_model_is_allowed(pathsec_sandbox):
+    """Over-block control for the hardlink guard: an ordinary file has one link."""
+    root, _outside = pathsec_sandbox
+    model = root / "plain.mco"
+    model.write_text("m")
+    validate_model_resource(str(model), context="sweep")
+    validate_tool_path(str(model), context="sweep", for_write=True)
+
+
+def test_directory_model_is_not_hardlink_rejected(pathsec_sandbox):
+    """Directories always have st_nlink >= 2, so the guard must apply to regular
+    files only or every corpus directory would be refused."""
+    root, _outside = pathsec_sandbox
+    corpus = root / "sihan"
+    corpus.mkdir()
+    validate_model_resource(str(corpus), context="sweep")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "malt_temp.mco",
+        _DEFAULT_RESOURCE,
+        "edu/stanford/nlp/models/pos-tagger/english-left3words.tagger",
+    ],
+)
+def test_benign_resource_names_still_pass(value):
+    """The values NLTK itself uses must survive every check added above."""
+    validate_model_resource(value, context="sweep")
+
+
+# ---------------------------------------------------------------------------
+# Exotic vectors: NUL truncation, '~', NTFS streams, UNC shares and blocking
+# device nodes. Each of these leaked when first run and drove a guard.
+# ---------------------------------------------------------------------------
+
+
+def _exotic_vectors(root):
+    vectors = [
+        ("tilde-expansion", "~/.ssh/id_rsa"),
+        *([] if os.name == "posix" else [("ads-stream", "model.mco:evil")]),
+        ("unc-backslash", "\\\\server\\share\\evil.mco"),
+        ("unc-slash", "//server/share/evil.mco"),
+        ("nul-in-middle", "model\x00.mco"),
+        ("jar-url", "jar:file:///etc/passwd!/x"),
+        ("double-slash", "//etc//passwd"),
+        ("dotdot-alone", ".."),
+    ]
+    if os.name == "posix":
+        # Character devices and procfs exist only here; on Windows these are
+        # ordinary non-existent relative names and prove nothing.
+        vectors += [
+            ("dev-stdin", "/dev/stdin"),
+            ("dev-null", "/dev/null"),
+            ("proc-environ", "/proc/self/environ"),
+            ("case-folded-etc", "/ETC/PASSWD"),
+            ("overlong-name", "/" + ("A" * 300) + "/evil.mco"),
+            ("root-only", "/"),
+        ]
+    else:
+        vectors += [
+            ("windows-device", "NUL"),
+            ("windows-system-file", "C:\\Windows\\System32\\config\\SAM"),
+            ("drive-relative", "C:evil.mco"),
+        ]
+
+    fifo = root / "fifo.mco"
+    try:
+        os.mkfifo(fifo)
+    except (AttributeError, OSError):  # pragma: no cover - not on Windows
+        pass
+    else:
+        vectors.append(("fifo-in-root", str(fifo)))
+    return vectors
+
+
+def test_validate_model_resource_refuses_exotic_vectors(pathsec_sandbox):
+    root, _outside = pathsec_sandbox
+    leaked = []
+    for name, value in _exotic_vectors(root):
+        try:
+            validate_model_resource(value, context="sweep")
+        except (PermissionError, ValueError, OSError):
+            continue
+        leaked.append(name)
+    assert leaked == [], f"validate_model_resource let these through: {leaked}"
+
+
+@pytest.mark.skipif(not hasattr(__import__("socket"), "AF_UNIX"), reason="no AF_UNIX")
+def test_unix_socket_model_is_refused(pathsec_sandbox):
+    """A socket planted in a data root is not a model; reading it would block."""
+    import socket
+
+    root, _outside = pathsec_sandbox
+    path = str(root / "s.sock")
+    sock = socket.socket(socket.AF_UNIX)
+    try:
+        sock.bind(path)
+        with pytest.raises(PermissionError):
+            validate_model_resource(path, context="sweep")
+    finally:
+        sock.close()
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "$EVIL_HOME/passwd",
+        "..\uff0f..\uff0fetc\uff0fpasswd",
+        "%2e%2e/%2e%2e/etc/passwd",
+    ],
+    ids=["env-var", "fullwidth-solidus", "percent-encoded"],
+)
+def test_benign_lookalikes_stay_literal(pathsec_sandbox, value):
+    """These are permitted because nothing downstream expands or decodes them:
+    they stay literal filenames. The test pins that assumption, so if a sink ever
+    starts expanding them this fails instead of silently reading /etc.
+    """
+    validate_model_resource(value, context="sweep")
+    assert not os.path.exists(value)
+    assert not os.path.realpath(os.path.expandvars(value)).startswith("/etc/")
+
+
+def test_java_inner_class_resource_is_allowed():
+    """Over-block control: '$' is legal in a JVM resource name, so the option and
+    stream checks must not reject it."""
+    validate_model_resource("edu/stanford/Foo$Bar.ser.gz", context="sweep")
+
+
+def test_windows_drive_path_is_not_stream_rejected():
+    """Over-block control: 'C:\\...' is a drive prefix, not an NTFS stream."""
+    import re as _re
+
+    from nltk.pathsec import validate_model_resource as _vmr
+
+    try:
+        _vmr("C:\\models\\english.ser.gz", context="sweep")
+    except ValueError as exc:
+        assert "alternate data stream" not in str(exc), exc
+    except PermissionError:
+        # On Windows this IS an absolute path, so it is (correctly) refused for
+        # being outside the data roots. That is not the stream rejection.
+        pass
+    assert _re.match(r"^[A-Za-z]:[\\/]", "C:\\models\\english.ser.gz")
+
+
+# ---------------------------------------------------------------------------
+# Regressions found while building this PR. Each one shipped a bug that the
+# mocked tests missed, so they are pinned here permanently.
+# ---------------------------------------------------------------------------
+
+
+def test_regression_generate_malt_command_needs_no_trained_attribute(pathsec_sandbox):
+    """Regression: generate_malt_command briefly branched on a private ``_trained``
+    attribute, which broke every caller that built a parser without it."""
+    import nltk.parse.malt as malt
+
+    parser = object.__new__(malt.MaltParser)
+    parser.model = "malt_temp.mco"
+    parser._working_dir = None
+    parser.additional_java_args = []
+    infile = os.path.join(parser.working_dir, "in.conll")
+    with pathsec.open(infile, "w") as handle:
+        handle.write("")
+    cmd = parser.generate_malt_command(infile, None, mode="learn")
+    assert cmd[cmd.index("-c") + 1] == "malt_temp.mco"
+
+
+def test_regression_trained_bare_model_resolves_to_working_dir(pathsec_sandbox):
+    """Regression: after train(), ``self.model`` is still the bare name
+    ``malt_temp.mco`` while ``_trained`` is True. Resolving that against the CWD
+    made every post-training parse fail with a security violation."""
+    root, _outside = pathsec_sandbox
+    parser = _malt("malt_temp.mco", trained=True)
+    infile = os.path.join(parser.working_dir, "in.conll")
+    outfile = os.path.join(parser.working_dir, "out.conll")
+    with pathsec.open(infile, "w") as handle:
+        handle.write("")
+    cmd = parser.generate_malt_command(infile, outfile, mode="parse")
+    workingdir = cmd[cmd.index("-w") + 1]
+    assert os.path.realpath(workingdir).startswith(os.path.realpath(str(root)))
+    assert os.path.realpath(workingdir) != os.path.realpath(os.getcwd())
+
+
+def test_regression_working_dir_setter_rejects_empty(pathsec_sandbox):
+    """Regression: an empty working_dir passed validate_path and reached
+    MaltParser as ``-w ""``, i.e. the current working directory."""
+    parser = _malt("malt_temp.mco", trained=False)
+    for value in ("", "   "):
+        with pytest.raises(ValueError):
+            parser.working_dir = value
+
+
+def test_regression_has_java_probe_actually_executes():
+    """Regression: the JVM probe used to accept any ``java`` on PATH. macOS ships
+    a /usr/bin/java stub that resolves fine and then fails at exec, which turned
+    the end-to-end tests into hard failures instead of skips."""
+    import subprocess
+
+    result = _has_java()
+    assert isinstance(result, bool)
+    if result:
+        from nltk.internals import find_binary
+
+        binary = find_binary(
+            "java", env_vars=("JAVAHOME", "JAVA_HOME"), verbose=False, binary_names=None
+        )
+        assert subprocess.run([binary, "-version"], capture_output=True).returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# MaltParser -i / -o. Both are public: generate_malt_command() takes them
+# directly and train_from_file() is the public route to -i. -i is READ by the
+# JVM and -o is WRITTEN by it, so an unbounded value is an arbitrary file read
+# and an arbitrary file write.
+# ---------------------------------------------------------------------------
+
+
+def _malt_in_sandbox(root):
+    parser = _malt("malt_temp.mco", trained=False)
+    parser.malt_jars = []
+    infile = os.path.join(parser.working_dir, "in.conll")
+    with pathsec.open(infile, "w") as handle:
+        handle.write("")
+    return parser, infile
+
+
+def test_malt_input_file_refuses_every_hostile_vector(pathsec_sandbox):
+    """-i is an arbitrary-file-read primitive without a guard."""
+    root, outside = pathsec_sandbox
+    parser, _infile = _malt_in_sandbox(root)
+    leaked = []
+    for name, value in _hostile_vectors(root, outside):
+        try:
+            parser.generate_malt_command(value, None, mode="learn")
+        except (PermissionError, ValueError, OSError):
+            continue
+        leaked.append(name)
+    assert leaked == [], f"MaltParser -i accepted: {leaked}"
+
+
+def test_malt_output_file_refuses_every_hostile_vector(pathsec_sandbox):
+    """-o is an arbitrary-file-WRITE primitive without a guard."""
+    root, outside = pathsec_sandbox
+    parser, infile = _malt_in_sandbox(root)
+    leaked = []
+    for name, value in _hostile_vectors(root, outside):
+        try:
+            parser.generate_malt_command(infile, value, mode="parse")
+        except (PermissionError, ValueError, OSError):
+            continue
+        leaked.append(name)
+    assert leaked == [], f"MaltParser -o accepted: {leaked}"
+
+
+def test_malt_train_from_file_refuses_outside_corpus(pathsec_sandbox):
+    """train_from_file is the public route to -i."""
+    root, outside = pathsec_sandbox
+    parser, _infile = _malt_in_sandbox(root)
+    corpus = outside / "steal.conll"
+    corpus.write_text("1\ta\t_\tNN\t_\t_\t0\tROOT\t_\t_\n")
+    for target in ("/etc/passwd", str(corpus)):
+        with pytest.raises((PermissionError, ValueError)):
+            parser.train_from_file(target)
+
+
+def test_malt_in_sandbox_input_and_output_are_allowed(pathsec_sandbox):
+    """Over-block control: the internal callers pass temp files inside
+    working_dir, which must keep working."""
+    root, _outside = pathsec_sandbox
+    parser, infile = _malt_in_sandbox(root)
+    outfile = os.path.join(parser.working_dir, "out.conll")
+    cmd = parser.generate_malt_command(infile, outfile, mode="parse")
+    assert cmd[cmd.index("-i") + 1] == infile
+    assert cmd[cmd.index("-o") + 1] == outfile
+
+
+def test_teeth_malt_io_guard_is_load_bearing(pathsec_sandbox, monkeypatch):
+    """Neuter the guard and -o reaches the JVM again."""
+    import nltk.parse.malt as malt
+
+    root, outside = pathsec_sandbox
+    parser, infile = _malt_in_sandbox(root)
+    monkeypatch.setattr(malt, "validate_tool_path", _passthrough)
+    target = str(outside / "pwned.conll")
+    cmd = parser.generate_malt_command(infile, target, mode="parse")
+    assert cmd[cmd.index("-o") + 1] == target
+
+
+def test_malt_revalidates_on_every_call(pathsec_sandbox):
+    """No cached verdict: a model swapped after a successful call is re-checked,
+    so an attacker cannot 'warm up' the parser with a benign value first."""
+    root, outside = pathsec_sandbox
+    parser, infile = _malt_in_sandbox(root)
+    parser.generate_malt_command(infile, None, mode="learn")
+    evil = outside / "evil.mco"
+    evil.write_text("x")
+    parser.model = str(evil)
+    with pytest.raises((PermissionError, ValueError)):
+        parser.generate_malt_command(infile, None, mode="learn")
+
+
+def test_edited_wrappers_never_widen_the_sandbox(pathsec_sandbox):
+    """Regression guard for the worst bug class in this audit: a loader that
+    appends its target to nltk.data.path and clears the pathsec root cache
+    disarms validate_path process-wide. None of the modules touched here may do
+    that, whatever else they change.
+    """
+    import nltk.data
+
+    before = list(nltk.data.path)
+    root, outside = pathsec_sandbox
+    parser, infile = _malt_in_sandbox(root)
+    for target in ("/etc/passwd", str(outside / "evil.mco")):
+        for call in (
+            lambda t=target: parser.generate_malt_command(t, None, mode="learn"),
+            lambda t=target: setattr(parser, "working_dir", t),
+            lambda t=target: validate_model_resource(t, context="widen"),
+        ):
+            try:
+                call()
+            except (PermissionError, ValueError, OSError):
+                pass
+    assert list(nltk.data.path) == before
+    with pytest.raises(PermissionError):
+        pathsec.validate_path("/etc/passwd", context="widen-check")
+
+
+# ---------------------------------------------------------------------------
+# validate_tool_path. Contract differs from validate_model_resource: this one
+# never accepts a bare resource name, because the tool opens the value directly.
+# ---------------------------------------------------------------------------
+
+
+def test_validate_tool_path_refuses_every_hostile_vector(pathsec_sandbox):
+    root, outside = pathsec_sandbox
+    leaked = []
+    for name, value in _hostile_vectors(root, outside) + _exotic_vectors(root):
+        try:
+            validate_tool_path(value, context="sweep")
+        except (PermissionError, ValueError, OSError):
+            continue
+        leaked.append(name)
+    assert leaked == [], f"validate_tool_path let these through: {leaked}"
+
+
+def test_validate_tool_path_rejects_bare_resource_names(pathsec_sandbox):
+    """Unlike a model argument, an -i/-o value is never a classpath resource: a
+    bare name would resolve against the current working directory."""
+    for value in ("in.conll", "malt_temp.mco", _DEFAULT_RESOURCE):
+        with pytest.raises((PermissionError, ValueError)):
+            validate_tool_path(value, context="sweep")
+
+
+def test_validate_tool_path_allows_in_sandbox_paths(pathsec_sandbox):
+    """Over-block control, including a not-yet-created output file."""
+    root, _outside = pathsec_sandbox
+    existing = root / "in.conll"
+    existing.write_text("")
+    validate_tool_path(str(existing), context="sweep")
+    # A destination the tool will create does not exist yet.
+    validate_tool_path(str(root / "out.conll"), context="sweep", must_exist=False)
+
+
+def test_malt_output_file_refuses_hardlink(pathsec_sandbox):
+    """-o is written by the JVM, so a hardlinked target would clobber the file
+    it aliases outside the roots."""
+    root, outside = pathsec_sandbox
+    alias = _hardlink_into(root, outside)
+    parser, infile = _malt_in_sandbox(root)
+    with pytest.raises(PermissionError):
+        parser.generate_malt_command(infile, alias, mode="parse")
+
+
+def test_validate_tool_path_refuses_fifo(pathsec_sandbox):
+    """An output path that is a FIFO would block the JVM forever."""
+    root, _outside = pathsec_sandbox
+    fifo = root / "out.fifo"
+    try:
+        os.mkfifo(fifo)
+    except (AttributeError, OSError):  # pragma: no cover - not on Windows
+        pytest.skip("mkfifo unavailable")
+    with pytest.raises(PermissionError):
+        validate_tool_path(str(fifo), context="sweep")
+
+
+def test_validate_tool_path_is_exported():
+    assert "validate_tool_path" in pathsec.__all__
+
+
+def test_regression_bare_model_name_is_not_probed_against_cwd(pathsec_sandbox):
+    """Regression: validate_model_resource decided "is this a real path?" with
+    os.path.exists(), which resolves relative to the CWD. A stray malt_temp.mco
+    in the user's directory therefore made the DEFAULT MaltParser() flow die with
+    a security violation. Older NLTK wrote exactly that file into the CWD, so an
+    upgrade would have tripped it.
+    """
+    root, _outside = pathsec_sandbox
+    os.chdir(str(root.parent))
+    decoy = root.parent / "malt_temp.mco"
+    decoy.write_text("decoy")
+    try:
+        validate_model_resource("malt_temp.mco", context="sweep")
+        parser, infile = _malt_in_sandbox(root)
+        parser.model = "malt_temp.mco"
+        cmd = parser.generate_malt_command(infile, None, mode="learn")
+        assert cmd[cmd.index("-c") + 1] == "malt_temp.mco"
+    finally:
+        decoy.unlink()
+
+
+def test_regression_staging_dirs_are_cleaned_up(tmp_path):
+    """Regression: every parser that touched working_dir left a directory under
+    the data root forever. The shared tempdir it replaced was OS-reaped, but a
+    data root is not, so the dir is now removed at interpreter exit.
+
+    Run in a real subprocess: atexit only fires when the process ends.
+    """
+    import subprocess
+    import sys
+
+    root = tmp_path / "nltk_data"
+    root.mkdir()
+    script = (
+        "import nltk.data, nltk.pathsec as ps;"
+        f"nltk.data.path[:] = [{str(root)!r}];"
+        "ps._ALLOWED_ROOTS_CACHE = None; ps._LAST_DATA_PATHS = None;"
+        "from nltk.parse.malt import MaltParser;"
+        "p = MaltParser.__new__(MaltParser); p._working_dir = None;"
+        "print(p.working_dir)"
+    )
+    env = dict(os.environ, PYTHONPATH=os.pathsep.join(sys.path))
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, env=env
+    )
+    assert result.returncode == 0, result.stderr
+    staged = result.stdout.strip()
+    assert staged.startswith(str(root))
+    assert not os.path.exists(staged), f"staging dir leaked after exit: {staged}"
+
+
+def test_working_dir_none_resets_to_lazy_allocation(pathsec_sandbox):
+    """Regression: assigning None used to raise; it now restores the unset state
+    so the property allocates again."""
+    root, _outside = pathsec_sandbox
+    parser = _malt("malt_temp.mco", trained=False)
+    first = parser.working_dir
+    parser.working_dir = None
+    assert parser.working_dir != first or os.path.isdir(parser.working_dir)
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["NUL", "CON", "COM1", "LPT1", "nul.ser.gz", "models/COM9.mco", "AUX"],
+)
+@pytest.mark.skipif(os.name == "posix", reason="POSIX: these are ordinary names")
+def test_reserved_windows_device_names_are_refused(value):
+    """On Windows these resolve to a device (a serial port, the null device) no
+    matter which directory they appear in. On POSIX they are ordinary filenames,
+    so the check is deliberately platform-conditional: refusing them there would
+    break legitimate files."""
+    with pytest.raises(ValueError):
+        validate_model_resource(value, context="sweep")
+
+
+@pytest.mark.parametrize("value", ["CONTEXT.mco", "console.ser.gz", "nulls.mco"])
+def test_names_merely_starting_like_a_device_are_allowed(value):
+    """Over-block control: the check is on the whole stem, not a prefix."""
+    validate_model_resource(value, context="sweep")
+
+
+@pytest.mark.parametrize("value", ["C:evil.mco", "C:models\\evil.mco", "D:x.ser.gz"])
+@pytest.mark.skipif(os.name == "posix", reason="POSIX: ':' is an ordinary char")
+def test_drive_relative_paths_are_refused(value):
+    """Windows CI found this: "C:name" is drive-RELATIVE, meaning "name in the
+    current directory of drive C", so it escapes the location that was validated.
+    It is not the same as the absolute "C:\\name"."""
+    with pytest.raises(ValueError):
+        validate_model_resource(value, context="sweep")
+    with pytest.raises(PermissionError):
+        validate_tool_path(value, context="sweep")
+
+
+def test_both_guards_share_one_syntax_gate(pathsec_sandbox):
+    """Windows CI found that validate_tool_path skipped the name checks that
+    validate_model_resource applied, so a value refused by one was accepted by
+    the other. They must stay in agreement on syntax."""
+    root, outside = pathsec_sandbox
+    disagreements = []
+    for name, value in _hostile_vectors(root, outside) + _exotic_vectors(root):
+        verdicts = []
+        for guard in (validate_model_resource, validate_tool_path):
+            try:
+                guard(value, context="sweep")
+                verdicts.append("allowed")
+            except (PermissionError, ValueError, OSError):
+                verdicts.append("refused")
+        # validate_tool_path is strictly stricter: it may refuse where the model
+        # guard allows a bare resource name, but never the reverse.
+        if verdicts[0] == "refused" and verdicts[1] == "allowed":
+            disagreements.append(name)
+    assert disagreements == [], f"tool_path weaker than model_resource: {disagreements}"
+
+
+# ---------------------------------------------------------------------------
+# Time-of-check/time-of-use at the API boundary. __fspath__ is allowed to
+# return a different answer on every call, so a guard that resolves the path
+# separately from the code that uses it validates one file while the tool opens
+# another. Both parsers leaked this way until the guards started returning the
+# resolved string for the caller to use.
+# ---------------------------------------------------------------------------
+
+
+class _MutatingPath:
+    """A legal os.PathLike whose __fspath__ answers differently each call."""
+
+    def __init__(self, first, rest):
+        self._calls = 0
+        self._first = first
+        self._rest = rest
+
+    def __fspath__(self):
+        self._calls += 1
+        return self._first if self._calls == 1 else self._rest
+
+    def __str__(self):
+        return self._first
+
+
+def _resolve(value):
+    return os.fspath(value) if hasattr(value, "__fspath__") else value
+
+
+def test_mutating_path_that_starts_hostile_is_refused(pathsec_sandbox):
+    """The other ordering: hostile on the guard's call. Must still be refused."""
+    root, outside = pathsec_sandbox
+    evil = outside / "evil.mco"
+    evil.write_text("x")
+    good = root / "ok.mco"
+    good.write_text("m")
+    with pytest.raises((PermissionError, ValueError)):
+        validate_model_resource(_MutatingPath(str(evil), str(good)), context="sweep")
+
+
+def test_guards_return_the_resolved_string(pathsec_sandbox):
+    """The contract callers rely on: use the return value, never the original."""
+    root, _outside = pathsec_sandbox
+    model = root / "m.mco"
+    model.write_text("m")
+    assert validate_model_resource(model, context="sweep") == str(model)
+    assert validate_tool_path(model, context="sweep") == str(model)
+    assert validate_model_resource(_DEFAULT_RESOURCE, context="sweep") == (
+        _DEFAULT_RESOURCE
+    )
+
+
+@pytest.mark.parametrize("value", [None, ["/etc/passwd"], object()])
+def test_non_path_inputs_are_a_clean_security_rejection(value):
+    """A TypeError would escape a caller's except (ValueError, PermissionError)
+    and surface as a crash rather than a refusal.
+
+    bytes are NOT here: a bytes path is a legal spelling on POSIX, so it is
+    decoded and checked rather than refused.
+
+    Integers are deliberately absent: throughout pathsec an int is a file
+    descriptor, not a path, and validate_path short-circuits on one. Treating it
+    as a bad path here would contradict that convention.
+
+    The exception type follows each guard's own convention: a malformed value is
+    a ValueError from validate_model_resource, and a PermissionError from the
+    tool-path guards, which report every refusal that way.
+    """
+    with pytest.raises(ValueError):
+        validate_model_resource(value, context="sweep")
+    with pytest.raises(PermissionError):
+        validate_tool_path(value, context="sweep")
+
+
+@pytest.mark.parametrize(
+    "name", ["evil.mco.", "evil.mco ", "evil.mco...", "evil.mco. "]
+)
+def test_trailing_dot_or_space_is_refused(name):
+    """Windows silently strips these, so the name that is checked is not the name
+    that is opened."""
+    with pytest.raises(ValueError):
+        validate_model_resource(name, context="sweep")
+
+
+class _DotPathObject:
+    """validate_path reads a ``.path`` attribute in preference to __fspath__
+    (it supports NLTK's PathPointer objects). An object whose ``.path`` is
+    benign and whose __fspath__ is hostile therefore passes the check and is
+    resolved to the hostile value by whoever consumes it."""
+
+    def __init__(self, benign, hostile):
+        self.path = benign
+        self._hostile = hostile
+
+    def __fspath__(self):
+        return self._hostile
+
+    def __str__(self):
+        return self.path
+
+
+@pytest.mark.parametrize("slot", ["model", "input"])
+def test_segmenter_refuses_dot_path_objects(pathsec_sandbox, monkeypatch, slot):
+    """Both the model and the input file leaked this way: the guard read .path
+    and the JVM would have resolved __fspath__."""
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, outside = pathsec_sandbox
+    _trap_java(monkeypatch, seg, {})
+    evil = outside / "evil.ser.gz"
+    evil.write_text("x")
+    good = str(root / "ok.ser.gz")
+    with pathsec.open(good, "w", encoding="utf-8") as handle:
+        handle.write("m")
+    inside = str(root / "in.txt")
+    with pathsec.open(inside, "w", encoding="utf-8") as handle:
+        handle.write("x")
+
+    if slot == "model":
+        tool = _segmenter(monkeypatch, str(root), model=_DotPathObject(good, str(evil)))
+        target = inside
+    else:
+        tool = _segmenter(monkeypatch, str(root), model=good)
+        target = _DotPathObject(inside, "/etc/passwd")
+    with pytest.raises((PermissionError, ValueError)):
+        tool.segment_file(target)
+
+
+def test_segmenter_argv_carries_validated_strings(pathsec_sandbox, monkeypatch):
+    """Over-block control plus the positive invariant: what reaches the JVM is
+    the exact string the guard returned, as a str."""
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, _outside = pathsec_sandbox
+    sink = _trap_java(monkeypatch, seg, {})
+    model = str(root / "ok.ser.gz")
+    with pathsec.open(model, "w", encoding="utf-8") as handle:
+        handle.write("m")
+    inside = str(root / "in.txt")
+    with pathsec.open(inside, "w", encoding="utf-8") as handle:
+        handle.write("x")
+
+    tool = _segmenter(monkeypatch, str(root), model=model)
+    with pytest.raises(_ReachedJVM):
+        tool.segment_file(inside)
+    for flag in ("-loadClassifier", "-textFile"):
+        value = sink["cmd"][sink["cmd"].index(flag) + 1]
+        assert isinstance(value, str)
+        assert os.path.realpath(value).startswith(os.path.realpath(str(root)))
+
+
+def test_dot_path_object_is_refused_by_both_guards(pathsec_sandbox):
+    root, outside = pathsec_sandbox
+    evil = outside / "evil.mco"
+    evil.write_text("x")
+    good = root / "ok.mco"
+    good.write_text("m")
+    sneaky = _DotPathObject(str(good), str(evil))
+    for guard in (validate_model_resource, validate_tool_path):
+        with pytest.raises((PermissionError, ValueError)):
+            guard(sneaky, context="sweep")
+
+
+class _LyingStr(str):
+    """A str subclass whose inspection methods lie.
+
+    os.fspath() returns a str subclass unchanged, so every syntactic check would
+    otherwise run on attacker-controlled methods while the value handed to the
+    tool still carries the real, hostile characters.
+    """
+
+    def __str__(self):
+        return "safe"
+
+    def startswith(self, *args, **kwargs):
+        return False
+
+    def strip(self, *args, **kwargs):
+        return "safe"
+
+    def rstrip(self, *args, **kwargs):
+        return self
+
+    def replace(self, *args, **kwargs):
+        return "safe/name.mco"
+
+    def split(self, *args, **kwargs):
+        return ["safe", "name.mco"]
+
+    def lower(self):
+        return "safe"
+
+    def __contains__(self, item):
+        return False
+
+
+class _LyingFsPath:
+    def __fspath__(self):
+        return _LyingStr("-Xmx99g")
+
+
+@pytest.mark.parametrize(
+    "payload",
+    ["-Xmx99g", "../../../etc/passwd", "file:///etc/passwd", "model\x00.mco"]
+    + ([] if os.name == "posix" else ["NUL", "evil.mco.", "name:stream"]),
+)
+def test_lying_str_subclass_is_refused(payload):
+    """Every check must see the real characters, not what the subclass claims."""
+    for guard in (validate_model_resource, validate_tool_path):
+        with pytest.raises((PermissionError, ValueError)):
+            guard(_LyingStr(payload), context="sweep")
+
+
+def test_lying_subclass_returned_by_fspath_is_refused():
+    for guard in (validate_model_resource, validate_tool_path):
+        with pytest.raises((PermissionError, ValueError)):
+            guard(_LyingFsPath(), context="sweep")
+
+
+def test_guards_always_return_an_exact_str(pathsec_sandbox):
+    """The value callers put into argv must be a plain str, so that nothing can
+    re-resolve or re-inspect it differently later."""
+    root, _outside = pathsec_sandbox
+    model = root / "ok.mco"
+    model.write_text("m")
+
+    class _BenignSubclass(str):
+        pass
+
+    for value in (str(model), _BenignSubclass(str(model)), model, _DEFAULT_RESOURCE):
+        assert type(validate_model_resource(value, context="sweep")) is str
+    assert type(validate_tool_path(model, context="sweep")) is str
+
+
+def test_benign_str_subclass_still_works(pathsec_sandbox):
+    """Over-block control: subclassing str is legal, lying about it is not."""
+    root, _outside = pathsec_sandbox
+    model = root / "ok.mco"
+    model.write_text("m")
+
+    class _BenignSubclass(str):
+        pass
+
+    assert validate_model_resource(_BenignSubclass(str(model)), context="sweep") == str(
+        model
+    )
+
+
+# ---------------------------------------------------------------------------
+# corenlp_options is SPLIT into separate argv elements, so it can append a
+# second -model. Verified directly against the JVM that Stanford's
+# LexicalizedParser honours the LAST occurrence, so an injected option replaced
+# the model the guard had just checked and the parser deserialized that file.
+# ---------------------------------------------------------------------------
+
+
+def _stanford_with_options(model_path, options):
+    parser = _stanford_parser(model_path)
+    parser.corenlp_options = options
+    return parser
+
+
+@pytest.mark.parametrize(
+    "name",
+    [".\n./TARGET", ".\t./TARGET", ".\r./TARGET", ".\x0b./TARGET", "model\x0c.mco"],
+    ids=["lf", "tab", "cr", "vtab", "formfeed"],
+)
+def test_control_characters_are_refused(name):
+    """Python 3.14's url2pathname follows the WHATWG rules and STRIPS tab, LF and
+    CR, so a name containing them passes a '..' check here and then BECOMES a
+    traversal downstream. Verified against a real 3.14.4 interpreter:
+
+        url2pathname('.\\n./TARGET') -> '../TARGET'
+
+    A legitimate model or corpus filename never contains a control character, so
+    they are refused outright rather than normalised.
+    """
+    for guard in (validate_model_resource, validate_tool_path):
+        with pytest.raises((PermissionError, ValueError)):
+            guard(name, context="sweep")
+
+
+def test_control_character_guard_does_not_block_ordinary_names(pathsec_sandbox):
+    """Over-block control: spaces are legal in a filename, control characters
+    are not."""
+    root, _outside = pathsec_sandbox
+    spaced = root / "my model.ser.gz"
+    spaced.write_text("m")
+    validate_model_resource(str(spaced), context="sweep")
+    validate_model_resource(_DEFAULT_RESOURCE, context="sweep")
+
+
+# ---------------------------------------------------------------------------
+# StanfordSegmenter's options dict is joined into ONE comma-separated -options
+# argv element, so a key containing ',' or '=' injects extra option pairs. Same
+# class as the parser's corenlp_options, in the sibling wrapper.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "key",
+    ["normalize=true,serDictionary", "a,b", "a=b", "a b", "a\nb", "a\tb", "", "   "],
+    ids=[
+        "comma-and-equals",
+        "comma",
+        "equals",
+        "space",
+        "newline",
+        "tab",
+        "empty",
+        "whitespace",
+    ],
+)
+def test_segmenter_option_keys_cannot_inject_pairs(key):
+    from nltk.tokenize.stanford_segmenter import _validated_options
+
+    with pytest.raises(ValueError):
+        _validated_options({key: "1"})
+
+
+def test_segmenter_option_values_are_bounded(pathsec_sandbox):
+    """A value that names a file must stay inside the data roots."""
+    from nltk.tokenize.stanford_segmenter import _validated_options
+
+    root, outside = pathsec_sandbox
+    evil = outside / "evil.gz"
+    evil.write_text("x")
+    for value in ("/etc/passwd", str(evil)):
+        with pytest.raises((PermissionError, ValueError)):
+            _validated_options({"serDictionary": value})
+
+
+def test_segmenter_benign_options_still_work(pathsec_sandbox):
+    """Over-block control: ordinary settings, numbers and in-root paths pass."""
+    from nltk.tokenize.stanford_segmenter import _validated_options
+
+    root, _outside = pathsec_sandbox
+    good = root / "ok.gz"
+    good.write_text("m")
+    assert _validated_options({"normalize": "true", "keepAll": "false"}) == {
+        "normalize": "true",
+        "keepAll": "false",
+    }
+    assert _validated_options({"maxLen": 40}) == {"maxLen": 40}
+    assert _validated_options({"serDictionary": str(good)}) == {
+        "serDictionary": str(good)
+    }
+    assert _validated_options({}) == {}
+
+
+def test_teeth_segmenter_options_guard_is_load_bearing():
+    """Without the guard the injected pair lands in the built option string."""
+    import json as _json
+
+    options = {"normalize=true,serDictionary": "/etc/passwd"}
+    unguarded = ",".join(f"{k}={_json.dumps(v)}" for k, v in options.items())
+    assert "serDictionary" in unguarded.split(",")[1]
+
+
+def test_segmenter_out_of_root_jar_is_refused_despite_approved_checksum(
+    pathsec_sandbox, monkeypatch
+):
+    """The checksum allowlist is not a location check. A jar outside the roots
+    must still be refused, even when its sha256 has been approved."""
+    import hashlib as _hashlib
+
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, outside = pathsec_sandbox
+    evil_jar = outside / "evil.jar"
+    evil_jar.write_bytes(b"PK\x05\x06" + b"\0" * 18)
+    digest = _hashlib.sha256(evil_jar.read_bytes()).hexdigest()
+    monkeypatch.setenv("NLTK_SEGMENTER_ALLOW_SHA256", digest)
+
+    tool = object.__new__(seg.StanfordSegmenter)
+    tool._stanford_jar = str(evil_jar)
+    tool._jar_sha256_cache = {}
+    with pytest.raises((PermissionError, ValueError)):
+        tool._validate_classpath()
+
+
+# ---------------------------------------------------------------------------
+# Surfaces probed and found CLEAN. Pinned so a later change cannot open them
+# without a test noticing. Each was verified by execution, not by reading.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "java_class",
+    ["-jar", "-Xmx99g", "-javaagent:/tmp/evil.jar", "@/tmp/argfile"],
+)
+def test_segmenter_java_class_cannot_be_an_option(
+    pathsec_sandbox, monkeypatch, java_class
+):
+    """java_class is caller-supplied and lands in the JVM's MAIN CLASS slot, so
+    an option-shaped value would be read as a JVM option instead. internals.java
+    already refuses it; this pins that it keeps doing so."""
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, _outside = pathsec_sandbox
+    inside = str(root / "in.txt")
+    with pathsec.open(inside, "w", encoding="utf-8") as handle:
+        handle.write("x")
+    tool = _segmenter(monkeypatch, str(root))
+    tool._java_class = java_class
+    with pytest.raises((ValueError, PermissionError)):
+        tool.segment_file(inside)
+
+
+@pytest.mark.parametrize(
+    "option",
+    [
+        "-XX:OnOutOfMemoryError=touch /tmp/pwned",
+        "-javaagent:/tmp/evil.jar",
+        "@/tmp/argfile",
+        "-jar /tmp/evil.jar",
+    ],
+)
+def test_wrapper_java_options_hit_the_allowlist(pathsec_sandbox, monkeypatch, option):
+    """The JVM option allowlist lives in internals.java. This confirms it is
+    actually reached through THIS wrapper rather than assumed."""
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, _outside = pathsec_sandbox
+    inside = str(root / "in.txt")
+    with pathsec.open(inside, "w", encoding="utf-8") as handle:
+        handle.write("x")
+    tool = _segmenter(monkeypatch, str(root))
+    tool.java_options = option
+    with pytest.raises((ValueError, PermissionError)):
+        tool.segment_file(inside)
+
+
+@pytest.mark.skipif(
+    os.name != "posix",
+    reason="POSIX-shaped traversal and resolve() fallback; hardening, not a fixed vuln",
+)
+def test_unresolvable_path_with_traversal_or_nul_is_refused(pathsec_sandbox):
+    """validate_path falls back to validating only the prefix up to ".zip" when
+    resolve() fails, and resolve() also fails on a NUL. Refusing an unresolvable
+    path that still contains a traversal or a NUL keeps that fallback from
+    approving a value on a harmless prefix.
+
+    No usable escape was found through this (a NUL path cannot be opened by
+    Python and truncates in a subprocess), so this is hardening rather than a
+    fixed vulnerability.
+    """
+    import zipfile as _zipfile
+
+    root, _outside = pathsec_sandbox
+    archive = str(root / "corpus.zip")
+    with _zipfile.ZipFile(archive, "w") as handle:
+        handle.writestr("member.txt", "hello")
+    for suspect in (
+        f"{archive}/\x00../../../etc/passwd",
+        f"{archive}/../../../../etc/passwd",
+    ):
+        with pytest.raises((PermissionError, ValueError)):
+            pathsec.validate_path(suspect, context="sweep")
+
+
+def test_zip_member_paths_still_validate(pathsec_sandbox):
+    """Over-block control for the change above: virtual zip member paths are the
+    reason that fallback exists and must keep working."""
+    import zipfile as _zipfile
+
+    from nltk.data import ZipFilePathPointer
+
+    root, _outside = pathsec_sandbox
+    archive = str(root / "corpus.zip")
+    with _zipfile.ZipFile(archive, "w") as handle:
+        handle.writestr("member.txt", "hello")
+    for good in (archive, f"{archive}/member.txt", f"{archive}/sub/dir/member.txt"):
+        pathsec.validate_path(good, context="sweep")
+    assert ZipFilePathPointer(archive, "member.txt").open().read() == b"hello"
+
+
+# ---------------------------------------------------------------------------
+# Entry-point matrix. The recurring real bug in this PR was a guard placed on
+# ONE method while a sibling built its argv before validating. segment_file was
+# fixed first and segment_sents/segment still leaked. This drives the attack
+# through EVERY public entry point so a new method cannot reopen it quietly.
+# ---------------------------------------------------------------------------
+
+
+def _segmenter_entry_points():
+    return {
+        "segment_file": lambda tool, path: tool.segment_file(path),
+        "segment_sents": lambda tool, _path: tool.segment_sents([["中", "文"]]),
+        "segment": lambda tool, _path: tool.segment(["中", "文"]),
+    }
+
+
+@pytest.mark.parametrize("entry", sorted(_segmenter_entry_points()))
+@pytest.mark.parametrize("hostile", ["mutating", "dot-path", "plain-outside"])
+def test_every_segmenter_entry_point_refuses_hostile_models(
+    pathsec_sandbox, monkeypatch, entry, hostile
+):
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, outside = pathsec_sandbox
+    sink = _trap_java(monkeypatch, seg, {})
+    evil = str(outside / "evil.ser.gz")
+    (outside / "evil.ser.gz").write_text("x")
+    good = str(root / "ok.ser.gz")
+    with pathsec.open(good, "w", encoding="utf-8") as handle:
+        handle.write("m")
+    inside = str(root / "in.txt")
+    with pathsec.open(inside, "w", encoding="utf-8") as handle:
+        handle.write("x")
+
+    model = {
+        "mutating": _MutatingPath(good, evil),
+        "dot-path": _DotPathObject(good, evil),
+        "plain-outside": evil,
+    }[hostile]
+    tool = _segmenter(monkeypatch, str(root), model=model)
+
+    try:
+        _segmenter_entry_points()[entry](tool, inside)
+    except (PermissionError, ValueError):
+        return
+    except _ReachedJVM:
+        pass
+    # If it reached the JVM at all, the argv must hold the validated string.
+    handed = sink["cmd"][sink["cmd"].index("-loadClassifier") + 1]
+    resolved = _resolve(handed)
+    assert isinstance(handed, str), f"{entry} put a {type(handed).__name__} in argv"
+    assert os.path.realpath(str(resolved)).startswith(
+        os.path.realpath(str(root))
+    ), f"{entry} handed the JVM a path outside the roots: {resolved}"
+
+
+@pytest.mark.parametrize("entry", sorted(_segmenter_entry_points()))
+def test_every_segmenter_entry_point_still_works(pathsec_sandbox, monkeypatch, entry):
+    """Over-block control for the matrix above."""
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, _outside = pathsec_sandbox
+    sink = _trap_java(monkeypatch, seg, {})
+    good = str(root / "ok.ser.gz")
+    with pathsec.open(good, "w", encoding="utf-8") as handle:
+        handle.write("m")
+    inside = str(root / "in.txt")
+    with pathsec.open(inside, "w", encoding="utf-8") as handle:
+        handle.write("x")
+
+    tool = _segmenter(monkeypatch, str(root), model=good)
+    with pytest.raises(_ReachedJVM):
+        _segmenter_entry_points()[entry](tool, inside)
+    assert sink["cmd"][sink["cmd"].index("-loadClassifier") + 1] == good
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        "parse_sents",
+        "raw_parse_sents",
+        "tagged_parse_sents",
+        "raw_parse",
+        "tagged_parse",
+    ],
+)
+def test_every_parser_entry_point_refuses_a_mutating_model(
+    pathsec_sandbox, monkeypatch, entry
+):
+    """All five public parser methods funnel through _execute, which replaces the
+    -model argv entry with the validated string. This proves it for each."""
+    import nltk.parse.stanford as st
+
+    root, outside = pathsec_sandbox
+    sink = _trap_java(monkeypatch, st, {})
+    evil = outside / "evil.ser.gz"
+    evil.write_text("x")
+    good = root / "ok.ser.gz"
+    good.write_text("m")
+
+    parser = _stanford_parser(_MutatingPath(str(good), str(evil)))
+    calls = {
+        "parse_sents": lambda p: p.parse_sents([["hi", "there"]]),
+        "raw_parse_sents": lambda p: p.raw_parse_sents(["hi there"]),
+        "tagged_parse_sents": lambda p: p.tagged_parse_sents([[("hi", "UH")]]),
+        "raw_parse": lambda p: p.raw_parse("hi there"),
+        "tagged_parse": lambda p: p.tagged_parse([("hi", "UH")]),
+    }
+    try:
+        calls[entry](parser)
+    except (PermissionError, ValueError):
+        return
+    except _ReachedJVM:
+        pass
+    handed = sink["cmd"][sink["cmd"].index("-model") + 1]
+    assert isinstance(handed, str), f"{entry} put a {type(handed).__name__} in argv"
+    assert os.path.realpath(_resolve(handed)).startswith(os.path.realpath(str(root)))
+
+
+def test_validate_model_paths_returns_the_validated_strings(
+    pathsec_sandbox, monkeypatch
+):
+    """The contract the segmenter's argv builders rely on: the guard hands back
+    what it checked, so nothing has to re-read shared mutable state."""
+    root, _outside = pathsec_sandbox
+    model = str(root / "m.ser.gz")
+    dictionary = str(root / "d.ser.gz")
+    sihan = str(root / "sihan")
+    for path in (model, dictionary):
+        with pathsec.open(path, "w", encoding="utf-8") as handle:
+            handle.write("x")
+    os.mkdir(sihan)
+
+    tool = _segmenter(monkeypatch, str(root), model=model)
+    tool._dict = dictionary
+    tool._sihan_corpora_dict = sihan
+    assert tool._validate_model_paths() == (model, dictionary, sihan)
+
+    unset = _segmenter(monkeypatch, str(root))
+    assert unset._validate_model_paths() == (None, None, None)
+
+
+def test_segmenter_argv_survives_a_concurrent_model_swap(pathsec_sandbox, monkeypatch):
+    """A background thread rewriting self._model must never land an out-of-root
+    path in the argv. The builders take the guard's return value rather than
+    re-reading the attribute, so the checked value and the used value are the
+    same object.
+
+    No leak was observed here before the change either, so this documents the
+    property rather than reproducing a past failure.
+    """
+    import threading
+
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, outside = pathsec_sandbox
+    evil = str(outside / "evil.ser.gz")
+    (outside / "evil.ser.gz").write_text("x")
+    good = str(root / "ok.ser.gz")
+    with pathsec.open(good, "w", encoding="utf-8") as handle:
+        handle.write("m")
+    inside = str(root / "in.txt")
+    with pathsec.open(inside, "w", encoding="utf-8") as handle:
+        handle.write("x")
+
+    handed = []
+
+    def fake_java(cmd, *args, **kwargs):
+        handed.append(cmd[cmd.index("-loadClassifier") + 1])
+        raise _ReachedJVM
+
+    monkeypatch.setattr(seg, "java", fake_java)
+    tool = _segmenter(monkeypatch, str(root), model=good)
+
+    stop = threading.Event()
+
+    def flipper():
+        while not stop.is_set():
+            tool._model = evil
+            tool._model = good
+
+    thread = threading.Thread(target=flipper, daemon=True)
+    thread.start()
+    try:
+        for _ in range(200):
+            for call in (
+                lambda: tool.segment_file(inside),
+                lambda: tool.segment_sents([["中", "文"]]),
+            ):
+                try:
+                    call()
+                except (_ReachedJVM, PermissionError, ValueError):
+                    pass
+    finally:
+        stop.set()
+        thread.join(timeout=5)
+
+    escaped = [
+        value
+        for value in handed
+        if not os.path.realpath(str(value)).startswith(os.path.realpath(str(root)))
+    ]
+    assert escaped == [], f"a concurrent write reached the JVM argv: {escaped[:3]}"
+
+
+def test_file_descriptors_pass_through_both_guards():
+    """An int is a file descriptor everywhere in pathsec, never a path."""
+    assert validate_tool_path(0, context="sweep") == 0
+
+
+def test_validate_tool_dir_returns_the_checked_string(pathsec_sandbox):
+    """Directories go through validate_tool_dir, which must hand back the checked
+    string for the same reason validate_tool_path does."""
+    from nltk.pathsec import validate_tool_dir
+
+    root, outside = pathsec_sandbox
+    corpus = root / "sihan"
+    corpus.mkdir()
+    assert validate_tool_dir(str(corpus), context="sweep") == str(corpus)
+    with pytest.raises((PermissionError, ValueError)):
+        validate_tool_dir(str(outside / "elsewhere"), context="sweep")

--- a/nltk/test/unit/test_redos_caller_patterns.py
+++ b/nltk/test/unit/test_redos_caller_patterns.py
@@ -75,3 +75,46 @@ def test_util_routes_through_redos():
     assert module.__name__ == "nltk.util", module.__name__
     source = inspect.getsource(module)
     assert "redos.compile" in source, "nltk.util no longer bounds its regex"
+
+
+@pytest.mark.parametrize(
+    "code, expected",
+    [
+        (
+            "from nltk.stem.regexp import RegexpStemmer;"
+            "print(RegexpStemmer('ing$|s$|e$').stem('running'))",
+            "runn",
+        ),
+        ("from nltk.util import re_show; re_show('o+','foo')", "f{oo}"),
+        (
+            "from nltk.tokenize import RegexpTokenizer;"
+            "print(RegexpTokenizer(r'\\w+').tokenize('hi there'))",
+            "['hi', 'there']",
+        ),
+    ],
+    ids=["stemmer", "re_show", "tokenizer"],
+)
+def test_ordinary_patterns_still_produce_the_right_answer(code, expected):
+    """Over-block control: bounding the engine must not change results."""
+    result = _run(code)
+    assert result.returncode == 0, result.stderr
+    assert expected in result.stdout, result.stdout
+
+
+def test_the_bounded_modules_route_through_redos():
+    """Pin the mechanism, not just the timing.
+
+    A future edit could swap redos.compile back to re.compile and these timing
+    tests would still pass on a fast machine with a smaller bait string.
+    """
+    import importlib
+    import inspect
+
+    # importlib, not "import nltk.util as util": the package star-imports
+    # nltk.stem, whose own util module shadows the nltk.util ATTRIBUTE, so the
+    # plain import silently hands back nltk.stem.util instead.
+    for name in ("nltk.stem.regexp", "nltk.util"):
+        module = importlib.import_module(name)
+        assert module.__name__ == name, f"{name} resolved to {module.__name__}"
+        source = inspect.getsource(module)
+        assert "redos.compile" in source, f"{name} no longer bounds its regex"

--- a/nltk/test/unit/test_stanford_arg_injection.py
+++ b/nltk/test/unit/test_stanford_arg_injection.py
@@ -1,0 +1,87 @@
+# Natural Language Toolkit: Stanford wrapper argument-injection regression
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""The Stanford model path and the JVM option list must not be injectable.
+
+Covers CVE-2026-12841 / GHSA-m4rf-3fr8-xwx3 (JVM argument injection via the
+per-call options), the cmd[0]/@argfile guard, and the JVM-injecting environment
+variables stripped from the child. StanfordTagger bounds its model with
+validate_tool_path, which refuses a leading-dash token that would become a tool
+flag, plus traversal / out-of-root / NUL.
+"""
+
+import os
+
+import pytest
+
+from nltk import internals
+from nltk.pathsec import validate_tool_path
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["-loadClassifier", "-props", "/etc/passwd", "../../etc/passwd", "ok\x00.tagger"],
+)
+def test_stanford_model_path_is_bounded(model):
+    """The value StanfordTagger hands the JVM as its model argument."""
+    with pytest.raises((PermissionError, ValueError)):
+        validate_tool_path(model, context="StanfordTagger.tag_sents")
+
+
+_INJECTION_OPTIONS = [
+    ["-jar"],
+    ["@/tmp/f"],
+    ["-XX:OnError=touch /tmp/x"],
+    ["-XX:OnOutOfMemoryError=x"],
+    ["-Djava.ext.dirs=/tmp"],
+    ["-Djava.rmi.server.codebase=http://x/"],
+    ["-javaagent:/tmp/a.jar"],
+    ["-agentlib:jdwp=transport=dt_socket"],
+    ["--module-path=/tmp/evil"],
+    ["-p", "/tmp"],
+    ["-Xmx512m ; rm -rf /"],
+    ["-Xmx$(id)"],
+    ["-verbose:gc\n-XX:OnError=x"],
+    ["--add-modules", "a$(id)"],
+]
+
+
+@pytest.mark.parametrize("options", _INJECTION_OPTIONS)
+def test_injection_java_options_are_rejected(options):
+    with pytest.raises(ValueError):
+        internals._validate_java_options(options)
+
+
+def test_benign_java_options_pass():
+    internals._validate_java_options(
+        ["-Xmx512m", "-verbose:gc", "-server", "--add-modules", "java.se.ee"]
+    )
+
+
+@pytest.mark.parametrize(
+    "var",
+    [
+        "JAVA_TOOL_OPTIONS",
+        "_JAVA_OPTIONS",
+        "JDK_JAVA_OPTIONS",
+        "IBM_JAVA_OPTIONS",
+        "OPENJ9_JAVA_OPTIONS",
+        "CLASSPATH",
+    ],
+)
+def test_jvm_injecting_env_vars_are_stripped(monkeypatch, var):
+    monkeypatch.setenv(var, "-XX:OnError=touch /tmp/pwned")
+    child = internals._java_child_env()
+    assert var not in child
+    assert "PATH" in child  # ordinary env survives
+
+
+@pytest.mark.parametrize(
+    "cmd", [["-jar"], [" -version"], ["\t@/tmp/f"], ["Main", "@/tmp/f"]]
+)
+def test_cmd0_and_argfile_are_rejected(cmd):
+    with pytest.raises((ValueError, internals.UntrustedJarError, OSError)):
+        internals.java(cmd, classpath=None)


### PR DESCRIPTION
This ports the remaining unmerged security regression tests from the
`fix-ghsa-8mgp-patch` branch onto `develop`. It is a test-only change: every
source guard these tests exercise is already merged on `develop` (each of
`nltk/pathsec.py`, `nltk/tokenize/repp.py`, `nltk/tokenize/punkt.py`,
`nltk/sentiment/sentiment_analyzer.py`, `nltk/parse/transitionparser.py`,
`nltk/parse/dependencygraph.py`, `nltk/parse/malt.py`, `nltk/tag/stanford.py`,
`nltk/tag/perceptron.py`, `nltk/tag/crf.py`, `nltk/chunk/named_entity.py`,
`nltk/stem/regexp.py`, `nltk/util.py`, `nltk/data.py`, `nltk/downloader.py`,
`nltk/internals.py` is byte-identical between `develop` and the branch), so no
source module was patched. The tests simply pin behaviour `develop` already
has.

## Source modules patched
None. All guards are already on `develop`; this change adds tests only.

## Guards these tests cover (already on develop)
- Path/model containment (CWE-22, CWE-59, CWE-377/378): `validate_model_resource`,
  `validate_tool_path`, and the pathsec open/write sandbox, exercised across the
  Stanford segmenter, Malt parser, Boxer, and every model-artifact save/load path
  (perceptron, maxent, crf, tbl, transitionparser, punkt).
- Java argument/classpath/environment injection (CWE-88, CWE-78): Stanford and
  Malt reject dangerous `-` options, untrusted/relative classpath entries, and
  JVM-injecting env vars before `Popen`.
- ReDoS on caller-supplied regexes (CWE-1333): `RegexpStemmer` and
  `nltk.util.re_show` route through `nltk.redos.compile`.
- Archive extraction (CWE-22 zip-slip, CWE-409 decompression bomb): symlink
  members are written as regular files, high entry counts and gzip bombs are
  refused.
- Corpus-reader fileid containment: reader fileids and symlinks cannot escape the
  data root.

## Test files added (net-new files)
- `test_pathsec_sweep_wrappers.py` — 75 tests (10 skip when no JVM/POSIX-only)
- `test_model_artifact_pathsec.py` — 77 tests
- `test_corpus_reader_traversal.py` — 6 tests
- `test_archive_extraction_hardening.py` — 5 tests
- `test_stanford_arg_injection.py` — 5 tests

## Net-new tests appended to files already on develop
Existing tests in these files are left untouched; only the listed tests are added.
- `test_pathsec.py` — +12 (hardened-write symlink/hardlink/absolute-escape,
  `file://` authorization bypass, averaged-perceptron save/load containment,
  staging under a data root)
- `test_package_resource_guard.py` — +4 (a caller-supplied root cannot widen past
  the data roots, including a lying/symlinked root)
- `test_redos_caller_patterns.py` — +2 (`test_ordinary_patterns_still_produce_the_right_answer`,
  `test_the_bounded_modules_route_through_redos`)
- `test_path_traversal_security.py` — +1 (`test_out_of_sandbox_save_location_is_refused`)

187 net-new test functions total.

## Deferred (not included)
- `test_file_io_guard_coverage.py` — a meta-test of the "no un-sandboxed open()"
  guard tooling. It asserts the guard scans the whole `nltk` package and that no
  source module creates temp files outside a data root. That belongs with the
  guard-tooling/source convergence work, not this test-only port, so it is left
  out here.
- The `RegexpTokenizer`/`RegexpTagger` cases of the branch's rewritten
  `test_a_catastrophic_pattern_does_not_hang` are dropped because that test name
  already exists on `develop` (in `test_stem_regexp_redos.py`); only the
  net-new, non-colliding redos tests are kept.

## Excluded as duplicates (whole files, zero net-new tests)
Every test in these branch files already exists on `develop`, so nothing was
brought over: `test_platform_detection.py`, `test_pathsec_sweep_chunk.py`,
`test_open_datafile.py`, `test_java_injection_exploit.py`,
`test_java_per_call_options_security.py`, `test_data_security.py`,
`test_downloader_atomic.py`, `test_downloader_unzip.py`.

## Verification
All added/modified test files pass on `develop` with a real JVM available
(`JAVA_HOME=/usr/local/opt/openjdk`); JVM- and POSIX-only tests skip when the
runtime is absent. `import nltk` and every exercised module import cleanly, and
pre-commit (black/isort/ruff/pyupgrade + the un-sandboxed-open guard) is green.
No test name added here collides with an existing test anywhere under
`nltk/test/`.
