### PR TITLE
Route top-level nltk regexes through nltk.redos (CWE-1333/CWE-400)

### DIFF
--- a/nltk/data.py
+++ b/nltk/data.py
@@ -51,6 +51,7 @@ from io import BytesIO, TextIOWrapper
 from urllib.parse import unquote
 from urllib.request import url2pathname
 
+from nltk import redos
 from nltk.pathsec import ZipFile
 from nltk.pathsec import open as _secure_open
 from nltk.pathsec import urlopen as _secure_urlopen
@@ -59,7 +60,7 @@ from nltk.pathsec import validate_path as _validate_path
 # Reject unsafe no-protocol paths: traversal segments, trailing '..', absolute paths,
 # backslashes, Windows drive letters. Use a raw-string pattern and do not anchor only
 # at the start — we'll use search() for safety checks.
-_UNSAFE_NO_PROTOCOL_RE = re.compile(r"(?:\.\./|\.\.$|^/|\\|[A-Za-z]:[/\\])")
+_UNSAFE_NO_PROTOCOL_RE = redos.compile(r"(?:\.\./|\.\.$|^/|\\|[A-Za-z]:[/\\])")
 
 
 def _assert_no_encoded_bypass(name, error_label=None):
@@ -97,7 +98,7 @@ def _assert_no_encoded_bypass(name, error_label=None):
 
 # Python 3.14's url2pathname follows the WHATWG URL rules, so it silently strips
 # ASCII tab / LF / CR and truncates at "#" or "?". Earlier versions keep them.
-_URL_REWRITTEN_CHARS_RE = re.compile(r"[\t\n\r#?]")
+_URL_REWRITTEN_CHARS_RE = redos.compile(r"[\t\n\r#?]")
 
 
 def _assert_no_normalized_bypass(name, error_label=None):
@@ -459,7 +460,7 @@ def split_resource_url(resource_url):
         if path_.startswith("/"):
             path_ = "/" + path_.lstrip("/")
     else:
-        path_ = re.sub(r"^/{0,2}", "", path_)
+        path_ = redos.sub(r"^/{0,2}", "", path_)
 
     return protocol, path_
 
@@ -530,7 +531,7 @@ def normalize_resource_url(resource_url):
         # Reject Windows drive-letter paths even when explicitly using the
         # nltk: protocol. This prevents smuggling filesystem paths through
         # nltk: URLs.
-        if re.match(r"^[A-Za-z]:[/\\]", name):
+        if redos.match(r"^[A-Za-z]:[/\\]", name):
             raise ValueError(f"Unsafe resource path: {resource_url!r}")
         # If "nltk:" is used with an absolute path, treat it as "file://"
         if os.path.isabs(name):
