### PR TITLE
Route nltk.corpus regexes through nltk.redos (CWE-1333/CWE-400)

### DIFF
--- a/nltk/corpus/__init__.py
+++ b/nltk/corpus/__init__.py
@@ -59,8 +59,8 @@ For example, to read a list of the words in the Brown Corpus, use
 
 """
 
-import re
 
+from nltk import redos
 from nltk.corpus.reader import *
 from nltk.corpus.util import LazyCorpusLoader
 from nltk.tokenize import RegexpTokenizer
@@ -440,7 +440,7 @@ propbank: PropbankCorpusReader = LazyCorpusLoader(
     "prop.txt",
     r"frames/.*\.xml",
     "verbs.txt",
-    lambda filename: re.sub(r"^wsj/\d\d/", "", filename),
+    lambda filename: redos.sub(r"^wsj/\d\d/", "", filename),
     treebank,
 )  # Must be defined *after* treebank corpus.
 nombank: NombankCorpusReader = LazyCorpusLoader(
@@ -449,7 +449,7 @@ nombank: NombankCorpusReader = LazyCorpusLoader(
     "nombank.1.0",
     r"frames/.*\.xml",
     "nombank.1.0.words",
-    lambda filename: re.sub(r"^wsj/\d\d/", "", filename),
+    lambda filename: redos.sub(r"^wsj/\d\d/", "", filename),
     treebank,
 )  # Must be defined *after* treebank corpus.
 propbank_ptb: PropbankCorpusReader = LazyCorpusLoader(

--- a/nltk/corpus/reader/api.py
+++ b/nltk/corpus/reader/api.py
@@ -11,11 +11,10 @@ API for corpus readers.
 """
 
 import os
-import re
 from collections import defaultdict
 from itertools import chain
 
-from nltk import pathsec
+from nltk import pathsec, redos
 from nltk.corpus.reader.util import *
 from nltk.data import FileSystemPathPointer, PathPointer, ZipFilePathPointer
 from nltk.pathsec import validate_path
@@ -86,7 +85,7 @@ class CorpusReader:
 
         # Convert the root to a path pointer, if necessary.
         if isinstance(root, str) and not isinstance(root, PathPointer):
-            m = re.match(r"(.*\.zip)/?(.*)$|", root)
+            m = redos.match(r"(.*\.zip)/?(.*)$|", root)
             zipfile, zipentry = m.groups()
             if zipfile:
                 root = ZipFilePathPointer(zipfile, zipentry)
@@ -113,11 +112,12 @@ class CorpusReader:
         # If encoding was specified as a list of regexps, then convert
         # it to a dictionary.
         if isinstance(encoding, list):
+            # caller regexps matched against fileids: bound compile + match time
+            compiled_encoding = [(redos.compile(rx), enc) for rx, enc in encoding]
             encoding_dict = {}
             for fileid in self._fileids:
-                for x in encoding:
-                    (regexp, enc) = x
-                    if re.match(regexp, fileid):
+                for rx, enc in compiled_encoding:
+                    if rx.match(fileid):
                         encoding_dict[fileid] = enc
                         break
             encoding = encoding_dict
@@ -372,8 +372,9 @@ class CategorizedCorpusReader:
         self._c2f = defaultdict(set)
 
         if self._pattern is not None:
+            pattern_rx = redos.compile(self._pattern)  # caller cat_pattern: bound both
             for file_id in self._fileids:
-                category = re.match(self._pattern, file_id).group(1)
+                category = pattern_rx.match(file_id).group(1)
                 self._add(file_id, category)
 
         elif self._map is not None:

--- a/nltk/corpus/reader/bcp47.py
+++ b/nltk/corpus/reader/bcp47.py
@@ -5,9 +5,9 @@
 # URL: <https://www.nltk.org/>
 # For license information, see LICENSE.TXT
 
-import re
 from warnings import warn
 
+from nltk import redos
 from nltk.corpus.reader import CorpusReader
 from nltk.xmlsec import parse as safe_parse
 
@@ -70,12 +70,12 @@ class BCP47CorpusReader(CorpusReader):
         up = "[A-Z]"
         alnum = "[a-zA-Z0-9]"
         self.format = {
-            "language": re.compile(f"{low*3}?"),
-            "extlang": re.compile(f"{low*3}"),
-            "script": re.compile(f"{up}{low*3}"),
-            "region": re.compile(f"({up*2})|({dig*3})"),
-            "variant": re.compile(f"{alnum*4}{(alnum+'?')*4}"),
-            "singleton": re.compile(f"{low}"),
+            "language": redos.compile(f"{low*3}?"),
+            "extlang": redos.compile(f"{low*3}"),
+            "script": redos.compile(f"{up}{low*3}"),
+            "region": redos.compile(f"({up*2})|({dig*3})"),
+            "variant": redos.compile(f"{alnum*4}{(alnum+'?')*4}"),
+            "singleton": redos.compile(f"{low}"),
         }
 
     def data_dict(self, records):

--- a/nltk/corpus/reader/bracket_parse.py
+++ b/nltk/corpus/reader/bracket_parse.py
@@ -11,16 +11,17 @@ Corpus reader for corpora that consist of parenthesis-delineated parse trees.
 
 import sys
 
+from nltk import redos
 from nltk.corpus.reader.api import *
 from nltk.corpus.reader.util import *
 from nltk.tag import map_tag
 from nltk.tree import Tree
 
 # we use [^\s()]+ instead of \S+? to avoid matching ()
-SORTTAGWRD = re.compile(r"\((\d+) ([^\s()]+) ([^\s()]+)\)")
-TAGWORD = re.compile(r"\(([^\s()]+) ([^\s()]+)\)")
-WORD = re.compile(r"\([^\s()]+ ([^\s()]+)\)")
-EMPTY_BRACKETS = re.compile(r"\s*\(\s*\(")
+SORTTAGWRD = redos.compile(r"\((\d+) ([^\s()]+) ([^\s()]+)\)")
+TAGWORD = redos.compile(r"\(([^\s()]+) ([^\s()]+)\)")
+WORD = redos.compile(r"\([^\s()]+ ([^\s()]+)\)")
+EMPTY_BRACKETS = redos.compile(r"\s*\(\s*\(")
 
 # Alpino word/category nodes are one-per-line XML elements. ``AlpinoCorpusReader``
 # parses each one by pulling its attributes out with a single linear scan instead
@@ -28,18 +29,21 @@ EMPTY_BRACKETS = re.compile(r"\s*\(\s*\(")
 # patterns backtracked quadratically on a long, malformed ``<node ...`` line
 # (CWE-1333). ``^`` (with re.MULTILINE) plus the ``[^>\n]`` class keep every match
 # inside a single tag on a single line, so each line is scanned at most once.
