### PR TITLE
Add redos.source_of/reharden and picklesec.harden_object_graph

### DIFF
--- a/nltk/picklesec.py
+++ b/nltk/picklesec.py
@@ -580,3 +580,38 @@ def allowlisted_pickle_load(
     return AllowlistUnpickler(
         file, allowed_globals=allowed_globals, allowed_modules=allowed_modules
     ).load()
+
+
+def harden_object_graph(root: Any, visit: Any, *, max_nodes: int = 5_000_000) -> Any:
+    """Walk a reconstructed graph so ``visit`` can neutralise hostile STATE an
+    allowlisting unpickler does not gate (BUILD / ``__setstate__`` / REDUCE). The
+    walk is iterative, cycle-safe and capped at ``max_nodes`` (else UnpicklingError).
+    """
+    stack = [root]
+    seen = set()
+    visited = 0
+    while stack:
+        obj = stack.pop()
+        oid = id(obj)
+        if oid in seen:
+            continue
+        seen.add(oid)
+        visited += 1
+        if visited > max_nodes:
+            raise pickle.UnpicklingError(
+                "reconstructed object graph exceeds the safety bound; refusing"
+            )
+        # visit returns truthy to claim the node fully and stop descending it.
+        if visit(obj):
+            continue
+        if isinstance(obj, dict):
+            stack.extend(obj.keys())
+            stack.extend(obj.values())
+            continue
+        if isinstance(obj, (list, tuple, set, frozenset)):
+            stack.extend(obj)
+            continue
+        state = getattr(obj, "__dict__", None)
+        if isinstance(state, dict):
+            stack.extend(state.values())
+    return root

--- a/nltk/redos.py
+++ b/nltk/redos.py
@@ -56,7 +56,7 @@ so it is a drop-in replacement for a compiled pattern at those call sites.
 
 import regex
 
-__all__ = ["DEFAULT_TIMEOUT", "TimedPattern", "compile"]
+__all__ = ["DEFAULT_TIMEOUT", "TimedPattern", "compile", "source_of", "reharden"]
 
 #: Wall-clock seconds any single caller-supplied-pattern match may run before it
 #: is abandoned with :class:`TimeoutError`. Legitimate tokenizing / tagging /
@@ -221,3 +221,27 @@ def compile(pattern, flags=0, timeout=_UNSET):
     src = getattr(pattern, "pattern", pattern)
     compiled = regex.compile(src, flags)
     return TimedPattern(compiled, timeout)
+
+
+def source_of(pattern):
+    """The trusted source string of a ``str`` / compiled ``re`` / ``regex`` /
+    :class:`TimedPattern`. Raises :class:`ValueError` for a pattern object that
+    exposes no string source, so an unbounded one cannot be rebuilt from it."""
+    if isinstance(pattern, str):
+        return pattern
+    src = getattr(pattern, "pattern", None)
+    if isinstance(src, (bytes, bytearray)):
+        src = bytes(src).decode("latin-1")
+    if isinstance(src, str):
+        return src
+    raise ValueError(
+        "regex pattern object exposes no string source; refusing to rebuild an "
+        "unbounded pattern from it"
+    )
+
+
+def reharden(pattern, flags=0):
+    """Re-derive a fresh, wall-clock-capped :class:`TimedPattern` from ``pattern``'s
+    SOURCE, discarding any existing wrapper. Unlike :func:`compile`, an incoming
+    ``TimedPattern`` is never returned as-is, so a disabled cap cannot survive."""
+    return compile(source_of(pattern), flags)

--- a/nltk/test/unit/test_picklesec_harden_graph.py
+++ b/nltk/test/unit/test_picklesec_harden_graph.py
@@ -1,0 +1,95 @@
+# Natural Language Toolkit: tests for picklesec.harden_object_graph
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""The bounded, cycle-safe post-unpickle state walk.
+An allowlist gates WHICH classes are built, not the STATE they are handed; this
+walk lets a visitor neutralise that state without recursing, looping or unbounded."""
+
+import pickle
+
+import pytest
+
+from nltk.picklesec import harden_object_graph
+
+
+class Node:
+    def __init__(self, **kw):
+        self.__dict__.update(kw)
+
+
+def _collector(seen):
+    def visit(obj):
+        seen.append(obj)
+        return False
+
+    return visit
+
+
+def test_returns_the_root_unchanged():
+    root = Node()
+    assert harden_object_graph(root, lambda o: False) is root
+
+
+def test_visits_nested_object_attributes():
+    seen = []
+    a = Node(x=1)
+    a.child = Node(y=2)
+    harden_object_graph(a, _collector(seen))
+    assert a in seen and a.child in seen and 1 in seen and 2 in seen
+
+
+def test_descends_dict_keys_and_values():
+    seen = []
+    harden_object_graph({"k": "v"}, _collector(seen))
+    assert "k" in seen and "v" in seen
+
+
+@pytest.mark.parametrize("container", [[1, 2], (1, 2), {1, 2}, frozenset({1, 2})])
+def test_descends_every_sequence_kind(container):
+    seen = []
+    harden_object_graph(container, _collector(seen))
+    assert 1 in seen and 2 in seen
+
+
+def test_cycle_terminates_and_visits_each_node_once():
+    a, b = Node(), Node()
+    a.b = b
+    b.a = a  # cycle
+    seen = []
+    harden_object_graph(a, _collector(seen))
+    assert seen.count(a) == 1 and seen.count(b) == 1
+
+
+def test_truthy_visit_stops_descent_into_that_node():
+    inner = Node(secret="unreached")
+    root = Node(inner=inner)
+    seen = []
+
+    def visit(obj):
+        seen.append(obj)
+        return obj is root  # claim root, do not descend into inner
+
+    harden_object_graph(root, visit)
+    assert root in seen and inner not in seen
+
+
+def test_node_cap_raises_unpickling_error():
+    root = [Node() for _ in range(10)]
+    with pytest.raises(pickle.UnpicklingError):
+        harden_object_graph(root, lambda o: False, max_nodes=3)
+
+
+def test_visitor_neutralises_state_on_every_matching_node():
+    leaves = [Node(timeout=None) for _ in range(5)]
+    root = Node(children=leaves)
+
+    def visit(obj):
+        if isinstance(obj, Node) and getattr(obj, "timeout", "keep") is None:
+            obj.timeout = "CAPPED"
+        return False
+
+    harden_object_graph(root, visit)
+    assert all(leaf.timeout == "CAPPED" for leaf in leaves)

--- a/nltk/test/unit/test_redos_rehardening.py
+++ b/nltk/test/unit/test_redos_rehardening.py
@@ -1,0 +1,79 @@
+# Natural Language Toolkit: tests for redos.source_of / redos.reharden
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""Re-deriving a trusted, capped pattern from an untrusted reconstructed one.
+``source_of`` extracts only the source string; ``reharden`` recompiles it under
+a fresh wall-clock cap, so a disabled/absent cap on the input cannot survive."""
+
+import re
+
+import pytest
+import regex
+
+from nltk import redos
+from nltk.redos import _UNSET, TimedPattern
+
+CATASTROPHIC = r"(a|a)*$"
+
+
+def test_source_of_string_is_itself():
+    assert redos.source_of("a+b*") == "a+b*"
+
+
+def test_source_of_compiled_regex():
+    assert redos.source_of(regex.compile("[0-9]+")) == "[0-9]+"
+
+
+def test_source_of_stdlib_re():
+    assert redos.source_of(re.compile("x?y")) == "x?y"
+
+
+def test_source_of_timedpattern_even_with_cap_disabled():
+    tp = TimedPattern(regex.compile(CATASTROPHIC), timeout=None)
+    assert redos.source_of(tp) == CATASTROPHIC
+
+
+def test_source_of_bytes_pattern_is_decoded():
+    assert redos.source_of(regex.compile(b"ab+")) == "ab+"
+
+
+def test_source_of_sourceless_raises():
+    with pytest.raises(ValueError):
+        redos.source_of(object())
+
+
+def test_reharden_string_is_capped():
+    tp = redos.reharden("a+")
+    assert isinstance(tp, TimedPattern)
+    assert tp._timeout is _UNSET  # -> DEFAULT_TIMEOUT applies at match time
+
+
+def test_reharden_discards_a_disabled_cap():
+    hostile = TimedPattern(regex.compile(CATASTROPHIC), timeout=None)
+    fresh = redos.reharden(hostile)
+    assert isinstance(fresh, TimedPattern)
+    assert fresh is not hostile
+    assert fresh._timeout is _UNSET  # the disabled cap did NOT survive
+
+
+def test_compile_returns_disabled_cap_as_is_but_reharden_does_not():
+    """The exact reason reharden exists: compile short-circuits on a TimedPattern
+    and hands the uncapped wrapper straight back; reharden rebuilds from source."""
+    hostile = TimedPattern(regex.compile(CATASTROPHIC), timeout=None)
+    assert redos.compile(hostile) is hostile
+    assert redos.compile(hostile)._timeout is None  # cap still disabled
+    assert redos.reharden(hostile)._timeout is _UNSET  # cap restored
+
+
+def test_reharden_preserves_matching_behaviour():
+    tp = redos.reharden(regex.compile("[0-9]+"))
+    assert tp.match("123") is not None
+    assert tp.match("abc") is None
+
+
+def test_reharden_sourceless_raises():
+    with pytest.raises(ValueError):
+        redos.reharden(object())


### PR DESCRIPTION
Two small, reusable primitives for hardening objects rebuilt by an allowlisting unpickler. An allowlist (e.g. `picklesec.AllowlistUnpickler`) gates *which* classes a pickle may build, but not the *state* those classes are handed via `BUILD` / `__setstate__` / `REDUCE`, so an attacker using only allowlisted names can still steer a reconstructed object into hostile territory (an uncapped regex, a disabled timeout, an oversized graph).

### `nltk/redos.py`
- **`source_of(pattern)`** — returns only the trusted *source string* of a `str` / compiled `re` / `regex` / `TimedPattern`, or raises `ValueError` if the object exposes no string source.
- **`reharden(pattern, flags=0)`** — recompiles that source under a fresh wall-clock cap. Unlike `compile()`, which short-circuits and returns an incoming `TimedPattern` **as-is**, `reharden` rebuilds from source, so a `TimedPattern` whose `_timeout` was set to `None` (cap disabled) cannot survive.

### `nltk/picklesec.py`
- **`harden_object_graph(root, visit, *, max_nodes=5_000_000)`** — a bounded, cycle-safe, iterative walk over a reconstructed graph (dict keys/values, list/tuple/set/frozenset, `__dict__`). It calls `visit(obj)` once per unique node so a caller can neutralise hostile state; `visit` returns truthy to stop descending a node. The walk uses no native recursion, a visited-set for cycles, and a node cap (raising `pickle.UnpicklingError`) so it cannot become the DoS it prevents.

### Why
These were factored out of the `nltk.tbl.demo` model-loading hardening so `tbl` and the other allowlist-unpickler callers can share one implementation instead of each re-deriving the walk and the regex re-capping. No existing call site is changed in this PR; it only adds the primitives and their tests.

### Tests
- `test_redos_rehardening.py` — source extraction from str/compiled/`TimedPattern`/bytes, `ValueError` on a sourceless object, and that `reharden` discards a disabled cap while `compile` returns it as-is.
- `test_picklesec_harden_graph.py` — visits nested attributes, descends every container kind, terminates on cycles (each node once), honours the truthy stop-descent signal, enforces the node cap, and lets a visitor mutate state across the whole graph.