### PR TITLE
Re-check the normalized form of a no-protocol resource path against traversal (CWE-22)

### DIFF
--- a/nltk/data.py
+++ b/nltk/data.py
@@ -97,31 +97,50 @@ def _assert_no_encoded_bypass(name, error_label=None):
 
 
 # Python 3.14's url2pathname follows the WHATWG URL rules, so it silently strips
-# ASCII tab / LF / CR and truncates at "#" or "?". Earlier versions keep them.
-_URL_REWRITTEN_CHARS_RE = redos.compile(r"[\t\n\r#?]")
+# ASCII tab / LF / CR and truncates at "#" or "?". Refuse the whole control-char
+# range (C0 0x00-0x1f, DEL 0x7f) plus the Unicode newline-likes (NEL 0x85, line
+# and paragraph separators 0x2028/0x2029) and #/?, not just the three characters
+# stripped today: none belongs in a resource name, and refusing them all means a
+# FUTURE url2pathname that strips a different control cannot splice a "../" the
+# raw-form check never saw. Truncation only ever happens at "#"/"?".
+_URL_REWRITTEN_CHARS_RE = redos.compile(r"[\x00-\x1f\x7f\x85\u2028\u2029#?]")
 
 
 def _assert_no_normalized_bypass(name, error_label=None):
     """
-    Reject *name* if :func:`url2pathname` would silently rewrite it.
+    Reject *name* if :func:`url2pathname` would rewrite it into an escaping path.
 
-    Sibling of :func:`_assert_no_encoded_bypass`, for the same "the name that
-    was validated must be the name that is used" rule but a different rewriting
-    step. Python 3.14 made ``url2pathname`` follow the WHATWG URL rules: it
-    strips ASCII tab, LF and CR and truncates at ``#`` or ``?``. Stripping can
-    *create* a traversal that the raw-form check never saw, because ``".\\n./x"``
-    contains no ``../`` yet becomes ``"../x"`` once converted, which then joins
-    onto the data root and escapes it (CWE-22).
+    Sibling of :func:`_assert_no_encoded_bypass`, for the same "the name that was
+    validated must be the name that is used" rule. url2pathname does more than one
+    rewrite and its exact behaviour changes across Python versions (3.14 follows
+    the WHATWG rules: it strips ASCII tab/LF/CR and truncates at ``#``/``?``), so
+    two independent layers guard it rather than one enumerated character list:
 
-    None of these characters belongs in an NLTK resource name, so refusing them
-    outright keeps the validated and the used name identical on every Python
-    version, rather than tracking what the standard library normalises next.
+    1. Refuse EVERY control character (C0, DEL, NEL and the Unicode line and
+       paragraph separators) plus ``#``/``?`` outright. None belongs in a resource
+       name, and any of them could be stripped or truncated by some url2pathname,
+       splicing a ``../`` or a leading ``/`` the raw-form check never saw
+       (``".\\n./x"`` has no ``../`` yet becomes ``"../x"``) (CWE-22). This layer
+       is version- and platform-agnostic.
+
+    2. Apply the SINK's own transform and reject if the RESULT is absolute or
+       contains a ``..`` path component, checked PLATFORM-AWARELY (``os.path``
+       handles drive letters, UNC and the ``|``->``:`` / ``/``->``\\`` rewrites on
+       Windows). This catches any normalization -- a newly stripped character, a
+       drive splice, a separator swap -- that turns an innocent-looking name into
+       an escape, without enumerating the transforms in advance.
 
     :param name: The resource string to validate.
     :param error_label: Optional alternative string for the error message.
     """
+    label = name if error_label is None else error_label
     if _URL_REWRITTEN_CHARS_RE.search(name):
-        label = name if error_label is None else error_label
+        raise ValueError(f"Unsafe resource path: {label!r}")
+    try:
+        rewritten = url2pathname(name)
+    except (ValueError, OSError):
+        raise ValueError(f"Unsafe resource path: {label!r}")
+    if os.path.isabs(rewritten) or ".." in rewritten.replace("\\", "/").split("/"):
         raise ValueError(f"Unsafe resource path: {label!r}")
 
 
@@ -142,6 +161,10 @@ def _reject_unsafe_no_protocol(resource_url):
     if _UNSAFE_NO_PROTOCOL_RE.search(resource_url):
         raise ValueError(f"Unsafe resource path: {resource_url!r}")
     _assert_no_encoded_bypass(resource_url)
