### PR TITLE
Route nltk.translate regexes through nltk.redos (CWE-1333/CWE-400)

### DIFF
--- a/nltk/translate/chrf_score.py
+++ b/nltk/translate/chrf_score.py
@@ -7,9 +7,9 @@
 # For license information, see LICENSE.TXT
 
 """ChrF score implementation"""
-import re
 from collections import Counter, defaultdict
 
+from nltk import redos
 from nltk.util import ngrams
 
 
@@ -104,7 +104,7 @@ def _preprocess(sent, ignore_whitespace):
         sent = " ".join(sent)
 
     if ignore_whitespace:
-        sent = re.sub(r"\s+", "", sent)
+        sent = redos.sub(r"\s+", "", sent)
     return sent
 
 


### PR DESCRIPTION
Every regular expression in `nltk/translate` runs over input a caller can influence (a corpus file, a token stream, a caller-supplied pattern), so a catastrophically backtracking pattern or a compile-time bomb is a denial of service (CWE-1333 / CWE-400).

This routes every bare `re.*` / `regex.*` compile and match in `nltk/translate` through **`nltk.redos`**, the single choke point that already ships on `develop`:

- `redos.compile(...)` rejects a compile-time bomb up front (`redos.check_pattern`) and wraps every match in a wall-clock timeout (`TimedPattern`);
- the `re`-compatible module helpers (`redos.match` / `search` / `sub` / `subn` / `split` / `findall` / `finditer` / `fullmatch`) route the inline calls through the same guards.

No behaviour change: the same patterns are compiled and matched, only the DoS bound is added. `re.I` / `re.U` / `re.escape` and other non-pattern members stay on the stdlib module.

### Files
`chrf_score.py`.

### Testing (Python 3.13)
- `nltk/test/unit/translate/` (83 passed); `sentence_chrf` scored a pair;
- every `nltk.translate.*` module imports clean.

Split out of the GHSA-8mgp hardening effort (#3753) so the routing can be reviewed per submodule. The tree-wide CI guard that keeps new regexes routed lands in a final PR once every submodule is converted.