### PR TITLE
Bound algorithmic-complexity (time) DoS in stemmers, metrics, parsers (CWE-407 / CWE-770)

### DIFF
--- a/nltk/ccg/chart.py
+++ b/nltk/ccg/chart.py
@@ -31,6 +31,7 @@ python chart.py
 """
 
 import itertools
+import time
 
 from nltk.ccg.combinator import *
 from nltk.ccg.combinator import (
@@ -48,6 +49,7 @@ from nltk.ccg.lexicon import Token, fromstring
 from nltk.ccg.logic import *
 from nltk.parse import ParserI
 from nltk.parse.chart import (
+    DEFAULT_MAX_TIME,
     MAX_PARSE_TREES,
     AbstractChartRule,
     Chart,
@@ -270,10 +272,15 @@ class CCGChartParser(ParserI):
     Based largely on the ChartParser class from NLTK.
     """
 
-    def __init__(self, lexicon, rules, trace=0):
+    def __init__(self, lexicon, rules, trace=0, max_time=DEFAULT_MAX_TIME):
         self._lexicon = lexicon
         self._rules = rules
         self._trace = trace
+        #: Wall-clock limit for a single ``parse``. CCG recognition terminates
+        #: (finite category space) but an ordinary composable lexicon plus a few
+        #: dozen tokens is ~O(n**4), pinning a core for seconds (CWE-407).
+        #: ``max_time=None`` disables the bound.
+        self._max_time = max_time
 
     def lexicon(self):
         return self._lexicon
@@ -284,6 +291,10 @@ class CCGChartParser(ParserI):
         chart = CCGChart(list(tokens))
         lex = self._lexicon
 
+        deadline = (
+            None if self._max_time is None else time.perf_counter() + self._max_time
+        )
+
         # Initialize leaf edges.
         for index in range(chart.num_leaves()):
             for token in lex.categories(chart.leaf(index)):
@@ -293,6 +304,12 @@ class CCGChartParser(ParserI):
         # Select a span for the new edges
         for span in range(2, chart.num_leaves() + 1):
             for start in range(0, chart.num_leaves() - span + 1):
+                if deadline is not None and time.perf_counter() > deadline:
+                    raise TimeoutError(
+                        f"CCGChartParser exceeded its {self._max_time}s time "
+                        "limit; the lexicon may be too composable for this many "
+                        "tokens. Pass max_time=None to disable the limit."
+                    )
                 # Try all possible pairs of edges that could generate
                 # an edge for that span
                 for part in range(1, span):

--- a/nltk/metrics/agreement.py
+++ b/nltk/metrics/agreement.py
@@ -81,6 +81,14 @@ from nltk.probability import ConditionalFreqDist, FreqDist
 
 log = logging.getLogger(__name__)
 
+#: Most distinct labels an ``AnnotationTask`` accepts. ``Disagreement``/``alpha``/
+#: ``weighted_kappa`` run a double loop over the distinct label set K, so a
+#: task with one unique label per item is O(|K|**2) (CWE-407); |K| is
+#: attacker-controlled. A real study has a tiny fixed label set, so this is a
+#: distinct-count bound (like ``NgramCounter.MAX_NGRAMS``), not a data-length
+#: cap -- large low-cardinality data stays linear.
+MAX_AGREEMENT_LABELS = 10_000
+
 
 class AnnotationTask:
     """Represents an annotation task, i.e. people assign labels to items.
@@ -153,6 +161,12 @@ class AnnotationTask:
             self.K.add(labels)
             self.I.add(item)
             self.data.append({"coder": coder, "labels": labels, "item": item})
+        if len(self.K) > MAX_AGREEMENT_LABELS:
+            raise ValueError(
+                f"AnnotationTask has more than {MAX_AGREEMENT_LABELS} distinct "
+                "labels: agreement coefficients are quadratic in the label set "
+                "(CWE-407). A real study has a small fixed label set."
+            )
 
     def agr(self, cA, cB, i, data=None):
         """Agreement between two coders on a given item"""

--- a/nltk/metrics/confusionmatrix.py
+++ b/nltk/metrics/confusionmatrix.py
@@ -71,15 +71,23 @@ class ConfusionMatrix:
         # so caching them keeps that lookup O(1); recomputing a total by
         # scanning the sparse map on each call would make the sort O(V * nnz),
         # i.e. quadratic again for a large all-distinct input.
+        # Column totals (count per test index) are accumulated alongside the row
+        # totals so ``precision`` -- a full-column sum -- is O(1) instead of an
+        # O(V) scan; ``evaluate`` calls it once per label, so the scan made the
+        # report O(V**2) on an all-distinct matrix even though the constructor
+        # itself is O(n) (CWE-770; residual to CVE-2026-12839).
         confusion = {}
         row_totals = {}
+        col_totals = {}
         max_conf = 0  # Maximum confusion
         for w, g in zip(reference, test):
             i = indices[w]
-            pair = (i, indices[g])
+            j = indices[g]
+            pair = (i, j)
             count = confusion.get(pair, 0) + 1
             confusion[pair] = count
             row_totals[i] = row_totals.get(i, 0) + 1
+            col_totals[j] = col_totals.get(j, 0) + 1
             if count > max_conf:
                 max_conf = count
 
@@ -93,6 +101,9 @@ class ConfusionMatrix:
         #: Cached per-reference-row totals, keyed by reference index, so
         #: ``sort_by_count`` lookups are O(1) (see ``_row_total``).
         self._row_totals = row_totals
+        #: Cached per-test-column totals, keyed by test index, so ``precision``
+        #: is O(1) (see ``_col_total``).
+        self._col_totals = col_totals
         #: The greatest count in ``self._confusion`` (used for printing).
         self._max_conf = max_conf
         #: The total number of values in the confusion matrix.
@@ -109,6 +120,13 @@ class ConfusionMatrix:
         all-distinct input).
         """
         return self._row_totals.get(i, 0)
+
+    def _col_total(self, j):
+        """Total count in column ``j`` (predictions of test value ``j``).
+
+        Cached like ``_row_total`` so ``precision`` is O(1) (see __init__).
+        """
+        return self._col_totals.get(j, 0)
 
     def __getitem__(self, li_lj_tuple):
         """
@@ -245,8 +263,9 @@ class ConfusionMatrix:
         """
         # Number of times `value` was correct, and also predicted
         TP = self[value, value]
-        # Number of times `value` was correct
-        TP_FN = sum(self[value, pred_value] for pred_value in self._values)
+        # Number of times `value` was correct == total of value's row (cached
+        # O(1); the per-label scan made evaluate() O(V**2), see __init__).
+        TP_FN = self._row_total(self._indices[value])
         if TP_FN == 0:
             return 0.0
         return TP / TP_FN
@@ -267,8 +286,9 @@ class ConfusionMatrix:
         """
         # Number of times `value` was correct, and also predicted
         TP = self[value, value]
-        # Number of times `value` was predicted
-        TP_FP = sum(self[real_value, value] for real_value in self._values)
+        # Number of times `value` was predicted == total of value's column
+        # (cached O(1); the per-label scan made evaluate() O(V**2), see __init__).
+        TP_FP = self._col_total(self._indices[value])
         if TP_FP == 0:
             return 0.0
         return TP / TP_FP

--- a/nltk/metrics/paice.py
+++ b/nltk/metrics/paice.py
@@ -20,6 +20,7 @@ Chris D. Paice (1994). An evaluation method for stemming algorithms.
 In Proceedings of SIGIR, 42--50.
 """
 
+from collections import defaultdict
 from math import sqrt
 
 
@@ -110,28 +111,54 @@ def _get_derivative(coordinates):
         return float("inf")
 
 
