### PR TITLE
Route nltk.draw regexes through nltk.redos (CWE-1333/CWE-400)

### DIFF
--- a/nltk/draw/cfg.py
+++ b/nltk/draw/cfg.py
@@ -46,7 +46,6 @@ Visualization tools for CFGs.
 #   - disconnect top & bottom -- right click
 #     - if connected to top & bottom, then disconnect
 
-import re
 from tkinter import (
     Button,
     Canvas,
@@ -60,6 +59,7 @@ from tkinter import (
     Toplevel,
 )
 
+from nltk import redos
 from nltk.draw.tree import TreeSegmentWidget, tree_to_treesegment
 from nltk.draw.util import (
     CanvasFrame,
@@ -160,16 +160,16 @@ class CFGEditor:
     # Regular expressions used by _analyze_line.  Precompile them, so
     # we can process the text faster.
     ARROW = SymbolWidget.SYMBOLS["rightarrow"]
-    _LHS_RE = re.compile(r"(^\s*\w+\s*)(->|(" + ARROW + "))")
-    _ARROW_RE = re.compile(r"\s*(->|(" + ARROW + r"))\s*")
-    _PRODUCTION_RE = re.compile(
+    _LHS_RE = redos.compile(r"(^\s*\w+\s*)(->|(" + ARROW + "))")
+    _ARROW_RE = redos.compile(r"\s*(->|(" + ARROW + r"))\s*")
+    _PRODUCTION_RE = redos.compile(
         r"(^\s*\w+\s*)"
         + "(->|("  # LHS
         + ARROW
         + r"))\s*"
         + r"((\w+|'[\w ]*'|\"[\w ]*\"|\|)\s*)*$"  # arrow
     )  # RHS
-    _TOKEN_RE = re.compile("\\w+|->|'[\\w ]+'|\"[\\w ]+\"|(" + ARROW + ")")
+    _TOKEN_RE = redos.compile("\\w+|->|'[\\w ]+'|\"[\\w ]+\"|(" + ARROW + ")")
     _BOLD = ("helvetica", -12, "bold")
 
     def __init__(self, parent, cfg=None, set_cfg_callback=None):
@@ -479,8 +479,8 @@ class CFGEditor:
 
         # Get the text, normalize it, and split it into lines.
         text = self._textwidget.get("1.0", "end")
-        text = re.sub(self.ARROW, "->", text)
-        text = re.sub("\t", " ", text)
+        text = redos.sub(self.ARROW, "->", text)
+        text = redos.sub("\t", " ", text)
         lines = text.split("\n")
 
         # Convert each line to a CFG production


### PR DESCRIPTION
Every regular expression in `nltk/draw` runs over input a caller can influence (a corpus file, a token stream, a caller-supplied pattern), so a catastrophically backtracking pattern or a compile-time bomb is a denial of service (CWE-1333 / CWE-400).

This routes every bare `re.*` / `regex.*` compile and match in `nltk/draw` through **`nltk.redos`**, the single choke point that already ships on `develop`:

- `redos.compile(...)` rejects a compile-time bomb up front (`redos.check_pattern`) and wraps every match in a wall-clock timeout (`TimedPattern`);
- the `re`-compatible module helpers (`redos.match` / `search` / `sub` / `subn` / `split` / `findall` / `finditer` / `fullmatch`) route the inline calls through the same guards.

No behaviour change: the same patterns are compiled and matched, only the DoS bound is added. `re.I` / `re.U` / `re.escape` and other non-pattern members stay on the stdlib module.

### Files
`cfg.py`.

### Testing (Python 3.13)
- `nltk.draw.cfg` imports clean (Tkinter GUI module, no headless unit test);
- every `nltk.draw.*` module imports clean.

Split out of the GHSA-8mgp hardening effort (#3753) so the routing can be reviewed per submodule. The tree-wide CI guard that keeps new regexes routed lands in a final PR once every submodule is converted.