### PR TITLE
Route nltk.sem regexes through nltk.redos (CWE-1333/CWE-400)

### DIFF
--- a/nltk/sem/boxer.py
+++ b/nltk/sem/boxer.py
@@ -30,13 +30,13 @@ For example::
 
 import operator
 import os
-import re
 import shutil
 import subprocess
 import tempfile
 from functools import reduce
 from optparse import OptionParser
 
+from nltk import redos
 from nltk.internals import find_binary_iter
 from nltk.sem.drt import (
     DRS,
@@ -806,7 +806,7 @@ class BoxerOutputDrsParser(DrtParser):
 
     def parse_variable(self):
         var = self.token()
-        assert re.match(r"^[exps]\d+$", var), var
+        assert redos.match(r"^[exps]\d+$", var), var
         return var
 
     def parse_index(self):

--- a/nltk/sem/chat80.py
+++ b/nltk/sem/chat80.py
@@ -130,6 +130,7 @@ import shelve
 import sys
 
 import nltk.data
+from nltk import redos
 from nltk.pathsec import open as pathsec_open
 from nltk.pathsec import validate_path
 from nltk.picklesec import RestrictedUnpickler
@@ -529,11 +530,14 @@ def _str2records(filename, rel):
     Read a file into memory and convert each relation clause into a list.
     """
     recs = []
+    # ``rel`` (caller relation name) is spliced into a regex run over each line;
+    # redos.compile bounds compile + match time.
+    rel_rx = redos.compile(re.escape(rel) + r"\(")  # rel is a literal relation name
     contents = nltk.data.load("corpora/chat80/%s" % filename, format="text")
     for line in contents.splitlines():
         if line.startswith(rel):
-            line = re.sub(rel + r"\(", "", line)
-            line = re.sub(r"\)\.$", "", line)
+            line = rel_rx.sub("", line)
+            line = redos.sub(r"\)\.$", "", line)
             record = line.split(",")
             recs.append(record)
     return recs

--- a/nltk/sem/evaluate.py
+++ b/nltk/sem/evaluate.py
@@ -20,6 +20,7 @@ import sys
 import textwrap
 from pprint import pformat
 
+from nltk import redos
 from nltk.decorators import decorator  # this used in code that is commented out
 from nltk.sem.logic import (
     AbstractVariableExpression,
@@ -184,10 +185,13 @@ class Valuation(dict):
 # in the run length and lets a single valuation string pin a CPU core
 # (CWE-1333; CVE-2026-12890). The lookbehind only lets ``=+`` start at the
 # beginning of a run, so interior positions fail in O(1); the split result is
-# unchanged.
-_VAL_SPLIT_RE = re.compile(r"\s*(?<!=)=+>\s*")
-_ELEMENT_SPLIT_RE = re.compile(r"\s*,\s*")
-_TUPLES_RE = re.compile(
+# unchanged. The CVE fix closed the ``=``-run direction, but the leading ``\s*``
+# of each pattern is still retried by split/findall over an internal whitespace
+# run (``line.strip()`` only trims the ends), so route all three through
+# redos.compile for a wall-clock bound on that residual (CWE-1333).
+_VAL_SPLIT_RE = redos.compile(r"\s*(?<!=)=+>\s*")
+_ELEMENT_SPLIT_RE = redos.compile(r"\s*,\s*")
+_TUPLES_RE = redos.compile(
     r"""\s*
                                 (\([^)]+\))  # tuple-expression
                                 \s*""",

--- a/nltk/sem/logic.py
+++ b/nltk/sem/logic.py
@@ -12,10 +12,10 @@ top of the typed lambda calculus.
 """
 
 import operator
-import re
 from collections import defaultdict
 from functools import reduce, total_ordering
 
+from nltk import redos
 from nltk.internals import Counter
 from nltk.util import Trie
 
@@ -66,7 +66,7 @@ class Tokens:
     TOKENS = BINOPS + EQ_LIST + NEQ_LIST + QUANTS + LAMBDA_LIST + PUNCT + NOT_LIST
 
     # Special
-    SYMBOLS = [x for x in TOKENS if re.match(r"^[-\\.(),!&^|>=<]*$", x)]
+    SYMBOLS = [x for x in TOKENS if redos.match(r"^[-\\.(),!&^|>=<]*$", x)]
 
 
 def boolean_ops():
@@ -1191,7 +1191,9 @@ class Expression(SubstituteBindingsI):
         :return: set of ``Variable`` objects
         """
         return self.free() | {
-            p for p in self.predicates() | self.constants() if re.match("^[?@]", p.name)
+            p
+            for p in self.predicates() | self.constants()
+            if redos.match("^[?@]", p.name)
         }
 
     def free(self):
@@ -2030,7 +2032,7 @@ def is_indvar(expr):
     :return: bool True if expr is of the correct form
     """
     assert isinstance(expr, str), "%s is not a string" % expr
-    return re.match(r"^[a-df-z]\d*$", expr) is not None
+    return redos.match(r"^[a-df-z]\d*$", expr) is not None
 
 
 def is_funcvar(expr):
