### PR TITLE
Bound JSON deserialization against deep-nesting crash and resource DoS

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,3 +50,15 @@ repos:
       language: system
       pass_filenames: false
       always_run: true
+    - id: all-json-through-jsontags
+      name: every JSON deserialization routes through nltk.jsontags
+      description: >-
+        json.load/loads build an unbounded object graph, so a deeply nested or
+        oversized document is a DoS (uncontrolled recursion CWE-674 / resource
+        exhaustion CWE-400). Fails on any json.load/loads/JSONDecoder call
+        outside nltk.jsontags itself; read through jsontags.safe_json_load /
+        safe_json_loads, which bound nesting depth and size.
+      entry: python tools/check_all_json_through_jsontags.py
+      language: system
+      pass_filenames: false
+      always_run: true

--- a/nltk/corpus/reader/twitter.py
+++ b/nltk/corpus/reader/twitter.py
@@ -10,11 +10,11 @@ A reader for corpora that consist of Tweets. It is assumed that the Tweets
 have been serialised into line-delimited JSON.
 """
 
-import json
 import os
 
 from nltk.corpus.reader.api import CorpusReader
 from nltk.corpus.reader.util import StreamBackedCorpusView, ZipFilePathPointer, concat
+from nltk.jsontags import safe_json_loads
 from nltk.tokenize import TweetTokenizer
 
 
@@ -131,6 +131,8 @@ class TwitterCorpusReader(CorpusReader):
             line = stream.readline()
             if not line:
                 return tweets
-            tweet = json.loads(line)
+            # Tweet JSON is genuinely untrusted third-party data; bound its size
+            # and nesting depth so a hostile line cannot crash the interpreter.
+            tweet = safe_json_loads(line, context="TwitterCorpusReader._read_tweets")
             tweets.append(tweet)
         return tweets

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -1526,11 +1526,14 @@ def load(
     elif format == "pickle":
         resource_val = restricted_pickle_load(opened_resource.read())
     elif format == "json":
-        import json
+        from nltk.jsontags import json_tags, safe_json_load
 
-        from nltk.jsontags import json_tags
-
-        resource_val = json.load(opened_resource)
+        # Bound size and structural depth before the recursive C JSON decoder
+        # runs: a data-root resource is only as trusted as its contents, so
+        # safe_json_load rejects over-deep/over-large JSON with a ValueError.
+        resource_val = safe_json_load(
+            opened_resource, context=f"nltk.data.load({resource_url})"
+        )
         tag = None
         if len(resource_val) != 1:
             tag = next(resource_val.keys())

--- a/nltk/help.py
+++ b/nltk/help.py
@@ -9,11 +9,11 @@
 Provide structured access to documentation.
 """
 
-import json
 import re
 from textwrap import wrap
 
 from nltk.data import find, open_datafile
+from nltk.jsontags import safe_json_load
 
 
 def brown_tagset(tagpattern=None):
@@ -46,7 +46,9 @@ def _print_entries(tags, tagdict):
 def _format_tagset(tagset, tagpattern=None):
     # Load tagset from json file.
     with open_datafile(find("help/tagsets_json/PY3_json/"), f"{tagset}.json") as fin:
-        tagdict = json.load(fin)
+        # Bounded parse (size + nesting depth) so a tampered tagset file cannot
+        # crash the interpreter through the recursive C decoder.
+        tagdict = safe_json_load(fin, context="nltk.help._format_tagset")
 
     if not tagpattern:
         _print_entries(sorted(tagdict), tagdict)

--- a/nltk/jsontags.py
+++ b/nltk/jsontags.py
@@ -20,6 +20,132 @@ json_tags = {}
 
 TAG_PREFIX = "!"
 
+JSON_MAX_DEPTH = 2000
+"""Hard cap on the structural nesting depth handed to the C JSON decoder.
+
+CPython's C accelerator recurses in C, so when a process has raised its
+recursion limit a deeply nested document overflows the C stack and segfaults
+the interpreter (an uncatchable crash) instead of raising a bounded
+``RecursionError``. Over-deep input is therefore rejected before parsing. 2000
+sits far above any real NLTK artifact (model weights nest 2 deep, tagsets 2,
+tweets a handful) and far below the C-stack limit at which the accelerator
+crashes.
+"""
+
+JSON_MAX_BYTES = 200 * 1024 * 1024
+"""Upper bound (in bytes) on a JSON document loaded from an NLTK resource.
+
+200 MiB clears the largest shipped model (the Russian perceptron weights are
+about 30 MB) with headroom while refusing an unbounded-memory payload. It is
+deliberately generous: the depth guard, not this size guard, is what
+neutralises the crash primitive; this one only bounds memory and, together with
+the interpreter's ``int_max_str_digits`` default, the giant-integer conversion
+cost.
+"""
+
+# Keep only the six bytes that can change structural nesting depth or open and
+# close a string literal; ``_scan_json_depth`` deletes everything else at C
+# speed before its Python-level scan (see that function's docstring).
+_STRUCTURAL_BYTES = b'"\\[]{}'
+_IDENTITY_TABLE = bytes(range(256))
+_NON_STRUCTURAL = bytes(i for i in range(256) if i not in _STRUCTURAL_BYTES)
+
+
+def _scan_json_depth(data, limit):
+    """Return the maximum structural nesting depth of *data*, stopping early.
+
+    Brackets inside string literals do not count, and backslash escapes are
+    honoured, so the result matches what the parser would actually nest. The
+    scan returns as soon as the depth exceeds ``limit`` (so a hostile payload
+    is rejected after only a few thousand bytes), and it never recurses, so it
+    cannot itself be the crash it is guarding against.
+
+    Every byte that cannot change nesting depth or open/close a string literal
+    is deleted at C speed by :meth:`bytes.translate` before the Python-level
+    loop runs, so a legit multi-megabyte model is scanned in well under a
+    second while brackets buried in string values are still counted correctly.
+    """
+    if isinstance(data, str):
+        data = data.encode("utf-8", "surrogatepass")
+    residue = bytes(data).translate(_IDENTITY_TABLE, _NON_STRUCTURAL)
+    depth = 0
+    max_depth = 0
+    in_string = False
+    escaped = False
+    for byte in residue:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif byte == 0x5C:  # backslash
+                escaped = True
+            elif byte == 0x22:  # closing quote
+                in_string = False
+            continue
+        if byte == 0x22:  # opening quote
+            in_string = True
+        elif byte == 0x5B or byte == 0x7B:  # '[' or '{'
+            depth += 1
+            if depth > max_depth:
+                max_depth = depth
+                if max_depth > limit:
+                    return max_depth
+        elif byte == 0x5D or byte == 0x7D:  # ']' or '}'
+            depth -= 1
+    return max_depth
+
+
+def safe_json_loads(
+    data,
+    *,
+    max_depth=JSON_MAX_DEPTH,
+    max_bytes=JSON_MAX_BYTES,
+    context="NLTK JSON",
+):
+    """Parse ``data`` (``str`` or ``bytes``) with a size and nesting-depth bound.
+
+    This is a drop-in replacement for :func:`json.loads` for untrusted or
+    only-partly-trusted resources (model files, data resources, tweet lines).
+    It refuses an over-large or over-deep document *before* handing it to the
+    recursive C decoder, so a malicious payload raises a bounded ``ValueError``
+    instead of exhausting memory or overflowing the C stack. Giant integers are
+    still bounded by the interpreter's ``sys.get_int_max_str_digits()`` default
+    during :func:`json.loads`.
+    """
+    size = len(data)
+    if size > max_bytes:
+        raise ValueError(
+            f"{context}: JSON document is {size} bytes, over the "
+            f"{max_bytes}-byte limit"
+        )
+    depth = _scan_json_depth(data, max_depth)
+    if depth > max_depth:
+        raise ValueError(
+            f"{context}: JSON nesting depth exceeds the maximum allowed "
+            f"({max_depth})"
+        )
+    return json.loads(data)
+
+
+def safe_json_load(
+    fp,
+    *,
+    max_depth=JSON_MAX_DEPTH,
+    max_bytes=JSON_MAX_BYTES,
+    context="NLTK JSON",
+):
+    """Read a JSON document from a file-like object under the same bounds.
+
+    Reads at most ``max_bytes`` (plus one probe byte) so a gigantic file cannot
+    be slurped into memory before it is rejected, then defers to
+    :func:`safe_json_loads`. Works with both text and binary streams.
+    """
+    data = fp.read(max_bytes + 1)
+    if len(data) > max_bytes:
+        raise ValueError(f"{context}: JSON resource exceeds the {max_bytes}-byte limit")
+    return safe_json_loads(
+        data, max_depth=max_depth, max_bytes=max_bytes, context=context
+    )
+
 
 def register_tag(cls):
     """
@@ -73,4 +199,13 @@ class JSONTaggedDecoder(json.JSONDecoder):
         return obj_cls.decode_json_obj(obj[obj_tag])
 
 
-__all__ = ["register_tag", "json_tags", "JSONTaggedEncoder", "JSONTaggedDecoder"]
+__all__ = [
+    "register_tag",
+    "json_tags",
+    "JSONTaggedEncoder",
+    "JSONTaggedDecoder",
+    "safe_json_load",
+    "safe_json_loads",
+    "JSON_MAX_DEPTH",
+    "JSON_MAX_BYTES",
+]

--- a/nltk/jsontags.py
+++ b/nltk/jsontags.py
@@ -51,6 +51,36 @@ _IDENTITY_TABLE = bytes(range(256))
 _NON_STRUCTURAL = bytes(i for i in range(256) if i not in _STRUCTURAL_BYTES)
 
 
+_POS_INF = float("inf")
+
+
+def _reject_non_finite(token):
+    """``parse_constant`` hook: refuse ``NaN`` / ``Infinity`` / ``-Infinity``.
+
+    These three are a CPython ``json`` extension, not RFC 8259, so a standards
+    conformant document never contains them and no shipped NLTK resource does.
+    An attacker-supplied model weight or tweet field could, though, and a NaN
+    weight silently poisons every downstream score while an Infinity can turn a
+    comparison into a hang, so untrusted input is held to strict JSON.
+    """
+    raise ValueError(f"non-finite JSON constant {token!r} is not allowed")
+
+
+def _finite_float(token):
+    """``parse_float`` hook: refuse a numeric literal that overflows to infinity.
+
+    ``parse_constant`` only catches the ``Infinity`` word; a plain numeric token
+    with a huge exponent (``1e400``) is valid JSON syntax but overflows an IEEE
+    double to ``inf`` without going through it. Rejecting the overflow too keeps
+    the non-finite guarantee complete. The check runs only on tokens the parser
+    already treats as floats, so integers and small floats are unaffected.
+    """
+    value = float(token)
+    if value == _POS_INF or value == -_POS_INF:
+        raise ValueError(f"non-finite JSON number {token!r} overflows to infinity")
+    return value
+
+
 def _scan_json_depth(data, limit):
     """Return the maximum structural nesting depth of *data*, stopping early.
 
@@ -123,7 +153,12 @@ def safe_json_loads(
             f"{context}: JSON nesting depth exceeds the maximum allowed "
             f"({max_depth})"
         )
