### PR TITLE
Route nltk.stem regexes through nltk.redos (CWE-1333/CWE-400)

### DIFF
--- a/nltk/stem/arlstem.py
+++ b/nltk/stem/arlstem.py
@@ -24,8 +24,8 @@ index, over-stemming index and stemming weight), and the results showed that
 ARLSTem is promising and producing high performances. This stemmer is not
 based on any dictionary and can be used on-line effectively.
 """
-import re
 
+from nltk import redos
 from nltk.stem.api import StemmerI
 
 
@@ -41,9 +41,9 @@ class ARLSTem(StemmerI):
 
     def __init__(self):
         # different Alif with hamza
-        self.re_hamzated_alif = re.compile(r"[\u0622\u0623\u0625]")
-        self.re_alifMaqsura = re.compile(r"[\u0649]")
-        self.re_diacritics = re.compile(r"[\u064B-\u065F]")
+        self.re_hamzated_alif = redos.compile(r"[\u0622\u0623\u0625]")
+        self.re_alifMaqsura = redos.compile(r"[\u0649]")
+        self.re_diacritics = redos.compile(r"[\u064B-\u065F]")
 
         # Alif Laam, Laam Laam, Fa Laam, Fa Ba
         self.pr2 = ["\u0627\u0644", "\u0644\u0644", "\u0641\u0644", "\u0641\u0628"]

--- a/nltk/stem/arlstem2.py
+++ b/nltk/stem/arlstem2.py
@@ -25,8 +25,8 @@ results showed that the new version considerably improves the under-stemming
 errors that are common to light stemmers. Both ARLSTem and ARLSTem2 can be run
 online and do not use any dictionary.
 """
-import re
 
+from nltk import redos
 from nltk.stem.api import StemmerI
 
 
@@ -49,9 +49,9 @@ class ARLSTem2(StemmerI):
 
     def __init__(self):
         # different Alif with hamza
-        self.re_hamzated_alif = re.compile(r"[\u0622\u0623\u0625]")
-        self.re_alifMaqsura = re.compile(r"[\u0649]")
-        self.re_diacritics = re.compile(r"[\u064B-\u065F]")
+        self.re_hamzated_alif = redos.compile(r"[\u0622\u0623\u0625]")
+        self.re_alifMaqsura = redos.compile(r"[\u0649]")
+        self.re_diacritics = redos.compile(r"[\u064B-\u065F]")
 
         # Alif Laam, Laam Laam, Fa Laam, Fa Ba
         self.pr2 = ["\u0627\u0644", "\u0644\u0644", "\u0641\u0644", "\u0641\u0628"]

--- a/nltk/stem/cistem.py
+++ b/nltk/stem/cistem.py
@@ -7,9 +7,9 @@
 # URL: <https://www.nltk.org/>
 # For license information, see LICENSE.TXT
 
-import re
 from typing import Tuple
 
+from nltk import redos
 from nltk.stem.api import StemmerI
 
 
@@ -42,9 +42,9 @@ class Cistem(StemmerI):
     :type case_insensitive: bool
     """
 
-    strip_ge = re.compile(r"^ge(.{4,})")
-    repl_xx = re.compile(r"(.)\1")
-    repl_xx_back = re.compile(r"(.)\*")
+    strip_ge = redos.compile(r"^ge(.{4,})")
+    repl_xx = redos.compile(r"(.)\1")
+    repl_xx_back = redos.compile(r"(.)\*")
     # The end-anchored suffix patterns (e[mr]$, nd$, t$, [esn]$) are applied by
     # direct end-of-string character checks in ``_segment_inner`` (see there),
     # not via ``re``, so that stemming is linear rather than quadratic in the

--- a/nltk/stem/isri.py
+++ b/nltk/stem/isri.py
@@ -28,8 +28,8 @@ Additional adjustments were made to improve the algorithm:
 increases the word ambiguities and changes the original root.
 
 """