-ALPINO_NODE = re.compile(
+ALPINO_NODE = redos.compile(
     r"^[ \t]*<node (?P<body>[^>\n]*?)(?P<selfclose>/?)>", re.MULTILINE
 )
-ALPINO_ATTR = re.compile(r'(\w+)="([^"]*)"')
+# ALPINO_NODE (above) was hardened, but ALPINO_ATTR.findall over the node body
+# is itself O(n**2): the leading greedy ``\w+`` is retried by findall at every
+# position of a long attribute-less body. redos.compile bounds it (CWE-1333).
+ALPINO_ATTR = redos.compile(r'(\w+)="([^"]*)"')
 # The old substitutions captured ``begin="(\d+)"``, ``pos="(\w+)"``,
 # ``cat="(\w+)"`` and ``word="([^"]+)"``, i.e. they only converted a node when
 # these fields had the expected shape (else the tag was left untouched). Keep
 # those constraints so behaviour is byte-for-byte identical on malformed input --
 # in particular, ``ordered`` output must not emit a non-numeric ``begin`` that
 # would then fail to match ``SORTTAGWRD`` and skew the tagging/ordering.
-ALPINO_DIGITS = re.compile(r"\d+")
-ALPINO_WORD = re.compile(r"\w+")
+ALPINO_DIGITS = redos.compile(r"\d+")
+ALPINO_WORD = redos.compile(r"\w+")
 
 
 def _alpino_node_to_sexpr(match, ordered):
@@ -113,19 +117,18 @@ class BracketParseCorpusReader(SyntaxCorpusReader):
             toks = read_regexp_block(stream, start_re=r"^\(")
             # Strip any comments out of the tokens.
             if self._comment_char:
-                toks = [
-                    re.sub("(?m)^%s.*" % re.escape(self._comment_char), "", tok)
-                    for tok in toks
-                ]
+                comment_src = "(?m)^%s.*" % re.escape(self._comment_char)
+                comment_rx = redos.compile(comment_src)  # bound compile + match time
+                toks = [comment_rx.sub("", tok) for tok in toks]
             return toks
         else:
             assert 0, "bad block type"
 
     def _normalize(self, t):
         # Replace leaves of the form (!), (,), with (! !), (, ,)
-        t = re.sub(r"\((.)\)", r"(\1 \1)", t)
+        t = redos.sub(r"\((.)\)", r"(\1 \1)", t)
         # Replace leaves of the form (tag word root) with (tag word)
-        t = re.sub(r"\(([^\s()]+) ([^\s()]+) [^\s()]+\)", r"(\1 \2)", t)
+        t = redos.sub(r"\(([^\s()]+) ([^\s()]+) [^\s()]+\)", r"(\1 \2)", t)
         return t
 
     def _parse(self, t):
@@ -249,9 +252,9 @@ class AlpinoCorpusReader(BracketParseCorpusReader):
             return ""
         # convert XML to sexpr notation
         t = ALPINO_NODE.sub(lambda m: _alpino_node_to_sexpr(m, ordered), t)
-        t = re.sub(r"  </node>", r")", t)
-        t = re.sub(r"<sentence>.*</sentence>", r"", t)
-        t = re.sub(r"</?alpino_ds.*>", r"", t)
+        t = redos.sub(r"  </node>", r")", t)
+        t = redos.sub(r"<sentence>.*</sentence>", r"", t)
+        t = redos.sub(r"</?alpino_ds.*>", r"", t)
         return t
 
     def _tag(self, t, tagset=None):

--- a/nltk/corpus/reader/childes.py
+++ b/nltk/corpus/reader/childes.py
@@ -12,11 +12,11 @@ Corpus reader for the XML version of the CHILDES corpus.
 
 __docformat__ = "epytext en"
 
-import re
 from collections import defaultdict
 
 from defusedxml.ElementTree import parse as safe_parse
 
+from nltk import redos
 from nltk.corpus.reader.util import concat
 from nltk.corpus.reader.xmldocs import XMLCorpusReader
 from nltk.util import LazyConcatenation, LazyMap, flatten
@@ -282,7 +282,7 @@ class CHILDESCorpusReader(XMLCorpusReader):
 
     def convert_age(self, age_year):
         "Calculate age in months from a string in CHILDES format"
-        m = re.match(r"P(\d+)Y(\d+)M?(\d?\d?)D?", age_year)
+        m = redos.match(r"P(\d+)Y(\d+)M?(\d?\d?)D?", age_year)
         if m is None:
             # A string that does not fit the CHILDES age shape would otherwise
             # make ``m.group(1)`` raise a cryptic ``AttributeError`` out of this
@@ -565,12 +565,12 @@ class CHILDESCorpusReader(XMLCorpusReader):
             path = urlbase + "/" + fileid
         else:
             full = self.root + "/" + fileid
-            full = re.sub(r"\\", "/", full)
+            full = redos.sub(r"\\", "/", full)
             if "/childes/" in full.lower():
                 # Discard /data-xml/ if present
-                path = re.findall(r"(?i)/childes(?:/data-xml)?/(.*)\.xml", full)[0]
+                path = redos.findall(r"(?i)/childes(?:/data-xml)?/(.*)\.xml", full)[0]
             elif "eng-usa" in full.lower():
-                path = "Eng-USA/" + re.findall(r"/(?i)Eng-USA/(.*)\.xml", full)[0]
+                path = "Eng-USA/" + redos.findall(r"/(?i)Eng-USA/(.*)\.xml", full)[0]
             else:
                 path = fileid
 

--- a/nltk/corpus/reader/comparative_sents.py
+++ b/nltk/corpus/reader/comparative_sents.py
@@ -33,19 +33,19 @@ Related papers:
     Proceedings of the 22nd International Conference on Computational Linguistics
     (Coling-2008), Manchester, 18-22 August, 2008.
 """
-import re
 
+from nltk import redos
 from nltk.corpus.reader.api import *
 from nltk.tokenize import *
 
 # Regular expressions for dataset components
-STARS = re.compile(r"^\*+$")
-COMPARISON = re.compile(r"<cs-[1234]>")
-CLOSE_COMPARISON = re.compile(r"</cs-[1234]>")
-GRAD_COMPARISON = re.compile(r"<cs-[123]>")
-NON_GRAD_COMPARISON = re.compile(r"<cs-4>")
-ENTITIES_FEATS = re.compile(r"(\d)_((?:[\.\w\s/-](?!\d_))+)")
-KEYWORD = re.compile(r"\(([^\(]*)\)$")
+STARS = redos.compile(r"^\*+$")
+COMPARISON = redos.compile(r"<cs-[1234]>")
+CLOSE_COMPARISON = redos.compile(r"</cs-[1234]>")
+GRAD_COMPARISON = redos.compile(r"<cs-[123]>")
+NON_GRAD_COMPARISON = redos.compile(r"<cs-4>")
+ENTITIES_FEATS = redos.compile(r"(\d)_((?:[\.\w\s/-](?!\d_))+)")
+KEYWORD = redos.compile(r"\(([^\(]*)\)$")
 
 
 class Comparison:
@@ -226,10 +226,10 @@ class ComparativeSentencesCorpusReader(CorpusReader):
             line = stream.readline()
             if not line:
                 return []  # end of file.
-            comparison_tags = re.findall(COMPARISON, line)
+            comparison_tags = redos.findall(COMPARISON, line)
             if comparison_tags:
-                grad_comparisons = re.findall(GRAD_COMPARISON, line)
-                non_grad_comparisons = re.findall(NON_GRAD_COMPARISON, line)
+                grad_comparisons = redos.findall(GRAD_COMPARISON, line)
+                non_grad_comparisons = redos.findall(NON_GRAD_COMPARISON, line)
                 # Advance to the next line (it contains the comparative sentence)
                 comparison_text = stream.readline().strip()
                 if self._word_tokenizer:
@@ -242,7 +242,7 @@ class ComparativeSentencesCorpusReader(CorpusReader):
                 if grad_comparisons:
                     # Each comparison tag has its own relations on a separate line
                     for comp in grad_comparisons:
-                        comp_type = int(re.match(r"<cs-(\d)>", comp).group(1))
+                        comp_type = int(redos.match(r"<cs-(\d)>", comp).group(1))
                         comparison = Comparison(
                             text=comparison_text, comp_type=comp_type
                         )
@@ -265,7 +265,7 @@ class ComparativeSentencesCorpusReader(CorpusReader):
                 if non_grad_comparisons:
                     for comp in non_grad_comparisons:
                         # comp_type in this case should always be 4.
-                        comp_type = int(re.match(r"<cs-(\d)>", comp).group(1))
+                        comp_type = int(redos.match(r"<cs-(\d)>", comp).group(1))
                         comparison = Comparison(
                             text=comparison_text, comp_type=comp_type
                         )
@@ -283,16 +283,16 @@ class ComparativeSentencesCorpusReader(CorpusReader):
     def _read_sent_block(self, stream):
         while True:
             line = stream.readline()
-            if re.match(STARS, line):
+            if redos.match(STARS, line):
                 while True:
                     line = stream.readline()
-                    if re.match(STARS, line):
+                    if redos.match(STARS, line):
                         break
                 continue
             if (
-                not re.findall(COMPARISON, line)
+                not redos.findall(COMPARISON, line)
                 and not ENTITIES_FEATS.findall(line)
-                and not re.findall(CLOSE_COMPARISON, line)
+                and not redos.findall(CLOSE_COMPARISON, line)
             ):
                 if self._sent_tokenizer:
                     return [

--- a/nltk/corpus/reader/framenet.py
+++ b/nltk/corpus/reader/framenet.py
@@ -23,6 +23,7 @@ from itertools import zip_longest
 from operator import itemgetter
 from pprint import pprint
 
+from nltk import redos
 from nltk.corpus.reader import XMLCorpusReader, XMLCorpusView
 from nltk.util import LazyConcatenation, LazyIteratorList, LazyMap
 
@@ -1654,10 +1655,11 @@ warnings(True) to display corpus consistency warnings when loading data
         :return: A list of frame objects.
         :rtype: list(AttrDict)
         """
+        pat_rx = redos.compile(pat)  # caller regex: bound compile + match
         return PrettyList(
             f
             for f in self.frames()
-            if any(re.search(pat, luName) for luName in f.lexUnit)
+            if any(pat_rx.search(luName) for luName in f.lexUnit)
         )
 
     def lu_basic(self, fn_luid):
@@ -2126,10 +2128,11 @@ warnings(True) to display corpus consistency warnings when loading data
         """
         if not self._frame_idx:
             self._buildframeindex()
+        name_rx = redos.compile(name) if name is not None else None
         return {
             fID: finfo.name
             for fID, finfo in self._frame_idx.items()
-            if name is None or re.search(name, finfo.name) is not None
+            if name is None or name_rx.search(finfo.name) is not None
         }
 
     def fes(self, name=None, frame=None):
@@ -2177,11 +2180,12 @@ warnings(True) to display corpus consistency warnings when loading data
         else:
             frames = self.frames()
 
+        name_rx = redos.compile(name, re.I) if name is not None else None
         return PrettyList(
             fe
             for f in frames
             for fename, fe in f.FE.items()
-            if name is None or re.search(name, fename, re.I)
+            if name is None or name_rx.search(fename)
         )
 
     def lus(self, name=None, frame=None):
@@ -2330,11 +2334,12 @@ warnings(True) to display corpus consistency warnings when loading data
         """
         if not self._lu_idx:
             self._buildluindex()
+        name_rx = redos.compile(name) if name is not None else None
         return {
             luID: luinfo.name
             for luID, luinfo in self._lu_idx.items()
             if luinfo.status not in self._bad_statuses
-            and (name is None or re.search(name, luinfo.name) is not None)
+            and (name is None or name_rx.search(luinfo.name) is not None)
         }
 
     def docs_metadata(self, name=None):
@@ -2380,8 +2385,9 @@ warnings(True) to display corpus consistency warnings when loading data
         if name is None:
             return ftlist
         else:
+            name_rx = redos.compile(name)  # bound compile + match
             return PrettyList(
-                x for x in ftlist if re.search(name, x["filename"]) is not None
+                x for x in ftlist if name_rx.search(x["filename"]) is not None
             )
 
     def docs(self, name=None):
@@ -2455,6 +2461,8 @@ warnings(True) to display corpus consistency warnings when loading data
                     )
         if frame is None and fe is not None and not isinstance(fe, str):
             frame = fe.frame
