### PR TITLE
Stage REPP scratch input in an nltk.data root instead of the shared system temp

### DIFF
--- a/nltk/test/unit/test_repp_security.py
+++ b/nltk/test/unit/test_repp_security.py
@@ -67,3 +67,39 @@ def test_absolute_path_still_accepted(tmp_path, monkeypatch):
     assert os.path.realpath(
         ReppTokenizer(pathlib.Path(abs_dir)).repp_dir
     ) == os.path.realpath(str(abs_dir))
+
+
+def test_scratch_input_is_staged_in_a_data_root_and_cleaned_up(monkeypatch):
+    """The temp input must land inside a pathsec data root, not shared /tmp
+    (CWE-377, CWE-378), and be removed afterwards (CWE-459), mirroring the
+    boxer/megam/tadm make_staging_dir migration."""
+    import tempfile
+
+    from nltk import pathsec
+
+    assert not hasattr(ReppTokenizer, "working_dir")  # shared-temp attr is gone
+
+    tok = object.__new__(ReppTokenizer)
+    tok.repp_dir = "/x"
+    tok.encoding = "utf8"
+
+    captured = {}
+
+    def fake_execute(cmd):
+        path = cmd[-1]
+        roots = [os.path.realpath(str(r)) for r in pathsec._get_allowed_roots()]
+        captured["path"] = path
+        captured["existed"] = os.path.exists(path)
+        captured["in_root"] = any(os.path.realpath(path).startswith(r) for r in roots)
+        captured["in_shared_tmp"] = path.startswith(tempfile.gettempdir() + os.sep)
+        return b""  # empty output; we only assert on staging, not parsing
+
+    monkeypatch.setattr(ReppTokenizer, "_execute", staticmethod(fake_execute))
+    try:
+        list(tok.tokenize_sents(["hello world"]))
+    except ValueError:
+        pass  # empty fake output yields no triples; irrelevant to staging
+
+    assert captured["existed"] and captured["in_root"]
+    assert not captured["in_shared_tmp"]
+    assert not os.path.exists(captured["path"])  # cleaned up in the finally

--- a/nltk/tokenize/repp.py
+++ b/nltk/tokenize/repp.py
@@ -9,12 +9,13 @@
 
 import os
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
 
 from nltk import redos
-from nltk.data import ZipFilePathPointer
+from nltk.data import ZipFilePathPointer, make_staging_dir
 from nltk.internals import find_dir
 from nltk.tokenize.api import TokenizerI
 
@@ -54,8 +55,6 @@ class ReppTokenizer(TokenizerI):
 
     def __init__(self, repp_dir, encoding="utf8"):
         self.repp_dir = self.find_repptokenizer(repp_dir)
-        # Set a directory to store the temporary files.
-        self.working_dir = tempfile.gettempdir()
         # Set an encoding for the input strings.
         self.encoding = encoding
 
@@ -79,22 +78,30 @@ class ReppTokenizer(TokenizerI):
         :return: A list of tuples of tokens
         :rtype: iter(tuple(str))
         """
-        with tempfile.NamedTemporaryFile(
-            prefix="repp_input.", dir=self.working_dir, mode="w", delete=False
-        ) as input_file:
-            # Write sentences to temporary input file.
-            for sent in sentences:
-                input_file.write(str(sent) + "\n")
-            input_file.close()
-            # Generate command to run REPP.
-            cmd = self.generate_repp_command(input_file.name)
-            # Decode the stdout and strips the ending newline.
-            repp_output = self._execute(cmd).decode(self.encoding).strip()
-            for tokenized_sent in self.parse_repp_outputs(repp_output):
-                if not keep_token_positions:
-                    # Removes token position information.
-                    tokenized_sent, starts, ends = zip(*tokenized_sent)
-                yield tokenized_sent
+        # Stage the scratch input inside an allowed nltk.data root, never the
+        # shared system temp dir (world writable, not a pathsec root; CWE-377/378),
+        # and remove it afterwards so the file does not leak (CWE-459). Mirrors
+        # the make_staging_dir migration already applied to boxer/megam/tadm.
+        staging_dir = make_staging_dir(prefix="repp-")
+        try:
+            with tempfile.NamedTemporaryFile(
+                prefix="repp_input.", dir=staging_dir, mode="w", delete=False
+            ) as input_file:
+                # Write sentences to temporary input file.
+                for sent in sentences:
+                    input_file.write(str(sent) + "\n")
+                input_file.close()
+                # Generate command to run REPP.
+                cmd = self.generate_repp_command(input_file.name)
+                # Decode the stdout and strips the ending newline.
+                repp_output = self._execute(cmd).decode(self.encoding).strip()
+        finally:
+            shutil.rmtree(staging_dir, ignore_errors=True)
+        for tokenized_sent in self.parse_repp_outputs(repp_output):
+            if not keep_token_positions:
+                # Removes token position information.
+                tokenized_sent, starts, ends = zip(*tokenized_sent)
+            yield tokenized_sent
 
     def generate_repp_command(self, inputfilename):
         """


### PR DESCRIPTION
## What

`ReppTokenizer.tokenize_sents` wrote its scratch input file to `tempfile.gettempdir()` (the shared, world-writable system temp) and left it behind after use. This stages the scratch file inside a private `0o700` `make_staging_dir()` under an allowed `nltk.data` root instead, and removes the staging directory in a `finally`.

## Why

- **CWE-377 / CWE-378** — insecure, predictable temporary file created in a world-writable shared location, outside the pathsec data roots.
- **CWE-459** — the scratch input file was not cleaned up after use.

This mirrors the `make_staging_dir` migration already applied to the `boxer` / `megam` / `tadm` wrappers.

## Changes

- `nltk/tokenize/repp.py` — drop the `working_dir = tempfile.gettempdir()` attribute; create the `NamedTemporaryFile` with `dir=staging_dir` where `staging_dir = make_staging_dir(prefix="repp-")`, and `shutil.rmtree` the staging dir in a `finally`. The `NamedTemporaryFile` is still used, but only for a collision-free filename **inside** the staged 0700 directory, never the system temp.
- `nltk/test/unit/test_repp_security.py` — add a regression test that drives `tokenize_sents` through a stubbed `_execute` and asserts the scratch path lands inside a pathsec data root, is never under the shared temp, and is removed afterwards.

## Testing

`python -m pytest nltk/test/unit/test_repp_security.py` — 4 passed on the current `develop` base. `make_staging_dir` and `pathsec` are already present on `develop`, so the change is self-contained.
