### PR TITLE
Add and expand security / ReDoS attack test coverage

### DIFF
--- a/nltk/test/unit/test_attack_deser_rce_expanded.py
+++ b/nltk/test/unit/test_attack_deser_rce_expanded.py
@@ -286,7 +286,11 @@ class TestPersistentIdOpcodesRefused:
 # AllowlistUnpickler with no allowlist refuses them as denied or unlisted.
 _ALIASED_GLOBALS = [
     ("os.path", "system"),  # os.path is a module alias under the os subtree
+    ("os", "popen"),
+    ("nt", "system"),  # the Windows os backing module; refused before import
+    ("nt", "popen"),
     ("importlib", "import_module"),
+    ("pty", "spawn"),
     ("operator", "attrgetter"),
     ("operator", "itemgetter"),
     ("functools", "partial"),
@@ -297,13 +301,16 @@ _ALIASED_GLOBALS = [
     ("builtins", "__import__"),
     ("builtins", "exec"),
     ("builtins", "eval"),
+    ("builtins", "compile"),
     ("subprocess", "Popen"),
+    ("subprocess", "getoutput"),
     ("marshal", "loads"),
     ("_pickle", "loads"),
 ]
 
 _POSIX_ALIASED_GLOBALS = [
     ("posix", "system"),
+    ("posix", "popen"),
     ("_posixsubprocess", "fork_exec"),
 ]
 

--- a/nltk/test/unit/test_attack_dos_expanded.py
+++ b/nltk/test/unit/test_attack_dos_expanded.py
@@ -516,6 +516,54 @@ def test_redos_caller_patterns_group_b():
     )
 
 
+_CHILD_REDOS_C = (
+    _CHILD_PREAMBLE
+    + r"""
+import nltk.redos as _R
+_R.DEFAULT_TIMEOUT = 0.5
+
+TO = %(to)r
+S = %(s)r
+
+# Additional sinks fed the identical-branch backstop pattern the engine cannot
+# linearise, so the wall-clock timeout is what must bound each.
+from nltk.tokenize import RegexpTokenizer
+guarded("span_tokenize_gaps",
+        lambda: list(RegexpTokenizer(TO, gaps=True).span_tokenize(S)))
+
+from nltk.chunk.regexp import ChunkRule, RegexpChunkParser
+guarded("chunk_parser_overlap",
+        lambda: RegexpChunkParser([ChunkRule("<a|a>*<b>", "x")],
+                                  chunk_label="NP").parse([("a", "a")] * 80))
+
+# A benign large tokenize must still return the right count, quickly (over-block
+# control): a legitimate corpus-sized input is not collateral damage.
+def _benign():
+    toks = RegexpTokenizer(r"\w+").tokenize("word " * 50000)
+    report("benign_large_tokenize", "BOUNDED" if len(toks) == 50000 else "ERROR",
+           str(len(toks)))
+try:
+    _benign()
+except Exception as e:  # noqa
+    report("benign_large_tokenize", "ERROR", type(e).__name__)
+"""
+    % {"to": _EVIL_TIMEOUT, "s": _EVIL_S}
+)
+
+
+def test_redos_caller_patterns_group_c():
+    res = _run_child(_CHILD_REDOS_C, GUARDED_BUDGET)
+    _assert_no_hang(res, "ReDoS group C")
+    _assert_cases(
+        res,
+        {
+            "span_tokenize_gaps": {"BOUNDED", "REFUSED"},
+            "chunk_parser_overlap": {"BOUNDED", "REFUSED"},
+            "benign_large_tokenize": {"BOUNDED"},
+        },
+    )
+
+
 # ==========================================================================
 # Family 3: algorithmic blow-ups (CWE-407 / CWE-400 / CWE-674)
 # ==========================================================================