+        fe_rx = redos.compile(fe, re.I) if isinstance(fe, str) else None
+        fe2_rx = redos.compile(fe2, re.I) if isinstance(fe2, str) else None
 
         # narrow down to frames matching criteria
 
@@ -2485,8 +2493,7 @@ warnings(True) to display corpus consistency warnings when loading data
                     frames = PrettyLazyIteratorList(
                         f
                         for f in frames
-                        if fe in f.FE
-                        or any(re.search(fe, ffe, re.I) for ffe in f.FE.keys())
+                        if fe in f.FE or any(fe_rx.search(ffe) for ffe in f.FE.keys())
                     )
                 else:
                     if fe.frame not in frames:
@@ -2501,7 +2508,7 @@ warnings(True) to display corpus consistency warnings when loading data
                             f
                             for f in frames
                             if fe2 in f.FE
-                            or any(re.search(fe2, ffe, re.I) for ffe in f.FE.keys())
+                            or any(fe2_rx.search(ffe) for ffe in f.FE.keys())
                         )
                     # else we already narrowed it to a single frame
         else:  # frame, luNamePattern are None. fe, fe2 are None or strings
@@ -2522,13 +2529,13 @@ warnings(True) to display corpus consistency warnings when loading data
                 fes = fes2 = None  # FEs of interest
                 if fe is not None:
                     fes = (
-                        {ffe for ffe in f.FE.keys() if re.search(fe, ffe, re.I)}
+                        {ffe for ffe in f.FE.keys() if fe_rx.search(ffe)}
                         if isinstance(fe, str)
                         else {fe.name}
                     )
                     if fe2 is not None:
                         fes2 = (
-                            {ffe for ffe in f.FE.keys() if re.search(fe2, ffe, re.I)}
+                            {ffe for ffe in f.FE.keys() if fe2_rx.search(ffe)}
                             if isinstance(fe2, str)
                             else {fe2.name}
                         )
@@ -2812,7 +2819,7 @@ warnings(True) to display corpus consistency warnings when loading data
 
             data = data.replace("<t>", "")
             data = data.replace("</t>", "")
-            data = re.sub('<fex name="[^"]+">', "", data)
+            data = redos.sub('<fex name="[^"]+">', "", data)
             data = data.replace("</fex>", "")
             data = data.replace("<fen>", "")
             data = data.replace("</fen>", "")

--- a/nltk/corpus/reader/knbc.py
+++ b/nltk/corpus/reader/knbc.py
@@ -7,8 +7,8 @@
 
 # For more information, see http://lilyx.net/pages/nltkjapanesecorpus.html
 
-import re
 
