### PR TITLE
Route nltk.sentiment regexes through nltk.redos (CWE-1333/CWE-400)

### DIFF
--- a/nltk/sentiment/util.py
+++ b/nltk/sentiment/util.py
@@ -19,6 +19,7 @@ import time
 from copy import deepcopy
 
 import nltk
+from nltk import redos
 from nltk.corpus import CategorizedPlaintextCorpusReader
 from nltk.data import load
 from nltk.pathsec import open as pathsec_open
@@ -40,10 +41,10 @@ NEGATION = r"""
     |
     n't"""
 
-NEGATION_RE = re.compile(NEGATION, re.VERBOSE)
+NEGATION_RE = redos.compile(NEGATION, re.VERBOSE)
 
 CLAUSE_PUNCT = r"^[.:;!?]$"
-CLAUSE_PUNCT_RE = re.compile(CLAUSE_PUNCT)
+CLAUSE_PUNCT_RE = redos.compile(CLAUSE_PUNCT)
 
 # Happy and sad emoticons
 
@@ -394,11 +395,11 @@ def json2csv_preprocess(
                 text = row[fields.index("text")]
                 # Remove retweets
                 if skip_retweets:
-                    if re.search(r"\bRT\b", text):
+                    if redos.search(r"\bRT\b", text):
                         continue
                 # Remove tweets containing ":P" and ":-P" emoticons
                 if skip_tongue_tweets:
-                    if re.search(r"\:\-?P\b", text):
+                    if redos.search(r"\:\-?P\b", text):
                         continue
                 # Remove tweets containing both happy and sad emoticons
                 if skip_ambiguous_tweets:
@@ -408,7 +409,7 @@ def json2csv_preprocess(
                             continue
                 # Strip off emoticons from all tweets
                 if strip_off_emoticons:
-                    row[fields.index("text")] = re.sub(
+                    row[fields.index("text")] = redos.sub(
                         r"(?!\n)\s+", " ", EMOTICON_RE.sub("", text)
                     )
                 # Remove duplicate tweets

--- a/nltk/sentiment/vader.py
+++ b/nltk/sentiment/vader.py
@@ -27,6 +27,7 @@ import string
 from itertools import product
 
 import nltk.data
+from nltk import redos
 from nltk.util import pairwise
 
 
@@ -192,7 +193,7 @@ class VaderConstants:
     }
 
     # for removing punctuation
-    REGEX_REMOVE_PUNCTUATION = re.compile(f"[{re.escape(string.punctuation)}]")
+    REGEX_REMOVE_PUNCTUATION = redos.compile(f"[{re.escape(string.punctuation)}]")
 
     PUNC_LIST = [
         ".",


### PR DESCRIPTION
Every regular expression in `nltk/sentiment` runs over tweet / review text a caller supplies, so a catastrophically backtracking pattern or a compile-time bomb is a denial of service (CWE-1333 / CWE-400).

This routes every bare `re.*` / `regex.*` compile and match in `nltk/sentiment` through **`nltk.redos`**, the single choke point that already ships on `develop`:

- `redos.compile(...)` rejects a compile-time bomb up front (`redos.check_pattern`) and wraps every match in a wall-clock timeout (`TimedPattern`);
- the `re`-compatible module helpers (`redos.search` / `sub` / `compile` ...) route the inline calls through the same guards.

No behaviour change: the same patterns (`NEGATION_RE`, `CLAUSE_PUNCT_RE`, the tweet cleanups) are compiled and matched, only the DoS bound is added. `re.VERBOSE` and other flag members stay on the stdlib module.

### Files
`util.py`, `vader.py`.

`util.py` is routed in place against `develop` (only the `re.*` calls plus the added `redos` import); the unrelated `json.loads` -> `jsontags.safe_json_loads` bounded-parse change the umbrella branch also makes here is left for its own PR, so this change stays purely regex routing.

### Testing (Python 3.13)
- `pytest -k "sentiment or vader"` (7 passed, 1 skipped);
- `SentimentIntensityAnalyzer().polarity_scores(...)` and `mark_negation(...)` produce correct output on real text;
- every `nltk.sentiment.*` module imports clean.

Split out of the GHSA-8mgp hardening effort (#3753) so the routing can be reviewed per submodule. The tree-wide CI guard that keeps new regexes routed lands in a final PR once every submodule is converted.
