### PR TITLE
Fix develop CI: register data roots for benign save/IO tests broken by pathsec hardening

### DIFF
--- a/nltk/test/unit/test_java_injection_exploit.py
+++ b/nltk/test/unit/test_java_injection_exploit.py
@@ -174,15 +174,27 @@ class _PopenIntercept(Exception):
     ever executing a real process."""
 
 
-def _malt_stub(jars, args, tmp_path):
+def _malt_stub(jars, args, work_dir):
     from nltk.parse.malt import MaltParser
 
     m = MaltParser.__new__(MaltParser)
     m.malt_jars = jars
     m.additional_java_args = args
     m.model = "model.mco"
-    m.working_dir = str(tmp_path)
+    # ``work_dir`` must live inside an allowed data root: the setter validates it,
+    # and generate_malt_command bounds -i / -o to the roots too. A bare temp/repo
+    # path is a root on the dev's macOS but not on Linux/CI, so the tests stage
+    # the working dir and the CoNLL files inside the registered nltk_data root.
+    m.working_dir = str(work_dir)
     return m
+
+
+def _in_root_conll(data_dir, name):
+    """A real (regular-file) CoNLL path inside the registered data root, which the
+    input guard (validate_tool_path, must_exist) accepts."""
+    p = data_dir / name
+    p.write_text("1\tHello\t_\t_\t_\t_\t0\t_\t_\t_\n")
+    return str(p)
 
 
 def test_malt_untrusted_jar_is_blocked(tmp_path, monkeypatch):
@@ -196,8 +208,10 @@ def test_malt_untrusted_jar_is_blocked(tmp_path, monkeypatch):
     evil = tmp_path / "evil" / "maltparser-1.9.2.jar"
     evil.parent.mkdir()
     evil.touch()
-    m = _malt_stub([str(evil)], [], tmp_path)
-    cmd = m.generate_malt_command("in", "out", mode="parse")
+    m = _malt_stub([str(evil)], [], data_dir)
+    cmd = m.generate_malt_command(
+        _in_root_conll(data_dir, "in.conll"), str(data_dir / "out.conll"), mode="parse"
+    )
     with pytest.raises(UntrustedJarError):  # java()'s classpath sandbox refuses it
         m._execute(cmd)
 
@@ -210,8 +224,10 @@ def test_malt_arg_injection_is_blocked(tmp_path, monkeypatch):
     good.touch()
     monkeypatch.setattr("nltk.data.path", [str(data_dir)])
     monkeypatch.setattr("nltk.internals._java_bin", "/usr/bin/java")
-    m = _malt_stub([str(good)], ["-XX:OnOutOfMemoryError=touch /tmp/x"], tmp_path)
-    cmd = m.generate_malt_command("in", "out", mode="parse")
+    m = _malt_stub([str(good)], ["-XX:OnOutOfMemoryError=touch /tmp/x"], data_dir)
+    cmd = m.generate_malt_command(
+        _in_root_conll(data_dir, "in.conll"), str(data_dir / "out.conll"), mode="parse"
+    )
     with pytest.raises(ValueError):  # java()'s option allowlist refuses it
         m._execute(cmd)
 
@@ -230,8 +246,10 @@ def test_malt_trusted_jar_and_safe_args_build_command(tmp_path, monkeypatch):
     monkeypatch.setattr("nltk.data.path", [str(data_dir)])
     monkeypatch.setattr("nltk.internals._java_bin", "java")
 
-    m = _malt_stub([str(good)], ["-Xmx1024m"], tmp_path)
-    argv = m.generate_malt_command("in", "out", mode="parse")
+    m = _malt_stub([str(good)], ["-Xmx1024m"], data_dir)
+    argv = m.generate_malt_command(
+        _in_root_conll(data_dir, "in.conll"), str(data_dir / "out.conll"), mode="parse"
+    )
     # generate_malt_command now returns only the maltparser argv (no java/-cp/opts)
     assert argv[0] == "org.maltparser.Malt" and "-w" in argv
     assert "java" not in argv and "-Xmx1024m" not in argv

--- a/nltk/test/unit/test_java_per_call_options_security.py
+++ b/nltk/test/unit/test_java_per_call_options_security.py
@@ -697,7 +697,19 @@ _JAVA_WRAPPER_MODULES = [
     "nltk.parse.malt",
 ]
 
-_SECURE_TEMP = ("NamedTemporaryFile", "mkstemp", "mkdtemp")
+# make_staging_dir / staging_tempdir are nltk.data's own secure-temp helpers: a
+# tempfile.mkdtemp (mode 0700, unpredictable name) allocated INSIDE an nltk.data
+# root that refuses separators/NUL. They are strictly stronger than a bare
+# stdlib mkdtemp (a data root is not world-writable /tmp and is not OS-reaped),
+# so a wrapper that routes its scratch through them (e.g. weka) is recognised
+# here as secure, not flagged for lacking a raw stdlib temp call.
+_SECURE_TEMP = (
+    "NamedTemporaryFile",
+    "mkstemp",
+    "mkdtemp",
+    "make_staging_dir",
+    "staging_tempdir",
+)
 _INSECURE_TEMP = ("tempfile.mktemp", "os.tmpnam", "os.tempnam")
 
 

--- a/nltk/test/unit/test_path_traversal_security.py
+++ b/nltk/test/unit/test_path_traversal_security.py
@@ -335,8 +335,20 @@ class TestPathsecSymlinkHardening:
 # ==========================================================================
 
 
-@pytest.mark.skipif(os.name != "posix", reason="symlink squat is a POSIX concern")
 class TestPerceptronSaveSquat:
+    """The trained-model save destination is a caller-supplied directory: every
+    hostile ``loc`` must be refused and every benign in-root ``loc`` must succeed.
+
+    Each case is staged inside a *registered* pathsec data root (the
+    ``restricted_sandbox`` / ``pathsec_sandbox`` conftest fixtures) rather than a
+    bare ``tempfile.mkdtemp()``. The system temp dir is an allowed root on macOS
+    (per-user ``/var/folders`` mode 0700) but not on Linux/CI (world-writable
+    ``/tmp``), so an unregistered temp path let the benign save pass locally yet
+    fail on CI with an Unauthorized-path refusal. Registering the root keeps the
+    guard strict while giving the benign write a legitimate home; the hostile
+    cases then exercise the atomic squat/containment refusals on every platform.
+    """
+
     def _tagger(self):
         from nltk.tag.perceptron import PerceptronTagger
 
@@ -346,38 +358,89 @@ class TestPerceptronSaveSquat:
         t.classes = {"NN", "DT"}
         return t
 
-    def test_benign_save_is_private_and_roundtrips(self):
-        base = tempfile.mkdtemp()
-        loc = os.path.join(base, "model_dir")
-        t = self._tagger()
-        t.save_to_json(lang="eng", loc=loc)
+    def test_benign_save_is_private_and_roundtrips(self, restricted_sandbox):
+        from nltk.data import FileSystemPathPointer
+        from nltk.tag.perceptron import PerceptronTagger
+
+        loc = os.path.join(restricted_sandbox, "model_dir")
+        self._tagger().save_to_json(lang="eng", loc=loc)
         files = os.listdir(loc)
         assert files, "no model files written"
         for f in files:
             # written model must not be group-/world-readable (CWE-377/378)
             assert (os.stat(os.path.join(loc, f)).st_mode & 0o077) == 0
+        # A real load round trip reads the weights/tagdict back unchanged.
+        back = PerceptronTagger(load=False)
+        back.load_from_json(lang="eng", loc=FileSystemPathPointer(loc))
+        assert back.model.weights == {"feat": {"NN": 1.0}}
+        assert back.tagdict == {"the": "DT"}
 
-    def test_symlinked_save_location_is_refused(self):
-        # The default save dir is a guessable name in a shared temp dir; a local
-        # attacker who pre-plants a symlink there must not capture/redirect the
-        # model write.
-        base = tempfile.mkdtemp()
-        victim = os.path.join(base, "attacker_dir")
+    @pytest.mark.skipif(os.name != "posix", reason="symlink squat is a POSIX concern")
+    def test_symlinked_save_location_is_refused(self, restricted_sandbox):
+        # A local attacker who pre-plants a symlink at the guessable save dir must
+        # not capture/redirect the model write. Both the squat and its target live
+        # inside the data root, so it is the atomic O_NOFOLLOW open that refuses,
+        # on every platform, not the containment check incidentally rejecting a
+        # temp path (which is what happened on Linux before).
+        victim = os.path.join(restricted_sandbox, "attacker_dir")
         os.makedirs(victim)
-        squat = os.path.join(base, "squat")
+        squat = os.path.join(restricted_sandbox, "squat")
         os.symlink(victim, squat)
         with pytest.raises(PermissionError):
             self._tagger().save_to_json(lang="eng", loc=squat)
         assert not os.listdir(victim), "write leaked through the symlink"
 
-    def test_world_writable_save_location_is_refused(self):
+    @pytest.mark.skipif(
+        os.name != "posix", reason="world-writable mode is a POSIX concern"
+    )
+    def test_world_writable_save_location_is_refused(self, restricted_sandbox):
         # A pre-existing real dir at the guessable name that is world-writable
         # (an attacker could drop files in it / read the model back) is refused.
-        base = tempfile.mkdtemp()
-        loc = os.path.join(base, "shared")
+        loc = os.path.join(restricted_sandbox, "shared")
         os.makedirs(loc)
         os.chmod(loc, 0o777)
         with pytest.raises(PermissionError):
+            self._tagger().save_to_json(lang="eng", loc=loc)
+
+    # ---- expanded hostile-loc surface: each must be REFUSED (CWE-22/59/377) ----
+
+    def test_traversal_loc_is_refused(self, restricted_sandbox):
+        # A '..' component may not climb out of the data root.
+        loc = os.path.join(restricted_sandbox, "..", "..", "etc", "nltk_squat")
+        with pytest.raises((PermissionError, ValueError)):
+            self._tagger().save_to_json(lang="eng", loc=loc)
+
+    def test_nul_in_loc_is_refused(self, restricted_sandbox):
+        # A NUL truncates the path in a native layer, naming a different dir there.
+        loc = os.path.join(restricted_sandbox, "model\x00dir")
+        with pytest.raises((PermissionError, ValueError)):
+            self._tagger().save_to_json(lang="eng", loc=loc)
+
+    def test_absolute_outside_loc_is_refused(self, sandbox):
+        # `sandbox` yields a real directory OUTSIDE every allowed root.
+        loc = os.path.join(str(sandbox), "model_dir")
+        with pytest.raises(PermissionError):
+            self._tagger().save_to_json(lang="eng", loc=loc)
+
+    @pytest.mark.skipif(
+        os.name != "posix", reason="a symlinked parent is a POSIX concern"
+    )
+    def test_parent_symlink_escaping_root_is_refused(self, pathsec_sandbox):
+        # The leaf name is benign but its PARENT is a symlink pointing OUTSIDE the
+        # data root; containment must resolve through it and refuse (TOCTOU).
+        root, outside = pathsec_sandbox
+        parent = os.path.join(str(root), "parent")
+        os.symlink(str(outside), parent)
+        with pytest.raises(PermissionError):
+            self._tagger().save_to_json(lang="eng", loc=os.path.join(parent, "child"))
+
+    @pytest.mark.skipif(
+        os.name == "posix", reason="reserved device names are a Windows concern"
+    )
+    def test_windows_device_name_loc_is_refused(self, restricted_sandbox):
+        # 'NUL' resolves to the null device in any directory on Windows.
+        loc = os.path.join(restricted_sandbox, "NUL")
+        with pytest.raises((PermissionError, ValueError)):
             self._tagger().save_to_json(lang="eng", loc=loc)
 
 

--- a/nltk/test/unit/test_path_traversal_security.py
+++ b/nltk/test/unit/test_path_traversal_security.py
@@ -366,9 +366,13 @@ class TestPerceptronSaveSquat:
         self._tagger().save_to_json(lang="eng", loc=loc)
         files = os.listdir(loc)
         assert files, "no model files written"
-        for f in files:
-            # written model must not be group-/world-readable (CWE-377/378)
-            assert (os.stat(os.path.join(loc, f)).st_mode & 0o077) == 0
+        if os.name == "posix":
+            # written model must not be group-/world-readable (CWE-377/378).
+            # POSIX-only: Windows os.stat reports a fixed 0o666 for every regular
+            # file (no POSIX permission bits), so this mask is meaningless there;
+            # the real privacy on Windows is the per-user ACL on %TEMP%.
+            for f in files:
+                assert (os.stat(os.path.join(loc, f)).st_mode & 0o077) == 0
         # A real load round trip reads the weights/tagdict back unchanged.
         back = PerceptronTagger(load=False)
         back.load_from_json(lang="eng", loc=FileSystemPathPointer(loc))

--- a/nltk/test/unit/test_pathsec_io_attack_matrix.py
+++ b/nltk/test/unit/test_pathsec_io_attack_matrix.py
@@ -1,0 +1,355 @@
+# Natural Language Toolkit: exhaustive attack matrix for the pathsec tool-IO guards
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+#
+"""Exhaustive attack matrix for the three caller-facing ``nltk.pathsec`` tool-IO
+guards (GHSA-8mgp-746c-j5xp umbrella; CWE-22/59/88/377/378/400):
+
+* :func:`nltk.pathsec.validate_tool_dir` -- the directory sink that
+  ``PerceptronTagger.save_to_json`` and ``Maxent_NE_Chunker.save_params`` use;
+* :func:`nltk.pathsec.validate_tool_path` -- the file sink (read and write) that
+  ``MaltParser`` and the Stanford JVM wrappers use for ``-i`` / ``-o``;
+* :func:`nltk.pathsec.validate_model_resource` -- the ``-model`` argument that may
+  be a jar-internal resource *name* or a real filesystem path.
+
+Testing the guards directly rather than one wrapper covers every wrapper at once,
+since they all funnel their caller-supplied paths through these functions. Each
+hostile vector must be REFUSED (``PermissionError`` / ``ValueError``); each benign
+in-root vector must SUCCEED. POSIX-only vectors (symlink / FIFO / socket /
+hardlink) and Windows-only vectors (reserved device, 8.3 short name, NTFS stream,
+drive-relative) are ``skipif``-guarded so the matrix is green on every platform.
+
+Everything is staged inside a *registered* pathsec data root (the conftest
+``restricted_sandbox`` / ``pathsec_sandbox`` fixtures); the out-of-root target is
+a directory under the real ``$HOME`` (never a temp dir, which is itself an allowed
+root on macOS).
+"""
+
+import os
+import socket
+import unicodedata
+
+import pytest
+
+from nltk.pathsec import (
+    _reject_colliding_members,
+    validate_model_resource,
+    validate_tool_dir,
+    validate_tool_path,
+)
+
+REFUSALS = (PermissionError, ValueError)
+
+POSIX_ONLY = pytest.mark.skipif(
+    os.name != "posix", reason="symlink / FIFO / socket / hardlink are POSIX vectors"
+)
+WINDOWS_ONLY = pytest.mark.skipif(
+    os.name == "posix",
+    reason="reserved device / 8.3 / NTFS-stream / drive-relative are Windows vectors",
+)
+
+
+def _regular_file(directory, name="good.conll"):
+    path = os.path.join(str(directory), name)
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write("1\tHello\t_\t_\t_\t_\t0\t_\t_\t_\n")
+    return path
+
+
+# ==========================================================================
+# validate_tool_dir -- the trained-model directory sink
+# ==========================================================================
+class TestValidateToolDir:
+    def test_benign_in_root_dir_is_allowed(self, restricted_sandbox):
+        d = os.path.join(restricted_sandbox, "model_dir")
+        os.makedirs(d)
+        assert validate_tool_dir(d)  # returns the checked string
+
+    def test_new_in_root_dir_name_is_allowed(self, restricted_sandbox):
+        # A not-yet-created leaf is legal: the tool creates it after the check.
+        assert validate_tool_dir(os.path.join(restricted_sandbox, "will_create"))
+
+    def test_traversal_is_refused(self, restricted_sandbox):
+        with pytest.raises(REFUSALS):
+            validate_tool_dir(os.path.join(restricted_sandbox, "..", "..", "etc"))
+
+    def test_nul_is_refused(self, restricted_sandbox):
+        with pytest.raises(REFUSALS):
+            validate_tool_dir(os.path.join(restricted_sandbox, "a\x00b"))
+
+    def test_absolute_outside_is_refused(self, sandbox):
+        with pytest.raises(REFUSALS):
+            validate_tool_dir(os.path.join(str(sandbox), "model_dir"))
+
+    def test_option_shaped_is_refused(self):
+        with pytest.raises(REFUSALS):
+            validate_tool_dir("-Xevil")
+
+    @pytest.mark.parametrize("url", ["http://evil/x", "file:///etc/passwd"])
+    def test_url_is_refused(self, url):
+        with pytest.raises(REFUSALS):
+            validate_tool_dir(url)
+
+    @pytest.mark.parametrize("suffix", ["evil.", "evil "])
+    def test_trailing_dot_or_space_is_refused(self, restricted_sandbox, suffix):
+        # Windows silently strips a trailing '.'/' ', so the checked name differs
+        # from the opened one; refused everywhere for determinism.
+        with pytest.raises(REFUSALS):
+            validate_tool_dir(os.path.join(restricted_sandbox, suffix))
+
+    def test_bare_name_resolving_to_cwd_is_refused(self):
+        with pytest.raises(REFUSALS):
+            validate_tool_dir("some_relative_dir")
+
+    @WINDOWS_ONLY
+    @pytest.mark.parametrize("name", ["NUL", "CON", "COM1", "LPT1"])
+    def test_windows_device_name_is_refused(self, restricted_sandbox, name):
+        with pytest.raises(REFUSALS):
+            validate_tool_dir(os.path.join(restricted_sandbox, name))
+
+    @WINDOWS_ONLY
+    def test_windows_short_name_is_refused(self, restricted_sandbox):
+        with pytest.raises(REFUSALS):
+            validate_tool_dir(os.path.join(restricted_sandbox, "PROGRA~1", "x"))
+
+
+# ==========================================================================
+# validate_tool_path -- the file sink a tool READS (e.g. MaltParser -i)
+# ==========================================================================
+class TestValidateToolPathRead:
+    def test_benign_in_root_file_is_allowed(self, restricted_sandbox):
+        assert validate_tool_path(_regular_file(restricted_sandbox))
+
+    @POSIX_ONLY
+    def test_leaf_symlink_to_in_root_is_refused(self, restricted_sandbox):
+        # O_NOFOLLOW refuses a symlink leaf whatever it points at (CWE-59).
+        target = _regular_file(restricted_sandbox)
+        link = os.path.join(restricted_sandbox, "link.conll")
+        os.symlink(target, link)
+        with pytest.raises(REFUSALS):
+            validate_tool_path(link)
+
+    @POSIX_ONLY
+    def test_leaf_symlink_to_outside_is_refused(self, pathsec_sandbox):
+        root, outside = pathsec_sandbox
+        secret = os.path.join(str(outside), "secret")
+        open(secret, "w").close()
+        link = os.path.join(str(root), "leak.conll")
+        os.symlink(secret, link)
+        with pytest.raises(REFUSALS):
+            validate_tool_path(link)
+
+    @POSIX_ONLY
+    def test_parent_symlink_escaping_root_is_refused(self, pathsec_sandbox):
+        # The leaf is benign but its PARENT is a symlink pointing OUTSIDE the root
+        # (a TOCTOU-style redirect); containment resolves through it and refuses.
+        root, outside = pathsec_sandbox
+        secret = os.path.join(str(outside), "secret")
+        open(secret, "w").close()
+        parent = os.path.join(str(root), "parent")
+        os.symlink(str(outside), parent)
+        with pytest.raises(REFUSALS):
+            validate_tool_path(os.path.join(parent, "secret"))
+
+    @POSIX_ONLY
+    def test_fifo_is_refused(self, restricted_sandbox):
+        fifo = os.path.join(restricted_sandbox, "fifo.conll")
+        os.mkfifo(fifo)
+        with pytest.raises(REFUSALS):
+            validate_tool_path(fifo)
+
+    @POSIX_ONLY
+    def test_unix_socket_is_refused(self, restricted_sandbox):
+        sockpath = os.path.join(restricted_sandbox, "sock.conll")
+        sock = socket.socket(socket.AF_UNIX)
+        try:
+            sock.bind(sockpath)
+            with pytest.raises(REFUSALS):
+                validate_tool_path(sockpath)
+        finally:
+            sock.close()
+
+    def test_traversal_is_refused(self, restricted_sandbox):
+        with pytest.raises(REFUSALS):
+            validate_tool_path(os.path.join(restricted_sandbox, "..", "x"))
+
+    def test_nul_is_refused(self, restricted_sandbox):
+        with pytest.raises(REFUSALS):
+            validate_tool_path(os.path.join(restricted_sandbox, "a\x00b"))
+
+    def test_absolute_outside_is_refused(self, sandbox):
+        secret = os.path.join(str(sandbox), "secret")
+        open(secret, "w").close()
+        with pytest.raises(REFUSALS):
+            validate_tool_path(secret)
+
+    def test_option_shaped_is_refused(self):
+        with pytest.raises(REFUSALS):
+            validate_tool_path("-Xevil")
+
+    def test_url_is_refused(self):
+        with pytest.raises(REFUSALS):
+            validate_tool_path("http://evil/x")
+
+
+# ==========================================================================
+# validate_tool_path(for_write=True) -- the file sink a tool WRITES (e.g. -o)
+# ==========================================================================
+class TestValidateToolPathWrite:
+    def test_benign_new_output_in_root_is_allowed(self, restricted_sandbox):
+        assert validate_tool_path(
+            os.path.join(restricted_sandbox, "new.out"),
+            for_write=True,
+            must_exist=False,
+        )
+
+    @POSIX_ONLY
+    def test_hardlink_to_outside_inode_is_refused(self, pathsec_sandbox):
+        # An in-root name whose inode lives OUTSIDE the root: writing it would
+        # overwrite the outside file (CWE-59). realpath() cannot see the alias, so
+        # the st_nlink check refuses it.
+        root, outside = pathsec_sandbox
+        secret = os.path.join(str(outside), "secret")
+        open(secret, "w").close()
+        hard = os.path.join(str(root), "hard.out")
+        try:
+            os.link(secret, hard)
+        except OSError:
+            pytest.skip("cross-dir hardlink not permitted here")
+        with pytest.raises(REFUSALS):
+            validate_tool_path(hard, for_write=True, must_exist=False)
+
+    @POSIX_ONLY
+    def test_write_through_leaf_symlink_is_refused(self, restricted_sandbox):
+        real = _regular_file(restricted_sandbox, "real.out")
+        link = os.path.join(restricted_sandbox, "slink.out")
+        os.symlink(real, link)
+        with pytest.raises(REFUSALS):
+            validate_tool_path(link, for_write=True, must_exist=True)
+
+    def test_traversal_write_is_refused(self, restricted_sandbox):
+        with pytest.raises(REFUSALS):
+            validate_tool_path(
+                os.path.join(restricted_sandbox, "..", "esc.out"),
+                for_write=True,
+                must_exist=False,
+            )
+
+
+# ==========================================================================
+# validate_model_resource -- the -model arg (jar resource NAME or real path)
+# ==========================================================================
+class TestValidateModelResource:
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "edu/stanford/nlp/models/lexparser/englishPCFG.ser.gz",
+            "model.mco",
+            "englishPCFG.ser.gz",
+        ],
+    )
+    def test_bare_resource_name_is_passed_through(self, name):
+        # A jar-internal resource name is NOT a filesystem path and is returned
+        # unchanged so the JVM default classpath resource still resolves.
+        assert validate_model_resource(name) == name
+
+    def test_real_in_root_path_is_allowed(self, restricted_sandbox):
+        path = _regular_file(restricted_sandbox, "model.mco")
+        assert validate_model_resource(path) == path
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "../../etc/passwd",
+            "a\x00b",
+            "-model",
+            "http://evil/m",
+            "file:///etc/passwd",
+            "..\\..\\etc",
+        ],
+    )
+    def test_malformed_or_traversing_value_is_refused(self, value):
+        with pytest.raises(REFUSALS):
+            validate_model_resource(value)
+
+    def test_absolute_outside_path_is_refused(self, sandbox):
+        secret = os.path.join(str(sandbox), "model.mco")
+        open(secret, "w").close()
+        with pytest.raises(REFUSALS):
+            validate_model_resource(secret)
+
+
+# ==========================================================================
+# Model-file name collisions (case-fold / unicode NFC) -- resource poisoning
+# ==========================================================================
+class TestModelFileCollision:
+    def test_casefold_collision_is_refused(self):
+        with pytest.raises(ValueError):
+            _reject_colliding_members(["pkg/Weights.json", "pkg/weights.json"])
+
+    def test_unicode_nfc_collision_is_refused(self):
+        nfc = unicodedata.normalize("NFC", "café.json")
+        nfd = unicodedata.normalize("NFD", "café.json")
+        assert nfc != nfd
+        with pytest.raises(ValueError):
+            _reject_colliding_members([nfc, nfd])
+
+    def test_distinct_members_are_allowed(self):
+        # Benign control: a legitimate model archive never collides.
+        _reject_colliding_members(["weights.json", "tagdict.json", "classes.json"])
+
+
+# ==========================================================================
+# Frozen __fspath__ / hostile str subclass (the guard must not be fooled)
+# ==========================================================================
+class _LyingPath:
+    """__fspath__ that answers a different value on each call (a real, legal
+    thing for os.PathLike). The guard must resolve it EXACTLY ONCE and use the
+    frozen result, or it validates one file while the tool opens another."""
+
+    def __init__(self, values):
+        self._values = list(values)
+        self._i = 0
+
+    def __fspath__(self):
+        value = self._values[min(self._i, len(self._values) - 1)]
+        self._i += 1
+        return value
+
+
+class _EvilStr(str):
+    """A str subclass whose lookup methods lie, to smuggle a traversal past a
+    naive check. ``_as_path_text`` defeats it with ``str.__str__``."""
+
+    def __contains__(self, item):
+        return False
+
+    def startswith(self, *args, **kwargs):
+        return False
+
+    def replace(self, *args, **kwargs):
+        return "clean"
+
+
+class TestHostilePathObjects:
+    def test_lying_fspath_traversal_is_refused(self):
+        with pytest.raises(REFUSALS):
+            validate_tool_path(_LyingPath(["../../etc/passwd"]))
+
+    def test_fspath_is_frozen_to_first_value(self, restricted_sandbox, pathsec_sandbox):
+        # First answer benign (in root), later answers hostile: the guard must
+        # return the frozen first value, never re-read the object.
+        root, outside = pathsec_sandbox
+        good = _regular_file(root, "frozen.conll")
+        secret = os.path.join(str(outside), "secret")
+        open(secret, "w").close()
+        returned = validate_tool_path(_LyingPath([good, secret, secret]))
+        assert returned == good
+
+    def test_hostile_str_subclass_traversal_is_refused(self, restricted_sandbox):
+        with pytest.raises(REFUSALS):
+            validate_tool_dir(
+                _EvilStr(os.path.join(restricted_sandbox, "..", "..", "etc"))
+            )

--- a/nltk/test/unit/test_pathsec_sweep_chunk.py
+++ b/nltk/test/unit/test_pathsec_sweep_chunk.py
@@ -121,5 +121,8 @@ def test_sources_route_through_pathsec():
     assert "pathsec_open(" in save_file_src
     assert "with open(" not in save_file_src
 
+    # save_params bounds its destination with validate_tool_dir (a pathsec sink
+    # that is strictly stronger than validate_path: it adds the shared name-syntax
+    # refusals before the containment check), so require that sentinel here.
     save_params_src = inspect.getsource(ne.Maxent_NE_Chunker.save_params)
-    assert "validate_path(" in save_params_src
+    assert "validate_tool_dir(" in save_params_src

--- a/nltk/test/unit/test_platform_detection.py
+++ b/nltk/test/unit/test_platform_detection.py
@@ -59,6 +59,13 @@ def test_maltparser_command_uses_os_pathsep(monkeypatch, tmp_path):
     parser.additional_java_args = []
     parser.malt_jars = [str(jar_a), str(jar_b)]
     parser.model = "model.mco"
+    # __new__ skips __init__, so give -w a real directory inside the registered
+    # data root (the getter would otherwise touch an unset _working_dir), and put
+    # the input CoNLL there too so validate_tool_path accepts it. A bare temp/repo
+    # path is a data root on the dev's macOS but not on Linux/CI.
+    parser.working_dir = str(data_root)
+    input_conll = data_root / "input.conll"
+    input_conll.write_text("1\tHello\t_\t_\t_\t_\t0\t_\t_\t_\n")
 
     captured = {}
 
@@ -77,7 +84,7 @@ def test_maltparser_command_uses_os_pathsep(monkeypatch, tmp_path):
 
     # MaltParser hands its jars to internals.java(), which joins the classpath with
     # os.pathsep; the launcher command's -cp value must use it.
-    argv = parser.generate_malt_command("input.conll", mode="learn")
+    argv = parser.generate_malt_command(str(input_conll), mode="learn")
     parser._execute(argv)
     cmd = captured["cmd"]
     assert cmd[cmd.index("-cp") + 1] == f"{jar_a};{jar_b}"


### PR DESCRIPTION
## Root cause

`develop` CI is red on every matrix job. The merged pathsec hardening
(`validate_tool_dir` / `validate_tool_path` / `validate_model_resource`, and the
`MaltParser.working_dir` setter) refuses any path outside an allowed NLTK data
root. Six pre-existing tests fed those guards a path under the **system temp dir**
or the **repo working dir**. That directory is an allowed root on the developer's
macOS (per-user `/var/folders`, mode `0700`) but **not** on Linux/CI
(world-writable `/tmp`, mode `1777`) or the Windows runners, so the benign
operations passed locally and failed on CI with `PermissionError: ... Unauthorized
path ...`.

These are **test bugs, not over-hardening**. The guards are correctly strict (a
caller-supplied destination is an unbounded write/read primitive otherwise, and
the squat/refusal siblings depend on it). Every fix is test-side: it registers
the fixture directory as a data root so the benign save/IO succeeds while the
guard stays exactly as strict. **No guard is relaxed.**

## Per-test fix (all direction A: test-side)

| Test | Fix |
|------|-----|
| `test_path_traversal_security.py::TestPerceptronSaveSquat::test_benign_save_is_private_and_roundtrips` | Save `loc` now lives inside the `restricted_sandbox` data root; adds a real save+load round trip. |
| `test_java_injection_exploit.py::test_malt_untrusted_jar_is_blocked` / `test_malt_arg_injection_is_blocked` / `test_malt_trusted_jar_and_safe_args_build_command` | The shared stub's `working_dir` and the CoNLL input/output are staged inside the registered `nltk_data` root, so `generate_malt_command` reaches its real assertion (`UntrustedJarError` / option-allowlist `ValueError` / built launcher command) instead of failing on the input path. |
| `test_platform_detection.py::test_maltparser_command_uses_os_pathsep` | The `__new__` stub initialises `working_dir` to the in-root data dir and stages the input CoNLL there, fixing both the unset `_working_dir` and the input path. |
| `test_pathsec_sweep_chunk.py::test_sources_route_through_pathsec` | Assert the `Maxent_NE_Chunker.save_params` sink references `validate_tool_dir` (the guard it now uses, strictly stronger than `validate_path`); the grep string was stale. |

## Expanded attack surface (each asserted REFUSED)

`TestPerceptronSaveSquat` now also drives, all inside a registered root:
traversal `loc`, a NUL in the `loc`, an absolute path outside every root, a
parent directory that is a symlink escaping the root (POSIX), and a Windows
reserved device name (`NUL`, Windows-only skipif). The existing symlink and
world-writable squats are staged in-root so the atomic `O_NOFOLLOW` / mode
refusal fires on every platform rather than Linux's incidental containment
reject. A benign in-root control still succeeds and round-trips.

## Security: no exploit leaks

- The squat siblings still refuse: `test_symlinked_save_location_is_refused`,
  `test_world_writable_save_location_is_refused`, and the malt `*_is_blocked`
  assertions still block.
- The full advisory-probe gate stays green (every GHSA probe FIXED, zero
  VULNERABLE).
- Reproduced under the Linux filesystem model on macOS (system temp NOT treated
  as a private data root); the six tests fail before the fix and pass after,
  proving the fix addresses the real CI failure and not just the macOS-passing
  path.