### PR TITLE
Route nltk.app regexes through nltk.redos (CWE-1333/CWE-400)

### DIFF
--- a/nltk/app/chunkparser_app.py
+++ b/nltk/app/chunkparser_app.py
@@ -16,7 +16,6 @@ parser ``nltk.chunk.RegexpChunkParser``.
 # and what part of the data is being used as the development set.
 
 import random
-import re
 import textwrap
 import time
 from tkinter import (
@@ -34,6 +33,7 @@ from tkinter import (
 from tkinter.filedialog import askopenfilename, asksaveasfilename
 from tkinter.font import Font
 
+from nltk import redos
 from nltk.chunk import ChunkScore, RegexpChunkParser
 from nltk.chunk.regexp import RegexpChunkRule
 from nltk.corpus import conll2000, treebank_chunk
@@ -307,13 +307,13 @@ class RegexpChunkApp:
 
     def normalize_grammar(self, grammar):
         # Strip comments
-        grammar = re.sub(r"((\\.|[^#])*)(#.*)?", r"\1", grammar)
+        grammar = redos.sub(r"((\\.|[^#])*)(#.*)?", r"\1", grammar)
         # Normalize whitespace
-        grammar = re.sub(" +", " ", grammar)
-        grammar = re.sub(r"\n\s+", r"\n", grammar)
+        grammar = redos.sub(" +", " ", grammar)
+        grammar = redos.sub(r"\n\s+", r"\n", grammar)
         grammar = grammar.strip()
         # [xx] Hack: automatically backslash $!
-        grammar = re.sub(r"([^\\])\$", r"\1\\$", grammar)
+        grammar = redos.sub(r"([^\\])\$", r"\1\\$", grammar)
         return grammar
 
     def __init__(
@@ -1055,7 +1055,7 @@ class RegexpChunkApp:
                         "\t%s\t%s" % item
                         for item in sorted(
                             list(self.tagset.items()),
-                            key=lambda t_w: re.match(r"\w+", t_w[0])
+                            key=lambda t_w: redos.match(r"\w+", t_w[0])
                             and (0, t_w[0])
                             or (1, t_w[0]),
                         )
@@ -1068,7 +1068,7 @@ class RegexpChunkApp:
                 C = "1.0 + %d chars"
                 for tag, params in self.HELP_AUTOTAG:
                     pattern = f"(?s)(<{tag}>)(.*?)(</{tag}>)"
-                    for m in re.finditer(pattern, text):
+                    for m in redos.finditer(pattern, text):
                         self.helpbox.tag_add("elide", C % m.start(1), C % m.end(1))
                         self.helpbox.tag_add(
                             "tag-%s" % tag, C % m.start(2), C % m.end(2)
@@ -1222,14 +1222,14 @@ class RegexpChunkApp:
         for lineno, line in enumerate(grammar.split("\n")):
             if not line.strip():
                 continue
-            m = re.match(r"(\\.|[^#])*(#.*)?", line)
+            m = redos.match(r"(\\.|[^#])*(#.*)?", line)
             comment_start = None
             if m.group(2):
                 comment_start = m.start(2)
                 s = "%d.%d" % (lineno + 1, m.start(2))
                 e = "%d.%d" % (lineno + 1, m.end(2))
                 self.grammarbox.tag_add("comment", s, e)
-            for m in re.finditer("[<>{}]", line):
+            for m in redos.finditer("[<>{}]", line):
                 if comment_start is not None and m.start() >= comment_start:
                     break
                 s = "%d.%d" % (lineno + 1, m.start())
@@ -1245,7 +1245,7 @@ class RegexpChunkApp:
         self.grammarbox.tag_remove("error", "1.0", "end")
         self._grammarcheck_errs = []
         for lineno, line in enumerate(grammar.split("\n")):
-            line = re.sub(r"((\\.|[^#])*)(#.*)?", r"\1", line)
+            line = redos.sub(r"((\\.|[^#])*)(#.*)?", r"\1", line)
             line = line.strip()
             if line:
                 try:
@@ -1414,7 +1414,7 @@ class RegexpChunkApp:
         self.update()
         with open(filename) as infile:
             grammar = infile.read()
-        grammar = re.sub(
+        grammar = redos.sub(
             r"^\# Regexp Chunk Parsing Grammar[\s\S]*" "F-score:.*\n", "", grammar
         ).lstrip()
         self.grammarbox.insert("1.0", grammar)

--- a/nltk/app/concordance_app.py
+++ b/nltk/app/concordance_app.py
@@ -26,6 +26,7 @@ from tkinter import (
 )
 from tkinter.font import Font
 
+from nltk import redos
 from nltk.corpus import (
     alpino,
     brown,
@@ -665,8 +666,9 @@ class ConcordanceSearchModel:
             sent_pos, i, sent_count = [], 0, 0
             for sent in self.model.tagged_sents[self.model.last_sent_searched :]:
                 try:
-                    m = re.search(q, sent)
-                except re.error:
+                    # redos.search bounds the compile and match (wall-clock) time.
+                    m = redos.search(q, sent)
+                except (re.error, TimeoutError):
                     self.model.reset_results()
                     self.model.queue.put(SEARCH_ERROR_EVENT)
                     return
@@ -688,8 +690,8 @@ class ConcordanceSearchModel:
         def processed_query(self):
             new = []
             for term in self.model.query.split():
-                term = re.sub(r"\.", r"[^/ ]", term)
-                if re.match("[A-Z]+$", term):
+                term = redos.sub(r"\.", r"[^/ ]", term)
+                if redos.match("[A-Z]+$", term):
                     new.append(BOUNDARY + WORD_OR_TAG + "/" + term + BOUNDARY)
                 elif "/" in term:
                     new.append(BOUNDARY + term + BOUNDARY)

--- a/nltk/app/nemo_app.py
+++ b/nltk/app/nemo_app.py
@@ -11,6 +11,8 @@ import itertools
 import re
 from tkinter import SEL_FIRST, SEL_LAST, Frame, Label, PhotoImage, Scrollbar, Text, Tk
 
+from nltk import redos
+
 windowTitle = "Finding (and Replacing) Nemo"
 initialFind = r"n(.*?)e(.*?)m(.*?)o"
 initialRepl = r"M\1A\2K\3I"
@@ -99,11 +101,13 @@ class FindZone(Zone):
         for color in colors:
             self.txt.tag_remove(color, "1.0", "end")
             self.txt.tag_remove("emph" + color, "1.0", "end")
-        self.rex = re.compile("")  # default value in case of malformed regexp
-        self.rex = re.compile(self.fld.get("1.0", "end")[:-1], re.MULTILINE)
+        self.rex = redos.compile("")  # default value in case of malformed regexp
+        # GUI field regexes run .sub over the whole buffer; redos.compile refuses a
+        # compile-time DoS and returns a match-time (wall-clock) bounded pattern.
+        self.rex = redos.compile(self.fld.get("1.0", "end")[:-1], re.MULTILINE)
         try:
-            re.compile("(?P<emph>%s)" % self.fld.get(SEL_FIRST, SEL_LAST))
-            self.rexSel = re.compile(
+            redos.compile("(?P<emph>%s)" % self.fld.get(SEL_FIRST, SEL_LAST))
+            self.rexSel = redos.compile(
                 "%s(?P<emph>%s)%s"
                 % (
                     self.fld.get("1.0", SEL_FIRST),
@@ -149,9 +153,9 @@ def app():
     sz.fld.bind("<Button-1>", launchRefresh)
     sz.fld.bind("<ButtonRelease-1>", launchRefresh)
     sz.fld.bind("<B1-Motion>", launchRefresh)
-    sz.rexSel = re.compile("")
+    sz.rexSel = redos.compile("")
     rz = ReplaceZone("repl", initialRepl, "")
-    rex0 = re.compile(r"(?<!\\)\\([0-9]+)")
+    rex0 = redos.compile(r"(?<!\\)\\([0-9]+)")
     root.bind_all("<Key>", launchRefresh)
     launchRefresh(None)
     root.mainloop()


### PR DESCRIPTION
Every regular expression in `nltk/app` runs over GUI-entered text, a loaded grammar, or a searched corpus, so a catastrophically backtracking pattern or a compile-time bomb is a denial of service (CWE-1333 / CWE-400).

This routes every bare `re.*` / `regex.*` compile and match in `nltk/app` through **`nltk.redos`**, the single choke point that already ships on `develop`:

- `redos.compile(...)` rejects a compile-time bomb up front (`redos.check_pattern`) and wraps every match in a wall-clock timeout (`TimedPattern`);
- the `re`-compatible module helpers (`redos.match` / `search` / `sub` / `finditer` ...) route the inline calls through the same guards.

In `concordance_app.py` the caller's search regex is pre-compiled once through `redos.compile` and the per-sentence match is caught as `TimeoutError`, so a pathological query can no longer hang the UI thread.

No behaviour change: the same patterns are compiled and matched, only the DoS bound is added.

### Files
`chunkparser_app.py`, `concordance_app.py`, `nemo_app.py`.

`chunkparser_app.py` is routed in place against `develop` (only the `re.*` calls and the import change); the unrelated operator-file-path `open()` sandboxing that the umbrella branch also touches here is left for its own PR, so this change stays purely regex routing.

### Testing (Python 3.13)
- every `nltk.app.*` module imports clean (the apps are Tkinter GUIs with no headless unit test);
- `nltk/app` AST-checks clean of any bare `re`/`regex` pattern call.

Split out of the GHSA-8mgp hardening effort (#3753) so the routing can be reviewed per submodule. The tree-wide CI guard that keeps new regexes routed lands in a final PR once every submodule is converted.