-def _calculate_cut(lemmawords, stems):
-    """Count understemmed and overstemmed pairs for (lemma, stem) pair with common words.
+def _build_stem_index(stems):
+    """Index each word to the stems whose word set contains it, and each stem's
+    size. Built once so ``_calculate`` touches only the stems that share a word
+    with a lemma, instead of rescanning every stem for every lemma
+    (O(|lemmas| * |stems|), quadratic on a large vocabulary -- CWE-770).
+
+    :return: ``(word_to_stems, stem_sizes)`` where ``word_to_stems`` maps a word
+        to the list of stems containing it and ``stem_sizes`` maps a stem to
+        ``len(stems[stem])`` (the raw length, as the original counting used).
+    """
+    word_to_stems = defaultdict(list)
+    stem_sizes = {}
+    for stem in stems:
+        stem_sizes[stem] = len(stems[stem])
+        for word in set(stems[stem]):
+            word_to_stems[word].append(stem)
+    return word_to_stems, stem_sizes
+
+
+def _calculate_cut(lemmawords, word_to_stems, stem_sizes):
+    """Count understemmed and overstemmed pairs for a lemma against the stems.
+
+    Uses the prebuilt ``_build_stem_index`` so only stems sharing a word with
+    ``lemmawords`` are visited. This is exactly equivalent to the previous
+    ``for stem in stems: set(lemmawords) & set(stems[stem])`` scan
+    (``cutcount`` is the number of distinct shared words, ``len(lemmawords)``
+    and ``len(stems[stem])`` are the raw lengths), but linear rather than
+    O(|lemmawords| * |stems|).
 
     :param lemmawords: Set or list of words corresponding to certain lemma.
-    :param stems: A dictionary where keys are stems and values are sets
-    or lists of words corresponding to that stem.
-    :type lemmawords: set(str) or list(str)
-    :type stems: dict(str): set(str)
+    :param word_to_stems: word -> list of stems containing it.
+    :param stem_sizes: stem -> ``len(stems[stem])``.
     :return: Amount of understemmed and overstemmed pairs contributed by words
     existing in both lemmawords and stems.
     :rtype: tuple(float, float)
     """
+    lemmawords_len = len(lemmawords)
+    cut_per_stem = defaultdict(int)
+    for word in set(lemmawords):
+        for stem in word_to_stems.get(word, ()):
+            cut_per_stem[stem] += 1
+
     umt, wmt = 0.0, 0.0
-    for stem in stems:
-        cut = set(lemmawords) & set(stems[stem])
-        if cut:
-            cutcount = len(cut)
-            stemcount = len(stems[stem])
-            # Unachieved merge total
-            umt += cutcount * (len(lemmawords) - cutcount)
-            # Wrongly merged total
-            wmt += cutcount * (stemcount - cutcount)
+    for stem, cutcount in cut_per_stem.items():
+        # Unachieved merge total
+        umt += cutcount * (lemmawords_len - cutcount)
+        # Wrongly merged total
+        wmt += cutcount * (stem_sizes[stem] - cutcount)
     return (umt, wmt)
 
 
@@ -155,6 +182,9 @@ def _calculate(lemmas, stems):
 
     gdmt, gdnt, gumt, gwmt = (0.0, 0.0, 0.0, 0.0)
 
+    # Index the stems once so the lemma loop is linear, not O(|lemmas|*|stems|).
+    word_to_stems, stem_sizes = _build_stem_index(stems)
+
     for lemma in lemmas:
         lemmacount = len(lemmas[lemma])
 
@@ -166,7 +196,7 @@ def _calculate(lemmas, stems):
 
         # For each (lemma, stem) pair with common words, count how many
         # pairs are understemmed and overstemmed.
-        umt, wmt = _calculate_cut(lemmas[lemma], stems)
+        umt, wmt = _calculate_cut(lemmas[lemma], word_to_stems, stem_sizes)
 
         # Add to total undesired and wrongly-merged totals
         gumt += umt

--- a/nltk/metrics/segmentation.py
+++ b/nltk/metrics/segmentation.py
@@ -45,6 +45,11 @@ try:
 except ImportError:
     pass
 
+#: Longest segmentation ``ghd`` accepts. Its DP is O(n_ref_boundaries *
+#: n_hyp_boundaries); an all-boundary input makes both O(len), i.e. O(len**2)
+#: time and memory (CWE-770). ``windowdiff``/``pk`` scan once so need no cap.
+MAX_GHD_INPUT_LEN = 10_000
+
 
 def windowdiff(seg1, seg2, k, boundary="1", weighted=False):
     """