--- a/nltk/test/unit/test_attack_pickle_candidates_expanded.py
+++ b/nltk/test/unit/test_attack_pickle_candidates_expanded.py
@@ -1,0 +1,628 @@
+# Natural Language Toolkit: systematic picklesec denylist / evasion attack matrix
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""Systematic candidate sweep for :mod:`nltk.picklesec` (GHSA-8mgp).
+
+The sibling suites (``test_attack_deser_rce_expanded``, ``test_pickle_gadget*``,
+``test_pickle_allowlist_security``, ``test_attack_allowlist_*``,
+``test_attack_warnonly_loaders_expanded``) exercise hand picked gadgets and the
+opcode landscape. This file closes the coverage in the other direction: it walks
+picklesec's OWN guard tables and proves, entry by entry and through the REAL
+unpicklers, that every denied thing is denied and every audited safe thing still
+loads. Concretely it asserts:
+
+* every module in :data:`~nltk.picklesec._DENIED_MODULE_PREFIXES` is refused at
+  ``find_class`` (as the bare module, as a submodule) AND is refused as an
+  ``allowed_modules`` configuration entry;
+* every pair in :data:`~nltk.picklesec._DENIED_GLOBALS` is refused at
+  ``find_class`` and as an ``allowed_globals`` entry;
+* every qualname in :data:`~nltk.picklesec._DENIED_SCISTACK_QUALNAMES` is refused
+  when re exported under a numpy submodule, and as an ``allowed_globals`` entry;
+* every pair in :data:`~nltk.picklesec._GUARDED_GLOBALS` resolves to the guarded
+  wrapper (not the raw callable), and the wrapper refuses an object bearing dtype;
+* every audited primitive in :data:`~nltk.picklesec._SAFE_DENIED_GLOBALS` still
+  loads when explicitly allowlisted, yet stays refused when it is not;
+* ``__reduce_ex__`` protocols 0 through 5 of an RCE gadget are each refused with
+  no side effect (a stock unpickler runs the same payload, proving the teeth);
+* allowlist evasion by case, whitespace, unicode confusable, FRAME framing, memo
+  reference and nested pickle in pickle is refused, never executed; and
+* the warn only :class:`~nltk.picklesec.WarningUnpickler` still warns (once per
+  instance, with its context) while the restricted path refuses the same gadget.
+
+Every malicious vector is driven through a real ``RestrictedUnpickler`` /
+``AllowlistUnpickler`` (or ``allowlisted_pickle_load``); nothing is mocked. A
+refusal must be a ``pickle.UnpicklingError`` (picklesec), not a path or import
+error, and no attacker side effect (a sentinel file) may appear.
+"""
+
+import io
+import os
+import pickle
+import sys
+import types
+import warnings
+
+import pytest
+
+from nltk.picklesec import (
+    _DENIED_GLOBALS,
+    _DENIED_MODULE_PREFIXES,
+    _DENIED_SCISTACK_QUALNAMES,
+    _GUARDED_GLOBALS,
+    _SAFE_DENIED_GLOBALS,
+    PICKLE_WARNING,
+    AllowlistUnpickler,
+    RestrictedUnpickler,
+    WarningUnpickler,
+    _guarded_scalar,
+    allowlisted_pickle_load,
+    pickle_load,
+)
+
+POSIX_ONLY = pytest.mark.skipif(os.name != "posix", reason="POSIX only global")
+
+_THIS = __name__
+
+# A broad, over permissive scientific stack allow: the worst case a careless
+# downstream caller could configure. Even here nothing dangerous may resolve.
+_BROAD = ("numpy", "scipy", "sklearn", "pandas")
+
+
+def record_execution(path=None, *args, **kwargs):
+    """Stand in for an arbitrary code execution sink; writes a marker if reached."""
+    if path:
+        with open(path, "wb") as handle:
+            handle.write(b"executed")
+    return 0
+
+
+class _MarkerGadget:
+    """A reduce gadget whose reconstruction calls :func:`record_execution`.
+
+    The callable is a global of THIS test module, so a stock unpickler resolves
+    and runs it (teeth), while every guarded unpickler refuses the global.
+    """
+
+    def __init__(self, marker):
+        self._marker = marker
+
+    def __reduce__(self):
+        return (record_execution, (self._marker,))
+
+
+def _benign_loader():
+    """An ``AllowlistUnpickler`` whose only allowance is ``builtins.int``.
+
+    ``find_class`` on it exercises the guards in isolation: nothing dangerous is
+    allowlisted, so any refusal comes from a denylist / module guard, never from a
+    permissive allowance.
+    """
+    return AllowlistUnpickler(io.BytesIO(b""), allowed_globals=(("builtins", "int"),))
+
+
+def _broad_loader():
+    return AllowlistUnpickler(io.BytesIO(b""), allowed_modules=_BROAD)
+
+
+def _su(text):
+    raw = text.encode()
+    return pickle.SHORT_BINUNICODE + bytes([len(raw)]) + raw
+
+
+# ===========================================================================
+# A. Denylist coverage: every guard table entry is actually denied.
+# ===========================================================================
+
+
+class TestDeniedModulePrefixesAreEnforced:
+    """Every :data:`_DENIED_MODULE_PREFIXES` entry must be unreachable at
+    ``find_class`` and unconfigurable as an ``allowed_modules`` entry."""
+
+    @pytest.mark.parametrize("module", sorted(_DENIED_MODULE_PREFIXES))
+    def test_bare_denied_module_is_refused_by_find_class(self, module):
+        with pytest.raises(pickle.UnpicklingError):
+            _benign_loader().find_class(module, "some_attr")
+
+    @pytest.mark.parametrize("module", sorted(_DENIED_MODULE_PREFIXES))
+    def test_submodule_of_denied_module_is_refused(self, module):
+        """The prefix guard matches ``module == deny`` or ``deny + "."``; a crafted
+        submodule under a denied namespace must be refused too."""
+        with pytest.raises(pickle.UnpicklingError):
+            _benign_loader().find_class(module + ".evil", "some_attr")
+
+    @pytest.mark.parametrize("module", sorted(_DENIED_MODULE_PREFIXES))
+    def test_denied_module_cannot_be_allowlisted_at_construction(self, module):
+        """A caller cannot re open a denied namespace: the constructor validates
+        ``allowed_modules`` and refuses a denied entry before any byte is read."""
+        with pytest.raises(pickle.UnpicklingError):
+            AllowlistUnpickler(io.BytesIO(b""), allowed_modules=(module,))
+
+
+class TestDeniedGlobalsAreEnforced:
+    """Every :data:`_DENIED_GLOBALS` pair must be refused by the exact match guard
+    and rejected as a caller supplied ``allowed_globals`` entry."""
+
+    @pytest.mark.parametrize("pair", sorted(_DENIED_GLOBALS))
+    def test_exact_denied_global_is_refused_by_find_class(self, pair):
+        module, name = pair
+        with pytest.raises(pickle.UnpicklingError):
+            _benign_loader().find_class(module, name)
+
+    @pytest.mark.parametrize("pair", sorted(_DENIED_GLOBALS))
+    def test_denied_global_cannot_be_allowlisted_at_construction(self, pair):
+        module, name = pair
+        with pytest.raises(pickle.UnpicklingError):
+            AllowlistUnpickler(io.BytesIO(b""), allowed_globals=(pair,))
+
+
+class TestScistackQualnameSinksAreEnforced:
+    """Every :data:`_DENIED_SCISTACK_QUALNAMES` entry is refused wherever it
+    resolves in the scientific stack, even under a submodule the export name /
+    prefix denylists never enumerate (CWE-502). Proven by re exporting a synthetic
+    callable carrying the denied qualname under a fresh numpy submodule."""
+
+    numpy = pytest.importorskip("numpy")
+
+    @pytest.mark.parametrize("qualname", sorted(_DENIED_SCISTACK_QUALNAMES))
+    def test_reexported_sink_qualname_is_refused_under_broad_allow(
+        self, qualname, monkeypatch
+    ):
+        import numpy
+
+        modname = "numpy._candidate_probe_" + qualname.lower().replace("-", "_")
+
+        def sink(*args, **kwargs):
+            return "PWNED"
+
+        sink.__module__ = modname
+        sink.__qualname__ = qualname
+        fake = types.ModuleType(modname)
+        setattr(fake, qualname, sink)
+        monkeypatch.setitem(sys.modules, modname, fake)
+        monkeypatch.setattr(numpy, modname.split(".", 1)[1], fake, raising=False)
+
+        with pytest.raises(pickle.UnpicklingError):
+            _broad_loader().find_class(modname, qualname)
+
+    @pytest.mark.parametrize("qualname", sorted(_DENIED_SCISTACK_QUALNAMES))
+    def test_sink_qualname_cannot_be_allowlisted_under_a_sci_root(self, qualname):
+        """Configuring ``allowed_globals`` with a sci stack I/O sink qualname is
+        refused at construction, independent of whether it currently resolves."""
+        with pytest.raises(pickle.UnpicklingError):
+            AllowlistUnpickler(io.BytesIO(b""), allowed_globals=(("numpy", qualname),))
+
+
+# ===========================================================================
+# B. Guarded globals and audited safe primitives.
+# ===========================================================================
+
+
+class TestGuardedGlobalsAreWrapped:
+    numpy = pytest.importorskip("numpy")
+
+    @pytest.mark.parametrize("pair", sorted(_GUARDED_GLOBALS))
+    def test_guarded_global_resolves_to_the_wrapper_not_the_raw_callable(self, pair):
+        """``find_class`` must hand back the guarded wrapper for every
+        :data:`_GUARDED_GLOBALS` spelling, never numpy's raw ``scalar`` (which is a
+        nested unpickle sink for an object dtype)."""
+        module, name = pair
+        real = getattr(__import__(module, fromlist=[name]), name)
+        resolved = _broad_loader().find_class(module, name)
+        assert callable(resolved)
+        assert resolved is not real, f"{module}.{name} resolved to the raw callable"
+
+    def test_guarded_scalar_refuses_object_dtype_but_allows_numeric(self):
+        """The wrapper refuses an object bearing dtype (the gadget) before numpy
+        deserializes anything, and passes a genuine numeric scalar unchanged."""
+        import numpy
+
+        real = getattr(numpy, "_core", getattr(numpy, "core", None)).multiarray.scalar
+        wrapped = _guarded_scalar(real)
+        with pytest.raises(pickle.UnpicklingError):
+            wrapped(numpy.dtype("O"), b"")
+        value = wrapped(numpy.dtype("float64"), numpy.float64(2.5).tobytes())
+        assert float(value) == pytest.approx(2.5)
+
+    def test_object_dtype_scalar_reduce_is_refused_end_to_end(self):
+        """The full REDUCE gadget (``scalar(dtype('O'), <bytes>)``), built from only
+        allowlisted names, is refused by ``allowlisted_pickle_load`` itself."""
+        import numpy
+
+        marker = {"reached": False}
+
+        class Canary:
+            def __reduce__(self):
+                marker["reached"] = True
+                return (dict, ([("PWNED", 1)],))
+
+        class ScalarEscape:
+            def __reduce__(self):
+                ma = getattr(numpy, "_core", getattr(numpy, "core", None)).multiarray
+                return (ma.scalar, (numpy.dtype("O"), pickle.dumps(Canary())))
+
+        allow = {
+            ("numpy", "dtype"),
+            ("numpy._core.multiarray", "scalar"),
+            ("numpy.core.multiarray", "scalar"),
+        }
+        with pytest.raises(pickle.UnpicklingError):
+            allowlisted_pickle_load(
+                io.BytesIO(pickle.dumps(ScalarEscape(), protocol=5)),
+                allowed_globals=allow,
+            )
+
+
+class TestSafeDeniedPrimitives:
+    """The audited :data:`_SAFE_DENIED_GLOBALS` primitives (a few immutable builtin
+    types plus the inert ``object`` sentinel) must load when explicitly named, yet
+    stay refused when the caller did not allowlist them."""
+
+    @pytest.mark.parametrize("pair", sorted(_SAFE_DENIED_GLOBALS))
+    def test_safe_primitive_loads_when_explicitly_allowlisted(self, pair):
+        import builtins
+
+        module, name = pair
+        loader = AllowlistUnpickler(io.BytesIO(b""), allowed_globals=(pair,))
+        assert loader.find_class(module, name) is getattr(builtins, name)
+
+    @pytest.mark.parametrize("pair", sorted(_SAFE_DENIED_GLOBALS))
+    def test_safe_primitive_refused_when_not_allowlisted(self, pair):
+        """The exemption is opt in: a loader that allowlists only ``builtins.int``
+        must still refuse ``builtins.str`` / ``builtins.object`` and the rest."""
+        module, name = pair
+        if pair == ("builtins", "int"):
+            pytest.skip("int is the single primitive the benign loader allowlists")
+        with pytest.raises(pickle.UnpicklingError):
+            _benign_loader().find_class(module, name)
+
+    def test_defaultdict_int_container_round_trips(self):
+        """Benign control that leans on the ``builtins.int`` exemption: a
+        ``defaultdict(int)`` (the shape a Punkt parameter table carries) round trips
+        through the allowlist without a false positive."""
+        import collections
+
+        dd = collections.defaultdict(int)
+        dd["a"] += 3
+        dd["b"] += 1
+        out = allowlisted_pickle_load(
+            io.BytesIO(pickle.dumps(dd, protocol=4)),
+            allowed_globals={
+                ("collections", "defaultdict"),
+                ("builtins", "int"),
+            },
+        )
+        assert out == {"a": 3, "b": 1}
+
+
+# ===========================================================================
+# C. __reduce_ex__ protocol matrix: an RCE gadget refused at every protocol.
+# ===========================================================================
+
+
+class TestReduceProtocolMatrix:
+    """A reduce gadget serialized at each pickle protocol (0 through 5) drives a
+    different opcode shape (text GLOBAL at proto 0/1, STACK_GLOBAL at proto 4/5),
+    yet every shape routes the callable through ``find_class`` and is refused."""
+
+    @pytest.mark.parametrize("protocol", range(pickle.HIGHEST_PROTOCOL + 1))
+    def test_stock_unpickler_executes_each_protocol(self, protocol, tmp_path):
+        """Teeth: without the guard, the gadget runs and writes the marker at every
+        protocol, so the guarded assertions below are not vacuous."""
+        marker = tmp_path / f"stock_p{protocol}"
+        payload = pickle.dumps(_MarkerGadget(str(marker)), protocol=protocol)
+        pickle.Unpickler(io.BytesIO(payload)).load()
+        assert marker.exists(), f"protocol {protocol} gadget is not armed"
+
+    @pytest.mark.parametrize("protocol", range(pickle.HIGHEST_PROTOCOL + 1))
+    @pytest.mark.parametrize("loader", ["restricted", "allowlist"])
+    def test_guarded_unpicklers_refuse_each_protocol(self, protocol, loader, tmp_path):
+        marker = tmp_path / f"guarded_{loader}_p{protocol}"
+        payload = pickle.dumps(_MarkerGadget(str(marker)), protocol=protocol)
+        if loader == "restricted":
+            run = lambda: RestrictedUnpickler(io.BytesIO(payload)).load()
+        else:
+            run = lambda: AllowlistUnpickler(io.BytesIO(payload)).load()
+        with pytest.raises(pickle.UnpicklingError):
+            run()
+        assert not marker.exists(), f"protocol {protocol} executed via {loader}"
+
+    @POSIX_ONLY
+    @pytest.mark.parametrize("protocol", range(pickle.HIGHEST_PROTOCOL + 1))
+    def test_os_system_reduce_refused_at_each_protocol(self, protocol, tmp_path):
+        """The classic ``os.system`` reduce (a real shell touch) is refused at every
+        protocol and never runs."""
+        marker = tmp_path / f"ossys_p{protocol}"
+
+        class OsGadget:
+            def __reduce__(self):
+                return (os.system, (f"touch {marker}",))
+
+        payload = pickle.dumps(OsGadget(), protocol=protocol)
+        with pytest.raises(pickle.UnpicklingError):
+            allowlisted_pickle_load(io.BytesIO(payload), allowed_modules=_BROAD)
+        assert not marker.exists()
+
+
+# ===========================================================================
+# D. Allowlist evasion: case, whitespace, confusables, framing, memo, nesting.
+# ===========================================================================
+
+
+class TestAllowlistEvasion:
+    _CASE_VARIANTS = ["OS", "Os", "oS", "SUBPROCESS", "Builtins", "BUILTINS"]
+    _WHITESPACE_VARIANTS = [" os", "os ", "os\t", "\tos", "os\n", " subprocess"]
+    # Cyrillic small letter 'o' (U+043E) and 'ѕ' (U+0455) resemble ASCII o / s.
+    _CONFUSABLE_VARIANTS = ["оs", "oѕ", "оѕ", "subprocesѕ"]
+
+    @pytest.mark.parametrize("module", _CASE_VARIANTS)
+    def test_case_variant_module_is_not_reconstructable(self, module):
+        """A case altered module name is neither denied nor allowlisted, so under a
+        broad sci stack allow it is refused, not silently resolved to ``os``."""
+        with pytest.raises(pickle.UnpicklingError):
+            _broad_loader().find_class(module, "system")
+
+    @pytest.mark.parametrize("module", _WHITESPACE_VARIANTS)
+    def test_whitespace_padded_module_is_not_reconstructable(self, module):
+        with pytest.raises(pickle.UnpicklingError):
+            _broad_loader().find_class(module, "system")
+
+    @pytest.mark.parametrize("module", _CONFUSABLE_VARIANTS)
+    def test_unicode_confusable_module_is_not_reconstructable(self, module):
+        with pytest.raises(pickle.UnpicklingError):
+            _broad_loader().find_class(module, "system")
+
+    def test_framed_gadget_is_refused_and_does_not_execute(self, tmp_path):
+        """A FRAME (0x95) wrapped pickle does not bypass ``find_class``: the framed
+        gadget global is still refused, and the marker is never written."""
+        marker = tmp_path / "framed"
+        body = (
+            _su(_THIS)
+            + _su("record_execution")
+            + pickle.STACK_GLOBAL
+            + _su(str(marker))
+            + pickle.TUPLE1
+            + pickle.REDUCE
+            + pickle.STOP
+        )
+        payload = (
+            pickle.PROTO
+            + bytes([4])
+            + pickle.FRAME
+            + len(body).to_bytes(8, "little")
+            + body
+        )
+        with pytest.raises(pickle.UnpicklingError):
+            AllowlistUnpickler(io.BytesIO(payload)).load()
+        assert not marker.exists()
+
+    def test_memo_cannot_prestage_a_denied_global(self):
+        """A GLOBAL then BINPUT (memoize) then BINGET (reuse) cannot smuggle a
+        denied global: the global is refused when it is FIRST created, before any
+        memo slot is filled."""
+        payload = (
+            pickle.PROTO
+            + bytes([4])
+            + _su("os")
+            + _su("system")
+            + pickle.STACK_GLOBAL
+            + pickle.BINPUT
+            + bytes([0])
+            + pickle.STOP
+        )
+        with pytest.raises(pickle.UnpicklingError):
+            AllowlistUnpickler(io.BytesIO(payload), allowed_modules=_BROAD).load()
+
+    def test_get_of_unfilled_memo_slot_is_refused(self):
+        """A BINGET referencing an empty memo slot cannot conjure an object; the
+        load is refused, and nothing is executed."""
+        payload = pickle.PROTO + bytes([4]) + pickle.BINGET + bytes([0]) + pickle.STOP
+        with pytest.raises((pickle.UnpicklingError, KeyError)):
+            AllowlistUnpickler(io.BytesIO(payload)).load()
+
+    @pytest.mark.parametrize(
+        "module,name",
+        [
+            ("pickle", "loads"),
+            ("_pickle", "loads"),
+            ("marshal", "loads"),
+        ],
+    )
+    def test_nested_pickle_in_pickle_loader_is_refused(self, module, name, tmp_path):
+        """Pickle in pickle: an outer REDUCE that calls a nested deserializer
+        (``pickle.loads`` / ``_pickle.loads`` / ``marshal.loads``) on inner bytes is
+        refused, so the inner (unrestricted) payload never runs. The inner bytes are
+        a genuine ``os`` gadget to prove the nesting was real."""
+        marker = tmp_path / f"nested_{module}_{name}"
+
+        class InnerGadget:
+            def __reduce__(self):
+                return (record_execution, (str(marker),))
+
+        inner = pickle.dumps(InnerGadget(), protocol=4)
+        payload = (
+            pickle.PROTO
+            + bytes([4])
+            + _su(module)
+            + _su(name)
+            + pickle.STACK_GLOBAL
+            + pickle.SHORT_BINBYTES
+            + bytes([len(inner)])
+            + inner
+            + pickle.TUPLE1
+            + pickle.REDUCE
+            + pickle.STOP
+        )
+        with pytest.raises(pickle.UnpicklingError):
+            AllowlistUnpickler(io.BytesIO(payload), allowed_modules=_BROAD).load()
+        assert not marker.exists()
+
+    @pytest.mark.parametrize("name", ["_reconstructor", "__newobj__"])
+    def test_copyreg_object_injection_gadgets_are_refused(self, name):
+        """``copyreg._reconstructor`` / ``copyreg.__newobj__`` are object injection
+        primitives; ``copyreg`` is a denied module, so both are refused even under a
+        broad allow. ``__newobj__`` is additionally a dunder (a second guard)."""
+        with pytest.raises(pickle.UnpicklingError):
+            _broad_loader().find_class("copyreg", name)
+
+
+# ===========================================================================
+# E. WarningUnpickler and the warn only loader contract.
+# ===========================================================================
+
+
+class TestWarningUnpicklerContract:
+    def test_warns_exactly_once_per_instance_across_two_loads(self):
+        """``WarningUnpickler`` emits :data:`PICKLE_WARNING` on its first ``load``
+        and never again on the same instance (the ``_warned`` latch), even when the
+        stream carries two concatenated pickles."""
+        buf = pickle.dumps({"a": 1}, protocol=4)
+        unpickler = WarningUnpickler(io.BytesIO(buf + buf))
+        with warnings.catch_warnings(record=True) as record:
+            warnings.simplefilter("always")
+            first = unpickler.load()
+            second = unpickler.load()
+        assert first == {"a": 1} and second == {"a": 1}
+        runtime = [w for w in record if issubclass(w.category, RuntimeWarning)]
+        assert len(runtime) == 1, f"expected one warning, got {len(runtime)}"
+        assert PICKLE_WARNING in str(runtime[0].message)
+
+    def test_context_is_included_in_the_warning(self):
+        buf = pickle.dumps([1, 2, 3], protocol=4)
+        with warnings.catch_warnings(record=True) as record:
+            warnings.simplefilter("always")
+            WarningUnpickler(io.BytesIO(buf), context="LoadChartMenu").load()
+        assert any("LoadChartMenu" in str(w.message) for w in record)
+
+    def test_no_context_gives_the_bare_warning(self):
+        buf = pickle.dumps("plain", protocol=4)
+        with warnings.catch_warnings(record=True) as record:
+            warnings.simplefilter("always")
+            WarningUnpickler(io.BytesIO(buf)).load()
+        messages = [str(w.message) for w in record]
+        assert any(m == PICKLE_WARNING for m in messages), messages
+
+    def test_warn_only_executes_but_restricted_refuses_the_same_payload(self, tmp_path):
+        """Boundary contract. The SAME reduce payload:
+
+        * runs through ``WarningUnpickler`` after warning (it is warn only, not a
+          security boundary): the marker is written; and
+        * is REFUSED by ``RestrictedUnpickler`` (the boundary): the marker for the
+          restricted attempt is never written.
+        """
+        warn_marker = tmp_path / "warnonly_ran"
+        restricted_marker = tmp_path / "restricted_ran"
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            WarningUnpickler(
+                io.BytesIO(pickle.dumps(_MarkerGadget(str(warn_marker)), protocol=4))
+            ).load()
+        assert warn_marker.exists(), "warn only loader did not execute; no teeth"
+
+        with pytest.raises(pickle.UnpicklingError):
+            RestrictedUnpickler(
+                io.BytesIO(
+                    pickle.dumps(_MarkerGadget(str(restricted_marker)), protocol=4)
+                )
+            ).load()
+        assert not restricted_marker.exists()
+
+    def test_pickle_load_helper_warns_on_benign_and_restricted_refuses_gadget(
+        self, tmp_path
+    ):
+        """``pickle_load(restricted=False)`` warns then returns benign data;
+        ``pickle_load(restricted=True)`` refuses a gadget before it can run."""
+        with pytest.warns(RuntimeWarning):
+            out = pickle_load(io.BytesIO(pickle.dumps({"ok": [1, 2]}, protocol=4)))
+        assert out == {"ok": [1, 2]}
+
+        marker = tmp_path / "helper_restricted"
+        with pytest.raises(pickle.UnpicklingError):
+            pickle_load(
+                io.BytesIO(pickle.dumps(_MarkerGadget(str(marker)), protocol=4)),
+                restricted=True,
+            )
+        assert not marker.exists()
+
+
+# ===========================================================================
+# F. Benign controls: no false positive over blocking from the guard machinery.
+# ===========================================================================
+
+
+class TestBenignControlsStillLoad:
+    def test_numpy_array_round_trips_under_broad_allow(self):
+        """A genuine numeric numpy array reconstructs through a broad numpy allow;
+        the guarded ``scalar`` wrapper and the denylists must not block it."""
+        numpy = pytest.importorskip("numpy")
+        allow = {
+            ("numpy", "ndarray"),
+            ("numpy", "dtype"),
+            ("numpy._core.multiarray", "_reconstruct"),
+            ("numpy.core.multiarray", "_reconstruct"),
+            ("numpy._core.multiarray", "scalar"),
+            ("numpy.core.multiarray", "scalar"),
+            ("numpy._core.numeric", "_frombuffer"),
+            ("numpy.core.numeric", "_frombuffer"),
+        }
+        arr = numpy.array([[1.5, 2.5], [3.5, 4.5]])
+        out = allowlisted_pickle_load(
+            io.BytesIO(pickle.dumps(arr, protocol=4)),
+            allowed_globals=allow,
+            allowed_modules=("numpy",),
+        )
+        assert numpy.array_equal(out, arr)
+
+    def test_scipy_sparse_matrix_round_trips(self):
+        """A real scipy sparse matrix (the shape a fitted model carries) loads under
+        a numpy/scipy allow without a false positive."""
+        numpy = pytest.importorskip("numpy")
+        sparse = pytest.importorskip("scipy.sparse")
+        matrix = sparse.csr_matrix(numpy.array([[1.0, 0.0], [0.0, 2.0]]))
+        out = allowlisted_pickle_load(
+            io.BytesIO(pickle.dumps(matrix, protocol=4)),
+            allowed_modules=("numpy", "scipy"),
+        )
+        assert (out.toarray() == matrix.toarray()).all()
+
+    def test_restricted_unpickler_round_trips_plain_containers(self):
+        """The globals free container shapes NLTK actually pickles still load under
+        the strictest (all globals denied) unpickler."""
+        value = {"tags": ["NN", "VB"], "counts": (1, 2, 3), "seen": {1, 2}}
+        out = RestrictedUnpickler(io.BytesIO(pickle.dumps(value, protocol=4))).load()
+        assert out == value
+
+    def test_real_svc_model_round_trips_through_model_allowlist(self):
+        """A genuinely fitted sklearn SVC (the transition parser artifact) still
+        loads through its exact model allowlist: the hardening does not over block a
+        legitimate model."""
+        numpy = pytest.importorskip("numpy")
+        svm = pytest.importorskip("sklearn.svm")
+        pytest.importorskip("scipy")
+        from nltk.parse.transitionparser import (
+            _MODEL_ALLOWED_GLOBALS,
+            _MODEL_ALLOWED_MODULES,
+        )
+
+        features = numpy.array([[0.0, 1.0], [1.0, 0.0], [1.0, 1.0], [0.0, 0.0]])
+        model = svm.SVC().fit(features, [0, 1, 0, 1])
+        restored = allowlisted_pickle_load(
+            io.BytesIO(pickle.dumps(model)),
+            allowed_globals=_MODEL_ALLOWED_GLOBALS,
+            allowed_modules=_MODEL_ALLOWED_MODULES,
+        )
+        assert (model.predict(features) == restored.predict(features)).all()
+
+    def test_real_punkt_tokenizer_round_trips(self):
+        """A trained Punkt tokenizer loads through ``punkt_pickle_load`` and
+        tokenizes identically after the round trip."""
+        from nltk.tokenize.punkt import PunktSentenceTokenizer, punkt_pickle_load
+
+        tokenizer = PunktSentenceTokenizer()
+        tokenizer.train("Dr. Smith arrived. It works! Mr. Jones left.")
+        restored = punkt_pickle_load(io.BytesIO(pickle.dumps(tokenizer, protocol=4)))
+        sample = "A test. Another one."
+        assert restored.tokenize(sample) == tokenizer.tokenize(sample)

--- a/nltk/test/unit/test_attack_redos_candidates_expanded.py
+++ b/nltk/test/unit/test_attack_redos_candidates_expanded.py
@@ -1,0 +1,501 @@
+# Natural Language Toolkit: expanded ReDoS candidate sweep
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org>
+# For license information, see LICENSE.TXT
+
+r"""Broadened adversarial sweep for the ``nltk.redos`` ReDoS / algorithmic-DoS
+chokepoint (GHSA-8mgp umbrella, CWE-1333 / CWE-400).
+
+Every regular expression in NLTK routes through :mod:`nltk.redos`, so a
+catastrophically backtracking pattern, a hostile *input* against an otherwise
+innocent pattern, or an oversized / deeply nested / counted-repetition source
+must never hang a CPU core. This module widens the proven-candidate battery
+beyond ``test_redos.py`` and ``test_attack_dos_expanded.py``:
+
+* **Match-time backtracking** -- identical / overlapping alternation branches
+  (``(a|a)*$`` and relatives) and ``.*``-driven counted groups (``(.*a){25}z``)
+  that neither ``re`` nor the ``regex`` optimiser linearises: only the
+  wall-clock timeout stops them, and it MUST fire.
+* **Malicious input, innocent pattern** -- the same fixed pattern returns fast
+  on a benign input but must be *bounded* (timeout fires) on a crafted long
+  input; ``re`` alone would hang.
+* **Compile-time refusal** -- a source past ``MAX_PATTERN_LENGTH``, nested past
+  ``MAX_NESTING_DEPTH``, or with a counted repetition past ``MAX_REPEAT_PRODUCT``
+  (plus huge alternations and giant ``{...}`` counts) is refused before any
+  engine sees it.
+* **Caller sinks** -- ``RegexpStemmer`` / ``RegexpTokenizer`` / ``RegexpTagger``
+  / ``featstruct`` rename / ``Valuation`` parse / chunk rules / ``tgrep`` are fed
+  a hostile pattern or input and asserted bounded (refused or fast), never hung.
+* **Benign controls** -- ordinary regexes still compile and match correctly and
+  quickly, and legitimately large-but-safe inputs still process.
+
+The batteries that could genuinely *hang* if a guard were removed run in a fresh
+child interpreter under a hard :mod:`subprocess` wall-clock budget (the same
+plumbing style as ``test_attack_dos_expanded.py``): a removed guard shows up as
+``subprocess.TimeoutExpired`` and *fails* the test rather than wedging the suite.
+The compile-refusal and benign batteries cannot hang (refusal is instant, benign
+input is linear), so they run in-process for speed and exactness.
+"""
+
+import os
+import subprocess
+import sys
+import time
+from collections import namedtuple
+
+import pytest
+
+from nltk import redos
+from nltk.redos import MAX_NESTING_DEPTH, MAX_PATTERN_LENGTH, MAX_REPEAT_PRODUCT
+
+# ==========================================================================
+# Subprocess plumbing (a genuine hang -> TimeoutExpired -> test failure)
+# ==========================================================================
+
+# Head-room over the child's short redos timeout plus a cold ``import nltk`` on a
+# loaded machine. A guarded child that does not finish inside this really hung.
+GUARDED_BUDGET = 40.0
+# A stock (unguarded) control is expected to spin forever; this is only how long
+# we wait before concluding "yes, it hangs". Short: the stdlib sink imports only
+# ``re`` / ``regex``.
+STOCK_TEETH_TIMEOUT = 8.0
+
+_ChildResult = namedtuple("_ChildResult", "timed_out returncode cases stdout stderr")
+
+
+def _parse_cases(stdout):
+    cases = {}
+    for line in (stdout or "").splitlines():
+        if line.startswith("CASE|"):
+            parts = line.split("|", 3)
+            if len(parts) >= 3:
+                cases[parts[1]] = parts[2]
+    return cases
+
+
+def _run_child(code, budget):
+    """Run ``code`` in a fresh interpreter under a hard wall-clock ``budget``.
+
+    The child inherits the parent's ``sys.path`` so it imports the very NLTK
+    under test, and a cold import cannot be mistaken for a hang.
+    """
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(sys.path)
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            timeout=budget,
+            env=env,
+        )
+    except subprocess.TimeoutExpired as exc:
+        out, err = exc.stdout or "", exc.stderr or ""
+        if isinstance(out, bytes):
+            out = out.decode("utf-8", "replace")
+        if isinstance(err, bytes):
+            err = err.decode("utf-8", "replace")
+        return _ChildResult(True, None, _parse_cases(out), out, err)
+    return _ChildResult(
+        False, proc.returncode, _parse_cases(proc.stdout), proc.stdout, proc.stderr
+    )
+
+
+def _assert_no_hang(res, family):
+    assert not res.timed_out, (
+        f"{family}: a guarded sink did NOT return inside {GUARDED_BUDGET}s "
+        f"(possible hang / removed guard). stdout so far:\n{res.stdout}\n"
+        f"stderr:\n{res.stderr}"
+    )
+
+
+def _assert_cases(res, expected):
+    for name, allowed in expected.items():
+        assert name in res.cases, (
+            f"case {name!r} never reported (child crashed before it?).\n"
+            f"stdout:\n{res.stdout}\nstderr:\n{res.stderr}"
+        )
+        assert res.cases[name] in allowed, (
+            f"case {name!r} reported {res.cases[name]!r}, expected one of "
+            f"{sorted(allowed)}.\nstdout:\n{res.stdout}\nstderr:\n{res.stderr}"
+        )
+
+
+# A short redos timeout keeps the timeout-family cases fast; ``report`` /
+# ``guarded`` mirror the reporting protocol used across the DoS suites.
+_CHILD_PREAMBLE = r"""
+import sys, re, time
+import nltk.redos as _R
+_R.DEFAULT_TIMEOUT = 0.5
+from nltk import redos
+
+def report(name, verdict, detail=""):
+    print("CASE|%s|%s|%s" % (name, verdict, detail))
+    sys.stdout.flush()
+
+def guarded(name, fn, refusing=(ValueError, TimeoutError, re.error)):
+    start = time.perf_counter()
+    try:
+        fn()
+        report(name, "BOUNDED", "%.3f" % (time.perf_counter() - start))
+    except refusing as e:
+        report(name, "REFUSED", type(e).__name__)
+    except Exception as e:  # noqa
+        report(name, "ERROR", "%s:%s" % (type(e).__name__, str(e)[:60]))
+"""
+
+
+# ==========================================================================
+# Confirmed pattern families (empirically triaged against the real guard)
+# ==========================================================================
+
+#: Alternation of identical / overlapping branches: neither ``re`` nor the
+#: ``regex`` optimiser linearises these, so ONLY the wall-clock timeout stops the
+#: exponential backtracking -> the timeout MUST fire (REFUSED with TimeoutError).
+#: Each pattern is paired with the specific bait that drives its backtracking
+#: (a generic all-``a`` bait would leave a ``\d`` / ``ab`` pattern with nothing
+#: to backtrack over, so it would finish fast and mask a removed guard).
+TIMEOUT_FAMILY = [
+    (r"(a|a)*$", "a" * 96 + "!"),  # two identical single-char branches
+    (r"(a|a|a|a)*$", "a" * 96 + "!"),  # four identical branches
+    (r"(aa|aa)*$", "a" * 96 + "!"),  # identical two-char branches
+    (r"(ab|ab)*$", "ab" * 48 + "!"),  # identical multi-char branches
+    (r"([ab]|[ab])*$", "a" * 96 + "!"),  # identical character-class branches
+    (r"(a|a)+b", "a" * 96),  # ``+`` instead of ``*``
+    (r"(a|a){10,}$", "a" * 96 + "!"),  # counted-open alternation loop
+    (r"(\d|\d)*$", "1" * 96 + "!"),  # identical metacharacter branches
+]
+
+#: Nested quantifiers / backreference / lookahead shapes the ``regex`` optimiser
+#: DOES linearise: these must finish fast and must NOT raise (kept so a future
+#: engine regression that reverts them to hangs -- which the timeout would then
+#: have to catch -- is visible).
+DEFUSED_FAMILY = [
+    r"(a+)+$",
+    r"(a*)*$",
+    r"((a*)*)*$",
+    r"([a-z]+)*$",
+    r"(a?){30}a{30}",
+    r"^(([a-z])+.)+[A-Z]([a-z])+$",
+    r"(\w+\s?)*$",
+    r"(a+)+\1$",  # backreference blow-up, linearised
+    r"(?=(a+))\1a",  # unbounded lookahead + backref, linearised
+    r"(\d+)*$",
+    r"(a|a|b)*$",  # a single distinct branch lets the engine defuse it
+]
+
+
+# ==========================================================================
+# Family 1: match-time backtracking -- the timeout MUST fire (subprocess)
+# ==========================================================================
+
+
+def _redos_match_child():
+    body = _CHILD_PREAMBLE + "\n"
+    for i, (pat, bait) in enumerate(TIMEOUT_FAMILY):
+        body += f"guarded('to_{i}', lambda: redos.compile({pat!r}).search({bait!r}))\n"
+    # ``(.*a){25}z`` catastrophically backtracks in BOTH engines on a long,
+    # z-less input: the timeout is the only thing that stops it.
+    body += "guarded('nested_dotstar', lambda: redos.compile(r'(.*a){25}z').search('a'*400))\n"
+    for i, pat in enumerate(DEFUSED_FAMILY):
+        body += (
+            f"guarded('def_{i}', lambda: redos.compile({pat!r}).search('a'*96+'!'))\n"
+        )
+    return body
+
+
+def test_match_time_backtracking_families_bounded():
+    res = _run_child(_redos_match_child(), GUARDED_BUDGET)
+    _assert_no_hang(res, "match-time backtracking")
+    expected = {}
+    # Every timeout-family pattern MUST hit the wall-clock cap (REFUSED).
+    for i in range(len(TIMEOUT_FAMILY)):
+        expected[f"to_{i}"] = {"REFUSED"}
+    expected["nested_dotstar"] = {"REFUSED"}
+    # Every defused-family pattern MUST finish fast (BOUNDED), never raise.
+    for i in range(len(DEFUSED_FAMILY)):
+        expected[f"def_{i}"] = {"BOUNDED"}
+    _assert_cases(res, expected)
+
+
+# ==========================================================================
+# Family 2: malicious input against an otherwise innocent pattern
+# ==========================================================================
+
+
+def _malicious_input_child():
+    return (
+        _CHILD_PREAMBLE
+        + r"""
+# The SAME fixed pattern: benign short input returns instantly; a crafted long
+# input drives catastrophic backtracking that the timeout must cut off. This is
+# the classic "innocent validator, hostile payload" ReDoS.
+P1 = r"(.*a){25}z"
+guarded("innocent_short_input", lambda: redos.compile(P1).search("aaz"))
+guarded("innocent_long_input",  lambda: redos.compile(P1).search("a" * 500))
+
+# An anchored identical-branch alternation: a valid all-``a`` string matches to
+# the ``$`` on the first try (fast), but appending a single trailing byte makes
+# the ``$`` fail and forces catastrophic backtracking over the ``a``-run -- a
+# hang under stock ``re``, bounded here by the timeout. Same pattern, the input
+# is the whole difference.
+P2 = r"(a|a)*$"
+guarded("overlap_benign_input", lambda: redos.compile(P2).search("a" * 90))
+guarded("overlap_hostile_input", lambda: redos.compile(P2).search("a" * 90 + "!"))
+
+# findall / finditer / split / sub over the hostile input are each bounded too
+# (the timeout wraps every match method, not just search).
+guarded("hostile_findall",  lambda: redos.compile(r"(a|a)*$").findall("a" * 90 + "!"))
+guarded("hostile_finditer", lambda: list(redos.compile(r"(a|a)*$").finditer("a" * 90 + "!")))
+guarded("hostile_split",    lambda: redos.compile(r"(a|a)*$").split("a" * 90 + "!"))
+guarded("hostile_sub",      lambda: redos.compile(r"(a|a)*$").sub("x", "a" * 90 + "!"))
+"""
+    )
+
+
+def test_malicious_input_innocent_pattern_bounded():
+    res = _run_child(_malicious_input_child(), GUARDED_BUDGET)
+    _assert_no_hang(res, "malicious input / innocent pattern")
+    _assert_cases(
+        res,
+        {
+            "innocent_short_input": {"BOUNDED"},
+            "innocent_long_input": {"REFUSED"},
+            "overlap_benign_input": {"BOUNDED"},
+            "overlap_hostile_input": {"REFUSED"},
+            "hostile_findall": {"REFUSED"},
+            "hostile_finditer": {"REFUSED"},
+            "hostile_split": {"REFUSED"},
+            "hostile_sub": {"REFUSED"},
+        },
+    )
+
+
+# ==========================================================================
+# Family 3: caller sinks fed a hostile pattern / input (subprocess)
+# ==========================================================================
+
+
+def _caller_sinks_child():
+    return (
+        _CHILD_PREAMBLE
+        + r"""
+BAIT = "a" * 96 + "!"
+
+from nltk.stem.regexp import RegexpStemmer
+guarded("stemmer_overlap", lambda: RegexpStemmer(r"(a|a)*$").stem(BAIT))
+guarded("stemmer_nested",  lambda: RegexpStemmer(r"(.*a){25}z").stem("a" * 300))
+
+from nltk.tokenize import RegexpTokenizer
+guarded("tokenizer_overlap", lambda: RegexpTokenizer(r"(a|a)*$").tokenize(BAIT))
+guarded("tokenizer_gaps",    lambda: list(RegexpTokenizer(r"(a|a)*$", gaps=True).span_tokenize(BAIT)))
+
+from nltk.tag import RegexpTagger
+guarded("tagger_nested", lambda: RegexpTagger([(r"(.*a){25}z", "X"), (r".*", "NN")]).tag([BAIT]))
+
+# featstruct: a caller variable name whose long digit run drives the (now
+# linear) trailing-digit strip; both trailing and interior runs must stay fast.
+from nltk.featstruct import FeatStruct
+guarded("featstruct_trailing_digits", lambda: FeatStruct("[a=?x" + "0" * 100000 + "]").rename_variables())
+guarded("featstruct_interior_digits", lambda: FeatStruct("[a=?x" + "0" * 100000 + "z]").rename_variables())
+
+# valuation: a long run of the separator's leading char must split in linear
+# time. The hostile line has no valid separator, so parsing may raise its own
+# (fast) error -- the security property is that it returns quickly, not hangs.
+from nltk.sem.evaluate import read_valuation
+def _val():
+    try:
+        read_valuation("sym " + "=" * 300000)
+    except Exception:  # noqa -- a fast parse error is fine; a hang is not
+        pass
+guarded("valuation_long_run", _val)
+
+# chunk rule whose tag pattern derives an identical-branch backtracking regex.
+from nltk.chunk.regexp import ChunkRule, RegexpChunkParser
+def _chunk():
+    RegexpChunkParser([ChunkRule("<a|a>*<b>", "x")], chunk_label="NP").parse([("a", "a")] * 96)
+guarded("chunk_overlap_tag", _chunk)
+
+# tgrep /regex/ node literal over a hostile node label.
+try:
+    from nltk.tgrep import tgrep_compile, tgrep_nodes
+    from nltk.tree import ParentedTree
+    _tree = ParentedTree("a" * 96, ["x"])
+    guarded("tgrep_overlap", lambda: list(tgrep_nodes(tgrep_compile("/(a|a)*$/"), [_tree])))
+except ImportError:
+    report("tgrep_overlap", "BOUNDED", "pyparsing-absent")
+"""
+    )
+
+
+def test_caller_sinks_hostile_pattern_bounded():
+    res = _run_child(_caller_sinks_child(), GUARDED_BUDGET)
+    _assert_no_hang(res, "caller sinks")
+    _assert_cases(
+        res,
+        {
+            "stemmer_overlap": {"BOUNDED", "REFUSED"},
+            "stemmer_nested": {"BOUNDED", "REFUSED"},
+            "tokenizer_overlap": {"BOUNDED", "REFUSED"},
+            "tokenizer_gaps": {"BOUNDED", "REFUSED"},
+            "tagger_nested": {"BOUNDED", "REFUSED"},
+            "featstruct_trailing_digits": {"BOUNDED"},
+            "featstruct_interior_digits": {"BOUNDED"},
+            "valuation_long_run": {"BOUNDED"},
+            "chunk_overlap_tag": {"BOUNDED", "REFUSED"},
+            "tgrep_overlap": {"BOUNDED", "REFUSED"},
+        },
+    )
+
+
+# ==========================================================================
+# Family 4: compile-time refusal (in-process -- refusal is instant, no hang)
+# ==========================================================================
+
+# Short, shallow sources whose counted repetitions the engine would expand into
+# millions of copies at COMPILE time, plus over-long / over-nested sources. The
+# match-time timeout runs too late for these, so ``check_pattern`` refuses them
+# up front with a ``ValueError``.
+_COMPILE_REFUSED = [
+    pytest.param("a" * (MAX_PATTERN_LENGTH + 1), id="over_length"),
+    pytest.param("(a)" * (MAX_PATTERN_LENGTH // 3 + 1), id="many_groups_over_length"),
+    pytest.param(
+        "(" * (MAX_NESTING_DEPTH + 1) + "a" + ")" * (MAX_NESTING_DEPTH + 1),
+        id="deep_group_nesting",
+    ),
+    pytest.param("(" * (MAX_NESTING_DEPTH + 5), id="unbalanced_paren_flood"),
+    pytest.param(
+        "(?V1)" + "[" * (MAX_NESTING_DEPTH + 5) + "a" + "]" * (MAX_NESTING_DEPTH + 5),
+        id="deep_char_class_nesting",
+    ),
+    pytest.param("a{%d}" % (MAX_REPEAT_PRODUCT + 1), id="bare_atom_count"),
+    pytest.param("(ab){%d}" % (MAX_REPEAT_PRODUCT // 2 + 1), id="group_count"),
+    pytest.param("((ab){1000}){1000}", id="nested_counts_multiply"),
+    pytest.param("(?:(?:(?:a){1000}){1000}){1000}", id="triple_nested_counts"),
+    pytest.param("a{500000,1000000}", id="range_minimum_expands"),
+    pytest.param("a{1000000,}", id="open_range_minimum"),
+    pytest.param("a{" + "9" * 20000 + "}", id="giant_count_digits"),
+    pytest.param("|".join("tok%d" % i for i in range(200000)), id="huge_alternation"),
+    pytest.param("(?:xyz){40000}", id="noncapturing_group_bomb"),
+]
+
+
+@pytest.mark.parametrize("pattern", _COMPILE_REFUSED)
+def test_compile_time_bombs_refused(pattern):
+    with pytest.raises(ValueError):
+        redos.compile(pattern)
+    # ``check_pattern`` alone (used by callers that compile with raw re/regex)
+    # must refuse it too, so no bypass leaks around ``compile``.
+    with pytest.raises(ValueError):
+        redos.check_pattern(pattern)
+
+
+# Shapes that LOOK bomb-like but are genuinely bounded -- the guard must not
+# over-block them (a range from 0 does not expand its minimum; a moderate fixed
+# count is fine; escaped / character-class parens are not group nesting).
+_COMPILE_ALLOWED = [
+    pytest.param("(a){0,1000000}", id="zero_range_no_expansion"),
+    pytest.param("[a-z]{0,1000000}", id="class_zero_range"),
+    pytest.param("(?:ab){2,50}", id="moderate_range"),
+    pytest.param(r"(\d{1,3}\.){3}\d{1,3}", id="ip_like"),
+    pytest.param("a" * MAX_PATTERN_LENGTH, id="at_length_limit"),
+    pytest.param(
+        "(" * MAX_NESTING_DEPTH + "a" + ")" * MAX_NESTING_DEPTH, id="at_nesting_limit"
+    ),
+    pytest.param(r"\(" * (MAX_NESTING_DEPTH + 50), id="escaped_parens_not_nesting"),
+    pytest.param("[()]" * (MAX_NESTING_DEPTH + 50), id="class_parens_not_groups"),
+    pytest.param("(?:a){50001}", id="just_over_half_limit"),
+]
+
+
+@pytest.mark.parametrize("pattern", _COMPILE_ALLOWED)
+def test_bounded_lookalikes_still_compile(pattern):
+    tp = redos.compile(pattern)
+    assert isinstance(tp, redos.TimedPattern)
+    redos.check_pattern(pattern)  # must not raise
+
+
+# ==========================================================================
+# Family 5: benign controls -- ordinary regexes still work, and fast
+# ==========================================================================
+
+
+class TestBenignStillWorks:
+    def test_ordinary_patterns_match_correctly(self):
+        assert redos.compile(r"\w+").findall("Good muffins here") == [
+            "Good",
+            "muffins",
+            "here",
+        ]
+        assert redos.compile(r"\s+").split("a b  c") == ["a", "b", "c"]
+        assert redos.compile(r"a").sub("X", "banana") == "bXnXnX"
+        assert redos.compile(r"(?P<n>\d+)").search("x42").group("n") == "42"
+        assert redos.fullmatch(r"[0-9]{3}-[0-9]{4}", "555-1234") is not None
+        assert redos.compile(r"(ab|cd)+").search("abcdab").group() == "abcdab"
+
+    def test_ordinary_patterns_are_fast(self):
+        # A tight wall-clock bound: an ordinary pattern must resolve well inside a
+        # second, so a regression that made it backtrack would fail here rather
+        # than merely slow the suite.
+        start = time.perf_counter()
+        for _ in range(200):
+            redos.compile(r"^-?[0-9]+(\.[0-9]+)?$").search("-3.14159")
+        assert time.perf_counter() - start < 2.0
+
+    def test_legitimate_large_but_safe_input_processes(self):
+        # A large, benign corpus-sized input must still process linearly and fast.
+        start = time.perf_counter()
+        hits = redos.compile(r"\w+").findall("word " * 200000)
+        assert len(hits) == 200000
+        assert time.perf_counter() - start < 3.0
+
+    def test_large_safe_split_is_linear(self):
+        start = time.perf_counter()
+        parts = redos.compile(r"\s+").split("a " * 100000)
+        assert len(parts) == 100001
+        assert time.perf_counter() - start < 3.0
+
+    def test_benign_caller_sinks_still_correct(self):
+        from nltk.stem import RegexpStemmer
+        from nltk.tag import RegexpTagger
+        from nltk.tokenize import RegexpTokenizer
+
+        assert RegexpTokenizer(r"\w+").tokenize("hello world foo") == [
+            "hello",
+            "world",
+            "foo",
+        ]
+        assert RegexpStemmer(r"ing$", min=4).stem("running") == "runn"
+        assert RegexpTagger([(r"^\d+$", "CD"), (r".*", "NN")]).tag(["12", "cats"]) == [
+            ("12", "CD"),
+            ("cats", "NN"),
+        ]
+
+
+# ==========================================================================
+# Teeth: prove a NEW candidate is genuinely hostile without the guard
+# ==========================================================================
+
+
+def test_teeth_stock_untimed_regex_hangs_on_counted_open_alternation():
+    # ``(a|a){10,}$`` is in TIMEOUT_FAMILY: the ``regex`` optimiser does NOT
+    # linearise it, so without the wall-clock timeout it hangs -- proving the
+    # timeout (not the engine swap) is what bounds this shape.
+    env = dict(os.environ, PYTHONPATH=os.pathsep.join(sys.path))
+    with pytest.raises(subprocess.TimeoutExpired):
+        subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import regex; regex.compile(r'(a|a){10,}$').search('a'*80+'!'); print('x')",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=STOCK_TEETH_TIMEOUT,
+            env=env,
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/nltk/test/unit/test_attack_sqli_chat80_expanded.py
+++ b/nltk/test/unit/test_attack_sqli_chat80_expanded.py
@@ -1,0 +1,148 @@
+# Natural Language Toolkit: SQL-injection attack tests (chat80)
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""SQL-injection attack tests for the parameterized sqlite sink in
+``nltk.sem.chat80.cities2table``.
+
+Corpus field values reach sqlite only through a bound-parameter INSERT
+(``insert into city_table values (?,?,?)``), so a crafted field value such as
+``' OR 1=1 --`` or ``;DROP TABLE city_table;--`` is stored as a literal string
+and cannot alter the statement. These tests drive the REAL ``cities2table``
+end-to-end: a crafted Prolog corpus file is placed under a sandbox data root,
+parsed by the real ``_str2records``, and inserted by the real sqlite cursor;
+the resulting database is then inspected to prove the payloads were bound, the
+table survived, and a benign row still returns the right answer.
+"""
+
+import inspect
+import os
+import sqlite3
+
+import pytest
+
+from nltk.sem import chat80
+
+# The ``restricted_sandbox`` fixture is provided by nltk/test/unit/conftest.py:
+# it enforces pathsec against a single throwaway data root and points
+# nltk.data.path at it, so both the crafted corpus file and the db live inside
+# the sandbox (cities2table validate_path()s the db path).
+
+# Every payload is a single Chat-80 field value. Chat-80 uses the comma as its
+# field delimiter, so payloads are deliberately comma-free (a comma would just
+# be parsed as a field boundary, never reaching SQL); each still carries the
+# quote / semicolon / comment / UNION / backslash tricks that a naive string
+# concat would honour.
+SQLI_PAYLOADS = {
+    "or_1_eq_1": "z' OR 1=1 --",
+    "stacked_drop": "z';DROP TABLE city_table;--",
+    "stacked_delete": "z'); DELETE FROM city_table; --",
+    "union_select": "z' UNION SELECT name FROM sqlite_master --",
+    "comment_inline": "z'/**/OR/**/'1'='1",
+    "quote_backslash": "z' \" \\ --",
+    "double_quote": 'z" OR "1"="1',
+    "unicode_quote": "z’ OR 1=1 --",  # U+2019 right single quote
+    "null_byte_ish": "z'||(SELECT sqlite_version())||'",
+}
+
+BENIGN = ("athens", "greece", 1368)
+
+
+def _write_corpus(root, records, relfile):
+    """Write ``records`` as a Chat-80 ``city(...)`` Prolog file under the
+    sandbox data root's ``corpora/chat80`` dir, where nltk.data.load finds it."""
+    chat80_dir = os.path.join(root, "corpora", "chat80")
+    os.makedirs(chat80_dir, exist_ok=True)
+    path = os.path.join(chat80_dir, relfile)
+    with open(path, "w", encoding="utf8") as f:
+        for city, country, pop in records:
+            f.write(f"city({city},{country},{pop}).\n")
+    return path
+
+
+def _build_table(root, records, relfile="sqli.pl", dbname="cities_sqli.db"):
+    """Drive the REAL cities2table over a crafted corpus, returning the db path."""
+    _write_corpus(root, records, relfile)
+    db = os.path.join(root, dbname)
+    chat80.cities2table(relfile, "city", db, setup=True)
+    return db
+
+
+def test_cities2table_binds_values_no_concat_source():
+    """Static guard: the sink uses placeholder binding, never a value spliced
+    into the SQL text. The only ``%`` formatting is the fixed table name."""
+    src = inspect.getsource(chat80.cities2table)
+    assert "values (?,?,?)" in src
+    # The record tuple is passed as the 2nd arg to execute(), i.e. bound.
+    assert "execute(" in src and "% table_name, t)" in src
+
+
+def test_all_payloads_are_bound_and_roundtrip(restricted_sandbox):
+    """Every SQLi payload is stored verbatim (proving it was a bound parameter,
+    not interpreted as SQL) and the table survives the DROP/DELETE payloads."""
+    root = restricted_sandbox
+    # population index lets us look each crafted row back up unambiguously
+    records = [BENIGN]
+    payload_pop = {}
+    for i, (name, payload) in enumerate(SQLI_PAYLOADS.items(), start=1):
+        pop = 1000 + i
+        payload_pop[name] = (payload, pop)
+        records.append((payload, "france", pop))
+
+    db = _build_table(root, records)
+
+    con = sqlite3.connect(db)
+    try:
+        cur = con.cursor()
+        # 1. table survived every stacked DROP/DELETE payload
+        cur.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='city_table'"
+        )
+        assert cur.fetchone() is not None, "city_table was dropped by a payload"
+
+        # 2. no row was deleted: every record we wrote is present
+        cur.execute("SELECT COUNT(*) FROM city_table")
+        assert cur.fetchone()[0] == len(records)
+
+        # 3. each payload round-trips byte-for-byte -> it was bound, not parsed
+        for name, (payload, pop) in payload_pop.items():
+            cur.execute("SELECT City FROM city_table WHERE Population = ?", (pop,))
+            stored = cur.fetchone()
+            assert stored is not None, f"payload row missing: {name}"
+            assert stored[0] == payload, f"payload mutated for {name}: {stored[0]!r}"
+    finally:
+        con.close()
+
+
+def test_benign_query_returns_right_answer(restricted_sandbox):
+    """A legitimate field value is inserted and read back correctly (BENIGN)."""
+    root = restricted_sandbox
+    db = _build_table(root, [BENIGN, ("paris_city", "france", 999)])
+    con = sqlite3.connect(db)
+    try:
+        cur = con.cursor()
+        cur.execute(
+            "SELECT Country, Population FROM city_table WHERE City = ?", ("athens",)
+        )
+        row = cur.fetchone()
+        assert row == ("greece", 1368)
+    finally:
+        con.close()
+
+
+def test_sql_query_benign_reads_installed_corpus():
+    """Drive the real sql_query() against the installed city.db (BENIGN)."""
+    import nltk.data
+
+    try:
+        nltk.data.find("corpora/city_database/city.db")
+    except LookupError:
+        pytest.skip("city_database corpus not installed")
+
+    cur = chat80.sql_query(
+        "corpora/city_database/city.db",
+        "SELECT Country FROM city_table WHERE City = 'athens'",
+    )
+    assert cur.fetchall() == [("greece",)]