@@ -2042,7 +2044,7 @@ def is_funcvar(expr):
     :return: bool True if expr is of the correct form
     """
     assert isinstance(expr, str), "%s is not a string" % expr
-    return re.match(r"^[A-Z]\d*$", expr) is not None
+    return redos.match(r"^[A-Z]\d*$", expr) is not None
 
 
 def is_eventvar(expr):
@@ -2054,7 +2056,7 @@ def is_eventvar(expr):
     :return: bool True if expr is of the correct form
     """
     assert isinstance(expr, str), "%s is not a string" % expr
-    return re.match(r"^e\d*$", expr) is not None
+    return redos.match(r"^e\d*$", expr) is not None
 
 
 def demo():

--- a/nltk/sem/relextract.py
+++ b/nltk/sem/relextract.py
@@ -26,6 +26,9 @@ import html
 import re
 from collections import defaultdict
 
+from nltk import redos
+from nltk.redos import reharden
+
 # Dictionary that associates corpora with NE classes
 NE_CLASSES = {
     "ieer": [
@@ -124,7 +127,7 @@ def list2sym(lst):
     """
     sym = _join(lst, "_", untag=True)
     sym = sym.lower()
-    ENT = re.compile(r"&(\w+?);")
+    ENT = redos.compile(r"&(\w+?);")
     sym = ENT.sub(descape_entity, sym)
     sym = sym.replace(".", "")
     return sym
@@ -250,6 +253,11 @@ def extract_rels(subjclass, objclass, doc, corpus="ace", pattern=None, window=10
 
     reldicts = semi_rel2reldict(pairs)
 
+    if pattern is not None:
+        # A caller-supplied pattern is run over corpus text; re-derive it under the
+        # ReDoS wall-clock cap (and the compile-time source guard) before matching.
+        pattern = reharden(pattern)
+
     relfilter = lambda x: (
         x["subjclass"] == subjclass
         and len(x["filler"].split()) <= window
@@ -330,7 +338,7 @@ def in_demo(trace=0, sql=True):
 
             warnings.warn("Cannot import sqlite; sql flag will be ignored.")
 
-    IN = re.compile(r".*\bin\b(?!\b.+ing)")
+    IN = redos.compile(r".*\bin\b(?!\b.+ing)")
 
     print()
     print("IEER: in(ORG, LOC) -- just the clauses:")
@@ -404,7 +412,7 @@ def roles_demo(trace=0):
     writer|
     ,\sof\sthe?\s*  # "X, of (the) Y"
     """
-    ROLES = re.compile(roles, re.VERBOSE)
+    ROLES = redos.compile(roles, re.VERBOSE)
 
     print()
     print("IEER: has_role(PER, ORG) -- raw rtuples:")
@@ -466,7 +474,7 @@ def conllned(trace=1):
     .*       # followed by anything
     van/Prep # followed by van ('of')
     """
-    VAN = re.compile(vnv, re.VERBOSE)
+    VAN = redos.compile(vnv, re.VERBOSE)
 
     print()
     print("Dutch CoNLL2002: van(PER, ORG) -- raw rtuples with context:")
@@ -497,7 +505,7 @@ def conllesp():
     del/SP
     )
     """
-    DE = re.compile(de, re.VERBOSE)
+    DE = redos.compile(de, re.VERBOSE)
 
     print()
     print("Spanish CoNLL2002: de(ORG, LOC) -- just the first 10 clauses:")
@@ -516,7 +524,7 @@ def ne_chunked():
     print()
     print("1500 Sentences from Penn Treebank, as processed by NLTK NE Chunker")
     print("=" * 45)
-    ROLE = re.compile(
+    ROLE = redos.compile(
         r".*(chairman|president|trader|scientist|economist|analyst|partner).*"
     )
     rels = []


### PR DESCRIPTION
Every regular expression in `nltk/sem` runs over input a caller can influence (a corpus file, a token stream, a caller-supplied pattern), so a catastrophically backtracking pattern or a compile-time bomb is a denial of service (CWE-1333 / CWE-400).

This routes every bare `re.*` / `regex.*` compile and match in `nltk/sem` through **`nltk.redos`**, the single choke point that already ships on `develop`:

- `redos.compile(...)` rejects a compile-time bomb up front (`redos.check_pattern`) and wraps every match in a wall-clock timeout (`TimedPattern`);
- the `re`-compatible module helpers (`redos.match` / `search` / `sub` / `subn` / `split` / `findall` / `finditer` / `fullmatch`) route the inline calls through the same guards.

No behaviour change: the same patterns are compiled and matched, only the DoS bound is added. `re.I` / `re.U` / `re.escape` and other non-pattern members stay on the stdlib module.

### Files
`boxer.py`, `chat80.py`, `evaluate.py`, `logic.py`, `relextract.py`.

### Testing (Python 3.13)
- `test_logic.py` + `test_sem_evaluate.py` + `test_chat80.py` (9 passed); `logic.Expression.fromstring` parsed a formula;
- every `nltk.sem.*` module imports clean.

Split out of the GHSA-8mgp hardening effort (#3753) so the routing can be reviewed per submodule. The tree-wide CI guard that keeps new regexes routed lands in a final PR once every submodule is converted.