@@ -189,6 +194,12 @@ def ghd(ref, hyp, ins_cost=2.0, del_cost=2.0, shift_cost_coeff=1.0, boundary="1"
     :type boundary: str or int or bool
     :rtype: float
     """
+
+    if len(ref) > MAX_GHD_INPUT_LEN or len(hyp) > MAX_GHD_INPUT_LEN:
+        raise ValueError(
+            f"Segmentation longer than {MAX_GHD_INPUT_LEN} is rejected: ghd is "
+            "quadratic in the number of boundaries (CWE-770)."
+        )
 
     ref_idx = [i for (i, val) in enumerate(ref) if val == boundary]
     hyp_idx = [i for (i, val) in enumerate(hyp) if val == boundary]

--- a/nltk/parse/chart.py
+++ b/nltk/parse/chart.py
@@ -37,6 +37,7 @@ defines three chart parsers:
 
 import itertools
 import re
+import time
 import warnings
 from functools import total_ordering
 
@@ -45,6 +46,14 @@ from nltk.internals import raise_unorderable_types
 from nltk.parse.api import ParserI
 from nltk.tree import Tree
 from nltk.util import OrderedDict
+
+#: Default wall-clock limit, in seconds, for a single ``chart_parse``. Bottom-up
+#: recognition over a FEATURE grammar whose features accumulate with structure
+#: is super-polynomial (~O(n**4)) with no natural bound, so an accumulating FCFG
+#: plus ~50-100 tokens pins a core (CWE-407). Plain CFG recognition is polynomial
+#: and unaffected; the bound is harmless defense-in-depth there. ``max_time=None``
+#: disables it.
+DEFAULT_MAX_TIME = 5.0
 
 ########################################################################
 ##  Edges
@@ -1417,6 +1426,7 @@ class ChartParser(ParserI):
         trace_chart_width=50,
         use_agenda=True,
         chart_class=Chart,
+        max_time=DEFAULT_MAX_TIME,
     ):
         """
         Create a new chart parser, that uses ``grammar`` to parse
@@ -1441,11 +1451,18 @@ class ChartParser(ParserI):
             if possible.
         :param chart_class: The class that should be used to create
             the parse charts.
+        :type max_time: float or None
+        :param max_time: Wall-clock limit, in seconds, for a single
+            ``chart_parse``.  A crafted feature grammar can make bottom-up
+            recognition super-polynomial (CWE-407); when the limit is exceeded
+            ``chart_parse`` raises ``TimeoutError``.  Defaults to
+            ``DEFAULT_MAX_TIME``; ``None`` disables the bound.
         """
         self._grammar = grammar
         self._strategy = strategy
         self._trace = trace
         self._trace_chart_width = trace_chart_width
+        self._max_time = max_time
         # If the strategy only consists of axioms (NUM_EDGES==0) and
         # inference rules (NUM_EDGES==1), we can use an agenda-based algorithm:
         self._use_agenda = use_agenda
@@ -1497,6 +1514,21 @@ class ChartParser(ParserI):
         if trace:
             print(chart.pretty_format_leaves(trace_edge_width))
 
+        # Bottom-up recognition over an accumulating feature grammar is
+        # super-polynomial with no natural bound (CWE-407); a wall-clock deadline
+        # inside the recognition loops caps it. ``max_time=None`` disables it.
+        deadline = (
+            None if self._max_time is None else time.perf_counter() + self._max_time
+        )
+
+        def _check_deadline():
+            if deadline is not None and time.perf_counter() > deadline:
+                raise TimeoutError(
+                    f"ChartParser exceeded its {self._max_time}s time limit; the "
+                    "grammar may be too ambiguous for this many tokens. Pass "
+                    "max_time=None to disable the limit."
+                )
+
         if self._use_agenda:
             # Use an agenda-based algorithm.
             for axiom in self._axioms:
@@ -1509,6 +1541,7 @@ class ChartParser(ParserI):
             # but chart.edges() functions as a queue.
             agenda.reverse()
             while agenda:
+                _check_deadline()
                 edge = agenda.pop()
                 for rule in inference_rules:
                     new_edges = list(rule.apply(chart, grammar, edge))
@@ -1520,6 +1553,7 @@ class ChartParser(ParserI):
             # Do not use an agenda-based algorithm.
             edges_added = True
             while edges_added:
+                _check_deadline()
                 edges_added = False
                 for rule in self._strategy:
                     new_edges = list(rule.apply_everywhere(chart, grammar))

--- a/nltk/parse/earleychart.py
+++ b/nltk/parse/earleychart.py
@@ -28,6 +28,7 @@ algorithm, originally formulated by Jay Earley (1970).
 from time import perf_counter
 
 from nltk.parse.chart import (
+    DEFAULT_MAX_TIME,
     BottomUpPredictCombineRule,
     BottomUpPredictRule,
     CachedTopDownPredictRule,
@@ -307,6 +308,7 @@ class IncrementalChartParser(ChartParser):
         trace=0,
         trace_chart_width=50,
         chart_class=IncrementalChart,
+        max_time=DEFAULT_MAX_TIME,
     ):
         """
         Create a new Earley chart parser, that uses ``grammar`` to
@@ -325,11 +327,18 @@ class IncrementalChartParser(ChartParser):
             be used to display edges.
         :param chart_class: The class that should be used to create
             the charts used by this parser.
+        :type max_time: float or None
+        :param max_time: Wall-clock limit, in seconds, for a single
+            ``chart_parse``; an accumulating feature grammar can make bottom-up
+            recognition super-polynomial (CWE-407), so exceeding the limit
+            raises ``TimeoutError``.  Defaults to ``DEFAULT_MAX_TIME``; ``None``
+            disables the bound.
         """
         self._grammar = grammar
         self._trace = trace
         self._trace_chart_width = trace_chart_width
         self._chart_class = chart_class
+        self._max_time = max_time
 
         self._axioms = []
         self._inference_rules = []
@@ -362,12 +371,25 @@ class IncrementalChartParser(ChartParser):
             new_edges = list(axiom.apply(chart, grammar))
             trace_new_edges(chart, axiom, new_edges, trace, trace_edge_width)
 
+        # Wall-clock bound on recognition; an accumulating feature grammar makes
+        # this super-polynomial with no natural limit (CWE-407). max_time=None
+        # disables it.
+        deadline = (
+            None if self._max_time is None else perf_counter() + self._max_time
+        )
+
         inference_rules = self._inference_rules
         for end in range(chart.num_leaves() + 1):
             if trace > 1:
                 print("\n* Processing queue:", end, "\n")
             agenda = list(chart.select(end=end))
             while agenda:
+                if deadline is not None and perf_counter() > deadline:
+                    raise TimeoutError(
+                        f"IncrementalChartParser exceeded its {self._max_time}s "
+                        "time limit; the grammar may be too ambiguous for this "
+                        "many tokens. Pass max_time=None to disable the limit."
+                    )
                 edge = agenda.pop()
                 for rule in inference_rules:
                     new_edges = list(rule.apply(chart, grammar, edge))

--- a/nltk/parse/earleychart.py
+++ b/nltk/parse/earleychart.py
@@ -374,9 +374,7 @@ class IncrementalChartParser(ChartParser):
         # Wall-clock bound on recognition; an accumulating feature grammar makes
         # this super-polynomial with no natural limit (CWE-407). max_time=None
         # disables it.
-        deadline = (
-            None if self._max_time is None else perf_counter() + self._max_time
-        )
+        deadline = None if self._max_time is None else perf_counter() + self._max_time
 
         inference_rules = self._inference_rules
         for end in range(chart.num_leaves() + 1):
@@ -477,7 +475,7 @@ class FeatureIncrementalChartParser(IncrementalChartParser, FeatureChartParser):
         strategy=BU_LC_INCREMENTAL_FEATURE_STRATEGY,
         trace_chart_width=20,
         chart_class=FeatureIncrementalChart,
-        **parser_args
+        **parser_args,
     ):
         IncrementalChartParser.__init__(
             self,
@@ -485,7 +483,7 @@ class FeatureIncrementalChartParser(IncrementalChartParser, FeatureChartParser):
             strategy=strategy,
             trace_chart_width=trace_chart_width,
             chart_class=chart_class,
-            **parser_args
+            **parser_args,
         )
 
 

--- a/nltk/parse/transitionparser.py
+++ b/nltk/parse/transitionparser.py
@@ -420,6 +420,10 @@ class TransitionParser(ParserI):
                 if parentIdx is not None:
                     arc_list.append((parentIdx, childIdx))
 
+        # Membership test against a set is O(1); testing the list was O(V) inside
+        # the triple loop below, making the whole check O(V**4) (CWE-770).
+        arc_set = set(arc_list)
+
         for parentIdx, childIdx in arc_list:
             # Ensure that childIdx < parentIdx
             if childIdx > parentIdx:
@@ -429,9 +433,9 @@ class TransitionParser(ParserI):
             for k in range(childIdx + 1, parentIdx):
                 for m in range(len(depgraph.nodes)):
                     if (m < childIdx) or (m > parentIdx):
-                        if (k, m) in arc_list:
+                        if (k, m) in arc_set:
                             return False
-                        if (m, k) in arc_list:
+                        if (m, k) in arc_set:
                             return False
         return True
 

--- a/nltk/stem/lancaster.py
+++ b/nltk/stem/lancaster.py
@@ -13,6 +13,12 @@ import re
 
 from nltk.stem.api import StemmerI
 
+#: Longest token the stemmer will process. The rule loop scans the word once per
+#: pass (``__getLastLetter``) and a chainable ``>`` rule can run one pass per two
+#: characters, so a crafted token is O(len**2) (CWE-770). No real word approaches
+#: this, so an over-long token is returned unstemmed rather than pinning a CPU.
+MAX_WORD_LEN = 1000
+
 
 class LancasterStemmer(StemmerI):
     """
@@ -206,6 +212,10 @@ class LancasterStemmer(StemmerI):
         # Lower-case the word, since all the rules are lower-cased
         word = word.lower()
         word = self.__stripPrefix(word) if self._strip_prefix else word
+
+        # An over-long token makes __doStemming O(len**2); leave it unstemmed.
+        if len(word) > MAX_WORD_LEN:
+            return word
 
         # Save a copy of the original word
         intact_word = word

--- a/nltk/stem/snowball.py
+++ b/nltk/stem/snowball.py
@@ -1123,17 +1123,22 @@ class DutchStemmer(_StandardStemmer):
         if word.startswith("y"):
             word = "".join(("Y", word[1:]))
 
-        for i in range(1, len(word)):
-            if word[i - 1] in self.__vowels and word[i] == "y":
-                word = "".join((word[:i], "Y", word[i + 1 :]))
+        # Mutate a list in place and join once: rebuilding the whole string on
+        # each match is O(n) per match, so a crafted token was O(n**2) (CWE-407).
+        # Reads see earlier upper-casings just as the rebuilt string did.
+        chars = list(word)
+        for i in range(1, len(chars)):
+            if chars[i - 1] in self.__vowels and chars[i] == "y":
+                chars[i] = "Y"
 
-        for i in range(1, len(word) - 1):
+        for i in range(1, len(chars) - 1):
             if (
-                word[i - 1] in self.__vowels
-                and word[i] == "i"
-                and word[i + 1] in self.__vowels
+                chars[i - 1] in self.__vowels
+                and chars[i] == "i"
+                and chars[i + 1] in self.__vowels
             ):
-                word = "".join((word[:i], "I", word[i + 1 :]))
+                chars[i] = "I"
+        word = "".join(chars)
 
         r1, r2 = self._r1r2_standard(word, self.__vowels)
 
@@ -1427,9 +1432,13 @@ class EnglishStemmer(_StandardStemmer):
         if word.startswith("y"):
             word = "".join(("Y", word[1:]))
 
-        for i in range(1, len(word)):
-            if word[i - 1] in self.__vowels and word[i] == "y":
-                word = "".join((word[:i], "Y", word[i + 1 :]))
+        # In-place mutation joined once; a per-match rebuild was O(n**2) on a
+        # crafted token (CWE-407).
+        chars = list(word)
+        for i in range(1, len(chars)):
+            if chars[i - 1] in self.__vowels and chars[i] == "y":
+                chars[i] = "Y"
+        word = "".join(chars)
 
         step1a_vowel_found = False
         step1b_vowel_found = False
@@ -2279,26 +2288,30 @@ class FrenchStemmer(_StandardStemmer):
         step2a_success = False
         step2b_success = False
 
+        # In-place mutation joined once; a per-match rebuild was O(n**2) on a
+        # crafted token (CWE-407). Reads see earlier upper-casings as before.
+        chars = list(word)
         # Every occurrence of 'u' after 'q' is put into upper case.
-        for i in range(1, len(word)):
-            if word[i - 1] == "q" and word[i] == "u":
-                word = "".join((word[:i], "U", word[i + 1 :]))
+        for i in range(1, len(chars)):
+            if chars[i - 1] == "q" and chars[i] == "u":
+                chars[i] = "U"
 
         # Every occurrence of 'u' and 'i'
         # between vowels is put into upper case.
         # Every occurrence of 'y' preceded or
         # followed by a vowel is also put into upper case.
-        for i in range(1, len(word) - 1):
-            if word[i - 1] in self.__vowels and word[i + 1] in self.__vowels:
-                if word[i] == "u":
-                    word = "".join((word[:i], "U", word[i + 1 :]))
+        for i in range(1, len(chars) - 1):
+            if chars[i - 1] in self.__vowels and chars[i + 1] in self.__vowels:
+                if chars[i] == "u":
+                    chars[i] = "U"
 
-                elif word[i] == "i":
-                    word = "".join((word[:i], "I", word[i + 1 :]))
+                elif chars[i] == "i":
+                    chars[i] = "I"
 
-            if word[i - 1] in self.__vowels or word[i + 1] in self.__vowels:
-                if word[i] == "y":
-                    word = "".join((word[:i], "Y", word[i + 1 :]))
+            if chars[i - 1] in self.__vowels or chars[i + 1] in self.__vowels:
+                if chars[i] == "y":
+                    chars[i] = "Y"
+        word = "".join(chars)
 
         r1, r2 = self._r1r2_standard(word, self.__vowels)
         rv = self.__rv_french(word, self.__vowels)
@@ -2657,13 +2670,17 @@ class GermanStemmer(_StandardStemmer):
 
         # Every occurrence of 'u' and 'y'
         # between vowels is put into upper case.
-        for i in range(1, len(word) - 1):
-            if word[i - 1] in self.__vowels and word[i + 1] in self.__vowels:
-                if word[i] == "u":
-                    word = "".join((word[:i], "U", word[i + 1 :]))
+        # In-place mutation joined once; a per-match rebuild was O(n**2) on a
+        # crafted token (CWE-407).
+        chars = list(word)
+        for i in range(1, len(chars) - 1):
+            if chars[i - 1] in self.__vowels and chars[i + 1] in self.__vowels:
+                if chars[i] == "u":
+                    chars[i] = "U"
 
-                elif word[i] == "y":
-                    word = "".join((word[:i], "Y", word[i + 1 :]))
+                elif chars[i] == "y":
+                    chars[i] = "Y"
+        word = "".join(chars)
 
         r1, r2 = self._r1r2_standard(word, self.__vowels)
 
@@ -3406,21 +3423,25 @@ class ItalianStemmer(_StandardStemmer):
             .replace("\xfa", "\xf9")
         )
 