@@ -579,13 +580,13 @@ def normalize_resource_name(resource_name, allow_relative=True, relative_path=No
     >>> windows or normalize_resource_name('/dir/file', True, '/') == '/dir/file'
     True
     """
-    is_dir = bool(re.search(r"[\\/.]$", resource_name)) or resource_name.endswith(
+    is_dir = bool(redos.search(r"[\\/.]$", resource_name)) or resource_name.endswith(
         os.path.sep
     )
     if _is_windows():
         resource_name = resource_name.lstrip("/")
     else:
-        resource_name = re.sub(r"^/+", "/", resource_name)
+        resource_name = redos.sub(r"^/+", "/", resource_name)
     if allow_relative:
         resource_name = os.path.normpath(resource_name)
     else:
@@ -1134,7 +1135,7 @@ def find(resource_name, paths=None):
     # DOTALL matters for termination, not just matching: without it a name
     # containing a newline never looks like a zip, so the ".zip/" fallback below
     # recurses on an ever-growing name instead of stopping (CWE-407 / CWE-1333).
-    m = re.match(r"(.*?\.zip)/?(.*)$", resource_name, re.DOTALL)
+    m = redos.match(r"(.*?\.zip)/?(.*)$", resource_name, re.DOTALL)
     if m:
         zipfile, zipentry = m.groups()
     else:
@@ -1276,7 +1277,7 @@ def retrieve(resource_url, filename=None, verbose=True):
         if resource_url.startswith("file:"):
             filename = os.path.split(resource_url)[-1]
         else:
-            filename = re.sub(r"(^\w+:)?.*/", "", resource_url)
+            filename = redos.sub(r"(^\w+:)?.*/", "", resource_url)
     if os.path.exists(filename):
         filename = os.path.abspath(filename)
         raise ValueError("File %r already exists!" % filename)
@@ -1614,7 +1615,7 @@ def show_cfg(resource_url, escape="##"):
     for l in lines:
         if l.startswith(escape):
             continue
-        if re.match("^$", l):
+        if redos.match("^$", l):
             continue
         print(l)
 
@@ -2186,7 +2187,7 @@ class SeekableUnicodeStreamReader:
 
     def _check_bom(self):
         # Normalize our encoding name
-        enc = re.sub("[ -]", "", self.encoding.lower())
+        enc = redos.sub("[ -]", "", self.encoding.lower())
 
         # Look up our encoding in the BOM table.
         bom_info = self._BOM_TABLE.get(enc)

--- a/nltk/featstruct.py
+++ b/nltk/featstruct.py
@@ -93,6 +93,7 @@ import copy
 import re
 from functools import total_ordering
 
+from nltk import redos
 from nltk.internals import raise_unorderable_types, read_str
 from nltk.sem.logic import (
     Expression,
@@ -1293,7 +1294,7 @@ def _rename_variable(var, used_vars):
     # (CWE-1333; CVE-2026-12919). The lookbehind only lets ``\d+`` start at the
     # beginning of a run, so interior positions fail in O(1); the result is
     # unchanged.
-    name, n = re.sub(r"(?<!\d)\d+$", "", var.name), 2
+    name, n = redos.sub(r"(?<!\d)\d+$", "", var.name), 2
     if not name:
         name = "?"
     while Variable(f"{name}{n}") in used_vars:
@@ -2079,7 +2080,7 @@ class SlashFeature(Feature):
 
 
 class RangeFeature(Feature):
-    RANGE_RE = re.compile(r"(-?\d+):(-?\d+)")
+    RANGE_RE = redos.compile(r"(-?\d+):(-?\d+)")
 
     def read_value(self, s, position, reentrances, parser):
         m = self.RANGE_RE.match(s, position)
@@ -2206,17 +2207,17 @@ class FeatStructReader:
             self._error(s, "end of string", position)
         return value
 
-    _START_FSTRUCT_RE = re.compile(r"\s*(?:\((\d+)\)\s*)?(\??[\w-]+)?(\[)")
-    _END_FSTRUCT_RE = re.compile(r"\s*]\s*")
-    _SLASH_RE = re.compile(r"/")
-    _FEATURE_NAME_RE = re.compile(r'\s*([+-]?)([^\s\(\)<>"\'\-=\[\],]+)\s*')
-    _REENTRANCE_RE = re.compile(r"\s*->\s*")
-    _TARGET_RE = re.compile(r"\s*\((\d+)\)\s*")
-    _ASSIGN_RE = re.compile(r"\s*=\s*")
-    _COMMA_RE = re.compile(r"\s*,\s*")
-    _BARE_PREFIX_RE = re.compile(r"\s*(?:\((\d+)\)\s*)?(\??[\w-]+\s*)()")
+    _START_FSTRUCT_RE = redos.compile(r"\s*(?:\((\d+)\)\s*)?(\??[\w-]+)?(\[)")
+    _END_FSTRUCT_RE = redos.compile(r"\s*]\s*")
+    _SLASH_RE = redos.compile(r"/")
+    _FEATURE_NAME_RE = redos.compile(r'\s*([+-]?)([^\s\(\)<>"\'\-=\[\],]+)\s*')
+    _REENTRANCE_RE = redos.compile(r"\s*->\s*")
+    _TARGET_RE = redos.compile(r"\s*\((\d+)\)\s*")
+    _ASSIGN_RE = redos.compile(r"\s*=\s*")
+    _COMMA_RE = redos.compile(r"\s*,\s*")
+    _BARE_PREFIX_RE = redos.compile(r"\s*(?:\((\d+)\)\s*)?(\??[\w-]+\s*)()")
     # This one is used to distinguish fdicts from flists:
-    _START_FDICT_RE = re.compile(
+    _START_FDICT_RE = redos.compile(
         r"(%s)|(%s\s*(%s\s*(=|->)|[+-]%s|\]))"
         % (
             _BARE_PREFIX_RE.pattern,
@@ -2504,19 +2505,19 @@ class FeatStructReader:
     #: important here!)
     VALUE_HANDLERS = [
         ("read_fstruct_value", _START_FSTRUCT_RE),
-        ("read_var_value", re.compile(r"\?[a-zA-Z_][a-zA-Z0-9_]*")),
-        ("read_str_value", re.compile("[uU]?[rR]?(['\"])")),
-        ("read_int_value", re.compile(r"-?\d+")),
-        ("read_sym_value", re.compile(r"[a-zA-Z_][a-zA-Z0-9_]*")),
+        ("read_var_value", redos.compile(r"\?[a-zA-Z_][a-zA-Z0-9_]*")),
+        ("read_str_value", redos.compile("[uU]?[rR]?(['\"])")),
+        ("read_int_value", redos.compile(r"-?\d+")),
+        ("read_sym_value", redos.compile(r"[a-zA-Z_][a-zA-Z0-9_]*")),
         (
             "read_app_value",
-            re.compile(r"<(app)\((\?[a-z][a-z]*)\s*," r"\s*(\?[a-z][a-z]*)\)>"),
+            redos.compile(r"<(app)\((\?[a-z][a-z]*)\s*," r"\s*(\?[a-z][a-z]*)\)>"),
         ),
         #       ('read_logic_value', re.compile(r'<([^>]*)>')),
         # lazily match any character after '<' until we hit a '>' not preceded by '-'
-        ("read_logic_value", re.compile(r"<(.*?)(?<!-)>")),
-        ("read_set_value", re.compile(r"{")),
-        ("read_tuple_value", re.compile(r"\(")),
+        ("read_logic_value", redos.compile(r"<(.*?)(?<!-)>")),
+        ("read_set_value", redos.compile(r"{")),
+        ("read_tuple_value", redos.compile(r"\(")),
     ]
 
     def read_fstruct_value(self, s, position, reentrances, match):
@@ -2571,7 +2572,7 @@ class FeatStructReader:
         cp = re.escape(close_paren)
         position = match.end()
         # Special syntax of empty tuples:
-        m = re.compile(r"\s*/?\s*%s" % cp).match(s, position)
+        m = redos.compile(r"\s*/?\s*%s" % cp).match(s, position)
         if m:
             return seq_class(), m.end()
         # Read values:
@@ -2579,7 +2580,7 @@ class FeatStructReader:
         seen_plus = False
         while True:
             # Close paren: return value.
-            m = re.compile(r"\s*%s" % cp).match(s, position)
+            m = redos.compile(r"\s*%s" % cp).match(s, position)
             if m:
                 if seen_plus:
                     return plus_class(values), m.end()
@@ -2591,7 +2592,7 @@ class FeatStructReader:
             values.append(val)
 
             # Comma or looking at close paren
-            m = re.compile(r"\s*(,|\+|(?=%s))\s*" % cp).match(s, position)
+            m = redos.compile(r"\s*(,|\+|(?=%s))\s*" % cp).match(s, position)
             if not m:
                 raise ValueError("',' or '+' or '%s'" % cp, position)
             if m.group(1) == "+":

--- a/nltk/grammar.py
+++ b/nltk/grammar.py
@@ -72,6 +72,7 @@ import re
 from collections import deque
 from functools import total_ordering
 
+from nltk import redos
 from nltk.featstruct import SLASH, TYPE, FeatDict, FeatStruct, FeatStructReader
 from nltk.internals import raise_unorderable_types
 from nltk.probability import ImmutableProbabilisticMixIn
@@ -1365,10 +1366,10 @@ def _read_fcfg_production(input, fstruct_reader):
 
 # Parsing generic grammars
 
-_ARROW_RE = re.compile(r"\s* -> \s*", re.VERBOSE)
-_PROBABILITY_RE = re.compile(r"( \[ [\d\.]+ \] ) \s*", re.VERBOSE)
-_TERMINAL_RE = re.compile(r'( "[^"]*" | \'[^\']*\' ) \s*', re.VERBOSE)
-_DISJUNCTION_RE = re.compile(r"\| \s*", re.VERBOSE)
+_ARROW_RE = redos.compile(r"\s* -> \s*", re.VERBOSE)
+_PROBABILITY_RE = redos.compile(r"( \[ [\d\.]+ \] ) \s*", re.VERBOSE)
+_TERMINAL_RE = redos.compile(r'( "[^"]*" | \'[^\']*\' ) \s*', re.VERBOSE)
+_DISJUNCTION_RE = redos.compile(r"\| \s*", re.VERBOSE)
 
 
 def _read_production(line, nonterm_parser, probabilistic=False):
@@ -1491,7 +1492,7 @@ def read_grammar(input, nonterm_parser, probabilistic=False, encoding=None):
     return (start, productions)
 
 
-_STANDARD_NONTERM_RE = re.compile(r"( [\w/][\w/^<>-]* ) \s*", re.VERBOSE)
+_STANDARD_NONTERM_RE = redos.compile(r"( [\w/][\w/^<>-]* ) \s*", re.VERBOSE)
 
 
 def standard_nonterm_parser(string, pos):
@@ -1505,7 +1506,7 @@ def standard_nonterm_parser(string, pos):
 # Reading Dependency Grammars
 #################################################################
 
-_READ_DG_RE = re.compile(
+_READ_DG_RE = redos.compile(
     r"""^\s*                # leading whitespace
                               ('[^']+')\s*        # single-quoted lhs
                               (?:[-=]+>)\s*        # arrow
@@ -1518,7 +1519,7 @@ _READ_DG_RE = re.compile(
                                  *$""",  # zero or more copies
     re.VERBOSE,
 )
-_SPLIT_DG_RE = re.compile(r"""('[^']'|[-=]+>|"[^"]+"|'[^']+'|\|)""")
+_SPLIT_DG_RE = redos.compile(r"""('[^']'|[-=]+>|"[^"]+"|'[^']+'|\|)""")
 
 
 def _read_dependency_production(s):

--- a/nltk/help.py
+++ b/nltk/help.py
@@ -10,9 +10,9 @@ Provide structured access to documentation.
 """
 
 import json
-import re
 from textwrap import wrap
 
+from nltk import redos
 from nltk.data import find, open_datafile
 
 
@@ -53,7 +53,7 @@ def _format_tagset(tagset, tagpattern=None):
     elif tagpattern in tagdict:
         _print_entries([tagpattern], tagdict)
     else:
-        tagpattern = re.compile(tagpattern)
+        tagpattern = redos.compile(tagpattern)
         tags = [tag for tag in sorted(tagdict) if tagpattern.match(tag)]
         if tags:
             _print_entries(tags, tagdict)

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -19,6 +19,7 @@ import types
 import warnings
 from xml.etree import ElementTree
 
+from nltk import redos
 from nltk.pathsec import validate_path
 
 ##########################################################################
@@ -51,10 +52,12 @@ _java_options = []
 # ``trusted_raw_options`` escape hatch (see ``java()``), taking responsibility.
 # Heap/stack sizing (-Xmx512m / -mx2g / -Xms128m / -Xss4m; no-X aliases are what
 # Stanford/CoreNLP pass). Anchored to number+unit so no suffix rides a bare prefix.
-_SAFE_SIZING_RE = re.compile(r"\A-(xmx|mx|xms|ms|xss|ss)\d+[kmgt]?\Z", re.IGNORECASE)
+_SAFE_SIZING_RE = redos.compile(r"\A-(xmx|mx|xms|ms|xss|ss)\d+[kmgt]?\Z", re.IGNORECASE)
 
 # -verbose diagnostic output: bare or one standard category (-verbose:gc etc.).
-_SAFE_VERBOSE_RE = re.compile(r"\A-verbose(:(class|gc|jni|module))?\Z", re.IGNORECASE)
+_SAFE_VERBOSE_RE = redos.compile(
+    r"\A-verbose(:(class|gc|jni|module))?\Z", re.IGNORECASE
+)
 
 # Exact no-argument flags (mode / VM selectors); no suffix may ride these.
 _SAFE_JVM_EXACT = frozenset(
@@ -66,7 +69,7 @@ _SAFE_JVM_EXACT = frozenset(
 # comma-separated list of module names -- it names JDK modules, and because
 # ``--module-path`` / ``-p`` is NOT allowlisted it cannot point at attacker code.
 # Restrict the value to a plain module-list shape so nothing else rides through.
-_MODULE_LIST_RE = re.compile(r"\A[A-Za-z0-9_.,-]+\Z")
+_MODULE_LIST_RE = redos.compile(r"\A[A-Za-z0-9_.,-]+\Z")
 
 # Every flag the allowlist accepts (heap/stack sizing, -verbose, -server/-client,
 # --add-modules) is a single simple token; none contains whitespace or a shell
@@ -469,7 +472,7 @@ class ReadError(ValueError):
         return f"Expected {self.expected} at {self.position}"
 
 
-_STRING_START_RE = re.compile(r"[uU]?[rR]?(\"\"\"|\'\'\'|\"|\')")
+_STRING_START_RE = redos.compile(r"[uU]?[rR]?(\"\"\"|\'\'\'|\"|\')")
 
 
 def read_str(s, start_position):
@@ -512,7 +515,7 @@ def read_str(s, start_position):
     quotemark = m.group(1)
 
     # Find the close quote.
-    _STRING_END_RE = re.compile(r"\\|%s" % quotemark)
+    _STRING_END_RE = redos.compile(r"\\|%s" % quotemark)
     position = m.end()
     while True:
         match = _STRING_END_RE.search(s, position)
@@ -531,7 +534,7 @@ def read_str(s, start_position):
         raise ReadError("valid escape sequence", start_position) from e
 
 
-_READ_INT_RE = re.compile(r"-?\d+")
+_READ_INT_RE = redos.compile(r"-?\d+")
 
 
 def read_int(s, start_position):
@@ -569,7 +572,7 @@ def read_int(s, start_position):
     return int(m.group()), m.end()
 
 
-_READ_NUMBER_VALUE = re.compile(r"-?(\d*)([.]?\d*)?")
+_READ_NUMBER_VALUE = redos.compile(r"-?(\d*)([.]?\d*)?")
 
 
 def read_number(s, start_position):
@@ -676,7 +679,7 @@ def _add_epytext_field(obj, field, message):
     # it from the new field, and check its indentation.
     if obj.__doc__:
         obj.__doc__ = obj.__doc__.rstrip() + "\n\n"
-        indents = re.findall(r"(?<=\n)[ ]+(?!\s)", obj.__doc__.expandtabs())
+        indents = redos.findall(r"(?<=\n)[ ]+(?!\s)", obj.__doc__.expandtabs())
         if indents:
             indent = min(indents)
     # If we don't have a docstring, add an empty one.
@@ -750,9 +753,9 @@ class Deprecated:
         # Construct an appropriate warning.
         doc = dep_cls.__doc__ or "".strip()
         # If there's a @deprecated field, strip off the field marker.
-        doc = re.sub(r"\A\s*@deprecated:", r"", doc)
+        doc = redos.sub(r"\A\s*@deprecated:", r"", doc)
         # Strip off any indentation.
-        doc = re.sub(r"(?m)^\s*", "", doc)
+        doc = redos.sub(r"(?m)^\s*", "", doc)
         # Construct a 'name' string.
         name = "Class %s" % dep_cls.__name__
         if cls != dep_cls:
@@ -1081,6 +1084,8 @@ def find_jar_iter(
     """
 
     assert isinstance(name_pattern, str)
+    # caller regex (when is_regex): bound compile + match time
+    name_rx = redos.compile(name_pattern) if is_regex else None
     assert not isinstance(searchpath, str)
     if isinstance(env_vars, str):
         env_vars = env_vars.split()
@@ -1111,7 +1116,7 @@ def find_jar_iter(
                         filename = os.path.basename(cp)
                         if (
                             is_regex
-                            and re.match(name_pattern, filename)
+                            and name_rx.match(filename)
                             or (not is_regex and filename == name_pattern)
                         ):
                             if verbose:
@@ -1129,7 +1134,7 @@ def find_jar_iter(
                         else:
                             # Look for file using regular expression
                             for file_name in os.listdir(cp):
-                                if re.match(name_pattern, file_name):
+                                if name_rx.match(file_name):
                                     if verbose:
                                         print(
                                             "[Found %s: %s]"
@@ -1156,7 +1161,7 @@ def find_jar_iter(
                         filename = os.path.basename(path_to_jar)
                         if (
                             is_regex
-                            and re.match(name_pattern, filename)
+                            and name_rx.match(filename)
                             or (not is_regex and filename == name_pattern)
                         ):
                             if verbose:
@@ -1172,7 +1177,7 @@ def find_jar_iter(
                 # Only yield an actual file whose name matches the pattern; the
                 # yield was previously outside both guards, returning every dir
                 # entry (subdirs / unrelated files) as if it were the jar.
-                if os.path.isfile(path_to_jar) and re.match(name_pattern, filename):
+                if os.path.isfile(path_to_jar) and name_rx.match(filename):
                     if verbose:
                         print(f"[Found {filename}: {path_to_jar}]")
                     yielded = True

--- a/nltk/langnames.py
+++ b/nltk/langnames.py
@@ -35,12 +35,12 @@ are also available:
 
 """
 
-import re
 from warnings import warn
 
+from nltk import redos
 from nltk.corpus import bcp47
 
-codepattern = re.compile("[a-z][a-z][a-z]?")
+codepattern = redos.compile("[a-z][a-z][a-z]?")
 
 
 def langname(tag, typ="full", strict=False):

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -26,10 +26,12 @@ from functools import lru_cache
 from pathlib import Path
 from urllib.parse import unquote, urlparse
 
+from nltk import redos
+
 # A URL is not a filesystem path: to the kernel "http://.." is the dir "http:"
 # then a ".." traversal. Anchored, whitespace-tolerant, case-insensitive match.
-_URL_SCHEME_RE = re.compile(r"^\s*(?:https?|ftp)://", re.IGNORECASE)
-_FILE_SCHEME_RE = re.compile(r"^\s*file:", re.IGNORECASE)
+_URL_SCHEME_RE = redos.compile(r"^\s*(?:https?|ftp)://", re.IGNORECASE)
+_FILE_SCHEME_RE = redos.compile(r"^\s*file:", re.IGNORECASE)
 
 # Security Enforcement Toggle
 # ENFORCE = False
@@ -437,11 +439,11 @@ def _reject_bad_name_syntax(text, context, error=ValueError):
     # ("name in the current directory of drive C"), so it escapes the validated
     # location. Both are Windows-only: on POSIX ':' is an ordinary filename
     # character and refusing it would break legitimate names.
-    if os.name != "posix" and ":" in text and not re.match(r"^[A-Za-z]:[\\/]", text):
+    if os.name != "posix" and ":" in text and not redos.match(r"^[A-Za-z]:[\\/]", text):
         _refuse("contains ':', which names an NTFS alternate data stream")
     # On Windows a leading separator with no drive is relative to the CURRENT
     # drive, so it names a different file than the same string does on POSIX.
-    if os.name != "posix" and re.match(r"^[\\/]", text):
+    if os.name != "posix" and redos.match(r"^[\\/]", text):
         _refuse("is relative to the current drive; give a full path with a drive")
     # Windows silently strips a trailing dot or space, so "evil.mco." is checked
     # as one name and opened as another. Refused everywhere for determinism.
@@ -464,7 +466,7 @@ def _reject_bad_name_syntax(text, context, error=ValueError):
                 or component.upper() in _WINDOWS_DEVICE_NAMES
             ):
                 _refuse(f"contains a reserved Windows device ({component!r})")
-            if re.search(r"~[0-9]", component):
+            if redos.search(r"~[0-9]", component):
                 _refuse("contains an 8.3 short name, which aliases another file")
 
 

--- a/nltk/test/unit/test_text.py
+++ b/nltk/test/unit/test_text.py
@@ -46,14 +46,17 @@ def test_default_timeout_resolved_at_call_time(monkeypatch):
     earlier (a literal default would have bound the value at definition time).
     """
     import nltk.text as text_mod
+    from nltk.redos import TimedPattern
 
     captured = {}
 
-    def fake_findall(pattern, string, timeout=None):
+    def fake_findall(self, string, *args, timeout=None, **kwargs):
         captured["timeout"] = timeout
         return []
 
-    monkeypatch.setattr(text_mod.regex, "findall", fake_findall)
+    # findall now routes through redos.compile(regexp).findall(..., timeout=...);
+    # intercept the wrapped pattern's method to observe the resolved timeout.
+    monkeypatch.setattr(TimedPattern, "findall", fake_findall)
 
     # TokenSearcher.findall resolves the module constant at call time.
     monkeypatch.setattr(text_mod, "TOKENSEARCH_TIMEOUT", 12.5)

--- a/nltk/text.py
+++ b/nltk/text.py
@@ -14,15 +14,13 @@ regular expression search over tokenized strings, and
 distributional similarity.
 """
 
-import re
 import sys
 import unicodedata
 from collections import Counter, defaultdict, namedtuple
 from functools import reduce
 from math import log
 
-import regex
-
+from nltk import redos
 from nltk.collocations import BigramCollocationFinder
 from nltk.lm import MLE
 from nltk.lm.preprocessing import padded_everygram_pipeline
@@ -319,10 +317,10 @@ class TokenSearcher:
             timeout = TOKENSEARCH_TIMEOUT
 
         # preprocess the regular expression
-        regexp = re.sub(r"\s", "", regexp)
-        regexp = re.sub(r"<", "(?:<(?:", regexp)
-        regexp = re.sub(r">", ")>)", regexp)
-        regexp = re.sub(r"(?<!\\)\.", "[^>]", regexp)
+        regexp = redos.sub(r"\s", "", regexp)
+        regexp = redos.sub(r"<", "(?:<(?:", regexp)
+        regexp = redos.sub(r">", ")>)", regexp)
+        regexp = redos.sub(r"(?<!\\)\.", "[^>]", regexp)
 
         # Perform the search with the third-party ``regex`` engine: unlike the
         # stdlib ``re`` it does not re-scan a long run of a quantified token from
@@ -331,7 +329,9 @@ class TokenSearcher:
         # indefinitely (CWE-1333). The output is identical to ``re.findall`` for
         # these patterns.
         try:
-            hits = regex.findall(regexp, self._raw, timeout=timeout)
+            # redos.compile refuses a compile-time DoS and wraps the pattern; its
+            # findall takes the per-call wall-clock timeout.
+            hits = redos.compile(regexp).findall(self._raw, timeout=timeout)
         except TimeoutError:
             raise TimeoutError(
                 f"TokenSearcher.findall exceeded its {timeout}s time limit; the "
@@ -706,7 +706,7 @@ class Text:
     # Helper Methods
     # ////////////////////////////////////////////////////////////
 
-    _CONTEXT_RE = re.compile(r"\w+|[\.\!\?]")
+    _CONTEXT_RE = redos.compile(r"\w+|[\.\!\?]")
 
     def _context(self, tokens, i):
         """

--- a/nltk/toolbox.py
+++ b/nltk/toolbox.py
@@ -11,10 +11,10 @@ Toolbox databases and settings files.
 """
 
 import codecs
-import re
 from io import StringIO
 from xml.etree.ElementTree import Element, ElementTree, SubElement, TreeBuilder
 
+from nltk import redos
 from nltk.data import PathPointer, find
 from nltk.pathsec import open as pathsec_open
 
@@ -67,8 +67,8 @@ class StandardFormat:
         join_string = "\n"
         line_regexp = r"^%s(?:\\(\S+)\s*)?(.*)$"
         # discard a BOM in the first line
-        first_line_pat = re.compile(line_regexp % "(?:\xef\xbb\xbf)?")
-        line_pat = re.compile(line_regexp % "")
+        first_line_pat = redos.compile(line_regexp % "(?:\xef\xbb\xbf)?")
+        line_pat = redos.compile(line_regexp % "")
         # need to get first line outside the loop for correct handling
         # of the first marker if it spans multiple lines
         file_iter = iter(self._file)
@@ -78,13 +78,13 @@ class StandardFormat:
         except StopIteration:
             # no more data is available, terminate the generator
             return
-        mobj = re.match(first_line_pat, line)
+        mobj = redos.match(first_line_pat, line)
         mkr, line_value = mobj.groups()
         value_lines = [line_value]
         self.line_num = 0
         for line in file_iter:
             self.line_num += 1
-            mobj = re.match(line_pat, line)
+            mobj = redos.match(line_pat, line)
             line_mkr, line_value = mobj.groups()
             if line_mkr:
                 yield (mkr, join_string.join(value_lines))
@@ -128,7 +128,7 @@ class StandardFormat:
         """
         if encoding is None and unicode_fields is not None:
             raise ValueError("unicode_fields is set but not encoding.")
-        unwrap_pat = re.compile(r"\n+")
+        unwrap_pat = redos.compile(r"\n+")
         for mkr, val in self.raw_fields():
             if unwrap:
                 val = unwrap_pat.sub(" ", val)
@@ -149,9 +149,9 @@ def _sanitize_marker(mkr):
     if not mkr:
         return "empty"
     # Replace non-word characters with underscores, preserving letters, numbers, hyphens, and dots
-    safe = re.sub(r"[^\w\-.]", "_", mkr)
+    safe = redos.sub(r"[^\w\-.]", "_", mkr)
     # XML element names cannot start with a digit, hyphen, or dot
-    if re.match(r"^[\d\-.]", safe):
+    if redos.match(r"^[\d\-.]", safe):
         safe = "_" + safe
     # Mitigate HTML element injection for web viewers / XSS
     if safe.lower() in {"script", "style", "iframe", "object", "embed", "link", "meta"}:
@@ -294,7 +294,7 @@ class ToolboxData(StandardFormat):
         return tb_etree
 
 
-_is_value = re.compile(r"\S")
+_is_value = redos.compile(r"\S")
 
 
 def to_sfm_string(tree, encoding=None, errors="strict", unicode_fields=None):
@@ -335,12 +335,12 @@ def to_sfm_string(tree, encoding=None, errors="strict", unicode_fields=None):
                     cur_encoding = "utf8"
                 else:
                     cur_encoding = encoding
-                if re.search(_is_value, value):
+                if redos.search(_is_value, value):
                     l.append((f"\\{mkr} {value}\n").encode(cur_encoding, errors))
                 else:
                     l.append((f"\\{mkr}{value}\n").encode(cur_encoding, errors))
             else:
-                if re.search(_is_value, value):
+                if redos.search(_is_value, value):
                     l.append(f"\\{mkr} {value}\n")
                 else:
                     l.append(f"\\{mkr}{value}\n")


### PR DESCRIPTION
Every regular expression in NLTK's top-level modules runs over input a caller can influence (a resource name/URL, a tagset file, a grammar, doc text, a toolbox record), so a catastrophically backtracking pattern or a compile-time bomb is a denial of service (CWE-1333 / CWE-400).

This routes every bare `re.*` / `regex.*` compile and match in the standalone top-level modules through **`nltk.redos`**, the single choke point that already ships on `develop`:

- `redos.compile(...)` rejects a compile-time bomb up front (`redos.check_pattern`) and wraps every match in a wall-clock timeout (`TimedPattern`);
- the `re`-compatible module helpers (`redos.match` / `search` / `sub` / `finditer` ...) route the inline calls through the same guards.

No behaviour change: the same patterns are compiled and matched, only the DoS bound is added. Flag members (`re.DOTALL`, `re.IGNORECASE`, `re.VERBOSE`, `re.escape`) stay on the stdlib module.

### Files
- **Taken as-is from the umbrella (routing is the only change):** `featstruct.py`, `grammar.py`, `internals.py`, `langnames.py`, `text.py`, `toolbox.py`.
- **Routed in place against `develop` (routing only):** `help.py`, `data.py`, `pathsec.py` — the unrelated bounded-JSON parse (`help.py`, `data.py`) and the SSRF 6to4/Teredo tunnel guard (`pathsec.py`) that the umbrella branch also touches in these files are left for their own PRs, so this change stays purely regex routing.
- **`test/unit/test_text.py`:** the `nltk.text` token-regex ReDoS regression test is adapted to intercept the resolved timeout on the `redos` `TimedPattern` instead of the bare `regex` module (coupled to `text.py`'s routing).

### Testing (Python 3.13)
- `test_text.py`, `test_quadratic_dos.py`, `test_pathsec.py`, `test_data.py`, `test_data_name_guards.py`, `test_data_security.py`, `test_internals.py`, `test_featstruct_redos.py`, `test_langnames.py`, `test_toolbox_xss.py`, `test_open_datafile.py` all pass (300+ tests); `import nltk` succeeds (no import cycle from `redos` reaching low-level `data.py` / `pathsec.py`);
- doctests for `data.py`, `pathsec.py`, `internals.py`, `grammar.py`, `featstruct.py` pass;
- `Text.concordance`, `FeatStruct`, `CFG.fromstring` and the `pathsec` URL/name guards exercised on real input.

Split out of the GHSA-8mgp hardening effort (#3753) so the routing can be reviewed per submodule. The tree-wide CI guard that keeps new regexes routed lands in a final PR once every submodule is converted.