--- a/nltk/test/unit/test_attack_tool_injection_candidates_expanded.py
+++ b/nltk/test/unit/test_attack_tool_injection_candidates_expanded.py
@@ -1,0 +1,509 @@
+"""Expanded external-tool / JVM invocation candidate matrix (GHSA-8mgp umbrella).
+
+This file ADDS coverage for the external-tool wrappers that are *not* already
+exercised by an existing security suite, driving each candidate through the REAL
+guard and proving that a hostile input is refused BEFORE any process is spawned,
+while a benign in-root input is accepted. The external binaries need not be
+installed: every guard must refuse (or, for the escape-hatch APIs, keep argv
+literal) before ``subprocess.Popen`` runs, so a recording spy stands in for the
+process layer and a blocked exploit leaves it empty.
+
+The surfaces targeted here, none owned by a file already in the suite, back the
+ledger rows "find_binary (CWD-relative refused) + validate_tool_path", "argv lists
+(never shell=True)" and the wrapper model/config-path rows:
+
+* ``nltk.classify.megam``: ``config_megam`` binary discovery (find_binary
+  CWD-relative refusal) and ``call_megam`` argv-list integrity (never shell=True;
+  a metacharacter argument stays a single literal argv element, never a shell
+  token). megam takes its training input as an in-root staged file and writes the
+  model to stdout, so it has no NLTK-controlled model-path sink; its whole
+  attack surface is the binary lookup plus the argv list.
+* ``nltk.inference.prover9`` / ``nltk.inference.mace``: ``_find_binary``
+  CWD-relative refusal for ``prover9`` / ``prooftrans`` / ``mace4`` /
+  ``interpformat`` and ``_call`` argv-list integrity. These provers take their
+  input on stdin (no file-path argument), so the binary lookup and the argv list
+  are the surface.
+* the ``internals.java()`` chokepoint as reached by the CoreNLP server wrapper:
+  an out-of-root ``path_to_jar`` classpath entry, an ``@argfile`` smuggled through
+  the free-form ``corenlp_options`` program-argument channel, and a disallowed
+  ``java_options`` JVM flag.
+* the generic ``internals.find_binary`` for a jar-shaped bare name and a
+  ``$PATH``-injection decoy, plus the MaltParser end-to-end path where an
+  out-of-root ``MALT_PARSER`` env var reaches the classpath sandbox.
+* a source-level assertion that NONE of the owned wrappers ever pass
+  ``shell=True``.
+
+Trusted / untrusted dirs are
+staged under the real ``$HOME`` (a private per-user system temp dir is itself a
+trusted pathsec root on macOS), registering only ``root`` so ``outside`` is
+genuinely outside every trusted root on Linux/macOS/Windows.
+"""
+
+import inspect
+import os
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+import nltk.data
+from nltk import internals, pathsec
+
+
+# =========================================================================== #
+# Fixtures and helpers
+# =========================================================================== #
+@pytest.fixture
+def atk_root(monkeypatch):
+    """Pin ``nltk.data.path`` to ONE fresh trusted root and expose an untrusted
+    ``outside`` dir, both under the real ``$HOME`` (see module docstring)."""
+    home = str(pathlib.Path.home())
+    root = os.path.realpath(tempfile.mkdtemp(prefix=".nltk_tic_root_", dir=home))
+    outside = os.path.realpath(tempfile.mkdtemp(prefix=".nltk_tic_out_", dir=home))
+    monkeypatch.setattr(pathsec, "ENFORCE", True)
+    monkeypatch.setattr(nltk.data, "path", [root])
+    monkeypatch.setattr(pathsec, "_ALLOWED_ROOTS_CACHE", None, raising=False)
+    monkeypatch.setattr(pathsec, "_LAST_DATA_PATHS", None, raising=False)
+    try:
+        yield SimpleNamespace(root=root, outside=outside)
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+        shutil.rmtree(outside, ignore_errors=True)
+
+
+class _FakeProc:
+    returncode = 0
+
+    def communicate(self, *a, **k):
+        # bytes so the wrappers' ``.decode(...)`` paths (prover9/senna) do not blow
+        # up; str-returning callers accept bytes here too.
+        return b"", b""
+
+    def poll(self):
+        return None
+
+
+@pytest.fixture
+def spy(monkeypatch):
+    """Record every ``subprocess.Popen`` argv without launching a process. A
+    refused exploit leaves the list empty; an escape-hatch API leaves the injected
+    token as a single literal argv element (no shell splitting)."""
+    calls = []
+
+    def _fake_popen(cmd, *a, **k):
+        calls.append(SimpleNamespace(argv=list(cmd), shell=k.get("shell", False)))
+        return _FakeProc()
+
+    # Every owned wrapper reaches Popen through the ``subprocess`` module object,
+    # except senna which does ``from subprocess import Popen``; patch both spellings.
+    monkeypatch.setattr(subprocess, "Popen", _fake_popen)
+    from nltk.classify import senna as _senna
+
+    monkeypatch.setattr(_senna, "Popen", _fake_popen)
+    monkeypatch.setattr(internals, "_java_bin", "java")
+    monkeypatch.setattr(internals, "_java_options", [])
+    return calls
+
+
+def _regular_file(dirpath, name, content=b""):
+    p = os.path.join(dirpath, name)
+    with open(p, "wb") as fh:
+        fh.write(content)
+    return p
+
+
+def _exec_file(dirpath, name):
+    p = _regular_file(dirpath, name)
+    os.chmod(p, 0o755)
+    return p
+
+
+# =========================================================================== #
+# 1. megam: config_megam binary discovery + call_megam argv integrity.
+# =========================================================================== #
+class TestMegamToolInjection:
+    _BIN_NAMES = ("megam", "megam.opt", "megam_686", "megam_i686.opt")
+
+    def test_cwd_relative_megam_binary_is_refused(self, monkeypatch, tmp_path):
+        """A bare ``megam`` resolvable ONLY in the CWD must not be run: a returned
+        relative path is executed from the current directory (CWE-426/427)."""
+        from nltk.classify import megam
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("MEGAM", raising=False)
+        for n in self._BIN_NAMES:
+            _exec_file(str(tmp_path), n)
+        monkeypatch.setattr(megam, "_megam_bin", None)
+        with pytest.raises(LookupError):
+            megam.config_megam()
+
+    def test_cwd_megam_does_not_shadow_absolute_env(self, monkeypatch, tmp_path):
+        """A planted CWD megam must not shadow an absolute ``MEGAM`` env var."""
+        from nltk.classify import megam
+
+        cwd = tmp_path / "cwd"
+        trusted = tmp_path / "trusted"
+        cwd.mkdir()
+        trusted.mkdir()
+        monkeypatch.chdir(cwd)
+        for n in self._BIN_NAMES:
+            _exec_file(str(cwd), n)
+        good = _exec_file(str(trusted), "megam")
+        monkeypatch.setenv("MEGAM", str(trusted))
+        monkeypatch.setattr(megam, "_megam_bin", None)
+        megam.config_megam()
+        assert os.path.isabs(megam._megam_bin)
+        assert os.path.realpath(megam._megam_bin) == os.path.realpath(good)
+
+    _HOSTILE_MEGAM_ARGS = [
+        ["-writeModel", "/etc/cron.d/evil"],  # option-shaped file write
+        ["; touch /tmp/pwned"],  # shell metacharacters
+        ["$(id)"],  # command substitution
+        ["multiclass", "/etc/passwd"],  # absolute read path
+        ["train\n-writeModel /etc/x"],  # embedded newline
+    ]
+
+    @pytest.mark.parametrize("args", _HOSTILE_MEGAM_ARGS)
+    def test_call_megam_keeps_hostile_args_literal_no_shell(
+        self, monkeypatch, spy, atk_root, args
+    ):
+        """``call_megam`` forwards its args verbatim (it is a low-level escape
+        hatch), so the security property is that they reach the process as
+        LITERAL argv elements via an argv list, never interpreted by a shell:
+        every hostile token appears unchanged in argv and ``shell`` is False."""
+        from nltk.classify import megam
+
+        monkeypatch.setattr(megam, "_megam_bin", _exec_file(atk_root.root, "megam"))
+        megam.call_megam(list(args))
+        assert len(spy) == 1
+        assert spy[0].shell is False
+        for tok in args:
+            assert tok in spy[0].argv  # literal, not shell-split
+        assert spy[0].argv[0] == megam._megam_bin
+
+    def test_call_megam_rejects_str_args(self, monkeypatch, spy, atk_root):
+        """A str (not list) is refused before any spawn: a shell would otherwise
+        be the only way to interpret it, and megam never uses one."""
+        from nltk.classify import megam
+
+        monkeypatch.setattr(megam, "_megam_bin", _exec_file(atk_root.root, "megam"))
+        with pytest.raises(TypeError):
+            megam.call_megam("multiclass /etc/passwd")
+        assert spy == []
+
+    def test_benign_megam_call_reaches_popen(self, monkeypatch, spy, atk_root):
+        """Benign control: a legit options list reaches the argv-list spawn."""
+        from nltk.classify import megam
+
+        bin_ = _exec_file(atk_root.root, "megam")
+        trainfile = _regular_file(atk_root.root, "train.megam")
+        monkeypatch.setattr(megam, "_megam_bin", bin_)
+        megam.call_megam(["-nobias", "-explicit", "multiclass", trainfile])
+        assert len(spy) == 1 and spy[0].shell is False
+        assert spy[0].argv == [bin_, "-nobias", "-explicit", "multiclass", trainfile]
+
+
+# =========================================================================== #
+# 2. prover9 / mace: _find_binary CWD refusal + _call argv integrity.
+# =========================================================================== #
+class TestProver9MaceToolInjection:
+    @pytest.mark.parametrize(
+        "factory,binname",
+        [
+            ("nltk.inference.prover9:Prover9", "prover9"),
+            ("nltk.inference.prover9:Prover9", "prooftrans"),
+            ("nltk.inference.mace:Mace", "mace4"),
+            ("nltk.inference.mace:Mace", "interpformat"),
+        ],
+    )
+    def test_cwd_relative_binary_is_refused(
+        self, monkeypatch, tmp_path, factory, binname
+    ):
+        """Each prover binary resolvable ONLY in the CWD must be refused
+        (CWE-426/427); the search path is a list of absolute dirs, so a bare name
+        never legitimately resolves relative to the CWD."""
+        import importlib
+
+        mod_name, cls_name = factory.split(":")
+        cls = getattr(importlib.import_module(mod_name), cls_name)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("PROVER9", raising=False)
+        _exec_file(str(tmp_path), binname)
+        obj = cls()
+        obj._binary_location = None
+        with pytest.raises(LookupError):
+            obj._find_binary(binname)
+
+    def test_cwd_does_not_shadow_absolute_prover9_env(self, monkeypatch, tmp_path):
+        from nltk.inference.prover9 import Prover9
+
+        cwd = tmp_path / "cwd"
+        trusted = tmp_path / "trusted"
+        cwd.mkdir()
+        trusted.mkdir()
+        monkeypatch.chdir(cwd)
+        _exec_file(str(cwd), "prover9")
+        good = _exec_file(str(trusted), "prover9")
+        monkeypatch.setenv("PROVER9", str(trusted))
+        p = Prover9()
+        p._binary_location = None
+        resolved = p._find_binary("prover9")
+        assert os.path.isabs(resolved)
+        assert os.path.realpath(resolved) == os.path.realpath(good)
+
+    _HOSTILE_CALL_ARGS = [
+        ["-f", "/etc/passwd"],
+        ["; rm -rf /"],
+        ["$(reboot)"],
+        ["striplabels\n-load /etc/x"],
+    ]
+
+    @pytest.mark.parametrize("args", _HOSTILE_CALL_ARGS)
+    def test_prover9_call_keeps_args_literal_no_shell(
+        self, monkeypatch, spy, atk_root, args
+    ):
+        """``_call`` builds ``[binary] + args`` and never uses a shell, so a
+        metacharacter/option/newline argument reaches the process as a single
+        literal argv element."""
+        from nltk.inference.prover9 import Prover9
+
+        binary = _exec_file(atk_root.root, "prover9")
+        Prover9()._call("clause.\n", binary, args=list(args))
+        assert len(spy) == 1 and spy[0].shell is False
+        assert spy[0].argv[0] == binary
+        for tok in args:
+            assert tok in spy[0].argv
+
+    def test_benign_prover9_call_reaches_popen(self, monkeypatch, spy, atk_root):
+        """Benign control: prover9's own fixed program args reach the spawn."""
+        from nltk.inference.prover9 import Prover9
+
+        binary = _exec_file(atk_root.root, "prooftrans")
+        Prover9()._call("proof.\n", binary, args=["striplabels"])
+        assert len(spy) == 1 and spy[0].shell is False
+        assert spy[0].argv == [binary, "striplabels"]
+
+    def test_mace_call_reaches_popen_via_shared_call(self, monkeypatch, spy, atk_root):
+        """Mace reuses prover9's ``_call``; a benign interpformat arg reaches the
+        argv-list spawn."""
+        from nltk.inference.mace import Mace
+
+        binary = _exec_file(atk_root.root, "interpformat")
+        Mace()._call("model.\n", binary, args=["standard"])
+        assert len(spy) == 1 and spy[0].shell is False
+        assert spy[0].argv == [binary, "standard"]
+
+
+# =========================================================================== #
+# 3. CoreNLP server flags routed through the internals.java() chokepoint.
+#    The wrapper hands corenlp_options (program args), java_options (JVM flags)
+#    and the discovered jars (classpath) to java(); that single hardened entry
+#    point is the guard, so it is driven directly with CoreNLP-shaped inputs.
+# =========================================================================== #
+_CORENLP_MAIN = "edu.stanford.nlp.pipeline.StanfordCoreNLPServer"
+
+
+class TestCoreNLPChokepoint:
+    def test_out_of_root_jar_is_refused_before_spawn(self, spy, atk_root):
+        """An out-of-root ``path_to_jar`` reaching the classpath is refused by the
+        jar sandbox before Popen (CWE-94)."""
+        evil = _regular_file(atk_root.outside, "stanford-corenlp.jar")
+        with pytest.raises(internals.UntrustedJarError):
+            internals.java([_CORENLP_MAIN], classpath=(evil,))
+        assert spy == []
+
+    @pytest.mark.parametrize(
+        "corenlp_options",
+        [
+            ["-preload", "tokenize", "@/tmp/argfile"],  # @argfile anywhere
+            ["@/tmp/props"],
+            ["-serverProperties", "x", "@/tmp/more"],
+        ],
+    )
+    def test_argfile_in_corenlp_options_is_refused(
+        self, spy, atk_root, corenlp_options
+    ):
+        """An ``@argfile`` smuggled through the free-form ``corenlp_options``
+        program-argument channel is refused in any position: the Java launcher
+        would expand it and inject arguments (CWE-88)."""
+        good = _regular_file(atk_root.root, "stanford-corenlp.jar")
+        with pytest.raises(ValueError):
+            internals.java([_CORENLP_MAIN, *corenlp_options], classpath=(good,))
+        assert spy == []
+
+    @pytest.mark.parametrize(
+        "java_options",
+        [
+            ["-XX:OnOutOfMemoryError=touch /tmp/pwned"],
+            ["-Djava.ext.dirs=/tmp/evil"],
+            ["-javaagent:/tmp/evil.jar"],
+            ["-jar", "/tmp/evil.jar"],
+        ],
+    )
+    def test_disallowed_java_option_is_refused(self, spy, atk_root, java_options):
+        good = _regular_file(atk_root.root, "stanford-corenlp.jar")
+        with pytest.raises(ValueError):
+            internals.java([_CORENLP_MAIN], classpath=(good,), options=java_options)
+        assert spy == []
+
+    def test_in_root_symlink_jar_pointing_outside_is_refused(self, spy, atk_root):
+        """POSIX symlink escape: an in-root classpath entry that is a symlink to an
+        outside jar is refused, because the sandbox resolves it with realpath and
+        sees the true (outside) inode before any spawn (CWE-59)."""
+        real = _regular_file(atk_root.root, "code.jar")  # a genuine in-root jar
+        outside_jar = _regular_file(atk_root.outside, "evil.jar")
+        link = os.path.join(atk_root.root, "linked.jar")
+        try:
+            os.symlink(outside_jar, link)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unavailable on this platform")
+        with pytest.raises(internals.UntrustedJarError):
+            internals.java([_CORENLP_MAIN], classpath=(real, link))
+        assert spy == []
+
+    def test_in_root_symlink_jar_pointing_in_root_is_accepted(self, spy, atk_root):
+        """POSIX benign control: an in-root symlink whose target is ALSO in-root
+        resolves inside the sandbox, so it is accepted and reaches the spawn; the
+        symlink refusal above is escape-specific, not a blanket ban on symlinks."""
+        real = _regular_file(atk_root.root, "code.jar")
+        link = os.path.join(atk_root.root, "alias.jar")
+        try:
+            os.symlink(real, link)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unavailable on this platform")
+        internals.java([_CORENLP_MAIN], classpath=(link,))
+        assert len(spy) == 1 and spy[0].shell is False
+        assert _CORENLP_MAIN in spy[0].argv
+
+    def test_benign_corenlp_launch_reaches_popen(self, spy, atk_root):
+        """Benign control: in-root jars, an allowlisted ``-mx2g`` java option and a
+        legitimate program-flag list build the launcher argv and reach the
+        (trapped) spawn, with the program flags kept literal and NO shell."""
+        code = _regular_file(atk_root.root, "stanford-corenlp.jar")
+        models = _regular_file(atk_root.root, "stanford-corenlp-models.jar")
+        internals.java(
+            [_CORENLP_MAIN, "-preload", "tokenize,ssplit", "-port", "9000"],
+            classpath=(code, models),
+            options=["-mx2g"],
+        )
+        assert len(spy) == 1 and spy[0].shell is False
+        argv = spy[0].argv
+        assert argv[0] == "java" and "-cp" in argv and _CORENLP_MAIN in argv
+        assert "-mx2g" in argv and argv.index("-mx2g") < argv.index(_CORENLP_MAIN)
+        cp = argv[argv.index("-cp") + 1]
+        assert cp == os.pathsep.join([code, models])
+        assert "" not in cp.split(os.pathsep)  # no CWD element
+
+
+# =========================================================================== #
+# 4. Generic find_binary: jar-shaped bare name + PATH-injection + MaltParser
+#    env-var-outside-root reaching the classpath sandbox end-to-end.
+# =========================================================================== #
+class TestBinaryResolutionCandidates:
+    def test_bare_jar_name_resolvable_only_in_cwd_is_refused(
+        self, monkeypatch, tmp_path
+    ):
+        """A bare ``<name>.jar`` (no directory component) resolvable only in the
+        CWD is refused: a returned relative path would be loaded/run from the CWD
+        (CWE-426/427)."""
+        monkeypatch.chdir(tmp_path)
+        name = "malt_" + uuid.uuid4().hex + ".jar"
+        _regular_file(str(tmp_path), name)
+        with pytest.raises(LookupError):
+            internals.find_binary(name, env_vars=(), searchpath=())
+        # Teeth: the raw iterator really surfaces the untrusted CWD-relative hit.
+        raw = list(internals.find_file_iter(name, (), ()))
+        assert any(not os.path.isabs(m) for m in raw), raw
+
+    def test_absolute_searchpath_hit_wins_over_path_injection_decoy(
+        self, monkeypatch, tmp_path
+    ):
+        """PATH-injection resilience: a planted CWD decoy plus a trusted absolute
+        searchpath hit must resolve to the absolute one, never the decoy."""
+        cwd = tmp_path / "cwd"
+        good = tmp_path / "good"
+        cwd.mkdir()
+        good.mkdir()
+        monkeypatch.chdir(cwd)
+        name = "tool_" + uuid.uuid4().hex
+        decoy = _exec_file(str(cwd), name)
+        trusted = _exec_file(str(good), name)
+        resolved = internals.find_binary(name, env_vars=(), searchpath=(str(good),))
+        assert os.path.isabs(resolved)
+        assert os.path.realpath(resolved) == os.path.realpath(trusted)
+        assert os.path.realpath(resolved) != os.path.realpath(decoy)
+
+    def test_absolute_path_to_bin_outside_root_is_the_callers_choice(
+        self, monkeypatch, tmp_path
+    ):
+        """Benign control / by-design: an ABSOLUTE explicit ``path_to_bin`` is the
+        caller's own choice and is honoured even outside any data root (find_binary
+        does not sandbox an explicit executable; the jar/model sinks are what
+        pathsec bounds)."""
+        target = _exec_file(str(tmp_path), "realbin")
+        resolved = internals.find_binary(
+            "realbin", path_to_bin=target, env_vars=(), searchpath=()
+        )
+        assert resolved == target
+
+    def test_malt_env_var_outside_root_jars_refused_at_classpath_sandbox(
+        self, spy, atk_root, monkeypatch
+    ):
+        """End-to-end: a ``MALT_PARSER`` pointing at an out-of-root install is
+        honoured by find_dir (an absolute env value), but the jars it yields are
+        refused by java()'s classpath sandbox before any spawn (CWE-94)."""
+        from nltk.parse.malt import MaltParser
+
+        # A stub MaltParser whose jars live OUTSIDE the trusted root, with an
+        # in-root working dir and in-root CoNLL input so only the jar containment
+        # is what fails.
+        evildir = os.path.join(atk_root.outside, "maltparser-1.9.2")
+        os.makedirs(evildir)
+        evil_jar = _regular_file(evildir, "maltparser-1.9.2.jar")
+        conll = _regular_file(
+            atk_root.root, "in.conll", b"1\tHi\t_\t_\t_\t_\t0\t_\t_\t_\n"
+        )
+
+        m = MaltParser.__new__(MaltParser)
+        m.malt_jars = [evil_jar]
+        m.additional_java_args = []
+        m.model = "malt_temp.mco"
+        m._working_dir = atk_root.root
+        cmd = m.generate_malt_command(
+            conll, os.path.join(atk_root.root, "o.conll"), mode="parse"
+        )
+        # _execute swallows OSError into a return code, but UntrustedJarError is a
+        # different type and propagates, proving the sandbox refused the jar.
+        with pytest.raises(internals.UntrustedJarError):
+            m._execute(cmd)
+        assert spy == []
+
+
+# =========================================================================== #
+# 5. Structural: none of the owned wrappers ever spawn with shell=True.
+# =========================================================================== #
+class TestNoShellTrueAnywhere:
+    _OWNED_MODULES = [
+        "nltk.internals",
+        "nltk.classify.weka",
+        "nltk.classify.megam",
+        "nltk.classify.senna",
+        "nltk.parse.malt",
+        "nltk.parse.corenlp",
+        "nltk.tag.senna",
+        "nltk.inference.prover9",
+        "nltk.inference.mace",
+        "nltk.sem.boxer",
+    ]
+
+    @pytest.mark.parametrize("mod_name", _OWNED_MODULES)
+    def test_module_source_never_sets_shell_true(self, mod_name):
+        import importlib
+
+        src = inspect.getsource(importlib.import_module(mod_name))
+        normalised = src.replace(" ", "").replace("\t", "")
+        assert "shell=True" not in normalised, f"{mod_name} passes shell=True"

