### PR TITLE
Route nltk.tokenize regexes through nltk.redos (CWE-1333/CWE-400)

### DIFF
--- a/nltk/tokenize/casual.py
+++ b/nltk/tokenize/casual.py
@@ -213,17 +213,17 @@ REGEXPS_PHONE = (REGEXPS[0], PHONE_REGEX, *REGEXPS[1:])
 # the core tokenizing regexes. They are compiled lazily.
 
 # WORD_RE performs poorly on these patterns:
-HANG_RE = regex.compile(r"([^\p{L}\p{N}])\1{3,}")
+HANG_RE = redos.compile(r"([^\p{L}\p{N}])\1{3,}")
 
 # The emoticon string gets its own regex so that we can preserve case for
 # them as needed:
-EMOTICON_RE = regex.compile(EMOTICONS, regex.VERBOSE | regex.I | regex.UNICODE)
+EMOTICON_RE = redos.compile(EMOTICONS, regex.VERBOSE | regex.I | regex.UNICODE)
 
 # These are for regularizing HTML entities to Unicode:
-ENT_RE = regex.compile(r"&(#?(x?))([^&;\s]+);")
+ENT_RE = redos.compile(r"&(#?(x?))([^&;\s]+);")
 
 # For stripping away handles from a tweet:
-HANDLES_RE = regex.compile(
+HANDLES_RE = redos.compile(
     r"(?<![A-Za-z0-9_!@#\$%&*])@"
     r"(([A-Za-z0-9_]){15}(?!@)|([A-Za-z0-9_]){1,14}(?![A-Za-z0-9_]*@))"
 )
@@ -404,7 +404,7 @@ class TweetTokenizer(TokenizerI):
         """Core TweetTokenizer regex"""
         # Compiles the regex for this and all future instantiations of TweetTokenizer.
         if not type(self)._WORD_RE:
-            type(self)._WORD_RE = regex.compile(
+            type(self)._WORD_RE = redos.compile(
                 f"({'|'.join(REGEXPS)})",
                 regex.VERBOSE | regex.I | regex.UNICODE,
             )
@@ -415,7 +415,7 @@ class TweetTokenizer(TokenizerI):
         """Secondary core TweetTokenizer regex"""
         # Compiles the regex for this and all future instantiations of TweetTokenizer.
         if not type(self)._PHONE_WORD_RE:
-            type(self)._PHONE_WORD_RE = regex.compile(
+            type(self)._PHONE_WORD_RE = redos.compile(
                 f"({'|'.join(REGEXPS_PHONE)})",
                 regex.VERBOSE | regex.I | regex.UNICODE,
             )
@@ -432,7 +432,7 @@ def reduce_lengthening(text):
     Replace repeated character sequences of length 3 or greater with sequences
     of length 3.
     """
-    pattern = regex.compile(r"(.)\1{2,}")
+    pattern = redos.compile(r"(.)\1{2,}")
     return pattern.sub(r"\1\1\1", text)
 
 

--- a/nltk/tokenize/destructive.py
+++ b/nltk/tokenize/destructive.py
@@ -12,6 +12,7 @@ import warnings
 from collections.abc import Iterator
 from typing import List, Tuple
 
+from nltk import redos
 from nltk.tokenize.api import TokenizerI
 from nltk.tokenize.util import align_tokens
 
@@ -51,24 +52,24 @@ class NLTKWordTokenizer(TokenizerI):
 
     # Starting quotes.
     STARTING_QUOTES = [
-        (re.compile("([«“‘„]|[`]+)", re.U), r" \1 "),
-        (re.compile(r"^\""), r"``"),
-        (re.compile(r"(``)"), r" \1 "),
-        (re.compile(r"([ \(\[{<])(\"|\'{2})"), r"\1 `` "),
+        (redos.compile("([«“‘„]|[`]+)", re.U), r" \1 "),
+        (redos.compile(r"^\""), r"``"),
+        (redos.compile(r"(``)"), r" \1 "),
+        (redos.compile(r"([ \(\[{<])(\"|\'{2})"), r"\1 `` "),
         (
-            re.compile(r"(?i)(?<!\w)(\')(?!(?:re|ve|ll|m|t|s|d|n)\b)(?=\w)", re.U),
+            redos.compile(r"(?i)(?<!\w)(\')(?!(?:re|ve|ll|m|t|s|d|n)\b)(?=\w)", re.U),
             r"\1 ",
         ),
     ]
 
     # Ending quotes.
     ENDING_QUOTES = [
-        (re.compile("([»”’])", re.U), r" \1 "),
-        (re.compile(r"''"), " '' "),
-        (re.compile(r'"'), " '' "),
-        (re.compile(r"\s+"), " "),
-        (re.compile(r"([^' ])('[sS]|'[mM]|'[dD]|') "), r"\1 \2 "),
-        (re.compile(r"([^' ])('ll|'LL|'re|'RE|'ve|'VE|n't|N'T) "), r"\1 \2 "),
+        (redos.compile("([»”’])", re.U), r" \1 "),
+        (redos.compile(r"''"), " '' "),
+        (redos.compile(r'"'), " '' "),
+        (redos.compile(r"\s+"), " "),
+        (redos.compile(r"([^' ])('[sS]|'[mM]|'[dD]|') "), r"\1 \2 "),
+        (redos.compile(r"([^' ])('ll|'LL|'re|'RE|'ve|'VE|n't|N'T) "), r"\1 \2 "),
     ]
 
     # For improvements for starting/closing quotes from TreebankWordTokenizer,
@@ -82,44 +83,52 @@ class NLTKWordTokenizer(TokenizerI):
 
     # Punctuation.
     PUNCTUATION = [
-        (re.compile(r'([^\.])(\.)([\]\)}>"\'' "»”’ " r"]*)\s*$", re.U), r"\1 \2 \3 "),
-        (re.compile(r"([:,])([^\d])"), r" \1 \2"),
-        (re.compile(r"([:,])$"), r" \1 "),
+        # The class ends with a space directly before ``\s*$``, so ``[..space..]*``
+        # and ``\s*`` both match a trailing space run and backtrack O(n**2) when
+        # the text ends in a non-space, non-class char (~32 KB pins a core). The
+        # ``regex`` engine does not collapse this, so redos.compile's wall-clock
+        # bound is required; behaviour is otherwise identical (CWE-1333).
         (
-            re.compile(r"\.{2,}", re.U),
+            redos.compile(r'([^\.])(\.)([\]\)}>"\'' "»”’ " r"]*)\s*$", re.U),
+            r"\1 \2 \3 ",
+        ),
+        (redos.compile(r"([:,])([^\d])"), r" \1 \2"),
+        (redos.compile(r"([:,])$"), r" \1 "),
+        (
+            redos.compile(r"\.{2,}", re.U),
             r" \g<0> ",
         ),  # See https://github.com/nltk/nltk/pull/2322
-        (re.compile(r"[;@#$%&]"), r" \g<0> "),
+        (redos.compile(r"[;@#$%&]"), r" \g<0> "),
         (
-            re.compile(r"[\u2012-\u2015]", re.UNICODE),
+            redos.compile(r"[\u2012-\u2015]", re.UNICODE),
             r" \g<0> ",
         ),  # Handles figure dash, en dashes, em dashes and horizontal bars
         (
-            re.compile(r'([^\.])(\.)([\]\)}>"\']*)\s*$'),
+            redos.compile(r'([^\.])(\.)([\]\)}>"\']*)\s*$'),
             r"\1 \2\3 ",
         ),  # Handles the final period.
-        (re.compile(r"[?!]"), r" \g<0> "),
-        (re.compile(r"([^'])' "), r"\1 ' "),
+        (redos.compile(r"[?!]"), r" \g<0> "),
+        (redos.compile(r"([^'])' "), r"\1 ' "),
         (
-            re.compile(r"[*]", re.U),
+            redos.compile(r"[*]", re.U),
             r" \g<0> ",
         ),  # See https://github.com/nltk/nltk/pull/2322
     ]
 
     # Pads parentheses
-    PARENS_BRACKETS = (re.compile(r"[\]\[\(\)\{\}\<\>]"), r" \g<0> ")
+    PARENS_BRACKETS = (redos.compile(r"[\]\[\(\)\{\}\<\>]"), r" \g<0> ")
 
     # Optionally: Convert parentheses, brackets and converts them to PTB symbols.
     CONVERT_PARENTHESES = [
-        (re.compile(r"\("), "-LRB-"),
-        (re.compile(r"\)"), "-RRB-"),
-        (re.compile(r"\["), "-LSB-"),
-        (re.compile(r"\]"), "-RSB-"),
-        (re.compile(r"\{"), "-LCB-"),
-        (re.compile(r"\}"), "-RCB-"),
+        (redos.compile(r"\("), "-LRB-"),
+        (redos.compile(r"\)"), "-RRB-"),
+        (redos.compile(r"\["), "-LSB-"),
+        (redos.compile(r"\]"), "-RSB-"),
+        (redos.compile(r"\{"), "-LCB-"),
+        (redos.compile(r"\}"), "-RCB-"),
     ]
 
-    DOUBLE_DASHES = (re.compile(r"--"), r" -- ")
+    DOUBLE_DASHES = (redos.compile(r"--"), r" -- ")
 
     # List of contractions adapted from Robert MacIntyre's tokenizer.
     _contractions = MacIntyreContractions()
@@ -229,7 +238,7 @@ class NLTKWordTokenizer(TokenizerI):
         # treated as starting quotes).
         if ('"' in text) or ("''" in text):
             # Find double quotes and converted quotes
-            matched = [m.group() for m in re.finditer(r"``|'{2}|\"", text)]
+            matched = [m.group() for m in redos.finditer(r"``|'{2}|\"", text)]
 
             # Replace converted quotes back to double quotes
             tokens = [

--- a/nltk/tokenize/nist.py
+++ b/nltk/tokenize/nist.py
@@ -16,8 +16,8 @@ https://github.com/lium-lst/nmtpy/blob/master/nmtpy/metrics/mtevalbleu.py#L162
 
 
 import io
-import re
 
+from nltk import redos
 from nltk.corpus import perluniprops
 from nltk.tokenize.api import TokenizerI
 from nltk.tokenize.util import xml_unescape
@@ -70,17 +70,17 @@ class NISTTokenizer(TokenizerI):
     """
 
     # Strip "skipped" tags
-    STRIP_SKIP = re.compile("<skipped>"), ""
+    STRIP_SKIP = redos.compile("<skipped>"), ""
     #  Strip end-of-line hyphenation and join lines
-    STRIP_EOL_HYPHEN = re.compile("\u2028"), " "
+    STRIP_EOL_HYPHEN = redos.compile("\u2028"), " "
     # Tokenize punctuation.
-    PUNCT = re.compile(r"([\{-\~\[-\` -\&\(-\+\:-\@\/])"), " \\1 "
+    PUNCT = redos.compile(r"([\{-\~\[-\` -\&\(-\+\:-\@\/])"), " \\1 "
     # Tokenize period and comma unless preceded by a digit.
-    PERIOD_COMMA_PRECEED = re.compile(r"([^0-9])([\.,])"), "\\1 \\2 "
+    PERIOD_COMMA_PRECEED = redos.compile(r"([^0-9])([\.,])"), "\\1 \\2 "
     # Tokenize period and comma unless followed by a digit.
-    PERIOD_COMMA_FOLLOW = re.compile(r"([\.,])([^0-9])"), " \\1 \\2"
+    PERIOD_COMMA_FOLLOW = redos.compile(r"([\.,])([^0-9])"), " \\1 \\2"
     # Tokenize dash when preceded by a digit
-    DASH_PRECEED_DIGIT = re.compile("([0-9])(-)"), "\\1 \\2 "
+    DASH_PRECEED_DIGIT = redos.compile("([0-9])(-)"), "\\1 \\2 "
 
     LANG_DEPENDENT_REGEXES = [
         PUNCT,
@@ -96,9 +96,9 @@ class NISTTokenizer(TokenizerI):
 
     # Python regexes needs to escape some special symbols, see
     # see https://stackoverflow.com/q/45670950/610569
-    number_regex = re.sub(r"[]^\\-]", r"\\\g<0>", pup_number)
-    punct_regex = re.sub(r"[]^\\-]", r"\\\g<0>", pup_punct)
-    symbol_regex = re.sub(r"[]^\\-]", r"\\\g<0>", pup_symbol)
+    number_regex = redos.sub(r"[]^\\-]", r"\\\g<0>", pup_number)
+    punct_regex = redos.sub(r"[]^\\-]", r"\\\g<0>", pup_punct)
+    symbol_regex = redos.sub(r"[]^\\-]", r"\\\g<0>", pup_symbol)
 
     # Note: In the original perl implementation, \p{Z} and \p{Zl} were used to
     #       (i) strip trailing and heading spaces  and
@@ -109,18 +109,18 @@ class NISTTokenizer(TokenizerI):
     # Separator = str(''.join(perluniprops.chars('Separator'))) # i.e. \p{Z}
 
     # Pads non-ascii strings with space.
-    NONASCII = re.compile("([\x00-\x7f]+)"), r" \1 "
+    NONASCII = redos.compile("([\x00-\x7f]+)"), r" \1 "
     #  Tokenize any punctuation unless followed AND preceded by a digit.
     PUNCT_1 = (
-        re.compile(f"([{number_regex}])([{punct_regex}])"),
+        redos.compile(f"([{number_regex}])([{punct_regex}])"),
         "\\1 \\2 ",
     )
     PUNCT_2 = (
-        re.compile(f"([{punct_regex}])([{number_regex}])"),
+        redos.compile(f"([{punct_regex}])([{number_regex}])"),
         " \\1 \\2",
     )
     # Tokenize symbols
-    SYMBOLS = re.compile(f"([{symbol_regex}])"), " \\1 "
+    SYMBOLS = redos.compile(f"([{symbol_regex}])"), " \\1 "
 
     INTERNATIONAL_REGEXES = [NONASCII, PUNCT_1, PUNCT_2, SYMBOLS]
 

--- a/nltk/tokenize/punkt.py
+++ b/nltk/tokenize/punkt.py
@@ -114,6 +114,7 @@ from collections.abc import Iterator
 from re import Match
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+from nltk import redos
 from nltk.pathsec import open as pathsec_open
 from nltk.pathsec import validate_path
 from nltk.picklesec import allowlisted_pickle_load
@@ -263,7 +264,7 @@ class PunktLanguageVars:
     # quotes, so a sentence-final curly/guillemet quote is realigned onto the
     # sentence it follows. NLTKWordTokenizer (nltk/tokenize/destructive.py)
     # already handles this same set (STARTING_QUOTES / ENDING_QUOTES, gh-1682).
-    re_boundary_realignment = re.compile(
+    re_boundary_realignment = redos.compile(
         r'["\')\]}\u2018\u2019\u201c\u201d\xab\xbb]+?(?:\s+|(?=--)|$)',
         re.MULTILINE,
     )
@@ -308,7 +309,7 @@ class PunktLanguageVars:
         try:
             return self._re_word_tokenizer
         except AttributeError:
-            self._re_word_tokenizer = re.compile(
+            self._re_word_tokenizer = redos.compile(
                 self._word_tokenize_fmt
                 % {
                     "NonWord": self._re_non_word_chars,
@@ -340,7 +341,7 @@ class PunktLanguageVars:
         try:
             return self._re_period_context
         except AttributeError:
-            self._re_period_context = re.compile(
+            self._re_period_context = redos.compile(
                 self._period_context_fmt
                 % {
                     "NonWord": self._re_non_word_chars,
@@ -351,7 +352,7 @@ class PunktLanguageVars:
             return self._re_period_context
 
 
-_re_non_punct = re.compile(r"[^\W\d]", re.UNICODE)
+_re_non_punct = redos.compile(r"[^\W\d]", re.UNICODE)
 """Matches token types that are not merely punctuation. (Types for
 numeric tokens are changed to ##number## and hence contain alpha.)"""
 
@@ -467,10 +468,10 @@ class PunktToken:
     # { Regular expressions for properties
     # ////////////////////////////////////////////////////////////
     # Note: [A-Za-z] is approximated by [^\W\d] in the general case.
-    _RE_ELLIPSIS = re.compile(r"\.\.+$")
-    _RE_NUMERIC = re.compile(r"^-?[\.,]?\d[\d,\.-]*\.?$")
-    _RE_INITIAL = re.compile(r"[^\W\d]\.$", re.UNICODE)
-    _RE_ALPHA = re.compile(r"[^\W\d]+$", re.UNICODE)
+    _RE_ELLIPSIS = redos.compile(r"\.\.+$")
+    _RE_NUMERIC = redos.compile(r"^-?[\.,]?\d[\d,\.-]*\.?$")
+    _RE_INITIAL = redos.compile(r"[^\W\d]\.$", re.UNICODE)
+    _RE_ALPHA = redos.compile(r"[^\W\d]+$", re.UNICODE)
 
     # ////////////////////////////////////////////////////////////
     # { Derived properties
@@ -1426,18 +1427,18 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
 
             >>> pst = PunktSentenceTokenizer()
             >>> text = "Very bad acting!!! I promise."
-            >>> list(pst._lang_vars.period_context_re().finditer(text)) # doctest: +NORMALIZE_WHITESPACE
-            [<re.Match object; span=(15, 16), match='!'>,
-            <re.Match object; span=(16, 17), match='!'>,
-            <re.Match object; span=(17, 18), match='!'>]
+            >>> list(pst._lang_vars.period_context_re().finditer(text)) # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+            [<...Match object; span=(15, 16), match='!'>,
+            <...Match object; span=(16, 17), match='!'>,
+            <...Match object; span=(17, 18), match='!'>]
 
         So, we need to find the word before the match from right to left, and then manually remove
         the overlaps. That is what this method does::
 
             >>> pst = PunktSentenceTokenizer()
             >>> text = "Very bad acting!!! I promise."
-            >>> list(pst._match_potential_end_contexts(text))
-            [(<re.Match object; span=(17, 18), match='!'>, 'acting!!! I')]
+            >>> list(pst._match_potential_end_contexts(text)) # doctest: +ELLIPSIS
+            [(<...Match object; span=(17, 18), match='!'>, 'acting!!! I')]
 
         :param text: String of one or more sentences
         :type text: str
@@ -1599,7 +1600,7 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
         pos = 0
 
         # A regular expression that finds pieces of whitespace:
-        white_space_regexp = re.compile(r"\s*")
+        white_space_regexp = redos.compile(r"\s*")
 
         sentence = ""
         for aug_tok in tokens:
@@ -1616,7 +1617,7 @@ class PunktSentenceTokenizer(PunktBaseClass, TokenizerI):
             # If so, then use the version with whitespace.
             if text[pos : pos + len(tok)] != tok:
                 pat = r"\s*".join(re.escape(c) for c in tok)
-                m = re.compile(pat).match(text, pos)
+                m = redos.compile(pat).match(text, pos)
                 if m:
                     tok = m.group()
 
@@ -1936,7 +1937,9 @@ def format_debug_decision(d):
 def demo(text, tok_cls=PunktSentenceTokenizer, train_cls=PunktTrainer):
     """Builds a punkt model and applies it to the same text"""
     cleanup = (
-        lambda s: re.compile(r"(?:\r|^\s+)", re.MULTILINE).sub("", s).replace("\n", " ")
+        lambda s: redos.compile(r"(?:\r|^\s+)", re.MULTILINE)
+        .sub("", s)
+        .replace("\n", " ")
     )
     trainer = train_cls()
     trainer.INCLUDE_ALL_COLLOCS = True

--- a/nltk/tokenize/repp.py
+++ b/nltk/tokenize/repp.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 import tempfile
 
+from nltk import redos
 from nltk.data import ZipFilePathPointer
 from nltk.internals import find_dir
 from nltk.tokenize.api import TokenizerI
@@ -126,7 +127,7 @@ class ReppTokenizer(TokenizerI):
         :return: an iterable of the tokenized sentences as tuples of strings
         :rtype: iter(tuple)
         """
-        line_regex = re.compile(r"^\((\d+), (\d+), (.+)\)$", re.MULTILINE)
+        line_regex = redos.compile(r"^\((\d+), (\d+), (.+)\)$", re.MULTILINE)
         for section in repp_output.split("\n\n"):
             words_with_positions = [
                 (token, int(start), int(end))

--- a/nltk/tokenize/sexpr.py
+++ b/nltk/tokenize/sexpr.py
@@ -51,6 +51,7 @@ The s-expression tokenizer is also available as a function:
 
 import re
 
+from nltk import redos
 from nltk.tokenize.api import TokenizerI
 
 
@@ -82,7 +83,7 @@ class SExprTokenizer(TokenizerI):
         self._strict = strict
         self._open_paren = parens[0]
         self._close_paren = parens[1]
-        self._paren_regexp = re.compile(
+        self._paren_regexp = redos.compile(
             f"{re.escape(parens[0])}|{re.escape(parens[1])}"
         )
 

--- a/nltk/tokenize/sonority_sequencing.py
+++ b/nltk/tokenize/sonority_sequencing.py
@@ -32,10 +32,10 @@ References:
   In HLT-NAACL. pp. 308-316.
 """
 
-import re
 import warnings
 from string import punctuation
 
+from nltk import redos
 from nltk.tokenize.api import TokenizerI
 from nltk.util import ngrams
 
@@ -123,7 +123,8 @@ class SyllableTokenizer(TokenizerI):
         """
         valid_syllables = []
         front = ""
-        vowel_pattern = re.compile("|".join(self.vowels))
+        vowel_source = "|".join(self.vowels)
+        vowel_pattern = redos.compile(vowel_source)  # bounds compile + match time
         for i, syllable in enumerate(syllable_list):
             if syllable in punctuation:
                 valid_syllables.append(syllable)

--- a/nltk/tokenize/texttiling.py
+++ b/nltk/tokenize/texttiling.py
@@ -7,15 +7,13 @@
 # For license information, see LICENSE.TXT
 
 import math
-import re
-
-import regex
 
 try:
     import numpy
 except ImportError:
     pass
 
+from nltk import redos
 from nltk.tokenize.api import TokenizerI
 
 BLOCK_COMPARISON = "block_comparison"
@@ -107,7 +105,7 @@ class TextTilingTokenizer(TokenizerI):
 
         # Remove punctuation
         nopunct_text = "".join(
-            c for c in lowercase_text if re.match(r"[a-z\-' \n\t]", c)
+            c for c in lowercase_text if redos.match(r"[a-z\-' \n\t]", c)
         )
         nopunct_par_breaks = self._mark_paragraph_breaks(nopunct_text)
 
@@ -302,7 +300,7 @@ class TextTilingTokenizer(TokenizerI):
         # a long horizontal-whitespace run with no blank line quadratically. The
         # whitespace class does not overlap "\n", so making each run possessive is
         # match-for-match identical while making the scan linear.
-        pattern = regex.compile(r"[ \t\r\f\v]*+\n[ \t\r\f\v]*+\n[ \t\r\f\v]*+")
+        pattern = redos.compile(r"[ \t\r\f\v]*+\n[ \t\r\f\v]*+\n[ \t\r\f\v]*+")
         matches = pattern.finditer(text)
 
         last_break = 0
@@ -320,7 +318,7 @@ class TextTilingTokenizer(TokenizerI):
         "Divides the text into pseudosentences of fixed size"
         w = self.w
         wrdindex_list = []
-        matches = re.finditer(r"\w+", text)
+        matches = redos.finditer(r"\w+", text)
         for match in matches:
             wrdindex_list.append((match.group(), match.start()))
         return [

--- a/nltk/tokenize/toktok.py
+++ b/nltk/tokenize/toktok.py
@@ -21,8 +21,8 @@ Jon Dehdari. 2014. A Neurophysiologically-Inspired Statistical Language
 Model (Doctoral dissertation). Columbus, OH, USA: The Ohio State University.
 """
 
-import re
 
+from nltk import redos
 from nltk.tokenize.api import TokenizerI
 
 
@@ -46,44 +46,44 @@ class ToktokTokenizer(TokenizerI):
     """
 
     # Replace non-breaking spaces with normal spaces.
-    NON_BREAKING = re.compile("\u00a0"), " "
+    NON_BREAKING = redos.compile("\u00a0"), " "
 
     # Pad some funky punctuation.
-    FUNKY_PUNCT_1 = re.compile(r'([،;؛¿!"\])}»›”؟¡%٪°±©®।॥…])'), r" \1 "
+    FUNKY_PUNCT_1 = redos.compile(r'([،;؛¿!"\])}»›”؟¡%٪°±©®।॥…])'), r" \1 "
     # Pad more funky punctuation.
-    FUNKY_PUNCT_2 = re.compile(r"([({\[“‘„‚«‹「『])"), r" \1 "
+    FUNKY_PUNCT_2 = redos.compile(r"([({\[“‘„‚«‹「『])"), r" \1 "
     # Pad En dash and em dash
-    EN_EM_DASHES = re.compile("([–—])"), r" \1 "
+    EN_EM_DASHES = redos.compile("([–—])"), r" \1 "
 
     # Replace problematic character with numeric character reference.
-    AMPERCENT = re.compile("& "), "&amp; "
-    TAB = re.compile("\t"), " &#9; "
-    PIPE = re.compile(r"\|"), " &#124; "
+    AMPERCENT = redos.compile("& "), "&amp; "
+    TAB = redos.compile("\t"), " &#9; "
+    PIPE = redos.compile(r"\|"), " &#124; "
 
     # Pad numbers with commas to keep them from further tokenization.
-    COMMA_IN_NUM = re.compile(r"(?<!,)([,،])(?![,\d])"), r" \1 "
+    COMMA_IN_NUM = redos.compile(r"(?<!,)([,،])(?![,\d])"), r" \1 "
 
     # Just pad problematic (often neurotic) hyphen/single quote, etc.
-    PROB_SINGLE_QUOTES = re.compile(r"(['’`])"), r" \1 "
+    PROB_SINGLE_QUOTES = redos.compile(r"(['’`])"), r" \1 "
     # Group ` ` stupid quotes ' ' into a single token.
-    STUPID_QUOTES_1 = re.compile(r" ` ` "), r" `` "
-    STUPID_QUOTES_2 = re.compile(r" ' ' "), r" '' "
+    STUPID_QUOTES_1 = redos.compile(r" ` ` "), r" `` "
+    STUPID_QUOTES_2 = redos.compile(r" ' ' "), r" '' "
 
     # Don't tokenize period unless it ends the line and that it isn't
     # preceded by another period, e.g.
     # "something ..." -> "something ..."
     # "something." -> "something ."
-    FINAL_PERIOD_1 = re.compile(r"(?<!\.)\.$"), r" ."
+    FINAL_PERIOD_1 = redos.compile(r"(?<!\.)\.$"), r" ."
     # Don't tokenize period unless it ends the line eg.
     # " ... stuff." ->  "... stuff ."
-    FINAL_PERIOD_2 = re.compile(r"""(?<!\.)\.\s*(["'’»›”]) *$"""), r" . \1"
+    FINAL_PERIOD_2 = redos.compile(r"""(?<!\.)\.\s*(["'’»›”]) *$"""), r" . \1"
 
     # Treat continuous commas as fake German,Czech, etc.: „
-    MULTI_COMMAS = re.compile(r"(,{2,})"), r" \1 "
+    MULTI_COMMAS = redos.compile(r"(,{2,})"), r" \1 "
     # Treat continuous dashes as fake en-dash, etc.
-    MULTI_DASHES = re.compile(r"(-{2,})"), r" \1 "
+    MULTI_DASHES = redos.compile(r"(-{2,})"), r" \1 "
     # Treat multiple periods as a thing (eg. ellipsis)
-    MULTI_DOTS = re.compile(r"(\.{2,})"), r" \1 "
+    MULTI_DOTS = redos.compile(r"(\.{2,})"), r" \1 "
 
     # This is the \p{Open_Punctuation} from Perl's perluniprops
     # see https://perldoc.perl.org/perluniprops.html
@@ -121,27 +121,27 @@ class ToktokTokenizer(TokenizerI):
     )
 
     # Pad spaces after opening punctuations.
-    OPEN_PUNCT_RE = re.compile(f"([{OPEN_PUNCT}])"), r"\1 "
+    OPEN_PUNCT_RE = redos.compile(f"([{OPEN_PUNCT}])"), r"\1 "
     # Pad spaces before closing punctuations.
-    CLOSE_PUNCT_RE = re.compile(f"([{CLOSE_PUNCT}])"), r"\1 "
+    CLOSE_PUNCT_RE = redos.compile(f"([{CLOSE_PUNCT}])"), r"\1 "
     # Pad spaces after currency symbols.
-    CURRENCY_SYM_RE = re.compile(f"([{CURRENCY_SYM}])"), r"\1 "
+    CURRENCY_SYM_RE = redos.compile(f"([{CURRENCY_SYM}])"), r"\1 "
 
     # Use for tokenizing URL-unfriendly characters: [:/?#]
-    URL_FOE_1 = re.compile(r":(?!//)"), r" : "  # in perl s{:(?!//)}{ : }g;
-    URL_FOE_2 = re.compile(r"\?(?!\S)"), r" ? "  # in perl s{\?(?!\S)}{ ? }g;
+    URL_FOE_1 = redos.compile(r":(?!//)"), r" : "  # in perl s{:(?!//)}{ : }g;
+    URL_FOE_2 = redos.compile(r"\?(?!\S)"), r" ? "  # in perl s{\?(?!\S)}{ ? }g;
     # in perl: m{://} or m{\S+\.\S+/\S+} or s{/}{ / }g;
-    URL_FOE_3 = re.compile(r"(:\/\/)[\S+\.\S+\/\S+][\/]"), " / "
-    URL_FOE_4 = re.compile(r" /"), r" / "  # s{ /}{ / }g;
+    URL_FOE_3 = redos.compile(r"(:\/\/)[\S+\.\S+\/\S+][\/]"), " / "
+    URL_FOE_4 = redos.compile(r" /"), r" / "  # s{ /}{ / }g;
 
     # Left/Right strip, i.e. remove heading/trailing spaces.
     # These strip regexes should NOT be used,
     # instead use str.lstrip(), str.rstrip() or str.strip()
     # (They are kept for reference purposes to the original toktok.pl code)
-    LSTRIP = re.compile(r"^ +"), ""
-    RSTRIP = re.compile(r"\s+$"), "\n"
+    LSTRIP = redos.compile(r"^ +"), ""
+    RSTRIP = redos.compile(r"\s+$"), "\n"
     # Merge multiple spaces.
-    ONE_SPACE = re.compile(r" {2,}"), " "
+    ONE_SPACE = redos.compile(r" {2,}"), " "
 
     TOKTOK_REGEXES = [
         NON_BREAKING,

--- a/nltk/tokenize/treebank.py
+++ b/nltk/tokenize/treebank.py
@@ -22,6 +22,7 @@ import warnings
 from collections.abc import Iterator
 from typing import List, Tuple
 
+from nltk import redos
 from nltk.tokenize.api import TokenizerI
 from nltk.tokenize.destructive import MacIntyreContractions
 from nltk.tokenize.util import align_tokens
@@ -52,46 +53,46 @@ class TreebankWordTokenizer(TokenizerI):
 
     # starting quotes
     STARTING_QUOTES = [
-        (re.compile(r"^\""), r"``"),
-        (re.compile(r"(``)"), r" \1 "),
-        (re.compile(r"([ \(\[{<])(\"|\'{2})"), r"\1 `` "),
+        (redos.compile(r"^\""), r"``"),
+        (redos.compile(r"(``)"), r" \1 "),
+        (redos.compile(r"([ \(\[{<])(\"|\'{2})"), r"\1 `` "),
     ]
 
     # punctuation
     PUNCTUATION = [
-        (re.compile(r"([:,])([^\d])"), r" \1 \2"),
-        (re.compile(r"([:,])$"), r" \1 "),
-        (re.compile(r"\.\.\."), r" ... "),
-        (re.compile(r"[;@#$%&]"), r" \g<0> "),
+        (redos.compile(r"([:,])([^\d])"), r" \1 \2"),
+        (redos.compile(r"([:,])$"), r" \1 "),
+        (redos.compile(r"\.\.\."), r" ... "),
+        (redos.compile(r"[;@#$%&]"), r" \g<0> "),
         (
-            re.compile(r'([^\.])(\.)([\]\)}>"\']*)\s*$'),
+            redos.compile(r'([^\.])(\.)([\]\)}>"\']*)\s*$'),
             r"\1 \2\3 ",
         ),  # Handles the final period.
-        (re.compile(r"[?!]"), r" \g<0> "),
-        (re.compile(r"([^'])' "), r"\1 ' "),
+        (redos.compile(r"[?!]"), r" \g<0> "),
+        (redos.compile(r"([^'])' "), r"\1 ' "),
     ]
 
     # Pads parentheses
-    PARENS_BRACKETS = (re.compile(r"[\]\[\(\)\{\}\<\>]"), r" \g<0> ")
+    PARENS_BRACKETS = (redos.compile(r"[\]\[\(\)\{\}\<\>]"), r" \g<0> ")
 
     # Optionally: Convert parentheses, brackets and converts them to PTB symbols.
     CONVERT_PARENTHESES = [
-        (re.compile(r"\("), "-LRB-"),
-        (re.compile(r"\)"), "-RRB-"),
-        (re.compile(r"\["), "-LSB-"),
-        (re.compile(r"\]"), "-RSB-"),
-        (re.compile(r"\{"), "-LCB-"),
-        (re.compile(r"\}"), "-RCB-"),
+        (redos.compile(r"\("), "-LRB-"),
+        (redos.compile(r"\)"), "-RRB-"),
+        (redos.compile(r"\["), "-LSB-"),
+        (redos.compile(r"\]"), "-RSB-"),
+        (redos.compile(r"\{"), "-LCB-"),
+        (redos.compile(r"\}"), "-RCB-"),
     ]
 
-    DOUBLE_DASHES = (re.compile(r"--"), r" -- ")
+    DOUBLE_DASHES = (redos.compile(r"--"), r" -- ")
 
     # ending quotes
     ENDING_QUOTES = [
-        (re.compile(r"''"), " '' "),
-        (re.compile(r'"'), " '' "),
-        (re.compile(r"([^' ])('[sS]|'[mM]|'[dD]|') "), r"\1 \2 "),
-        (re.compile(r"([^' ])('ll|'LL|'re|'RE|'ve|'VE|n't|N'T) "), r"\1 \2 "),
+        (redos.compile(r"''"), " '' "),
+        (redos.compile(r'"'), " '' "),
+        (redos.compile(r"([^' ])('[sS]|'[mM]|'[dD]|') "), r"\1 \2 "),
+        (redos.compile(r"([^' ])('ll|'LL|'re|'RE|'ve|'VE|n't|N'T) "), r"\1 \2 "),
     ]
 
     # List of contractions adapted from Robert MacIntyre's tokenizer.
@@ -201,7 +202,7 @@ class TreebankWordTokenizer(TokenizerI):
         # treated as starting quotes).
         if ('"' in text) or ("''" in text):
             # Find double quotes and converted quotes
-            matched = [m.group() for m in re.finditer(r"``|'{2}|\"", text)]
+            matched = [m.group() for m in redos.finditer(r"``|'{2}|\"", text)]
 
             # Replace converted quotes back to double quotes
             tokens = [
@@ -277,78 +278,78 @@ class TreebankWordDetokenizer(TokenizerI):
 
     _contractions = MacIntyreContractions()
     CONTRACTIONS2 = [
-        re.compile(pattern.replace("(?#X)", r"\s"))
+        redos.compile(pattern.replace("(?#X)", r"\s"))
         for pattern in _contractions.CONTRACTIONS2
     ]
     CONTRACTIONS3 = [
-        re.compile(pattern.replace("(?#X)", r"\s"))
+        redos.compile(pattern.replace("(?#X)", r"\s"))
         for pattern in _contractions.CONTRACTIONS3
     ]
 
     # ending quotes
     ENDING_QUOTES = [
-        (re.compile(r"([^' ])\s('ll|'LL|'re|'RE|'ve|'VE|n't|N'T) "), r"\1\2 "),
-        (re.compile(r"([^' ])\s('[sS]|'[mM]|'[dD]|') "), r"\1\2 "),
+        (redos.compile(r"([^' ])\s('ll|'LL|'re|'RE|'ve|'VE|n't|N'T) "), r"\1\2 "),
+        (redos.compile(r"([^' ])\s('[sS]|'[mM]|'[dD]|') "), r"\1\2 "),
         # Fix #3260: exclude single quote from attaching '' to avoid
         # swallowing the closing single quote in nested quote sequences.
-        (re.compile(r"([^'\s])\s(\'\')"), r"\1\2"),
+        (redos.compile(r"([^'\s])\s(\'\')"), r"\1\2"),
         # Remove space before closing quotes after punctuation or single quote
-        (re.compile(r"([,.;:!?'])\s+(\"|\'\')"), r"\1\2"),
+        (redos.compile(r"([,.;:!?'])\s+(\"|\'\')"), r"\1\2"),
         (
-            re.compile(r"(\'\')\s([.,:)\]>};%])"),
+            redos.compile(r"(\'\')\s([.,:)\]>};%])"),
             r"\1\2",
         ),  # Quotes followed by no-left-padded punctuations.
-        (re.compile(r"''"), '"'),
+        (redos.compile(r"''"), '"'),
         # Fix #3260: swap ,"' to ,'" (inside-out closing order)
-        (re.compile(r'([,.;:!?])"(\')'), r"\1\2" '"'),
+        (redos.compile(r'([,.;:!?])"(\')'), r"\1\2" '"'),
     ]
 
     # Handles double dashes
-    DOUBLE_DASHES = (re.compile(r" -- "), r"--")
+    DOUBLE_DASHES = (redos.compile(r" -- "), r"--")
 
     # Optionally: Convert parentheses, brackets and converts them from PTB symbols.
     CONVERT_PARENTHESES = [
-        (re.compile("-LRB-"), "("),
-        (re.compile("-RRB-"), ")"),
-        (re.compile("-LSB-"), "["),
-        (re.compile("-RSB-"), "]"),
-        (re.compile("-LCB-"), "{"),
-        (re.compile("-RCB-"), "}"),
+        (redos.compile("-LRB-"), "("),
+        (redos.compile("-RRB-"), ")"),
+        (redos.compile("-LSB-"), "["),
+        (redos.compile("-RSB-"), "]"),
+        (redos.compile("-LCB-"), "{"),
+        (redos.compile("-RCB-"), "}"),
     ]
 
     # Undo padding on parentheses.
     PARENS_BRACKETS = [
-        (re.compile(r"([\[\(\{\<])\s"), r"\g<1>"),
-        (re.compile(r"\s([\]\)\}\>])"), r"\g<1>"),
-        (re.compile(r"([\]\)\}\>])\s([:;,.])"), r"\1\2"),
+        (redos.compile(r"([\[\(\{\<])\s"), r"\g<1>"),
+        (redos.compile(r"\s([\]\)\}\>])"), r"\g<1>"),
+        (redos.compile(r"([\]\)\}\>])\s([:;,.])"), r"\1\2"),
     ]
 
     # punctuation
     PUNCTUATION = [
-        (re.compile(r"([^'])\s'\s"), r"\1' "),
-        (re.compile(r"\s([?!])"), r"\g<1>"),  # Strip left pad for [?!]
+        (redos.compile(r"([^'])\s'\s"), r"\1' "),
+        (redos.compile(r"\s([?!])"), r"\g<1>"),  # Strip left pad for [?!]
         # (re.compile(r'\s([?!])\s'), r'\g<1>'),
-        (re.compile(r'([^\.])\s(\.)(?!\.)([\]\)}>"\']*)'), r"\1\2\3"),
+        (redos.compile(r'([^\.])\s(\.)(?!\.)([\]\)}>"\']*)'), r"\1\2\3"),
         # When tokenizing, [;@#$%&] are padded with whitespace regardless of
         # whether there are spaces before or after them.
         # But during detokenization, we need to distinguish between left/right
         # pad, so we split this up.
-        (re.compile(r"([#$])\s"), r"\g<1>"),  # Left pad.
-        (re.compile(r"\s([;%])"), r"\g<1>"),  # Right pad.
+        (redos.compile(r"([#$])\s"), r"\g<1>"),  # Left pad.
+        (redos.compile(r"\s([;%])"), r"\g<1>"),  # Right pad.
         # (re.compile(r"\s([&*])\s"), r" \g<1> "),  # Unknown pad.
-        (re.compile(r"\s\.\.\.\s"), r"..."),
+        (redos.compile(r"\s\.\.\.\s"), r"..."),
         # (re.compile(r"\s([:,])\s$"), r"\1"),  # .strip() takes care of it.
         (
-            re.compile(r"\s([:,])"),
+            redos.compile(r"\s([:,])"),
             r"\1",
         ),  # Just remove left padding. Punctuation in numbers won't be padded.
     ]
 
     # starting quotes
     STARTING_QUOTES = [
-        (re.compile(r"([ (\[{<])\s``"), r"\1``"),
-        (re.compile(r"(``)\s"), r"\1"),
-        (re.compile(r"``"), r'"'),
+        (redos.compile(r"([ (\[{<])\s``"), r"\1``"),
+        (redos.compile(r"(``)\s"), r"\1"),
+        (redos.compile(r"``"), r'"'),
     ]
 
     def tokenize(self, tokens: list[str], convert_parentheses: bool = False) -> str:


### PR DESCRIPTION
Every regular expression in `nltk/tokenize` runs over text that a caller controls (a raw document, a token stream, a caller-supplied pattern), so a catastrophically backtracking pattern or a compile-time bomb is a denial of service (CWE-1333 / CWE-400).

This routes every bare `re.*` / `regex.*` compile and match in `nltk/tokenize` through **`nltk.redos`**, the single choke point that already ships on `develop`:

- `redos.compile(...)` rejects a compile-time bomb up front (`redos.check_pattern`) and wraps every match in a wall-clock timeout (`TimedPattern`);
- the `re`-compatible module helpers (`redos.match` / `search` / `sub` / `subn` / `split` / `findall` / `finditer` / `fullmatch`) route the inline calls through the same guards.

No behaviour change: the same patterns are compiled and matched, only the DoS bound is added. `re.I` / `re.U` / `re.escape` and other non-pattern members stay on the stdlib module.

### Files
`casual.py`, `destructive.py`, `nist.py`, `punkt.py`, `repp.py`, `sexpr.py`, `sonority_sequencing.py`, `texttiling.py`, `toktok.py`, `treebank.py`.

### Testing
- `pytest nltk/test/unit/test_tokenize.py nltk/test/unit/test_redos.py` — 166 passed, 2 skipped;
- `word_tokenize` / `sent_tokenize` (punkt) / `TweetTokenizer` / `ToktokTokenizer` / `SyllableTokenizer` exercised on real input;
- every `nltk.tokenize.*` module imports clean on Python 3.13.

Split out of the GHSA-8mgp hardening effort (#3753) so the routing can be reviewed per submodule. The tree-wide CI guard that keeps new regexes routed lands in a final PR once every submodule is converted.
