### PR TITLE
Harden RegexpStemmer against pre-compiled ReDoS patterns (CWE-1333)

### DIFF
--- a/nltk/stem/regexp.py
+++ b/nltk/stem/regexp.py
@@ -41,12 +41,15 @@ class RegexpStemmer(StemmerI):
     """
 
     def __init__(self, regexp, min=0):
-        if not hasattr(regexp, "pattern"):
-            # The pattern is caller-supplied and applied to caller text, so a
-            # catastrophically backtracking one hangs the process (CWE-1333).
-            # redos.compile gives it a wall-clock bound. See ``nltk/redos.py``.
-            regexp = redos.compile(regexp)
-        self._regexp = regexp
+        # ``regexp`` is documented "str or regexp" and is applied to caller
+        # text, so a catastrophically backtracking one hangs the process
+        # (CWE-1333). Route BOTH a string and a pre-compiled pattern through
+        # redos.compile: a raw stdlib pattern has no wall-clock bound, and the
+        # old ``hasattr(...,'pattern')`` guard let it through unhardened. This
+        # mirrors RegexpTokenizer/RegexpTagger. See ``nltk/redos.py``.
+        flags = getattr(regexp, "flags", 0)
+        pattern = getattr(regexp, "pattern", regexp)
+        self._regexp = redos.compile(pattern, flags)
         self._min = min
 
     def stem(self, word):

--- a/nltk/test/unit/test_stem_regexp_redos.py
+++ b/nltk/test/unit/test_stem_regexp_redos.py
@@ -77,3 +77,42 @@ def test_the_stemmer_routes_through_redos():
 
     source = inspect.getsource(nltk.stem.regexp)
     assert "redos.compile" in source, "RegexpStemmer no longer bounds its regex"
+
+
+def test_a_catastrophic_PRECOMPILED_pattern_does_not_hang():
+    """A pre-compiled ``re.Pattern`` (documented "str or regexp") must be
+    re-hardened too. The old ``hasattr(...,'pattern')`` guard let a raw stdlib
+    pattern through unbounded, so a caller handing in
+    ``re.compile('(a+)+$')`` re-opened the ReDoS the string path had closed
+    (CWE-1333 bypass; raw ``re`` ran ~24s on this bait).
+    """
+    code = (
+        "import re;from nltk.stem.regexp import RegexpStemmer;"
+        f"RegexpStemmer(re.compile({_EVIL!r})).stem({_BAIT!r})"
+    )
+    try:
+        _run(code)
+    except subprocess.TimeoutExpired:
+        pytest.fail("RegexpStemmer hung on a pre-compiled catastrophic pattern")
+
+
+def test_precompiled_pattern_flags_are_preserved():
+    """Re-hardening a pre-compiled pattern must keep its flags (e.g. re.I)."""
+    code = (
+        "import re;from nltk.stem.regexp import RegexpStemmer;"
+        "print(RegexpStemmer(re.compile('ING$', re.I)).stem('runnING'))"
+    )
+    result = _run(code)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "runn", result.stdout
+
+
+def test_precompiled_pattern_is_wrapped_as_timedpattern():
+    """Both the string and the pre-compiled path must yield a bounded pattern."""
+    import re
+
+    from nltk.redos import TimedPattern
+    from nltk.stem.regexp import RegexpStemmer
+
+    assert isinstance(RegexpStemmer(re.compile(r"(a|a)*z"))._regexp, TimedPattern)
+    assert isinstance(RegexpStemmer(r"(a|a)*z")._regexp, TimedPattern)


### PR DESCRIPTION
## Summary

`RegexpStemmer` accepts `"str or regexp"` and applies the pattern to caller-supplied text via `sub`. The current guard only routes **string** patterns through `redos.compile`; a **pre-compiled** `re.Pattern` passes the `hasattr(regexp, "pattern")` check and is stored unhardened, so a catastrophically backtracking pattern keeps its unbounded match time and can hang the process (CWE-1333).

This closes that bypass: both a string and a pre-compiled pattern are routed through `redos.compile` (carrying the original `flags`), so every `RegexpStemmer` regex gets a wall-clock bound regardless of how the caller supplied it. This mirrors the existing hardening in `RegexpTokenizer` and `RegexpTagger`.

## Change

`nltk/stem/regexp.py` — `RegexpStemmer.__init__`:

```python
flags = getattr(regexp, "flags", 0)
pattern = getattr(regexp, "pattern", regexp)
self._regexp = redos.compile(pattern, flags)
```

(replaces the `if not hasattr(regexp, "pattern"): regexp = redos.compile(regexp)` guard that let pre-compiled patterns through)

## Tests

`nltk/test/unit/test_stem_regexp_redos.py` — regression coverage for:
- a pre-compiled `re.Pattern` now becoming a wall-clock-bounded `TimedPattern`
- a hostile pre-compiled pattern raising on match-time ReDoS instead of hanging
- benign stemming output being unchanged (string and pre-compiled inputs)

All 6 tests pass; benign `RegexpStemmer` behaviour (`'cars'` → `'car'`, etc.) is unchanged.

This is one of a family of ReDoS-hardening changes descending from the GHSA-8mgp umbrella work.