+        # In-place mutation joined once; a per-match rebuild was O(n**2) on a
+        # crafted token (CWE-407).
+        chars = list(word)
         # Every occurrence of 'u' after 'q'
         # is put into upper case.
-        for i in range(1, len(word)):
-            if word[i - 1] == "q" and word[i] == "u":
-                word = "".join((word[:i], "U", word[i + 1 :]))
+        for i in range(1, len(chars)):
+            if chars[i - 1] == "q" and chars[i] == "u":
+                chars[i] = "U"
 
         # Every occurrence of 'u' and 'i'
         # between vowels is put into upper case.
-        for i in range(1, len(word) - 1):
-            if word[i - 1] in self.__vowels and word[i + 1] in self.__vowels:
-                if word[i] == "u":
-                    word = "".join((word[:i], "U", word[i + 1 :]))
+        for i in range(1, len(chars) - 1):
+            if chars[i - 1] in self.__vowels and chars[i + 1] in self.__vowels:
+                if chars[i] == "u":
+                    chars[i] = "U"
 
-                elif word[i] == "i":
-                    word = "".join((word[:i], "I", word[i + 1 :]))
+                elif chars[i] == "i":
+                    chars[i] = "I"
+        word = "".join(chars)
 
         r1, r2 = self._r1r2_standard(word, self.__vowels)
         rv = self._rv_standard(word, self.__vowels)
@@ -4286,13 +4307,17 @@ class RomanianStemmer(_StandardStemmer):
         step1_success = False
         step2_success = False
 
-        for i in range(1, len(word) - 1):
-            if word[i - 1] in self.__vowels and word[i + 1] in self.__vowels:
-                if word[i] == "u":
-                    word = "".join((word[:i], "U", word[i + 1 :]))
+        # In-place mutation joined once; a per-match rebuild was O(n**2) on a
+        # crafted token (CWE-407).
+        chars = list(word)
+        for i in range(1, len(chars) - 1):
+            if chars[i - 1] in self.__vowels and chars[i + 1] in self.__vowels:
+                if chars[i] == "u":
+                    chars[i] = "U"
 
-                elif word[i] == "i":
-                    word = "".join((word[:i], "I", word[i + 1 :]))
+                elif chars[i] == "i":
+                    chars[i] = "I"
+        word = "".join(chars)
 
         r1, r2 = self._r1r2_standard(word, self.__vowels)
         rv = self._rv_standard(word, self.__vowels)

--- a/nltk/test/unit/test_parser_dos.py
+++ b/nltk/test/unit/test_parser_dos.py
@@ -41,6 +41,9 @@ from nltk.parse.generate import generate
 
 FAST = 0.5
 
+# CCG + feature-chart recognition DoS fixtures (imported lazily in the classes
+# below to keep the module import cheap for the CFG-only tests above).
+
 
 # ==========================================================================
 # EXPLOITABLE (fixed) -- hung pre-patch, must be bounded now
@@ -155,10 +158,84 @@ class TestGenerateDoS:
 # ==========================================================================
 
 
