### PR TITLE
Route nltk.parse regexes through nltk.redos (CWE-1333/CWE-400)

### DIFF
--- a/nltk/parse/chart.py
+++ b/nltk/parse/chart.py
@@ -36,11 +36,11 @@ defines three chart parsers:
 """
 
 import itertools
-import re
 import time
 import warnings
 from functools import total_ordering
 
+from nltk import redos
 from nltk.grammar import PCFG, is_nonterminal, is_terminal
 from nltk.internals import raise_unorderable_types
 from nltk.parse.api import ParserI
@@ -1069,7 +1069,7 @@ class AbstractChartRule(ChartRuleI):
     # Default: return a name based on the class name.
     def __str__(self):
         # Add spaces between InitialCapsWords.
-        return re.sub("([a-z])([A-Z])", r"\1 \2", self.__class__.__name__)
+        return redos.sub("([a-z])([A-Z])", r"\1 \2", self.__class__.__name__)
 
 
 # ////////////////////////////////////////////////////////////

--- a/nltk/parse/corenlp.py
+++ b/nltk/parse/corenlp.py
@@ -8,11 +8,11 @@
 
 import json
 import os
-import re
 import socket
 import time
 from typing import List, Tuple
 
+from nltk import redos
 from nltk.internals import _java_options, config_java, find_jar_iter, java
 from nltk.parse.api import ParserI
 from nltk.parse.dependencygraph import DependencyGraph
@@ -66,7 +66,9 @@ class CoreNLPServer:
         )
 
         # find the most recent code and model jar
-        stanford_jar = max(jars, key=lambda model_name: re.match(self._JAR, model_name))
+        stanford_jar = max(
+            jars, key=lambda model_name: redos.match(self._JAR, model_name)
+        )
 
         if port is None:
             try:
@@ -90,7 +92,7 @@ class CoreNLPServer:
                 verbose=verbose,
                 is_regex=True,
             ),
-            key=lambda model_name: re.match(self._MODEL_JAR_PATTERN, model_name),
+            key=lambda model_name: redos.match(self._MODEL_JAR_PATTERN, model_name),
         )
 
         self.verbose = verbose


### PR DESCRIPTION
Every regular expression in `nltk/parse` runs over input a caller can influence (a corpus file, a token stream, a caller-supplied pattern), so a catastrophically backtracking pattern or a compile-time bomb is a denial of service (CWE-1333 / CWE-400).

This routes every bare `re.*` / `regex.*` compile and match in `nltk/parse` through **`nltk.redos`**, the single choke point that already ships on `develop`:

- `redos.compile(...)` rejects a compile-time bomb up front (`redos.check_pattern`) and wraps every match in a wall-clock timeout (`TimedPattern`);
- the `re`-compatible module helpers (`redos.match` / `search` / `sub` / `subn` / `split` / `findall` / `finditer` / `fullmatch`) route the inline calls through the same guards.

No behaviour change: the same patterns are compiled and matched, only the DoS bound is added. `re.I` / `re.U` / `re.escape` and other non-pattern members stay on the stdlib module.

### Files
`chart.py`, `corenlp.py`.

### Testing (Python 3.13)
- `test_chart_parser.py` + `test_parser_dos.py` (25 passed); a `ChartParser` parsed a sentence;
- every `nltk.parse.*` module imports clean.

Split out of the GHSA-8mgp hardening effort (#3753) so the routing can be reviewed per submodule. The tree-wide CI guard that keeps new regexes routed lands in a final PR once every submodule is converted.