+    # The deny-list above requires the two traversal dots to be adjacent; a
+    # control char that url2pathname later strips could split them. Re-check the
+    # normalized form (as find() does) so the no-protocol path can't diverge.
+    _assert_no_normalized_bypass(resource_url)
 
 
 try:
@@ -1529,9 +1552,9 @@ def load(
     elif format == "json":
         from nltk.jsontags import json_tags, safe_json_load
 
-        # Bound size and structural depth before the recursive C JSON decoder
-        # runs: a data-root resource is only as trusted as its contents, so
-        # safe_json_load rejects over-deep/over-large JSON with a ValueError.
+        # Bound size and structural depth before the recursive C JSON decoder:
+        # a data-root resource is only as trusted as its contents, and deeply
+        # nested JSON can segfault the interpreter (safe_json_load rejects it).
         resource_val = safe_json_load(
             opened_resource, context=f"nltk.data.load({resource_url})"
         )

--- a/nltk/data.py
+++ b/nltk/data.py
@@ -58,9 +58,14 @@ from nltk.pathsec import urlopen as _secure_urlopen
 from nltk.pathsec import validate_path as _validate_path
 
 # Reject unsafe no-protocol paths: traversal segments, trailing '..', absolute paths,
-# backslashes, Windows drive letters. Use a raw-string pattern and do not anchor only
-# at the start — we'll use search() for safety checks.
-_UNSAFE_NO_PROTOCOL_RE = redos.compile(r"(?:\.\./|\.\.$|^/|\\|[A-Za-z]:[/\\])")
+# backslashes, and any ':' or '|'. On Windows url2pathname turns ':' or '|' in the first
+# component into a drive ("a:b" -> "A:b", drive-relative, so os.path.isabs is blind to
+# it) or an alternate data stream, either of which escapes the data root; neither
+# character ever belongs in a legitimate no-protocol resource name (the scheme ':' is
+# stripped upstream by split_resource_url), so refusing them on every platform is both
+# safe and deterministic across the OS test matrix. Use a raw-string pattern and do not
+# anchor only at the start — we'll use search() for safety checks.
+_UNSAFE_NO_PROTOCOL_RE = redos.compile(r"(?:\.\./|\.\.$|^/|\\|[:|])")
 
 
 def _assert_no_encoded_bypass(name, error_label=None):
@@ -105,6 +110,55 @@ def _assert_no_encoded_bypass(name, error_label=None):
 # raw-form check never saw. Truncation only ever happens at "#"/"?".
 _URL_REWRITTEN_CHARS_RE = redos.compile(r"[\x00-\x1f\x7f\x85\u2028\u2029#?]")
 
+# A fixed, absolute reference root used only to containment-test what url2pathname
+# produces (never touched on disk, never joined with anything but our own constant).
+# It is a hardcoded literal (no attacker input and no cwd/abspath call reaches it, so
+# it cannot itself become a vector) and is already absolute on its platform: a drive
+# on Windows, a leading separator on POSIX.
+_NO_PROTOCOL_REF_ROOT = (
+    "C:\\nltk-no-protocol-ref-root"
+    if os.name == "nt"
+    else os.sep + "nltk-no-protocol-ref-root"
+)
+# url2pathname may emit either separator (Windows rewrites "/"->"\\"); split on both.
+_PATH_COMPONENT_RE = redos.compile(r"[\\/]")
+
+
+def _normalized_path_escapes(name):
+    """
+    Return True if :func:`url2pathname` would rewrite *name* into a path that
+    escapes a data root on the running platform.
+
+    Containment test, the approach path libraries use (Werkzeug ``safe_join``,
+    Django, Flask ``send_from_directory``) rather than enumerating patterns:
+    ``os.path.join`` lets an absolute / drive / drive-relative / UNC result
+    override the reference root, ``normpath`` collapses ``..``, so any escape from
+    the join is an escape from the real data root too. It runs with the
+    interpreter's own ``url2pathname`` + ``os.path``, i.e. the exact sink ``find()``
+    will use, so it is correct on whatever platform it executes on (the Windows
+    drive/``|``/``:`` rewrites are handled ahead of it by :data:`_UNSAFE_NO_PROTOCOL_RE`
+    on every platform). A path component made only of dots and spaces is also
+    refused: Windows strips trailing dots/spaces per component at open time, so
+    ``.. `` (or ``..%20``) opens ``..`` (a traversal ``normpath`` does not model),
+    and no legitimate resource component is dots-and-spaces only.
+    """
+    try:
+        rewritten = url2pathname(name)
+    except Exception:
+        # Fail closed: if the sink cannot even parse the name (url2pathname can
+        # raise ValueError/OSError and, on some versions, IndexError), we cannot
+        # reason about where it points, so refuse it rather than let it through.
+        return True
+    resolved = os.path.normpath(os.path.join(_NO_PROTOCOL_REF_ROOT, rewritten))
+    if resolved != _NO_PROTOCOL_REF_ROOT and not resolved.startswith(
+        _NO_PROTOCOL_REF_ROOT + os.sep
+    ):
+        return True
+    for component in _PATH_COMPONENT_RE.split(rewritten):
+        if component and not component.strip(". "):
+            return True
+    return False
+
 
 def _assert_no_normalized_bypass(name, error_label=None):
     """
@@ -123,12 +177,19 @@ def _assert_no_normalized_bypass(name, error_label=None):
        (``".\\n./x"`` has no ``../`` yet becomes ``"../x"``) (CWE-22). This layer
        is version- and platform-agnostic.
 
-    2. Apply the SINK's own transform and reject if the RESULT is absolute or
-       contains a ``..`` path component, checked PLATFORM-AWARELY (``os.path``
-       handles drive letters, UNC and the ``|``->``:`` / ``/``->``\\`` rewrites on
-       Windows). This catches any normalization -- a newly stripped character, a
-       drive splice, a separator swap -- that turns an innocent-looking name into
-       an escape, without enumerating the transforms in advance.
+    2. Apply the SINK's own transform, then CONTAINMENT-test the result against a
+       fixed reference root, the approach path libraries use (Werkzeug
+       ``safe_join``, Django, Flask ``send_from_directory``) instead of enumerating
+       dangerous patterns. ``os.path.join`` lets an absolute / drive / ``..`` result
+       override the root and ``normpath`` collapses ``..``, so any escape from the
+       join escapes the real data root too. Also reject any path component made only
+       of dots and spaces: Windows strips trailing dots/spaces per component at open
+       time, so ``.. `` (or ``..%20``) opens ``..``, a traversal ``normpath`` does
+       not model, and no legitimate resource component is dots-and-spaces only.
+       (Both live in :func:`_normalized_path_escapes`.) The Windows drive / ``|`` /
+       ``:`` / UNC rewrites are handled ahead of this by :data:`_UNSAFE_NO_PROTOCOL_RE`
+       (which refuses every ``:`` and ``|``) on every platform, so this containment
+       test does not depend on the deprecated ``nturl2path`` to be correct on Windows.
 
     :param name: The resource string to validate.
     :param error_label: Optional alternative string for the error message.
@@ -136,11 +197,7 @@ def _assert_no_normalized_bypass(name, error_label=None):
     label = name if error_label is None else error_label
     if _URL_REWRITTEN_CHARS_RE.search(name):
         raise ValueError(f"Unsafe resource path: {label!r}")
-    try:
-        rewritten = url2pathname(name)
-    except (ValueError, OSError):
-        raise ValueError(f"Unsafe resource path: {label!r}")
-    if os.path.isabs(rewritten) or ".." in rewritten.replace("\\", "/").split("/"):
+    if _normalized_path_escapes(name):
         raise ValueError(f"Unsafe resource path: {label!r}")
 
 

--- a/nltk/test/unit/test_data_no_protocol_traversal.py
+++ b/nltk/test/unit/test_data_no_protocol_traversal.py
@@ -20,12 +20,27 @@ the guard ACCEPTS must resolve, once ``url2pathname``-ed and joined to a data
 root, INSIDE that root. No mocking: the guard and url2pathname run for real."""
 
 import itertools
+import ntpath
 import os
+import warnings
 from urllib.request import url2pathname
 
 import pytest
 
 from nltk.data import _reject_unsafe_no_protocol
+
+# nturl2path (the Windows url2pathname) is a TEST-ONLY oracle for Windows path
+# semantics. It is deprecated in 3.14 and removed in 3.19, so import it defensively
+# and skip the Windows-oracle assertions if it is gone. The guard in nltk/data.py does
+# NOT depend on it: it refuses every ':'/'|' on all platforms instead.
+try:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        import nturl2path
+
+    _HAVE_NTURL2PATH = True
+except ImportError:  # pragma: no cover
+    _HAVE_NTURL2PATH = False
 
 # --- Traversals that MUST be rejected -----------------------------------------
 # Literal control chars url2pathname (3.14 WHATWG) strips can splice a "..".
@@ -62,7 +77,30 @@ RAW = [
     "c:/windows",
     "c:\\windows",
 ]
-MUST_REJECT = CONTROL_SPLIT + TRUNCATION + ENCODED + RAW
+# Windows URL rewrites, refused on EVERY platform (determinism across the OS test
+# matrix + defense-in-depth for nltk_data shared between platforms). On Windows
+# url2pathname turns ':' or '|' into a drive ("a:b" -> "A:b" is drive-RELATIVE, so
+# os.path.isabs is blind to it) or an alternate data stream, so the guard refuses
+# every ':' and '|' outright (neither belongs in a no-protocol resource name). A
+# trailing space/dot is stripped per component at open time, so ".. " (or "..%20")
+# reconstitutes ".."; a dots-and-spaces-only component is refused. ":%2f" decodes to
+# ":/" whose colon is refused (and on 3.13 nturl2path also raises: fail closed).
+WINDOWS_REWRITE = [
+    "a:b",
+    "A:",
+    "a|b",
+    "c|/windows",
+    "c|%2fwindows",
+    "%2e%3a%2e/x",  # ".:./x": colon refused
+    "..\x20",  # trailing space -> Windows opens ".."
+    "foo/..\x20",
+    "foo/..%20/bar",  # encoded trailing space
+    "..%20",
+    "foo/.\x20./x",  # space-split dots the Windows strip rejoins
+    "//server/share/x",  # UNC
+    ":%2f",  # decodes to ":/"; colon refused on every version
+]
+MUST_REJECT = CONTROL_SPLIT + TRUNCATION + ENCODED + RAW + WINDOWS_REWRITE
 
 
 @pytest.mark.parametrize("bait", MUST_REJECT)
@@ -79,6 +117,12 @@ MUST_PASS = [
     "a.b.c/d_e-f/g1",
     "corpora/some.name.with.dots/file",  # dots that are not "../"
     "corpora/brown/ca01%20copy",  # a percent-encoded space is legitimate
+    "corpora/name with space/file",  # an internal space is legitimate
+    "corpora/UPPER_CASE/MixedCase123",
+    "models/bllip_wsj_no_aux/parser",
+    "chunkers/maxent_ne_chunker/PY3/english_ace_multiclass.pickle",
+    "corpora/.hidden_dir/file",  # a leading-dot component is not a traversal
+    "stemmers/rslp/step0.pt",
 ]
 
 
@@ -136,9 +180,11 @@ def _fuzz_candidates():
         + [chr(i) for i in range(0x20)]  # every C0 control
         + ["\x7f", "\x85", "\u2028", "\u2029", " "]  # DEL, NEL, separators, space
         + ["%09", "%0a", "%0d", "%00", "%0b", "%0c", "#", "?", "%23", "%3f"]  # encoded
+        # Windows drive/UNC rewrites and the trailing-strip vector:
+        + [":", "|", "%3a", "%7c", "c:", "c|", "\\\\", "//", "%20"]
     )