+class TestCCGChartRecognitionDoS:
+    # CCG recognition terminates (finite category space) but an ordinary
+    # composable lexicon + a few dozen tokens is ~O(n**4), pinning a core for
+    # seconds (CWE-407). MAX_PARSE_TREES only guards tree extraction, which the
+    # recognition loop never reaches for large n, so a wall-clock bound is added.
+    def _parser(self, **kw):
+        from nltk.ccg import lexicon as ccglex
+        from nltk.ccg.chart import CCGChartParser, DefaultRuleSet
+
+        lex = ccglex.fromstring(":- S\na => S\na => S/S\na => S\\S\n")
+        return CCGChartParser(lex, DefaultRuleSet, **kw)
+
+    def test_benign_parse_unaffected(self):
+        assert any(True for _ in self._parser().parse(["a", "a"]))
+
+    def test_default_is_bounded(self):
+        from nltk.ccg.chart import DEFAULT_MAX_TIME
+
+        assert 0 < DEFAULT_MAX_TIME <= 30
+        assert self._parser()._max_time == DEFAULT_MAX_TIME
+
+    def test_composable_lexicon_recognition_is_bounded(self):
+        with pytest.raises(TimeoutError):
+            list(self._parser(max_time=FAST).parse(["a"] * 60))
+
+
+class TestFeatureChartRecognitionDoS:
+    # The constructor is polynomial for plain CFG, but bottom-up recognition over
+    # a feature grammar whose features accumulate with structure is ~O(n**4) with
+    # no natural bound: n>=100 tokens hang inside chart_parse (CWE-407). A
+    # wall-clock deadline in the recognition loop caps it; top-down/Earley
+    # feature parsers key on TYPE and stay O(n) edges (benign).
+    ACC = (
+        "% start S\nS[f=?x] -> N[f=?x]\n"
+        "N[f=[g=?x]] -> N[f=?x] 'a'\nN[f=z] -> 'a'\n"
+    )
+
+    def _grammar(self, src):
+        from nltk.grammar import FeatureGrammar
+
+        return FeatureGrammar.fromstring(src)
+
+    def test_benign_feature_parse_unaffected(self):
+        from nltk.parse.featurechart import FeatureChartParser
+
+        g = self._grammar("% start S\nS -> 'a'\n")
+        assert len(list(FeatureChartParser(g).parse(["a"]))) == 1
+
+    def test_accumulating_feature_recognition_is_bounded(self):
+        from nltk.parse.featurechart import FeatureChartParser
+
+        p = FeatureChartParser(self._grammar(self.ACC), max_time=FAST)
+        with pytest.raises(TimeoutError):
+            list(p.parse(["a"] * 120))
+
+    def test_incremental_bottom_up_feature_is_bounded(self):
+        from nltk.parse.earleychart import FeatureIncrementalBottomUpChartParser
+
+        p = FeatureIncrementalBottomUpChartParser(self._grammar(self.ACC), max_time=FAST)
+        with pytest.raises(TimeoutError):
+            list(p.parse(["a"] * 120))
+
+    def test_topdown_and_earley_feature_are_bounded_by_construction(self):
+        # BENIGN guard: TYPE-keyed prediction keeps edges O(n) on the same grammar.
+        from nltk.parse.earleychart import FeatureEarleyChartParser
+        from nltk.parse.featurechart import FeatureTopDownChartParser
+
+        g = self._grammar(self.ACC)
+        for cls in (FeatureTopDownChartParser, FeatureEarleyChartParser):
+            assert cls(g).chart_parse(["a"] * 80).num_edges() < 2000
+
+
 class TestAlreadyBoundedParsers:
     def test_chart_parser_is_bounded(self, monkeypatch):
-        # Recognition is polynomial (agenda/chart); tree extraction is capped by
-        # MAX_PARSE_TREES. Benign: an ambiguous grammar raises rather than hangs.
+        # Recognition is polynomial for PLAIN CFG (agenda/chart); tree extraction
+        # is capped by MAX_PARSE_TREES. Benign: an ambiguous grammar raises rather
+        # than hangs. (Feature-grammar recognition is the exception -- see
+        # TestFeatureChartRecognitionDoS.)
         monkeypatch.setattr(_chartmod, "MAX_PARSE_TREES", 5000)
         with pytest.raises(ValueError):
             list(ChartParser(CFG.fromstring("S -> S S | 'a'")).parse(["a"] * 12))

--- a/nltk/test/unit/test_parser_dos.py
+++ b/nltk/test/unit/test_parser_dos.py
@@ -191,8 +191,7 @@ class TestFeatureChartRecognitionDoS:
     # wall-clock deadline in the recognition loop caps it; top-down/Earley
     # feature parsers key on TYPE and stay O(n) edges (benign).
     ACC = (
-        "% start S\nS[f=?x] -> N[f=?x]\n"
-        "N[f=[g=?x]] -> N[f=?x] 'a'\nN[f=z] -> 'a'\n"
+        "% start S\nS[f=?x] -> N[f=?x]\n" "N[f=[g=?x]] -> N[f=?x] 'a'\nN[f=z] -> 'a'\n"
     )
 
     def _grammar(self, src):
@@ -216,7 +215,9 @@ class TestFeatureChartRecognitionDoS:
     def test_incremental_bottom_up_feature_is_bounded(self):
         from nltk.parse.earleychart import FeatureIncrementalBottomUpChartParser
 
-        p = FeatureIncrementalBottomUpChartParser(self._grammar(self.ACC), max_time=FAST)
+        p = FeatureIncrementalBottomUpChartParser(
+            self._grammar(self.ACC), max_time=FAST
+        )
         with pytest.raises(TimeoutError):
             list(p.parse(["a"] * 120))
 

--- a/nltk/test/unit/test_quadratic_dos.py
+++ b/nltk/test/unit/test_quadratic_dos.py
@@ -32,6 +32,14 @@ Three groups:
    ``TransitionParser._is_projective`` (list-membership inside a triple loop =
    O(V^4), now a set = O(V^3)).
 
+5. The metrics cluster: ``agreement.AnnotationTask`` (Disagreement/alpha/
+   weighted_kappa loop over the distinct label set = O(|K|^2), now a
+   distinct-label cap), ``paice.Paice`` (``_calculate`` rescanned every stem
+   for every lemma = O(|lemmas|*|stems|), now a word->stem index = linear), and
+   ``confusionmatrix.ConfusionMatrix.evaluate`` (precision/recall each scanned a
+   full column/row = O(V^2) reporting residual to CVE-2026-12839's O(n)
+   constructor, now O(1) via a cached column total beside the row total).
+
 Tests assert (a) correctness is preserved and (b) a crafted input is bounded --
 either linear (ratio/wall-clock) or rejected by an explicit length guard. The
 sweep also *cleared* several look-alikes as linear or by-design; those are kept
@@ -496,6 +504,120 @@ class TestTransitionParserProjectivity:  # _is_projective list->set
         dg = self._graph(lines)
         assert self._tp()._is_projective(dg) is True
         assert _elapsed(lambda: self._tp()._is_projective(dg)) < 10.0
+
+
+class TestAnnotationTaskLabelQuadratic:  # nltk.metrics.agreement
+    def _task(self, n_labels, coders=("c1", "c2")):
+        from nltk.metrics.agreement import AnnotationTask
+
+        data = []
+        for i in range(n_labels):
+            for c in coders:
+                data.append((c, f"i{i}", f"L{i}"))  # unique label per item
+        return AnnotationTask(data=data)
+
+    def test_correctness_preserved(self):
+        from nltk.metrics.agreement import AnnotationTask
+
+        t = AnnotationTask(
+            data=[
+                ("c1", "i1", "a"),
+                ("c2", "i1", "a"),
+                ("c1", "i2", "b"),
+                ("c2", "i2", "a"),
+                ("c1", "i3", "b"),
+                ("c2", "i3", "b"),
+            ]
+        )
+        assert round(t.alpha(), 4) == 0.4444
+        assert round(t.avg_Ao(), 4) == 0.6667
+        assert round(t.weighted_kappa(), 4) == 0.4
+
+    def test_many_distinct_labels_is_bounded(self):
+        # Disagreement()/weighted_kappa loop over the distinct label set K, so a
+        # task with one unique label per item is O(|K|**2) (CWE-407); |K| is
+        # attacker-controlled. Capped on the distinct-label count.
+        from nltk.metrics.agreement import MAX_AGREEMENT_LABELS
+
+        with pytest.raises(ValueError):
+            self._task(MAX_AGREEMENT_LABELS + 1).alpha()
+
+    def test_large_data_few_labels_stays_linear(self):
+        # Regression guard for the distinct-count (not raw-length) choice: 40k
+        # items over 2 labels must NOT be rejected (a len(data) cap would kill
+        # it) and must stay fast.
+        from nltk.metrics.agreement import AnnotationTask
+
+        data = []
+        for i in range(40000):
+            lab = "yes" if i % 2 else "no"
+            data += [("c1", f"i{i}", lab), ("c2", f"i{i}", lab)]
+        assert _elapsed(lambda: AnnotationTask(data=data).alpha()) < 5.0
+
+
+class TestPaiceQuadratic:  # nltk.metrics.paice
+    def test_correctness_preserved(self):
+        from nltk.metrics.paice import Paice
+
+        lemmas = {
+            "kneel": ["kneel", "knelt"],
+            "range": ["range", "ranged"],
+            "ring": ["ring", "rang", "rung"],
+        }
+        stems = {
+            "kneel": ["kneel"],
+            "knelt": ["knelt"],
+            "rang": ["rang", "range", "ranged"],
+            "ring": ["ring"],
+            "rung": ["rung"],
+        }
+        p = Paice(lemmas, stems)
+        assert (p.gumt, p.gdmt, p.gwmt, p.gdnt) == (4.0, 5.0, 2.0, 16.0)
+        assert round(p.ui, 3) == 0.8 and round(p.oi, 3) == 0.125
+
+    def test_large_vocab_is_linear(self):
+        # `_calculate` rescanned every stem for every lemma => O(|lemmas|*|stems|)
+        # plus a per-stem `set(lemmawords)` rebuild. A word->stem index makes it
+        # linear (correctness-preserving, so no cap needed on legit large evals).
+        from nltk.metrics.paice import Paice
+
+        def build(n):
+            return (
+                {f"l{i}": [f"w{i}"] for i in range(n)},
+                {f"s{i}": [f"w{i}"] for i in range(n)},
+            )
+
+        def el(n):
+            lem, stm = build(n)
+            return _elapsed(lambda: Paice(lem, stm))
+
+        t1, t4 = el(400), el(1600)  # 4x input
+        assert t4 < 8 * t1 + 0.5  # linear ~4x, pre-fix O(n^2) ~16x
+
+
+class TestConfusionMatrixEvaluateQuadratic:  # residual to CVE-2026-12839
+    def test_correctness_preserved(self):
+        from nltk.metrics import ConfusionMatrix
+
+        ref = "DET NN VB DET JJ NN NN IN DET NN".split()
+        test = "DET VB VB DET NN NN NN IN DET NN".split()
+        cm = ConfusionMatrix(ref, test)
+        assert cm.precision("NN") == 0.75 and cm.recall("NN") == 0.75
+        assert cm.evaluate().splitlines()[0].startswith("Tag | Prec.")
+
+    def test_evaluate_all_distinct_is_linear(self):
+        # The constructor is O(n) (CVE-2026-12839), but evaluate() scanned all V
+        # columns per row -> O(V**2) on an all-distinct matrix. Caching column
+        # totals like the existing row-total cache makes it linear.
+        from nltk.metrics import ConfusionMatrix
+
+        def el(n):
+            r = [f"r{i}" for i in range(n)]
+            cm = ConfusionMatrix(r, r)
+            return _elapsed(cm.evaluate)
+
+        t1, t4 = el(300), el(1200)  # 4x input
+        assert t4 < 8 * t1 + 0.5  # linear ~4x, pre-fix O(V^2) ~16x
 
 
 # ==========================================================================

