### PR TITLE
Route security-test fixtures through the pathsec I/O helpers

### DIFF
--- a/nltk/test/unit/test_data_security.py
+++ b/nltk/test/unit/test_data_security.py
@@ -192,7 +192,7 @@ def test_load_rejects_encoded_traversal_end_to_end(url):
 def test_find_zip_split_is_non_greedy(tmp_path):
     # Create a.zip containing an entry whose name includes another ".zip".
     zpath = tmp_path / "a.zip"
-    with zipfile.ZipFile(zpath, "w") as zf:
+    with pathsec.ZipFile(zpath, "w") as zf:
         zf.writestr("b.zip/c.txt", "ok")
 
     ptr = data.find("a.zip/b.zip/c.txt", paths=[str(tmp_path)])
@@ -236,7 +236,7 @@ def test_gzip_pointer_open_enforces_sandbox(tmp_path, monkeypatch):
 
     # legitimate gzip INSIDE the allowed root -> reads (decompressed)
     good = allowed / "good.gz"
-    with gzip.open(good, "wb") as fh:
+    with gzip.open(pathsec.open(good, "wb", context="test-fixture"), "wb") as fh:
         fh.write(b"hello-gz")
     with data.GzipFileSystemPathPointer(str(good)).open() as fp:
         assert fp.read() == b"hello-gz"

--- a/nltk/test/unit/test_downloader_atomic.py
+++ b/nltk/test/unit/test_downloader_atomic.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 
 import nltk.data
 import nltk.pathsec
+from nltk import pathsec
 from nltk.downloader import Downloader, Package
 
 from . import _mp_ctx
@@ -21,13 +22,13 @@ BIG_PAYLOAD = b"x" * (1024 * 1024)
 def _build_source_zip(source_dir):
     os.makedirs(source_dir, exist_ok=True)
     zip_path = os.path.join(source_dir, "abc.zip")
-    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_STORED) as zf:
+    with pathsec.ZipFile(zip_path, "w", zipfile.ZIP_STORED) as zf:
         zf.writestr("abc/dummy.txt", BIG_PAYLOAD)
     return zip_path
 
 
 def _zip_metadata(zip_path):
-    with open(zip_path, "rb") as f:
+    with pathsec.open(zip_path, "rb", context="test-fixture") as f:
         data = f.read()
     with zipfile.ZipFile(zip_path, "r") as zf:
         unzipped_size = sum(info.file_size for info in zf.infolist())
@@ -94,7 +95,7 @@ def _collect_debug(download_dir, pkg):
     }
 
     if os.path.exists(zip_path):
-        with open(zip_path, "rb") as f:
+        with pathsec.open(zip_path, "rb", context="test-fixture") as f:
             content = f.read()
         data["zip_md5"] = hashlib.md5(content).hexdigest()
         data["zip_sha256"] = hashlib.sha256(content).hexdigest()
@@ -207,7 +208,7 @@ class TestDownloaderAtomic(unittest.TestCase):
             self.assertTrue(os.path.exists(zip_path), msg=f"debug={debug}")
             self.assertTrue(os.path.exists(extracted_file), msg=f"debug={debug}")
 
-            with open(extracted_file, "rb") as f:
+            with pathsec.open(extracted_file, "rb", context="test-fixture") as f:
                 self.assertEqual(f.read(), BIG_PAYLOAD, msg=f"debug={debug}")
 
             dl = Downloader(download_dir=self.test_dir)
@@ -249,14 +250,17 @@ class TestDownloaderAtomic(unittest.TestCase):
 
     def _make_zip_with_members(self, members):
         """Build a ZIP in srv_dir with given {member_path: content} dict."""
-        srv_dir = tempfile.mkdtemp()
+        # Nest under source_dir, an already-registered pathsec data root, so the
+        # fixture write is allowed on Linux/Windows where /tmp is not a root.
+        srv_dir = tempfile.mkdtemp(dir=self.source_dir)
         buf = __import__("io").BytesIO()
         with zipfile.ZipFile(buf, "w", zipfile.ZIP_STORED) as zf:
             for path, content in members.items():
                 zf.writestr(path, content)
         zb = buf.getvalue()
         zip_path = os.path.join(srv_dir, "evil.zip")
-        open(zip_path, "wb").write(zb)
+        with pathsec.open(zip_path, "wb", context="test-fixture") as _fh:
+            _fh.write(zb)
         return srv_dir, zip_path, zb
 
     def _make_pkg(self, zip_path, zb, pkg_id, subdir, members):

--- a/nltk/test/unit/test_downloader_unzip.py
+++ b/nltk/test/unit/test_downloader_unzip.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
+from nltk import pathsec
 from nltk.downloader import ErrorMessage, _unzip_iter, _validate_member
 
 
@@ -13,7 +14,7 @@ def _make_zip(file_path: Path, members: dict[str, bytes]) -> None:
     """
     Create a ZIP file at file_path, with the given arcname->content mapping.
     """
-    with zipfile.ZipFile(file_path, "w") as zf:
+    with pathsec.ZipFile(file_path, "w") as zf:
         for arcname, content in members.items():
             zf.writestr(arcname, content)
 

--- a/nltk/test/unit/test_open_datafile.py
+++ b/nltk/test/unit/test_open_datafile.py
@@ -1,6 +1,7 @@
 import os
 import zipfile
 
+from nltk import pathsec
 from nltk.data import ZipFilePathPointer, open_datafile
 
 # NOTE: these tests use pytest's ``tmp_path`` (under the private pytest session
@@ -18,7 +19,7 @@ def _create_test_zip(root_dir, rel_dir, file_name, contents: bytes):
     zip_path = os.path.join(root_dir, "testdata.zip")
     arcname = os.path.join(rel_dir, file_name).replace(os.path.sep, "/")
 
-    with zipfile.ZipFile(zip_path, "w") as zf:
+    with pathsec.ZipFile(zip_path, "w") as zf:
         zf.writestr(arcname, contents)
 
     return zip_path, arcname


### PR DESCRIPTION
## Summary

Brings the test-fixture hardening for four security tests from the GHSA-8mgp branch. The fixtures that stage zip archives and scratch files now use `pathsec.ZipFile` / `pathsec.open(..., context="test-fixture")` instead of bare `zipfile.ZipFile` / `open()`, so the tests exercise the same sandboxed I/O the library itself uses and never open a path outside a data root.

Files:
- `nltk/test/unit/test_data_security.py`
- `nltk/test/unit/test_downloader_atomic.py`
- `nltk/test/unit/test_downloader_unzip.py`
- `nltk/test/unit/test_open_datafile.py`

## Behaviour

No test assertion changes — only the fixture I/O is rerouted. **60 passed, 1 skipped** against current `develop`.

## Scope note

Two of the six test files originally requested (`test_file_io_guard_coverage.py` and `test_regex_injection.py`) are intentionally **left out**: they assert `nltk.pathsec` / guard behaviour that only exists on the GHSA-8mgp umbrella branch (the whole-package `GUARDED_PATHS = ["nltk"]` guard, and control-character path-split hardening). They fail on `develop` as-is and will follow once their source dependencies land.