### PR TITLE
Route nltk.tree regexes through nltk.redos (CWE-1333/CWE-400)

### DIFF
--- a/nltk/tree/parsing.py
+++ b/nltk/tree/parsing.py
@@ -8,8 +8,8 @@
 # URL: <https://www.nltk.org/>
 # For license information, see LICENSE.TXT
 
-import re
 
+from nltk import redos
 from nltk.tree.tree import Tree
 
 ######################################################################
@@ -35,7 +35,7 @@ def sinica_parse(s):
     :param s: The string to be converted
     :type s: str
     """
-    tokens = re.split(r"([()| ])", s)
+    tokens = redos.split(r"([()| ])", s)
     for i in range(len(tokens)):
         if tokens[i] == "(":
             tokens[i - 1], tokens[i] = (

--- a/nltk/tree/prettyprinter.py
+++ b/nltk/tree/prettyprinter.py
@@ -17,7 +17,6 @@ Graph Algorithms and Applications, 10(2) 141--157 (2006)149.
 https://jgaa.info/accepted/2006/EschbachGuentherBecker2006.10.2.pdf
 """
 
-import re
 
 try:
     from html import escape
@@ -27,6 +26,7 @@ except ImportError:
 from collections import defaultdict
 from operator import itemgetter
 
+from nltk import redos
 from nltk.tree.tree import Tree
 from nltk.util import OrderedDict
 
@@ -390,7 +390,7 @@ class TreePrettyPrinter:
         maxchildcol = {}
         childcols = defaultdict(set)
         labels = {}
-        wrapre = re.compile(
+        wrapre = redos.compile(
             "(.{%d,%d}\\b\\W*|.{%d})" % (maxwidth - 4, maxwidth, maxwidth)
         )
         # collect labels and coordinates

--- a/nltk/tree/tree.py
+++ b/nltk/tree/tree.py
@@ -650,7 +650,7 @@ class Tree(list):
         """
         if not isinstance(brackets, str) or len(brackets) != 2:
             raise TypeError("brackets must be a length-2 string")
-        if re.search(r"\s", brackets):
+        if redos.search(r"\s", brackets):
             raise TypeError("whitespace brackets not allowed")
         # Construct a regexp that will tokenize the string.
         open_b, close_b = brackets
@@ -898,10 +898,10 @@ class Tree(list):
         :return: A latex qtree representation of this tree.
         :rtype: str
         """
-        reserved_chars = re.compile(r"([#\$%&~_\{\}])")
+        reserved_chars = redos.compile(r"([#\$%&~_\{\}])")
 
         pformat = self.pformat(indent=6, nodesep="", parens=("[.", " ]"))
-        return r"\Tree " + re.sub(reserved_chars, r"\\\1", pformat)
+        return r"\Tree " + redos.sub(reserved_chars, r"\\\1", pformat)
 
     def pformat_latex_forest(self):
         r"""
@@ -921,10 +921,10 @@ class Tree(list):
         :return: A latex forest representation of this tree.
         :rtype: str
         """
-        reserved_chars = re.compile(r"([#\$%&~_\{\}])")
+        reserved_chars = redos.compile(r"([#\$%&~_\{\}])")
 
         pformat = self.pformat(indent=2, parens=("[", " ]"), quotes=("[", "]"))
-        pformat = re.sub(reserved_chars, r"\\\1", pformat)
+        pformat = redos.sub(reserved_chars, r"\\\1", pformat)
         return "\\begin{forest}\n  " + pformat + "\n\\end{forest}"
 
     def _pformat_flat(self, nodesep, parens, quotes):


### PR DESCRIPTION
Every regular expression in `nltk/tree` runs over input a caller can influence (a corpus file, a token stream, a caller-supplied pattern), so a catastrophically backtracking pattern or a compile-time bomb is a denial of service (CWE-1333 / CWE-400).

This routes every bare `re.*` / `regex.*` compile and match in `nltk/tree` through **`nltk.redos`**, the single choke point that already ships on `develop`:

- `redos.compile(...)` rejects a compile-time bomb up front (`redos.check_pattern`) and wraps every match in a wall-clock timeout (`TimedPattern`);
- the `re`-compatible module helpers (`redos.match` / `search` / `sub` / `subn` / `split` / `findall` / `finditer` / `fullmatch`) route the inline calls through the same guards.

No behaviour change: the same patterns are compiled and matched, only the DoS bound is added. `re.I` / `re.U` / `re.escape` and other non-pattern members stay on the stdlib module.

### Files
`parsing.py`, `prettyprinter.py`, `tree.py`.

### Testing (Python 3.13)
- `test_tree.py` + `test_treetransforms.py` (9 passed); `Tree.fromstring` round-tripped;
- every `nltk.tree.*` module imports clean.

Split out of the GHSA-8mgp hardening effort (#3753) so the routing can be reviewed per submodule. The tree-wide CI guard that keeps new regexes routed lands in a final PR once every submodule is converted.