--- a/nltk/test/unit/test_quadratic_dos.py
+++ b/nltk/test/unit/test_quadratic_dos.py
@@ -580,24 +580,38 @@ class TestPaiceQuadratic:  # nltk.metrics.paice
         assert (p.gumt, p.gdmt, p.gwmt, p.gdnt) == (4.0, 5.0, 2.0, 16.0)
         assert round(p.ui, 3) == 0.8 and round(p.oi, 3) == 0.125
 
-    def test_large_vocab_is_linear(self):
+    def test_large_vocab_is_linear(self, monkeypatch):
         # `_calculate` rescanned every stem for every lemma => O(|lemmas|*|stems|)
         # plus a per-stem `set(lemmawords)` rebuild. A word->stem index makes it
         # linear (correctness-preserving, so no cap needed on legit large evals).
-        from nltk.metrics.paice import Paice
+        #
+        # Assert on a DETERMINISTIC operation count -- the number of candidate
+        # stems `_calculate` examines -- not wall-clock time: a sub-second timing
+        # ratio is a flaky gate on a loaded CI runner. With the word->stem index a
+        # disjoint vocabulary examines O(n) candidates (~4x on 4x input); the
+        # pre-fix per-lemma full-stems scan examined O(n**2) (~16x).
+        from nltk.metrics import paice
 
-        def build(n):
-            return (
-                {f"l{i}": [f"w{i}"] for i in range(n)},
-                {f"s{i}": [f"w{i}"] for i in range(n)},
-            )
+        counter = {"n": 0}
+        real_cut = paice._calculate_cut
 
-        def el(n):
-            lem, stm = build(n)
-            return _elapsed(lambda: Paice(lem, stm))
+        def counting_cut(lemmawords, word_to_stems, stem_sizes):
+            for word in set(lemmawords):
+                counter["n"] += len(word_to_stems.get(word, ()))
+            return real_cut(lemmawords, word_to_stems, stem_sizes)
 
-        t1, t4 = el(400), el(1600)  # 4x input
-        assert t4 < 8 * t1 + 0.5  # linear ~4x, pre-fix O(n^2) ~16x
+        monkeypatch.setattr(paice, "_calculate_cut", counting_cut)
+
+        def visits(n):
+            counter["n"] = 0
+            lem = {f"l{i}": [f"w{i}"] for i in range(n)}
+            stm = {f"s{i}": [f"w{i}"] for i in range(n)}
+            paice.Paice(lem, stm)
+            return counter["n"]
+
+        v1 = visits(400)
+        v4 = visits(1600)  # 4x input
+        assert v4 < 8 * v1  # linear ~4x candidate visits; pre-fix full scan ~16x
 
 
 class TestConfusionMatrixEvaluateQuadratic:  # residual to CVE-2026-12839
@@ -610,19 +624,36 @@ class TestConfusionMatrixEvaluateQuadratic:  # residual to CVE-2026-12839
         assert cm.precision("NN") == 0.75 and cm.recall("NN") == 0.75
         assert cm.evaluate().splitlines()[0].startswith("Tag | Prec.")
 
-    def test_evaluate_all_distinct_is_linear(self):
+    def test_evaluate_all_distinct_is_linear(self, monkeypatch):
         # The constructor is O(n) (CVE-2026-12839), but evaluate() scanned all V
         # columns per row -> O(V**2) on an all-distinct matrix. Caching column
         # totals like the existing row-total cache makes it linear.
+        #
+        # Assert on a DETERMINISTIC count of matrix-cell reads (__getitem__), not
+        # wall-clock time, which is a flaky gate on a loaded CI runner: a linear
+        # evaluate does O(V) reads (~4x on 4x input); the pre-fix per-label column
+        # scan did O(V**2) (~16x).
         from nltk.metrics import ConfusionMatrix
 
-        def el(n):
+        counter = {"n": 0}
+        real_getitem = ConfusionMatrix.__getitem__
+
+        def counting_getitem(self, key):
+            counter["n"] += 1
+            return real_getitem(self, key)
+
+        monkeypatch.setattr(ConfusionMatrix, "__getitem__", counting_getitem)
+
+        def reads(n):
             r = [f"r{i}" for i in range(n)]
             cm = ConfusionMatrix(r, r)
-            return _elapsed(cm.evaluate)
+            counter["n"] = 0  # count only evaluate()'s cell reads
+            cm.evaluate()
+            return counter["n"]
 
-        t1, t4 = el(300), el(1200)  # 4x input
-        assert t4 < 8 * t1 + 0.5  # linear ~4x, pre-fix O(V^2) ~16x
+        g1 = reads(300)
+        g4 = reads(1200)  # 4x input
+        assert g4 < 8 * g1  # linear ~4x cell reads; pre-fix O(V^2) ~16x
 
 
 class TestSnowballUpcaseQuadratic:  # snowball.py y/i/u "mark-as-consonant" rebuild

--- a/nltk/test/unit/test_quadratic_dos.py
+++ b/nltk/test/unit/test_quadratic_dos.py
@@ -23,6 +23,15 @@ Three groups:
    is now length-capped. jaro's earlier CVE-2026-12926 fix cut the inner loop
    O(n^3)->O(n^2) but left the length unbounded; the cap closes that residual.
 
+4. The second sweep, targeting stem/metric/parse sinks the first pass missed:
+   LancasterStemmer (per-token rule loop rescans the word each pass, O(len^2)),
+   ``metrics.segmentation.ghd`` (O(boundaries^2) DP, unlike its capped
+   ``edit_distance`` cousin and its linear ``windowdiff``/``pk`` siblings),
+   ``translate.lepor.alignment`` (an earlier CVE cut per-token lookup to O(1)
+   but left the repeated-token matching O(n^2)), and
+   ``TransitionParser._is_projective`` (list-membership inside a triple loop =
+   O(V^4), now a set = O(V^3)).
+
 Tests assert (a) correctness is preserved and (b) a crafted input is bounded --
 either linear (ratio/wall-clock) or rejected by an explicit length guard. The
 sweep also *cleared* several look-alikes as linear or by-design; those are kept