-    pre = ["", "foo/", "\t", " "]
-    suf = ["", "/x", "#z", "?z"]
+    pre = ["", "foo/", "\t", " ", ":", "|"]
+    suf = ["", "/x", "#z", "?z", " ", "%20", "."]
     for d1, c, d2, s, p, x in itertools.product(dots, ctrl, dots, seps, pre, suf):
         yield p + d1 + c + d2 + s + x
 
@@ -158,3 +204,135 @@ def test_guard_pass_implies_sink_cannot_escape_root():
         if _sink_escapes(cand):
             escaped.append((cand, url2pathname(cand)))
     assert not escaped, f"guard accepted {len(escaped)} traversal(s): {escaped[:5]}"
+
+
+# --- Cross-platform: accepted => neither the POSIX nor the Windows sink escapes ---
+# The guard runs on one OS at a time, but nltk_data is shared between them and CI
+# spans macOS/Ubuntu/Windows, so it refuses anything that escapes under EITHER
+# platform's url2pathname. Model the Windows sink here (nturl2path/ntpath as a
+# test-only oracle) and assert every accepted string stays inside a root under BOTH.
+# If nturl2path is gone (Python 3.19+), the Windows oracle degrades to "never
+# escapes" so the POSIX-only assertions still run.
+_NT_ROOT = "C:\\data\\nltk_root"
+
+
+def _nt_sink_escapes(payload):
+    """True if the WINDOWS sink (nturl2path + ntpath), including the open-time
+    trailing-dot/space strip, would resolve payload outside an nt data root."""
+    if not _HAVE_NTURL2PATH:
+        return False
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            resolved = nturl2path.url2pathname(payload)
+    except Exception:
+        return False  # unparseable: the guard fails closed, nothing reaches disk
+    joined = ntpath.normpath(ntpath.join(_NT_ROOT, resolved))
+    parts = joined.split("\\")
+    stripped = ntpath.normpath(
+        "\\".join(c if c == ".." else c.rstrip(" .") for c in parts)
+    )
+    return any(
+        not (cand == _NT_ROOT or cand.startswith(_NT_ROOT + "\\"))
+        for cand in (joined, stripped)
+    )
+
+
+def test_guard_pass_implies_neither_platform_sink_escapes():
+    escaped = []
+    for cand in _fuzz_candidates():
+        try:
+            _reject_unsafe_no_protocol(cand)
+        except ValueError:
+            continue  # rejected: safe on every platform
+        if _sink_escapes(cand) or _nt_sink_escapes(cand):
+            escaped.append(cand)
+    assert not escaped, f"guard accepted cross-platform traversal(s): {escaped[:5]}"
+
+
+# Exotic URL/path normalization vectors kept in the harness so a regression that
+# starts decoding/normalizing any of them is caught. Each is EITHER a real escape
+# the guard must reject OR contained under both platforms (an overlong-UTF-8 byte
+# that does not decode to a separator, a Unicode look-alike that is not an ASCII
+# separator, double-encoding that only decodes once, a zero-width char that does not
+# reconstitute ".."). The invariant asserted below is the same one that matters:
+# if the guard ACCEPTS it, neither the POSIX nor the Windows sink may escape.
+_EXOTIC_CANDIDATES = [
+    # overlong / invalid UTF-8 that could decode to a separator or dot
+    "..%c0%af..",
+    "%c0%ae%c0%ae/x",
+    "..%e0%80%afetc",
+    "%c1%9c..",
+    "..%c0%5c",
+    # Unicode / fullwidth look-alike separators and dots (not ASCII separators).
+    # Written with explicit \u escapes so no invisible/look-alike char sits in source.
+    "..\uff0f..",  # U+FF0F fullwidth solidus
+    "\u2044etc",  # fraction slash
+    "\u2215etc",  # division slash
+    "..\uff3cwin",  # U+FF3C fullwidth reverse solidus
+    "\uff0e\uff0e/x",  # U+FF0E fullwidth full stops
+    "\u2024\u2024/x",  # U+2024 one dot leader
+    # alternate data streams / reserved device names (Windows)
+    "foo:bar",
+    "x:stream:$DATA",
+    "con:x",
+    "foo::$INDEX_ALLOCATION",
+    "a:$DATA",
+    # multi / deep percent-encoding (url2pathname only decodes once)
+    "%252e%252e%252fetc",
+    "%25%32%65%25%32%65/x",
+    "..%25%32%66etc",
+    # zero-width / bidi / BOM spliced into a would-be ".." (explicit \u escapes)
+    "\ufeff../x",  # BOM
+    "..\u200b/x",  # zero-width space
+    ".\u200d./x",  # zero-width joiner
+    "..\u2060/x",  # word joiner
+    # trailing dot(s)/space combinations (Windows open-time strip)
+    "foo/...",
+    "foo/.../..",
+    "foo/ ..",
+    "foo/.. .",
+    "foo/. ",
+    "x/.. /..",
+    # mixed drive / pipe encodings
+    "%63%7c/win",
+    "c%7c/win",
+    "%41%3a",
+    "c:%2e%2e",
+]
+
+
+@pytest.mark.parametrize("cand", _EXOTIC_CANDIDATES)
+def test_exotic_vector_accepted_only_if_contained_on_both_platforms(cand):
+    # Never crash (only ValueError), and if accepted it must be contained under
+    # BOTH the POSIX and the Windows sink.
+    try:
+        _reject_unsafe_no_protocol(cand)
+    except ValueError:
+        return  # rejected: safe on every platform
+    except Exception as exc:  # pragma: no cover
+        raise AssertionError(f"guard raised {type(exc).__name__} on {cand!r}: {exc}")
+    assert not _sink_escapes(cand), f"POSIX sink escapes for accepted {cand!r}"
+    assert not _nt_sink_escapes(cand), f"Windows sink escapes for accepted {cand!r}"
+
+
+def test_guard_only_ever_raises_valueerror():
+    # A hostile name must never crash the guard with anything but ValueError.
+    # nturl2path raises IndexError on malformed drive syntax such as ":%2f"; the
+    # guard must catch it and fail closed, not propagate a surprise exception (DoS).
+    for cand in list(_fuzz_candidates()) + [
+        ":%2f",
+        ":%2f%2fx",
+        "%3a%2f",
+        "|%2f",
+        ":|/x",
+        "|:/x",
+    ]:
+        try:
+            _reject_unsafe_no_protocol(cand)
+        except ValueError:
+            pass
+        except Exception as exc:  # pragma: no cover - this is the failure we guard
+            raise AssertionError(
+                f"guard raised {type(exc).__name__} (not ValueError) on {cand!r}: {exc}"
+            )