--- a/nltk/test/unit/test_attack_xmlsec_candidates_expanded.py
+++ b/nltk/test/unit/test_attack_xmlsec_candidates_expanded.py
@@ -1,0 +1,482 @@
+# Natural Language Toolkit: expanded xmlsec candidate attack matrix
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""Net-new candidate matrix for ``nltk.xmlsec`` structured-format guards.
+
+Companion to ``test_xmlsec.py``, ``test_xml_attack_matrix.py``,
+``test_xml_entity_expansion_security.py`` and ``test_attack_xml_xss_expanded.py``.
+It drives a broad set of plausible XML inputs, benign and hostile alike, through
+the REAL guard, exercising BOTH entry points (:func:`nltk.xmlsec.fromstring` and
+:func:`nltk.xmlsec.parse`) and BOTH back ends:
+
+* ``defusedxml`` when it is installed, and
+* the standard-library fallback whose pre-scan (:func:`nltk.xmlsec._reject_entities`)
+  runs when ``defusedxml`` is absent (``HAVE_DEFUSEDXML`` False).
+
+Guarantees asserted for every hostile input: it RAISES the entity guard
+(``EntitiesForbidden`` / ``ValueError`` / ``ParseError``) OR, for a document that
+merely NAMES an external subset or carries an inert XInclude, it parses with NO
+outbound request (checked against a REAL loopback socket that must receive zero
+connections). Benign documents keep parsing, and a markup payload smuggled in
+CDATA / an attribute is neutralised at the serialization sink.
+
+No mocking: the real parser runs on each input; ``file:///etc/passwd`` is bait
+only (the raised exception is asserted, never file contents).
+"""
+
+import importlib
+import io
+import socket
+import sys
+import threading
+from xml.etree import ElementTree as StockET
+from xml.etree.ElementTree import ParseError
+
+import pytest
+
+from nltk import xmlsec
+
+# ===========================================================================
+# Payload builders
+# ===========================================================================
+
+
+def _billion_laughs(levels=6, seed="AAAAAAAAAA"):
+    """Classic nested lolN billion-laughs; each level multiplies by ten."""
+    decls = "".join(
+        f'<!ENTITY e{i} "{f"&e{i - 1};" * 10}">' for i in range(1, levels + 1)
+    )
+    return (
+        '<?xml version="1.0"?>'
+        f'<!DOCTYPE d [<!ENTITY e0 "{seed}">{decls}]>'
+        f"<d><e>&e{levels};</e></d>"
+    )
+
+
+def _quadratic(entity_size=20000, refs=100):
+    """Quadratic-blowup: one big entity referenced many times."""
+    return (
+        '<?xml version="1.0"?>'
+        f'<!DOCTYPE d [<!ENTITY a "{"A" * entity_size}">]>'
+        f"<d>{'&a;' * refs}</d>"
+    )
+
+
+def _flat_entity(size=5000, refs=50):
+    """A FLAT entity stock ElementTree expands (well under libexpat's cap);
+    used as clean teeth that the guard still refuses."""
+    return (
+        '<?xml version="1.0"?>'
+        f'<!DOCTYPE d [<!ENTITY a "{"A" * size}">]>'
+        f"<d>{'&a;' * refs}</d>"
+    )
+
+
+# Every one of these DECLARES or REFERENCES an entity and must be refused.
+ENTITY_REJECTED = {
+    "billion-laughs": _billion_laughs(),
+    "quadratic-blowup": _quadratic(),
+    "flat-entity": _flat_entity(),
+    "single-general-entity": '<!DOCTYPE d [<!ENTITY a "x">]><d><e>&a;</e></d>',
+    "external-general-file": (
+        '<?xml version="1.0"?>'
+        '<!DOCTYPE d [<!ENTITY xxe SYSTEM "file:///etc/passwd">]><d><e>&xxe;</e></d>'
+    ),
+    "external-general-http": (
+        '<?xml version="1.0"?>'
+        '<!DOCTYPE d [<!ENTITY xxe SYSTEM "http://169.254.169.254/latest">]>'
+        "<d><e>&xxe;</e></d>"
+    ),
+    "php-filter-wrapper": (
+        '<?xml version="1.0"?>'
+        "<!DOCTYPE d [<!ENTITY xxe SYSTEM "
+        '"php://filter/convert.base64-encode/resource=/etc/passwd">]><d><e>&xxe;</e></d>'
+    ),
+    "parameter-entity": '<?xml version="1.0"?><!DOCTYPE d [<!ENTITY % pe "x">]><d/>',
+    "external-parameter-entity": (
+        '<?xml version="1.0"?>'
+        '<!DOCTYPE d [<!ENTITY % pe SYSTEM "file:///etc/passwd">%pe;]><d/>'
+    ),
+    "recursive-entity-chain": (
+        '<?xml version="1.0"?>'
+        '<!DOCTYPE d [<!ENTITY a "&b;"><!ENTITY b "&c;"><!ENTITY c "boom">]>'
+        "<d><e>&a;</e></d>"
+    ),
+    "self-recursive-entity": (
+        '<?xml version="1.0"?><!DOCTYPE d [<!ENTITY a "&a;">]><d><e>&a;</e></d>'
+    ),
+    # Parser-differential decoys: a declaration hidden behind a bracket in a
+    # comment / PI / literal that a naive string screener would skip, but expat
+    # (and therefore the pre-scan) still acts on.
+    "bracket-hidden-in-comment": (
+        '<!DOCTYPE d [<!-- ] --><!ENTITY a "BOOM">]><d><e>&a;</e></d>'
+    ),
+    "bracket-in-system-literal": (
+        '<!DOCTYPE d SYSTEM "a[b.dtd" [<!ENTITY a "BOOM">]><d><e>&a;</e></d>'
+    ),
+    "decoy-doctype-in-pi": (
+        '<?pi <!DOCTYPE x [ ] > ?><!DOCTYPE d [<!ENTITY a "BOOM">]><d><e>&a;</e></d>'
+    ),
+}
+
+# These merely NAME an external DTD; ElementTree never fetches it, so they PARSE
+# but must issue no outbound request (checked against a live socket).
+EXTERNAL_DTD_NAMED = {
+    "doctype-system": (
+        '<?xml version="1.0"?>'
+        '<!DOCTYPE d SYSTEM "http://{host}:{port}/x.dtd"><d><e>Bob</e></d>'
+    ),
+    "doctype-public": (
+        '<?xml version="1.0"?>'
+        '<!DOCTYPE d PUBLIC "-//X//DTD Made Up//EN" '
+        '"http://{host}:{port}/x.dtd"><d><e>Bob</e></d>'
+    ),
+}
+
+# These REFERENCE an external resource and must be refused before any fetch.
+EXTERNAL_REF_NO_FETCH = {
+    "oob-parameter-entity": (
+        '<?xml version="1.0"?>'
+        '<!DOCTYPE d [<!ENTITY % rem SYSTEM "http://{host}:{port}/">%rem;]><d/>'
+    ),
+    "external-general-ref": (
+        '<?xml version="1.0"?>'
+        '<!DOCTYPE d [<!ENTITY x SYSTEM "http://{host}:{port}/">]><d><e>&x;</e></d>'
+    ),
+}
+
+# Benign controls that must keep parsing on both entry points and back ends.
+BENIGN_XML = {
+    "no-doctype": "<d><e>Bob</e></d>",
+    "nested-tree": "<corpus><doc id='1'><w pos='NN'>cat</w></doc></corpus>",
+    "builtin-escapes": "<d><e>a &amp; b &lt; c &gt; d &quot; e &apos;</e></d>",
+    "numeric-charref": "<d><e>&#65;&#x42;</e></d>",
+    "external-subset-named": '<!DOCTYPE d SYSTEM "apf.dtd"><d><e>Bob</e></d>',
+    "public-id-named": '<!DOCTYPE d PUBLIC "-//X//DTD//EN" "x.dtd"><d><e>Bob</e></d>',
+    "subset-no-entities": "<!DOCTYPE d [<!ELEMENT d ANY>]><d><e>Bob</e></d>",
+    "entity-word-in-text": "<d><e>the &lt;!ENTITY declaration</e></d>",
+    "entity-word-in-cdata": '<d><e><![CDATA[<!ENTITY a "x">]]></e></d>',
+}
+
+
+# ===========================================================================
+# Back-end fixture: force defusedxml present, then force the fallback
+# ===========================================================================
+
+
+@pytest.fixture(params=["defusedxml", "fallback"])
+def backend(request, monkeypatch):
+    """``nltk.xmlsec`` with each back end forced, restored on teardown."""
+    if request.param == "defusedxml":
+        pytest.importorskip("defusedxml")
+        module = importlib.reload(xmlsec)
+        assert module.HAVE_DEFUSEDXML
+    else:
+        # Hiding the module makes ``import defusedxml`` raise ImportError, so the
+        # reload selects the standard-library pre-scan (fallback) path.
+        monkeypatch.setitem(sys.modules, "defusedxml", None)
+        module = importlib.reload(xmlsec)
+        assert not module.HAVE_DEFUSEDXML
+    yield module
+    # Undo the patch before reloading so the module is left on its real back end.
+    monkeypatch.undo()
+    importlib.reload(xmlsec)
+
+
+def _raises_guard(func, *args):
+    """Assert ``func(*args)`` raises the entity guard, not something incidental."""
+    with pytest.raises((ValueError, ParseError)) as excinfo:
+        func(*args)
+    name = type(excinfo.value).__name__
+    assert "Forbidden" in name or "Entit" in str(excinfo.value) or name == "ParseError"
+    return excinfo.value
+
+
+class _Listener:
+    """A one-shot loopback listener that records any bytes it receives."""
+
+    def __init__(self):
+        self.sock = socket.socket()
+        self.sock.bind(("127.0.0.1", 0))
+        self.sock.listen(1)
+        self.sock.settimeout(3)
+        self.host, self.port = self.sock.getsockname()
+        self.connections = []
+        self._thread = threading.Thread(target=self._accept, daemon=True)
+        self._thread.start()
+
+    def _accept(self):
+        try:
+            connection, _ = self.sock.accept()
+            self.connections.append(connection.recv(64))
+            connection.close()
+        except OSError:
+            pass
+
+    def close(self):
+        self._thread.join(timeout=3)
+        self.sock.close()
+
+
+# ===========================================================================
+# 1. Entity declarations / references are refused on BOTH entry points.
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "payload", list(ENTITY_REJECTED.values()), ids=list(ENTITY_REJECTED)
+)
+def test_entity_payloads_refused_on_both_entry_points(backend, payload):
+    _raises_guard(backend.fromstring, payload)
+    _raises_guard(backend.parse, io.StringIO(payload))
+
+
+def test_billion_laughs_refused_not_truncated(backend):
+    """A deeper bomb is refused outright, not merely truncated."""
+    _raises_guard(backend.fromstring, _billion_laughs(levels=8))
+    _raises_guard(backend.parse, io.StringIO(_billion_laughs(levels=8)))
+
+
+# ===========================================================================
+# 2. Teeth: the payloads the guard refuses really do expand under stock
+#    ElementTree, so a guard that stopped working would balloon memory.
+# ===========================================================================
+
+
+def test_teeth_flat_entity_expands_under_stock_elementtree():
+    payload = _flat_entity(size=5000, refs=50)
+    stock = StockET.fromstring(payload)
+    # The flat entity expands directly into the root element's text.
+    assert len(stock.text) == 5000 * 50  # stock expands it
+    _raises_guard(xmlsec.fromstring, payload)  # xmlsec refuses the same bytes
+
+
+def test_teeth_nested_bomb_expands_under_stock_elementtree():
+    payload = _billion_laughs(levels=3, seed="AAAAAAAAAA")
+    stock = StockET.fromstring(payload)
+    assert len(stock.find("e").text) == 10 * 10**3
+    _raises_guard(xmlsec.fromstring, payload)
+
+
+# ===========================================================================
+# 3. External DTD merely NAMED: parses, but no outbound request may go out.
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "template", list(EXTERNAL_DTD_NAMED.values()), ids=list(EXTERNAL_DTD_NAMED)
+)
+def test_external_dtd_named_but_never_fetched(backend, template):
+    listener = _Listener()
+    payload = template.format(host=listener.host, port=listener.port)
+    try:
+        backend.fromstring(payload)  # naming an external subset is allowed
+    except (ValueError, ParseError):
+        pass
+    finally:
+        listener.close()
+    assert listener.connections == [], "the parser fetched the external DTD (SSRF)"
+
+
+@pytest.mark.parametrize(
+    "template", list(EXTERNAL_REF_NO_FETCH.values()), ids=list(EXTERNAL_REF_NO_FETCH)
+)
+def test_external_reference_refused_with_zero_connections(backend, template):
+    listener = _Listener()
+    payload = template.format(host=listener.host, port=listener.port)
+    try:
+        _raises_guard(backend.fromstring, payload)
+    finally:
+        listener.close()
+    assert listener.connections == [], "refusal still leaked an outbound request"
+
+
+# ===========================================================================
+# 4. XInclude: ElementTree does not process xi:include during a plain parse, so
+#    the include is INERT (no expansion) and issues no outbound request.
+# ===========================================================================
+
+XINCLUDE_NS = "http://www.w3.org/2001/XInclude"
+
+
+def test_xinclude_is_inert_and_never_fetched(backend):
+    listener = _Listener()
+    payload = (
+        '<?xml version="1.0"?>'
+        f'<root xmlns:xi="{XINCLUDE_NS}">'
+        f'<xi:include href="http://{listener.host}:{listener.port}/x" parse="text"/>'
+        "<keep>Bob</keep></root>"
+    )
+    try:
+        root = backend.fromstring(payload)
+        # The include element is present but unexpanded (inert), and the sibling
+        # content is intact; nothing was fetched.
+        include = root.find(f"{{{XINCLUDE_NS}}}include")
+        assert include is not None
+        assert root.find("keep").text == "Bob"
+    except (ValueError, ParseError):
+        pass  # a refusal is also acceptable; either way nothing may be fetched
+    finally:
+        listener.close()
+    assert listener.connections == [], "XInclude triggered an outbound fetch"
+
+
+def test_xinclude_pointing_at_local_file_does_not_disclose(backend, tmp_path):
+    secret = tmp_path / "secret.txt"
+    secret.write_text("NLTK-XINCLUDE-SENTINEL", encoding="utf-8")
+    payload = (
+        '<?xml version="1.0"?>'
+        f'<root xmlns:xi="{XINCLUDE_NS}">'
+        f'<xi:include href="{secret.as_uri()}" parse="text"/></root>'
+    )
+    root = backend.fromstring(payload)
+    text = "".join(root.itertext())
+    assert "NLTK-XINCLUDE-SENTINEL" not in text
+
+
+# ===========================================================================
+# 5. Encoding tricks: a non-ASCII encoding must not smuggle a declaration past
+#    the pre-scan (the fallback feeds bytes to expat in their own type).
+# ===========================================================================
+
+
+@pytest.mark.parametrize("encoding", ["utf-16", "utf-16-le", "utf-16-be"])
+def test_encoded_bomb_is_screened(backend, encoding):
+    payload = _billion_laughs(levels=6).encode(encoding)
+    _raises_guard(backend.parse, io.BytesIO(payload))
+
+
+def test_utf8_bom_prefixed_bomb_is_screened(backend):
+    payload = b"\xef\xbb\xbf" + _billion_laughs(levels=6).encode("utf-8")
+    _raises_guard(backend.parse, io.BytesIO(payload))
+
+
+# ===========================================================================
+# 6. CDATA / attribute XSS payload: xmlsec parses it as inert TEXT (never a live
+#    child element), and re-serialising the tree escapes it at the sink so no
+#    live <script> tag can emerge.
+# ===========================================================================
+
+
+def test_cdata_script_is_inert_text_and_escaped_at_sink(backend):
+    payload = (
+        '<d attr="&quot;&gt;&lt;script&gt;"><![CDATA[<script>alert(1)</script>]]></d>'
+    )
+    element = backend.fromstring(payload)
+    # CDATA content is inert text, not a parsed <script> child element.
+    assert element.text == "<script>alert(1)</script>"
+    assert list(element) == []
+    # Re-serialising escapes the special characters: no live tag survives.
+    serialized = StockET.tostring(element, encoding="unicode")
+    assert "<script>" not in serialized
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in serialized
+
+
+def test_attribute_markup_is_escaped_at_sink(backend):
+    payload = '<d><w note="&lt;img src=x onerror=alert(1)&gt;">cat</w></d>'
+    element = backend.fromstring(payload)
+    note = element.find("w").attrib["note"]
+    assert note == "<img src=x onerror=alert(1)>"  # inert attribute VALUE
+    serialized = StockET.tostring(element, encoding="unicode")
+    assert "<img" not in serialized  # re-escaped, no live tag at the sink
+
+
+# ===========================================================================
+# 7. BENIGN: ordinary XML keeps round-tripping on both entry points and back ends.
+# ===========================================================================
+
+
+@pytest.mark.parametrize("payload", list(BENIGN_XML.values()), ids=list(BENIGN_XML))
+def test_benign_xml_still_parses_on_both_entry_points(backend, payload):
+    assert (
+        backend.fromstring(payload).find("e") is not None
+        or backend.fromstring(payload).find("doc") is not None
+    )
+    assert backend.parse(io.StringIO(payload)).getroot() is not None
+
+
+def test_benign_tree_has_the_right_shape(backend):
+    root = backend.fromstring(
+        "<corpus><doc id='1'><w pos='NN'>cat</w><w pos='NN'>dog</w></doc></corpus>"
+    )
+    words = root.findall("./doc/w")
+    assert [w.text for w in words] == ["cat", "dog"]
+    assert [w.attrib["pos"] for w in words] == ["NN", "NN"]
+
+
+def test_parse_accepts_a_real_filename(backend, tmp_path):
+    good = tmp_path / "ok.xml"
+    good.write_text("<d><e>Bob</e></d>", encoding="utf-8")
+    assert backend.parse(str(good)).getroot().find("e").text == "Bob"
+    bomb = tmp_path / "bomb.xml"
+    bomb.write_text(_billion_laughs(), encoding="utf-8")
+    _raises_guard(backend.parse, str(bomb))
+
+
+# ===========================================================================
+# 8. Fallback pre-scan (HAVE_DEFUSEDXML False): _reject_entities is the guarantee
+#    when defusedxml is absent. Confirm it refuses entities directly and lets
+#    benign documents through, independent of which back end is installed.
+# ===========================================================================
+
+
+def _forced_fallback_module(monkeypatch):
+    """Reload ``nltk.xmlsec`` with ``defusedxml`` hidden so HAVE_DEFUSEDXML is
+    False and the module's own ``EntitiesForbidden`` / ``_reject_entities`` are
+    the pre-scan actually used in that configuration."""
+    monkeypatch.setitem(sys.modules, "defusedxml", None)
+    module = importlib.reload(xmlsec)
+    assert module.HAVE_DEFUSEDXML is False
+    return module
+
+
+def test_reject_entities_refuses_declarations_directly(monkeypatch):
+    # In the fallback configuration _reject_entities is the guarantee; its own
+    # standalone expat pass refuses any entity declaration or external reference.
+    module = _forced_fallback_module(monkeypatch)
+    try:
+        for payload in (
+            _billion_laughs(),
+            '<!DOCTYPE d [<!ENTITY a "x">]><d><e>&a;</e></d>',
+            '<!DOCTYPE d [<!ENTITY % pe "x">]><d/>',
+            '<?xml version="1.0"?><!DOCTYPE d [<!ENTITY xxe SYSTEM "file:///etc/passwd">]><d>&xxe;</d>',
+        ):
+            with pytest.raises(module.EntitiesForbidden):
+                module._reject_entities(payload)
+    finally:
+        monkeypatch.undo()
+        importlib.reload(xmlsec)
+
+
+def test_reject_entities_allows_benign_documents(monkeypatch):
+    # A benign document (no entity declaration) passes the pre-scan silently, and
+    # a document merely naming an external subset is allowed (never fetched).
+    module = _forced_fallback_module(monkeypatch)
+    try:
+        for payload in (
+            "<d><e>Bob</e></d>",
+            "<d><e>a &amp; b &lt; c</e></d>",
+            '<!DOCTYPE d SYSTEM "apf.dtd"><d><e>Bob</e></d>',
+            '<d><e><![CDATA[<!ENTITY a "x">]]></e></d>',
+        ):
+            assert module._reject_entities(payload) is None
+    finally:
+        monkeypatch.undo()
+        importlib.reload(xmlsec)
+
+
+def test_fallback_backend_refuses_entities_via_reject_entities(monkeypatch):
+    # Force the fallback (HAVE_DEFUSEDXML False) explicitly and confirm the
+    # entity refusal still holds through the public fromstring / parse API.
+    module = _forced_fallback_module(monkeypatch)
+    try:
+        _raises_guard(module.fromstring, _billion_laughs())
+        _raises_guard(module.parse, io.StringIO(_billion_laughs()))
+        # Benign still parses on the fallback.
+        assert module.fromstring("<d><e>Bob</e></d>").find("e").text == "Bob"
+    finally:
+        monkeypatch.undo()
+        importlib.reload(xmlsec)

--- a/nltk/test/unit/test_boxer_security.py
+++ b/nltk/test/unit/test_boxer_security.py
@@ -20,7 +20,9 @@ a ``$PATH`` lookup) keeps working.
 
 import os
 import shutil
+import subprocess
 import tempfile
+from types import SimpleNamespace
 
 import pytest
 
@@ -93,6 +95,37 @@ def test_absolute_bin_dir_is_accepted(tmp_path, monkeypatch):
     assert os.path.realpath(boxer._candc_bin) == os.path.realpath(
         os.path.join(abs_dir, "candc")
     )
+
+
+def test_boxer_call_uses_argv_list_never_shell(monkeypatch, tmp_path):
+    """``Boxer._call`` builds ``[binary] + args`` and spawns with an argv list and
+    NO shell, so a metacharacter argument reaches the process as a single literal
+    element, never a shell token. The candc/boxer binaries need not exist: Popen
+    is trapped and its argv inspected."""
+    binary = str(tmp_path / "candc")
+    hostile_args = ["--models", "; touch /tmp/pwned", "$(id)", "a\nb"]
+    captured = {}
+
+    class _FakeProc:
+        returncode = 0
+
+        def communicate(self, *a, **k):
+            return b"", b""
+
+    def _fake_popen(cmd, *a, **k):
+        captured["argv"] = list(cmd)
+        captured["shell"] = k.get("shell", False)
+        return _FakeProc()
+
+    monkeypatch.setattr(subprocess, "Popen", _fake_popen)
+
+    boxer = Boxer.__new__(Boxer)
+    boxer._call("some stdin input", binary, args=hostile_args)
+
+    assert captured["shell"] is False
+    assert captured["argv"][0] == binary
+    for tok in hostile_args:
+        assert tok in captured["argv"]  # literal, not shell-interpreted
 
 
 def test_boxer_scratch_file_staged_in_data_root(monkeypatch):

--- a/nltk/test/unit/test_redos.py
+++ b/nltk/test/unit/test_redos.py
@@ -130,6 +130,66 @@ class TestRedosModule:
         assert redos.compile(r"\w+").search("hello", timeout=None).group() == "hello"
 
 
+# Extra identical/overlapping-branch shapes (with the specific bait that drives
+# each one's backtracking). These broaden BACKSTOP_FAMILY: every one MUST hit the
+# wall-clock cap, so a removed timeout surfaces as a failed ``raises`` here.
+EXTRA_BACKSTOP = [
+    (r"(a|a|a|a)*$", "a" * 80 + "!"),
+    (r"(aa|aa)*$", "a" * 80 + "!"),
+    (r"(ab|ab)*$", "ab" * 40 + "!"),
+    (r"(a|a)+b", "a" * 80),
+    (r"(a|a){10,}$", "a" * 80 + "!"),
+    (r"(\d|\d)*$", "1" * 80 + "!"),
+]
+
+# Nested-quantifier / backreference / lookahead shapes the ``regex`` optimiser
+# linearises: these must finish FAST and must NOT raise.
+EXTRA_DEFUSED = [
+    r"(a?){30}a{30}",
+    r"^(([a-z])+.)+[A-Z]([a-z])+$",
+    r"(a+)+\1$",
+    r"(?=(a+))\1a",
+    r"(a|a|b)*$",
+]
+
+
+class TestExpandedBackstopFamily:
+    @pytest.mark.parametrize("pattern,bait", EXTRA_BACKSTOP)
+    def test_extra_identical_branch_patterns_fire_timeout(self, pattern, bait):
+        # Only the wall-clock cap stops these, so each must raise TimeoutError.
+        with pytest.raises(TimeoutError):
+            redos.compile(pattern).search(bait, timeout=0.4)
+
+    @pytest.mark.parametrize("pattern", EXTRA_DEFUSED)
+    def test_extra_defused_patterns_finish_fast(self, pattern):
+        start = time.perf_counter()
+        redos.compile(pattern).search("a" * 80 + "!", timeout=0.4)
+        assert time.perf_counter() - start < 2.0
+
+    def test_innocent_pattern_bounded_only_on_hostile_input(self):
+        # The SAME anchored pattern returns instantly on a valid all-``a`` string
+        # but must be timeout-bounded once a trailing byte forces backtracking.
+        rx = redos.compile(r"(a|a)*$")
+        assert rx.search("a" * 80).group() == "a" * 80  # benign: fast, correct
+        with pytest.raises(TimeoutError):
+            rx.search("a" * 80 + "!", timeout=0.4)  # hostile input: cap fires
+
+    def test_compile_time_bombs_refused(self):
+        for bomb in (
+            "a" * (redos.MAX_PATTERN_LENGTH + 1),  # over length
+            "(" * (redos.MAX_NESTING_DEPTH + 5),  # over nesting
+            "(abc){9999999}",  # counted-repetition blow-up
+            "|".join("a%d" % i for i in range(200000)),  # huge alternation
+        ):
+            with pytest.raises(ValueError):
+                redos.compile(bomb)
+
+    def test_benign_large_input_still_processes_fast(self):
+        start = time.perf_counter()
+        assert len(redos.compile(r"\w+").findall("word " * 100000)) == 100000
+        assert time.perf_counter() - start < 3.0
+
+
 # --------------------------------------------------------------------------
 # Sink: RegexpTokenizer / regexp_tokenize / regexp_span_tokenize
 # --------------------------------------------------------------------------

--- a/nltk/test/unit/test_redos_caller_patterns.py
+++ b/nltk/test/unit/test_redos_caller_patterns.py
@@ -125,6 +125,51 @@ def test_the_bounded_modules_route_through_redos():
         assert "redos.compile" in source, f"{name} no longer bounds its regex"
 
 
+def test_redos_search_broad_hostile_classes_all_catchable():
+    """Broaden the three hostile classes fed to ``redos.search`` (the entry the
+    Concordance GUI uses per sentence): several shapes of each must resolve to a
+    catchable exception -- ``re.error`` (malformed), ``ValueError`` (compile-time
+    DoS refused up front), or ``TimeoutError`` (match-time backtracking) -- and
+    NONE may hang or escape uncaught, so the GUI thread never wedges."""
+    code = (
+        "import re, nltk.redos as R; R.DEFAULT_TIMEOUT = 0.4\n"
+        "from nltk import redos\n"
+        "def malformed(p):\n"
+        "    try: redos.search(p, 'x'); return False\n"
+        "    except re.error: return True\n"
+        "def compbomb(p):\n"
+        "    try: redos.search(p, 'x'); return False\n"
+        "    except ValueError: return True\n"
+        "def backtrack(p, s):\n"
+        "    try: redos.search(p, s); return False\n"
+        "    except TimeoutError: return True\n"
+        "assert malformed('('), 'unbalanced ('\n"
+        "assert malformed('(?P<>x)'), 'empty group name'\n"
+        "assert malformed('a{2,1}'), 'bad range'\n"
+        "assert compbomb('(a){999999}'), 'counted bomb'\n"
+        "assert compbomb('(a{500}){500}{500}'), 'nested count bomb'\n"
+        "assert compbomb('a' * (R.MAX_PATTERN_LENGTH + 1)), 'over length'\n"
+        "assert backtrack(r'(a|a)*$', 'a'*70+'!'), 'identical-branch'\n"
+        "assert backtrack(r'(aa|aa)*$', 'a'*70+'!'), 'two-char branch'\n"
+        "assert backtrack(r'(.*a){25}z', 'a'*400), 'dotstar count'\n"
+        "print('OK')\n"
+    )
+    proc = _run(code)
+    assert proc.returncode == 0 and "OK" in proc.stdout, proc.stderr
+
+
+def test_redos_search_benign_large_input_is_correct_and_fast():
+    """The over-block control for ``redos.search``: an ordinary pattern over a
+    large benign input still returns the right match and does not hang."""
+    code = (
+        "from nltk import redos\n"
+        "m = redos.search(r'needle', 'hay ' * 100000 + 'needle')\n"
+        "print('FOUND' if m and m.group() == 'needle' else 'MISS')\n"
+    )
+    proc = _run(code)
+    assert proc.returncode == 0 and "FOUND" in proc.stdout, proc.stderr
+
+
 def test_concordance_query_all_hostile_classes_are_catchable():
     """The Concordance GUI compiles the USER's query per sentence via
     redos.search. Each hostile query class must raise a catchable exception

--- a/nltk/test/unit/test_redos_chokepoint_safety.py
+++ b/nltk/test/unit/test_redos_chokepoint_safety.py
@@ -283,3 +283,61 @@ class TestTimeoutIsTheGuarantee:
 
     def test_bytes_pattern_works(self):
         assert redos.compile(rb"\d+").findall(b"a1b22") == [b"1", b"22"]
+
+    @pytest.mark.parametrize(
+        "pattern,bait",
+        [
+            (r"(a|a)*$", "a" * 80 + "!"),
+            (r"(a|a|a|a)*$", "a" * 80 + "!"),
+            (r"(aa|aa)*$", "a" * 80 + "!"),
+            (r"([ab]|[ab])*$", "a" * 80 + "!"),
+            (r"(a|a)+b", "a" * 80),
+            (r"(a|a){10,}$", "a" * 80 + "!"),
+            (
+                r"(\d|\d)*$",
+                "1" * 80 + "!",
+            ),  # digit bait, not 'a', or it can't backtrack
+        ],
+    )
+    def test_identical_branch_alternations_fire_the_timeout(self, pattern, bait):
+        # The alternation-of-identical-branches family the ``regex`` optimiser
+        # cannot linearise: only the wall-clock cap stops the exponential
+        # backtracking, so every one MUST raise TimeoutError (not merely "finish
+        # eventually"). A short per-call timeout keeps the assertion fast; each
+        # bait is chosen so the pattern actually has something to backtrack over.
+        tp = redos.compile(pattern)
+        with pytest.raises(TimeoutError):
+            tp.search(bait, timeout=0.4)
+
+
+# ==========================================================================
+# every module-level helper puts a caller pattern through BOTH guards
+# ==========================================================================
+
+
+class TestHelpersRouteThroughGuards:
+    # A compile-time bomb must be refused, and a match-time bomb wall-clock
+    # bounded, through EACH re-compatible helper (not just ``search``/``match``),
+    # since any of them can be the inline entry point a caller reaches for.
+    @pytest.mark.parametrize(
+        "call",
+        [
+            lambda: redos.match("(x){999999}", "x"),
+            lambda: redos.fullmatch("(x){999999}", "x"),
+            lambda: redos.search("(x){999999}", "x"),
+            lambda: redos.findall("(x){999999}", "x"),
+            lambda: list(redos.finditer("(x){999999}", "x")),
+            lambda: redos.split("(x){999999}", "x"),
+            lambda: redos.sub("(x){999999}", "y", "x"),
+            lambda: redos.subn("(x){999999}", "y", "x"),
+        ],
+    )
+    def test_helper_refuses_compile_bomb(self, call):
+        with pytest.raises(ValueError):
+            call()
+
+    def test_helper_bounds_match_bomb(self):
+        # The identical-branch bomb is not linearised, so the helper's match-time
+        # timeout is what stops it; a short call bound keeps this quick.
+        with pytest.raises(TimeoutError):
+            redos.compile(r"(a|a)*$").search("a" * 80 + "!", timeout=0.4)

--- a/nltk/test/unit/test_redos_compile_dos.py
+++ b/nltk/test/unit/test_redos_compile_dos.py
@@ -86,6 +86,24 @@ def test_counted_repetition_expansion_refused(pattern):
 @pytest.mark.parametrize(
     "pattern",
     [
+        "(?:abc){40000}",  # non-capturing group body still counts
+        "(?P<g>ab){60000}",  # named group body (introducer excluded, body counted)
+        "(?=x)(?:aaa){50000}",  # zero-width lookahead + real bomb body
+        "(?:(?:ab){400}){400}",  # nested non-capturing counts multiply
+        "[abc]{200000}",  # a character class is one atom, counted x200000
+        "a{0}{999999}",  # a{0} is 0 copies, but the trailing {999999} on the group
+        "(a{300}){400}",  # 300 * 400 = 120000 over the limit
+        "x{99999}y{99999}z{99999}",  # sum across sequential counts exceeds the cap
+    ],
+)
+def test_more_counted_repetition_bombs_refused(pattern):
+    with pytest.raises(ValueError):
+        redos.compile(pattern)
+
+
+@pytest.mark.parametrize(
+    "pattern",
+    [
         "(a){0,1000000}",  # range from 0 does NOT expand -> must be allowed
         "(abc){0,1000000}",
         "[a-z]{0,1000000}",

--- a/nltk/test/unit/test_redos_rehardening.py
+++ b/nltk/test/unit/test_redos_rehardening.py
@@ -77,3 +77,43 @@ def test_reharden_preserves_matching_behaviour():
 def test_reharden_sourceless_raises():
     with pytest.raises(ValueError):
         redos.reharden(object())
+
+
+def test_source_of_bytearray_is_decoded():
+    # A pattern object whose ``.pattern`` is a bytearray (not just bytes) must
+    # still decode to its string source, exercising that branch of source_of.
+    class _P:
+        pattern = bytearray(b"cd+")
+
+    assert redos.source_of(_P()) == "cd+"
+
+
+def test_reharden_bytes_source_is_capped():
+    tp = redos.reharden(regex.compile(rb"\d+"))
+    assert isinstance(tp, TimedPattern)
+    assert tp.findall("a1b22") == ["1", "22"]
+
+
+def test_reharden_preserves_flags():
+    # Re-deriving from source must still honour explicitly passed flags.
+    tp = redos.reharden("abc", re.I)
+    assert tp.match("ABC") is not None
+
+
+def test_reharden_refuses_compile_bomb_in_source():
+    # A counted-repetition bomb planted in a reconstructed pattern's SOURCE is
+    # refused by reharden (which routes through compile -> check_pattern), so a
+    # disabled cap cannot be paired with an unbounded compile.
+    hostile = TimedPattern(regex.compile("a"), timeout=None)
+    hostile._rx = regex.compile("(abcdefghij){9999999}")
+    with pytest.raises(ValueError):
+        redos.reharden(hostile)
+
+
+def test_reharden_result_is_actually_capped_at_match_time():
+    # The whole point: reharden strips a disabled cap, so a catastrophic pattern
+    # rebuilt through it is bounded again by the wall-clock timeout.
+    hostile = TimedPattern(regex.compile(CATASTROPHIC), timeout=None)
+    fresh = redos.reharden(hostile)
+    with pytest.raises(TimeoutError):
+        fresh.search("a" * 80 + "!", timeout=0.4)

--- a/nltk/test/unit/test_stem_regexp_redos.py
+++ b/nltk/test/unit/test_stem_regexp_redos.py
@@ -116,3 +116,52 @@ def test_precompiled_pattern_is_wrapped_as_timedpattern():
 
     assert isinstance(RegexpStemmer(re.compile(r"(a|a)*z"))._regexp, TimedPattern)
     assert isinstance(RegexpStemmer(r"(a|a)*z")._regexp, TimedPattern)
+
+
+@pytest.fixture
+def fast_default_timeout(monkeypatch):
+    # Shorten the shared cap so the in-process hostile cases resolve quickly; the
+    # monkeypatch is reverted after the test, so no module state leaks.
+    from nltk import redos
+
+    monkeypatch.setattr(redos, "DEFAULT_TIMEOUT", 0.4)
+
+
+@pytest.mark.parametrize(
+    "pattern,text",
+    [
+        (r"(a|a)*$", "a" * 80 + "!"),  # identical-branch alternation
+        (r"(a|a)+b", "a" * 80),  # ``+`` variant
+        (r"(.*a){25}z", "a" * 300),  # ``.*``-driven counted group
+    ],
+)
+def test_hostile_pattern_over_single_long_token_is_bounded(
+    pattern, text, fast_default_timeout
+):
+    # The stemmer applies its caller regex with ``.sub`` over the (single) token;
+    # a hostile pattern against a long token must be wall-clock bounded, never
+    # hang. Completing fast (engine collapse) or raising TimeoutError are both
+    # bounded; a genuine hang would wedge here and the in-process short cap makes
+    # the TimeoutError branch quick.
+    import time
+
+    from nltk.stem.regexp import RegexpStemmer
+
+    start = time.perf_counter()
+    try:
+        RegexpStemmer(pattern).stem(text)
+    except TimeoutError:
+        pass
+    assert time.perf_counter() - start < 2.0
+
+
+def test_benign_large_token_still_stems_fast():
+    import time
+
+    from nltk.stem.regexp import RegexpStemmer
+
+    stemmer = RegexpStemmer(r"ing$", min=4)
+    start = time.perf_counter()
+    # A long benign token: the suffix strip is linear and correct.
+    assert stemmer.stem("a" * 100000 + "ing") == "a" * 100000
+    assert time.perf_counter() - start < 2.0

--- a/nltk/test/unit/test_valuation_redos.py
+++ b/nltk/test/unit/test_valuation_redos.py
@@ -66,3 +66,52 @@ def test_long_separator_run_parses_in_linear_time():
             "valuation parsing did not finish in time -> quadratic ReDoS (CWE-1333)"
         )
     assert proc.exitcode == 0, f"worker failed (exit code {proc.exitcode})"
+
+
+# Many separate long '=' runs across many lines: the per-line split must stay
+# linear on each, so the whole document is linear (not quadratic per line * lines).
+_EVIL_MULTILINE = "\n".join("s%d %s" % (i, "=" * 20_000) for i in range(200))
+
+
+def _parse_multiline_worker():
+    try:
+        read_valuation(_EVIL_MULTILINE)
+    except Exception:
+        pass
+    os._exit(0)
+
+
+def test_many_separator_runs_parse_in_linear_time():
+    """Many hostile '=' runs (one per line) must all stay linear."""
+    ctx = _mp_ctx()
+    proc = ctx.Process(target=_parse_multiline_worker)
+    proc.start()
+    proc.join(_TIMEOUT)
+    if proc.is_alive():
+        proc.terminate()
+        proc.join()
+        raise AssertionError(
+            "multi-line valuation parsing did not finish in time -> quadratic ReDoS"
+        )
+    assert proc.exitcode == 0, f"worker failed (exit code {proc.exitcode})"
+
+
+def test_valuation_split_routes_through_redos():
+    """Pin the mechanism: the valuation separator split uses the bounded
+    ``redos.compile`` pattern (not a raw ``re``), and the ``(?<!=)`` lookbehind
+    that makes the greedy ``=+`` run fail fast is still present."""
+    import inspect
+
+    import nltk.sem.evaluate
+
+    source = inspect.getsource(nltk.sem.evaluate)
+    assert "redos.compile" in source, "valuation no longer routes through redos"
+    assert "(?<!=)=+>" in source, "the fail-fast lookbehind was removed"
+
+
+def test_valuation_various_separators_preserved():
+    """The bounded split must not change parsing of legitimate separators."""
+    val = Valuation.fromstring("a => x\nb ===> y\nc => {(p, q)}")
+    assert val["a"] == "x"
+    assert val["b"] == "y"
+    assert sorted(val["c"]) == [("p", "q")]


### PR DESCRIPTION
## What

Adds and expands **security / ReDoS attack-test coverage**: 15 test files (5 new, 10 expanded) that exercise hardening already present on `develop`. **No source changes** — this is a test-only PR.

New:
- `test_attack_pickle_candidates_expanded.py` — pickle / deserialization RCE candidates (`nltk.picklesec`)
- `test_attack_redos_candidates_expanded.py` — ReDoS candidate patterns across chunk/featstruct/evaluate/stemmer/tagger/tokenizer, bounded by `nltk.redos` limits
- `test_attack_sqli_chat80_expanded.py` — SQL-injection-style relation-name handling in `nltk.sem.chat80`
- `test_attack_tool_injection_candidates_expanded.py` — external-tool / argument-injection candidates (`internals`, `pathsec`, `data`)
- `test_attack_xmlsec_candidates_expanded.py` — XML security candidates (`nltk.xmlsec`: XXE / entity expansion)

Expanded (additional cases only):
- `test_attack_deser_rce_expanded.py`, `test_attack_dos_expanded.py`, `test_boxer_security.py`,
  `test_redos.py`, `test_redos_caller_patterns.py`, `test_redos_chokepoint_safety.py`,
  `test_redos_compile_dos.py`, `test_redos_rehardening.py`, `test_stem_regexp_redos.py`,
  `test_valuation_redos.py`

## Why

These tighten regression coverage for the security and ReDoS hardening already merged on `develop` (the `nltk.redos` regex chokepoint, `picklesec` / `xmlsec` deserialization guards, `pathsec`, the `RegexpStemmer` / `RegexpTagger` / `RegexpTokenizer` anchoring, chat80 relation handling, and the boxer / external-tool paths). Every case pins a concrete attack string against the existing guard so a future regression is caught.

## Testing

All 15 files pass on the current `develop` with no source changes (the hardening they assert is already present). `black` / `isort` clean.

## Not included

Three sibling test files that depend on **unmerged** source were intentionally left out of this test-only PR, to be shipped with their source:
- `test_data_no_protocol_traversal.py` and the no-protocol cases in `test_regex_injection.py` (need the `nltk/data.py` guard — already in #3853)
- `test_attack_wordnet_xss_csrf_expanded.py` (needs the `nltk/app/wordnet_app.py` XSS-escaping fix)