-import re
 
+from nltk import redos
 from nltk.stem.api import StemmerI
 
 
@@ -124,9 +124,9 @@ class ISRIStemmer(StemmerI):
             6: ["\u0627", "\u0645"],
         }
 
-        self.re_short_vowels = re.compile(r"[\u064B-\u0652]")
-        self.re_hamza = re.compile(r"[\u0621\u0624\u0626]")
-        self.re_initial_hamza = re.compile(r"^[\u0622\u0623\u0625]")
+        self.re_short_vowels = redos.compile(r"[\u064B-\u0652]")
+        self.re_hamza = redos.compile(r"[\u0621\u0624\u0626]")
+        self.re_initial_hamza = redos.compile(r"^[\u0622\u0623\u0625]")
 
         self.stop_words = [
             "\u064a\u0643\u0648\u0646",

--- a/nltk/stem/lancaster.py
+++ b/nltk/stem/lancaster.py
@@ -9,8 +9,8 @@
 A word stemmer based on the Lancaster (Paice/Husk) stemming algorithm.
 Paice, Chris D. "Another Stemmer." ACM SIGIR Forum 24.3 (1990): 56-61.
 """
-import re
 
+from nltk import redos
 from nltk.stem.api import StemmerI
 
 #: Longest token the stemmer will process. The rule loop scans the word once per
@@ -194,7 +194,7 @@ class LancasterStemmer(StemmerI):
         """
         # If there is no argument for the function, use class' own rule tuple.
         rule_tuple = rule_tuple if rule_tuple else self._rule_tuple
-        valid_rule = re.compile(r"^[a-z]+\*?\d[a-z]*[>\.]?$")
+        valid_rule = redos.compile(r"^[a-z]+\*?\d[a-z]*[>\.]?$")
         # Empty any old rules from the rule set before adding new ones
         self.rule_dictionary = {}
 
@@ -229,7 +229,7 @@ class LancasterStemmer(StemmerI):
     def __doStemming(self, word, intact_word):
         """Perform the actual word stemming"""
 
-        valid_rule = re.compile(r"^([a-z]+)(\*?)(\d)([a-z]*)([>\.]?)$")
+        valid_rule = redos.compile(r"^([a-z]+)(\*?)(\d)([a-z]*)([>\.]?)$")
 
         proceed = True
 

--- a/nltk/stem/porter.py
+++ b/nltk/stem/porter.py
@@ -20,8 +20,8 @@ in many languages.
 
 __docformat__ = "plaintext"
 
-import re
 
+from nltk import redos
 from nltk.stem.api import StemmerI
 
 
@@ -727,11 +727,11 @@ def demo():
 
     # Convert the results to a string, and word-wrap them.
     results = " ".join(stemmed)
-    results = re.sub(r"(.{,70})\s", r"\1\n", results + " ").rstrip()
+    results = redos.sub(r"(.{,70})\s", r"\1\n", results + " ").rstrip()
 
     # Convert the original to a string, and word wrap it.
     original = " ".join(orig)
-    original = re.sub(r"(.{,70})\s", r"\1\n", original + " ").rstrip()
+    original = redos.sub(r"(.{,70})\s", r"\1\n", original + " ").rstrip()
 
     # Print the results.
     print("-Original-".center(70).replace(" ", "*").replace("-", " "))

--- a/nltk/stem/snowball.py
+++ b/nltk/stem/snowball.py
@@ -23,8 +23,8 @@ There is also a demo function: `snowball.demo()`.
 
 """
 
-import re
 
+from nltk import redos
 from nltk.corpus import stopwords
 from nltk.stem import porter
 from nltk.stem.api import StemmerI
@@ -317,25 +317,25 @@ class ArabicStemmer(_StandardStemmer):
     """
 
     # Normalize_pre stes
-    __vocalization = re.compile(
+    __vocalization = redos.compile(
         r"[\u064b-\u064c-\u064d-\u064e-\u064f-\u0650-\u0651-\u0652]"
     )  # ً، ٌ، ٍ، َ، ُ، ِ، ّ، ْ
 
-    __kasheeda = re.compile(r"[\u0640]")  # ـ tatweel/kasheeda
+    __kasheeda = redos.compile(r"[\u0640]")  # ـ tatweel/kasheeda
 
-    __arabic_punctuation_marks = re.compile(r"[\u060C-\u061B-\u061F]")  #  ؛ ، ؟
+    __arabic_punctuation_marks = redos.compile(r"[\u060C-\u061B-\u061F]")  #  ؛ ، ؟
 
     # Normalize_post
     __last_hamzat = ("\u0623", "\u0625", "\u0622", "\u0624", "\u0626")  # أ، إ، آ، ؤ، ئ
 
     # normalize other hamza's
-    __initial_hamzat = re.compile(r"^[\u0622\u0623\u0625]")  #  أ، إ، آ
+    __initial_hamzat = redos.compile(r"^[\u0622\u0623\u0625]")  #  أ، إ، آ
 
-    __waw_hamza = re.compile(r"[\u0624]")  # ؤ
+    __waw_hamza = redos.compile(r"[\u0624]")  # ؤ
 
-    __yeh_hamza = re.compile(r"[\u0626]")  # ئ
+    __yeh_hamza = redos.compile(r"[\u0626]")  # ئ
 
-    __alefat = re.compile(r"[\u0623\u0622\u0625]")  #  أ، إ، آ
+    __alefat = redos.compile(r"[\u0623\u0622\u0625]")  #  أ، إ، آ
 
     # Checks
     __checks1 = (
@@ -5936,9 +5936,9 @@ def demo():
         excerpt = udhr.words(udhr_corpus[language])[:300]
 
         stemmed = " ".join(stemmer.stem(word) for word in excerpt)
-        stemmed = re.sub(r"(.{,70})\s", r"\1\n", stemmed + " ").rstrip()
+        stemmed = redos.sub(r"(.{,70})\s", r"\1\n", stemmed + " ").rstrip()
         excerpt = " ".join(excerpt)
-        excerpt = re.sub(r"(.{,70})\s", r"\1\n", excerpt + " ").rstrip()
+        excerpt = redos.sub(r"(.{,70})\s", r"\1\n", excerpt + " ").rstrip()
 
         print("\n")
         print("-" * 70)


### PR DESCRIPTION
Every regular expression in `nltk/stem` runs over input a caller can influence (a corpus file, a token stream, a caller-supplied pattern), so a catastrophically backtracking pattern or a compile-time bomb is a denial of service (CWE-1333 / CWE-400).

This routes every bare `re.*` / `regex.*` compile and match in `nltk/stem` through **`nltk.redos`**, the single choke point that already ships on `develop`:

- `redos.compile(...)` rejects a compile-time bomb up front (`redos.check_pattern`) and wraps every match in a wall-clock timeout (`TimedPattern`);
- the `re`-compatible module helpers (`redos.match` / `search` / `sub` / `subn` / `split` / `findall` / `finditer` / `fullmatch`) route the inline calls through the same guards.

No behaviour change: the same patterns are compiled and matched, only the DoS bound is added. `re.I` / `re.U` / `re.escape` and other non-pattern members stay on the stdlib module.

### Files
`arlstem.py`, `arlstem2.py`, `cistem.py`, `isri.py`, `lancaster.py`, `porter.py`, `snowball.py`.

### Testing (Python 3.13)
- `test_stem.py` + `test_cistem.py` (15 passed); Porter/Snowball/Cistem/Lancaster stemmed real words;
- every `nltk.stem.*` module imports clean.

Split out of the GHSA-8mgp hardening effort (#3753) so the routing can be reviewed per submodule. The tree-wide CI guard that keeps new regexes routed lands in a final PR once every submodule is converted.