### PR TITLE
Route nltk.chunk regexes through nltk.redos (CWE-1333/CWE-400)

### DIFF
--- a/nltk/chunk/named_entity.py
+++ b/nltk/chunk/named_entity.py
@@ -13,6 +13,7 @@ Named entity chunker
 import os
 import re
 
+from nltk import redos
 from nltk.pathsec import open as pathsec_open
 from nltk.pathsec import validate_tool_dir
 from nltk.tag import ClassifierBasedTagger, pos_tag
@@ -182,11 +183,11 @@ class NEChunkParser(ChunkParserI):
 
 
 def shape(word):
-    if re.match(r"[0-9]+(\.[0-9]*)?|[0-9]*\.[0-9]+$", word, re.UNICODE):
+    if redos.match(r"[0-9]+(\.[0-9]*)?|[0-9]*\.[0-9]+$", word, re.UNICODE):
         return "number"
-    elif re.match(r"\W+$", word, re.UNICODE):
+    elif redos.match(r"\W+$", word, re.UNICODE):
         return "punct"
-    elif re.match(r"\w+$", word, re.UNICODE):
+    elif redos.match(r"\w+$", word, re.UNICODE):
         if word.istitle():
             return "upcase"
         elif word.islower():
@@ -253,18 +254,18 @@ def load_ace_file(textfile, fmt):
         text = infile.read()
 
     # Strip XML tags, since they don't count towards the indices
-    text = re.sub("<(?!/?TEXT)[^>]+>", "", text)
+    text = redos.sub("<(?!/?TEXT)[^>]+>", "", text)
 
     # Blank out anything before/after <TEXT>
     def subfunc(m):
         return " " * (m.end() - m.start() - 6)
 
-    text = re.sub(r"[\s\S]*<TEXT>", subfunc, text)
-    text = re.sub(r"</TEXT>[\s\S]*", "", text)
+    text = redos.sub(r"[\s\S]*<TEXT>", subfunc, text)
+    text = redos.sub(r"</TEXT>[\s\S]*", "", text)
 
     # Simplify quotes
-    text = re.sub("``", ' "', text)
-    text = re.sub("''", '" ', text)
+    text = redos.sub("``", ' "', text)
+    text = redos.sub("''", '" ', text)
 
     entity_types = {typ for (s, e, typ) in entities}
 

--- a/nltk/chunk/regexp.py
+++ b/nltk/chunk/regexp.py
@@ -8,8 +8,6 @@
 
 import re
 
-import regex
-
 from nltk import redos
 from nltk.chunk.api import ChunkParserI
 from nltk.tree import Tree
@@ -67,9 +65,9 @@ class ChunkString:
     # removed: they were never referenced anywhere, and both had the classic
     # nested-quantifier ReDoS shape ``(<...>+?)+?`` -- dead code that could only
     # ever be a footgun if resurrected.)
-    _VALID = re.compile(r"^(\{?%s\}?)*?$" % CHUNK_TAG)
-    _BRACKETS = re.compile(r"[^\{\}]+")
-    _BALANCED_BRACKETS = re.compile(r"(\{\})*$")
+    _VALID = redos.compile(r"^(\{?%s\}?)*?$" % CHUNK_TAG)
+    _BRACKETS = redos.compile(r"[^\{\}]+")
+    _BALANCED_BRACKETS = redos.compile(r"(\{\})*$")
 
     def __init__(self, chunk_struct, debug_level=1):
         """
@@ -144,7 +142,7 @@ class ChunkString:
         if verify_tags <= 0:
             return
 
-        tags1 = (re.split(r"[\{\}<>]+", s))[1:-1]
+        tags1 = (redos.split(r"[\{\}<>]+", s))[1:-1]
         tags2 = [self._tag(piece) for piece in self._pieces]
         if tags1 != tags2:
             raise ValueError(
@@ -166,7 +164,7 @@ class ChunkString:
         pieces = []
         index = 0
         piece_in_chunk = 0
-        for piece in re.split("[{}]", self._str):
+        for piece in redos.split("[{}]", self._str):
             # Find the list of tokens contained in this piece.
             length = piece.count("<")
             subsequence = self._pieces[index : index + length]
@@ -220,7 +218,7 @@ class ChunkString:
         # The substitution might have generated "empty chunks"
         # (substrings of the form "{}").  Remove them, so they don't
         # interfere with other transformations.
-        s = re.sub(r"\{\}", "", s)
+        s = redos.sub(r"\{\}", "", s)
 
         # Make sure that the transformation was legal.
         if self._debug > 1:
@@ -250,8 +248,8 @@ class ChunkString:
         :rtype: str
         """
         # Add spaces to make everything line up.