+from nltk import redos
 from nltk.corpus.reader.api import CorpusReader, SyntaxCorpusReader
 from nltk.corpus.reader.util import (
     FileSystemPathPointer,
@@ -69,7 +69,7 @@ class KNBCorpusReader(SyntaxCorpusReader):
         res = []
         for line in t.splitlines():
             # ignore the Bunsets headers
-            if not re.match(r"EOS|\*|\#|\+", line):
+            if not redos.match(r"EOS|\*|\#|\+", line):
                 cells = line.strip().split(" ")
                 res.append(cells[0])
 
@@ -80,7 +80,7 @@ class KNBCorpusReader(SyntaxCorpusReader):
         res = []
         for line in t.splitlines():
             # ignore the Bunsets headers
-            if not re.match(r"EOS|\*|\#|\+", line):
+            if not redos.match(r"EOS|\*|\#|\+", line):
                 cells = line.strip().split(" ")
                 # convert cells to morph tuples
                 res.append((cells[0], " ".join(cells[1:])))
@@ -95,7 +95,7 @@ class KNBCorpusReader(SyntaxCorpusReader):
                 # start of bunsetsu or tag
 
                 cells = line.strip().split(" ", 3)
-                m = re.match(r"([\-0-9]*)([ADIP])", cells[1])
+                m = redos.match(r"([\-0-9]*)([ADIP])", cells[1])
 
                 assert m is not None
 
@@ -137,7 +137,7 @@ def demo():
     fileids = [
         f
         for f in find_corpus_fileids(FileSystemPathPointer(root), ".*")
-        if re.search(r"\d\-\d\-[\d]+\-[\d]+", f)
+        if redos.search(r"\d\-\d\-[\d]+\-[\d]+", f)
     ]
 
     def _knbc_fileids_sort(x):

--- a/nltk/corpus/reader/lin.py
+++ b/nltk/corpus/reader/lin.py
@@ -5,10 +5,10 @@
 # URL: <https://www.nltk.org/>
 # For license information, see LICENSE.txt
 
-import re
 from collections import defaultdict
 from functools import reduce
 
+from nltk import redos
 from nltk.corpus.reader import CorpusReader
 from nltk.pathsec import open as pathsec_open
 
@@ -16,9 +16,12 @@ from nltk.pathsec import open as pathsec_open
 class LinThesaurusCorpusReader(CorpusReader):
     """Wrapper for the LISP-formatted thesauruses distributed by Dekang Lin."""
 
-    # Compiled regular expression for extracting the key from the first line of each
-    # thesaurus entry
-    _key_re = re.compile(r'\("?([^"]+)"? \(desc [0-9.]+\).+')
+    # Compiled regular expression for extracting the key from the first line of
+    # each thesaurus entry. ``[^"]+`` does not exclude ``(``, so on a paren-heavy
+    # line the greedy group spans the remainder, the required `` (desc ..)`` is
+    # absent, and ``sub`` retries at every position -- O(n**2) over corpus data.
+    # redos.compile bounds match time with a wall-clock timeout (CWE-1333).
+    _key_re = redos.compile(r'\("?([^"]+)"? \(desc [0-9.]+\).+')
 
     @staticmethod
     def __defaultdict_factory():

--- a/nltk/corpus/reader/mte.py
+++ b/nltk/corpus/reader/mte.py
@@ -6,6 +6,7 @@ import os
 import re
 from functools import reduce
 
+from nltk import redos
 from nltk.corpus.reader import TaggedCorpusReader, concat
 from nltk.corpus.reader.xmldocs import XMLCorpusView
 from nltk.pathsec import validate_path
@@ -76,7 +77,13 @@ class MTEFileReader:
         elif self._tags == "" and self._tagset == "universal":
             return (elt.text, MTETagConverter.msd_to_universal(elt.attrib["ana"]))
         else:
-            tags = re.compile("^" + re.sub("-", ".", self._tags) + ".*$")
+            # ``self._tags`` is a caller MSD tag filter where ``-`` means "any
+            # position"; escape every other char so a metacharacter cannot inject
+            # a different pattern (or an unbalanced ``(`` crash the whole corpus
+            # read), while keeping the intended ``-`` -> ``.`` wildcard.
+            tag_body = "".join("." if c == "-" else re.escape(c) for c in self._tags)
+            tag_src = r"\A" + tag_body + r".*\Z"
+            tags = redos.compile(tag_src)  # caller tags filter: bound compile + match
             if tags.match(elt.attrib["ana"]):
                 if self._tagset == "msd":
                     return (elt.text, elt.attrib["ana"])

--- a/nltk/corpus/reader/nkjp.py
+++ b/nltk/corpus/reader/nkjp.py
@@ -7,9 +7,9 @@
 
 import functools
 import os
-import re
 import tempfile
 
+from nltk import redos
 from nltk.corpus.reader.util import concat
 from nltk.corpus.reader.xmldocs import XMLCorpusReader, XMLCorpusView
 
@@ -298,15 +298,15 @@ class XML_Tool:
             line = " "
             while len(line):
                 line = fr.readline()
-                x = re.split(r"nkjp:[^ ]* ", line)  # in all files
+                x = redos.split(r"nkjp:[^ ]* ", line)  # in all files
                 ret = " ".join(x)
-                x = re.split("<nkjp:paren>", ret)  # in ann_segmentation.xml
+                x = redos.split("<nkjp:paren>", ret)  # in ann_segmentation.xml
                 ret = " ".join(x)
-                x = re.split("</nkjp:paren>", ret)  # in ann_segmentation.xml
+                x = redos.split("</nkjp:paren>", ret)  # in ann_segmentation.xml
                 ret = " ".join(x)
-                x = re.split("<choice>", ret)  # in ann_segmentation.xml
+                x = redos.split("<choice>", ret)  # in ann_segmentation.xml
                 ret = " ".join(x)
-                x = re.split("</choice>", ret)  # in ann_segmentation.xml
+                x = redos.split("</choice>", ret)  # in ann_segmentation.xml
                 ret = " ".join(x)
                 fw.write(ret)
             fr.close()

--- a/nltk/corpus/reader/panlex_swadesh.py
+++ b/nltk/corpus/reader/panlex_swadesh.py
@@ -7,9 +7,9 @@
 # For license information, see LICENSE.TXT
 
 
-import re
 from collections import defaultdict, namedtuple
 
+from nltk import redos
 from nltk.corpus.reader.api import *
 from nltk.corpus.reader.util import *
 from nltk.corpus.reader.wordlist import WordListCorpusReader
@@ -43,7 +43,9 @@ class PanlexSwadeshCorpusReader(WordListCorpusReader):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # Find the swadesh size using the fileids' path.
-        self.swadesh_size = re.match(r"swadesh([0-9].*)\/", self.fileids()[0]).group(1)
+        self.swadesh_size = redos.match(r"swadesh([0-9].*)\/", self.fileids()[0]).group(
+            1
+        )
         self._languages = {lang.panlex_uid: lang for lang in self.get_languages()}
         self._macro_langauges = self.get_macrolanguages()
 

--- a/nltk/corpus/reader/propbank.py
+++ b/nltk/corpus/reader/propbank.py
@@ -5,11 +5,11 @@
 # URL: <https://www.nltk.org/>
 # For license information, see LICENSE.TXT
 
-import re
 from functools import total_ordering
 
 from defusedxml.ElementTree import parse as safe_parse
 
+from nltk import redos
 from nltk.corpus.reader.api import *
 from nltk.corpus.reader.util import *
 from nltk.internals import raise_unorderable_types
@@ -513,7 +513,7 @@ class PropbankInflection:
     def __repr__(self):
         return "<PropbankInflection: %s>" % self
 
-    _VALIDATE = re.compile(r"[igpv\-][fpn\-][pob\-][3\-][ap\-]$")
+    _VALIDATE = redos.compile(r"[igpv\-][fpn\-][pob\-][3\-][ap\-]$")
 
     @staticmethod
     def parse(s):

--- a/nltk/corpus/reader/pros_cons.py
+++ b/nltk/corpus/reader/pros_cons.py
@@ -25,8 +25,8 @@ Related papers:
     Opinions on the Web". Proceedings of the 14th international World Wide Web
     conference (WWW-2005), May 10-14, 2005, in Chiba, Japan.
 """
-import re
 
+from nltk import redos
 from nltk.corpus.reader.api import *
 from nltk.tokenize import *
 
@@ -121,7 +121,7 @@ class ProsConsCorpusReader(CategorizedCorpusReader, CorpusReader):
             line = stream.readline()
             if not line:
                 continue
-            sent = re.match(r"^(?!\n)\s*<(Pros|Cons)>(.*)</(?:Pros|Cons)>", line)
+            sent = redos.match(r"^(?!\n)\s*<(Pros|Cons)>(.*)</(?:Pros|Cons)>", line)
             if sent:
                 sents.append(self._word_tokenizer.tokenize(sent.group(2).strip()))
         return sents

--- a/nltk/corpus/reader/reviews.py
+++ b/nltk/corpus/reader/reviews.py
@@ -61,23 +61,21 @@ Note: Some of the files (e.g. "ipod.txt", "Canon PowerShot SD500.txt") do not
     consideration.
 """
 
-import re
 
+from nltk import redos
 from nltk.corpus.reader.api import *
 from nltk.tokenize import *
 
-TITLE = re.compile(r"^\[t\](.*)$")  # [t] Title
+TITLE = redos.compile(r"^\[t\](.*)$")  # [t] Title
 # find 'feature' in feature[+3].
 # The feature label is "a word, then up to 50 single-whitespace-separated
-# words". The label length is *bounded* so that re.findall() cannot rescan a
-# long, bracket-less line quadratically: with the previous unbounded label
-# (``(?:(?:\w+\s)+)?\w+``) a crafted corpus line such as ``"word " * 100000``
-# makes each search position consume the rest of the line, hanging the reader
-# (ReDoS, CWE-1333). Real feature labels are short noun phrases, so the bound
-# does not affect normal corpora.
-FEATURES = re.compile(r"(\w+(?:\s\w+){0,50})\[((?:\+|\-)\d)\]")
-NOTES = re.compile(r"\[(?!t)(p|u|s|cc|cs)\]")  # find 'p' in camera[+2][p]
-SENT = re.compile(r"##(.*)$")  # find tokenized sentence
+# words". The ``{0,50}`` bound only stops the *space-separated* attack; a long
+# bracket-less run with no spaces (``"a" * 100000``) never enters that group and
+# the leading greedy ``\w+``, retried by findall at every position, is still
+# O(n**2). redos.compile bounds compile and match time regardless (CWE-1333).
+FEATURES = redos.compile(r"(\w+(?:\s\w+){0,50})\[((?:\+|\-)\d)\]")
+NOTES = redos.compile(r"\[(?!t)(p|u|s|cc|cs)\]")  # find 'p' in camera[+2][p]
+SENT = redos.compile(r"##(.*)$")  # find tokenized sentence
 
 
 class Review:
@@ -285,7 +283,7 @@ class ReviewsCorpusReader(CorpusReader):
             line = stream.readline()
             if not line:
                 return features
-            features.extend(re.findall(FEATURES, line))
+            features.extend(FEATURES.findall(line))
         return features
 
     def _read_review_block(self, stream):
@@ -293,7 +291,7 @@ class ReviewsCorpusReader(CorpusReader):
             line = stream.readline()
             if not line:
                 return []  # end of file.
-            title_match = re.match(TITLE, line)
+            title_match = redos.match(TITLE, line)
             if title_match:
                 review = Review(
                     title=title_match.group(1).strip()
@@ -309,13 +307,13 @@ class ReviewsCorpusReader(CorpusReader):
                 return [review]
             # Start of a new review: backup to just before it starts, and
             # return the review we've already collected.
-            if re.match(TITLE, line):
+            if redos.match(TITLE, line):
                 stream.seek(oldpos)
                 return [review]
             # Anything else is part of the review line.
-            feats = re.findall(FEATURES, line)
-            notes = re.findall(NOTES, line)
-            sent = re.findall(SENT, line)
+            feats = FEATURES.findall(line)
+            notes = redos.findall(NOTES, line)
+            sent = redos.findall(SENT, line)
             if sent:
                 sent = self._word_tokenizer.tokenize(sent[0])
             review_line = ReviewLine(sent=sent, features=feats, notes=notes)
@@ -331,7 +329,7 @@ class ReviewsCorpusReader(CorpusReader):
         words = []
         for i in range(20):  # Read 20 lines at a time.
             line = stream.readline()
-            sent = re.findall(SENT, line)
+            sent = redos.findall(SENT, line)
             if sent:
                 words.extend(self._word_tokenizer.tokenize(sent[0]))
         return words

--- a/nltk/corpus/reader/senseval.py
+++ b/nltk/corpus/reader/senseval.py
@@ -22,14 +22,18 @@ Each instance of the ambiguous words "hard", "interest", "line", and "serve"
 is tagged with a sense identifier, and supplied with context.
 """
 
-import re
 
-import regex
 from defusedxml.ElementTree import fromstring as safe_fromstring
 
+from nltk import redos
 from nltk.corpus.reader.api import *
 from nltk.corpus.reader.util import *
 from nltk.tokenize import *
+
+# ``(\s+)&(\s+)`` retried by sub over a whitespace run is O(n**2) on a crafted
+# instance block; the later _fixXML subs were hardened but this one was left on
+# plain ``re``. redos.compile bounds match time (CWE-1333).
+_LONE_AMP_RE = redos.compile(r"(\s+)&(\s+)")
 
 
 class SensevalInstance:
@@ -91,7 +95,7 @@ class SensevalCorpusView(StreamBackedCorpusView):
             # Start of a lexical element?
             if line.lstrip().startswith("<lexelt"):
                 lexelt_num += 1
-                m = re.search("item=(\"[^\"]+\"|'[^']+')", line)
+                m = redos.search("item=(\"[^\"]+\"|'[^']+')", line)
                 assert m is not None  # <lexelt> has no 'item=...'
                 lexelt = m.group(1)[1:-1]
                 if lexelt_num < len(self._lexelts):
@@ -165,31 +169,31 @@ def _fixXML(text):
     Fix the various issues with Senseval pseudo-XML.
     """
     # <~> or <^> => ~ or ^
-    text = re.sub(r"<([~\^])>", r"\1", text)
+    text = redos.sub(r"<([~\^])>", r"\1", text)
     # fix lone &
-    text = re.sub(r"(\s+)\&(\s+)", r"\1&amp;\2", text)
+    text = _LONE_AMP_RE.sub(r"\1&amp;\2", text)
     # fix """
-    text = re.sub(r'"""', "'\"'", text)
+    text = redos.sub(r'"""', "'\"'", text)
     # fix <s snum=dd> => <s snum="dd"/>
-    text = re.sub(r'(<[^<]*snum=)([^">]+)>', r'\1"\2"/>', text)
+    text = redos.sub(r'(<[^<]*snum=)([^">]+)>', r'\1"\2"/>', text)
     # fix foreign word tag
-    text = re.sub(r"<\&frasl>\s*<p[^>]*>", "FRASL", text)
+    text = redos.sub(r"<\&frasl>\s*<p[^>]*>", "FRASL", text)
     # remove <&I .>
-    text = re.sub(r"<\&I[^>]*>", "", text)
+    text = redos.sub(r"<\&I[^>]*>", "", text)
     # fix <{word}>
-    text = re.sub(r"<{([^}]+)}>", r"\1", text)
+    text = redos.sub(r"<{([^}]+)}>", r"\1", text)
     # remove <@>, <p>, </p>
-    text = re.sub(r"<(@|/?p)>", r"", text)
+    text = redos.sub(r"<(@|/?p)>", r"", text)
     # remove <&M .> and <&T .> and <&Ms .>
-    text = re.sub(r"<&\w+ \.>", r"", text)
+    text = redos.sub(r"<&\w+ \.>", r"", text)
     # remove <!DOCTYPE... > lines
-    text = re.sub(r"<!DOCTYPE[^>]*>", r"", text)
+    text = redos.sub(r"<!DOCTYPE[^>]*>", r"", text)
     # remove <[hi]> and <[/p]> etc
-    text = re.sub(r"<\[\/?[^>]+\]*>", r"", text)
+    text = redos.sub(r"<\[\/?[^>]+\]*>", r"", text)
     # take the thing out of the brackets: <&hellip;>
-    text = re.sub(r"<(\&\w+;)>", r"\1", text)
+    text = redos.sub(r"<(\&\w+;)>", r"\1", text)
     # and remove the & for those patterns that aren't regular XML
-    text = re.sub(r"&(?!amp|gt|lt|apos|quot)", r"", text)
+    text = redos.sub(r"&(?!amp|gt|lt|apos|quot)", r"", text)
     # fix 'abc <p="foo"/>' style tags - now <wf pos="foo">abc</wf>
     #
     # Possessive quantifiers (regex module) prevent catastrophic backtracking
@@ -198,8 +202,8 @@ def _fixXML(text):
     # <p="..."/> tag quadratically. The token class [^<>\s] cannot cross the
     # surrounding separators and \s cannot cross the literal '"', so making each
     # run possessive is match-for-match identical while making the scan linear.
-    text = regex.sub(
+    text = redos.sub(
         r'[ \t]*+([^<>\s]++)[ \t]*+<p="([^"]*+"?)"/>', r' <wf pos="\2">\1</wf>', text
     )
-    text = regex.sub(r"\s*+\"\s*+<p='\"'/>", " <wf pos='\"'>\"</wf>", text)
+    text = redos.sub(r"\s*+\"\s*+<p='\"'/>", " <wf pos='\"'>\"</wf>", text)
     return text

--- a/nltk/corpus/reader/sentiwordnet.py
+++ b/nltk/corpus/reader/sentiwordnet.py
@@ -35,8 +35,8 @@ http://sentiwordnet.isti.cnr.it/
     0.125
 """
 
-import re
 
+from nltk import redos
 from nltk.corpus.reader import CorpusReader
 
 
@@ -54,9 +54,9 @@ class SentiWordNetCorpusReader(CorpusReader):
 
     def _parse_src_file(self):
         lines = self.open(self._fileids[0]).read().splitlines()
-        lines = filter((lambda x: not re.search(r"^\s*#", x)), lines)
+        lines = filter((lambda x: not redos.search(r"^\s*#", x)), lines)
         for i, line in enumerate(lines):
-            fields = [field.strip() for field in re.split(r"\t+", line)]
+            fields = [field.strip() for field in redos.split(r"\t+", line)]
             try:
                 pos, offset, pos_score, neg_score, synset_terms, gloss = fields
             except BaseException as e:

--- a/nltk/corpus/reader/sinica_treebank.py
+++ b/nltk/corpus/reader/sinica_treebank.py
@@ -38,15 +38,16 @@ Chen Keh-Jiann and Yu-Ming Hsieh (2004) Chinese Treebanks and Grammar
 Extraction, Proceedings of IJCNLP-04, pp560-565.
 """
 
+from nltk import redos
 from nltk.corpus.reader.api import *
 from nltk.corpus.reader.util import *
 from nltk.tag import map_tag
 from nltk.tree import sinica_parse
 
-IDENTIFIER = re.compile(r"^#\S+\s")
-APPENDIX = re.compile(r"(?<=\))#.*$")
-TAGWORD = re.compile(r":([^:()|]+):([^:()|]+)")
-WORD = re.compile(r":[^:()|]+:([^:()|]+)")
+IDENTIFIER = redos.compile(r"^#\S+\s")
+APPENDIX = redos.compile(r"(?<=\))#.*$")
+TAGWORD = redos.compile(r":([^:()|]+):([^:()|]+)")
+WORD = redos.compile(r":[^:()|]+:([^:()|]+)")
 
 
 class SinicaTreebankCorpusReader(SyntaxCorpusReader):

--- a/nltk/corpus/reader/switchboard.py
+++ b/nltk/corpus/reader/switchboard.py
@@ -4,8 +4,8 @@
 # Author: Edward Loper <edloper@gmail.com>
 # URL: <https://www.nltk.org/>
 # For license information, see LICENSE.TXT
-import re
 
+from nltk import redos
 from nltk.corpus.reader.api import *
 from nltk.corpus.reader.util import *
 from nltk.tag import map_tag, str2tuple
@@ -109,7 +109,7 @@ class SwitchboardCorpusReader(CorpusReader):
     def _tagged_words_block_reader(self, stream, tagset=None):
         return sum(self._tagged_discourses_block_reader(stream, tagset)[0], [])
 
-    _UTTERANCE_RE = re.compile(r"(\w+)\.(\d+)\:\s*(.*)")
+    _UTTERANCE_RE = redos.compile(r"(\w+)\.(\d+)\:\s*(.*)")
     _SEP = "/"
 
     def _parse_utterance(self, utterance, include_tag, tagset=None):

--- a/nltk/corpus/reader/timit.py
+++ b/nltk/corpus/reader/timit.py
@@ -121,6 +121,7 @@ The 4 functions are as follows.
 import sys
 import time
 
+from nltk import redos
 from nltk.corpus.reader.api import *
 from nltk.internals import import_from_stdlib
 from nltk.tree import Tree
@@ -233,7 +234,7 @@ class TimitCorpusReader(CorpusReader):
             for line in fp:
                 if not line.strip() or line[0] == ";":
                     continue
-                m = re.match(r"\s*(\S+)\s+/(.*)/\s*$", line)
+                m = redos.match(r"\s*(\S+)\s+/(.*)/\s*$", line)
                 if not m:
                     raise ValueError("Bad line: %r" % line)
                 _transcriptions[m.group(1)] = m.group(2).split()

--- a/nltk/corpus/reader/util.py
+++ b/nltk/corpus/reader/util.py
@@ -14,6 +14,7 @@ import tempfile
 from functools import reduce
 from xml.etree import ElementTree
 
+from nltk import redos
 from nltk.data import (
     FileSystemPathPointer,
     PathPointer,
@@ -547,7 +548,7 @@ def read_alignedsent_block(stream):
         # Other line:
         else:
             s += line
-            if re.match(r"^\d+-\d+", line) is not None:
+            if redos.match(r"^\d+-\d+", line) is not None:
                 return [s]
 
 
@@ -558,12 +559,17 @@ def read_regexp_block(stream, start_re, end_re=None):
     tokens end with lines that match ``end_re``; otherwise, tokens end
     whenever the next line matching ``start_re`` or EOF is found.
     """
+    # start_re / end_re are caller-supplied and matched per line (a line can be
+    # adversarially long), so compile through redos to bound compile AND match.
+    start_rx = redos.compile(start_re)
+    end_rx = redos.compile(end_re) if end_re is not None else None
+
     # Scan until we find a line matching the start regexp.
     while True:
         line = stream.readline()
         if not line:
             return []  # end of file.
-        if re.match(start_re, line):
+        if start_rx.match(line):
             break
 
     # Scan until we find another line matching the regexp, or EOF.
@@ -575,11 +581,11 @@ def read_regexp_block(stream, start_re, end_re=None):
         if not line:
             return ["".join(lines)]
         # End of token:
-        if end_re is not None and re.match(end_re, line):
+        if end_rx is not None and end_rx.match(line):
             return ["".join(lines)]
         # Start of new token: backup to just before it starts, and
         # return the token we've already collected.
-        if end_re is None and re.match(start_re, line):
+        if end_rx is None and start_rx.match(line):
             stream.seek(oldpos)
             return ["".join(lines)]
         # Anything else is part of the token.
@@ -620,7 +626,8 @@ def read_sexpr_block(stream, block_size=16384, comment_char=None):
         # on adding BOMs to the beginning of encoded strings.)
 
     if comment_char:
-        COMMENT = re.compile("(?m)^%s.*$" % re.escape(comment_char))
+        _comment_src = "(?m)^%s.*$" % re.escape(comment_char)
+        COMMENT = redos.compile(_comment_src)  # comment_char: bound compile + match
     # When a single s-expression spans more than one block, we grow ``block``
     # and re-parse it. Growing by a *fixed* amount re-parses (and, with a
     # comment_char, re-substitutes) the whole growing buffer on every step,
@@ -637,11 +644,11 @@ def read_sexpr_block(stream, block_size=16384, comment_char=None):
             # would make our offset wrong.)
             if comment_char:
                 block += stream.readline()
-                block = re.sub(COMMENT, _sub_space, block)
+                block = COMMENT.sub(_sub_space, block)
             # Read the block.
             tokens, offset = _parse_sexpr_block(block)
             # Skip whitespace
-            offset = re.compile(r"\s*").search(block, offset).end()
+            offset = redos.compile(r"\s*").search(block, offset).end()
 
             # Move to the end position.
             if encoding is None:
@@ -676,7 +683,7 @@ def _parse_sexpr_block(block):
     start = end = 0
 
     while end < len(block):
-        m = re.compile(r"\S").search(block, end)
+        m = redos.compile(r"\S").search(block, end)
         if not m:
             return tokens, end
 
@@ -684,7 +691,7 @@ def _parse_sexpr_block(block):
 
         # Case 1: sexpr is not parenthesized.
         if m.group() != "(":
-            m2 = re.compile(r"[\s(]").search(block, start)
+            m2 = redos.compile(r"[\s(]").search(block, start)
             if m2:
                 end = m2.start()
             else:
@@ -695,7 +702,7 @@ def _parse_sexpr_block(block):
         # Case 2: parenthesized sexpr.
         else:
             nesting = 0
-            for m in re.compile(r"[()]").finditer(block, start):
+            for m in redos.compile(r"[()]").finditer(block, start):
                 if m.group() == "(":
                     nesting += 1
                 else:
@@ -733,6 +740,7 @@ def find_corpus_fileids(root, regexp):
         pathsec.validate_path(root, context="find_corpus_fileids")
 
     regexp += "$"
+    regexp_rx = redos.compile(regexp)  # caller fileid regexp: bound compile + match
 
     # Find fileids in a zipfile: scan the zipfile's namelist.  Filter
     # out entries that end in '/' -- they're directories.
@@ -742,7 +750,7 @@ def find_corpus_fileids(root, regexp):
             for name in root.zipfile.namelist()
             if not name.endswith("/")
         ]
-        items = [name for name in fileids if re.match(regexp, name)]
+        items = [name for name in fileids if regexp_rx.match(name)]
         return sorted(items)
 
     # Find fileids in a directory: use os.walk to search subdirectories,
@@ -783,14 +791,14 @@ def find_corpus_fileids(root, regexp):
             items += [
                 prefix + fileid
                 for fileid in fileids
-                if re.match(regexp, prefix + fileid)
+                if regexp_rx.match(prefix + fileid)
             ]
         return sorted(items)
 
     # HuggingFace PathPointer: delegate to its fileids() method (duck typing,
     # avoids a circular import of nltk.huggingface.dataset here).
     elif hasattr(root, "fileids"):
-        return [fid for fid in root.fileids() if re.match(regexp, fid)]
+        return [fid for fid in root.fileids() if regexp_rx.match(fid)]
 
     else:
         raise AssertionError("Don't know how to handle %r" % root)
@@ -818,7 +826,7 @@ def tagged_treebank_para_block_reader(stream):
     while True:
         line = stream.readline()
         # End of paragraph:
-        if re.match(r"======+\s*$", line):
+        if redos.match(r"======+\s*$", line):
             if para.strip():
                 return [para]
         # End of file:

--- a/nltk/corpus/reader/verbnet.py
+++ b/nltk/corpus/reader/verbnet.py
@@ -12,10 +12,10 @@ For details about VerbNet see:
 https://verbs.colorado.edu/~mpalmer/projects/verbnet.html
 """
 
-import re
 import textwrap
 from collections import defaultdict
 
+from nltk import redos
 from nltk.corpus.reader.xmldocs import XMLCorpusReader
 
 
@@ -80,13 +80,13 @@ class VerbnetCorpusReader(XMLCorpusReader):
         """The VerbNet version string for this corpus instance."""
         return self._version
 
-    _LONGID_RE = re.compile(r"([A-Za-z_]+)-([\d.-]+)$")
+    _LONGID_RE = redos.compile(r"([A-Za-z_]+)-([\d.-]+)$")
     """Regular expression that matches (and decomposes) longids"""
 
-    _SHORTID_RE = re.compile(r"[\d.\-]+$")
+    _SHORTID_RE = redos.compile(r"[\d.\-]+$")
     """Regular expression that matches shortids"""
 
-    _INDEX_RE = re.compile(
+    _INDEX_RE = redos.compile(
         r'<MEMBER name="\??([^"]+)" wn="([^"]*)"[^>]+>|' r'<VNSUBCLASS ID="([^"]+)"/?>'
     )
     """Regular expression used by ``_index()`` to quickly scan the corpus

--- a/nltk/corpus/reader/wordnet.py
+++ b/nltk/corpus/reader/wordnet.py
@@ -32,13 +32,13 @@ https://omwn.org/
 
 import math
 import os
-import re
 import warnings
 from collections import defaultdict, deque
 from functools import total_ordering
 from itertools import chain, islice
 from operator import itemgetter
 
+from nltk import redos
 from nltk.corpus.reader import CorpusReader
 from nltk.internals import deprecated
 from nltk.probability import FreqDist
@@ -119,7 +119,7 @@ VERB_FRAME_STRINGS = (
     "Somebody %s out of somebody",
 )
 
-SENSENUM_RE = re.compile(r"\.[\d]+\.")
+SENSENUM_RE = redos.compile(r"\.[\d]+\.")
 
 
 ######################################################################
@@ -1500,7 +1500,7 @@ class WordNetCorpusReader(CorpusReader):
         fh = self._data_file(ADJ)
         fh.seek(0)
         for line in fh:
-            match = re.search(r"Word[nN]et (\d+\+?|\d+\.\d+) Copyright", line)
+            match = redos.search(r"Word[nN]et (\d+\+?|\d+\.\d+) Copyright", line)
             if match is not None:
                 version = match.group(1)
                 fh.seek(0)
@@ -1645,8 +1645,8 @@ class WordNetCorpusReader(CorpusReader):
         try:
             # parse out the definitions and examples from the gloss
             columns_str, gloss = data_file_line.strip().split("|")
-            definition = re.sub(r"[\"].*?[\"]", "", gloss).strip()
-            examples = re.findall(r'"([^"]*)"', gloss)
+            definition = redos.sub(r"[\"].*?[\"]", "", gloss).strip()
+            examples = redos.findall(r'"([^"]*)"', gloss)
             for example in examples:
                 synset._examples.append(example)
 
@@ -1676,7 +1676,7 @@ class WordNetCorpusReader(CorpusReader):
                 # get the lex_id (used for sense_keys)
                 lex_id = int(_next_token(), 16)
                 # If the lemma has a syntactic marker, extract it.
-                m = re.match(r"(.*?)(\(.*\))?$", lemma_name)
+                m = redos.match(r"(.*?)(\(.*\))?$", lemma_name)
                 lemma_name, syn_mark = m.groups()
                 # create the lemma object
                 lemma = Lemma(self, synset, lemma_name, lexname_index, lex_id, syn_mark)

--- a/nltk/corpus/reader/xmldocs.py
+++ b/nltk/corpus/reader/xmldocs.py
@@ -21,6 +21,7 @@ import codecs
 from defusedxml.ElementTree import fromstring as safe_fromstring
 from defusedxml.ElementTree import parse as safe_parse
 
+from nltk import redos
 from nltk.corpus.reader.api import CorpusReader
 from nltk.corpus.reader.util import *
 from nltk.data import SeekableUnicodeStreamReader
@@ -146,7 +147,7 @@ class XMLCorpusView(StreamBackedCorpusView):
         if elt_handler:
             self.handle_elt = elt_handler
 
-        self._tagspec = re.compile(tagspec + r"\Z")
+        self._tagspec = redos.compile(tagspec + r"\Z")  # bound compile + match time
         """The tag specification for this corpus view."""
 
         self._tag_context = {0: ()}
@@ -189,10 +190,10 @@ class XMLCorpusView(StreamBackedCorpusView):
             return "utf-32-le"
         if s.startswith(codecs.BOM_UTF8):
             return "utf-8"
-        m = re.match(rb'\s*<\?xml\b.*\bencoding="([^"]+)"', s)
+        m = redos.match(rb'\s*<\?xml\b.*\bencoding="([^"]+)"', s)
         if m:
             return m.group(1).decode()
-        m = re.match(rb"\s*<\?xml\b.*\bencoding='([^']+)'", s)
+        m = redos.match(rb"\s*<\?xml\b.*\bencoding='([^']+)'", s)
         if m:
             return m.group(1).decode()
         # No encoding found -- what should the default be?
@@ -235,7 +236,7 @@ class XMLCorpusView(StreamBackedCorpusView):
     # to its first terminator keeps validation linear while matching the same
     # well-formed fragments. (The CDATA brackets are also escaped so they match
     # a literal ``<![CDATA[`` rather than being read as a character class.)
-    _VALID_XML_RE = re.compile(
+    _VALID_XML_RE = redos.compile(
         r"""
         [^<]*
         (
@@ -250,13 +251,13 @@ class XMLCorpusView(StreamBackedCorpusView):
 
     #: A regular expression used to extract the tag name from a start tag,
     #: end tag, or empty-elt tag string.
-    _XML_TAG_NAME = re.compile(r"<\s*(?:/\s*)?([^\s>]+)")
+    _XML_TAG_NAME = redos.compile(r"<\s*(?:/\s*)?([^\s>]+)")
 
     #: A regular expression used to find all start-tags, end-tags, and
     #: empty-elt tags in an XML file.  This regexp is more lenient than
     #: the XML spec -- e.g., it allows spaces in some places where the
     #: spec does not.
-    _XML_PIECE = re.compile(
+    _XML_PIECE = redos.compile(
         r"""
         # Include these so we can skip them:
         (?P<COMMENT>        <!--.*?-->                          )|
@@ -309,9 +310,9 @@ class XMLCorpusView(StreamBackedCorpusView):
                 return fragment
 
             # Do we have a fragment that will never be well-formed?
-            if re.search("[<>]", fragment).group(0) == ">":
+            if redos.search("[<>]", fragment).group(0) == ">":
                 pos = stream.tell() - (
-                    len(fragment) - re.search("[<>]", fragment).end()
+                    len(fragment) - redos.search("[<>]", fragment).end()
                 )
                 raise ValueError('Unexpected ">" near char %s' % pos)
 
@@ -345,6 +346,8 @@ class XMLCorpusView(StreamBackedCorpusView):
         """
         if tagspec is None:
             tagspec = self._tagspec
+        if isinstance(tagspec, str):
+            tagspec = redos.compile(tagspec)  # caller-passed raw tagspec: bound both
         if elt_handler is None:
             elt_handler = self.handle_elt
 
@@ -381,7 +384,7 @@ class XMLCorpusView(StreamBackedCorpusView):
                     context.append(name)
                     # Is this one of the elts we're looking for?
                     if elt_start is None:
-                        if re.match(tagspec, "/".join(context)):
+                        if tagspec.match("/".join(context)):
                             elt_start = piece.start()
                             elt_depth = len(context)
 
@@ -404,7 +407,7 @@ class XMLCorpusView(StreamBackedCorpusView):
                 elif piece.group("EMPTY_ELT_TAG"):
                     name = self._XML_TAG_NAME.match(piece.group()).group(1)
                     if elt_start is None:
-                        if re.match(tagspec, "/".join(context) + "/" + name):
+                        if tagspec.match("/".join(context) + "/" + name):
                             elts.append((piece.group(), "/".join(context) + "/" + name))
 
             if elt_start is not None:

--- a/nltk/corpus/reader/ycoe.py
+++ b/nltk/corpus/reader/ycoe.py
@@ -18,8 +18,8 @@ to the YCOE standard: https://www-users.york.ac.uk/~lang22/YCOE/YcoeHome.htm
 """
 
 import os
-import re
 
+from nltk import redos
 from nltk.corpus.reader.api import *
 from nltk.corpus.reader.bracket_parse import BracketParseCorpusReader
 from nltk.corpus.reader.tagged import TaggedCorpusReader
@@ -136,8 +136,8 @@ class YCOEParseCorpusReader(BracketParseCorpusReader):
     that strips out (CODE ...) and (ID ...) nodes."""
 
     def _parse(self, t):
-        t = re.sub(r"(?u)\((CODE|ID)[^\)]*\)", "", t)
-        if re.match(r"\s*\(\s*\)\s*$", t):
+        t = redos.sub(r"(?u)\((CODE|ID)[^\)]*\)", "", t)
+        if redos.match(r"\s*\(\s*\)\s*$", t):
             return None
         return BracketParseCorpusReader._parse(self, t)
 

--- a/nltk/corpus/util.py
+++ b/nltk/corpus/util.py
@@ -10,10 +10,10 @@
 ######################################################################
 
 import gc
-import re
 import types
 
 import nltk
+from nltk import redos
 
 TRY_ZIPFILE_FIRST = False
 
@@ -68,7 +68,7 @@ class LazyCorpusLoader:
 
     def __load(self):
         # Find the corpus root directory.
-        zip_name = re.sub(r"(([^/]+)(/.*)?)", r"\2.zip/\1/", self.__name)
+        zip_name = redos.sub(r"(([^/]+)(/.*)?)", r"\2.zip/\1/", self.__name)
         if TRY_ZIPFILE_FIRST:
             try:
                 root = nltk.data.find(f"{self.subdir}/{zip_name}")


### PR DESCRIPTION
Every regular expression in `nltk/corpus` runs over corpus data or a caller-supplied fileid / category / tag pattern, so a catastrophically backtracking pattern or a compile-time bomb is a denial of service (CWE-1333 / CWE-400).

This routes every bare `re.*` / `regex.*` compile and match in `nltk/corpus` (readers + `corpus/util.py` + `corpus/__init__.py`) through **`nltk.redos`**, the single choke point that already ships on `develop`:

- `redos.compile(...)` rejects a compile-time bomb up front (`redos.check_pattern`) and wraps every match in a wall-clock timeout (`TimedPattern`);
- the `re`-compatible module helpers (`redos.match` / `search` / `sub` / `subn` / `split` / `findall` / `finditer` / `fullmatch`) route the inline calls through the same guards.

Caller-influenceable fileid / category / MSD-tag regexps (in `reader/api.py`, `reader/util.py`, `reader/mte.py`, `reader/xmldocs.py`, `reader/framenet.py`) are pre-compiled once through `redos.compile` and matched via the bounded pattern object, and the `mte` tag filter escapes its literal splice so a metacharacter cannot inject a different pattern. No behaviour change otherwise: the same patterns are compiled and matched, only the DoS bound is added. `re.I` / `re.escape` and other non-pattern members stay on the stdlib module.

### Files (26)
`corpus/__init__.py`, `corpus/util.py`, and the readers: `api`, `bcp47`, `bracket_parse`, `childes`, `comparative_sents`, `framenet`, `knbc`, `lin`, `mte`, `nkjp`, `panlex_swadesh`, `propbank`, `pros_cons`, `reviews`, `senseval`, `sentiwordnet`, `sinica_treebank`, `switchboard`, `timit`, `util`, `verbnet`, `wordnet`, `xmldocs`, `ycoe`.

### Testing (Python 3.13)
- `test_corpus_reader.py`, `test_corpus_util.py`, `test_corpus_views.py`, `test_seekable_unicode_stream_reader.py`, `test_corpus_reader_traversal.py`, `test_corpus_reader_pathsec.py` (56 passed);
- `BracketParseCorpusReader` and `PlaintextCorpusReader` (fileid-regex matching) exercised on a real temp corpus;
- every `nltk.corpus.*` module imports clean.

Split out of the GHSA-8mgp hardening effort (#3753) so the routing can be reviewed per submodule. The tree-wide CI guard that keeps new regexes routed lands in a final PR once every submodule is converted.
