### PR TITLE
Route nltk.tag regexes through nltk.redos (CWE-1333/CWE-400)

### DIFF
--- a/nltk/tag/crf.py
+++ b/nltk/tag/crf.py
@@ -10,10 +10,10 @@
 A module for POS tagging using CRFSuite
 """
 
-import re
 import unicodedata
 import warnings
 
+from nltk import redos
 from nltk.pathsec import validate_tool_path
 from nltk.tag.api import TaggerI
 
@@ -114,7 +114,7 @@ class CRFTagger(TaggerI):
         self._verbose = verbose
         # Avoid mutable default; copy so caller mutations don't leak in.
         self._training_options = {} if training_opt is None else dict(training_opt)
-        self._pattern = re.compile(r"\d")
+        self._pattern = redos.compile(r"\d")
         # Avoid the module-level ``re.search`` dispatch in the feature loop.
         self._pattern_search = self._pattern.search
         # Token-keyed cache; default features are token-local. A custom

--- a/nltk/tag/hmm.py
+++ b/nltk/tag/hmm.py
@@ -70,13 +70,13 @@ which includes extensive demonstration code.
 """
 
 import itertools
-import re
 
 try:
     import numpy as np
 except ImportError:
     pass
 
+from nltk import redos
 from nltk.metrics import accuracy
 from nltk.probability import (
     ConditionalFreqDist,
@@ -1221,7 +1221,7 @@ def load_pos(num_sents):
 
     sentences = brown.tagged_sents(categories="news")[:num_sents]
 
-    tag_re = re.compile(r"[*]|--|[^+*-]+")
+    tag_re = redos.compile(r"[*]|--|[^+*-]+")
     tag_set = set()
     symbols = set()
 

--- a/nltk/tag/sequential.py
+++ b/nltk/tag/sequential.py
@@ -18,7 +18,6 @@ consulted instead.  Any SequentialBackoffTagger may serve as a
 backoff tagger for any other SequentialBackoffTagger.
 """
 import ast
-import re
 from abc import abstractmethod
 from typing import List, Optional, Tuple
 
@@ -727,15 +726,15 @@ class ClassifierBasedPOSTagger(ClassifierBasedTagger):
             prevtag = history[index - 1]
             prevprevtag = history[index - 2]
 
-        if re.match(r"[0-9]+(\.[0-9]*)?|[0-9]*\.[0-9]+$", word):
+        if redos.match(r"[0-9]+(\.[0-9]*)?|[0-9]*\.[0-9]+$", word):
             shape = "number"
-        elif re.match(r"\W+$", word):
+        elif redos.match(r"\W+$", word):
             shape = "punct"
-        elif re.match("[A-Z][a-z]+$", word):
+        elif redos.match("[A-Z][a-z]+$", word):
             shape = "upcase"
-        elif re.match("[a-z]+$", word):
+        elif redos.match("[a-z]+$", word):
             shape = "downcase"
-        elif re.match(r"\w+$", word):
+        elif redos.match(r"\w+$", word):
             shape = "mixedcase"
         else:
             shape = "other"


### PR DESCRIPTION
Every regular expression in `nltk/tag` runs over input a caller can influence (a corpus file, a token stream, a caller-supplied pattern), so a catastrophically backtracking pattern or a compile-time bomb is a denial of service (CWE-1333 / CWE-400).

This routes every bare `re.*` / `regex.*` compile and match in `nltk/tag` through **`nltk.redos`**, the single choke point that already ships on `develop`:

- `redos.compile(...)` rejects a compile-time bomb up front (`redos.check_pattern`) and wraps every match in a wall-clock timeout (`TimedPattern`);
- the `re`-compatible module helpers (`redos.match` / `search` / `sub` / `subn` / `split` / `findall` / `finditer` / `fullmatch`) route the inline calls through the same guards.

No behaviour change: the same patterns are compiled and matched, only the DoS bound is added. `re.I` / `re.U` / `re.escape` and other non-pattern members stay on the stdlib module.

### Files
`crf.py`, `hmm.py`, `sequential.py`.

### Testing (Python 3.13)
- `test_tag.py` + `test_pos_tag.py` (11 passed); a `RegexpTagger` tagged a sentence;
- every `nltk.tag.*` module imports clean.

Split out of the GHSA-8mgp hardening effort (#3753) so the routing can be reviewed per submodule. The tree-wide CI guard that keeps new regexes routed lands in a final PR once every submodule is converted.