-        str = re.sub(r">(?!\})", r"> ", self._str)
-        str = re.sub(r"([^\{])<", r"\1 <", str)
+        str = redos.sub(r">(?!\})", r"> ", self._str)
+        str = redos.sub(r"([^\{])<", r"\1 <", str)
         if str[0] == "<":
             str = " " + str
         return str
@@ -382,7 +380,7 @@ class RegexpChunkRule:
         <ChunkRule: '<DT>?<NN.*>+'>
         """
         # Split off the comment (but don't split on '\#')
-        m = re.match(r"(?P<rule>(\\.|[^#])*)(?P<comment>#.*)?", s)
+        m = redos.match(r"(?P<rule>(\\.|[^#])*)(?P<comment>#.*)?", s)
         rule = m.group("rule").strip()
         comment = (m.group("comment") or "")[1:].strip()
 
@@ -400,8 +398,8 @@ class RegexpChunkRule:
             elif "{}" in rule:
                 left, right = rule.split("{}")
                 return MergeRule(left, right, comment)
-            elif re.match("[^{}]*{[^{}]*}[^{}]*", rule):
-                left, chunk, right = re.split("[{}]", rule)
+            elif redos.match("[^{}]*{[^{}]*}[^{}]*", rule):
+                left, chunk, right = redos.split("[{}]", rule)
                 return ChunkRuleWithContext(left, chunk, right, comment)
             else:
                 raise ValueError("Illegal chunk pattern: %s" % rule)
@@ -432,7 +430,7 @@ class ChunkRule(RegexpChunkRule):
             of this rule.
         """
         self._pattern = tag_pattern