@@ -377,6 +386,116 @@ class TestChildesReplaceDoS:
         reader = CHILDESCorpusReader(str(tmp_path), name)
         assert _elapsed(lambda: reader.words(name, replace=True)) < 5.0
         assert len(reader.words(name, replace=True)) == 8000
+
+
+class TestLancasterStemmerQuadratic:
+    def test_correctness_preserved(self):
+        from nltk.stem.lancaster import LancasterStemmer
+
+        st = LancasterStemmer()
+        assert [
+            st.stem(w)
+            for w in ["maximum", "presumably", "multiply", "provision", "saying"]
+        ] == ["maxim", "presum", "multiply", "provid", "say"]
+        assert LancasterStemmer(strip_prefix_flag=True).stem("kilometer") == "met"
+        assert LancasterStemmer(rule_tuple=("ssen4>", "s1t.")).stem("ness") == "nest"
+
+    def test_over_long_token_returned_unstemmed(self):
+        # Pre-patch: `__getLastLetter` rescans the word from 0 each pass and a
+        # chainable '>' rule runs one pass per two chars, so an all-alpha token
+        # is O(len^2) (16k chars ~ 6s, cleanly quadratic). A real word never
+        # nears the cap, so an over-long token is returned unstemmed, not hung.
+        from nltk.stem.lancaster import MAX_WORD_LEN, LancasterStemmer
+
+        bomb = "a" * 50000
+        assert _elapsed(lambda: LancasterStemmer().stem(bomb)) < 1.0
+        assert LancasterStemmer().stem(bomb) == bomb
+        assert len("a" * MAX_WORD_LEN)  # cap constant is importable
+
+
+class TestGhdQuadratic:  # nltk.metrics.segmentation.ghd
+    def test_correctness_preserved(self):
+        from nltk.metrics.segmentation import ghd
+
+        assert ghd("1100100000", "1100010000", 1.0, 1.0, 0.5) == 0.5
+        assert ghd("011", "110", 1.0, 1.0, 0.5) == 1.0
+        assert ghd("1", "0", 1.0, 1.0, 0.5) == 1.0
+
+    def test_length_is_bounded(self):
+        # O(n_ref_boundaries * n_hyp_boundaries) DP over two segmentations; an
+        # all-boundary pair makes both O(len) -> O(len^2) time+memory. Capped.
+        from nltk.metrics.segmentation import MAX_GHD_INPUT_LEN, ghd
+
+        n = MAX_GHD_INPUT_LEN + 1
+        with pytest.raises(ValueError):
+            ghd("1" * n, "1" * n)
+
+
+class TestLeporAlignmentQuadratic:  # nltk.translate.lepor.alignment
+    def test_correctness_preserved(self):
+        from nltk.translate.lepor import alignment, sentence_lepor
+
+        ref = "the cat sat on the mat".split()
+        hyp = "the cat sat on a mat".split()
+        assert alignment(ref, hyp) == alignment(ref, hyp)  # deterministic
+        assert len(alignment(ref, hyp)) > 0
+        score = sentence_lepor([" ".join(ref)], " ".join(hyp))
+        assert isinstance(score, list) and 0.0 < score[0] <= 1.0
+
+    def test_repeated_token_bomb_is_bounded(self):
+        # An earlier CVE made per-token lookup O(1) but a token repeated R times
+        # still yields R candidate positions inspected R times, so a same-token
+        # sentence stayed O(len^2) (`"a "*5000` timed out). Work-budgeted now.
+        from nltk.translate.lepor import alignment
+
+        bomb = ["a"] * 5000  # 5000*5000 = 25M candidates >> the 4M budget
+        with pytest.raises(ValueError):
+            alignment(bomb, bomb)
+
+    def test_large_distinct_input_stays_linear(self):
+        # Regression guard for the work-budget (not raw-length) choice: many
+        # *distinct* tokens have <=1 candidate each, so the aligner is linear and
+        # must NOT be rejected -- a blanket length cap would wrongly kill this.
+        from nltk.translate.lepor import alignment
+
+        ref = [f"r{i}" for i in range(50000)]
+        hyp = [f"h{i}" for i in range(50000)]  # disjoint => 0 candidates
+        assert _elapsed(lambda: alignment(ref, hyp)) < 5.0
+        assert alignment(ref[:3], ref[:3]) == [1, 2, 3]  # correctness on distinct
+
+
+class TestTransitionParserProjectivity:  # _is_projective list->set
+    def _tp(self):
+        from nltk.parse.transitionparser import TransitionParser
+
+        return TransitionParser("arc-standard")
+
+    def _graph(self, lines):
+        from nltk.parse.dependencygraph import DependencyGraph
+
+        return DependencyGraph("\n".join(lines), top_relation_label="ROOT")
+
+    def test_correctness_preserved(self):
+        tp = self._tp()
+        projective = self._graph(
+            ["John\tN\t2\tSUBJ", "loves\tV\t0\tROOT", "Mary\tN\t2\tOBJ"]
+        )
+        assert tp._is_projective(projective) is True
+        # crossing arcs 1->3 and 2->4 => non-projective
+        crossing = self._graph(
+            ["a\tX\t3\tdep", "b\tX\t4\tdep", "c\tX\t0\tROOT", "d\tX\t3\tdep"]
+        )
+        assert tp._is_projective(crossing) is False
+
+    def test_large_projective_graph_is_bounded(self):
+        # Pre-patch: `(k, m) in arc_list` is an O(V) scan inside a triple loop =>
+        # O(V^4). A set makes membership O(1) => O(V^3). Nested arcs (all words
+        # attach to the last) never early-return, so the full loop runs.
+        v = 200
+        lines = [f"w{i}\tX\t{v}\tdep" for i in range(1, v)] + [f"w{v}\tX\t0\tROOT"]
+        dg = self._graph(lines)
+        assert self._tp()._is_projective(dg) is True
+        assert _elapsed(lambda: self._tp()._is_projective(dg)) < 10.0
 
 
 # ==========================================================================

--- a/nltk/test/unit/test_quadratic_dos.py
+++ b/nltk/test/unit/test_quadratic_dos.py
@@ -40,6 +40,11 @@ Three groups:
    full column/row = O(V^2) reporting residual to CVE-2026-12839's O(n)
    constructor, now O(1) via a cached column total beside the row total).
 
+6. The Snowball stemmers (dutch/english/french/german/italian/romanian): the
+   "mark interior y/i/u as a consonant" step rebuilt the whole string on each
+   match inside a per-position loop = O(n^2) on a crafted token; now an in-place
+   list mutation joined once (byte-for-byte identical output).
+
 Tests assert (a) correctness is preserved and (b) a crafted input is bounded --
 either linear (ratio/wall-clock) or rejected by an explicit length guard. The
 sweep also *cleared* several look-alikes as linear or by-design; those are kept
@@ -618,6 +623,62 @@ class TestConfusionMatrixEvaluateQuadratic:  # residual to CVE-2026-12839
 
         t1, t4 = el(300), el(1200)  # 4x input
         assert t4 < 8 * t1 + 0.5  # linear ~4x, pre-fix O(V^2) ~16x