-    return json.loads(data)
+    # Reject every non-finite value: the NaN/Infinity/-Infinity words via
+    # parse_constant, and a numeric literal that overflows to inf via
+    # parse_float, so no non-finite value reaches a model weight or a tweet.
+    return json.loads(
+        data, parse_constant=_reject_non_finite, parse_float=_finite_float
+    )
 
 
 def safe_json_load(
@@ -170,10 +205,27 @@ class JSONTaggedDecoder(json.JSONDecoder):
     #: Prevents denial of service from deeply nested payloads.
     MAX_DECODE_DEPTH = 200
 
+    #: Upper bound (bytes) on a document handed to the tagged decoder, matching
+    #: ``safe_json_loads`` so this path is size-bounded as well as depth-bounded.
+    MAX_DECODE_BYTES = JSON_MAX_BYTES
+
+    def __init__(self, **kwargs):
+        # Reject non-finite values by default (NaN/Infinity words and numeric
+        # overflow to inf), matching safe_json_loads; a caller may still override
+        # parse_constant / parse_float explicitly.
+        kwargs.setdefault("parse_constant", _reject_non_finite)
+        kwargs.setdefault("parse_float", _finite_float)
+        super().__init__(**kwargs)
+
     def decode(self, s):
-        # Bound nesting BEFORE ``super().decode`` runs the recursive C accelerator,
-        # which can overflow the C stack (an uncatchable segfault, not a
-        # ``RecursionError``) before ``decode_obj``'s Python check is reached.
+        # Bound size, then nesting, BEFORE ``super().decode`` runs the recursive
+        # C accelerator, which can overflow the C stack (an uncatchable segfault,
+        # not a ``RecursionError``) before ``decode_obj``'s Python check runs.
+        if len(s) > self.MAX_DECODE_BYTES:
+            raise ValueError(
+                f"JSON document is {len(s)} bytes, over the "
+                f"{self.MAX_DECODE_BYTES}-byte limit"
+            )
         if _scan_json_depth(s, self.MAX_DECODE_DEPTH) > self.MAX_DECODE_DEPTH:
             raise ValueError(
                 f"JSON nesting depth exceeds maximum allowed ({self.MAX_DECODE_DEPTH})"

--- a/nltk/jsontags.py
+++ b/nltk/jsontags.py
@@ -15,6 +15,7 @@ using it.
 """
 
 import json
+import math
 
 json_tags = {}
 
@@ -30,6 +31,12 @@ the interpreter (an uncatchable crash) instead of raising a bounded
 sits far above any real NLTK artifact (model weights nest 2 deep, tagsets 2,
 tweets a handful) and far below the C-stack limit at which the accelerator
 crashes.
+
+The C accelerator parses a document up to this depth cheaply, so a value within
+the cap loads on every supported interpreter; ``safe_json_loads`` keeps it on the
+C scanner (see there) rather than the pure-Python scanner, which recurses in
+Python and would ``RecursionError`` a few hundred levels deep under the default
+recursion limit.
 """
 
 JSON_MAX_BYTES = 200 * 1024 * 1024
@@ -79,6 +86,32 @@ def _finite_float(token):
     if value == _POS_INF or value == -_POS_INF:
         raise ValueError(f"non-finite JSON number {token!r} overflows to infinity")
     return value
+
+
+def _reject_non_finite_walk(obj, context="NLTK JSON"):
+    """Refuse any non-finite float anywhere in an already-parsed JSON value.
+
+    ``safe_json_loads`` parses on the C scanner (no ``parse_constant`` /
+    ``parse_float`` hooks, which would force the recursive pure-Python scanner),
+    so the NaN/Infinity/-Infinity words and any numeric literal that overflowed an
+    IEEE double to ``inf`` are caught here instead. The walk is ITERATIVE (an
+    explicit stack, never recursion), so a document nested up to JSON_MAX_DEPTH
+    cannot make this check itself overflow the stack (CWE-674). Returns ``obj`` so
+    it can wrap the parse in one expression.
+    """
+    stack = [obj]
+    while stack:
+        cur = stack.pop()
+        if isinstance(cur, float):
+            if not math.isfinite(cur):
+                raise ValueError(
+                    f"{context}: non-finite JSON number (NaN/Infinity) is not allowed"
+                )
+        elif isinstance(cur, dict):
+            stack.extend(cur.values())
+        elif isinstance(cur, list):
+            stack.extend(cur)
+    return obj
 
 
 def _scan_json_depth(data, limit):
@@ -162,12 +195,22 @@ def safe_json_loads(
             f"{context}: JSON nesting depth exceeds the maximum allowed "
             f"({max_depth})"
         )
-    # Reject every non-finite value: the NaN/Infinity/-Infinity words via
-    # parse_constant, and a numeric literal that overflows to inf via
-    # parse_float, so no non-finite value reaches a model weight or a tweet.
-    return json.loads(
-        data, parse_constant=_reject_non_finite, parse_float=_finite_float
-    )
+    # Parse with the DEFAULT (C accelerator) scanner: it handles nesting up to
+    # JSON_MAX_DEPTH cheaply on every interpreter. Supplying parse_constant /
+    # parse_float, as this function used to, forces json.loads onto the
+    # pure-Python scanner on CPython <= 3.11 (the C scanner gained hook support
+    # in 3.12), and that scanner recurses in Python and raises RecursionError
+    # only a few hundred levels deep under the default recursion limit -- so a
+    # document within the cap crashed instead of loading. Non-finite values are
+    # instead rejected AFTER the parse by an ITERATIVE walk (``_reject_non_finite``)
+    # that cannot itself recurse. A RecursionError from a caller already near the
+    # limit is still converted to a clean ValueError so uncontrolled recursion can
+    # never escape (CWE-674), mirroring JSONTaggedDecoder.decode.
+    try:
+        parsed = json.loads(data)
+    except RecursionError:
+        raise ValueError(f"{context}: JSON nesting too deep to parse safely") from None
+    return _reject_non_finite_walk(parsed, context)
 
 
 def safe_json_load(

--- a/nltk/jsontags.py
+++ b/nltk/jsontags.py
@@ -171,6 +171,13 @@ class JSONTaggedDecoder(json.JSONDecoder):
     MAX_DECODE_DEPTH = 200
 
     def decode(self, s):
+        # Bound nesting BEFORE ``super().decode`` runs the recursive C accelerator,
+        # which can overflow the C stack (an uncatchable segfault, not a
+        # ``RecursionError``) before ``decode_obj``'s Python check is reached.
+        if _scan_json_depth(s, self.MAX_DECODE_DEPTH) > self.MAX_DECODE_DEPTH:
+            raise ValueError(
+                f"JSON nesting depth exceeds maximum allowed ({self.MAX_DECODE_DEPTH})"
+            )
         try:
             return self.decode_obj(super().decode(s))
         except RecursionError:

--- a/nltk/jsontags.py
+++ b/nltk/jsontags.py
@@ -141,6 +141,11 @@ def safe_json_loads(
     still bounded by the interpreter's ``sys.get_int_max_str_digits()`` default
     during :func:`json.loads`.
     """
+    if not isinstance(data, (str, bytes, bytearray)):
+        # Fail with a clear type error at the chokepoint rather than deep inside
+        # the size/scan path (where a list of small ints, say, would otherwise
+        # slip through ``len`` and ``bytes()`` before ``json.loads`` rejects it).
+        raise TypeError(f"{context}: expected str or bytes, got {type(data).__name__}")
     size = len(data)
     if size > max_bytes:
         raise ValueError(

--- a/nltk/jsontags.py
+++ b/nltk/jsontags.py
@@ -146,13 +146,17 @@ def safe_json_loads(
         # the size/scan path (where a list of small ints, say, would otherwise
         # slip through ``len`` and ``bytes()`` before ``json.loads`` rejects it).
         raise TypeError(f"{context}: expected str or bytes, got {type(data).__name__}")
-    size = len(data)
+    # Measure size and scan depth on the UTF-8 byte view so the cap is a true
+    # byte cap: a non-ASCII str has more UTF-8 bytes than code points, and
+    # counting code points would let an oversized payload slip past the limit.
+    raw = data.encode("utf-8", "surrogatepass") if isinstance(data, str) else data
+    size = len(raw)
     if size > max_bytes:
         raise ValueError(
             f"{context}: JSON document is {size} bytes, over the "
             f"{max_bytes}-byte limit"
         )
-    depth = _scan_json_depth(data, max_depth)
+    depth = _scan_json_depth(raw, max_depth)
     if depth > max_depth:
         raise ValueError(
             f"{context}: JSON nesting depth exceeds the maximum allowed "
@@ -177,9 +181,16 @@ def safe_json_load(
 
     Reads at most ``max_bytes`` (plus one probe byte) so a gigantic file cannot
     be slurped into memory before it is rejected, then defers to
-    :func:`safe_json_loads`. Works with both text and binary streams.
+    :func:`safe_json_loads`. When the stream exposes a binary ``buffer`` the read
+    is taken from it so the cap bounds bytes rather than characters (a text
+    stream's ``read(n)`` counts code points, and one non-ASCII code point is
+    several UTF-8 bytes); a text stream without a buffer falls back to a
+    character read and :func:`safe_json_loads` still enforces the cap on the
+    encoded byte length. Works with both text and binary streams.
     """
-    data = fp.read(max_bytes + 1)
+    # Prefer the binary buffer so the byte cap bounds the read itself.
+    reader = getattr(fp, "buffer", fp)
+    data = reader.read(max_bytes + 1)
     if len(data) > max_bytes:
         raise ValueError(f"{context}: JSON resource exceeds the {max_bytes}-byte limit")
     return safe_json_loads(
@@ -226,12 +237,15 @@ class JSONTaggedDecoder(json.JSONDecoder):
         # Bound size, then nesting, BEFORE ``super().decode`` runs the recursive
         # C accelerator, which can overflow the C stack (an uncatchable segfault,
         # not a ``RecursionError``) before ``decode_obj``'s Python check runs.
-        if len(s) > self.MAX_DECODE_BYTES:
+        # Measure on the UTF-8 byte view so the cap counts bytes, not code points.
+        raw = s.encode("utf-8", "surrogatepass") if isinstance(s, str) else s
+        size = len(raw)
+        if size > self.MAX_DECODE_BYTES:
             raise ValueError(
-                f"JSON document is {len(s)} bytes, over the "
+                f"JSON document is {size} bytes, over the "
                 f"{self.MAX_DECODE_BYTES}-byte limit"
             )
-        if _scan_json_depth(s, self.MAX_DECODE_DEPTH) > self.MAX_DECODE_DEPTH:
+        if _scan_json_depth(raw, self.MAX_DECODE_DEPTH) > self.MAX_DECODE_DEPTH:
             raise ValueError(
                 f"JSON nesting depth exceeds maximum allowed ({self.MAX_DECODE_DEPTH})"
             )

--- a/nltk/sentiment/util.py
+++ b/nltk/sentiment/util.py
@@ -11,7 +11,6 @@ Utility methods for Sentiment Analysis.
 """
 
 import csv
-import json
 import random
 import re
 import sys
@@ -21,6 +20,7 @@ from copy import deepcopy
 import nltk
 from nltk.corpus import CategorizedPlaintextCorpusReader
 from nltk.data import load
+from nltk.jsontags import safe_json_loads
 from nltk.pathsec import open as pathsec_open
 from nltk.tokenize import PunktTokenizer
 from nltk.tokenize.casual import EMOTICON_RE
@@ -388,7 +388,8 @@ def json2csv_preprocess(
             tweets_cache = []
         i = 0
         for line in fp:
-            tweet = json.loads(line)
+            # Untrusted tweet line: bound size and nesting depth before parsing.
+            tweet = safe_json_loads(line, context="sentiment.json2csv_preprocess")
             row = extract_fields(tweet, fields)
             try:
                 text = row[fields.index("text")]

--- a/nltk/tag/perceptron.py
+++ b/nltk/tag/perceptron.py
@@ -25,6 +25,7 @@ from nltk.data import (
     make_staging_dir,
     open_datafile,
 )
+from nltk.jsontags import safe_json_load
 from nltk.pathsec import _fd_realpath
 from nltk.pathsec import open as pathsec_open
 from nltk.pathsec import validate_path, validate_tool_dir, validate_tool_path
@@ -214,7 +215,10 @@ class AveragedPerceptron:
         # Refuse a planted FIFO/socket/device before pathsec.open blocks on it.
         validate_tool_path(path, context="AveragedPerceptron.load")
         with pathsec_open(path, context="AveragedPerceptron.load") as fin:
-            self.weights = json.load(fin)
+            # Bound size and nesting depth before the recursive C decoder runs:
+            # a model file with a raised recursion limit could otherwise
+            # segfault the interpreter (uncatchable) on deeply nested JSON.
+            self.weights = safe_json_load(fin, context="AveragedPerceptron.load")
 
     def encode_json_obj(self):
         return self.weights
@@ -483,7 +487,10 @@ class PerceptronTagger(TaggerI):
         # the application, since trusting a caller path would disarm pathsec.
         def load_param(json_file):
             with open_datafile(loc, json_file) as fin:
-                return json.load(fin)
+                # Same bounded parse as AveragedPerceptron.load: reject an
+                # over-deep or over-large param file before the C decoder can
+                # crash on it, without touching legit (shallow) model shapes.
+                return safe_json_load(fin, context="PerceptronTagger.load_from_json")
 
         self.decode_json_params(
             load_param(js_file) for js_file in self.param_files(lang)

--- a/nltk/test/unit/test_attack_json_loaders_expanded.py
+++ b/nltk/test/unit/test_attack_json_loaders_expanded.py
@@ -1007,7 +1007,7 @@ def test_hash_collision_object_is_linear_not_quadratic():
 def test_mixed_array_object_deep_nesting_refused():
     # CVE-2021-45958 class (ujson deep-nesting stack overflow): the scanner
     # counts both '[' and '{', so an alternating [{ tower is bounded too.
-    from nltk.jsontags import safe_json_loads, JSON_MAX_DEPTH
+    from nltk.jsontags import JSON_MAX_DEPTH, safe_json_loads
 
     d = JSON_MAX_DEPTH + 50
     payload = '{"a":[' * (d // 2) + "1" + "]}" * (d // 2)

--- a/nltk/test/unit/test_attack_json_loaders_expanded.py
+++ b/nltk/test/unit/test_attack_json_loaders_expanded.py
@@ -777,3 +777,71 @@ def test_sentiment_preprocess_deep_tweet_line_no_crash():
         timeout=60,
     )
     assert_no_crash_and_rejected(proc)
+
+
+# Non-finite values: NaN / Infinity / -Infinity are a CPython json extension,
+# not RFC 8259, and a numeric literal can also overflow an IEEE double to inf.
+# safe_json_loads and JSONTaggedDecoder refuse every non-finite value so an
+# attacker cannot smuggle one into a model weight or a tweet field, while finite
+# values (including the largest representable double) still parse.
+
+
+def test_helper_rejects_nan_infinity_constants():
+    from nltk.jsontags import safe_json_loads
+
+    for token in ("NaN", "Infinity", "-Infinity", '{"w": NaN}', "[1, 2, Infinity]"):
+        with pytest.raises(ValueError, match="non-finite"):
+            safe_json_loads(token)
+
+
+def test_helper_rejects_numeric_overflow_to_infinity():
+    from nltk.jsontags import safe_json_loads
+
+    # Valid JSON number syntax whose value overflows a double to inf; caught by
+    # parse_float rather than parse_constant.
+    for token in ("1e400", "1e999999", "-1e999999", "1.8e308", '{"w": 1e400}'):
+        with pytest.raises(ValueError, match="non-finite"):
+            safe_json_loads(token)
+
+
+def test_helper_finite_edge_floats_still_parse():
+    from nltk.jsontags import safe_json_loads
+
+    # The largest finite double parses; a tiny exponent underflows to 0.0
+    # (finite); ordinary floats are unaffected.
+    assert safe_json_loads("1.5e308") == 1.5e308
+    assert safe_json_loads("1e-999999") == 0.0
+    assert safe_json_loads('{"w": [0.5, -1.25, 1e10]}') == {"w": [0.5, -1.25, 1e10]}
+
+
+def test_tagged_decoder_rejects_non_finite():
+    from nltk.jsontags import JSONTaggedDecoder
+
+    for token in ("NaN", "Infinity", '{"x": -Infinity}', "1e400", '{"x": 1e999999}'):
+        with pytest.raises(ValueError, match="non-finite"):
+            JSONTaggedDecoder().decode(token)
+    # Finite control still decodes.
+    assert JSONTaggedDecoder().decode('{"x": 1.5}') == {"x": 1.5}
+
+
+def test_tagged_decoder_rejects_oversize_document():
+    from nltk.jsontags import JSONTaggedDecoder
+
+    decoder = JSONTaggedDecoder()
+    decoder.MAX_DECODE_BYTES = 100  # shrink the cap so the test stays cheap
+    with pytest.raises(ValueError, match="over the"):
+        decoder.decode('"' + "a" * 1000 + '"')
+    # A document under the cap still decodes.
+    assert decoder.decode('{"a": 1}') == {"a": 1}
+
+
+def test_averaged_perceptron_load_rejects_non_finite_weight(tmp_path):
+    # End-to-end: a model file carrying a non-finite weight is refused by the
+    # loader (which funnels through safe_json_load), so a poisoned weight never
+    # reaches the tagger's scoring.
+    from nltk.tag.perceptron import AveragedPerceptron
+
+    path = tmp_path / "weights.json"
+    path.write_text('{"the": {"NN": Infinity, "DT": 0.5}}', encoding="utf-8")
+    with pytest.raises(ValueError, match="non-finite"):
+        AveragedPerceptron().load(str(path))

--- a/nltk/test/unit/test_attack_json_loaders_expanded.py
+++ b/nltk/test/unit/test_attack_json_loaders_expanded.py
@@ -233,6 +233,135 @@ def test_helper_stream_size_cap_bounds_memory():
         safe_json_load(huge, max_bytes=100)
 
 
+# JSONTaggedDecoder (NLTK model-artifact tag decoder): its ``super().decode``
+# runs the recursive C accelerator, so it must bound nesting BEFORE that call,
+# not only in the later Python ``decode_obj`` walk (GHSA-rf74-v2fm-23pw).
+
+
+def test_tagged_decoder_deep_nesting_prescanned_not_crashed():
+    from nltk.jsontags import JSONTaggedDecoder
+
+    payload = "[" * DEEP + "]" * DEEP
+    with pytest.raises(ValueError, match="nesting depth"):
+        JSONTaggedDecoder().decode(payload)
+
+
+def test_tagged_decoder_deep_via_json_loads_cls_refused():
+    # The stdlib entry point (json.loads(..., cls=JSONTaggedDecoder)) routes
+    # through the same decode(), so it is bounded too.
+    from nltk.jsontags import JSONTaggedDecoder
+
+    payload = '{"a":' * DEEP + "1" + "}" * DEEP
+    with pytest.raises(ValueError, match="nesting depth"):
+        json.loads(payload, cls=JSONTaggedDecoder)
+
+
+def test_tagged_decoder_benign_tagged_roundtrip():
+    from nltk.jsontags import JSONTaggedDecoder, JSONTaggedEncoder, register_tag
+
+    @register_tag
+    class _Point:
+        json_tag = "test_attack_json._Point"
+
+        def __init__(self, n):
+            self.n = n
+
+        def encode_json_obj(self):
+            return self.n
+
+        @classmethod
+        def decode_json_obj(cls, obj):
+            return cls(obj)
+
+    encoded = json.dumps(_Point(7), cls=JSONTaggedEncoder)
+    restored = JSONTaggedDecoder().decode(encoded)
+    assert isinstance(restored, _Point) and restored.n == 7
+
+
+def test_tagged_decoder_unknown_tag_refused():
+    from nltk.jsontags import JSONTaggedDecoder
+
+    with pytest.raises(ValueError, match="Unknown tag"):
+        JSONTaggedDecoder().decode('{"!nltk.not.a.real.tag": 1}')
+
+
+def test_tagged_decoder_depth_at_limit_still_decodes():
+    from nltk.jsontags import JSONTaggedDecoder
+
+    # A document exactly at the decode-depth limit is legitimate and still loads.
+    ok = JSONTaggedDecoder().decode("[" * 200 + "]" * 200)
+    assert isinstance(ok, list)
+
+
+# The structural-depth scan is the whole guarantee, so it must never UNDERCOUNT
+# real nesting (which would let a deep payload slip past): brackets inside string
+# literals must not count; real brackets outside them always must.
+
+
+def test_scan_ignores_brackets_inside_strings():
+    from nltk.jsontags import _scan_json_depth
+
+    # An array holding one string full of brackets nests exactly one level.
+    assert _scan_json_depth('["' + "[{" * 5000 + '"]', 10**9) == 1
+
+
+def test_scan_honors_escaped_quotes_and_backslashes():
+    from nltk.jsontags import _scan_json_depth
+
+    # \" does not close the string (brackets after it are still in-string);
+    # \\ then " does close it (the following bracket is real, depth 2).
+    assert _scan_json_depth('["a\\"[[[b"]', 10**9) == 1
+    assert _scan_json_depth('["a\\\\"[]', 10**9) == 2
+
+
+def test_scan_does_not_undercount_deep_nesting_after_strings():
+    from nltk.jsontags import _scan_json_depth
+
+    # Real deep nesting hidden after a closed string with escape trickery is
+    # still fully counted, so safe_json_loads cannot be tricked into accepting it.
+    payload = '"a\\"]}[b"' + "[" * 4000 + "]" * 4000
+    assert _scan_json_depth(payload, 10**9) == 4000
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '["' + "[" * 500 + '"]',  # brackets buried in a string
+        '"\\""' + "[{" * 300,  # escaped quote then real mixed nesting
+        "{" + '"k":' * 150 + "1" + "}" * 150,  # deep via object values
+        "[{" * 150 + "1" + "}]" * 150,  # deep via mixed brackets
+    ],
+)
+def test_scan_soundness_accepted_inputs_do_not_out_nest_the_scan(payload):
+    from nltk.jsontags import _scan_json_depth
+
+    # For each adversarial input, the scan's depth must be >= the depth the real
+    # parser reaches, so an accepted document can never recurse past the bound.
+    scanned = _scan_json_depth(payload, 10**9)
+    try:
+        parsed = json.loads(payload)
+    except ValueError:
+        return  # malformed: no object graph, nothing to out-nest
+    assert scanned >= _actual_depth(parsed)
+
+
+def _actual_depth(obj):
+    if isinstance(obj, dict):
+        return 1 + max((_actual_depth(v) for v in obj.values()), default=0)
+    if isinstance(obj, list):
+        return 1 + max((_actual_depth(v) for v in obj), default=0)
+    return 0
+
+
+def test_giant_shallow_array_bounded_by_size_not_depth():
+    from nltk.jsontags import safe_json_loads
+
+    # A huge but shallow array is not a depth attack; the size cap bounds it.
+    payload = "[" + ",".join("0" for _ in range(5000)) + "]"
+    with pytest.raises(ValueError, match="over the"):
+        safe_json_loads(payload, max_bytes=100)
+
+
 # Teeth: the stock decoder hard-crashes on the same payload, proving the guard
 # above is non-vacuous, and the guard survives that payload with the recursion
 # limit lifted.

--- a/nltk/test/unit/test_attack_json_loaders_expanded.py
+++ b/nltk/test/unit/test_attack_json_loaders_expanded.py
@@ -1,0 +1,650 @@
+# Natural Language Toolkit: expanded JSON deserialization attack harness
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""Expanded JSON deserialization attack matrix (GHSA-8mgp companion).
+
+"json.load is not safe either": a malicious JSON document can crash or stall a
+process even though JSON carries no code. This suite drives each hostile input
+through the REAL nltk caller path (perceptron model load, ``nltk.data.load``,
+``nltk.help`` tagset lookup, tweet readers) and holds every site to one hard
+property:
+
+* a hostile document is REFUSED with a bounded ``ValueError`` (or otherwise
+  caught) and NEVER crashes the interpreter, even when the process recursion
+  limit has been raised, and
+* a benign control loads and works.
+
+The teeth are explicit: the SAME deeply nested payload is first run through the
+stock C ``json`` decoder with a raised recursion limit and shown to hard-crash
+the interpreter (a fatal signal), so the guarded assertions below it are real,
+not vacuous.
+
+Vectors covered: deeply nested arrays and objects (C-stack overflow), giant
+integers (int/str conversion cost), oversized documents (memory), duplicate
+keys and unexpected top-level types (shape confusion), and a perceptron model
+whose weight/tagdict values are hostile strings (confirming the values are inert
+data, never evaluated).
+
+Cross platform notes: subprocess fixtures are staged under ``$HOME`` (never
+``/tmp``), every file is opened with an explicit encoding, subprocesses carry a
+wall-clock timeout, and the fatal-signal teeth are guarded with a POSIX-only
+``skipif``.
+"""
+
+import io
+import json
+import os
+import signal
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+import nltk
+
+POSIX_ONLY = pytest.mark.skipif(os.name != "posix", reason="POSIX-only fatal signal")
+
+# Depth that reliably overflows the C stack of the stock decoder once the
+# recursion limit is lifted, while staying a tiny (~1.6 MB) payload.
+DEEP = 400_000
+# A recursion limit high enough that the C decoder recurses into a real C-stack
+# overflow instead of raising a bounded RecursionError first.
+RECLIMIT = 5_000_000
+# The repo root so a "python -c" child imports THIS worktree's nltk (the parent
+# directory of the nltk package, i.e. two levels up from nltk/__init__.py).
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(nltk.__file__)))
+
+# Child-side preamble: stage a private data root under $HOME, register it, turn
+# on pathsec enforcement, and expose the hostile-payload builders. Everything a
+# scenario body needs is defined here so the bodies stay short.
+PREAMBLE = textwrap.dedent(
+    """
+    import io, json, os, pathlib, shutil, sys, tempfile
+
+    import nltk, nltk.data
+    from nltk import pathsec
+
+    DEEP = {deep}
+
+    def stage_root():
+        root = tempfile.mkdtemp(prefix="nltk_attack_root_", dir=str(pathlib.Path.home()))
+        pathsec.ENFORCE = True
+        nltk.data.path[:] = [root]
+        pathsec._ALLOWED_ROOTS_CACHE = None
+        pathsec._LAST_DATA_PATHS = None
+        return root
+
+    def deep_array():
+        return "[" * DEEP + "]" * DEEP
+
+    def deep_object():
+        return '{{"a":' * DEEP + "1" + "}}" * DEEP
+
+    def giant_int():
+        return "1" + "0" * 10_000_000
+
+    def ok(tag=""):
+        print("RESULT:OK:" + str(tag))
+        sys.stdout.flush()
+
+    def rejected(exc):
+        print("RESULT:REJECTED:" + type(exc).__name__ + ":" + str(exc)[:80])
+        sys.stdout.flush()
+
+    def write_text(path, text):
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(text)
+    """
+).format(deep=DEEP)
+
+
+def run_child(body, *, timeout=60, reclimit=None, memcap_bytes=None):
+    """Run a child interpreter (PREAMBLE + body) with a wall-clock timeout.
+
+    Returns the completed process. ``reclimit`` lifts the recursion limit so the
+    deep-nesting vector can reach a real C-stack overflow; ``memcap_bytes`` caps
+    address space where the platform supports it (belt and suspenders on top of
+    the size guard). Neither is on by default.
+    """
+    prologue = ""
+    if reclimit is not None:
+        prologue += f"import sys as _s; _s.setrecursionlimit({reclimit})\n"
+    if memcap_bytes is not None:
+        prologue += textwrap.dedent(
+            f"""
+            try:
+                import resource as _r
+                _soft, _hard = _r.getrlimit(_r.RLIMIT_AS)
+                _cap = {memcap_bytes}
+                if _hard == _r.RLIM_INFINITY or _cap < _hard:
+                    _r.setrlimit(_r.RLIMIT_AS, (_cap, _hard))
+            except (ImportError, ValueError, OSError):
+                pass
+            """
+        )
+    src = PREAMBLE + "\n" + prologue + textwrap.dedent(body)
+    env = dict(os.environ)
+    env["PYTHONPATH"] = REPO_ROOT + os.pathsep + env.get("PYTHONPATH", "")
+    return subprocess.run(
+        [sys.executable, "-c", src],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        cwd=REPO_ROOT,
+        env=env,
+    )
+
+
+def assert_no_crash_and_rejected(proc):
+    """The guarded child must exit cleanly and report a bounded rejection."""
+    assert proc.returncode == 0, (
+        f"guarded caller crashed (returncode={proc.returncode}); "
+        f"stdout={proc.stdout!r} stderr={proc.stderr[-400:]!r}"
+    )
+    assert "RESULT:REJECTED:" in proc.stdout, (
+        f"expected a bounded rejection; stdout={proc.stdout!r} "
+        f"stderr={proc.stderr[-400:]!r}"
+    )
+
+
+# In-process unit checks on the shared chokepoint (safe_json_load / _loads):
+# every caller funnels through these, so a bounded rejection here is inherited
+# everywhere, and none of these can crash the interpreter (no subprocess).
+
+
+def test_helper_parses_benign_control():
+    from nltk.jsontags import safe_json_loads
+
+    assert safe_json_loads('{"a": [1, 2, 3], "b": {"c": 4}}') == {
+        "a": [1, 2, 3],
+        "b": {"c": 4},
+    }
+
+
+def test_helper_rejects_deep_array_bounded():
+    from nltk.jsontags import safe_json_loads
+
+    payload = "[" * DEEP + "]" * DEEP
+    with pytest.raises(ValueError, match="nesting depth"):
+        safe_json_loads(payload)
+
+
+def test_helper_rejects_deep_object_bounded():
+    from nltk.jsontags import safe_json_loads
+
+    payload = '{"a":' * DEEP + "1" + "}" * DEEP
+    with pytest.raises(ValueError, match="nesting depth"):
+        safe_json_loads(payload)
+
+
+def test_helper_rejects_oversize_document():
+    from nltk.jsontags import safe_json_loads
+
+    # A small explicit cap keeps the test cheap while exercising the same guard
+    # every caller inherits at its 200 MiB default.
+    with pytest.raises(ValueError, match="over the"):
+        safe_json_loads('"' + "a" * 1000 + '"', max_bytes=100)
+
+
+def test_helper_giant_integer_raises_not_hangs():
+    from nltk.jsontags import safe_json_loads
+
+    # The interpreter's int/str conversion limit bounds the parse: a bounded
+    # ValueError, not a multi-second quadratic conversion.
+    with pytest.raises(ValueError):
+        safe_json_loads("[" + "1" + "0" * 10_000_000 + "]")
+
+
+def test_helper_duplicate_keys_last_value_wins():
+    from nltk.jsontags import safe_json_loads
+
+    # Standard json semantics, preserved: no ambiguity or misbehavior.
+    assert safe_json_loads('{"a": 1, "a": 2, "a": 3}') == {"a": 3}
+
+
+def test_helper_unexpected_top_level_types_parse_or_bound():
+    from nltk.jsontags import safe_json_loads
+
+    # Non-object top levels are valid JSON and parse to plain data.
+    assert safe_json_loads("123") == 123
+    assert safe_json_loads('"hello"') == "hello"
+    assert safe_json_loads("[1, 2, 3]") == [1, 2, 3]
+    # A deep top-level array is still rejected by the depth guard.
+    with pytest.raises(ValueError, match="nesting depth"):
+        safe_json_loads("[" * DEEP + "]" * DEEP)
+
+
+def test_helper_reads_text_and_binary_streams():
+    from nltk.jsontags import safe_json_load
+
+    assert safe_json_load(io.StringIO('{"x": 1}')) == {"x": 1}
+    assert safe_json_load(io.BytesIO(b'{"x": 1}')) == {"x": 1}
+
+
+def test_helper_stream_size_cap_bounds_memory():
+    from nltk.jsontags import safe_json_load
+
+    huge = io.StringIO('"' + "a" * 5000 + '"')
+    with pytest.raises(ValueError, match="exceeds the"):
+        safe_json_load(huge, max_bytes=100)
+
+
+# Teeth: the stock decoder hard-crashes on the same payload, proving the guard
+# above is non-vacuous, and the guard survives that payload with the recursion
+# limit lifted.
+
+
+@POSIX_ONLY
+def test_teeth_raw_json_deep_array_hard_crashes():
+    proc = run_child(
+        """
+        import json
+        json.loads(deep_array())
+        ok("raw parsed, no crash")
+        """,
+        reclimit=RECLIMIT,
+        timeout=60,
+    )
+    # Without the depth guard this payload is not safely parsable: a raised
+    # recursion limit overflows the C stack into a fatal SIGSEGV pre-3.12, or a
+    # RecursionError on 3.12+. The bounded loader rejects it before parsing.
+    fatal = {-signal.SIGSEGV, -signal.SIGABRT, -signal.SIGBUS}
+    crashed = proc.returncode in fatal
+    recursion_error = proc.returncode != 0 and "RecursionError" in (proc.stderr or "")
+    assert crashed or recursion_error, (
+        "stock json.loads was expected to hard-crash or raise RecursionError on "
+        f"deeply nested input but returncode={proc.returncode}, "
+        f"stdout={proc.stdout!r}, stderr={(proc.stderr or '')[-200:]!r}"
+    )
+    assert "raw parsed" not in proc.stdout
+
+
+def test_teeth_raw_json_giant_int_raises_not_hangs():
+    # No fatal signal here: the int/str limit turns the giant integer into a
+    # bounded ValueError. The value of the teeth is that it returns quickly
+    # (the timeout would trip if it hung on an unbounded conversion).
+    proc = run_child(
+        """
+        import json
+        try:
+            json.loads(giant_int())
+            print("RESULT:OK:parsed")
+        except ValueError:
+            print("RESULT:REJECTED:ValueError")
+        """,
+        timeout=30,
+    )
+    assert proc.returncode == 0
+    assert "RESULT:REJECTED:ValueError" in proc.stdout
+
+
+@POSIX_ONLY
+def test_guard_survives_deep_array_with_raised_recursion_limit():
+    proc = run_child(
+        """
+        from nltk.jsontags import safe_json_loads
+        try:
+            safe_json_loads(deep_array())
+            ok("parsed (unexpected)")
+        except ValueError as exc:
+            rejected(exc)
+        """,
+        reclimit=RECLIMIT,
+        timeout=60,
+    )
+    assert_no_crash_and_rejected(proc)
+
+
+# Real caller paths, each with the recursion limit lifted so a leak would
+# surface as a crash. Each site: hostile -> bounded rejection, no crash; plus a
+# benign control that loads and works.
+
+
+@POSIX_ONLY
+def test_averaged_perceptron_load_deep_weights_no_crash():
+    proc = run_child(
+        """
+        from nltk.tag.perceptron import AveragedPerceptron
+        root = stage_root()
+        path = os.path.join(root, "weights.json")
+        write_text(path, deep_array())
+        try:
+            AveragedPerceptron().load(path)
+            ok("loaded (unexpected)")
+        except ValueError as exc:
+            rejected(exc)
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+        """,
+        reclimit=RECLIMIT,
+        timeout=60,
+    )
+    assert_no_crash_and_rejected(proc)
+
+
+def test_averaged_perceptron_load_benign_control():
+    proc = run_child(
+        """
+        from nltk.tag.perceptron import AveragedPerceptron
+        root = stage_root()
+        path = os.path.join(root, "weights.json")
+        write_text(path, json.dumps({"bias": {"NN": 1.5, "DT": -0.25}}))
+        ap = AveragedPerceptron()
+        ap.load(path)
+        assert ap.weights == {"bias": {"NN": 1.5, "DT": -0.25}}, ap.weights
+        ok("weights round-tripped")
+        shutil.rmtree(root, ignore_errors=True)
+        """,
+        timeout=60,
+    )
+    assert proc.returncode == 0, proc.stderr[-400:]
+    assert "RESULT:OK:weights round-tripped" in proc.stdout
+
+
+@POSIX_ONLY
+def test_perceptron_load_from_json_deep_model_no_crash():
+    proc = run_child(
+        """
+        from nltk.tag.perceptron import PerceptronTagger
+        root = stage_root()
+        model = os.path.join(root, "model")
+        os.mkdir(model)
+        for attr in ("weights", "tagdict", "classes"):
+            write_text(
+                os.path.join(model, "averaged_perceptron_tagger_xxx.%s.json" % attr),
+                deep_array(),
+            )
+        try:
+            PerceptronTagger(load=False).load_from_json(lang="xxx", loc=model)
+            ok("loaded (unexpected)")
+        except ValueError as exc:
+            rejected(exc)
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+        """,
+        reclimit=RECLIMIT,
+        timeout=60,
+    )
+    assert_no_crash_and_rejected(proc)
+
+
+def test_perceptron_train_save_load_tag_benign_control():
+    # The functionality gate: a freshly trained tagger saves its JSON, reloads
+    # it through the guarded path, and tags correctly.
+    proc = run_child(
+        """
+        from nltk.data import FileSystemPathPointer
+        from nltk.tag.perceptron import PerceptronTagger
+        tagger = PerceptronTagger(load=False)
+        train = [
+            [("today", "NN"), ("is", "VBZ"), ("good", "JJ"), ("day", "NN")],
+            [("yes", "NNS"), ("it", "PRP"), ("beautiful", "JJ")],
+        ]
+        tagger.train(train, save_loc=tagger.save_dir)
+        reloaded = PerceptronTagger(loc=FileSystemPathPointer(tagger.save_dir))
+        assert reloaded.classes == tagger.classes, reloaded.classes
+        tagged = reloaded.tag(["today", "is", "a", "beautiful", "day"])
+        assert [t for _, t in tagged], tagged
+        ok("trained/saved/loaded/tagged")
+        """,
+        timeout=90,
+    )
+    assert proc.returncode == 0, proc.stderr[-400:]
+    assert "RESULT:OK:trained/saved/loaded/tagged" in proc.stdout
+
+
+def test_perceptron_model_values_are_inert_data_not_code():
+    # A model whose weight and tagdict values are hostile strings must load them
+    # as plain data (no eval/exec, no side effect), never as code. JSON has no
+    # globals, and the caller does arithmetic on the values, never eval.
+    proc = run_child(
+        """
+        from nltk.tag.perceptron import AveragedPerceptron
+        root = stage_root()
+        sentinel = os.path.join(root, "SENTINEL")
+        payload = "__import__('os').system('touch %s')" % sentinel
+        path = os.path.join(root, "weights.json")
+        write_text(path, json.dumps({"bias": {"NN": payload}}))
+        ap = AveragedPerceptron()
+        ap.load(path)
+        # The smuggled string is present verbatim as inert data ...
+        assert ap.weights["bias"]["NN"] == payload, ap.weights
+        # ... and nothing executed it.
+        assert not os.path.exists(sentinel), "code execution smuggled through JSON!"
+        ok("inert data, no execution")
+        shutil.rmtree(root, ignore_errors=True)
+        """,
+        timeout=60,
+    )
+    assert proc.returncode == 0, proc.stderr[-400:]
+    assert "RESULT:OK:inert data, no execution" in proc.stdout
+
+
+@POSIX_ONLY
+def test_data_load_json_deep_resource_no_crash():
+    proc = run_child(
+        """
+        import nltk.data
+        root = stage_root()
+        write_text(os.path.join(root, "hostile.json"), deep_array())
+        try:
+            nltk.data.load("hostile.json", format="json", cache=False)
+            ok("loaded (unexpected)")
+        except ValueError as exc:
+            rejected(exc)
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+        """,
+        reclimit=RECLIMIT,
+        timeout=60,
+    )
+    assert_no_crash_and_rejected(proc)
+    # The rejection is the depth guard firing before the tag gate, not the
+    # pre-existing tag error.
+    assert "nesting depth" in proc.stdout
+
+
+def test_data_load_json_benign_reaches_tag_gate_unchanged():
+    """Guarded parse SUCCEEDS on a benign object; behavior is unchanged.
+
+    The format="json" tag gate is pre-existing and rejects every plain object;
+    the point here is that the object is fully parsed and the same tag-gate
+    error is raised, not a JSON parse failure.
+    """
+    proc = run_child(
+        """
+        import nltk.data
+        root = stage_root()
+        write_text(os.path.join(root, "benign.json"), json.dumps({"a": 1}))
+        try:
+            nltk.data.load("benign.json", format="json", cache=False)
+            print("RESULT:OK:returned")
+        except ValueError as exc:
+            print("RESULT:REJECTED:ValueError:" + str(exc)[:60])
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+        """,
+        timeout=60,
+    )
+    assert proc.returncode == 0, proc.stderr[-400:]
+    # Parse succeeded; the pre-existing tag gate is what rejects it.
+    assert "Unknown json tag" in proc.stdout
+
+
+@POSIX_ONLY
+def test_help_tagset_deep_file_no_crash():
+    proc = run_child(
+        """
+        import nltk.help
+        root = stage_root()
+        d = os.path.join(root, "help", "tagsets_json", "PY3_json")
+        os.makedirs(d)
+        write_text(os.path.join(d, "brown_tagset.json"), deep_array())
+        try:
+            nltk.help.brown_tagset()
+            ok("printed (unexpected)")
+        except ValueError as exc:
+            rejected(exc)
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+        """,
+        reclimit=RECLIMIT,
+        timeout=60,
+    )
+    assert_no_crash_and_rejected(proc)
+
+
+def test_help_tagset_benign_control():
+    proc = run_child(
+        """
+        import nltk.help
+        root = stage_root()
+        d = os.path.join(root, "help", "tagsets_json", "PY3_json")
+        os.makedirs(d)
+        write_text(
+            os.path.join(d, "brown_tagset.json"),
+            json.dumps({"NN": ["noun", "the dog barked"]}),
+        )
+        nltk.help.brown_tagset("NN")
+        ok("tagset printed")
+        shutil.rmtree(root, ignore_errors=True)
+        """,
+        timeout=60,
+    )
+    assert proc.returncode == 0, proc.stderr[-400:]
+    assert "RESULT:OK:tagset printed" in proc.stdout
+
+
+@POSIX_ONLY
+def test_twitter_reader_deep_tweet_line_no_crash():
+    proc = run_child(
+        """
+        from nltk.corpus.reader.twitter import TwitterCorpusReader
+        root = stage_root()
+        write_text(os.path.join(root, "tweets.json"), deep_array() + "\\n")
+        try:
+            reader = TwitterCorpusReader(root, r".*\\.json")
+            reader.strings("tweets.json")
+            ok("read (unexpected)")
+        except ValueError as exc:
+            rejected(exc)
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+        """,
+        reclimit=RECLIMIT,
+        timeout=60,
+    )
+    assert_no_crash_and_rejected(proc)
+
+
+def test_twitter_reader_benign_control():
+    proc = run_child(
+        """
+        from nltk.corpus.reader.twitter import TwitterCorpusReader
+        root = stage_root()
+        line = json.dumps({"text": "hello world", "id": 1})
+        write_text(os.path.join(root, "tweets.json"), line + "\\n")
+        reader = TwitterCorpusReader(root, r".*\\.json")
+        strings = reader.strings("tweets.json")
+        assert strings == ["hello world"], strings
+        ok("tweet text read")
+        shutil.rmtree(root, ignore_errors=True)
+        """,
+        timeout=60,
+    )
+    assert proc.returncode == 0, proc.stderr[-400:]
+    assert "RESULT:OK:tweet text read" in proc.stdout
+
+
+@POSIX_ONLY
+def test_json2csv_deep_tweet_line_no_crash():
+    proc = run_child(
+        """
+        import io
+        from nltk.twitter.common import json2csv
+        root = stage_root()
+        out = os.path.join(root, "out.csv")
+        fp = io.StringIO(deep_array() + "\\n")
+        try:
+            json2csv(fp, out, ["id"], gzip_compress=False)
+            ok("wrote (unexpected)")
+        except ValueError as exc:
+            rejected(exc)
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+        """,
+        reclimit=RECLIMIT,
+        timeout=60,
+    )
+    assert_no_crash_and_rejected(proc)
+
+
+def test_json2csv_benign_control():
+    proc = run_child(
+        """
+        import io
+        from nltk.twitter.common import json2csv
+        root = stage_root()
+        out = os.path.join(root, "out.csv")
+        line = json.dumps({"id": 42, "text": "hi"})
+        json2csv(io.StringIO(line + "\\n"), out, ["id"], gzip_compress=False)
+        with open(out, "r", encoding="utf-8") as fh:
+            data = fh.read()
+        assert "42" in data, data
+        ok("csv row written")
+        shutil.rmtree(root, ignore_errors=True)
+        """,
+        timeout=60,
+    )
+    assert proc.returncode == 0, proc.stderr[-400:]
+    assert "RESULT:OK:csv row written" in proc.stdout
+
+
+def test_sentiment_preprocess_benign_control():
+    proc = run_child(
+        """
+        from nltk.sentiment.util import json2csv_preprocess
+        root = stage_root()
+        infile = os.path.join(root, "tweets.json")
+        out = os.path.join(root, "out.csv")
+        write_text(infile, json.dumps({"text": "a lovely day"}) + "\\n")
+        json2csv_preprocess(
+            infile, out, ["text"], gzip_compress=False, remove_duplicates=False
+        )
+        with open(out, "r", encoding="utf-8") as fh:
+            data = fh.read()
+        assert "lovely" in data, data
+        ok("preprocess row written")
+        shutil.rmtree(root, ignore_errors=True)
+        """,
+        timeout=60,
+    )
+    assert proc.returncode == 0, proc.stderr[-400:]
+    assert "RESULT:OK:preprocess row written" in proc.stdout
+
+
+@POSIX_ONLY
+def test_sentiment_preprocess_deep_tweet_line_no_crash():
+    proc = run_child(
+        """
+        from nltk.sentiment.util import json2csv_preprocess
+        root = stage_root()
+        infile = os.path.join(root, "tweets.json")
+        out = os.path.join(root, "out.csv")
+        write_text(infile, deep_array() + "\\n")
+        try:
+            json2csv_preprocess(infile, out, ["text"], gzip_compress=False)
+            ok("wrote (unexpected)")
+        except ValueError as exc:
+            rejected(exc)
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+        """,
+        reclimit=RECLIMIT,
+        timeout=60,
+    )
+    assert_no_crash_and_rejected(proc)

--- a/nltk/test/unit/test_attack_json_loaders_expanded.py
+++ b/nltk/test/unit/test_attack_json_loaders_expanded.py
@@ -984,3 +984,77 @@ def test_leading_whitespace_flood_is_bounded_by_size():
     assert safe_json_loads(" " * 200_000 + "1") == 1
     with pytest.raises(ValueError, match="over the"):
         safe_json_loads(" " * 200 + "1", max_bytes=100)
+
+
+# ==========================================================================
+# Wider-ecosystem JSON CVE/CWE classes (Python stdlib, ujson, jackson /
+# fastjson / Newtonsoft polymorphic deserialization, hash-collision DoS),
+# confirmed against the same chokepoint.
+# ==========================================================================
+
+
+def test_hash_collision_object_is_linear_not_quadratic():
+    # CVE-2011-4815 class: a huge key set. Python's randomized SipHash and the
+    # size cap keep insertion linear, so a many-key object is bounded, not a
+    # quadratic hash-collision DoS.
+    from nltk.jsontags import safe_json_loads
+
+    payload = "{" + ",".join(f'"{i}":0' for i in range(200_000)) + "}"
+    parsed = safe_json_loads(payload)
+    assert len(parsed) == 200_000
+
+
+def test_mixed_array_object_deep_nesting_refused():
+    # CVE-2021-45958 class (ujson deep-nesting stack overflow): the scanner
+    # counts both '[' and '{', so an alternating [{ tower is bounded too.
+    from nltk.jsontags import safe_json_loads, JSON_MAX_DEPTH
+
+    d = JSON_MAX_DEPTH + 50
+    payload = '{"a":[' * (d // 2) + "1" + "]}" * (d // 2)
+    with pytest.raises(ValueError, match="nesting depth"):
+        safe_json_loads(payload)
+
+
+def test_trailing_and_concatenated_data_refused():
+    # Parser-differential smuggling: trailing, leading or concatenated documents
+    # are rejected, so two parsers cannot disagree on the value.
+    from nltk.jsontags import safe_json_loads
+
+    for payload in ('{"a":1}garbage', '{"a":1}{"b":2}', "[1,2]  [3,4]", 'x{"a":1}'):
+        with pytest.raises(ValueError):
+            safe_json_loads(payload)
+
+
+def test_non_rfc_number_syntax_refused():
+    # RFC-8259 strictness: leading zeros, a leading '+', a bare or trailing dot,
+    # hex/octal/underscore literals and a digitless exponent are all refused
+    # (each is accepted by some other language's parser, a smuggling risk).
+    from nltk.jsontags import safe_json_loads
+
+    for payload in ("01", "+1", ".5", "1.", "0x1F", "0o17", "1_000", "1e", "--1"):
+        with pytest.raises(ValueError):
+            safe_json_loads(payload)
+    # Negative zero is valid JSON and parses to 0.
+    assert safe_json_loads("-0") == 0
+
+
+def test_nested_tag_bomb_via_tagged_decoder_refused():
+    # CWE-502 (jackson / fastjson / Newtonsoft polymorphic-deserialization
+    # class): a tower of single-key '!'-tag objects is bounded by the tagged
+    # decoder's depth cap, never unbounded reconstruction.
+    from nltk.jsontags import JSONTaggedDecoder
+
+    payload = '{"!x":' * 300 + "1" + "}" * 300
+    with pytest.raises(ValueError):
+        JSONTaggedDecoder().decode(payload)
+
+
+def test_huge_single_token_is_size_bounded():
+    # A single enormous string or number token is bounded by the byte cap, not
+    # unbounded (CWE-400 / CWE-789).
+    from nltk.jsontags import safe_json_loads
+
+    with pytest.raises(ValueError, match="over the"):
+        safe_json_loads('"' + "a" * 1000 + '"', max_bytes=200)
+    # A large-but-under-cap token still parses.
+    assert safe_json_loads('"' + "a" * 5000 + '"') == "a" * 5000

--- a/nltk/test/unit/test_attack_json_loaders_expanded.py
+++ b/nltk/test/unit/test_attack_json_loaders_expanded.py
@@ -845,3 +845,142 @@ def test_averaged_perceptron_load_rejects_non_finite_weight(tmp_path):
     path.write_text('{"the": {"NN": Infinity, "DT": 0.5}}', encoding="utf-8")
     with pytest.raises(ValueError, match="non-finite"):
         AveragedPerceptron().load(str(path))
+
+
+# ==========================================================================
+# Advisory / CWE coverage map and net-new edge vectors on the chokepoint.
+#
+# jsontags is the single place all JSON deserialization funnels through, so a
+# defence proven here is inherited by every caller. The cases below name the
+# reported advisory or weakness class each one guards against.
+# ==========================================================================
+
+
+def test_ghsa_rf74_tagged_decoder_recursion_bounded():
+    # GHSA-rf74-v2fm-23pw / CWE-674: unbounded recursion in decode_obj. The deep
+    # document is refused with a bounded ValueError, never a RecursionError.
+    from nltk.jsontags import JSONTaggedDecoder
+
+    with pytest.raises(ValueError):
+        JSONTaggedDecoder().decode("[" * 5000 + "]" * 5000)
+
+
+def test_cwe400_resource_exhaustion_size_and_int_bounded():
+    # CWE-400 / CWE-770 / CVE-2020-10735: a large document is refused by the byte
+    # cap and a giant integer by the interpreter's int/str conversion limit.
+    from nltk.jsontags import safe_json_loads
+
+    with pytest.raises(ValueError, match="over the"):
+        safe_json_loads('"' + "a" * 1000 + '"', max_bytes=100)
+    with pytest.raises(ValueError):
+        safe_json_loads("1" + "0" * 5000)
+
+
+def test_cwe502_tag_reconstruction_only_from_allowlist():
+    # CWE-502: the tag path reconstructs only pre-registered classes; an unknown
+    # tag is refused, so an attacker cannot name an arbitrary class or module.
+    from nltk.jsontags import JSONTaggedDecoder
+
+    with pytest.raises(ValueError, match="Unknown tag"):
+        JSONTaggedDecoder().decode('{"!nltk.evil.RCE": {"cmd": "x"}}')
+
+
+def test_cwe20_input_type_validation_is_a_clean_type_error():
+    # CWE-20: a non str/bytes input fails at the chokepoint with a clear
+    # TypeError rather than slipping into the size/scan path.
+    from nltk.jsontags import safe_json_loads
+
+    for bad in (None, 123, [1, 2], {"a": 1}, memoryview(b'{"a":1}')):
+        with pytest.raises(TypeError, match="expected str or bytes"):
+            safe_json_loads(bad)
+    # bytes and bytearray are valid and parse.
+    assert safe_json_loads(b'{"a": 1}') == {"a": 1}
+    assert safe_json_loads(bytearray(b'{"a": 1}')) == {"a": 1}
+
+
+def test_unicode_forms_parse_or_reject_but_never_crash():
+    from nltk.jsontags import safe_json_loads
+
+    # Standard json: lone surrogates, escaped null and bidi controls parse to a
+    # str (inert data); an invalid \x escape, a \U escape and a byte-order mark
+    # are rejected. None crash.
+    assert isinstance(safe_json_loads(r'"\ud800"'), str)  # lone high surrogate
+    assert isinstance(safe_json_loads(r'"\udc00"'), str)  # lone low surrogate
+    assert safe_json_loads('"a\\u0000b"') == "a\x00b"
+    assert safe_json_loads('"x\\u202ey"') == "x‮y"  # RTL override
+    for bad in (r'"\x41"', r'"\U0001F600"', '﻿{"a":1}'):
+        with pytest.raises(ValueError):
+            safe_json_loads(bad)
+
+
+def test_scanner_hidden_brackets_never_undercount_or_bypass():
+    from nltk.jsontags import _scan_json_depth, safe_json_loads
+
+    # Brackets buried in a CLOSED string are correctly counted (real brackets
+    # after it are not lost), and an UNTERMINATED string that hides brackets is
+    # invalid json and rejected by json.loads, so neither bypasses the guard.
+    escaped = '"\\""' + "[" * 5000 + "]" * 5000
+    assert _scan_json_depth(escaped, 10**9) == 5000
+    with pytest.raises(ValueError):
+        safe_json_loads(escaped)
+    unterminated = '"' + "[" * 5000  # never closed
+    assert _scan_json_depth(unterminated, 10**9) == 0
+    with pytest.raises(ValueError):
+        safe_json_loads(unterminated)
+    # Brackets entirely inside a valid string are a depth-0 string value.
+    assert safe_json_loads('"' + "[" * 500 + "]" * 500 + '"') == "[" * 500 + "]" * 500
+
+
+def test_extreme_bound_parameters_fail_closed():
+    from nltk.jsontags import safe_json_loads
+
+    assert safe_json_loads("1", max_depth=0) == 1  # flat is within depth 0
+    with pytest.raises(ValueError, match="nesting depth"):
+        safe_json_loads("[1]", max_depth=0)
+    with pytest.raises(ValueError, match="over the"):
+        safe_json_loads("1", max_bytes=-1)
+    with pytest.raises(ValueError, match="nesting depth"):
+        safe_json_loads("[1]", max_depth=-5)
+
+
+def test_encoder_circular_reference_is_refused_not_infinite():
+    # The encode side must not spin forever on a self-referential object; json's
+    # circular-reference check turns it into a bounded ValueError.
+    import json as _json
+
+    from nltk.jsontags import JSONTaggedEncoder
+
+    cyclic = {}
+    cyclic["self"] = cyclic
+    with pytest.raises(ValueError):
+        _json.dumps(cyclic, cls=JSONTaggedEncoder)
+
+
+def test_stream_partial_reads_fail_closed_not_bypass():
+    # A stream that returns short partial reads truncates the document; the
+    # single bounded read then hands json.loads an incomplete document, which is
+    # refused. It cannot be used to smuggle more than max_bytes past the cap.
+    from nltk.jsontags import safe_json_load
+
+    class PartialStream:
+        def __init__(self, data):
+            self.data = data
+            self.pos = 0
+
+        def read(self, n=-1):
+            chunk = self.data[self.pos : self.pos + 3]
+            self.pos += 3
+            return chunk
+
+    with pytest.raises(ValueError):
+        safe_json_load(PartialStream('{"abcdefgh": 1}'))
+
+
+def test_leading_whitespace_flood_is_bounded_by_size():
+    # A flood of insignificant whitespace is O(n) to skip and bounded by the byte
+    # cap, so it neither hangs nor slips past the guard.
+    from nltk.jsontags import safe_json_loads
+
+    assert safe_json_loads(" " * 200_000 + "1") == 1
+    with pytest.raises(ValueError, match="over the"):
+        safe_json_loads(" " * 200 + "1", max_bytes=100)

--- a/nltk/test/unit/test_attack_json_loaders_expanded.py
+++ b/nltk/test/unit/test_attack_json_loaders_expanded.py
@@ -34,6 +34,9 @@ wall-clock timeout, and the fatal-signal teeth are guarded with a POSIX-only
 ``skipif``.
 """
 
+import ast
+import gzip
+import importlib.util
 import io
 import json
 import os
@@ -1058,3 +1061,165 @@ def test_huge_single_token_is_size_bounded():
         safe_json_loads('"' + "a" * 1000 + '"', max_bytes=200)
     # A large-but-under-cap token still parses.
     assert safe_json_loads('"' + "a" * 5000 + '"') == "a" * 5000
+
+
+# ==========================================================================
+# The byte cap is a BYTE cap, not a code-point cap. A non-ASCII str has more
+# UTF-8 bytes than code points, so counting len() on a str would let an
+# oversized multibyte payload slip past (a memory-exhaustion bypass). Every
+# entry point measures the encoded byte length.
+# ==========================================================================
+
+
+def test_byte_cap_counts_utf8_bytes_not_code_points_loads():
+    # 40 '€' code points are 120 UTF-8 bytes: under a 60-code-point count but
+    # over a 60-byte cap, so it must be refused, and the reported size is bytes.
+    from nltk.jsontags import safe_json_loads
+
+    payload = '"' + "€" * 40 + '"'
+    assert len(payload) < 60 < len(payload.encode("utf-8"))
+    with pytest.raises(ValueError, match="122 bytes, over the 60-byte"):
+        safe_json_loads(payload, max_bytes=60)
+    # bytes input is already byte-measured, and a small non-ASCII doc still loads.
+    assert safe_json_loads('{"c": "€"}') == {"c": "€"}
+    assert safe_json_loads('{"c": "€"}'.encode()) == {"c": "€"}
+
+
+def test_byte_cap_counts_utf8_bytes_not_code_points_decoder():
+    # Same for JSONTaggedDecoder.decode: the argument is a str, so len() would
+    # undercount a multibyte document handed to the recursive C accelerator.
+    from nltk.jsontags import JSONTaggedDecoder
+
+    decoder = JSONTaggedDecoder()
+    decoder.MAX_DECODE_BYTES = 60
+    payload = '"' + "€" * 40 + '"'
+    with pytest.raises(ValueError, match="122 bytes, over the 60-byte"):
+        decoder.decode(payload)
+
+
+def test_byte_cap_counts_utf8_bytes_not_code_points_stream():
+    # And for safe_json_load: a text stream's read(n) counts characters, so the
+    # cap is enforced on the encoded byte length (via the binary buffer when the
+    # stream exposes one). A multibyte doc over the byte cap is refused.
+    from nltk.jsontags import safe_json_load
+
+    payload = '"' + "€" * 40 + '"'
+    raw = payload.encode("utf-8")
+    text_stream = io.TextIOWrapper(io.BytesIO(raw), encoding="utf-8")
+    with pytest.raises(ValueError, match="exceeds the|over the"):
+        safe_json_load(text_stream, max_bytes=60)
+    # A binary stream is byte-measured directly, and an under-cap doc still loads.
+    assert safe_json_load(io.BytesIO('{"c": "€"}'.encode())) == {"c": "€"}
+
+
+def test_decompression_bomb_feeding_json_is_size_bounded():
+    # CWE-409: a small gzip blob inflates to a huge JSON document. Whatever
+    # decompresses it hands the inflated bytes to the chokepoint, where the byte
+    # cap refuses them before the recursive parse runs. (nltk.data's gz path also
+    # bounds the inflate itself; this proves the chokepoint is a second wall.)
+    from nltk.jsontags import safe_json_load, safe_json_loads
+
+    inflated = '"' + "a" * 2_000_000 + '"'
+    compressed = gzip.compress(inflated.encode("utf-8"))
+    assert len(compressed) < len(inflated) // 10  # genuinely a bomb
+    decompressed = gzip.decompress(compressed)
+    with pytest.raises(ValueError, match="over the"):
+        safe_json_loads(decompressed, max_bytes=1000)
+    with pytest.raises(ValueError, match="exceeds the|over the"):
+        safe_json_load(io.BytesIO(decompressed), max_bytes=1000)
+
+
+def test_jsonpickle_style_py_object_tag_is_inert_not_resolved():
+    # CWE-502 (jsonpickle / jackson polymorphic-typing class): a document that
+    # mimics another framework's type hints (``py/object``, ``py/reduce``,
+    # ``__reduce__``) carries no nltk '!' tag, so the tagged decoder returns it
+    # as a plain dict of inert data. No class is named, resolved or constructed.
+    from nltk.jsontags import JSONTaggedDecoder
+
+    for payload in (
+        '{"py/object": "os.system", "args": ["id"]}',
+        '{"py/reduce": [{"py/type": "os.system"}, ["id"]]}',
+        '{"__reduce__": ["subprocess.Popen", ["sh"]]}',
+    ):
+        result = JSONTaggedDecoder().decode(payload)
+        assert isinstance(result, dict)
+    # And a single-key object whose key merely LOOKS tag-like but is unregistered
+    # is refused, never resolved to an arbitrary class.
+    with pytest.raises(ValueError, match="Unknown tag"):
+        JSONTaggedDecoder().decode('{"!os.system": ["id"]}')
+
+
+# ==========================================================================
+# CI guard (tools/check_all_json_through_jsontags.py): it is the structural
+# enforcement that keeps every future JSON read on the chokepoint, so its
+# bypasses are part of the attack surface. Load the real guard module and drive
+# its AST visitor over each import/call shape that must (or must not) be flagged.
+# ==========================================================================
+
+
+def _load_json_guard():
+    path = os.path.join(REPO_ROOT, "tools", "check_all_json_through_jsontags.py")
+    if not os.path.exists(path):
+        pytest.skip("guard script is only present in a source checkout")
+    spec = importlib.util.spec_from_file_location("_nltk_json_guard", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _guard_flags(guard, source):
+    visitor = guard._JsonCallVisitor("<test>", set())
+    visitor.visit(ast.parse(source))
+    return visitor.violations
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "import json\njson.loads(x)",
+        "import json as j\nj.load(x)",
+        "from json import loads\nloads(x)",
+        "from json import loads as L\nL(x)",
+        # Bypasses the reviewer flagged: submodule import-from, import-as, a
+        # dotted attribute chain, and a bare submodule import.
+        "from json.decoder import JSONDecoder\nJSONDecoder().decode(x)",
+        "from json.decoder import JSONDecoder as JD\nJD().decode(x)",
+        "import json.decoder as jd\njd.JSONDecoder().decode(x)",
+        "import json.decoder\njson.decoder.JSONDecoder().decode(x)",
+        "from json import decoder\ndecoder.JSONDecoder().decode(x)",
+        "from json import *\nloads(x)",
+        # Drop-in accelerators are guarded the same way.
+        "import ujson\nujson.loads(x)",
+        "import simplejson as json\njson.load(x)",
+    ],
+)
+def test_json_guard_flags_every_bare_deserialization_shape(source):
+    guard = _load_json_guard()
+    assert _guard_flags(guard, source), f"guard missed a bypass:\n{source}"
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "obj.load(x)",  # a load() method on some unrelated object
+        "import pickle\npickle.load(x)",  # a different (separately guarded) module
+        "import yaml\nyaml.safe_load(x)",
+        "import json\njson.dumps(x)",  # serialization is not guarded
+        "import json\njson.dump(x, fp)",
+        "self.json.loads(x)",  # attribute named json on some object, not the module
+        "from nltk.jsontags import safe_json_loads\nsafe_json_loads(x)",  # the wrapper
+    ],
+)
+def test_json_guard_ignores_legitimate_shapes(source):
+    guard = _load_json_guard()
+    assert not _guard_flags(guard, source), f"guard false-positived:\n{source}"
+
+
+def test_json_guard_passes_clean_on_the_shipped_tree(monkeypatch):
+    # The guard must still report zero violations on the real package after being
+    # strengthened, so the new bypass coverage did not introduce a false positive.
+    # Run it in-process (no subprocess) with cwd at the repo root so its relative
+    # GUARDED_PATHS resolve.
+    guard = _load_json_guard()
+    monkeypatch.chdir(REPO_ROOT)
+    assert guard.main() == 0

--- a/nltk/test/unit/test_attack_jsontags_candidates_expanded.py
+++ b/nltk/test/unit/test_attack_jsontags_candidates_expanded.py
@@ -25,6 +25,7 @@ No mocking: the actual decoder / parser runs on each input.
 """
 
 import json
+import sys
 
 import pytest
 
@@ -77,27 +78,22 @@ def test_deep_nesting_refused_by_tagged_decoder():
         json.loads(over, cls=JSONTaggedDecoder)
 
 
-def test_depth_exactly_at_limit_is_handled_without_crashing():
-    # A document nested to exactly the depth cap must be handled SAFELY on every
-    # interpreter, never crashing: the C accelerator parses it where it can reach
-    # that depth under the default recursion limit (CPython 3.12+), and where it
-    # cannot (CPython <= 3.11 raises RecursionError a few hundred levels in) the
-    # guard rejects it with a bounded ValueError instead. Either outcome is
-    # acceptable; a RecursionError escaping to the caller is NOT (CWE-674). Forcing
-    # a parse everywhere would mean raising the interpreter recursion limit, which
-    # risks a C-stack segfault (a worse, uncatchable failure) on a constrained
-    # stack, so a clean rejection is the correct behaviour there.
+def test_depth_exactly_at_limit_is_handled_per_interpreter():
+    # A document nested to exactly the depth cap has a DETERMINISTIC, asserted
+    # outcome on each interpreter, never a RecursionError or crash:
+    #   * CPython 3.12+: the C accelerator reaches the full cap depth under the
+    #     default recursion limit, so it PARSES.
+    #   * CPython <= 3.11: the accelerator recursion-limits a few hundred levels
+    #     in, so the guard REJECTS it with a bounded ValueError. Raising the
+    #     recursion limit to force a parse would risk an uncatchable C-stack
+    #     segfault, so a clean rejection is the correct behaviour there.
     at = "[" * JSON_MAX_DEPTH + "]" * JSON_MAX_DEPTH
-    try:
-        result = safe_json_loads(at)
-    except RecursionError:
-        pytest.fail(
-            "safe_json_loads leaked a RecursionError at the depth cap (CWE-674)"
-        )
-    except ValueError:
-        pass  # cleanly rejected on an interpreter that cannot parse this depth
+    if sys.version_info >= (3, 12):
+        assert isinstance(safe_json_loads(at), list)
     else:
-        assert isinstance(result, list)  # parsed where the interpreter can
+        # A RecursionError is not a ValueError, so a leak fails this assertion.
+        with pytest.raises(ValueError):
+            safe_json_loads(at)
     # The 200-deep tagged decoder is well under any recursion limit, so it parses
     # on every supported interpreter.
     dec = (
@@ -422,22 +418,19 @@ DEEP_OVER_CAP = [JSON_MAX_DEPTH + 1, JSON_MAX_DEPTH + 500, 5000, 20000, 100000]
 
 
 class TestNoRecursionErrorLeak:
-    def test_full_depth_document_at_the_cap_is_handled_without_crashing(self):
-        # The previously-CRASHING case (RecursionError leaked to the caller): a
-        # document nested to EXACTLY the 2000 cap must now be handled safely on
-        # every interpreter -- parsed by the C accelerator where it can reach that
+    def test_full_depth_document_at_the_cap_is_handled_per_interpreter(self):
+        # The previously-CRASHING case (RecursionError leaked to the caller), now
+        # with a DETERMINISTIC asserted outcome per interpreter and NEVER a
+        # RecursionError: parsed by the C accelerator where it reaches the cap
         # depth (CPython 3.12+), rejected with a bounded ValueError where the
-        # parser cannot (CPython <= 3.11), and NEVER a RecursionError. This is the
-        # regression the patch caught up to: no crash, on any interpreter.
+        # accelerator recursion-limits first (CPython <= 3.11).
         at = "[" * JSON_MAX_DEPTH + "]" * JSON_MAX_DEPTH
-        try:
-            result = safe_json_loads(at)
-        except RecursionError:
-            pytest.fail("RecursionError leaked at the depth cap (CWE-674)")
-        except ValueError:
-            pass
+        if sys.version_info >= (3, 12):
+            assert isinstance(safe_json_loads(at), list)
         else:
-            assert isinstance(result, list)
+            # A RecursionError is not a ValueError, so a leak fails this assertion.
+            with pytest.raises(ValueError):
+                safe_json_loads(at)
         dec = "[" * JSONTaggedDecoder.MAX_DECODE_DEPTH + "]" * (
             JSONTaggedDecoder.MAX_DECODE_DEPTH
         )

--- a/nltk/test/unit/test_attack_jsontags_candidates_expanded.py
+++ b/nltk/test/unit/test_attack_jsontags_candidates_expanded.py
@@ -1,0 +1,460 @@
+# Natural Language Toolkit: expanded jsontags candidate attack matrix
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""Net-new candidate matrix for ``nltk.jsontags`` structured-format guards.
+
+This file is a companion to ``test_attack_json_loaders_expanded.py`` and
+``test_json_serialization.py``. It drives a broad set of plausible inputs,
+benign and hostile alike, through the REAL structured-format chokepoints:
+
+* :func:`nltk.jsontags.safe_json_loads` / :func:`nltk.jsontags.safe_json_load`
+  (the depth cap ``JSON_MAX_DEPTH``, the size cap ``JSON_MAX_BYTES`` and the
+  non-finite refusal every caller inherits), and
+* :class:`nltk.jsontags.JSONTaggedDecoder` (the model-artifact tag decoder whose
+  reconstruction is gated by a ``!``-prefixed allowlist).
+
+Every hostile candidate is held to one hard property: it is REFUSED with a
+bounded ``ValueError`` (or a clean ``TypeError`` at the type gate), never a hang
+or an interpreter crash, and never a class named by an attacker. Every benign
+candidate PARSES (and, for a registered tag, round-trips to the real object).
+
+No mocking: the actual decoder / parser runs on each input.
+"""
+
+import json
+
+import pytest
+
+from nltk.jsontags import (
+    JSON_MAX_BYTES,
+    JSON_MAX_DEPTH,
+    TAG_PREFIX,
+    JSONTaggedDecoder,
+    JSONTaggedEncoder,
+    register_tag,
+    safe_json_load,
+    safe_json_loads,
+)
+
+# Depths comfortably past each cap while staying tiny (a few thousand bytes):
+# past the loader's JSON_MAX_DEPTH default, and past the tagged decoder's 200.
+OVER_LOADER_DEPTH = JSON_MAX_DEPTH + 500
+OVER_DECODER_DEPTH = JSONTaggedDecoder.MAX_DECODE_DEPTH + 300
+
+
+# ===========================================================================
+# 1. Deep nesting past the cap: arrays, objects, and mixed towers, on both
+#    the loader chokepoint and the tagged decoder (whose super().decode drives
+#    the recursive C accelerator, so it must bound depth BEFORE that call).
+# ===========================================================================
+
+DEEP_PAYLOADS = {
+    "deep-array": "[" * OVER_LOADER_DEPTH + "]" * OVER_LOADER_DEPTH,
+    "deep-object": '{"a":' * OVER_LOADER_DEPTH + "1" + "}" * OVER_LOADER_DEPTH,
+    "deep-mixed": '{"a":[' * (OVER_LOADER_DEPTH // 2)
+    + "1"
+    + "]}" * (OVER_LOADER_DEPTH // 2),
+}
+
+
+@pytest.mark.parametrize(
+    "payload", list(DEEP_PAYLOADS.values()), ids=list(DEEP_PAYLOADS)
+)
+def test_deep_nesting_refused_by_loader(payload):
+    with pytest.raises(ValueError, match="nesting depth"):
+        safe_json_loads(payload)
+
+
+def test_deep_nesting_refused_by_tagged_decoder():
+    over = "[" * OVER_DECODER_DEPTH + "]" * OVER_DECODER_DEPTH
+    with pytest.raises(ValueError, match="nesting depth"):
+        JSONTaggedDecoder().decode(over)
+    # The stdlib entry point routes through the same decode(), so it is bounded.
+    with pytest.raises(ValueError, match="nesting depth"):
+        json.loads(over, cls=JSONTaggedDecoder)
+
+
+def test_depth_exactly_at_limit_still_parses():
+    # A document exactly at each depth limit is legitimate and must still load.
+    assert isinstance(
+        safe_json_loads("[" * JSON_MAX_DEPTH + "]" * JSON_MAX_DEPTH), list
+    )
+    at = (
+        "[" * JSONTaggedDecoder.MAX_DECODE_DEPTH
+        + "]" * JSONTaggedDecoder.MAX_DECODE_DEPTH
+    )
+    assert isinstance(JSONTaggedDecoder().decode(at), list)
+
+
+# ===========================================================================
+# 2. Oversize payload past JSON_MAX_BYTES. The default is 200 MiB; the guard
+#    is exercised with a small explicit cap (the same code path every caller
+#    inherits at the default) and the documented constant is pinned.
+# ===========================================================================
+
+
+def test_size_cap_is_the_documented_default():
+    assert JSON_MAX_BYTES == 200 * 1024 * 1024
+    assert JSONTaggedDecoder.MAX_DECODE_BYTES == JSON_MAX_BYTES
+
+
+def test_oversize_document_refused_by_loader():
+    with pytest.raises(ValueError, match="over the"):
+        safe_json_loads('"' + "a" * 4000 + '"', max_bytes=100)
+    # An under-cap document still parses.
+    assert safe_json_loads('"' + "a" * 50 + '"', max_bytes=100) == "a" * 50
+
+
+def test_oversize_document_refused_by_stream():
+    import io
+
+    with pytest.raises(ValueError, match="exceeds the|over the"):
+        safe_json_load(io.BytesIO(b'"' + b"a" * 4000 + b'"'), max_bytes=100)
+
+
+def test_oversize_document_refused_by_tagged_decoder():
+    decoder = JSONTaggedDecoder()
+    decoder.MAX_DECODE_BYTES = 100  # shrink so the test stays cheap
+    with pytest.raises(ValueError, match="over the"):
+        decoder.decode('"' + "a" * 4000 + '"')
+    assert decoder.decode('{"a": 1}') == {"a": 1}
+
+
+# ===========================================================================
+# 3. Non-finite floats: NaN / Infinity / -Infinity words (parse_constant) and
+#    numeric literals overflowing an IEEE double to inf (parse_float). All must
+#    be refused; every finite value, including the largest double, must parse.
+# ===========================================================================
+
+NON_FINITE = [
+    "NaN",
+    "Infinity",
+    "-Infinity",
+    '{"w": NaN}',
+    "[1, 2, Infinity]",
+    '{"nested": {"w": -Infinity}}',
+    "1e400",
+    "-1e400",
+    "1e999999",
+    '{"w": 1e400}',
+    "[1e309]",
+]
+
+
+@pytest.mark.parametrize("payload", NON_FINITE)
+def test_non_finite_refused_by_loader(payload):
+    with pytest.raises(ValueError, match="non-finite"):
+        safe_json_loads(payload)
+
+
+@pytest.mark.parametrize("payload", ["NaN", "Infinity", '{"x": -Infinity}', "1e400"])
+def test_non_finite_refused_by_tagged_decoder(payload):
+    with pytest.raises(ValueError, match="non-finite"):
+        JSONTaggedDecoder().decode(payload)
+
+
+def test_finite_edge_floats_still_parse():
+    assert safe_json_loads("1.7976931348623157e308") == 1.7976931348623157e308
+    assert safe_json_loads("5e-324") == 5e-324  # smallest subnormal double
+    assert safe_json_loads("1e-999999") == 0.0  # underflow to finite zero
+    assert safe_json_loads('{"w": [0.5, -1.25, 1e10]}') == {"w": [0.5, -1.25, 1e10]}
+
+
+# ===========================================================================
+# 4. A "!tag" whose class is NOT on the allowlist must be refused: the tag path
+#    reconstructs only pre-registered classes, so an attacker cannot name an
+#    arbitrary module or class (CWE-502).
+# ===========================================================================
+
+UNKNOWN_TAGS = [
+    '{"!nltk.not.a.real.tag": 1}',
+    '{"!nltk.evil.RCE": {"cmd": "x"}}',
+    '{"!os.system": ["id"]}',
+    '{"!subprocess.Popen": [["sh", "-c", "id"]]}',
+    '{"!builtins.eval": "1+1"}',
+]
+
+
+@pytest.mark.parametrize("payload", UNKNOWN_TAGS)
+def test_unknown_tag_refused(payload):
+    with pytest.raises(ValueError, match="Unknown tag"):
+        JSONTaggedDecoder().decode(payload)
+
+
+# ===========================================================================
+# 5. Spoofed / forged tag prefix. The fully-qualified "tag:nltk.org,2011:" form
+#    is only honoured when it carries the "!" marker AND is registered; a forged
+#    "!"-prefixed variant is an unknown tag, while a key that merely LOOKS
+#    class-like but lacks the "!" marker is returned as inert data, never
+#    resolved to a class.
+# ===========================================================================
+
+
+def test_forged_qualified_prefix_with_bang_is_unknown_tag():
+    # "!tag:nltk.org,2011:..." carries the "!" marker but is not registered.
+    with pytest.raises(ValueError, match="Unknown tag"):
+        JSONTaggedDecoder().decode('{"!tag:nltk.org,2011:evil.RCE": {"cmd": "x"}}')
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '{"tag:nltk.org,2011:evil": 1}',  # qualified form WITHOUT the "!" marker
+        '{"nltk.tag.DefaultTagger": "NN"}',  # a real class name, but no "!" marker
+        '{"os.system": ["id"]}',
+    ],
+)
+def test_tag_like_key_without_bang_marker_is_inert(payload):
+    # No "!" marker => not treated as a tag => returned as a plain dict of inert
+    # data. No class is named, resolved or constructed.
+    result = JSONTaggedDecoder().decode(payload)
+    assert isinstance(result, dict)
+
+
+def test_multi_key_object_with_a_tag_key_is_inert():
+    # A tag object is single-key; a two-key object is never a tag, so a "!"-keyed
+    # entry buried alongside another key is inert data, not a reconstruction.
+    result = JSONTaggedDecoder().decode(
+        '{"!nltk.tag.sequential.DefaultTagger": "NN", "x": 1}'
+    )
+    assert result == {"!nltk.tag.sequential.DefaultTagger": "NN", "x": 1}
+
+
+def test_nested_tag_bomb_is_depth_bounded():
+    # A tower of single-key "!"-tag objects is bounded by the decoder's depth
+    # cap, never unbounded reconstruction (jackson / fastjson polymorphic class).
+    payload = '{"!x":' * OVER_DECODER_DEPTH + "1" + "}" * OVER_DECODER_DEPTH
+    with pytest.raises(ValueError):
+        JSONTaggedDecoder().decode(payload)
+
+
+# ===========================================================================
+# 6. Duplicate keys: standard json last-value-wins semantics, preserved on both
+#    the loader and the tagged decoder (no ambiguity or misbehaviour).
+# ===========================================================================
+
+
+def test_duplicate_keys_last_value_wins_loader():
+    assert safe_json_loads('{"a": 1, "a": 2, "a": 3}') == {"a": 3}
+    assert safe_json_loads('{"a": 1, "b": 2, "a": 9}') == {"a": 9, "b": 2}
+
+
+def test_duplicate_keys_last_value_wins_tagged_decoder():
+    assert JSONTaggedDecoder().decode('{"a": 1, "a": 2}') == {"a": 2}
+    # A duplicated "!"-tag key collapses to one entry, then is gated as a tag:
+    # unregistered => refused (never a silent second-value reconstruction).
+    with pytest.raises(ValueError, match="Unknown tag"):
+        JSONTaggedDecoder().decode('{"!nltk.nope": 1, "!nltk.nope": 2}')
+
+
+# ===========================================================================
+# 7. Unicode escapes and forms: they parse to inert str data or are refused as
+#    invalid JSON, but never crash the decoder.
+# ===========================================================================
+
+
+def test_unicode_escapes_parse_as_inert_data():
+    assert safe_json_loads(r'"café"') == "café"
+    assert safe_json_loads('"a\\u0000b"') == "a\x00b"  # escaped NUL is data
+    assert safe_json_loads('"x\\u202ey"') == "x‮y"  # RTL override, inert
+    assert isinstance(safe_json_loads(r'"\ud800"'), str)  # lone surrogate, inert
+    # A surrogate pair escape composes to one astral code point.
+    assert safe_json_loads(r'"😀"') == "\U0001f600"
+    # Raw non-ASCII round-trips through the byte-measured path.
+    assert safe_json_loads('{"k": "猫"}') == {"k": "猫"}
+
+
+@pytest.mark.parametrize("payload", [r'"\x41"', r'"\U0001F600"', '﻿{"a":1}'])
+def test_invalid_unicode_forms_refused_not_crashed(payload):
+    with pytest.raises(ValueError):
+        safe_json_loads(payload)
+
+
+# ===========================================================================
+# 8. Integer / float edge values: valid finite numbers parse; a giant integer
+#    is bounded by the interpreter's int/str conversion limit (a ValueError, not
+#    a quadratic hang); non-RFC number syntax is refused.
+# ===========================================================================
+
+
+def test_integer_and_float_edges_parse():
+    assert safe_json_loads("9223372036854775808") == 9223372036854775808  # > int64
+    assert safe_json_loads("-9223372036854775809") == -9223372036854775809
+    assert safe_json_loads("0") == 0
+    assert safe_json_loads("-0") == 0  # negative zero integer normalises
+    assert safe_json_loads("-0.0") == 0.0
+    assert (
+        safe_json_loads("123456789012345678901234567890")
+        == 123456789012345678901234567890
+    )
+    assert safe_json_loads("[1, 2.5, -3, 4e2, 5E-1]") == [1, 2.5, -3, 400.0, 0.5]
+
+
+def test_giant_integer_raises_not_hangs():
+    with pytest.raises(ValueError):
+        safe_json_loads("1" + "0" * 10_000_000)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    ["01", "+1", ".5", "1.", "0x1F", "0o17", "1_000", "1e", "- 1", "Infinity1"],
+)
+def test_non_rfc_number_syntax_refused(payload):
+    with pytest.raises(ValueError):
+        safe_json_loads(payload)
+
+
+# ===========================================================================
+# 9. BENIGN: a legit allowlisted tag round-trips to the real object. Both a
+#    genuinely registered NLTK class (DefaultTagger) and a locally registered
+#    class are exercised, confirming the gate is a functional round-trip, not a
+#    blanket refusal.
+# ===========================================================================
+
+
+def test_registered_nltk_tag_round_trips():
+    import nltk.tag  # noqa: F401  (import registers the tagger tags)
+    from nltk.tag import DefaultTagger
+
+    encoded = json.dumps(DefaultTagger("NN"), cls=JSONTaggedEncoder)
+    assert encoded == '{"!nltk.tag.sequential.DefaultTagger": "NN"}'
+    restored = JSONTaggedDecoder().decode(encoded)
+    assert isinstance(restored, DefaultTagger)
+    assert restored._tag == "NN"
+
+
+def test_locally_registered_tag_round_trips():
+    @register_tag
+    class _Widget:
+        json_tag = "test_candidates._Widget"
+
+        def __init__(self, n):
+            self.n = n
+
+        def encode_json_obj(self):
+            return {"n": self.n}
+
+        @classmethod
+        def decode_json_obj(cls, obj):
+            return cls(obj["n"])
+
+    assert TAG_PREFIX + "test_candidates._Widget" in json.loads(
+        json.dumps(_Widget(3), cls=JSONTaggedEncoder)
+    )
+    restored = JSONTaggedDecoder().decode(json.dumps(_Widget(3), cls=JSONTaggedEncoder))
+    assert isinstance(restored, _Widget) and restored.n == 3
+
+
+def test_benign_plain_documents_parse():
+    assert safe_json_loads('{"a": [1, 2, 3], "b": {"c": 4}}') == {
+        "a": [1, 2, 3],
+        "b": {"c": 4},
+    }
+    assert safe_json_loads("[]") == []
+    assert safe_json_loads("{}") == {}
+    assert safe_json_loads("true") is True
+    assert safe_json_loads("null") is None
+    # A benign untagged object passes cleanly through the tagged decoder too.
+    assert JSONTaggedDecoder().decode('{"weights": {"NN": 1.5}}') == {
+        "weights": {"NN": 1.5}
+    }
+
+
+# ===========================================================================
+# 10. Input-type gate (CWE-20): a non str/bytes input fails at the chokepoint
+#     with a clear TypeError; bytes and bytearray are accepted and parse.
+# ===========================================================================
+
+
+@pytest.mark.parametrize("bad", [None, 123, 4.5, [1, 2], {"a": 1}, memoryview(b"{}")])
+def test_non_str_bytes_input_is_a_clean_type_error(bad):
+    with pytest.raises(TypeError, match="expected str or bytes"):
+        safe_json_loads(bad)
+
+
+def test_bytes_and_bytearray_inputs_parse():
+    assert safe_json_loads(b'{"a": 1}') == {"a": 1}
+    assert safe_json_loads(bytearray(b'{"a": 1}')) == {"a": 1}
+    # Byte cap counts UTF-8 bytes, not code points: 40 euro signs = 120 bytes.
+    payload = '"' + "€" * 40 + '"'
+    assert len(payload) < 60 < len(payload.encode("utf-8"))
+    with pytest.raises(ValueError, match="over the"):
+        safe_json_loads(payload, max_bytes=60)
+
+
+# ===========================================================================
+# Uncontrolled-recursion leak (CWE-674). safe_json_loads used to pass
+# parse_constant / parse_float, which forces json.loads onto the PURE-PYTHON
+# scanner on CPython <= 3.11 (the C scanner gained hook support in 3.12); that
+# scanner recurses in Python and raises RecursionError only a few hundred levels
+# deep under the default recursion limit (measured ~450), so a document WITHIN the
+# 2000 cap crashed json.loads with a RecursionError that escaped to the caller
+# instead of loading. The strengthened guard parses on the C scanner (which
+# handles the full cap cheaply on every interpreter), rejects non-finite values
+# afterwards with an ITERATIVE walk, and converts any residual RecursionError to a
+# clean ValueError. pytest.raises(ValueError) is used deliberately: a
+# RecursionError is a RuntimeError, NOT a ValueError, so a leak fails the test
+# rather than passing it.
+# ===========================================================================
+
+DEEP_OVER_CAP = [JSON_MAX_DEPTH + 1, JSON_MAX_DEPTH + 500, 5000, 20000, 100000]
+
+
+class TestNoRecursionErrorLeak:
+    def test_full_depth_document_at_the_cap_still_parses(self):
+        # The previously-crashing case: a document nested to EXACTLY the 2000 cap
+        # must load on this interpreter under its default recursion limit, on both
+        # entry points. This is the regression the patch had to catch up to.
+        at = "[" * JSON_MAX_DEPTH + "]" * JSON_MAX_DEPTH
+        assert isinstance(safe_json_loads(at), list)
+        dec = "[" * JSONTaggedDecoder.MAX_DECODE_DEPTH + "]" * (
+            JSONTaggedDecoder.MAX_DECODE_DEPTH
+        )
+        assert isinstance(JSONTaggedDecoder().decode(dec), list)
+
+    @pytest.mark.parametrize("depth", DEEP_OVER_CAP)
+    def test_over_cap_is_valueerror_not_recursionerror(self, depth):
+        doc = "[" * depth + "]" * depth
+        with pytest.raises(ValueError):
+            safe_json_loads(doc)
+        with pytest.raises(ValueError):
+            json.loads(doc, cls=JSONTaggedDecoder)
+
+    def test_recursionerror_type_never_escapes(self):
+        # An explicit type check: a very deep tower must not surface as a
+        # RecursionError from either the loader or the tagged decoder.
+        doc = "[" * (JSON_MAX_DEPTH * 30) + "]" * (JSON_MAX_DEPTH * 30)
+        for call in (
+            lambda: safe_json_loads(doc),
+            lambda: json.loads(doc, cls=JSONTaggedDecoder),
+            lambda: JSONTaggedDecoder().decode(doc),
+        ):
+            try:
+                call()
+            except RecursionError:
+                pytest.fail("deep JSON leaked a RecursionError (CWE-674)")
+            except ValueError:
+                pass
+            else:
+                pytest.fail("over-deep document was not rejected")
+
+    def test_recursionerror_from_the_parser_is_caught_as_valueerror(self, monkeypatch):
+        # The C scanner parses the full cap without ever recursing to the limit,
+        # so a RecursionError does not arise in normal operation and cannot be
+        # provoked by lowering sys.setrecursionlimit. Inject one at the parser
+        # boundary (json.loads) to prove the guard's CWE-674 conversion still
+        # fires: safe_json_loads MUST turn a RecursionError from the parser into a
+        # clean ValueError and never let it escape (belt-and-suspenders for a
+        # caller already near the limit or a stack-heavier scanner). This
+        # fault-injects the failure at the boundary; it does not mock the guard.
+        import nltk.jsontags as jt
+
+        def _raise_recursion(*args, **kwargs):
+            raise RecursionError("simulated deep parse")
+
+        monkeypatch.setattr(jt.json, "loads", _raise_recursion)
+        with pytest.raises(ValueError):
+            jt.safe_json_loads("[1]")  # depth 1 passes the scan; the parse raises

--- a/nltk/test/unit/test_attack_jsontags_candidates_expanded.py
+++ b/nltk/test/unit/test_attack_jsontags_candidates_expanded.py
@@ -77,16 +77,34 @@ def test_deep_nesting_refused_by_tagged_decoder():
         json.loads(over, cls=JSONTaggedDecoder)
 
 
-def test_depth_exactly_at_limit_still_parses():
-    # A document exactly at each depth limit is legitimate and must still load.
-    assert isinstance(
-        safe_json_loads("[" * JSON_MAX_DEPTH + "]" * JSON_MAX_DEPTH), list
-    )
-    at = (
+def test_depth_exactly_at_limit_is_handled_without_crashing():
+    # A document nested to exactly the depth cap must be handled SAFELY on every
+    # interpreter, never crashing: the C accelerator parses it where it can reach
+    # that depth under the default recursion limit (CPython 3.12+), and where it
+    # cannot (CPython <= 3.11 raises RecursionError a few hundred levels in) the
+    # guard rejects it with a bounded ValueError instead. Either outcome is
+    # acceptable; a RecursionError escaping to the caller is NOT (CWE-674). Forcing
+    # a parse everywhere would mean raising the interpreter recursion limit, which
+    # risks a C-stack segfault (a worse, uncatchable failure) on a constrained
+    # stack, so a clean rejection is the correct behaviour there.
+    at = "[" * JSON_MAX_DEPTH + "]" * JSON_MAX_DEPTH
+    try:
+        result = safe_json_loads(at)
+    except RecursionError:
+        pytest.fail(
+            "safe_json_loads leaked a RecursionError at the depth cap (CWE-674)"
+        )
+    except ValueError:
+        pass  # cleanly rejected on an interpreter that cannot parse this depth
+    else:
+        assert isinstance(result, list)  # parsed where the interpreter can
+    # The 200-deep tagged decoder is well under any recursion limit, so it parses
+    # on every supported interpreter.
+    dec = (
         "[" * JSONTaggedDecoder.MAX_DECODE_DEPTH
         + "]" * JSONTaggedDecoder.MAX_DECODE_DEPTH
     )
-    assert isinstance(JSONTaggedDecoder().decode(at), list)
+    assert isinstance(JSONTaggedDecoder().decode(dec), list)
 
 
 # ===========================================================================
@@ -404,12 +422,22 @@ DEEP_OVER_CAP = [JSON_MAX_DEPTH + 1, JSON_MAX_DEPTH + 500, 5000, 20000, 100000]
 
 
 class TestNoRecursionErrorLeak:
-    def test_full_depth_document_at_the_cap_still_parses(self):
-        # The previously-crashing case: a document nested to EXACTLY the 2000 cap
-        # must load on this interpreter under its default recursion limit, on both
-        # entry points. This is the regression the patch had to catch up to.
+    def test_full_depth_document_at_the_cap_is_handled_without_crashing(self):
+        # The previously-CRASHING case (RecursionError leaked to the caller): a
+        # document nested to EXACTLY the 2000 cap must now be handled safely on
+        # every interpreter -- parsed by the C accelerator where it can reach that
+        # depth (CPython 3.12+), rejected with a bounded ValueError where the
+        # parser cannot (CPython <= 3.11), and NEVER a RecursionError. This is the
+        # regression the patch caught up to: no crash, on any interpreter.
         at = "[" * JSON_MAX_DEPTH + "]" * JSON_MAX_DEPTH
-        assert isinstance(safe_json_loads(at), list)
+        try:
+            result = safe_json_loads(at)
+        except RecursionError:
+            pytest.fail("RecursionError leaked at the depth cap (CWE-674)")
+        except ValueError:
+            pass
+        else:
+            assert isinstance(result, list)
         dec = "[" * JSONTaggedDecoder.MAX_DECODE_DEPTH + "]" * (
             JSONTaggedDecoder.MAX_DECODE_DEPTH
         )

--- a/nltk/twitter/common.py
+++ b/nltk/twitter/common.py
@@ -12,9 +12,9 @@ the `twython` library to have been installed.
 """
 import csv
 import gzip
-import json
 
 from nltk.internals import deprecated
+from nltk.jsontags import safe_json_loads
 
 HIER_SEPARATOR = "."
 
@@ -123,7 +123,8 @@ def json2csv(
     writer.writerow(fields)
     # process the file
     for line in fp:
-        tweet = json.loads(line)
+        # Untrusted tweet line: bound size and nesting depth before parsing.
+        tweet = safe_json_loads(line, context="twitter.json2csv")
         row = extract_fields(tweet, fields)
         writer.writerow(row)
     outf.close()
@@ -198,7 +199,8 @@ def json2csv_entities(
     header = get_header_field_list(main_fields, entity_type, entity_fields)
     writer.writerow(header)
     for line in tweets_file:
-        tweet = json.loads(line)
+        # Untrusted tweet line: bound size and nesting depth before parsing.
+        tweet = safe_json_loads(line, context="twitter.json2csv_entities")
         if _is_composed_key(entity_type):
             key, value = _get_key_value_composed(entity_type)
             object_json = _get_entity_recursive(tweet, key)

--- a/tools/check_all_json_through_jsontags.py
+++ b/tools/check_all_json_through_jsontags.py
@@ -73,7 +73,21 @@ _JSON_MODULES = frozenset({"json", "simplejson", "ujson", "orjson", "_json"})
 # excluded; ``JSONDecoder`` is a deserializer constructor and is guarded.
 _GUARDED_FUNCS = frozenset({"load", "loads", "JSONDecoder"})
 
+# Deserialization-relevant json submodules. ``json.decoder`` holds
+# ``JSONDecoder``; ``from json import decoder`` / ``import json.decoder`` route a
+# call through it, so those bindings are tracked as module aliases too.
+_JSON_SUBMODULES = frozenset({"decoder", "scanner"})
+
 SUPPRESS_MARKER = "# json-load ok"
+
+
+def _attr_root_name(node):
+    # Walk an attribute chain (``json.decoder`` down to ``json``) to its root
+    # Name, so a guarded call reached through a submodule attribute is still
+    # attributed to the json module at the root of the chain.
+    while isinstance(node, ast.Attribute):
+        node = node.value
+    return node.id if isinstance(node, ast.Name) else None
 
 
 class _JsonCallVisitor(ast.NodeVisitor):
@@ -95,28 +109,40 @@ class _JsonCallVisitor(ast.NodeVisitor):
 
     def visit_Import(self, node):
         for alias in node.names:
-            if alias.name in _JSON_MODULES:
-                self._module_aliases.add(alias.asname or alias.name)
+            # ``import json`` / ``import json as j`` / ``import json.decoder`` /
+            # ``import json.decoder as jd``: bind whatever name lands in scope.
+            root = alias.name.split(".", 1)[0]
+            if root in _JSON_MODULES:
+                self._module_aliases.add(alias.asname or root)
         self.generic_visit(node)
 
     def visit_ImportFrom(self, node):
-        if node.module in _JSON_MODULES:
+        module = node.module or ""
+        # ``from json.decoder import JSONDecoder`` roots at ``json`` too, so key
+        # off the top package, not the exact submodule name.
+        if module.split(".", 1)[0] in _JSON_MODULES:
             for alias in node.names:
                 if alias.name == "*":
                     # ``from json import *`` pulls the guarded callables in
                     # untracked; refuse it outright.
-                    self._flag(node, f"from {node.module} import *")
+                    self._flag(node, f"from {module} import *")
                 elif alias.name in _GUARDED_FUNCS:
+                    # ``from json import loads`` / ``from json.decoder import JSONDecoder``.
                     self._func_aliases[alias.asname or alias.name] = alias.name
+                elif module in _JSON_MODULES and alias.name in _JSON_SUBMODULES:
+                    # ``from json import decoder`` binds a submodule; track it so
+                    # ``decoder.JSONDecoder(...)`` is still caught.
+                    self._module_aliases.add(alias.asname or alias.name)
         self.generic_visit(node)
 
     def visit_Call(self, node):
         func = node.func
-        # ``json.loads(...)`` / ``j.load(...)``: attribute on a json module.
+        # ``json.loads(...)`` / ``jd.JSONDecoder(...)`` / a guarded attribute on
+        # a json submodule chain (``json.decoder.JSONDecoder(...)``).
         if isinstance(func, ast.Attribute) and func.attr in _GUARDED_FUNCS:
-            recv = func.value
-            if isinstance(recv, ast.Name) and recv.id in self._module_aliases:
-                self._flag(node, f"{recv.id}.{func.attr}(...)")
+            root = _attr_root_name(func.value)
+            if root is not None and root in self._module_aliases:
+                self._flag(node, f"{root}.{func.attr}(...)")
         # ``loads(...)``: a guarded func imported bare from a json module.
         elif isinstance(func, ast.Name) and func.id in self._func_aliases:
             self._flag(node, f"{func.id}(...)  [from json]")

--- a/tools/check_all_json_through_jsontags.py
+++ b/tools/check_all_json_through_jsontags.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+# Natural Language Toolkit: JSON-deserialization CI guard
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+"""Fail if any JSON is deserialized with bare ``json`` instead of nltk.jsontags.
+
+``json.load`` / ``json.loads`` build an arbitrary object graph from the input
+with no bound on nesting depth or size, so a deeply nested or oversized document
+from an untrusted source is a denial of service: unbounded recursion crashes the
+interpreter (CWE-674) and a huge document exhausts memory/CPU (CWE-400).
+``nltk.jsontags`` is the choke point that makes JSON reading safe:
+:func:`~nltk.jsontags.safe_json_loads` and :func:`~nltk.jsontags.safe_json_load`
+are drop-in replacements for ``json.loads`` / ``json.load`` that enforce a max
+nesting depth and byte cap, and :class:`~nltk.jsontags.JSONTaggedDecoder` bounds
+the decode depth for the tag machinery.
+
+This guard enforces the policy structurally: any call to ``json.load``,
+``json.loads`` or ``json.JSONDecoder`` (on the bare ``json`` / ``simplejson`` /
+``ujson`` / ``orjson`` / ``_json`` module, under any import alias, or imported
+bare with ``from json import loads``) anywhere under ``nltk/`` is a violation.
+Read through ``jsontags.safe_json_load`` / ``safe_json_loads`` instead.
+
+Serialization (``json.dump`` / ``json.dumps``) is NOT guarded: writing runs no
+untrusted input and cannot recurse or allocate on an attacker's behalf.
+
+The things that are not violations are structural, not exceptions:
+
+* ``nltk/jsontags.py`` itself: it is the wrapper every call routes *through*, so
+  it necessarily uses the ``json`` module directly (just as ``nltk/pathsec.py``
+  is the sandbox ``check_no_unsandboxed_open`` is built around).
+* the safe wrappers themselves (``safe_json_load`` / ``safe_json_loads`` /
+  ``JSONTaggedDecoder``) are called by their own names, not on the ``json``
+  module, so they are (correctly) ignored.
+
+A deliberate, reviewed exception may be annotated with a trailing
+``# json-load ok: <reason>`` comment on the same line.
+
+An AST check is used rather than a text search so that ``obj.load(...)`` (a method
+on some other object), ``pickle.load(...)``, ``yaml.load(...)`` etc. are correctly
+ignored: only a call whose receiver resolves to the bare ``json`` (or a sibling)
+module, or a name imported directly from it, matches. Import aliases
+(``import json as j``, ``from json import loads``) are tracked per file so neither
+can smuggle a bare deserialization past the guard.
+
+Usage: ``python tools/check_all_json_through_jsontags.py`` (exit 1 on any
+violation).
+"""
+
+import ast
+import os
+import sys
+
+# The whole shipped package is guarded. Everything here is currently routed
+# through jsontags; the guard keeps it that way as the codebase changes.
+GUARDED_PATHS = ["nltk"]
+
+# The test tree is exempt: tests legitimately exercise raw ``json`` behaviour
+# (e.g. to craft the deep/oversized payloads jsontags must refuse, or to assert
+# on stdlib semantics), and a test is not part of the library's attack surface.
+_EXEMPT_PREFIXES = (os.path.join("nltk", "test"),)
+
+# ``nltk/jsontags.py`` is the wrapper itself: it must use ``json`` directly.
+_EXEMPT_FILES = (os.path.join("nltk", "jsontags.py"),)
+
+# The stdlib / drop-in json modules whose deserializing calls must go through
+# jsontags. The C accelerator ``_json`` is included for completeness.
+_JSON_MODULES = frozenset({"json", "simplejson", "ujson", "orjson", "_json"})
+
+# Attributes that deserialize JSON (unbounded recursion / allocation) and so must
+# route through jsontags. ``dump`` / ``dumps`` serialise and are intentionally
+# excluded; ``JSONDecoder`` is a deserializer constructor and is guarded.
+_GUARDED_FUNCS = frozenset({"load", "loads", "JSONDecoder"})
+
+SUPPRESS_MARKER = "# json-load ok"
+
+
+class _JsonCallVisitor(ast.NodeVisitor):
+    def __init__(self, path, suppressed_lines):
+        self.path = path
+        self.suppressed_lines = suppressed_lines
+        self.violations = []
+        # Local name -> json module (``import json`` / ``import json as j`` /
+        # ``import ujson as json``). Seeded so a file that shadows without
+        # importing (unlikely) still trips on the bare module names.
+        self._module_aliases = set(_JSON_MODULES)
+        # Local name -> the guarded func it was imported as
+        # (``from json import loads`` -> ``loads``).
+        self._func_aliases = {}
+
+    def _flag(self, node, what):
+        if node.lineno not in self.suppressed_lines:
+            self.violations.append((node.lineno, what))
+
+    def visit_Import(self, node):
+        for alias in node.names:
+            if alias.name in _JSON_MODULES:
+                self._module_aliases.add(alias.asname or alias.name)
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node):
+        if node.module in _JSON_MODULES:
+            for alias in node.names:
+                if alias.name == "*":
+                    # ``from json import *`` pulls the guarded callables in
+                    # untracked; refuse it outright.
+                    self._flag(node, f"from {node.module} import *")
+                elif alias.name in _GUARDED_FUNCS:
+                    self._func_aliases[alias.asname or alias.name] = alias.name
+        self.generic_visit(node)
+
+    def visit_Call(self, node):
+        func = node.func
+        # ``json.loads(...)`` / ``j.load(...)``: attribute on a json module.
+        if isinstance(func, ast.Attribute) and func.attr in _GUARDED_FUNCS:
+            recv = func.value
+            if isinstance(recv, ast.Name) and recv.id in self._module_aliases:
+                self._flag(node, f"{recv.id}.{func.attr}(...)")
+        # ``loads(...)``: a guarded func imported bare from a json module.
+        elif isinstance(func, ast.Name) and func.id in self._func_aliases:
+            self._flag(node, f"{func.id}(...)  [from json]")
+        self.generic_visit(node)
+
+
+def _iter_py_files(paths):
+    for base in paths:
+        for root, _dirs, files in os.walk(base):
+            for name in sorted(files):
+                if name.endswith(".py"):
+                    yield os.path.join(root, name)
+
+
+def _is_exempt(path):
+    norm = os.path.normpath(path)
+    if norm in {os.path.normpath(f) for f in _EXEMPT_FILES}:
+        return True
+    return any(norm == p or norm.startswith(p + os.sep) for p in _EXEMPT_PREFIXES)
+
+
+def _suppressed_lines(source):
+    return {
+        i
+        for i, line in enumerate(source.splitlines(), start=1)
+        if SUPPRESS_MARKER in line
+    }
+
+
+def main():
+    violations = []
+    for path in _iter_py_files(GUARDED_PATHS):
+        if _is_exempt(path):
+            continue
+        try:
+            with open(path, encoding="utf-8") as fh:
+                source = fh.read()
+            tree = ast.parse(source, filename=path)
+        except (OSError, SyntaxError) as exc:
+            print(f"{path}: could not parse ({exc})", file=sys.stderr)
+            violations.append((path, 0, "unparseable"))
+            continue
+        visitor = _JsonCallVisitor(path, _suppressed_lines(source))
+        visitor.visit(tree)
+        for lineno, what in visitor.violations:
+            violations.append((path, lineno, what))
+
+    if violations:
+        print(
+            "JSON deserialization must route through nltk.jsontags, not bare json "
+            f"(found {len(violations)}):\n",
+            file=sys.stderr,
+        )
+        for path, lineno, what in violations:
+            print(f"  {path}:{lineno}: {what}", file=sys.stderr)
+        print(
+            "\nRead through jsontags.safe_json_load / safe_json_loads (or "
+            "JSONTaggedDecoder for tagged objects); they bound nesting depth and "
+            "size. See nltk/jsontags.py. A reviewed exception may be annotated "
+            f"with a trailing '{SUPPRESS_MARKER}: <reason>' comment.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("OK: every JSON deserialization routes through nltk.jsontags.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Bound JSON deserialization against deep-nesting crash and resource DoS

Split out of the GHSA-8mgp hardening effort (#3753) as a focused, self-contained change.

### The problem

Several `json.load` / `json.loads` sites consume file, resource or tweet data and feed it straight to the stock CPython C decoder:

- `AveragedPerceptron.load` and `PerceptronTagger.load_from_json`
- `nltk.data.load(format="json")`
- `nltk.help` tagset lookup
- the tweet readers in `nltk.corpus.reader.twitter`, `nltk.twitter.common` and `nltk.sentiment.util`

The C accelerator recurses in C. Once a process has raised its recursion limit, a deeply nested document (a few hundred KB of `[[[...]]]`) overflows the C stack and **segfaults the interpreter** — an uncatchable crash — instead of raising a bounded `RecursionError` (**CWE-674**, uncontrolled recursion). A large or giant-integer payload can also drive unbounded memory / CPU (**CWE-400**, resource exhaustion). At the default recursion limit these sites are already safe, but any application that lifts the limit turns untrusted JSON (a tampered model, a data resource, a tweet line) into a crash primitive.

### The bound

Add a shared bounded loader to `nltk.jsontags` (self-contained; depends only on the stdlib `json`):

```python
safe_json_loads(data, *, max_depth=JSON_MAX_DEPTH, max_bytes=JSON_MAX_BYTES, context=...)
safe_json_load(fp,     *, max_depth=JSON_MAX_DEPTH, max_bytes=JSON_MAX_BYTES, context=...)
```

Enforcement, applied **before** the recursive C parse runs:

1. **Size cap** (`JSON_MAX_BYTES`, default 200 MiB). `safe_json_load` reads at most `max_bytes + 1` bytes so a gigantic file cannot be slurped into memory before it is rejected.
2. **Structural nesting-depth cap** (`JSON_MAX_DEPTH`, default 2000). A non-recursive byte-level pre-scan (`_scan_json_depth`) counts `[`/`{` depth, ignoring brackets inside string literals and honouring backslash escapes, and exits early as soon as the limit is exceeded. Non-structural bytes are stripped at C speed via `bytes.translate`, so a legit 30 MB perceptron model scans in well under a second.

An over-deep or over-large document raises a plain, bounded `ValueError` instead of segfaulting or exhausting memory. Giant integers remain bounded by the interpreter's `int_max_str_digits` default during the parse, with the size cap as a backstop.

### Callers routed through the bound

`nltk/data.py`, `nltk/help.py`, `nltk/tag/perceptron.py`, `nltk/sentiment/util.py`, `nltk/twitter/common.py`, `nltk/corpus/reader/twitter.py` — each now parses through `safe_json_load` / `safe_json_loads`. This only bounds a crash/memory primitive: the perceptron does arithmetic on the parsed values and never `eval`/`exec`s them, so no code execution is involved either way.

### Tests

`nltk/test/unit/test_attack_json_loaders_expanded.py` drives deep-nesting, oversize, giant-integer, duplicate-key and hostile-model-shape payloads through **each real caller** in a subprocess with a raised recursion limit and a wall-clock timeout. It asserts no interpreter crash and a bounded rejection, and proves the guard is non-vacuous by showing the same payload hard-crashes the stock decoder. Benign controls confirm a trained tagger still saves, loads and tags, tagset lookup still works, tweets still parse, and a benign document still round-trips through the JSON tag machinery unchanged.

- `pytest nltk/test/unit/test_attack_json_loaders_expanded.py` → **27 passed**.
- A benign deep-but-legal JSON still loads; an over-deep / oversized payload is refused with a bounded `ValueError`.