-        regexp = re.compile(
+        regexp = redos.compile(
             "(?P<chunk>%s)%s"
             % (tag_pattern2re_pattern(tag_pattern), ChunkString.IN_STRIP_PATTERN)
         )
@@ -477,7 +475,7 @@ class StripRule(RegexpChunkRule):
             of this rule.
         """
         self._pattern = tag_pattern
-        regexp = re.compile(
+        regexp = redos.compile(
             "(?P<strip>%s)%s"
             % (tag_pattern2re_pattern(tag_pattern), ChunkString.IN_CHUNK_PATTERN)
         )
@@ -520,7 +518,9 @@ class UnChunkRule(RegexpChunkRule):
             of this rule.
         """
         self._pattern = tag_pattern
-        regexp = re.compile(r"\{(?P<chunk>%s)\}" % tag_pattern2re_pattern(tag_pattern))
+        regexp = redos.compile(
+            r"\{(?P<chunk>%s)\}" % tag_pattern2re_pattern(tag_pattern)
+        )
         RegexpChunkRule.__init__(self, regexp, r"\g<chunk>", descr)
 
     def __repr__(self):
@@ -573,12 +573,12 @@ class MergeRule(RegexpChunkRule):
         """
         # Ensure that the individual patterns are coherent.  E.g., if
         # left='(' and right=')', then this will raise an exception:
-        re.compile(tag_pattern2re_pattern(left_tag_pattern))
-        re.compile(tag_pattern2re_pattern(right_tag_pattern))
+        redos.compile(tag_pattern2re_pattern(left_tag_pattern))
+        redos.compile(tag_pattern2re_pattern(right_tag_pattern))
 
         self._left_tag_pattern = left_tag_pattern
         self._right_tag_pattern = right_tag_pattern
-        regexp = re.compile(
+        regexp = redos.compile(
             "(?P<left>%s)}{(?=%s)"
             % (
                 tag_pattern2re_pattern(left_tag_pattern),
@@ -642,12 +642,12 @@ class SplitRule(RegexpChunkRule):
         """
         # Ensure that the individual patterns are coherent.  E.g., if
         # left='(' and right=')', then this will raise an exception:
-        re.compile(tag_pattern2re_pattern(left_tag_pattern))
-        re.compile(tag_pattern2re_pattern(right_tag_pattern))
+        redos.compile(tag_pattern2re_pattern(left_tag_pattern))
+        redos.compile(tag_pattern2re_pattern(right_tag_pattern))
 
         self._left_tag_pattern = left_tag_pattern
         self._right_tag_pattern = right_tag_pattern
-        regexp = re.compile(
+        regexp = redos.compile(
             "(?P<left>%s)(?=%s)"
             % (
                 tag_pattern2re_pattern(left_tag_pattern),
@@ -712,12 +712,12 @@ class ExpandLeftRule(RegexpChunkRule):
         """
         # Ensure that the individual patterns are coherent.  E.g., if
         # left='(' and right=')', then this will raise an exception:
-        re.compile(tag_pattern2re_pattern(left_tag_pattern))
-        re.compile(tag_pattern2re_pattern(right_tag_pattern))
+        redos.compile(tag_pattern2re_pattern(left_tag_pattern))
+        redos.compile(tag_pattern2re_pattern(right_tag_pattern))
 
         self._left_tag_pattern = left_tag_pattern
         self._right_tag_pattern = right_tag_pattern
-        regexp = re.compile(
+        regexp = redos.compile(
             r"(?P<left>%s)\{(?P<right>%s)"
             % (
                 tag_pattern2re_pattern(left_tag_pattern),
@@ -782,12 +782,12 @@ class ExpandRightRule(RegexpChunkRule):
         """
         # Ensure that the individual patterns are coherent.  E.g., if
         # left='(' and right=')', then this will raise an exception:
-        re.compile(tag_pattern2re_pattern(left_tag_pattern))
-        re.compile(tag_pattern2re_pattern(right_tag_pattern))
+        redos.compile(tag_pattern2re_pattern(left_tag_pattern))
+        redos.compile(tag_pattern2re_pattern(right_tag_pattern))
 
         self._left_tag_pattern = left_tag_pattern
         self._right_tag_pattern = right_tag_pattern
-        regexp = re.compile(
+        regexp = redos.compile(
             r"(?P<left>%s)\}(?P<right>%s)"
             % (
                 tag_pattern2re_pattern(left_tag_pattern),
@@ -861,14 +861,14 @@ class ChunkRuleWithContext(RegexpChunkRule):
         """
         # Ensure that the individual patterns are coherent.  E.g., if
         # left='(' and right=')', then this will raise an exception:
-        re.compile(tag_pattern2re_pattern(left_context_tag_pattern))
-        re.compile(tag_pattern2re_pattern(chunk_tag_pattern))
-        re.compile(tag_pattern2re_pattern(right_context_tag_pattern))
+        redos.compile(tag_pattern2re_pattern(left_context_tag_pattern))
+        redos.compile(tag_pattern2re_pattern(chunk_tag_pattern))
+        redos.compile(tag_pattern2re_pattern(right_context_tag_pattern))
 
         self._left_context_tag_pattern = left_context_tag_pattern
         self._chunk_tag_pattern = chunk_tag_pattern
         self._right_context_tag_pattern = right_context_tag_pattern
-        regexp = re.compile(
+        regexp = redos.compile(
             "(?P<left>%s)(?P<chunk>%s)(?P<right>%s)%s"
             % (
                 tag_pattern2re_pattern(left_context_tag_pattern),
@@ -914,7 +914,7 @@ class ChunkRuleWithContext(RegexpChunkRule):
 # same language, because a run of ``A``s is just several single-``A`` iterations
 # of the outer star -- while making the scan linear. See huntr report
 # https://huntr.com/bounties/aff8ef29-2f20-46a4-ae13-7ce6010e26a5.
-CHUNK_TAG_PATTERN = re.compile(
+CHUNK_TAG_PATTERN = redos.compile(
     r"^(({}|<{}>)*)$".format(r"([^\{\}<>]|\{\d+,?\}|\{\d*,\d+\})", r"[^\{\}<>]+")
 )
 
@@ -955,10 +955,14 @@ def tag_pattern2re_pattern(tag_pattern):
     :return: A regular expression pattern corresponding to
         ``tag_pattern``.
     """
+    # A caller tag pattern is arbitrary; refuse an over-long one up front so the
+    # regex-based validity check and expansion below run on a bounded input.
+    redos.check_pattern(tag_pattern)
+
     # Clean up the regular expression
-    tag_pattern = re.sub(r"\s", "", tag_pattern)
-    tag_pattern = re.sub(r"<", "(<(", tag_pattern)
-    tag_pattern = re.sub(r">", ")>)", tag_pattern)
+    tag_pattern = redos.sub(r"\s", "", tag_pattern)
+    tag_pattern = redos.sub(r"<", "(<(", tag_pattern)
+    tag_pattern = redos.sub(r">", ")>)", tag_pattern)
 
     # Check the regular expression
     if not CHUNK_TAG_PATTERN.match(tag_pattern):
@@ -977,9 +981,12 @@ def tag_pattern2re_pattern(tag_pattern):
 
     tc_rev = reverse_str(ChunkString.CHUNK_TAG_CHAR)
     reversed = reverse_str(tag_pattern)
-    reversed = re.sub(r"\.(?!\\(\\\\)*($|[^\\]))", tc_rev, reversed)
+    reversed = redos.sub(r"\.(?!\\(\\\\)*($|[^\\]))", tc_rev, reversed)
     tag_pattern = reverse_str(reversed)
 
+    # Every chunk rule compiles this expansion (with raw ``re.compile``), so refuse
+    # a caller tag pattern whose expansion is a compile-time DoS (CWE-1333) here.
+    redos.check_pattern(tag_pattern)
     return tag_pattern
 
 
@@ -1241,7 +1248,7 @@ class RegexpParser(ChunkParserI):
         """
         rules = []
         lhs = None
-        pattern = regex.compile("(?P<nonterminal>(\\.|[^:])*)(:(?P<rule>.*))")
+        pattern = redos.compile("(?P<nonterminal>(\\.|[^:])*)(:(?P<rule>.*))")
         for line in grammar.split("\n"):
             line = line.strip()
 

--- a/nltk/chunk/util.py
+++ b/nltk/chunk/util.py
@@ -8,6 +8,7 @@
 
 import re
 
+from nltk import redos
 from nltk.metrics import accuracy as _accuracy
 from nltk.tag.mapping import map_tag
 from nltk.tag.util import str2tuple
@@ -121,6 +122,8 @@ class ChunkScore:
         self._max_fp = kwargs.get("max_fp_examples", 100)
         self._max_fn = kwargs.get("max_fn_examples", 100)
         self._chunk_label = kwargs.get("chunk_label", ".*")
+        # caller regex: compiled once through redos (bounds compile + match time)
+        self._chunk_label_rx = redos.compile(self._chunk_label)
         self._tp_num = 0
         self._fp_num = 0
         self._fn_num = 0
@@ -151,8 +154,8 @@ class ChunkScore:
         :type guessed: chunk structure
         :param guessed: The chunked sentence to be scored.
         """
-        self._correct |= _chunksets(correct, self._count, self._chunk_label)
-        self._guessed |= _chunksets(guessed, self._count, self._chunk_label)
+        self._correct |= _chunksets(correct, self._count, self._chunk_label_rx)
+        self._guessed |= _chunksets(guessed, self._count, self._chunk_label_rx)
         self._count += 1
         self._measuresNeedUpdate = True
         # Keep track of per-tag accuracy (if possible)
@@ -304,11 +307,12 @@ class ChunkScore:
 # extract chunks, and assign unique id, the absolute position of
 # the first word of the chunk
 def _chunksets(t, count, chunk_label):
+    # chunk_label is a redos-compiled TimedPattern (bounds compile + match time)
     pos = 0
     chunks = []
     for child in t:
         if isinstance(child, Tree):
-            if re.match(chunk_label, child.label()):
+            if chunk_label.match(child.label()):
                 chunks.append(((count, pos), child.freeze()))
             pos += len(child.leaves())
         else:
@@ -336,7 +340,7 @@ def tagstr2tree(
     :rtype: Tree
     """
 
-    WORD_OR_BRACKET = re.compile(r"\[|\]|[^\[\]\s]+")
+    WORD_OR_BRACKET = redos.compile(r"\[|\]|[^\[\]\s]+")
 
     stack = [Tree(root_label, [])]
     for match in WORD_OR_BRACKET.finditer(s):
@@ -367,7 +371,7 @@ def tagstr2tree(
 
 ### CONLL
 
-_LINE_RE = re.compile(r"(\S+)\s+(\S+)\s+([IOB])-?(\S+)?")
+_LINE_RE = redos.compile(r"(\S+)\s+(\S+)\s+([IOB])-?(\S+)?")
 
 
 def conllstr2tree(s, chunk_types=("NP", "PP", "VP"), root_label="S"):
@@ -501,7 +505,7 @@ def tree2conllstr(t):
 
 ### IEER
 
-_IEER_DOC_RE = re.compile(
+_IEER_DOC_RE = redos.compile(
     r"<DOC>\s*"
     r"(<DOCNO>\s*(?P<docno>.+?)\s*</DOCNO>\s*)?"
     r"(<DOCTYPE>\s*(?P<doctype>.+?)\s*</DOCTYPE>\s*)?"
@@ -513,7 +517,7 @@ _IEER_DOC_RE = re.compile(
     re.DOTALL,
 )
 
-_IEER_TYPE_RE = re.compile(r'<b_\w+\s+[^>]*?type="(?P<type>\w+)"')
+_IEER_TYPE_RE = redos.compile(r'<b_\w+\s+[^>]*?type="(?P<type>\w+)"')
 
 
 def _ieer_read_text(s, root_label):
@@ -522,7 +526,7 @@ def _ieer_read_text(s, root_label):
     # return the empty list in place of a Tree
     if s is None:
         return []
-    for piece_m in re.finditer(r"<[^>]+>|[^\s<]+", s):
+    for piece_m in redos.finditer(r"<[^>]+>|[^\s<]+", s):
         piece = piece_m.group()
         try:
             if piece.startswith("<b_"):


### PR DESCRIPTION
Every regular expression in `nltk/chunk` runs over a caller-supplied chunk grammar, a tag string, or corpus text, so a catastrophically backtracking pattern or a compile-time bomb is a denial of service (CWE-1333 / CWE-400).

This routes every bare `re.*` / `regex.*` compile and match in `nltk/chunk` through **`nltk.redos`**, the single choke point that already ships on `develop`:

- `redos.compile(...)` rejects a compile-time bomb up front (`redos.check_pattern`) and wraps every match in a wall-clock timeout (`TimedPattern`);
- the `re`-compatible module helpers (`redos.match` / `search` / `sub` ...) route the inline calls through the same guards.

No behaviour change: the same patterns are compiled and matched, only the DoS bound is added. Flag members such as `re.UNICODE` stay on the stdlib module.

### Files
`named_entity.py`, `regexp.py`, `util.py`.

`named_entity.py` is routed in place against `develop` (only the `re.*` calls plus the added `redos` import); the unrelated `pickle` -> `picklesec` migration the umbrella branch also makes here is left for its own PR, so this change stays purely regex routing.

### Testing (Python 3.13)
- `pytest -k chunk` over `nltk/test/unit/` passes;
- a `RegexpParser` chunk grammar parsed a tagged sentence;
- every `nltk.chunk.*` module imports clean.

Split out of the GHSA-8mgp hardening effort (#3753) so the routing can be reviewed per submodule. The tree-wide CI guard that keeps new regexes routed lands in a final PR once every submodule is converted.