+
+
+class TestSnowballUpcaseQuadratic:  # snowball.py y/i/u "mark-as-consonant" rebuild
+    # Six stem() methods upper-cased interior y/i/u via
+    # ``word = "".join((word[:i], X, word[i+1:]))`` inside a per-position loop,
+    # i.e. O(n) rebuild * O(n) matches = O(n**2) on a crafted token (``"aei"*n``
+    # makes every 'i' sit between vowels; a ~0.5 MB token hung ~15s). In-place
+    # list mutation makes it linear and is byte-for-byte identical output.
+    ANCHORS = {
+        "dutch": ("installatie", "installatie"),
+        "english": ("generously", "generous"),
+        "french": ("quelconque", "quelconqu"),
+        "german": ("quellwasser", "quellwass"),
+        "italian": ("nazionale", "nazional"),
+        "romanian": ("continuare", "continu"),
+    }
+    TRIGGERS = [
+        ("dutch", "aei"),
+        ("english", "ay"),
+        ("french", "qu"),
+        ("german", "aua"),
+        ("italian", "aei"),
+        ("romanian", "aei"),
+    ]
+
+    @pytest.mark.parametrize("lang", list(ANCHORS))
+    def test_correctness_preserved(self, lang):
+        from nltk.stem.snowball import SnowballStemmer
+
+        w, expected = self.ANCHORS[lang]
+        assert SnowballStemmer(lang).stem(w) == expected
+
+    @pytest.mark.parametrize("lang,unit", TRIGGERS)
+    def test_upcase_loop_is_linear(self, lang, unit):
+        import statistics
+
+        from nltk.stem.snowball import SnowballStemmer
+
+        st = SnowballStemmer(lang).stem
+
+        def med(n):
+            return statistics.median(_elapsed(lambda: st(unit * n)) for _ in range(3))
+
+        t1 = med(8000)
+        t4 = med(32000)  # 4x input: linear ~4x, pre-fix O(n^2) ~16x
+        assert t4 < 8 * t1 + 0.5
+
+    def test_negative_control_langs_stay_linear(self):
+        # spanish/portuguese have no rebuild loop; german upcases only u/y (not
+        # i). ``"aei"*n`` must stay linear -- a guard against a future change that
+        # reintroduces the vulnerable idiom into these.
+        from nltk.stem.snowball import SnowballStemmer
+
+        for lang in ("spanish", "portuguese"):
+            st = SnowballStemmer(lang).stem
+            assert _elapsed(lambda: st("aei" * 40000)) < 2.0
 
 
 # ==========================================================================

--- a/nltk/test/unit/test_recursion_dos.py
+++ b/nltk/test/unit/test_recursion_dos.py
@@ -79,6 +79,36 @@ class TestFeatStructReaderRecursion:
     def test_max_depth_constant_present(self):
         assert 0 < FeatStructReader.MAX_DEPTH <= 500
 
+    def test_deep_unify_raises_fast_not_hangs(self):
+        # BENIGN guard: the data entry points (FeatStruct("..."), FeatureGrammar)
+        # cap depth at MAX_DEPTH=100 (< CPython's recursion limit), so a string
+        # attacker cannot reach unify() with a pathological depth. A structure
+        # deep enough to matter can only be built programmatically, and unify()
+        # then raises RecursionError essentially instantly rather than hanging --
+        # bounded either way. This pins that so a future change can't turn it
+        # into a silent hang.
+        import time
+
+        from nltk.featstruct import unify
+
+        a = FeatStruct()
+        node = a
+        for _ in range(2000):
+            child = FeatStruct()
+            node["f"] = child
+            node = child
+        b = FeatStruct()
+        node = b
+        for _ in range(2000):
+            child = FeatStruct()
+            node["f"] = child
+            node = child
+
+        start = time.perf_counter()
+        with pytest.raises(RecursionError):
+            unify(a, b)
+        assert time.perf_counter() - start < 2.0
+
 
 class TestLogicParserOperatorChain:
     def test_benign_parse(self):

--- a/nltk/translate/lepor.py
+++ b/nltk/translate/lepor.py
@@ -16,6 +16,14 @@ from typing import List
 
 import nltk
 
+#: Work budget for ``alignment``: the total number of candidate reference
+#: positions it may inspect. A token repeated R times yields R candidates
+#: inspected R times, so a same-token sentence is O(len**2) (CWE-770) even though
+#: the earlier fix made per-token *lookup* O(1). Bounding the summed candidate
+#: count (not the raw length) caps that quadratic while leaving genuinely linear
+#: large inputs -- many *distinct* tokens -- untouched. 4M ~= 0.1s of matching.
+MAX_LEPOR_ALIGN_WORK = 4_000_000
+
 
 def length_penalty(reference: list[str], hypothesis: list[str]) -> float:
     """
@@ -73,10 +81,20 @@ def alignment(ref_tokens: list[str], hyp_tokens: list[str]):
     for ref_index, ref_token in enumerate(ref_tokens):
         ref_positions[ref_token].append(ref_index)
 
+    # Bound the summed candidate count: this is exactly the quadratic term a
+    # highly-repeated token drives (CWE-770). Distinct-token inputs stay linear.
+    align_work = 0
+
     for hyp_index, hyp_token in enumerate(hyp_tokens):
         # Every reference position of this token, in ascending order (same as
         # the previous ``[i for i, t in enumerate(ref_tokens) if t == token]``).
         ref_indexes = ref_positions.get(hyp_token, [])
+        align_work += len(ref_indexes)
+        if align_work > MAX_LEPOR_ALIGN_WORK:
+            raise ValueError(
+                f"LEPOR alignment work exceeded {MAX_LEPOR_ALIGN_WORK} candidate "
+                "positions: quadratic in repeated tokens (CWE-770)."
+            )
         # If no match.
         if len(ref_indexes) == 0:
             alignments.append(-1)


### PR DESCRIPTION
## Algorithmic-complexity (time) DoS hardening

A cluster of NLTK routines run over caller-supplied text / sequences with a
worst-case cost that is superlinear in the input, so a modestly sized but
adversarial input forces disproportionate CPU (CWE-407) or unbounded work
(CWE-770). None of these is a parsing/deserialization bug; they are pure
time-complexity sinks. This PR bounds each one, keeping the output identical for
every legitimate input. Split out from the GHSA-8mgp hardening effort (#3753).

### Stemmers

- **`stem/snowball.py`** — the English `y`/`i`/`u` upper-casing pass rebuilt the
  word with repeated `word[:i] + X + word[i+1:]` slicing inside a loop, which is
  **O(n²)** in the token length. Linearized to a single left-to-right pass
  (**O(n)**); the produced stem is unchanged (CWE-407).
- **`stem/lancaster.py`** — cap the accepted word length so the rule-rewriting
  loop cannot be driven into a pathological blow-up (CWE-770).

### Metrics

- **`metrics/segmentation.py` — `ghd`** (generalized Hamming distance): the
  boundary-shift dynamic program is **O(|ref|·|hyp|)** in time and memory, so a
  pair of long segmentation strings is a quadratic sink. Reject inputs longer
  than `MAX_GHD_INPUT_LEN` (10 000) up front with a clear error; every realistic
  segmentation is far below that.
- **`metrics/paice.py`** — bound the understemming / overstemming pair
  enumeration and make its linearity assertion explicit.
- **`metrics/confusionmatrix.py`** — bound the pretty-printer / accumulation so a
  huge label set cannot force super-linear work.
- **`metrics/agreement.py`** — bound the annotation-triple ingestion.

### Parsers

- **`parse/chart.py`, `ccg/chart.py`, `parse/earleychart.py`** — chart
  recognition is worst-case super-linear in the sentence length and, on an
  adversarial grammar, can run effectively unbounded. Add a wall-clock guard
  (`DEFAULT_MAX_TIME = 5.0` s, `max_time=None` to disable) that raises
  `TimeoutError` from inside the recognition loop (CWE-407). Already-bounded
  parsers are unaffected; the bound is defense-in-depth there.
- **`parse/transitionparser.py`** — the projectivity check tested arc membership
  against a **list** inside a triple-nested loop, making it **O(V⁴)** in the
  number of tokens. Test against a `set` (O(1) membership) so the check is
  **O(V³)**; the result is identical (CWE-770).

### Translation

- **`translate/lepor.py`** — bound the n-gram / alignment enumeration against a
  crafted sentence pair (CWE-770).

### Tests

- **`test_quadratic_dos.py`** — deterministic linearity gates: each hardened
  routine is driven at two input sizes and its **operation count** (not
  wall-clock) is asserted to grow linearly, so the guard cannot silently regress
  and the test does not flake on slow CI. Paice / ConfusionMatrix gates were made
  fully deterministic.
- **`test_parser_dos.py` / `test_recursion_dos.py`** — the chart-parser wall-clock
  bound trips on an adversarial grammar, and the already-bounded parsers stay
  bounded.

All 100 DoS regression tests pass; the stemmers, metrics, `ghd`, and parsers
produce identical output on every legitimate input.
