### PR TITLE
Route nltk.ccg regexes through nltk.redos (CWE-1333/CWE-400)

### DIFF
--- a/nltk/ccg/lexicon.py
+++ b/nltk/ccg/lexicon.py
@@ -11,6 +11,7 @@ CCG Lexicons
 import re
 from collections import defaultdict
 
+from nltk import redos
 from nltk.ccg.api import CCGVar, Direction, FunctionalCategory, PrimitiveCategory
 from nltk.internals import deprecated
 from nltk.sem.logic import Expression
@@ -20,16 +21,16 @@ from nltk.sem.logic import Expression
 # ------------
 
 # Parses a primitive category and subscripts
-PRIM_RE = re.compile(r"""([A-Za-z]+)(\[[A-Za-z,]+\])?""")
+PRIM_RE = redos.compile(r"""([A-Za-z]+)(\[[A-Za-z,]+\])?""")
 
 # Separates the next primitive category from the remainder of the
 # string
-NEXTPRIM_RE = re.compile(r"""([A-Za-z]+(?:\[[A-Za-z,]+\])?)(.*)""")
+NEXTPRIM_RE = redos.compile(r"""([A-Za-z]+(?:\[[A-Za-z,]+\])?)(.*)""")
 
 # Separates the next application operator from the remainder.
 # The modifier slot also accepts `_`, marking a variable direction
 # (e.g. `(S\_NP)/(S\_NP)` for a polymorphic adverb).
-APP_RE = re.compile(r"""([\\/])([.,_]?)([.,]?)(.*)""")
+APP_RE = redos.compile(r"""([\\/])([.,_]?)([.,]?)(.*)""")
 
 # Parses the definition of the right-hand side (rhs) of either a word or a family.
 # The identifier and the arrow alternative ``[-=]+>`` both match ``-``/``=``, so the
@@ -40,16 +41,16 @@ APP_RE = re.compile(r"""([\\/])([.,_]?)([.,]?)(.*)""")
 # so the arrow is tried once: the parse is linear, the usual whitespace-separated
 # ``ident <sep> rhs`` form is unchanged, and the compact ``ident<sep>rhs`` form is
 # still accepted (and now splits sensibly, e.g. ``a-->b`` -> ``a``/``-->``/``b``).
-LEX_RE = re.compile(r"""([\S_]*?[^\s=-])\s*(::|[-=]+>)\s*(.+)""", re.UNICODE)
+LEX_RE = redos.compile(r"""([\S_]*?[^\s=-])\s*(::|[-=]+>)\s*(.+)""", re.UNICODE)
 
 # Parses the right hand side that contains category and maybe semantic predicate
-RHS_RE = re.compile(r"""([^{}]*[^ {}])\s*(\{[^}]+\})?""", re.UNICODE)
+RHS_RE = redos.compile(r"""([^{}]*[^ {}])\s*(\{[^}]+\})?""", re.UNICODE)
 
 # Parses the semantic predicate
-SEMANTICS_RE = re.compile(r"""\{([^}]+)\}""", re.UNICODE)
+SEMANTICS_RE = redos.compile(r"""\{([^}]+)\}""", re.UNICODE)
 
 # Strips comments from a line
-COMMENTS_RE = re.compile("""([^#]*)(?:#.*)?""")
+COMMENTS_RE = redos.compile("""([^#]*)(?:#.*)?""")
 
 
 class Token:

--- a/nltk/ccg/logic.py
+++ b/nltk/ccg/logic.py
@@ -8,8 +8,8 @@
 Helper functions for CCG semantics computation
 """
 import copy
-import re
 
+from nltk import redos
 from nltk.sem.logic import *
 
 
@@ -28,7 +28,7 @@ def barendregt_normalize(expr, counters=None):
 
     if isinstance(expr, VariableBinderExpression):
         # Extract the alphabetic prefix
-        match = re.match(r"^([A-Za-z_]+)", expr.variable.name)
+        match = redos.match(r"^([A-Za-z_]+)", expr.variable.name)
         base = match.group(1) if match else "v"
 
         # Group into pedagogical type pools to satisfy NLTK's type constraints


### PR DESCRIPTION
Every regular expression in `nltk/ccg` runs over input a caller can influence (a corpus file, a token stream, a caller-supplied pattern), so a catastrophically backtracking pattern or a compile-time bomb is a denial of service (CWE-1333 / CWE-400).

This routes every bare `re.*` / `regex.*` compile and match in `nltk/ccg` through **`nltk.redos`**, the single choke point that already ships on `develop`:

- `redos.compile(...)` rejects a compile-time bomb up front (`redos.check_pattern`) and wraps every match in a wall-clock timeout (`TimedPattern`);
- the `re`-compatible module helpers (`redos.match` / `search` / `sub` / `subn` / `split` / `findall` / `finditer` / `fullmatch`) route the inline calls through the same guards.

No behaviour change: the same patterns are compiled and matched, only the DoS bound is added. `re.I` / `re.U` / `re.escape` and other non-pattern members stay on the stdlib module.

### Files
`lexicon.py`, `logic.py`.

### Testing (Python 3.13)
- `test_ccg_dir.py` (6 passed); `lexicon.fromstring` parsed a categorial grammar;
- every `nltk.ccg.*` module imports clean.

Split out of the GHSA-8mgp hardening effort (#3753) so the routing can be reviewed per submodule. The tree-wide CI guard that keeps new regexes routed lands in a final PR once every submodule is converted.