### PR TITLE
Route nltk.classify regexes through nltk.redos (CWE-1333/CWE-400)

### DIFF
--- a/nltk/classify/textcat.py
+++ b/nltk/classify/textcat.py
@@ -29,6 +29,7 @@ https://borel.slu.edu/crubadan/index.html
 
 from sys import maxsize
 
+from nltk import redos
 from nltk.util import trigrams
 
 # Note: this is NOT "re" you're likely used to. The regex module
@@ -70,7 +71,7 @@ class TextCat:
 
     def remove_punctuation(self, text):
         """Get rid of punctuation except apostrophes"""
-        return re.sub(r"[^\P{P}\']+", "", text)
+        return redos.sub(r"[^\P{P}\']+", "", text)
 
     def profile(self, text):
         """Create FreqDist of trigrams within text"""

--- a/nltk/classify/weka.py
+++ b/nltk/classify/weka.py
@@ -10,13 +10,13 @@ Classifiers that make use of the external 'Weka' package.
 """
 
 import os
-import re
 import subprocess
 import tempfile
 import time
 import warnings
 from sys import stdin
 
+from nltk import redos
 from nltk.classify.api import ClassifierI
 from nltk.data import make_staging_dir
 from nltk.internals import config_java, java
@@ -163,7 +163,7 @@ class WekaClassifier(ClassifierI):
             os.rmdir(temp_dir)
 
     def parse_weka_distribution(self, s):
-        probs = [float(v) for v in re.split("[*,]+", s) if v.strip()]
+        probs = [float(v) for v in redos.split("[*,]+", s) if v.strip()]
         probs = dict(zip(self._formatter.labels(), probs))
         return DictionaryProbDist(probs)
 
@@ -190,7 +190,7 @@ class WekaClassifier(ClassifierI):
             ]
 
         # is this safe:?
-        elif re.match(r"^0 \w+ [01]\.[0-9]* \?\s*$", lines[0]):
+        elif redos.match(r"^0 \w+ [01]\.[0-9]* \?\s*$", lines[0]):
             return [line.split()[1] for line in lines if line.strip()]
 
         else:
@@ -413,7 +413,7 @@ class ARFF_Formatter:
         label = str(label)
         for ch in ("\n", "\r", "\t"):
             label = label.replace(ch, " ")
-        sanitized = re.sub(r"[^a-zA-Z0-9_\- ']", "", label)
+        sanitized = redos.sub(r"[^a-zA-Z0-9_\- ']", "", label)
         sanitized = sanitized.replace("'", "''")
         return sanitized
 


### PR DESCRIPTION
Every regular expression in `nltk/classify` runs over input a caller can influence (a corpus file, a token stream, a caller-supplied pattern), so a catastrophically backtracking pattern or a compile-time bomb is a denial of service (CWE-1333 / CWE-400).

This routes every bare `re.*` / `regex.*` compile and match in `nltk/classify` through **`nltk.redos`**, the single choke point that already ships on `develop`:

- `redos.compile(...)` rejects a compile-time bomb up front (`redos.check_pattern`) and wraps every match in a wall-clock timeout (`TimedPattern`);
- the `re`-compatible module helpers (`redos.match` / `search` / `sub` / `subn` / `split` / `findall` / `finditer` / `fullmatch`) route the inline calls through the same guards.

No behaviour change: the same patterns are compiled and matched, only the DoS bound is added. `re.I` / `re.U` / `re.escape` and other non-pattern members stay on the stdlib module.

### Files
`textcat.py`, `weka.py`.

### Testing (Python 3.13)
- `test_classify.py` (2 skipped, external deps); `textcat` and `weka` import clean;
- every `nltk.classify.*` module imports clean.

Split out of the GHSA-8mgp hardening effort (#3753) so the routing can be reviewed per submodule. The tree-wide CI guard that keeps new regexes routed lands in a final PR once every submodule is converted.