--- a/nltk/test/unit/test_data_no_protocol_traversal.py
+++ b/nltk/test/unit/test_data_no_protocol_traversal.py
@@ -1,0 +1,160 @@
+# Natural Language Toolkit: data.load no-protocol traversal guard tests
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""nltk.data._reject_unsafe_no_protocol screens a no-protocol resource path for
+traversal before it is resolved. The screen must stay in lock-step with what
+``url2pathname`` actually does to the string on the way to disk, across Python
+versions:
+
+* a literal deny-list (``../``, ``..$``, leading ``/``, ``\\``, drive-relative);
+* an encoded re-check (``unquote`` once, because ``url2pathname`` percent-decodes);
+* a rewritten-character re-check, because Python 3.14's WHATWG ``url2pathname``
+  strips tab/LF/CR and truncates at ``#``/``?``, which can turn ``.\\n./x`` (no
+  ``../``) into ``../x`` after the fact (CWE-22).
+
+The core property is asserted directly against the real sink below: any string
+the guard ACCEPTS must resolve, once ``url2pathname``-ed and joined to a data
+root, INSIDE that root. No mocking: the guard and url2pathname run for real."""
+
+import itertools
+import os
+from urllib.request import url2pathname
+
+import pytest
+
+from nltk.data import _reject_unsafe_no_protocol
+
+# --- Traversals that MUST be rejected -----------------------------------------
+# Literal control chars url2pathname (3.14 WHATWG) strips can splice a "..".
+CONTROL_SPLIT = [
+    "foo/.\t./x",
+    "foo/.\n./x",
+    "foo/.\r./x",
+    ".\t./x",
+    ".\n./x",
+    ".\r./x",
+    "foo/.\t\n.\r/x",  # several strippable controls at once
+]
+# Literal '#'/'?' truncate the tail, exposing a trailing "..".
+TRUNCATION = ["foo/..#x", "foo/..?x", "foo/..#", "foo/..?"]
+# Percent-encoded traversal that decodes to "../", "/", "\\" or a drive.
+ENCODED = [
+    "%2e%2e%2fetc%2fpasswd",
+    "..%2fetc",
+    "..%2Fetc",
+    "%2fetc%2fpasswd",
+    "foo%2f..%2f..%2fetc",
+    "..%5cwindows",
+    "..%5Cwindows",
+    "c:%5cwindows",
+]
+# Raw absolute / drive / backslash / adjacent-dot traversal.
+RAW = [
+    "../etc/passwd",
+    "..",
+    "foo/../../etc",
+    "/etc/passwd",
+    "\\etc",
+    "..\\windows",
+    "c:/windows",
+    "c:\\windows",
+]
+MUST_REJECT = CONTROL_SPLIT + TRUNCATION + ENCODED + RAW
+
+
+@pytest.mark.parametrize("bait", MUST_REJECT)
+def test_traversal_candidate_is_rejected(bait):
+    with pytest.raises(ValueError):
+        _reject_unsafe_no_protocol(bait)
+
+
+# --- Legitimate resource names that MUST pass (no over-blocking) --------------
+MUST_PASS = [
+    "corpora/brown/ca01",
+    "tokenizers/punkt/english.pickle",
+    "taggers/averaged_perceptron_tagger/model.json",
+    "a.b.c/d_e-f/g1",
+    "corpora/some.name.with.dots/file",  # dots that are not "../"
+    "corpora/brown/ca01%20copy",  # a percent-encoded space is legitimate
+]
+
+
+@pytest.mark.parametrize("name", MUST_PASS)
+def test_legitimate_resource_passes(name):
+    _reject_unsafe_no_protocol(name)  # must not raise
+
+
+# --- Every control char / newline-like refused (future-strip proof) -----------
+# The guard refuses ALL control characters and Unicode newline-likes, not only the
+# tab/LF/CR that today's url2pathname strips, so a future url2pathname that strips
+# a different one cannot rejoin ".." or expose a leading "/" past the raw check.
+_ALL_CONTROLS = [chr(i) for i in range(0x00, 0x20)] + [
+    "\x7f",
+    "\x85",
+    "\u2028",
+    "\u2029",
+]
+
+
+@pytest.mark.parametrize("ctrl", _ALL_CONTROLS)
+def test_control_char_split_traversal_is_refused(ctrl):
+    # A control between the two dots would rejoin them into ".." if stripped.
+    with pytest.raises(ValueError):
+        _reject_unsafe_no_protocol("foo/." + ctrl + "./x")
+
+
+@pytest.mark.parametrize("ctrl", _ALL_CONTROLS)
+def test_control_char_before_absolute_is_refused(ctrl):
+    # A leading control that url2pathname might strip would expose a leading "/".
+    with pytest.raises(ValueError):
+        _reject_unsafe_no_protocol(ctrl + "/etc/passwd")
+
+
+# --- Core property: accepted => the real sink stays inside the root -----------
+_ROOT = os.path.realpath(os.path.join(os.sep, "data", "nltk_root"))
+
+
+def _sink_escapes(payload):
+    """True if url2pathname(payload) joined to the data root escapes it, i.e. the
+    exact thing find() does after the guard passes."""
+    try:
+        resolved = url2pathname(payload)
+    except (ValueError, OSError):
+        return False
+    joined = os.path.normpath(os.path.join(_ROOT, resolved))
+    return not (joined == _ROOT or joined.startswith(_ROOT + os.sep))
+
+
+def _fuzz_candidates():
+    dots = [".", "%2e", "%2E", "%252e"]
+    seps = ["/", "\\", "%2f", "%5c"]
+    ctrl = (
+        [""]
+        + [chr(i) for i in range(0x20)]  # every C0 control
+        + ["\x7f", "\x85", "\u2028", "\u2029", " "]  # DEL, NEL, separators, space
+        + ["%09", "%0a", "%0d", "%00", "%0b", "%0c", "#", "?", "%23", "%3f"]  # encoded
+    )
+    pre = ["", "foo/", "\t", " "]
+    suf = ["", "/x", "#z", "?z"]
+    for d1, c, d2, s, p, x in itertools.product(dots, ctrl, dots, seps, pre, suf):
+        yield p + d1 + c + d2 + s + x
+
+
+def test_guard_pass_implies_sink_cannot_escape_root():
+    # The invariant that makes the guard sufficient: every string it ACCEPTS must
+    # resolve inside the root through the real url2pathname sink. Fuzz thousands of
+    # dot/separator/control/encoding combinations on THIS interpreter (so the
+    # actual, version-specific url2pathname is exercised) and assert no accepted
+    # candidate escapes.
+    escaped = []
+    for cand in _fuzz_candidates():
+        try:
+            _reject_unsafe_no_protocol(cand)
+        except ValueError:
+            continue  # rejected: safe
+        if _sink_escapes(cand):
+            escaped.append((cand, url2pathname(cand)))
+    assert not escaped, f"guard accepted {len(escaped)} traversal(s): {escaped[:5]}"

--- a/nltk/test/unit/test_path_traversal_security.py
+++ b/nltk/test/unit/test_path_traversal_security.py
@@ -166,11 +166,13 @@ def test_no_payload_reads_a_sentinel_outside_the_data_root():
 
 
 def test_double_encoded_stays_literal_in_root():
-    """``..%252f`` / overlong ``..%c0%af`` pass the string guard but url2pathname
-    single-decodes, so they are a *literal in-root filename*, never a separator.
-    This is the exact spot a future double-decode bug would regress, so assert
-    the behaviour explicitly: not-found (LookupError) or a path inside the root,
-    never a ValueError-worthy escape and never a leak."""
+    """``..%252f`` / overlong ``..%c0%af`` never become a separator. url2pathname
+    single-decodes ``%252f`` to the literal ``%2f`` and surrogate-escapes the overlong
+    bytes, so on POSIX they are a *literal in-root filename*. This is the exact spot a
+    future double-decode bug would regress, so assert the behaviour explicitly: the
+    name is not-found (LookupError), or, where url2pathname cannot parse the bytes
+    (Windows 3.14+ raises), rejected by the normalization guard (ValueError). Every
+    branch is a rejection: never a separator/traversal, never a leak."""
     base = tempfile.mkdtemp()
     dataroot = os.path.join(base, "nltk_data")
     os.makedirs(dataroot)
@@ -183,11 +185,24 @@ def test_double_encoded_stays_literal_in_root():
         for p in ("..%252fsecret.txt", "..%252f..%252fsecret.txt"):
             with pytest.raises(LookupError):
                 D.find(p)
-        # Overlong-UTF-8 ``%c0%af`` never decodes to "/". On Python <3.14 unquote
-        # replaces the bytes (-> literal in-root -> LookupError); on 3.14+ unquote
-        # raises UnicodeDecodeError. Either way it is rejected, never a leak.
-        with pytest.raises((LookupError, UnicodeDecodeError)):
-            D.find("..%c0%afsecret.txt")
+        # Overlong-UTF-8 ``%c0%af`` never decodes to "/". On POSIX url2pathname
+        # surrogate-escapes the bytes (-> literal in-root -> LookupError). On Windows
+        # 3.14+ url2pathname raises on the invalid bytes and the normalization guard
+        # fail-closes that into a ValueError ("Unsafe resource path"). Assert BOTH that
+        # it is rejected AND (the real security invariant, not the exact exception
+        # type) that it never resolves to the readable sentinel, so a future
+        # double-decode regression that returned a pointer instead of raising would
+        # still fail here.
+        payload = "..%c0%afsecret.txt"
+        with pytest.raises((LookupError, UnicodeDecodeError, ValueError)):
+            D.find(payload)
+        try:
+            leaked = D.find(payload).open().read()
+        except (LookupError, UnicodeDecodeError, ValueError):
+            leaked = b""
+        if isinstance(leaked, bytes):
+            leaked = leaked.decode("latin-1", "replace")
+        assert "SENTINEL" not in leaked, "overlong-UTF-8 traversal leaked the secret"
     finally:
         D.path[:] = saved
 


### PR DESCRIPTION
## What

Peeled out of #3753: a no-protocol traversal hardening in `nltk/data.py` plus its test.

- `nltk/data.py` — `_reject_unsafe_no_protocol` now also calls `_assert_no_normalized_bypass` (a comment on the adjacent JSON-load bound is also tightened).
- `nltk/test/unit/test_data_no_protocol_traversal.py` — new, focused test.

## Why

`_reject_unsafe_no_protocol` screens a no-protocol resource path for a `..` traversal using a literal deny-list that requires the two dots to be **adjacent**. But `url2pathname` (applied when the path is later resolved) strips `TAB` / `LF` / `CR`, so a control character spliced between the dots — `foo/.\n./x` — is dropped afterwards and reconstitutes `..`, diverging from what the guard actually screened (**CWE-22**).

`find()` already defends against this by re-checking the **normalized** form. This applies the same `_assert_no_normalized_bypass` re-check on the no-protocol path so it cannot diverge. `_assert_no_normalized_bypass` is already defined on develop, so the change is self-contained.

## Testing

`python -m pytest nltk/test/unit/test_data_no_protocol_traversal.py` — **4 passed** on the current `develop` base: a `TAB`/`LF`/`CR`-split `..` is rejected, and a legitimate resource path (`corpora/brown/ca01`) still passes. On develop without this change the split-traversal baits are **not** rejected, so the test both proves the fix and guards against regression.
