### PR TITLE
Guard model-artifact loaders against un-sandboxed open()

### DIFF
--- a/tools/check_no_unsandboxed_open.py
+++ b/tools/check_no_unsandboxed_open.py
@@ -36,6 +36,15 @@ GUARDED_PATHS = [
     "nltk/corpus/reader",
     "nltk/corpus/util.py",
     "nltk/data.py",
+    # Model-artifact save/load helpers: the same untrusted-path problem, and the
+    # exact family GHSA-8mgp-746c-j5xp was filed against.
+    "nltk/chunk/named_entity.py",
+    "nltk/classify/maxent.py",
+    "nltk/parse/transitionparser.py",
+    "nltk/tabdata.py",
+    "nltk/tag/perceptron.py",
+    "nltk/tbl/demo.py",
+    "nltk/tokenize/punkt.py",
 ]
 
 SUPPRESS_MARKER = "# sandboxed-open ok"


### PR DESCRIPTION
## Summary

Extends the `check_no_unsandboxed_open.py` CI guard's `GUARDED_PATHS` to cover the model-artifact save/load helpers — the exact family **GHSA-8mgp-746c-j5xp** was filed against:

- `nltk/chunk/named_entity.py`
- `nltk/classify/maxent.py`
- `nltk/parse/transitionparser.py`
- `nltk/tabdata.py`
- `nltk/tag/perceptron.py`
- `nltk/tbl/demo.py`
- `nltk/tokenize/punkt.py`

These already route their caller-influenceable model paths through the pathsec sandbox on `develop` (e.g. `maxent` uses `pathsec_open`, `perceptron`/`crf`/`tbl.demo` validate paths), so **the check passes as-is** — this is pure added coverage, not new hardening.

## Why

Adding these paths locks in the existing sandboxing and makes CI fail on any future bare `open()` in a model loader, closing the coverage gap for the GHSA-8mgp family. The guard is already wired into pre-commit (`no-unsandboxed-open`), so coverage extends automatically.

## Verification

- The extended guard **passes** against current `develop` (all 7 modules already sandboxed).
- The guard has **teeth**: injecting a bare `open("/tmp/evil.txt", "w")` into a newly-guarded module makes the check fail and report the offender; removing it clears the check.

This salvages the one piece of the WIP #3786 that is not otherwise on `develop` or in the GHSA-8mgp umbrella branch; #3786's other changes are already superseded (its model-loader guards landed on `develop`, `maxent` got a stronger `pathsec_open` treatment there, and its GHSA-8mgp probe teeth live in the umbrella branch).