### PR TITLE
Harden and standardize NLTK's external-tool wrappers on a pathsec trusted-spawn API (CWE-426/427/732/93/88)

### DIFF
--- a/EXTERNAL_TOOL_SECURITY.md
+++ b/EXTERNAL_TOOL_SECURITY.md
@@ -23,7 +23,7 @@ tools).
 | 3 | **No shell, absolute exec** | The command being re-interpreted by a shell | 78/88 | `pathsec.spawn_trusted` (`Popen([real, *args], executable=real)`, refuses `shell=True`) |
 | 4 | **Scrub the environment** | `LD_PRELOAD`/`DYLD_*`/`PYTHONPATH`/`GCONV_PATH`/… hijacking the child; a poisoned or empty `PATH` (empty is searched as the CWD) | 88/426 | `pathsec.safe_env` (deny-by-default whitelist; `PATH` locked to a no-command sentinel) |
 | 5 | **Bound the arguments** | An attacker-controlled value injected as a `-option` or an out-of-sandbox file path | 88/22 | `pathsec.validate_tool_path`, `pathsec.validate_model_resource`; a per-tool allowlist for option tokens (e.g. Senna's `SUPPORTED_OPERATIONS`) |
-| 6 | **Sanitize line-oriented I/O** | A CR/LF smuggling an extra input line into a line-oriented protocol | 93 | reject `\n`/`\r` in tokens fed to the tool (see Senna, REPP) |
+| 6 | **Sanitize line-oriented I/O** | Any control character (not just CR/LF) smuggling an extra field or input line into a line/field-delimited protocol | 93 | reject control characters in tokens fed to the tool, and require numeric fields be numeric (see Senna, REPP, MEGAM/TADM) |
 | 7 | **Control the CWD** | A tool that loads a plugin/config from `.` | 426 | pass a safe `cwd=` to `spawn_trusted` (only when the tool reads the CWD) |
 
 `spawn_trusted` bundles layers 1–4 (it calls `resolve_trusted_executable` and
@@ -56,13 +56,13 @@ a refusal as a clear error naming the untrusted path.
 | Wrapper | Module | Entry point | Guards | Notes |
 |---------|--------|-------------|--------|-------|
 | Senna | `classify/senna.py` | `tag_sents` | 1,2,3,4,5,6 | Reference implementation; 7 is N/A (reads only `-path` + stdin). PR #3858 |
-| REPP | `tokenize/repp.py` | `_execute` | 1,2,3,4 | Scratch input already staged via `make_staging_dir` |
-| TADM | `classify/tadm.py` | `call_tadm` | 1,2,3,4 | |
-| MEGAM | `classify/megam.py` | `call_megam` | 1,2,3,4 | Low-level escape hatch; args pass through as literal argv (5 is the caller's) |
-| Prover9 / Mace | `inference/prover9.py` | `Prover9Parent._call` + `prover9_input` | 1,2,3,4,6 | Shared `_call` covers both provers; `_assert_prover9_safe` rejects a formula that could inject list directives (CVE-2026-14709) |
+| REPP | `tokenize/repp.py` | `tokenize_sents` + `_execute` | 1,2,3,4,6 | Scratch input staged via `make_staging_dir`; `tokenize_sents` rejects a control character in a sentence (one sentence per line) |
+| TADM | `classify/tadm.py` | `call_tadm` + `write_tadm_file` | 1,2,3,4,6 | `write_tadm_file` requires each feature id/value be a finite number before the `%d` interpolation (space/newline-delimited format) |
+| MEGAM | `classify/megam.py` | `call_megam` + `write_megam_file` | 1,2,3,4,6 | Low-level escape hatch; args pass through as literal argv (5 is the caller's). `write_megam_file` requires feature ids to be non-negative ints and values/costs finite reals (space/`:`/`#`-delimited format) |
+| Prover9 / Mace | `inference/prover9.py` | `Prover9Parent._call` + `prover9_input` | 1,2,3,4,5,6 | Shared `_call` covers both provers; `_assert_prover9_safe` rejects a formula that could inject list directives (CVE-2026-14709); `_safe_seconds` bounds the `max_seconds`/`end_size` resource directive to a non-negative int (5, CWE-400) |
 | Boxer / C&C | `sem/boxer.py` | `Boxer._call` + `_call_candc` | 1,2,3,4,6 | `_call_candc` rejects a control character/quote in a discourse id or a `<META>`-leading input line; scratch write goes through `pathsec.open` |
-| Graphviz `dot` | `translate/api.py` | `AlignedSent._repr_svg_` | 1,2,3,4 | Strict policy refuses a Homebrew-`/usr/local/bin` `dot`; see trust policy |
-| HunPos | `tag/hunpos.py` | `HunposTagger.__init__` | 1,2,3,4,5 | `validate_tool_path` bounds the model argument (5); `spawn_trusted` adds 2,3,4 |
+| Graphviz `dot` | `translate/api.py` | `AlignedSent._repr_svg_` | 1,2,3,4 | Strict policy refuses a Homebrew-`/usr/local/bin` `dot`; see trust policy. DOT node labels are display-only (renderer, not interpreter) and operate on the caller's own data |
+| HunPos | `tag/hunpos.py` | `HunposTagger.__init__` + `tag` | 1,2,3,4,5,6 | `validate_tool_path` bounds the model argument (5); `spawn_trusted` adds 2,3,4; `tag` rejects a control character in a token (one token per line) |
 | Stanford / Malt / CoreNLP / Weka | `parse/*`, `tag/stanford.py`, `classify/weka.py` | via `internals.java` | 1,3,4,5 | JVM tools: `find_binary` locates `java`, `_java_child_env` scrubs the environment, `validate_model_resource`/`validate_tool_path` bound the jar/model. Exec-trust (2) of the `java` binary itself is not yet routed through `resolve_trusted_executable` |
 
 Layer 1 (`find_binary_iter`'s CWD-relative refusal) already applies uniformly to
@@ -90,8 +90,10 @@ Then add the wrapper-specific guards:
 - **Layer 5** — bound any caller-controlled option to an allowlist (see Senna's
   `SUPPORTED_OPERATIONS` check) and bound file-path arguments with
   `validate_tool_path` / `validate_model_resource`.
-- **Layer 6** — if the tool consumes a line-oriented stream, reject `\n`/`\r`
-  in the tokens.
+- **Layer 6** — if the tool consumes a line/field-delimited stream, reject any
+  control character (not just `\n`/`\r`) in the tokens, and if a field is meant
+  to be numeric (a feature id/value, a resource bound), validate it is numeric
+  before interpolating rather than trusting the encoding to produce one.
 - **Layer 7** — pass `cwd=` a trusted directory only if the tool loads anything
   from the current directory.
 

--- a/EXTERNAL_TOOL_SECURITY.md
+++ b/EXTERNAL_TOOL_SECURITY.md
@@ -1,0 +1,107 @@
+# Securing NLTK's external-tool wrappers
+
+Several NLTK modules shell out to a third-party executable (a native binary or a
+JVM tool). Running an external program from a library is a well-known source of
+vulnerabilities — untrusted search paths (CWE-426/427), loader injection
+(CWE-88/426), and argument/CRLF injection (CWE-88/93). This document describes
+the **layered guards** every such wrapper should apply and the **shared
+primitives** in `nltk.pathsec` / `nltk.internals` that implement them, so a new
+wrapper can be hardened by composition rather than re-inventing the checks.
+
+The design principle is: **treat "run an external tool" as a single
+security-critical primitive that is owned and audited once, not a
+`subprocess.Popen` call sprinkled across the codebase.** The chokepoints are
+`nltk.pathsec.spawn_trusted` (native binaries) and `nltk.internals.java` (JVM
+tools).
+
+## The seven layers
+
+| # | Layer | What it stops | CWE | Primitive |
+|---|-------|---------------|-----|-----------|
+| 1 | **Resolve, don't search untrusted** | A planted `./tool` (CWD) or a `PATH`/relative match run in place of the real binary | 426/427 | `nltk.internals.find_binary_iter` (refuses CWD-relative matches; requires a trusted absolute location) |
+| 2 | **Unswappable binary** | Another local user swapping the binary because it, or an ancestor directory, is group/world-writable | 426/732 | `pathsec.resolve_trusted_executable` (walks every directory from `/` to the target, following symlink hops; each must be owned by us/root and not group/world-writable) |
+| 3 | **No shell, absolute exec** | The command being re-interpreted by a shell | 78/88 | `pathsec.spawn_trusted` (`Popen([real, *args], executable=real)`, refuses `shell=True`) |
+| 4 | **Scrub the environment** | `LD_PRELOAD`/`DYLD_*`/`PYTHONPATH`/`GCONV_PATH`/… hijacking the child; a poisoned or empty `PATH` (empty is searched as the CWD) | 88/426 | `pathsec.safe_env` (deny-by-default whitelist; `PATH` locked to a no-command sentinel) |
+| 5 | **Bound the arguments** | An attacker-controlled value injected as a `-option` or an out-of-sandbox file path | 88/22 | `pathsec.validate_tool_path`, `pathsec.validate_model_resource`; a per-tool allowlist for option tokens (e.g. Senna's `SUPPORTED_OPERATIONS`) |
+| 6 | **Sanitize line-oriented I/O** | A CR/LF smuggling an extra input line into a line-oriented protocol | 93 | reject `\n`/`\r` in tokens fed to the tool (see Senna, REPP) |
+| 7 | **Control the CWD** | A tool that loads a plugin/config from `.` | 426 | pass a safe `cwd=` to `spawn_trusted` (only when the tool reads the CWD) |
+
+`spawn_trusted` bundles layers 1–4 (it calls `resolve_trusted_executable` and
+`safe_env` for you); the wrapper supplies layers 5–7 for its own arguments and
+I/O.
+
+## Trust policy: strict everywhere
+
+`spawn_trusted` **refuses** (raises `TrustError`) any binary whose path is not
+owned by us/root on a non-writable chain, and **fails closed on Windows** (POSIX
+mode bits do not describe who can write a Windows path, and NLTK does not assume
+`win32security`).
+
+Operator consequence: a tool installed in a **group/world-writable directory is
+refused**. Notably this includes Homebrew's `/usr/local/bin` (`drwxrwxr-x`) and
+many `pipx`/`~/tools` locations. Install external tools where **only you or root
+can write** (e.g. `/usr/local/bin` owned `root:wheel 0755`, `/opt/<tool>`, or a
+`0700` directory under your home), or point the wrapper's environment variable
+(`SENNA`, `MEGAM`, `HUNPOS_TAGGER`, …) at such a location. Each wrapper surfaces
+a refusal as a clear error naming the untrusted path.
+
+## Per-wrapper status
+
+| Wrapper | Module | Entry point | Guards | Notes |
+|---------|--------|-------------|--------|-------|
+| Senna | `classify/senna.py` | `tag_sents` | 1,2,3,4,5,6 | Reference implementation; 7 is N/A (reads only `-path` + stdin). PR #3858 |
+| REPP | `tokenize/repp.py` | `_execute` | 1,2,3,4 | Scratch input already staged via `make_staging_dir` |
+| TADM | `classify/tadm.py` | `call_tadm` | 1,2,3,4 | |
+| MEGAM | `classify/megam.py` | `call_megam` | 1,2,3,4 | Low-level escape hatch; args pass through as literal argv (5 is the caller's) |
+| Prover9 / Mace | `inference/prover9.py` | `Prover9Parent._call` | 1,2,3,4 | Shared `_call` covers both provers |
+| Boxer / C&C | `sem/boxer.py` | `Boxer._call` | 1,2,3,4 | |
+| Graphviz `dot` | `translate/api.py` | `AlignedSent._repr_svg_` | 1,2,3,4 | Strict policy refuses a Homebrew-`/usr/local/bin` `dot`; see trust policy |
+| HunPos | `tag/hunpos.py` | `HunposTagger.__init__` | 1,3,5 | **Partial** — has `validate_tool_path` (5) + no-shell (3); routing through `spawn_trusted` (2,4) is deferred pending a rework of its shared guard-test framework |
+| Stanford / Malt / CoreNLP / Weka | `parse/*`, `tag/stanford.py`, `classify/weka.py` | via `internals.java` | 1,3,4,5 | JVM tools: `find_binary` locates `java`, `_java_child_env` scrubs the environment, `validate_model_resource`/`validate_tool_path` bound the jar/model. Exec-trust (2) of the `java` binary itself is not yet routed through `resolve_trusted_executable` |
+
+Layer 1 (`find_binary_iter`'s CWD-relative refusal) already applies uniformly to
+**every** wrapper above, independent of the exec chokepoint.
+
+## Standardizing a new native-binary wrapper
+
+Replace a bare `subprocess.Popen(cmd, **kw)` where `cmd = [binary] + args`:
+
+```python
+from nltk.pathsec import TrustError, spawn_trusted
+
+try:
+    p = spawn_trusted(cmd[0], cmd[1:], **kw)   # layers 1-4
+except TrustError as e:
+    raise LookupError(
+        f"Refusing to run {cmd[0]!r}: it is not on a trusted path. Install it "
+        f"where only you (or root) can write ({e})."
+    ) from e
+stdout, stderr = p.communicate(...)
+```
+
+Then add the wrapper-specific guards:
+
+- **Layer 5** — bound any caller-controlled option to an allowlist (see Senna's
+  `SUPPORTED_OPERATIONS` check) and bound file-path arguments with
+  `validate_tool_path` / `validate_model_resource`.
+- **Layer 6** — if the tool consumes a line-oriented stream, reject `\n`/`\r`
+  in the tokens.
+- **Layer 7** — pass `cwd=` a trusted directory only if the tool loads anything
+  from the current directory.
+
+### Testing (real, not mocked)
+
+Mirror the pattern in `test_repp_security.py` / `test_tadm_security.py`:
+
+1. **Refusal test** — build the binary in a **world-writable** directory and
+   assert the wrapper raises before running (real `chmod`, no mock).
+2. **Trusted control** — stage the binary under a **private data root** with
+   `nltk.data.make_staging_dir(cleanup=True)` (never `/tmp`, which the strict
+   resolver refuses) and assert the spawn is reached with a resolved, absolute
+   `argv[0]` and no shell.
+
+Because the check runs *before* `Popen`, a test that builds its binary in
+`tmp_path` (which is `/tmp` on Linux) will be refused; stage under
+`make_staging_dir` instead. When spying on the spawn, patch the shared
+`subprocess.Popen` (which `pathsec` uses), not `<wrapper>.Popen` — the wrapper no
+longer imports `Popen` directly.

--- a/EXTERNAL_TOOL_SECURITY.md
+++ b/EXTERNAL_TOOL_SECURITY.md
@@ -32,10 +32,16 @@ I/O.
 
 ## Trust policy: strict everywhere
 
-`spawn_trusted` **refuses** (raises `TrustError`) any binary whose path is not
-owned by us/root on a non-writable chain, and **fails closed on Windows** (POSIX
-mode bits do not describe who can write a Windows path, and NLTK does not assume
-`win32security`).
+On POSIX, `spawn_trusted` **refuses** (raises `TrustError`) any binary whose path
+is not owned by us/root on a non-writable chain.
+
+On Windows the ownership check (layer 2) cannot run — POSIX mode bits do not
+describe who can write a Windows path, and NLTK does not assume `win32security`
+for a DACL check — so it degrades to **best effort** (a regular file at the
+resolved absolute path is accepted), relying on the other layers: `find_binary`
+refuses a CWD-relative match (the main Windows vector, cf. GitPython
+CVE-2023-40590), and `spawn_trusted` still refuses a shell and scrubs the
+environment. It does **not** fail closed, so Windows wrappers keep working.
 
 Operator consequence: a tool installed in a **group/world-writable directory is
 refused**. Notably this includes Homebrew's `/usr/local/bin` (`drwxrwxr-x`) and

--- a/EXTERNAL_TOOL_SECURITY.md
+++ b/EXTERNAL_TOOL_SECURITY.md
@@ -56,7 +56,7 @@ a refusal as a clear error naming the untrusted path.
 | Prover9 / Mace | `inference/prover9.py` | `Prover9Parent._call` | 1,2,3,4 | Shared `_call` covers both provers |
 | Boxer / C&C | `sem/boxer.py` | `Boxer._call` | 1,2,3,4 | |
 | Graphviz `dot` | `translate/api.py` | `AlignedSent._repr_svg_` | 1,2,3,4 | Strict policy refuses a Homebrew-`/usr/local/bin` `dot`; see trust policy |
-| HunPos | `tag/hunpos.py` | `HunposTagger.__init__` | 1,3,5 | **Partial** — has `validate_tool_path` (5) + no-shell (3); routing through `spawn_trusted` (2,4) is deferred pending a rework of its shared guard-test framework |
+| HunPos | `tag/hunpos.py` | `HunposTagger.__init__` | 1,2,3,4,5 | `validate_tool_path` bounds the model argument (5); `spawn_trusted` adds 2,3,4 |
 | Stanford / Malt / CoreNLP / Weka | `parse/*`, `tag/stanford.py`, `classify/weka.py` | via `internals.java` | 1,3,4,5 | JVM tools: `find_binary` locates `java`, `_java_child_env` scrubs the environment, `validate_model_resource`/`validate_tool_path` bound the jar/model. Exec-trust (2) of the `java` binary itself is not yet routed through `resolve_trusted_executable` |
 
 Layer 1 (`find_binary_iter`'s CWD-relative refusal) already applies uniformly to

--- a/EXTERNAL_TOOL_SECURITY.md
+++ b/EXTERNAL_TOOL_SECURITY.md
@@ -59,8 +59,8 @@ a refusal as a clear error naming the untrusted path.
 | REPP | `tokenize/repp.py` | `_execute` | 1,2,3,4 | Scratch input already staged via `make_staging_dir` |
 | TADM | `classify/tadm.py` | `call_tadm` | 1,2,3,4 | |
 | MEGAM | `classify/megam.py` | `call_megam` | 1,2,3,4 | Low-level escape hatch; args pass through as literal argv (5 is the caller's) |
-| Prover9 / Mace | `inference/prover9.py` | `Prover9Parent._call` | 1,2,3,4 | Shared `_call` covers both provers |
-| Boxer / C&C | `sem/boxer.py` | `Boxer._call` | 1,2,3,4 | |
+| Prover9 / Mace | `inference/prover9.py` | `Prover9Parent._call` + `prover9_input` | 1,2,3,4,6 | Shared `_call` covers both provers; `_assert_prover9_safe` rejects a formula that could inject list directives (CVE-2026-14709) |
+| Boxer / C&C | `sem/boxer.py` | `Boxer._call` + `_call_candc` | 1,2,3,4,6 | `_call_candc` rejects a control character/quote in a discourse id or a `<META>`-leading input line; scratch write goes through `pathsec.open` |
 | Graphviz `dot` | `translate/api.py` | `AlignedSent._repr_svg_` | 1,2,3,4 | Strict policy refuses a Homebrew-`/usr/local/bin` `dot`; see trust policy |
 | HunPos | `tag/hunpos.py` | `HunposTagger.__init__` | 1,2,3,4,5 | `validate_tool_path` bounds the model argument (5); `spawn_trusted` adds 2,3,4 |
 | Stanford / Malt / CoreNLP / Weka | `parse/*`, `tag/stanford.py`, `classify/weka.py` | via `internals.java` | 1,3,4,5 | JVM tools: `find_binary` locates `java`, `_java_child_env` scrubs the environment, `validate_model_resource`/`validate_tool_path` bound the jar/model. Exec-trust (2) of the `java` binary itself is not yet routed through `resolve_trusted_executable` |

--- a/nltk/classify/megam.py
+++ b/nltk/classify/megam.py
@@ -25,6 +25,7 @@ for details.
 import subprocess
 
 from nltk.internals import find_binary
+from nltk.pathsec import TrustError, spawn_trusted
 
 try:
     import numpy
@@ -167,9 +168,17 @@ def call_megam(args):
     if _megam_bin is None:
         config_megam()
 
-    # Call megam via a subprocess
+    # Route through the trusted-exec chokepoint: verify the megam binary is on a
+    # path no other local user can swap, refuse a shell, and scrub the loader
+    # environment before exec (CWE-426/427/732).
     cmd = [_megam_bin] + args
-    p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+    try:
+        p = spawn_trusted(cmd[0], cmd[1:], stdout=subprocess.PIPE)
+    except TrustError as e:
+        raise OSError(
+            f"Refusing to run megam at {cmd[0]!r}: it is not on a trusted path. "
+            f"Install megam where only you (or root) can write ({e})."
+        ) from e
     (stdout, stderr) = p.communicate()
 
     # Check the return code.

--- a/nltk/classify/megam.py
+++ b/nltk/classify/megam.py
@@ -22,6 +22,8 @@ for details.
 
 .. _megam: http://hal3.name/megam/
 """
+import math
+import numbers
 import subprocess
 
 from nltk.internals import find_binary
@@ -102,9 +104,11 @@ def write_megam_file(train_toks, encoding, stream, bernoulli=True, explicit=True
     for featureset, label in train_toks:
         # First, the instance number (or, in the weighted multiclass case, the cost of each label).
         if hasattr(encoding, "cost"):
-            stream.write(
-                ":".join(str(encoding.cost(featureset, label, l)) for l in labels)
-            )
+            costs = [
+                _megam_number(encoding.cost(featureset, label, l), "label cost")
+                for l in labels
+            ]
+            stream.write(":".join(str(c) for c in costs))
         else:
             stream.write("%d" % labelnum[label])
 
@@ -142,6 +146,30 @@ def parse_megam_weights(s, features_count, explicit=True):
     return weights
 
 
+def _megam_int(value, kind="feature id"):
+    # megam stdin is space delimited, one instance per line. A feature id that is
+    # not a bare non-negative integer could carry whitespace, a newline, or a
+    # ':'/'#' separator (from a hostile or buggy encoding) and split into extra
+    # fields or inject a whole new instance line (CWE-93). str() of an Integral is
+    # always separator free, so a type/range check is the guard.
+    if isinstance(value, bool) or not isinstance(value, numbers.Integral) or value < 0:
+        raise ValueError(f"MEGAM {kind} must be a non-negative integer, got {value!r}")
+    return int(value)
+
+
+def _megam_number(value, kind="feature value"):
+    # A megam feature value / per-label cost must be a finite real number for the
+    # same reason: only a numeric str() is free of the format's delimiters and
+    # cannot inject a line (CWE-93).
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, numbers.Real)
+        or not math.isfinite(value)
+    ):
+        raise ValueError(f"MEGAM {kind} must be a finite real number, got {value!r}")
+    return value
+
+
 def _write_megam_features(vector, stream, bernoulli):
     if not vector:
         raise ValueError(
@@ -150,13 +178,13 @@ def _write_megam_features(vector, stream, bernoulli):
     for fid, fval in vector:
         if bernoulli:
             if fval == 1:
-                stream.write(" %s" % fid)
+                stream.write(" %s" % _megam_int(fid))
             elif fval != 0:
                 raise ValueError(
                     "If bernoulli=True, then all" "features must be binary."
                 )
         else:
-            stream.write(f" {fid} {fval}")
+            stream.write(f" {_megam_int(fid)} {_megam_number(fval)}")
 
 
 def call_megam(args):

--- a/nltk/classify/senna.py
+++ b/nltk/classify/senna.py
@@ -39,8 +39,9 @@ Note: Unit tests for this module can be found in test/unit/test_senna.py
 
 from os import environ, path, sep
 from platform import architecture, system
-from subprocess import PIPE, Popen
+from subprocess import PIPE
 
+from nltk.pathsec import TrustError, spawn_trusted
 from nltk.tag.api import TaggerI
 
 
@@ -50,15 +51,9 @@ class Senna(TaggerI):
     def __init__(self, senna_path, operations, encoding="utf-8"):
         self._encoding = encoding
 
-        # Only accept an explicit *absolute* senna_path as the location of the
-        # senna executable. A relative path (e.g. ".") must NOT be resolved
-        # against the current working directory: executable() returns a path
-        # that contains a separator (e.g. "./senna-osx"), and subprocess.Popen()
-        # runs such a path directly from the CWD without consulting $PATH, so an
-        # attacker who can write a "senna-<platform>" file there would have it
-        # executed -- running code loaded from an untrusted location (CWE-829;
-        # an untrusted search path, CWE-426/CWE-427). A relative path falls
-        # through to the trusted SENNA environment variable instead.
+        # Only an ABSOLUTE senna_path is accepted; a relative one (e.g. ".") would
+        # make executable() a separator path Popen runs from the CWD without $PATH,
+        # executing a planted senna-<platform> file (CWE-426/CWE-427). Else use SENNA.
         self._path = None
         if path.isabs(senna_path):
             self._path = path.normpath(senna_path) + sep
@@ -127,29 +122,59 @@ class Senna(TaggerI):
         """
         encoding = self._encoding
 
-        if not path.isfile(self.executable(self._path)):
+        # self._path is a plain mutable attribute; a non-absolute (or non-str)
+        # reassignment makes executable() a CWD-relative path Popen runs without
+        # $PATH, executing a planted senna-<platform> binary (CWE-426/CWE-427).
+        if not (isinstance(self._path, str) and path.isabs(self._path)):
             raise LookupError(
-                "Senna executable expected at %s but not found"
-                % self.executable(self._path)
+                "Senna path %r is not an absolute string; a relative path would be "
+                "run from the current working directory. Construct Senna(...) with an "
+                "absolute senna_path or set the SENNA environment variable."
+                % (self._path,)
             )
+        executable = self.executable(self._path)
+        if not path.isfile(executable):
+            raise LookupError(
+                "Senna executable expected at %s but not found" % executable
+            )
+        # self.operations is a plain mutable attribute turned into '-<op>' flags;
+        # an arbitrary string would be an injected senna option (e.g. '-path'
+        # redirecting the data dir), so bound it to SUPPORTED_OPERATIONS (CWE-88).
+        invalid = [op for op in self.operations if op not in self.SUPPORTED_OPERATIONS]
+        if invalid:
+            raise ValueError(
+                f"Unsupported Senna operation(s) {invalid!r}; choose from "
+                f"{self.SUPPORTED_OPERATIONS!r}."
+            )
+        # spawn_trusted() (below) verifies executable is on a trusted path, refuses
+        # a shell, and scrubs the loader environment before exec (CWE-426/427/732).
+        _args = ["-path", self._path, "-usrtokens", "-iobtags"]
+        _args.extend(["-" + op for op in self.operations])
 
-        # Build the senna command to run the tagger
-        _senna_cmd = [
-            self.executable(self._path),
-            "-path",
-            self._path,
-            "-usrtokens",
-            "-iobtags",
-        ]
-        _senna_cmd.extend(["-" + op for op in self.operations])
+        # A CR/LF in a token adds an input line and breaks the 1:1 sentence->output
+        # mapping senna relies on, smuggling a spurious sentence or corrupting the
+        # alignment (CWE-93). Reject it, as the tokenizer/repp guards do.
+        for sentence in sentences:
+            for token in sentence:
+                if "\n" in token or "\r" in token:
+                    raise ValueError(
+                        "Senna input tokens must not contain newline or carriage "
+                        "return characters (CWE-93)."
+                    )
 
         # Serialize the actual sentences to a temporary string
         _input = "\n".join(" ".join(x) for x in sentences) + "\n"
         if isinstance(_input, str) and encoding:
             _input = _input.encode(encoding)
 
-        # Run the tagger and get the output
-        p = Popen(_senna_cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+        # Run the tagger and get the output.
+        try:
+            p = spawn_trusted(executable, _args, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+        except TrustError as e:
+            raise LookupError(
+                "Senna executable %r is not on a trusted path; install senna where "
+                "only you (or root) can write. (%s)" % (executable, e)
+            ) from e
         (stdout, stderr) = p.communicate(input=_input)
         senna_output = stdout
 

--- a/nltk/classify/senna.py
+++ b/nltk/classify/senna.py
@@ -152,14 +152,14 @@ class Senna(TaggerI):
         _args.extend(["-" + op for op in self.operations])
 
         # A CR/LF in a token adds an input line and breaks the 1:1 sentence->output
-        # mapping senna relies on, smuggling a spurious sentence or corrupting the
-        # alignment (CWE-93). Reject it, as the tokenizer/repp guards do.
+        # mapping (CWE-93); a NUL truncates the token in senna's C string layer.
+        # Reject any control character, as the tokenizer/repp guards do.
         for sentence in sentences:
             for token in sentence:
-                if "\n" in token or "\r" in token:
+                if any(ord(ch) < 0x20 and ch != "\t" for ch in token):
                     raise ValueError(
-                        "Senna input tokens must not contain newline or carriage "
-                        "return characters (CWE-93)."
+                        "Senna input tokens must not contain newline, carriage "
+                        "return, NUL or other control characters (CWE-93)."
                     )
 
         # Serialize the actual sentences to a temporary string

--- a/nltk/classify/senna.py
+++ b/nltk/classify/senna.py
@@ -41,7 +41,7 @@ from os import environ, path, sep
 from platform import architecture, system
 from subprocess import PIPE
 
-from nltk.pathsec import TrustError, spawn_trusted
+from nltk.pathsec import TrustError, has_line_unsafe_char, spawn_trusted
 from nltk.tag.api import TaggerI
 
 
@@ -152,14 +152,16 @@ class Senna(TaggerI):
         _args.extend(["-" + op for op in self.operations])
 
         # A CR/LF in a token adds an input line and breaks the 1:1 sentence->output
-        # mapping (CWE-93); a NUL truncates the token in senna's C string layer.
-        # Reject any control character, as the tokenizer/repp guards do.
+        # mapping (CWE-93); a NUL truncates the token in senna's C string layer;
+        # and a TAB splits senna's own tab-separated output line (parse_output
+        # below), mis-assigning tags. Reject any control character or line/
+        # paragraph separator, matching the other tool wrappers.
         for sentence in sentences:
             for token in sentence:
-                if any(ord(ch) < 0x20 and ch != "\t" for ch in token):
+                if has_line_unsafe_char(token):
                     raise ValueError(
-                        "Senna input tokens must not contain newline, carriage "
-                        "return, NUL or other control characters (CWE-93)."
+                        "Senna input tokens must not contain control characters "
+                        "or line separators (newline, tab, NUL, DEL, ...) (CWE-93)."
                     )
 
         # Serialize the actual sentences to a temporary string

--- a/nltk/classify/tadm.py
+++ b/nltk/classify/tadm.py
@@ -5,10 +5,10 @@
 # URL: <https://www.nltk.org/>
 # For license information, see LICENSE.TXT
 
-import subprocess
 import sys
 
 from nltk.internals import find_binary
+from nltk.pathsec import TrustError, spawn_trusted
 
 try:
     import numpy
@@ -80,9 +80,17 @@ def call_tadm(args):
     if _tadm_bin is None:
         config_tadm()
 
-    # Call tadm via a subprocess
+    # Route through the trusted-exec chokepoint: verify the tadm binary is on a
+    # path no other local user can swap, refuse a shell, and scrub the loader
+    # environment before exec (CWE-426/427/732).
     cmd = [_tadm_bin] + args
-    p = subprocess.Popen(cmd, stdout=sys.stdout)
+    try:
+        p = spawn_trusted(cmd[0], cmd[1:], stdout=sys.stdout)
+    except TrustError as e:
+        raise OSError(
+            f"Refusing to run tadm at {cmd[0]!r}: it is not on a trusted path. "
+            f"Install tadm where only you (or root) can write ({e})."
+        ) from e
     (stdout, stderr) = p.communicate()
 
     # Check the return code.

--- a/nltk/classify/tadm.py
+++ b/nltk/classify/tadm.py
@@ -5,6 +5,8 @@
 # URL: <https://www.nltk.org/>
 # For license information, see LICENSE.TXT
 
+import math
+import numbers
 import sys
 
 from nltk.internals import find_binary
@@ -23,6 +25,18 @@ def config_tadm(bin=None):
     _tadm_bin = find_binary(
         "tadm", bin, env_vars=["TADM"], binary_names=["tadm"], url="http://tadm.sf.net"
     )
+
+
+def _tadm_int(value, kind):
+    # tadm's stdin is space and newline delimited. The "%d" interpolation already
+    # rejects a string feature id/value with a TypeError, but validate up front so
+    # a hostile or buggy encoding cannot inject a field or line (CWE-93) and the
+    # error is clear. Reals are truncated as "%d" would; non-finite is refused.
+    if isinstance(value, bool) or not isinstance(value, numbers.Real):
+        raise ValueError(f"TADM {kind} must be a number, got {value!r}")
+    if not math.isfinite(value):
+        raise ValueError(f"TADM {kind} must be finite, got {value!r}")
+    return int(value)
 
 
 def write_tadm_file(train_toks, encoding, stream):
@@ -51,11 +65,12 @@ def write_tadm_file(train_toks, encoding, stream):
         stream.write(length_line)
         for known_label in labels:
             v = encoding.encode(featureset, known_label)
-            line = "%d %d %s\n" % (
-                int(label == known_label),
-                len(v),
-                " ".join("%d %d" % u for u in v),
+            pairs = " ".join(
+                "%d %d"
+                % (_tadm_int(fid, "feature id"), _tadm_int(fval, "feature value"))
+                for (fid, fval) in v
             )
+            line = "%d %d %s\n" % (int(label == known_label), len(v), pairs)
             stream.write(line)
 
 

--- a/nltk/inference/mace.py
+++ b/nltk/inference/mace.py
@@ -14,7 +14,7 @@ import os
 import tempfile
 
 from nltk.inference.api import BaseModelBuilderCommand, ModelBuilder
-from nltk.inference.prover9 import Prover9CommandParent, Prover9Parent
+from nltk.inference.prover9 import Prover9CommandParent, Prover9Parent, _safe_seconds
 from nltk.sem import Expression, Valuation
 from nltk.sem.logic import is_indvar
 
@@ -258,12 +258,13 @@ class Mace(Prover9Parent, ModelBuilder):
         :return: A tuple (stdout, returncode)
         :see: ``config_prover9``
         """
+        end_size = _safe_seconds(self._end_size, name="end_size")
         if self._mace4_bin is None:
             self._mace4_bin = self._find_binary("mace4", verbose)
 
         updated_input_str = ""
-        if self._end_size > 0:
-            updated_input_str += "assign(end_size, %d).\n\n" % self._end_size
+        if end_size > 0:
+            updated_input_str += "assign(end_size, %d).\n\n" % end_size
         updated_input_str += input_str
 
         return self._call(updated_input_str, self._mace4_bin, args, verbose)

--- a/nltk/inference/prover9.py
+++ b/nltk/inference/prover9.py
@@ -14,6 +14,7 @@ import os
 import subprocess
 
 import nltk
+from nltk import redos
 from nltk.inference.api import BaseProverCommand, Prover
 from nltk.pathsec import TrustError, spawn_trusted
 from nltk.sem.logic import (
@@ -146,12 +147,12 @@ class Prover9Parent:
         if assumptions:
             s += "formulas(assumptions).\n"
             for p9_assumption in convert_to_prover9(assumptions):
-                s += "    %s.\n" % p9_assumption
+                s += "    %s.\n" % _assert_prover9_safe(p9_assumption)
             s += "end_of_list.\n\n"
 
         if goal:
             s += "formulas(goals).\n"
-            s += "    %s.\n" % convert_to_prover9(goal)
+            s += "    %s.\n" % _assert_prover9_safe(convert_to_prover9(goal))
             s += "end_of_list.\n\n"
 
         return s
@@ -230,6 +231,26 @@ class Prover9Parent:
                 print("stderr:\n", stderr, "\n")
 
         return (stdout.decode("utf-8"), p.returncode)
+
+
+# A formula emitted by _convert_to_prover9 is one Prover9 term of connectives and
+# identifier atoms: never a control character (which would split the input into
+# extra lines or embed a NUL) nor a bare period (prover9_input appends the
+# terminating period itself), and never leads with a list keyword. A crafted term
+# carrying one could close the enclosing formulas(...) list and inject directives
+# such as end_of_list. fromstring only yields identifier atoms, so this rejects
+# only maliciously hand-built Expressions (CVE-2026-14709).
+_PROVER9_INJECTION_RE = redos.compile(r"[.\x00-\x08\x0a-\x1f\x7f]")
+_PROVER9_LIST_KEYWORD_RE = redos.compile(r"^\s*(?:end_of_list|formulas|clauses)\b")
+
+
+def _assert_prover9_safe(formula):
+    if _PROVER9_INJECTION_RE.search(formula) or _PROVER9_LIST_KEYWORD_RE.match(formula):
+        raise ValueError(
+            "refusing to build Prover9 input from a formula that could inject "
+            f"list directives: {formula!r}"
+        )
+    return formula
 
 
 def convert_to_prover9(input):

--- a/nltk/inference/prover9.py
+++ b/nltk/inference/prover9.py
@@ -262,6 +262,18 @@ def _assert_prover9_safe(formula):
     return formula
 
 
+def _safe_seconds(value, name="timeout"):
+    """A Prover9/Mace resource bound (assign(max_seconds, N)) must be a
+    non-negative integer: a negative or non-integer value is undefined to the
+    binary and, without the ``%d`` coercion, could inject into the input; 0 is the
+    documented "no timeout" and is the caller's own DoS choice (CWE-400)."""
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(
+            f"Prover9/Mace {name} must be a non-negative integer, got {value!r}"
+        )
+    return value
+
+
 def convert_to_prover9(input):
     """
     Convert a ``logic.Expression`` to Prover9 format.
@@ -388,12 +400,13 @@ class Prover9(Prover9Parent, Prover):
         :return: A tuple (stdout, returncode)
         :see: ``config_prover9``
         """
+        seconds = _safe_seconds(self._timeout)
         if self._prover9_bin is None:
             self._prover9_bin = self._find_binary("prover9", verbose)
 
         updated_input_str = ""
-        if self._timeout > 0:
-            updated_input_str += "assign(max_seconds, %d).\n\n" % self._timeout
+        if seconds > 0:
+            updated_input_str += "assign(max_seconds, %d).\n\n" % seconds
         updated_input_str += input_str
 
         stdout, returncode = self._call(

--- a/nltk/inference/prover9.py
+++ b/nltk/inference/prover9.py
@@ -233,10 +233,10 @@ class Prover9Parent:
         return (stdout.decode("utf-8"), p.returncode)
 
 
-# A converted formula is one Prover9 term; it may not carry a control char or a
-# bare period, or lead with a list keyword, or it could break out of the enclosing
-# formulas(...) list (CVE-2026-14709). prover9_input appends the period itself.
-_PROVER9_INJECTION_RE = redos.compile(r"[.\x00-\x08\x0a-\x1f\x7f]")
+# A converted formula is one Prover9 term; it may not carry a control char, a bare
+# period, a '%' comment or '#' label char, or lead with a list keyword, or it could
+# break out of the enclosing formulas(...) list (CVE-2026-14709).
+_PROVER9_INJECTION_RE = redos.compile(r"[.#%\x00-\x08\x0a-\x1f\x7f]")
 _PROVER9_LIST_KEYWORD_RE = redos.compile(r"^\s*(?:end_of_list|formulas|clauses)\b")
 
 
@@ -244,10 +244,13 @@ def _assert_prover9_safe(formula):
     """Return *formula* unchanged if it is safe to interpolate into Prover9 input,
     else raise ValueError.
 
-    A term from _convert_to_prover9 is connectives and identifier atoms, so a
-    control character (which would split the input into extra lines or embed a NUL)
-    or a leading list keyword (end_of_list/formulas/clauses) could close the
-    formulas(...) list and inject directives such as ``end_of_list.``.
+    A term from _convert_to_prover9 is connectives and identifier atoms, so none of
+    these belongs in one, and each can subvert the ``    <formula>.`` line the
+    caller builds: a control character splits the input into extra lines or embeds
+    a NUL; a bare period, or a '%' that comments out the period the caller appends,
+    merges or terminates the term early; a '#' injects a Prover9 label/answer; and
+    a leading list keyword (end_of_list/formulas/clauses) closes the
+    ``formulas(...)`` list and injects directives such as ``end_of_list.``.
     Expression.fromstring only yields identifier atoms, so this rejects only
     maliciously hand-built Expressions (CVE-2026-14709).
     """

--- a/nltk/inference/prover9.py
+++ b/nltk/inference/prover9.py
@@ -15,6 +15,7 @@ import subprocess
 
 import nltk
 from nltk.inference.api import BaseProverCommand, Prover
+from nltk.pathsec import TrustError, spawn_trusted
 from nltk.sem.logic import (
     AllExpression,
     AndExpression,
@@ -198,15 +199,27 @@ class Prover9Parent:
             print("Args:", args)
             print("Input:\n", input_str, "\n")
 
-        # Call prover9 via a subprocess
+        # Route through the trusted-exec chokepoint: verify the prover9/mace binary
+        # is on a path no other local user can swap, refuse a shell, and scrub the
+        # loader environment before exec (CWE-426/427/732).
         cmd = [binary] + args
         try:
             input_str = input_str.encode("utf8")
         except AttributeError:
             pass
-        p = subprocess.Popen(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, stdin=subprocess.PIPE
-        )
+        try:
+            p = spawn_trusted(
+                cmd[0],
+                cmd[1:],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.PIPE,
+            )
+        except TrustError as e:
+            raise LookupError(
+                f"Refusing to run {cmd[0]!r}: it is not on a trusted path. Install "
+                f"Prover9/Mace where only you (or root) can write ({e})."
+            ) from e
         (stdout, stderr) = p.communicate(input=input_str)
 
         if verbose:

--- a/nltk/inference/prover9.py
+++ b/nltk/inference/prover9.py
@@ -233,18 +233,24 @@ class Prover9Parent:
         return (stdout.decode("utf-8"), p.returncode)
 
 
-# A formula emitted by _convert_to_prover9 is one Prover9 term of connectives and
-# identifier atoms: never a control character (which would split the input into
-# extra lines or embed a NUL) nor a bare period (prover9_input appends the
-# terminating period itself), and never leads with a list keyword. A crafted term
-# carrying one could close the enclosing formulas(...) list and inject directives
-# such as end_of_list. fromstring only yields identifier atoms, so this rejects
-# only maliciously hand-built Expressions (CVE-2026-14709).
+# A converted formula is one Prover9 term; it may not carry a control char or a
+# bare period, or lead with a list keyword, or it could break out of the enclosing
+# formulas(...) list (CVE-2026-14709). prover9_input appends the period itself.
 _PROVER9_INJECTION_RE = redos.compile(r"[.\x00-\x08\x0a-\x1f\x7f]")
 _PROVER9_LIST_KEYWORD_RE = redos.compile(r"^\s*(?:end_of_list|formulas|clauses)\b")
 
 
 def _assert_prover9_safe(formula):
+    """Return *formula* unchanged if it is safe to interpolate into Prover9 input,
+    else raise ValueError.
+
+    A term from _convert_to_prover9 is connectives and identifier atoms, so a
+    control character (which would split the input into extra lines or embed a NUL)
+    or a leading list keyword (end_of_list/formulas/clauses) could close the
+    formulas(...) list and inject directives such as ``end_of_list.``.
+    Expression.fromstring only yields identifier atoms, so this rejects only
+    maliciously hand-built Expressions (CVE-2026-14709).
+    """
     if _PROVER9_INJECTION_RE.search(formula) or _PROVER9_LIST_KEYWORD_RE.match(formula):
         raise ValueError(
             "refusing to build Prover9 input from a formula that could inject "

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -17,6 +17,7 @@ import os
 import re
 import socket
 import stat
+import subprocess
 import sys
 import tempfile
 import urllib.request
@@ -57,23 +58,74 @@ _WINDOWS_DEVICE_NAMES = frozenset(
 )
 
 
+_MAX_LINK_HOPS = 40  # ELOOP-style bound on symlink chains
+
+# The child PATH. A trusted binary is executed by ABSOLUTE path and needs no PATH
+# to run, so the child is handed one that resolves NOTHING: a single absolute,
+# root-domain directory containing no executables (an unprivileged user cannot
+# create a sibling of it under /). This denies bare-name command resolution, so
+# a rich /usr/bin:/bin, which would let the child reach sh/python/any tool by
+# name, is deliberately NOT granted. It is also deliberately NOT empty: POSIX
+# execvp / subprocess search an EMPTY PATH element as the current directory, so
+# "" or an unset PATH would let a planted ./tool run instead (CWE-426).
+_LOCKED_PATH = "/nonexistent"
+
+# Only these variables reach a spawn_trusted child. Anything that can redirect a
+# dynamic linker, loader or interpreter (LD_*, DYLD_*, PYTHON*, PERL5LIB, ...) is
+# deliberately absent, so a trusted binary cannot be subverted through its env.
+_ENV_KEEP = frozenset(
+    {
+        "HOME",
+        "USER",
+        "LOGNAME",
+        "SHELL",
+        "TERM",
+        "TZ",
+        "LANG",
+        "LANGUAGE",
+        "LC_ALL",
+        "LC_CTYPE",
+        "LC_COLLATE",
+        "LC_MESSAGES",
+        "LC_NUMERIC",
+        "LC_TIME",
+    }
+)
+
+
+class TrustError(OSError):
+    """Raised by :func:`spawn_trusted` when the target fails verification."""
+
+
+def _private_stat(st):
+    """POSIX: owner is the effective user or root, and no group/world write bit."""
+    if st.st_uid not in (os.geteuid(), 0):
+        return False
+    return not (st.st_mode & (stat.S_IWGRP | stat.S_IWOTH))
+
+
 def is_private_dir(path):
     """Return True if *path* is a directory safe to trust as a data root: another
     *unprivileged local user* cannot plant files in it.
 
     This is the test that distinguishes a shared, world-writable temp directory
-    (Linux ``/tmp``, mode ``1777``) -- which a local attacker could use to plant
-    trusted-looking data (CWE-377/CWE-378) -- from a *private* per-user temp
+    (Linux ``/tmp``, mode ``1777``), which a local attacker could use to plant
+    trusted-looking data (CWE-377/CWE-378), from a *private* per-user temp
     directory (macOS ``$TMPDIR`` ``/var/folders/...`` mode ``0700``, Windows
     ``%TEMP%`` under the ACL-protected user profile), which is safe.
 
     Cross-platform:
-      * POSIX: the directory must be owned by the current user (or root) and be
-        neither group- nor world-writable (unless the writable group/other bit
-        is paired with the sticky bit *and* the dir is user-owned -- but we keep
-        it strict and simply reject any group/other-writable dir).
-      * Windows: ``st_uid``/mode are not meaningful; the per-user temp/profile is
-        ACL-protected, so a plain "exists and is a directory" check is used.
+      * POSIX: the directory must be owned by the effective user (or by root) and
+        be neither group- nor world-writable. A sticky world-writable directory
+        (``/tmp``) is rejected too: other users can still pre-create entries in it
+        and a pre-created entry wins any race.
+      * Windows: ``st_uid``/mode are not meaningful without pywin32; the per-user
+        temp/profile is ACL-protected, so a plain "exists and is a directory"
+        check is used (a heuristic, not a DACL check).
+
+    Owner/mode can also lie on NFS with uid squashing, some FUSE mounts, and
+    unprivileged user namespaces; POSIX ACLs surface in the group bits on Linux
+    ext4/xfs but not universally.
     """
     try:
         st = os.stat(path)
@@ -85,13 +137,162 @@ def is_private_dir(path):
         # Windows / other: rely on the per-user profile ACLs (no POSIX mode).
         return True
     # Must be owned by us (or by root, e.g. a system-wide /usr/share dir).
-    if st.st_uid not in (os.getuid(), 0):
+    if st.st_uid not in (os.geteuid(), 0):
         return False
     # Reject group- or world-writable directories: those let another account
     # write into (or, without the sticky bit, replace) the directory.
     if st.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
         return False
     return True
+
+
+def _resolve_private(path, _hops=0):
+    """Resolve *path* one component at a time, following each symlink hop and
+    applying :func:`is_private_dir` to every directory encountered (including
+    each intermediate link's holding directory and its target's ancestors).
+
+    Returns the fully resolved path, or None if the input is unusable or any
+    directory on the way is not private. Unlike ``os.path.realpath``, every
+    intermediate symlink hop is checked, so a link that passes through an
+    attacker-writable directory is refused. The check is strict: a shared,
+    world-writable directory is rejected even with the sticky bit (Linux
+    ``/tmp``), so a trusted binary must live under a private root. NLTK's own
+    scratch output goes through :func:`nltk.data.make_staging_dir`, which stages
+    inside a private data root, never in ``/tmp``.
+    """
+    if _hops > _MAX_LINK_HOPS:
+        return None
+    try:
+        text = os.fspath(path)
+    except TypeError:
+        return None  # not a path-like at all (int, None, list, ...)
+    # Only an absolute, NUL-free path is resolvable here. A relative path would
+    # be taken against the attacker-controllable CWD; a '..' component is refused
+    # rather than folded, because os.path.abspath/normpath collapse it LEXICALLY,
+    # before symlinks resolve, which would skip a link this walk must inspect.
+    if not isinstance(text, str) or "\x00" in text or not os.path.isabs(text):
+        return None
+    cur = os.sep
+    for part in text.split(os.sep):
+        if not part or part == os.curdir:  # '' and '.' are inert
+            continue
+        if part == os.pardir:  # '..' is never folded here; refuse it
+            return None
+        if not is_private_dir(cur):  # the directory that holds `part`
+            return None
+        nxt = os.path.join(cur, part)
+        try:
+            st = os.lstat(nxt)
+        except OSError:
+            return None
+        if stat.S_ISLNK(st.st_mode):
+            try:
+                link = os.readlink(nxt)
+            except OSError:
+                return None
+            # Re-resolve the target from the root (an absolute link replaces the
+            # base; a relative one joins onto its holding dir), so every ancestor
+            # of the target is checked too. Hop-bounded against symlink loops.
+            nxt = _resolve_private(os.path.join(cur, link), _hops + 1)
+            if nxt is None:
+                return None
+        cur = nxt
+    return cur
+
+
+def resolve_trusted_executable(target):
+    """Return the resolved path of *target* if no other unprivileged local user
+    can substitute it before it runs, else None (CWE-426/CWE-427/CWE-732).
+
+    POSIX: every directory from the root down to the target (following each
+    symlink hop) must be private (:func:`is_private_dir`), and the final target
+    must be a REGULAR file owned by us or root with no group/world write bit
+    (:func:`_private_stat`). The returned path is fully resolved, so callers
+    should execute THAT, not the original name. A same-UID attacker and root are
+    out of scope (they already control the process).
+
+    Non-POSIX (Windows): fails CLOSED and returns None. POSIX owner/mode bits do
+    not describe who can write a path there, and a real answer needs the object's
+    DACL (win32security), which is not a dependency NLTK can assume. Guessing
+    from environment-derived roots is not a trust boundary, so the safe answer is
+    to refuse: :func:`spawn_trusted` then raises, and a Windows caller must
+    supply the executable through a channel it has verified itself.
+    """
+    if os.name != "posix":
+        return None
+    real = _resolve_private(target)
+    if real is None:
+        return None
+    try:
+        st = os.stat(real)
+    except OSError:
+        return None
+    if not stat.S_ISREG(st.st_mode) or not _private_stat(st):
+        return None
+    return real
+
+
+def is_trusted_executable(target):
+    """Boolean form of :func:`resolve_trusted_executable`."""
+    return resolve_trusted_executable(target) is not None
+
+
+def safe_env():
+    """A minimal child environment for a trusted binary: the _ENV_KEEP names plus
+    a PATH that resolves no command.
+
+    Deny-by-default WHITELIST: everything outside _ENV_KEEP is dropped, so a
+    loader/interpreter variable (LD_*, DYLD_*, PYTHON*, PERL5LIB, GCONV_PATH,
+    LOCPATH, NLSPATH, TERMINFO, IFS, ...) is removed even if no denylist named it.
+    PATH is replaced with :data:`_LOCKED_PATH` so the child cannot resolve
+    ``sh``/``python``/any helper by bare name (a rich PATH is exactly what turns
+    one leaked writable directory, or a shell-out on attacker input, into full
+    command execution), while never being empty (an empty/unset PATH is searched
+    as the current directory, so a planted ``./tool`` would run, CWE-426). There
+    is no ``extra`` parameter, so nothing dropped here can be reintroduced.
+
+    This scrubs the ENVIRONMENT only; it is one layer, not the whole defense. The
+    binary's own trust (that it cannot be swapped) is :func:`resolve_trusted_
+    executable`'s job, and a child that loads a plugin or config from the current
+    working directory is the caller's concern (pass ``cwd=``). The kept identity
+    variables (HOME, SHELL, TZ) can still steer a tool's OWN config lookups; they
+    are retained because they are not loader-injection vectors and dropping them
+    breaks ordinary tools. A caller whose tool genuinely must find system
+    utilities by name should pass its own ``env`` with a PATH of validated,
+    non-writable directories.
+    """
+    env = {k: v for k, v in os.environ.items() if k in _ENV_KEEP}
+    env["PATH"] = _LOCKED_PATH
+    return env
+
+
+def spawn_trusted(target, args=(), **popen_kw):
+    """Verify *target* with :func:`resolve_trusted_executable` and start it with
+    :class:`subprocess.Popen`, raising :class:`TrustError` if it is untrusted.
+
+    ``shell`` may not be set (a shell would re-interpret the command); ``env``
+    defaults to :func:`safe_env` and ``close_fds`` to True. The resolved path is
+    what gets executed, and argv[0] is that same resolved path.
+
+    Executing the resolved path is race-free against the in-scope attacker
+    (another unprivileged local user). :func:`resolve_trusted_executable` has
+    already proved that every directory from the root down to the target is
+    owned by us or root and is not writable by anyone else, so no such user can
+    substitute the binary, or any component of its path, between the check and
+    the exec. A same-uid process and root are out of scope: they already control
+    this process, so no exec-time trick would contain them. This is why no
+    ``/proc/self/fd`` fexecve dance is used; it would only harden that
+    out-of-scope race while adding a Linux-only, magic-symlink exec path.
+    """
+    if popen_kw.get("shell"):
+        raise ValueError("spawn_trusted refuses shell=True")
+    popen_kw.setdefault("env", safe_env())
+    popen_kw.setdefault("close_fds", True)
+
+    real = resolve_trusted_executable(target)
+    if real is None:
+        raise TrustError(f"refusing to execute untrusted path: {target!r}")
+    return subprocess.Popen([real, *args], executable=real, **popen_kw)
 
 
 def _get_allowed_roots():

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -60,14 +60,9 @@ _WINDOWS_DEVICE_NAMES = frozenset(
 
 _MAX_LINK_HOPS = 40  # ELOOP-style bound on symlink chains
 
-# The child PATH. A trusted binary is executed by ABSOLUTE path and needs no PATH
-# to run, so the child is handed one that resolves NOTHING: a single absolute,
-# root-domain directory containing no executables (an unprivileged user cannot
-# create a sibling of it under /). This denies bare-name command resolution, so
-# a rich /usr/bin:/bin, which would let the child reach sh/python/any tool by
-# name, is deliberately NOT granted. It is also deliberately NOT empty: POSIX
-# execvp / subprocess search an EMPTY PATH element as the current directory, so
-# "" or an unset PATH would let a planted ./tool run instead (CWE-426).
+# The child PATH resolves NOTHING: a single absolute, root-domain directory with
+# no executables. It denies bare-name command lookup (a trusted binary is run by
+# absolute path) and is NOT empty (an empty PATH element is the CWD; see safe_env).
 _LOCKED_PATH = "/nonexistent"
 
 # Only these variables reach a spawn_trusted child. Anything that can redirect a
@@ -166,10 +161,9 @@ def _resolve_private(path, _hops=0):
         text = os.fspath(path)
     except TypeError:
         return None  # not a path-like at all (int, None, list, ...)
-    # Only an absolute, NUL-free path is resolvable here. A relative path would
-    # be taken against the attacker-controllable CWD; a '..' component is refused
-    # rather than folded, because os.path.abspath/normpath collapse it LEXICALLY,
-    # before symlinks resolve, which would skip a link this walk must inspect.
+    # Only an absolute, NUL-free path is resolvable. A relative path resolves
+    # against the attacker-controllable CWD; a '..' is refused, not folded, since
+    # os.path.abspath collapses it lexically before symlinks resolve (skips a link).
     if not isinstance(text, str) or "\x00" in text or not os.path.isabs(text):
         return None
     cur = os.sep

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -211,15 +211,15 @@ def resolve_trusted_executable(target):
     should execute THAT, not the original name. A same-UID attacker and root are
     out of scope (they already control the process).
 
-    Non-POSIX (Windows): fails CLOSED and returns None. POSIX owner/mode bits do
-    not describe who can write a path there, and a real answer needs the object's
-    DACL (win32security), which is not a dependency NLTK can assume. Guessing
-    from environment-derived roots is not a trust boundary, so the safe answer is
-    to refuse: :func:`spawn_trusted` then raises, and a Windows caller must
-    supply the executable through a channel it has verified itself.
+    Non-POSIX (Windows): best-effort (see :func:`_resolve_trusted_nonposix`). The
+    POSIX ownership check cannot run and NLTK does not assume win32security for a
+    DACL check, so this layer degrades to the others: ``find_binary_iter`` already
+    refuses a CWD-relative match (the main CWE-426 vector on Windows, cf. GitPython
+    CVE-2023-40590) and :func:`spawn_trusted` still refuses a shell and scrubs the
+    environment. It does NOT fail closed, so Windows tool wrappers keep working.
     """
     if os.name != "posix":
-        return None
+        return _resolve_trusted_nonposix(target)
     real = _resolve_private(target)
     if real is None:
         return None
@@ -230,6 +230,25 @@ def resolve_trusted_executable(target):
     if not stat.S_ISREG(st.st_mode) or not _private_stat(st):
         return None
     return real
+
+
+def _resolve_trusted_nonposix(target):
+    """Best-effort resolution on a non-POSIX platform (Windows).
+
+    POSIX owner/mode bits do not describe who can write a path, and a real
+    exec-trust answer needs the object's DACL (win32security), which NLTK does not
+    assume as a dependency, so the ownership layer cannot be enforced here. Rather
+    than fail closed (which would break every Windows tool wrapper), accept a
+    regular file at the resolved absolute path and rely on the other layers:
+    find_binary_iter refuses a CWD-relative match and spawn_trusted refuses a
+    shell and scrubs the loader environment. No environment-derived root allowlist
+    is consulted (that is not a trust boundary)."""
+    try:
+        real = os.path.realpath(target)
+        st = os.stat(real)
+    except OSError:
+        return None
+    return real if stat.S_ISREG(st.st_mode) else None
 
 
 def is_trusted_executable(target):

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -61,6 +61,16 @@ _WINDOWS_DEVICE_NAMES = frozenset(
 
 _MAX_LINK_HOPS = 40  # ELOOP-style bound on symlink chains
 
+#: Ceiling for a model/data file handed to an external tool via
+#: :func:`validate_tool_path` with ``max_bytes=MAX_TOOL_MODEL_BYTES``. A file in a
+#: data root is already regular (no FIFO/device/symlink), but the tool loads its
+#: whole content into memory; an attacker who can plant a file in a root could
+#: otherwise ship a multi-gigabyte model to exhaust memory in the tool's parser
+#: (CWE-400/CWE-1333). 512 MiB is far above any real POS/NER tagger model yet well
+#: below a memory-exhaustion payload. Raise it if a legitimately larger model is
+#: needed.
+MAX_TOOL_MODEL_BYTES = 512 * 1024 * 1024
+
 # The child PATH resolves NOTHING: a single absolute, root-domain directory with
 # no executables. It denies bare-name command lookup (a trusted binary is run by
 # absolute path) and is NOT empty (an empty PATH element is the CWD; see safe_env).
@@ -816,7 +826,13 @@ def _reject_aliased_or_special(text, context, check_links=False):
 
 
 def validate_tool_path(
-    path_input, context="NLTK tool", *, for_write=False, must_exist=True
+    path_input,
+    context="NLTK tool",
+    *,
+    for_write=False,
+    must_exist=True,
+    max_bytes=None,
+    require_private=False,
 ):
     """Bound a filesystem path handed to an external tool to read or write.
 
@@ -836,7 +852,13 @@ def validate_tool_path(
       own kernel path, so a symlink or an intermediate directory swapped in after
       the name check is refused (CWE-59);
     * refuses a FIFO, socket, device or directory, whose open would block forever
-      or stream unbounded data (CWE-400).
+      or stream unbounded data (CWE-400);
+    * with ``max_bytes``, refuses an over-large regular file the tool would load
+      whole into memory (a model-size bomb, CWE-400);
+    * with ``require_private``, refuses a file that is group/world-writable or not
+      owned by the caller or root, which another local user could plant or swap
+      before the tool parses it (CWE-426/CWE-732; POSIX only, best-effort on
+      Windows like the executable-trust check).
 
     A path-taking sink can never be fully race-free, since the callee re-resolves
     the name, but every attack that does not require winning that race is
@@ -862,16 +884,47 @@ def validate_tool_path(
     _reject_url_shaped(text, context)
     validate_path(text, context=context)
     _reject_aliased_or_special(text, context, check_links=for_write)
-    _reject_unsafe_open(text, context, must_exist)
+    _reject_unsafe_open(
+        text, context, must_exist, max_bytes=max_bytes, require_private=require_private
+    )
     return text
 
 
-def _reject_unsafe_open(raw, context, must_exist):
+def _reject_oversize(st, raw, context, max_bytes):
+    """Refuse a file whose size exceeds *max_bytes* (CWE-400). ``st`` is the stat
+    of the already-validated regular file, so this reads the size that was open,
+    not a re-resolved name."""
+    if max_bytes is not None and st.st_size > max_bytes:
+        raise PermissionError(
+            f"Security Violation [{context}]: file {raw!r} is {st.st_size} bytes, "
+            f"over the {max_bytes}-byte tool-model limit; a file this large in a "
+            f"data root would exhaust memory in the tool's parser (CWE-400)."
+        )
+
+
+def _reject_tamperable(st, raw, context, require_private):
+    """POSIX: refuse a file another local user could plant or swap. ``st`` is the
+    fstat of the already-opened (O_NOFOLLOW) fd, so the owner/mode checked is the
+    file the tool will read, not a re-resolved name (CWE-426/CWE-732)."""
+    if require_private and os.name == "posix" and not _private_stat(st):
+        raise PermissionError(
+            f"Security Violation [{context}]: file {raw!r} is group/world-writable "
+            f"or not owned by you or root; another local user could plant or swap "
+            f"the model content the tool then parses (CWE-426/CWE-732)."
+        )
+
+
+def _reject_unsafe_open(
+    raw, context, must_exist, max_bytes=None, require_private=False
+):
     """Open-time hardening for a path already bounded by :func:`validate_path`.
 
     Closes the window between the name check and the tool's own open: an
     intermediate directory or the leaf itself may be swapped for a symlink in
-    between, which no name-based check can see.
+    between, which no name-based check can see. When *max_bytes* is set, also
+    refuses an over-large regular file (a model-size memory bomb, CWE-400); when
+    *require_private* is set, refuses a file another local user could tamper with
+    (CWE-426/CWE-732).
     """
     if not ENFORCE:
         return
@@ -888,6 +941,8 @@ def _reject_unsafe_open(raw, context, must_exist):
             raise PermissionError(
                 f"Security Violation [{context}]: path {raw!r} is not a " "regular file"
             )
+        _reject_oversize(st, raw, context, max_bytes)
+        _reject_tamperable(st, raw, context, require_private)
         return
 
     flags = (
@@ -929,6 +984,8 @@ def _reject_unsafe_open(raw, context, must_exist):
                 f"{raw!r} (st_nlink={st.st_nlink}); a hardlink names an inode that "
                 "may live outside the sandbox (CWE-59)"
             )
+        _reject_oversize(st, raw, context, max_bytes)
+        _reject_tamperable(st, raw, context, require_private)
         actual = _fd_realpath(fd)
         validate_path(
             actual if actual is not None else os.path.realpath(raw), context=context

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -20,6 +20,7 @@ import stat
 import subprocess
 import sys
 import tempfile
+import unicodedata
 import urllib.request
 import warnings
 import zipfile
@@ -248,6 +249,50 @@ def _resolve_trusted_nonposix(target):
 def is_trusted_executable(target):
     """Boolean form of :func:`resolve_trusted_executable`."""
     return resolve_trusted_executable(target) is not None
+
+
+#: Unicode categories that must never appear in a token handed to a line-oriented
+#: tool: control characters (``Cc``), line/paragraph separators (``Zl``/``Zp``),
+#: and lone surrogates (``Cs``, which cannot be UTF-8 encoded and would otherwise
+#: raise UnicodeEncodeError as the token is written to the tool).
+_LINE_UNSAFE_CATEGORIES = frozenset({"Cc", "Zl", "Zp", "Cs"})
+
+
+def has_line_unsafe_char(token, allow_tab=False):
+    """Return True if *token* holds a character unsafe to hand to a line-oriented
+    external tool (CWE-93).
+
+    Unsafe means any Unicode control character (category ``Cc``, covering the C0
+    controls including TAB / CR / LF / NUL / the FS-GS-RS separators, the C1
+    controls, ``DEL`` and ``NEL``), a line or paragraph separator (``Zl`` / ``Zp``:
+    ``U+2028`` / ``U+2029``), or a lone surrogate (``Cs``). These are exactly the
+    characters that add or truncate a line on the tool's stdin, split a field in a
+    tab-separated stdout (TAB), or fail to UTF-8 encode (surrogate); the ``Cc`` +
+    ``Zl`` + ``Zp`` set matches ``str.splitlines()`` so no line break slips past.
+    Ordinary token content stays valid: letters, marks, numbers, punctuation,
+    symbols, ordinary and non-breaking spaces, and the format characters used in
+    real multilingual text (zero-width joiner / non-joiner, bidi marks) are never
+    flagged, so those tokens keep working.
+
+    ``allow_tab=True`` exempts a literal TAB, for a tool whose stdout is NOT
+    tab-delimited and that treats a tab as ordinary in-line whitespace (e.g. REPP
+    sentences, candc input lines). It stays blocked by default because a tab in a
+    token corrupts a tab-separated output line (Senna, hunpos).
+
+    Accepts ``str`` or ``bytes``. For ``bytes`` only the C0 controls and ``DEL``
+    are detected, because the C1 controls and the Unicode separators encode to
+    bytes ``0x80`` through ``0xBF`` that also serve as UTF-8 continuation bytes;
+    decode the bytes and pass the ``str`` to check those in full.
+    """
+    if isinstance(token, (bytes, bytearray)):
+        return any(
+            (b < 0x20 or b == 0x7F) and not (allow_tab and b == 0x09) for b in token
+        )
+    return any(
+        unicodedata.category(ch) in _LINE_UNSAFE_CATEGORIES
+        and not (allow_tab and ch == "\t")
+        for ch in token
+    )
 
 
 def safe_env():

--- a/nltk/sem/boxer.py
+++ b/nltk/sem/boxer.py
@@ -38,6 +38,7 @@ from optparse import OptionParser
 
 from nltk import redos
 from nltk.internals import find_binary_iter
+from nltk.pathsec import TrustError, spawn_trusted
 from nltk.sem.drt import (
     DRS,
     DrtApplicationExpression,
@@ -288,20 +289,30 @@ class Boxer:
             print("Input:", input_str)
             print("Command:", binary + " " + " ".join(args))
 
-        # Call via a subprocess
-        if input_str is None:
-            cmd = [binary] + args
-            p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            stdout, stderr = p.communicate()
-        else:
-            cmd = [binary] + args
-            p = subprocess.Popen(
-                cmd,
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-            )
-            stdout, stderr = p.communicate(input=input_str.encode("utf-8"))
+        # Route through the trusted-exec chokepoint: verify the candc/boxer binary
+        # is on a path no other local user can swap, refuse a shell, and scrub the
+        # loader environment before exec (CWE-426/427/732).
+        cmd = [binary] + args
+        try:
+            if input_str is None:
+                p = spawn_trusted(
+                    cmd[0], cmd[1:], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                )
+                stdout, stderr = p.communicate()
+            else:
+                p = spawn_trusted(
+                    cmd[0],
+                    cmd[1:],
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+                stdout, stderr = p.communicate(input=input_str.encode("utf-8"))
+        except TrustError as e:
+            raise LookupError(
+                f"Refusing to run {cmd[0]!r}: it is not on a trusted path. Install "
+                f"Boxer/C&C where only you (or root) can write ({e})."
+            ) from e
 
         if verbose:
             print("Return code:", p.returncode)

--- a/nltk/sem/boxer.py
+++ b/nltk/sem/boxer.py
@@ -181,6 +181,28 @@ class Boxer:
         :param filename: str A filename for the output file
         :return: stdout
         """
+        # candc reads a line-oriented input where <META>'id' marks a discourse
+        # boundary. A control character or quote in an id, or an input line that
+        # itself starts with <META>, would inject or misroute those boundaries.
+        for discourse_id in discourse_ids:
+            text = str(discourse_id)
+            if any(ord(c) < 0x20 or c in "'\"" for c in text):
+                raise ValueError(
+                    "A candc discourse id cannot contain a control character or "
+                    f"quote (it is interpolated into <META>'id'): {discourse_id!r}"
+                )
+        for discourse in inputs:
+            for line in discourse:
+                text = str(line)
+                if any(ord(c) < 0x20 and c != "\t" for c in text):
+                    raise ValueError(
+                        f"A candc input line cannot contain a control character: {line!r}"
+                    )
+                if text.startswith("<META>"):
+                    raise ValueError(
+                        "A candc input line cannot start with the <META> discourse "
+                        f"marker: {line!r}"
+                    )
         args = [
             "--models",
             os.path.join(self._candc_models_path, ["boxer", "questions"][question]),
@@ -209,6 +231,7 @@ class Boxer:
         # Imported here, not at module scope: nltk.data's import graph pulls in
         # nltk.sem, so a top level import can see a half built nltk.data module.
         from nltk.data import make_staging_dir
+        from nltk.pathsec import open as pathsec_open
 
         f = None
         # Stage the scratch input inside an allowed nltk.data root, never the
@@ -218,7 +241,10 @@ class Boxer:
             fd, temp_filename = tempfile.mkstemp(
                 prefix="boxer-", suffix=".in", text=True, dir=staging_dir
             )
-            f = os.fdopen(fd, "w")
+            # mkstemp gives a race-free path in the validated staging dir; write
+            # through pathsec_open rather than the raw fd.
+            os.close(fd)
+            f = pathsec_open(temp_filename, "w", context="Boxer._call_boxer")
             f.write(candc_out.decode("utf-8"))
         finally:
             if f:

--- a/nltk/sem/boxer.py
+++ b/nltk/sem/boxer.py
@@ -38,7 +38,7 @@ from optparse import OptionParser
 
 from nltk import redos
 from nltk.internals import find_binary_iter
-from nltk.pathsec import TrustError, spawn_trusted
+from nltk.pathsec import TrustError, has_line_unsafe_char, spawn_trusted
 from nltk.sem.drt import (
     DRS,
     DrtApplicationExpression,
@@ -186,17 +186,20 @@ class Boxer:
         # itself starts with <META>, would inject or misroute those boundaries.
         for discourse_id in discourse_ids:
             text = str(discourse_id)
-            if any(ord(c) < 0x20 or c in "'\"" for c in text):
+            if has_line_unsafe_char(text) or any(c in "'\"" for c in text):
                 raise ValueError(
-                    "A candc discourse id cannot contain a control character or "
-                    f"quote (it is interpolated into <META>'id'): {discourse_id!r}"
+                    "A candc discourse id cannot contain a control character, line "
+                    f"separator or quote (it is interpolated into <META>'id'): {discourse_id!r}"
                 )
         for discourse in inputs:
             for line in discourse:
                 text = str(line)
-                if any(ord(c) < 0x20 and c != "\t" for c in text):
+                # candc reads whole lines and its output is not tab-delimited, so a
+                # literal TAB is ordinary in-line whitespace here and stays allowed.
+                if has_line_unsafe_char(text, allow_tab=True):
                     raise ValueError(
-                        f"A candc input line cannot contain a control character: {line!r}"
+                        "A candc input line cannot contain a control character or "
+                        f"line separator: {line!r}"
                     )
                 if text.startswith("<META>"):
                     raise ValueError(

--- a/nltk/tag/hunpos.py
+++ b/nltk/tag/hunpos.py
@@ -12,10 +12,10 @@ A module for interfacing with the HunPos open-source POS-tagger.
 """
 
 import os
-from subprocess import PIPE, Popen
+from subprocess import PIPE
 
 from nltk.internals import find_binary, find_file
-from nltk.pathsec import validate_tool_path
+from nltk.pathsec import TrustError, spawn_trusted, validate_tool_path
 from nltk.tag.api import TaggerI
 
 _hunpos_url = "https://code.google.com/p/hunpos/"
@@ -97,13 +97,23 @@ class HunposTagger(TaggerI):
         # ``self._hunpos_model`` (from find_file) becomes argv to the hunpos-tag
         # subprocess pathsec.open cannot wrap; bound it before spawning (GHSA-8mgp-746c-j5xp).
         validate_tool_path(self._hunpos_model, context="HunposTagger.__init__")
-        self._hunpos = Popen(
-            [self._hunpos_bin, self._hunpos_model],
-            shell=False,
-            stdin=PIPE,
-            stdout=PIPE,
-            stderr=PIPE,
-        )
+        # Route through the trusted-exec chokepoint: verify the hunpos-tag binary
+        # is on a path no other local user can swap, refuse a shell, and scrub the
+        # loader environment before exec (CWE-426/427/732).
+        try:
+            self._hunpos = spawn_trusted(
+                self._hunpos_bin,
+                [self._hunpos_model],
+                stdin=PIPE,
+                stdout=PIPE,
+                stderr=PIPE,
+            )
+        except TrustError as e:
+            raise LookupError(
+                f"Refusing to run the HunPos tagger {self._hunpos_bin!r}: it is "
+                "not on a trusted path. Install HunPos where only you (or root) "
+                f"can write ({e})."
+            ) from e
         self._closed = False
 
     def __del__(self):

--- a/nltk/tag/hunpos.py
+++ b/nltk/tag/hunpos.py
@@ -136,15 +136,16 @@ class HunposTagger(TaggerI):
         The tokens should not contain any newline characters.
         """
         for token in tokens:
-            # Not an assert: python -O strips those, and a newline inside a token
-            # injects an extra line into the tagger's line-oriented stdin, which
-            # desynchronises every tag that follows.
-            newline = b"\n" if isinstance(token, bytes) else "\n"
-            if newline in token:
-                raise ValueError("Tokens should not contain newlines")
-            if isinstance(token, str):
-                token = token.encode(self._encoding)
-            self._hunpos.stdin.write(token + b"\n")
+            raw = token if isinstance(token, bytes) else token.encode(self._encoding)
+            # Not an assert (python -O strips those): a control char in a token
+            # injects an extra line into the tagger's line-oriented stdin or
+            # truncates the token, desynchronising every tag that follows.
+            if any(b < 0x20 and b != 0x09 for b in raw):
+                raise ValueError(
+                    "hunpos tokens must not contain newline, NUL or other control "
+                    "characters"
+                )
+            self._hunpos.stdin.write(raw + b"\n")
         # We write a final empty line to tell hunpos that the sentence is finished:
         self._hunpos.stdin.write(b"\n")
         self._hunpos.stdin.flush()

--- a/nltk/tag/hunpos.py
+++ b/nltk/tag/hunpos.py
@@ -15,7 +15,12 @@ import os
 from subprocess import PIPE
 
 from nltk.internals import find_binary, find_file
-from nltk.pathsec import TrustError, spawn_trusted, validate_tool_path
+from nltk.pathsec import (
+    TrustError,
+    has_line_unsafe_char,
+    spawn_trusted,
+    validate_tool_path,
+)
 from nltk.tag.api import TaggerI
 
 _hunpos_url = "https://code.google.com/p/hunpos/"
@@ -133,18 +138,22 @@ class HunposTagger(TaggerI):
 
     def tag(self, tokens):
         """Tags a single sentence: a list of words.
-        The tokens should not contain any newline characters.
+
+        A token may not contain any control character or Unicode line/paragraph
+        separator: a newline adds an input line, a NUL truncates the token, and a
+        TAB splits hunpos's own tab-separated output column (see the read loop
+        below), each desynchronising every tag that follows.
         """
         for token in tokens:
-            raw = token if isinstance(token, bytes) else token.encode(self._encoding)
-            # Not an assert (python -O strips those): a control char in a token
-            # injects an extra line into the tagger's line-oriented stdin or
-            # truncates the token, desynchronising every tag that follows.
-            if any(b < 0x20 and b != 0x09 for b in raw):
+            # Not an assert (python -O strips those): check the token itself so a
+            # str token's C1/NEL/separator characters are caught, not only the raw
+            # C0/DEL bytes, before it reaches the tagger's line-oriented stdin.
+            if has_line_unsafe_char(token):
                 raise ValueError(
-                    "hunpos tokens must not contain newline, NUL or other control "
-                    "characters"
+                    "hunpos tokens must not contain control characters or line "
+                    "separators (newline, tab, NUL, DEL, ...)"
                 )
+            raw = token if isinstance(token, bytes) else token.encode(self._encoding)
             self._hunpos.stdin.write(raw + b"\n")
         # We write a final empty line to tell hunpos that the sentence is finished:
         self._hunpos.stdin.write(b"\n")

--- a/nltk/tag/hunpos.py
+++ b/nltk/tag/hunpos.py
@@ -16,6 +16,7 @@ from subprocess import PIPE
 
 from nltk.internals import find_binary, find_file
 from nltk.pathsec import (
+    MAX_TOOL_MODEL_BYTES,
     TrustError,
     has_line_unsafe_char,
     spawn_trusted,
@@ -100,8 +101,17 @@ class HunposTagger(TaggerI):
         )
         self._encoding = encoding
         # ``self._hunpos_model`` (from find_file) becomes argv to the hunpos-tag
-        # subprocess pathsec.open cannot wrap; bound it before spawning (GHSA-8mgp-746c-j5xp).
-        validate_tool_path(self._hunpos_model, context="HunposTagger.__init__")
+        # subprocess pathsec.open cannot wrap; bound it before spawning
+        # (GHSA-8mgp-746c-j5xp). hunpos-tag (C++) reads the whole model into memory
+        # and parses it, so beyond containment also refuse a model another local
+        # user could plant/swap (require_private) or an oversized memory-bomb model
+        # (max_bytes), narrowing the "malicious in-root model" residual.
+        validate_tool_path(
+            self._hunpos_model,
+            context="HunposTagger.__init__",
+            max_bytes=MAX_TOOL_MODEL_BYTES,
+            require_private=True,
+        )
         # Route through the trusted-exec chokepoint: verify the hunpos-tag binary
         # is on a path no other local user can swap, refuse a shell, and scrub the
         # loader environment before exec (CWE-426/427/732).

--- a/nltk/test/unit/test_app_twitter_open_hardening.py
+++ b/nltk/test/unit/test_app_twitter_open_hardening.py
@@ -128,7 +128,7 @@ def test_tweetwriter_refuses_symlinked_output(tmp_path, sensitive):
 def test_chartcomparer_load_refuses_symlinked_source(tmp_path, sensitive):
     from nltk.app.chartparser_app import ChartComparer
 
-    link = tmp_path / "chart.pkl"
+    link = tmp_path / "chart.pickle"
     link.symlink_to(sensitive)
     comparer = object.__new__(ChartComparer)
     with pytest.raises(PermissionError):
@@ -141,7 +141,7 @@ def test_chartparserapp_save_refuses_symlinked_destination(
 ):
     import nltk.app.chartparser_app as cpa
 
-    link = tmp_path / "chart.pkl"
+    link = tmp_path / "chart.pickle"
     link.symlink_to(sensitive)
     monkeypatch.setattr(cpa, "asksaveasfilename", lambda *a, **k: str(link))
     app = object.__new__(cpa.ChartParserApp)
@@ -161,7 +161,7 @@ def test_real_chart_pickle_roundtrips_through_pathsec(tmp_path):
     from nltk.picklesec import pickle_dump
 
     chart = ChartParser(CFG.fromstring("S -> 'a'")).chart_parse(["a"])
-    path = tmp_path / "chart.pkl"
+    path = tmp_path / "chart.pickle"
     with pathsec_open(str(path), "wb", context="test") as handle:
         pickle_dump(chart, handle)
     with pathsec_open(str(path), "rb", context="test") as handle:

--- a/nltk/test/unit/test_app_twitter_open_hardening.py
+++ b/nltk/test/unit/test_app_twitter_open_hardening.py
@@ -128,7 +128,7 @@ def test_tweetwriter_refuses_symlinked_output(tmp_path, sensitive):
 def test_chartcomparer_load_refuses_symlinked_source(tmp_path, sensitive):
     from nltk.app.chartparser_app import ChartComparer
 
-    link = tmp_path / "chart.pickle"
+    link = tmp_path / "chart.pkl"
     link.symlink_to(sensitive)
     comparer = object.__new__(ChartComparer)
     with pytest.raises(PermissionError):
@@ -141,7 +141,7 @@ def test_chartparserapp_save_refuses_symlinked_destination(
 ):
     import nltk.app.chartparser_app as cpa
 
-    link = tmp_path / "chart.pickle"
+    link = tmp_path / "chart.pkl"
     link.symlink_to(sensitive)
     monkeypatch.setattr(cpa, "asksaveasfilename", lambda *a, **k: str(link))
     app = object.__new__(cpa.ChartParserApp)
@@ -161,7 +161,7 @@ def test_real_chart_pickle_roundtrips_through_pathsec(tmp_path):
     from nltk.picklesec import pickle_dump
 
     chart = ChartParser(CFG.fromstring("S -> 'a'")).chart_parse(["a"])
-    path = tmp_path / "chart.pickle"
+    path = tmp_path / "chart.pkl"
     with pathsec_open(str(path), "wb", context="test") as handle:
         pickle_dump(chart, handle)
     with pathsec_open(str(path), "rb", context="test") as handle:

--- a/nltk/test/unit/test_attack_java_tool_expanded.py
+++ b/nltk/test/unit/test_attack_java_tool_expanded.py
@@ -419,7 +419,9 @@ def hunpos_env(monkeypatch, atk_root):
 
     monkeypatch.setattr(hp, "find_binary", fake_find_binary)
     monkeypatch.setattr(hp, "find_file", fake_find_file)
-    monkeypatch.setattr(hp, "Popen", fake_popen)
+    # HunposTagger spawns via pathsec.spawn_trusted; trap that shared sink (fake_bin
+    # is a real file under the private atk_root, so the trust check accepts it).
+    monkeypatch.setattr("nltk.pathsec.subprocess.Popen", fake_popen)
     return SimpleNamespace(root=atk_root, bin=fake_bin, captured=captured)
 
 

--- a/nltk/test/unit/test_attack_tool_injection_candidates_expanded.py
+++ b/nltk/test/unit/test_attack_tool_injection_candidates_expanded.py
@@ -98,10 +98,9 @@ def spy(monkeypatch):
         calls.append(SimpleNamespace(argv=list(cmd), shell=k.get("shell", False)))
         return _FakeProc()
 
-    # Every owned wrapper reaches Popen through the ``subprocess`` module object;
-    # senna now spawns via ``nltk.pathsec.spawn_trusted``, which calls
-    # ``subprocess.Popen`` on that same shared module, so this one patch covers it
-    # too. (senna no longer does ``from subprocess import Popen``.)
+    # Every owned wrapper reaches Popen through the shared ``subprocess`` module;
+    # senna now spawns via ``pathsec.spawn_trusted`` (which calls subprocess.Popen
+    # on that same module), so this one patch covers it too.
     monkeypatch.setattr(subprocess, "Popen", _fake_popen)
     monkeypatch.setattr(internals, "_java_bin", "java")
     monkeypatch.setattr(internals, "_java_options", [])

--- a/nltk/test/unit/test_attack_tool_injection_candidates_expanded.py
+++ b/nltk/test/unit/test_attack_tool_injection_candidates_expanded.py
@@ -98,12 +98,11 @@ def spy(monkeypatch):
         calls.append(SimpleNamespace(argv=list(cmd), shell=k.get("shell", False)))
         return _FakeProc()
 
-    # Every owned wrapper reaches Popen through the ``subprocess`` module object,
-    # except senna which does ``from subprocess import Popen``; patch both spellings.
+    # Every owned wrapper reaches Popen through the ``subprocess`` module object;
+    # senna now spawns via ``nltk.pathsec.spawn_trusted``, which calls
+    # ``subprocess.Popen`` on that same shared module, so this one patch covers it
+    # too. (senna no longer does ``from subprocess import Popen``.)
     monkeypatch.setattr(subprocess, "Popen", _fake_popen)
-    from nltk.classify import senna as _senna
-
-    monkeypatch.setattr(_senna, "Popen", _fake_popen)
     monkeypatch.setattr(internals, "_java_bin", "java")
     monkeypatch.setattr(internals, "_java_options", [])
     return calls

--- a/nltk/test/unit/test_boxer_security.py
+++ b/nltk/test/unit/test_boxer_security.py
@@ -186,9 +186,8 @@ def test_boxer_scratch_file_staged_in_data_root(monkeypatch):
 
 # --- candc structured-input injection guard (integrated from #3850) ------------
 # ``Boxer._call_candc`` builds a line-oriented candc input where ``<META>'id'``
-# marks a discourse boundary. A control character or quote in a discourse id, or
-# an input line that itself starts with ``<META>``, would inject or misroute those
-# boundaries. The guard runs BEFORE the spawn.
+# marks a discourse boundary; a control char/quote in an id or a ``<META>``-leading
+# input line would inject or misroute those boundaries (the guard runs pre-spawn).
 
 
 def _candc_boxer(spy):

--- a/nltk/test/unit/test_boxer_security.py
+++ b/nltk/test/unit/test_boxer_security.py
@@ -97,12 +97,24 @@ def test_absolute_bin_dir_is_accepted(tmp_path, monkeypatch):
     )
 
 
-def test_boxer_call_uses_argv_list_never_shell(monkeypatch, tmp_path):
-    """``Boxer._call`` builds ``[binary] + args`` and spawns with an argv list and
-    NO shell, so a metacharacter argument reaches the process as a single literal
-    element, never a shell token. The candc/boxer binaries need not exist: Popen
-    is trapped and its argv inspected."""
-    binary = str(tmp_path / "candc")
+def test_boxer_call_uses_argv_list_never_shell(monkeypatch):
+    """``Boxer._call`` routes through ``pathsec.spawn_trusted`` and builds
+    ``[binary] + args`` as an argv list with NO shell, so a metacharacter argument
+    reaches the process as a single literal element, never a shell token. Under the
+    strict trust policy the binary must be a real file on a trusted path, so it is
+    staged under a private data root (not the shared temp, which is refused)."""
+    import nltk.data as nltk_data
+    import nltk.pathsec as ps
+
+    try:
+        base = nltk_data.make_staging_dir(prefix="boxer_test_", cleanup=True)
+    except PermissionError as exc:  # pragma: no cover - env-dependent
+        pytest.skip(f"no writable in-sandbox NLTK data root: {exc}")
+    binary = os.path.join(base, "candc")
+    with open(binary, "w") as handle:
+        handle.write("#!/bin/sh\nexit 0\n")
+    os.chmod(binary, 0o755)
+
     hostile_args = ["--models", "; touch /tmp/pwned", "$(id)", "a\nb"]
     captured = {}
 
@@ -117,13 +129,13 @@ def test_boxer_call_uses_argv_list_never_shell(monkeypatch, tmp_path):
         captured["shell"] = k.get("shell", False)
         return _FakeProc()
 
-    monkeypatch.setattr(subprocess, "Popen", _fake_popen)
+    monkeypatch.setattr(ps.subprocess, "Popen", _fake_popen)
 
     boxer = Boxer.__new__(Boxer)
     boxer._call("some stdin input", binary, args=hostile_args)
 
     assert captured["shell"] is False
-    assert captured["argv"][0] == binary
+    assert captured["argv"][0] == os.path.realpath(binary)  # resolved trusted path
     for tok in hostile_args:
         assert tok in captured["argv"]  # literal, not shell-interpreted
 

--- a/nltk/test/unit/test_boxer_security.py
+++ b/nltk/test/unit/test_boxer_security.py
@@ -182,3 +182,67 @@ def test_boxer_scratch_file_staged_in_data_root(monkeypatch):
         assert captured["contents"] == "ccg(1, t)."
     finally:
         shutil.rmtree(root, ignore_errors=True)
+
+
+# --- candc structured-input injection guard (integrated from #3850) ------------
+# ``Boxer._call_candc`` builds a line-oriented candc input where ``<META>'id'``
+# marks a discourse boundary. A control character or quote in a discourse id, or
+# an input line that itself starts with ``<META>``, would inject or misroute those
+# boundaries. The guard runs BEFORE the spawn.
+
+
+def _candc_boxer(spy):
+    boxer = Boxer.__new__(Boxer)
+    boxer._candc_models_path = "/models"
+    boxer._candc_bin = "/nonexistent/candc"  # never reached for a refused input
+    boxer._call = spy
+    return boxer
+
+
+@pytest.mark.parametrize(
+    "discourse_id",
+    ["a\nb", "a\rb", "a\x00b", "id'quote", 'id"dquote', "a\x0bb", "tab\tid"],
+)
+def test_candc_rejects_hostile_discourse_id(discourse_id):
+    called = []
+    boxer = _candc_boxer(lambda *a, **k: called.append(a) or ("", 0))
+    with pytest.raises(ValueError):
+        boxer._call_candc([["hello"]], [discourse_id], question=False)
+    assert called == [], "a hostile discourse id reached the candc spawn"
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "line\nwith newline",
+        "line\rwith cr",
+        "line\x00nul",
+        "ctrl\x0bchar",
+        "<META>'injected-boundary'",  # a line masquerading as a discourse marker
+    ],
+)
+def test_candc_rejects_hostile_input_line(line):
+    called = []
+    boxer = _candc_boxer(lambda *a, **k: called.append(a) or ("", 0))
+    with pytest.raises(ValueError):
+        boxer._call_candc([["ok first line", line]], ["0"], question=False)
+    assert called == [], "a hostile candc input line reached the spawn"
+
+
+def test_candc_benign_input_reaches_call_with_meta_boundary():
+    """Benign control: a normal discourse reaches the (trapped) spawn, with the
+    ``<META>'id'`` boundary and the input lines present and unmodified."""
+    captured = {}
+
+    def spy(input_str, binary, args, verbose):
+        captured["input"] = input_str
+        return ""
+
+    boxer = _candc_boxer(spy)
+    boxer._call_candc([["hello world", "second line"]], ["disc1"], question=False)
+    assert "<META>'disc1'" in captured["input"]
+    assert "hello world" in captured["input"]
+    assert "second line" in captured["input"]
+    # A tab is ordinary whitespace, allowed inside an input line.
+    boxer._call_candc([["a\ttabbed\tline"]], ["0"], question=False)
+    assert "a\ttabbed\tline" in captured["input"]

--- a/nltk/test/unit/test_boxer_security.py
+++ b/nltk/test/unit/test_boxer_security.py
@@ -200,7 +200,22 @@ def _candc_boxer(spy):
 
 @pytest.mark.parametrize(
     "discourse_id",
-    ["a\nb", "a\rb", "a\x00b", "id'quote", 'id"dquote', "a\x0bb", "tab\tid"],
+    [
+        "a\nb",  # LF
+        "a\rb",  # CR
+        "a\x00b",  # NUL
+        "id'quote",  # single quote (breaks the <META>'id' interpolation)
+        'id"dquote',  # double quote
+        "a\x0bb",  # vertical tab
+        "tab\tid",  # TAB (an id is never tab-bearing)
+        "a\x1eb",  # record separator
+        "a\x7fb",  # DEL (the reviewer's gap)
+        "a\x85b",  # NEL / C1 control
+        "a\x9fb",  # C1 control
+        "a\u2028b",  # Unicode line separator
+        "a\u2029b",  # Unicode paragraph separator
+        "a\ud800b",  # lone surrogate
+    ],
 )
 def test_candc_rejects_hostile_discourse_id(discourse_id):
     called = []
@@ -217,6 +232,14 @@ def test_candc_rejects_hostile_discourse_id(discourse_id):
         "line\rwith cr",
         "line\x00nul",
         "ctrl\x0bchar",
+        "ff\x0cfeed",  # form feed
+        "rs\x1esep",  # record separator
+        "del\x7fchar",  # DEL (the reviewer's gap)
+        "nel\x85char",  # NEL / C1 control
+        "c1\x9fchar",  # C1 control
+        "ls\u2028break",  # Unicode line separator
+        "ps\u2029break",  # Unicode paragraph separator
+        "sur\ud800rogate",  # lone surrogate
         "<META>'injected-boundary'",  # a line masquerading as a discourse marker
     ],
 )
@@ -226,6 +249,18 @@ def test_candc_rejects_hostile_input_line(line):
     with pytest.raises(ValueError):
         boxer._call_candc([["ok first line", line]], ["0"], question=False)
     assert called == [], "a hostile candc input line reached the spawn"
+
+
+@pytest.mark.parametrize("discourse_id", ["disc-1", "doc_42", "café", "文書"])
+def test_candc_accepts_legitimate_discourse_id(discourse_id):
+    """A discourse id of ordinary characters (including non-ASCII letters) is not
+    a control character or quote, so it must reach the candc spawn."""
+    captured = {}
+    boxer = _candc_boxer(
+        lambda input_str, *a, **k: captured.update(input=input_str) or ""
+    )
+    boxer._call_candc([["hello"]], [discourse_id], question=False)
+    assert f"<META>'{discourse_id}'" in captured["input"]
 
 
 def test_candc_benign_input_reaches_call_with_meta_boundary():

--- a/nltk/test/unit/test_hunpos_security.py
+++ b/nltk/test/unit/test_hunpos_security.py
@@ -94,3 +94,51 @@ def test_hunpos_trusted_binary_reaches_spawn_with_scrubbed_env(monkeypatch):
     assert calls[0].shell is False
     assert calls[0].argv == [os.path.realpath(binp), model]
     assert "LD_PRELOAD" not in (calls[0].env or {})
+
+
+# --- Layer-6 input guard: hunpos-tag reads one token per line (CWE-93) ---------
+
+
+def _tagger_with_fake_pipe(encoding=hp._hunpos_charset):
+    """A HunposTagger wired to a recording fake pipe, no real binary spawned."""
+    writes = []
+
+    class _Stdin:
+        def write(self, chunk):
+            writes.append(chunk)
+
+        def flush(self):
+            pass
+
+    class _Stdout:
+        def readline(self):
+            return b"\n"
+
+    tagger = object.__new__(hp.HunposTagger)
+    tagger._closed = False
+    tagger._encoding = encoding
+    tagger._hunpos = SimpleNamespace(
+        stdin=_Stdin(),
+        stdout=_Stdout(),
+        communicate=lambda *a, **k: (b"", b""),
+    )
+    return tagger, writes
+
+
+def test_control_char_token_is_refused():
+    """A newline/NUL/other control char in a token injects an extra line into
+    hunpos-tag's line-oriented stdin (or truncates the token), desynchronising
+    every following tag; the token is refused before it is written."""
+    tagger, writes = _tagger_with_fake_pipe()
+    for payload in ["good\nevil", "nul\x00here", "cr\rhere", "esc\x1bhere"]:
+        with pytest.raises(ValueError, match="control characters"):
+            tagger.tag([payload])
+    assert writes == [], "a control-char token must not be written to hunpos stdin"
+
+
+def test_tab_in_token_is_allowed():
+    """hunpos uses tab as its own output column separator, but a tab inside an
+    input token is harmless on the write side (one token per line); allow it."""
+    tagger, writes = _tagger_with_fake_pipe()
+    tagger.tag(["a\tb"])
+    assert b"a\tb\n" in writes

--- a/nltk/test/unit/test_hunpos_security.py
+++ b/nltk/test/unit/test_hunpos_security.py
@@ -1,0 +1,96 @@
+"""Trusted-exec routing for the HunPos tagger wrapper (CWE-426/427/732).
+
+``HunposTagger.__init__`` spawned ``hunpos-tag`` with a bare ``Popen``. It now
+routes through ``pathsec.spawn_trusted`` (the standardized native-wrapper
+chokepoint, strict trust policy like Senna): every directory from the root to the
+binary must be owned by us/root and not group/world-writable, no shell, and the
+child gets a scrubbed environment. The pre-existing ``validate_tool_path`` model
+guard (bounding the model argument to the data roots) is unchanged; these tests
+cover the added exec-trust and env-scrub layers.
+"""
+
+import os
+from types import SimpleNamespace
+
+import pytest
+
+import nltk.data as nltk_data
+import nltk.pathsec as ps
+import nltk.tag.hunpos as hp
+
+requires_posix_perms = pytest.mark.skipif(
+    not hasattr(os, "getuid"), reason="POSIX ownership/permission model"
+)
+
+
+def _staging(prefix="hunpos_sec_"):
+    try:
+        return nltk_data.make_staging_dir(prefix=prefix, cleanup=True)
+    except PermissionError as exc:  # pragma: no cover - env-dependent
+        pytest.skip(f"no writable in-sandbox NLTK data root: {exc}")
+
+
+def _model_in_root(base, name="en_wsj.model"):
+    """A real model file inside a data root, so validate_tool_path accepts it."""
+    path = os.path.join(base, name)
+    with open(path, "w") as handle:
+        handle.write("stub-model\n")
+    return path
+
+
+@requires_posix_perms
+def test_hunpos_refuses_untrusted_binary(tmp_path, monkeypatch):
+    """Strict trust: a hunpos-tag binary in a world-writable directory is refused
+    before running, even though the model argument is a valid in-root file."""
+    model = _model_in_root(_staging())  # passes validate_tool_path
+    install = tmp_path / "inst"
+    install.mkdir()
+    binp = install / "hunpos-tag"
+    binp.write_text("#!/bin/sh\nexit 0\n")
+    os.chmod(binp, 0o755)
+    os.chmod(install, 0o777)  # world-writable: another user could swap the binary
+
+    monkeypatch.setattr(hp, "find_binary", lambda *a, **k: str(binp))
+    monkeypatch.setattr(hp, "find_file", lambda p, **k: model)
+    with pytest.raises(LookupError):
+        hp.HunposTagger("en_wsj.model")
+
+
+def test_hunpos_trusted_binary_reaches_spawn_with_scrubbed_env(monkeypatch):
+    """Benign control: a hunpos-tag binary staged under a private data root reaches
+    the (trapped) spawn with an absolute resolved argv, no shell, and an
+    environment scrubbed of loader variables."""
+    base = _staging()
+    model = _model_in_root(base)
+    binp = os.path.join(base, "hunpos-tag")
+    with open(binp, "w") as handle:
+        handle.write("#!/bin/sh\nexit 0\n")
+    os.chmod(binp, 0o755)
+
+    monkeypatch.setenv("LD_PRELOAD", "/evil.so")
+    monkeypatch.setattr(hp, "find_binary", lambda *a, **k: binp)
+    monkeypatch.setattr(hp, "find_file", lambda p, **k: model)
+
+    calls = []
+
+    class _FakeProc:
+        returncode = 0
+
+        def communicate(self, *a, **k):
+            return b"", b""
+
+    def _fake_popen(cmd, *a, **k):
+        calls.append(
+            SimpleNamespace(
+                argv=list(cmd), shell=k.get("shell", False), env=k.get("env")
+            )
+        )
+        return _FakeProc()
+
+    monkeypatch.setattr(ps.subprocess, "Popen", _fake_popen)
+    hp.HunposTagger("en_wsj.model")
+
+    assert len(calls) == 1
+    assert calls[0].shell is False
+    assert calls[0].argv == [os.path.realpath(binp), model]
+    assert "LD_PRELOAD" not in (calls[0].env or {})

--- a/nltk/test/unit/test_hunpos_security.py
+++ b/nltk/test/unit/test_hunpos_security.py
@@ -162,3 +162,46 @@ def test_legitimate_multilingual_tokens_are_allowed():
     for token in ["café", "日本語", "नमस्ते", "العربية", "co op", "👨‍👩‍👧"]:
         tagger.tag([token])  # must not raise
         assert token.encode("utf-8") + b"\n" in writes
+
+
+# --- model-file guards: require_private + max_bytes (CWE-426/732/400) -----------
+
+
+def _staged_binary(base):
+    """A trusted (private-dir) hunpos-tag stub so __init__ reaches the model
+    validation; the model guard, not the exec-trust, is what these exercise."""
+    binp = os.path.join(base, "hunpos-tag")
+    with open(binp, "w") as handle:
+        handle.write("#!/bin/sh\nexit 0\n")
+    os.chmod(binp, 0o755)
+    return binp
+
+
+@requires_posix_perms
+def test_group_or_world_writable_model_is_refused(monkeypatch):
+    """A model another local user could swap (group/world-writable) is refused
+    before hunpos-tag ever parses it (require_private, CWE-426/CWE-732)."""
+    base = _staging()
+    binp = _staged_binary(base)
+    model = _model_in_root(base)
+    os.chmod(model, 0o666)  # world-writable: attacker could swap the model bytes
+    monkeypatch.setattr(hp, "find_binary", lambda *a, **k: binp)
+    monkeypatch.setattr(hp, "find_file", lambda p, **k: model)
+    with pytest.raises(PermissionError):
+        hp.HunposTagger("en_wsj.model")
+
+
+def test_oversize_model_is_refused(monkeypatch):
+    """A model larger than MAX_TOOL_MODEL_BYTES is refused (a memory-bomb the C
+    tagger would load whole, CWE-400). A tiny monkeypatched cap (read from hunpos's
+    module namespace at the call) avoids needing a giant file."""
+    base = _staging()
+    binp = _staged_binary(base)
+    model = os.path.join(base, "big.model")
+    with open(model, "wb") as fh:
+        fh.write(b"x" * 4096)  # over the 1024-byte cap below
+    monkeypatch.setattr(hp, "MAX_TOOL_MODEL_BYTES", 1024)
+    monkeypatch.setattr(hp, "find_binary", lambda *a, **k: binp)
+    monkeypatch.setattr(hp, "find_file", lambda p, **k: model)
+    with pytest.raises(PermissionError):
+        hp.HunposTagger("en_wsj.model")

--- a/nltk/test/unit/test_hunpos_security.py
+++ b/nltk/test/unit/test_hunpos_security.py
@@ -125,20 +125,40 @@ def _tagger_with_fake_pipe(encoding=hp._hunpos_charset):
     return tagger, writes
 
 
-def test_control_char_token_is_refused():
-    """A newline/NUL/other control char in a token injects an extra line into
-    hunpos-tag's line-oriented stdin (or truncates the token), desynchronising
-    every following tag; the token is refused before it is written."""
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "good\nevil",  # LF: extra input line
+        "nul\x00here",  # NUL: C-string truncation
+        "cr\rhere",  # CR
+        "esc\x1bhere",  # C0 control
+        "vt\x0bhere",  # vertical tab
+        "ff\x0chere",  # form feed
+        "rs\x1ehere",  # record separator (splitlines break)
+        "del\x7fhere",  # DEL (the reviewer's gap)
+        "nel\x85here",  # NEL, a C1 control and a splitlines break
+        "c1\x9fhere",  # C1 control
+        "ls\u2028here",  # Unicode line separator
+        "ps\u2029here",  # Unicode paragraph separator
+        "sur\ud800here",  # lone surrogate (would crash .encode())
+        "a\tb",  # TAB: splits hunpos's own tab-separated output column
+    ],
+)
+def test_control_char_token_is_refused(payload):
+    """A control character, line/paragraph separator or lone surrogate in a token
+    injects/truncates a line on hunpos-tag's stdin, splits its tab-separated
+    stdout, or fails to encode, desynchronising every following tag; the token is
+    refused before it is written."""
     tagger, writes = _tagger_with_fake_pipe()
-    for payload in ["good\nevil", "nul\x00here", "cr\rhere", "esc\x1bhere"]:
-        with pytest.raises(ValueError, match="control characters"):
-            tagger.tag([payload])
-    assert writes == [], "a control-char token must not be written to hunpos stdin"
+    with pytest.raises(ValueError, match="control characters"):
+        tagger.tag([payload])
+    assert writes == [], "an unsafe-char token must not be written to hunpos stdin"
 
 
-def test_tab_in_token_is_allowed():
-    """hunpos uses tab as its own output column separator, but a tab inside an
-    input token is harmless on the write side (one token per line); allow it."""
-    tagger, writes = _tagger_with_fake_pipe()
-    tagger.tag(["a\tb"])
-    assert b"a\tb\n" in writes
+def test_legitimate_multilingual_tokens_are_allowed():
+    """The guard must not overblock real token content: non-ASCII letters, marks,
+    symbols, non-breaking space and format characters (ZWJ/ZWNJ/bidi) all pass."""
+    tagger, writes = _tagger_with_fake_pipe(encoding="utf-8")
+    for token in ["café", "日本語", "नमस्ते", "العربية", "co op", "👨‍👩‍👧"]:
+        tagger.tag([token])  # must not raise
+        assert token.encode("utf-8") + b"\n" in writes

--- a/nltk/test/unit/test_megam_tadm_injection_security.py
+++ b/nltk/test/unit/test_megam_tadm_injection_security.py
@@ -1,0 +1,145 @@
+"""Feature-file injection guards for the megam and tadm writers (CWE-93).
+
+``write_megam_file`` / ``write_tadm_file`` serialise a training corpus into the
+line-oriented, space (and, for megam, ``:``/``#``) delimited format the external
+optimiser reads on stdin. The id/value/cost fields were interpolated with
+``%s`` / ``str()`` / an f-string, none of which enforce a numeric shape, so a
+feature id, feature value, or per-label cost carrying a space or newline (from a
+hostile or buggy encoding) could split into extra fields or inject a whole new
+instance line, corrupting the trained model.
+
+The writers now require feature ids to be non-negative integers and feature
+values / costs to be finite reals, whose ``str()`` is always separator free.
+These tests pin both the refusals and that genuine integer-encoded corpora still
+serialise unchanged.
+"""
+
+import io
+
+import pytest
+
+from nltk.classify.megam import _megam_int, _megam_number, write_megam_file
+from nltk.classify.tadm import _tadm_int, write_tadm_file
+
+# --- helper encodings emitting attacker-shaped fields --------------------------
+
+
+class _Enc:
+    """Minimal encoding stub: fixed labels, caller-supplied encode()/cost()."""
+
+    def __init__(self, labels, vector=None, cost=None):
+        self._labels = labels
+        self._vector = vector
+        self._cost = cost
+
+    def labels(self):
+        return self._labels
+
+    def encode(self, featureset, label):
+        return self._vector
+
+    # only present when a cost is supplied (write_megam_file uses hasattr)
+    def __getattr__(self, name):
+        if name == "cost" and self.__dict__.get("_cost") is not None:
+            return lambda fs, label, l: self._cost(l)
+        raise AttributeError(name)
+
+
+def _megam(enc, **kw):
+    buf = io.StringIO()
+    write_megam_file([({"x": 1}, enc.labels()[0])], enc, buf, **kw)
+    return buf.getvalue()
+
+
+def _tadm(enc):
+    buf = io.StringIO()
+    write_tadm_file([({"x": 1}, enc.labels()[0])], enc, buf)
+    return buf.getvalue()
+
+
+# --- megam feature id/value injection ------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_fid",
+    ["7\n0 99", "9 9", "3\t4", "5#6", "1:2", -1, 1.5, "12", True, None],
+)
+def test_megam_rejects_non_integer_feature_id(bad_fid):
+    enc = _Enc(["yes", "no"], vector=[(bad_fid, 1)])
+    with pytest.raises(ValueError, match="non-negative integer"):
+        _megam(enc, bernoulli=True, explicit=False)
+
+
+@pytest.mark.parametrize("bad_fval", ["1 2", "3\n4", "x", float("inf"), float("nan")])
+def test_megam_rejects_non_numeric_feature_value(bad_fval):
+    enc = _Enc(["yes", "no"], vector=[(1, bad_fval)])
+    with pytest.raises(ValueError, match="finite real number"):
+        _megam(enc, bernoulli=False, explicit=False)
+
+
+@pytest.mark.parametrize("bad_cost", ["0\n99 100", "1:2", "x", float("inf")])
+def test_megam_rejects_injected_label_cost(bad_cost):
+    enc = _Enc(["a", "b"], vector=[(1, 1)], cost=lambda l: bad_cost if l == "a" else 1)
+    with pytest.raises(ValueError, match="finite real number"):
+        _megam(enc, bernoulli=True, explicit=False)
+
+
+def test_megam_helpers_accept_legit_numbers():
+    assert _megam_int(0) == 0 and _megam_int(42) == 42
+    assert _megam_number(1) == 1 and _megam_number(-0.5) == -0.5
+
+
+# --- tadm feature id/value injection -------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad", ["5\n6", "7 8", "x", float("inf"), float("nan"), True, None]
+)
+def test_tadm_rejects_non_numeric_fields(bad):
+    enc = _Enc(["a", "b"], vector=[(bad, 1)])
+    with pytest.raises(ValueError):
+        _tadm(enc)
+
+
+def test_tadm_helper_truncates_finite_reals_like_percent_d():
+    # A finite real is truncated exactly as the original "%d" did (no injection),
+    # so legitimate integer-valued floats keep working.
+    assert _tadm_int(3, "feature id") == 3
+    assert _tadm_int(3.9, "feature value") == 3
+
+
+# --- legit corpora still serialise unchanged (real encodings, no mocks) --------
+
+
+def test_real_encodings_still_serialise():
+    from nltk.classify.maxent import (
+        BinaryMaxentFeatureEncoding,
+        TadmEventMaxentFeatureEncoding,
+        TypedMaxentFeatureEncoding,
+    )
+
+    train = [
+        ({"a": 1, "b": "x"}, "pos"),
+        ({"a": 2, "b": "y"}, "neg"),
+        ({"a": 1, "b": "y"}, "pos"),
+    ]
+
+    benc = BinaryMaxentFeatureEncoding.train(train)
+    buf = io.StringIO()
+    write_megam_file(train, benc, buf, bernoulli=True, explicit=False)
+    lines = buf.getvalue().splitlines()
+    assert len(lines) == len(train)
+    for line in lines:  # "<label-index> <fid> <fid> ..." all integers
+        assert all(tok.isdigit() for tok in line.split())
+
+    tenc = TypedMaxentFeatureEncoding.train(train)
+    buf = io.StringIO()
+    write_megam_file(train, tenc, buf, bernoulli=False, explicit=False)
+    assert buf.getvalue().splitlines()  # non-empty, no exception
+
+    tadmenc = TadmEventMaxentFeatureEncoding.train(train)
+    buf = io.StringIO()
+    write_tadm_file(train, tadmenc, buf)
+    out = buf.getvalue().splitlines()
+    # length line then one line per label, repeated per instance
+    assert out and out[0].isdigit()

--- a/nltk/test/unit/test_pathsec_sweep_tag.py
+++ b/nltk/test/unit/test_pathsec_sweep_tag.py
@@ -504,31 +504,63 @@ def _drive_stanford_tag(path):
     _no_jvm(lambda: tagger.tag(["What", "is"]))
 
 
+_HUNPOS_STUB_BIN = None
+
+
+def _hunpos_stub_bin():
+    """A real, absolute, TRUSTED hunpos-tag stub, reused across driver calls.
+
+    HunposTagger now spawns via ``pathsec.spawn_trusted``, whose strict trust
+    check rejects a bare name or a /tmp path. Staged under ``$HOME`` (a private
+    chain: /home/<user> is 0755, not group/world-writable) rather than the
+    pinned data-root sandbox, which the tests place under the system temp where
+    the chain is not guaranteed private. Cached and removed at interpreter exit.
+    """
+    global _HUNPOS_STUB_BIN
+    if _HUNPOS_STUB_BIN is None:
+        import atexit
+        import shutil
+        import tempfile
+
+        base = tempfile.mkdtemp(prefix=".nltk_hunpos_drv_", dir=os.path.expanduser("~"))
+        atexit.register(shutil.rmtree, base, ignore_errors=True)
+        binpath = os.path.join(base, "hunpos-tag")
+        with open(binpath, "w") as handle:
+            handle.write("#!/bin/sh\nexit 0\n")
+        os.chmod(binpath, 0o755)
+        _HUNPOS_STUB_BIN = binpath
+    return _HUNPOS_STUB_BIN
+
+
 def _drive_hunpos_init(path):
     """Drive HunposTagger.__init__ with find_file/find_binary stubbed out.
 
     The real ``find_file`` refuses anything that does not already exist, which
     would mask the guard for most vectors; stubbing it means the guard is the
-    only thing standing between the caller's string and the subprocess argv.
-    ``Popen`` is replaced so nothing is ever spawned.
+    only thing standing between the caller's string and the subprocess argv. The
+    sink (``pathsec.subprocess.Popen``, which ``spawn_trusted`` calls) is replaced
+    so nothing is ever spawned, and ``find_binary`` returns a trusted stub so the
+    exec-trust check passes and the model path reaches the argv.
     """
+    import nltk.pathsec as pathsec_module
     import nltk.tag.hunpos as hunpos_module
 
     def _boom(cmd, *args, **kwargs):
         raise _ReachedSink(list(cmd))
 
-    saved = (hunpos_module.find_file, hunpos_module.find_binary, hunpos_module.Popen)
+    stub = _hunpos_stub_bin()
+    saved_ff = hunpos_module.find_file
+    saved_fb = hunpos_module.find_binary
+    saved_popen = pathsec_module.subprocess.Popen
     hunpos_module.find_file = lambda p, **kw: p
-    hunpos_module.find_binary = lambda *a, **kw: "hunpos-tag"
-    hunpos_module.Popen = _boom
+    hunpos_module.find_binary = lambda *a, **kw: stub
+    pathsec_module.subprocess.Popen = _boom
     try:
         hunpos_module.HunposTagger(path)
     finally:
-        (
-            hunpos_module.find_file,
-            hunpos_module.find_binary,
-            hunpos_module.Popen,
-        ) = saved
+        hunpos_module.find_file = saved_ff
+        hunpos_module.find_binary = saved_fb
+        pathsec_module.subprocess.Popen = saved_popen
 
 
 class _ReachedSink(Exception):
@@ -1311,7 +1343,9 @@ def test_hunpos_env_var_model_outside_the_sandbox_is_refused(
         raise _ReachedSink(list(cmd))
 
     monkeypatch.setenv("HUNPOS_TAGGER", str(model))
-    monkeypatch.setattr(hunpos_module, "Popen", _boom)
+    # HunposTagger spawns via pathsec.spawn_trusted; trap that sink (the model
+    # guard must refuse before it is ever reached).
+    monkeypatch.setattr("nltk.pathsec.subprocess.Popen", _boom)
     with pytest.raises(PermissionError):
         hunpos_module.HunposTagger("en_wsj.model", path_to_bin=str(stub))
 

--- a/nltk/test/unit/test_pathsec_sweep_tag.py
+++ b/nltk/test/unit/test_pathsec_sweep_tag.py
@@ -130,24 +130,26 @@ def test_tagger_sources_route_through_pathsec():
     from nltk.chunk import named_entity
     from nltk.tag import crf, hunpos, perceptron, stanford
 
+    def _calls_validate_on(src, var):
+        # validate_tool_path is called on ``var``, tolerant of black wrapping the
+        # call across lines and of added keyword args (max_bytes/require_private).
+        return re.search(r"validate_tool_path\(\s*" + re.escape(var), src) is not None
+
     crf_set_src = inspect.getsource(crf.CRFTagger.set_model_file)
-    assert (
-        'validate_tool_path(model_file, context="CRFTagger.set_model_file")'
-        in crf_set_src
-    )
+    assert _calls_validate_on(crf_set_src, "model_file")
 
     crf_train_src = inspect.getsource(crf.CRFTagger.train)
-    assert 'validate_tool_path(model_file, context="CRFTagger.train"' in crf_train_src
+    assert _calls_validate_on(crf_train_src, "model_file")
 
     stanford_src = inspect.getsource(stanford.StanfordTagger.tag_sents)
     assert "validate_tool_path(" in stanford_src
     assert "self._stanford_model" in stanford_src
 
     stanford_init_src = inspect.getsource(stanford.StanfordTagger.__init__)
-    assert "validate_tool_path(self._stanford_model" in stanford_init_src
+    assert _calls_validate_on(stanford_init_src, "self._stanford_model")
 
     hunpos_src = inspect.getsource(hunpos.HunposTagger.__init__)
-    assert "validate_tool_path(self._hunpos_model" in hunpos_src
+    assert _calls_validate_on(hunpos_src, "self._hunpos_model")
 
     save_src = inspect.getsource(perceptron.PerceptronTagger.save_to_json)
     assert "validate_tool_dir(loc" in save_src

--- a/nltk/test/unit/test_pathsec_trusted_exec.py
+++ b/nltk/test/unit/test_pathsec_trusted_exec.py
@@ -278,19 +278,24 @@ def test_resolve_trusted_executable_rejects_binary_owned_by_other(staging, monke
 
 
 # --------------------------------------------------------------------------- #
-# Non-POSIX platform fails CLOSED (no Windows heuristic to fool).               #
+# Non-POSIX platform: best-effort, NOT fail-closed (keeps Windows working).      #
 # --------------------------------------------------------------------------- #
 
 
-def test_non_posix_platform_fails_closed(monkeypatch):
-    """On a non-POSIX os.name the resolver refuses everything: POSIX mode bits do
-    not answer 'who can write this path' on Windows, and NLTK does not assume
-    win32security, so the safe answer is to refuse rather than guess from env."""
+def test_non_posix_platform_is_best_effort(monkeypatch, tmp_path):
+    """On a non-POSIX os.name the POSIX ownership check cannot run, so resolve
+    degrades to best-effort: a regular file at a resolved absolute path is
+    accepted (relying on find_binary's CWD refusal + no-shell + env-scrub), while
+    a missing target is still refused. It must NOT fail closed, or every Windows
+    tool wrapper would break. No environment-derived root allowlist is used."""
+    binp = tmp_path / "tool.exe"
+    binp.write_text("stub")
     monkeypatch.setattr(ps.os, "name", "nt")
-    assert ps.resolve_trusted_executable("/bin/sh") is None
-    assert ps.is_trusted_executable("/bin/sh") is False
-    with pytest.raises(ps.TrustError):
-        ps.spawn_trusted("/bin/sh", ["-c", "true"])
+    assert ps.resolve_trusted_executable(str(binp)) == os.path.realpath(str(binp))
+    assert ps.is_trusted_executable(str(binp)) is True
+    # A missing / non-regular target is still refused.
+    assert ps.resolve_trusted_executable(str(tmp_path / "nope.exe")) is None
+    assert ps.resolve_trusted_executable(str(tmp_path)) is None  # a directory
 
 
 # --------------------------------------------------------------------------- #

--- a/nltk/test/unit/test_pathsec_trusted_exec.py
+++ b/nltk/test/unit/test_pathsec_trusted_exec.py
@@ -303,11 +303,9 @@ def test_non_posix_platform_is_best_effort(monkeypatch, tmp_path):
 # --------------------------------------------------------------------------- #
 
 
-# Every environment variable that can redirect a dynamic linker, loader,
-# interpreter, charset/locale module, terminfo/message catalog, shell word split,
-# or temp/config lookup. None may survive safe_env(): the whitelist drops them all
-# by default. Kept deliberately broad ("benign or not") so a new attack variable
-# added here fails loudly if it ever slips into _ENV_KEEP.
+# Every variable that can redirect a linker/loader/interpreter, charset-locale
+# module, terminfo/catalog, shell split, or temp/config lookup. None may survive
+# safe_env(); kept deliberately broad ("benign or not") to catch a slip.
 _DANGEROUS_ENV = [
     "LD_PRELOAD",
     "LD_LIBRARY_PATH",

--- a/nltk/test/unit/test_pathsec_trusted_exec.py
+++ b/nltk/test/unit/test_pathsec_trusted_exec.py
@@ -1,0 +1,547 @@
+"""Direct attack tests for the trusted-executable primitives in ``nltk.pathsec``.
+
+These exercise ``resolve_trusted_executable`` / ``_resolve_private`` /
+``is_private_dir`` / ``_private_stat`` / ``safe_env`` / ``spawn_trusted`` WITHOUT
+going through the Senna wrapper, so every defensive check has its own adversarial
+test: a world/group-writable directory or binary, a path under the shared
+``/tmp`` (rejected even with the sticky bit), a symlink through an
+attacker-writable directory, a ``..``/relative/NUL path, an owner other than us,
+a FIFO/socket/directory/device in the executable slot, symlink loops, loader
+variables in the environment, ``shell=True``, and a non-POSIX platform (which
+fails closed). Real files with real ``chmod``/``symlink``/``mkfifo`` and real
+``subprocess`` execution are used (no mocks), so a regression actually leaks
+here rather than being papered over by a stub.
+
+A benign install is staged with :func:`nltk.data.make_staging_dir`, i.e. inside a
+private data root, because the strict resolver deliberately refuses ``/tmp``;
+that is the only in-sandbox place a trusted binary may live on Linux.
+
+They also lock the minimalism decisions: no ``/proc/self/fd`` fexecve dance, no
+``safe_env(extra=...)`` escape hatch, no sticky-``/tmp`` traversal allowance, and
+no Windows heuristic (all were attack surface without an in-scope payoff).
+"""
+
+import inspect
+import os
+import shutil
+import socket
+import stat
+import subprocess
+import tempfile
+from types import SimpleNamespace
+
+import pytest
+
+import nltk.data as nltk_data
+import nltk.pathsec as ps
+
+POSIX = pytest.mark.skipif(
+    os.name != "posix", reason="POSIX ownership/permission model"
+)
+
+
+@pytest.fixture
+def staging():
+    """A private, in-sandbox base dir (never world-writable ``/tmp``). The strict
+    resolver rejects ``/tmp`` even with the sticky bit, so a benign install must
+    live under a private root; make_staging_dir is where NLTK stages output."""
+    try:
+        base = nltk_data.make_staging_dir(prefix="pathsec_test_", cleanup=True)
+    except PermissionError as exc:
+        pytest.skip(f"no writable in-sandbox NLTK data root to stage under: {exc}")
+    return base
+
+
+def _mkexec(dirpath, name="tool", mode=0o755, content="#!/bin/sh\nexit 0\n"):
+    """Create an executable regular file and return its path."""
+    os.makedirs(dirpath, exist_ok=True)
+    path = os.path.join(dirpath, name)
+    with open(path, "w") as handle:
+        handle.write(content)
+    os.chmod(path, mode)
+    return path
+
+
+# --------------------------------------------------------------------------- #
+# is_private_dir: strict for BOTH data roots and the executable walk.           #
+# --------------------------------------------------------------------------- #
+
+
+def test_is_private_dir_keeps_its_documented_contract():
+    """The docstring the reviewer asked to preserve must stay intact."""
+    doc = ps.is_private_dir.__doc__ or ""
+    assert "1777" in doc and "CWE-377" in doc and "Windows" in doc
+
+
+@POSIX
+def test_is_private_dir_rejects_world_and_group_writable(staging):
+    d = os.path.join(staging, "d")
+    os.mkdir(d)
+    os.chmod(d, 0o755)
+    assert ps.is_private_dir(d) is True
+    os.chmod(d, 0o775)  # group-writable
+    assert ps.is_private_dir(d) is False
+    os.chmod(d, 0o777)  # world-writable
+    assert ps.is_private_dir(d) is False
+
+
+@POSIX
+def test_is_private_dir_rejects_sticky_world_writable_tmp():
+    """A shared sticky temp (/tmp, 1777) is refused: strict, no sticky exception."""
+    if not (os.path.isdir("/tmp") and os.stat("/tmp").st_mode & stat.S_ISVTX):
+        pytest.skip("/tmp is not a sticky world-writable dir here")
+    assert ps.is_private_dir("/tmp") is False
+
+
+@POSIX
+def test_is_private_dir_rejects_non_directory_and_missing(staging):
+    f = _mkexec(staging, "f")
+    assert ps.is_private_dir(f) is False
+    assert ps.is_private_dir(os.path.join(staging, "nope")) is False
+
+
+@POSIX
+def test_is_private_dir_rejects_dir_owned_by_another_user(staging, monkeypatch):
+    d = os.path.join(staging, "d")
+    os.mkdir(d)
+    os.chmod(d, 0o755)
+    other = os.geteuid() + 4242  # capture before patching to avoid recursion
+    monkeypatch.setattr(ps.os, "geteuid", lambda: other)
+    assert ps.is_private_dir(d) is False
+
+
+# --------------------------------------------------------------------------- #
+# _resolve_private: input hygiene + component-wise symlink safety, strict.       #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["relative/path", "bin/sh", "", ".", "..", "a/b"],
+)
+def test_resolve_private_refuses_relative_input(bad):
+    assert ps._resolve_private(bad) is None
+
+
+@POSIX  # _resolve_private is POSIX-internal (uses os.geteuid via the dir check)
+def test_resolve_private_refuses_parent_traversal_without_folding():
+    """'..' is refused, never folded lexically (folding would skip a symlink)."""
+    assert ps._resolve_private("/usr/../bin/sh") is None
+    assert ps._resolve_private("/a/b/../../etc/passwd") is None
+
+
+def test_resolve_private_refuses_nul_and_non_str():
+    assert ps._resolve_private("/bin/sh\x00") is None
+    assert ps._resolve_private(b"/bin/sh") is None  # os.fspath keeps bytes -> refused
+    assert ps._resolve_private(1234) is None  # not a path-like -> None, not TypeError
+
+
+@POSIX
+def test_resolve_private_accepts_private_staging_chain(staging):
+    binp = _mkexec(os.path.join(staging, "install"), "tool")
+    assert ps._resolve_private(binp) == os.path.realpath(binp)
+
+
+@POSIX
+def test_resolve_private_refuses_world_writable_ancestor(staging):
+    install = os.path.join(staging, "install")
+    binp = _mkexec(install, "tool")
+    os.chmod(install, 0o777)  # world-writable holding dir
+    assert ps._resolve_private(binp) is None
+
+
+@POSIX
+def test_resolve_private_refuses_path_under_shared_tmp():
+    """The whole point of going strict: a path under world-writable /tmp is
+    refused, even though the leaf dir we create is a private 0700 mkdtemp."""
+    if not (os.path.isdir("/tmp")):
+        pytest.skip("no /tmp")
+    if not (os.stat("/tmp").st_mode & (stat.S_IWGRP | stat.S_IWOTH)):
+        pytest.skip("/tmp is not world-writable here")
+    d = tempfile.mkdtemp(dir="/tmp")
+    try:
+        binp = _mkexec(d, "tool")
+        assert ps._resolve_private(binp) is None
+        assert ps.resolve_trusted_executable(binp) is None
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
+@POSIX
+def test_resolve_private_refuses_intermediate_symlink_through_writable_dir(staging):
+    """A link that passes THROUGH an attacker-writable directory is refused;
+    os.path.realpath would collapse the hop and miss it (CWE-427)."""
+    final = os.path.join(staging, "usr", "local", "private")
+    os.makedirs(final)
+    _mkexec(final, "tool")
+
+    srv = os.path.join(staging, "srv")
+    os.makedirs(os.path.join(srv, "links"))
+    os.symlink(final, os.path.join(srv, "links", "bin"))  # intermediate hop
+    os.chmod(srv, 0o777)  # attacker can repoint srv/links/bin
+
+    os.makedirs(os.path.join(staging, "opt"))
+    os.symlink(os.path.join(srv, "links", "bin"), os.path.join(staging, "opt", "bin"))
+    target = os.path.join(staging, "opt", "bin", "tool")
+    assert ps._resolve_private(target) is None
+
+
+@POSIX
+def test_resolve_private_follows_symlink_to_private_target(staging):
+    real_dir = os.path.join(staging, "real")
+    binp = _mkexec(real_dir, "tool")
+    link = os.path.join(staging, "link")
+    os.symlink(real_dir, link)  # link -> private dir
+    assert ps._resolve_private(os.path.join(link, "tool")) == os.path.realpath(binp)
+
+
+@POSIX
+def test_resolve_private_bounds_symlink_loops(staging):
+    a = os.path.join(staging, "a")
+    b = os.path.join(staging, "b")
+    os.symlink(b, a)
+    os.symlink(a, b)  # a -> b -> a -> ...
+    assert ps._resolve_private(os.path.join(a, "x")) is None  # terminates, not a hang
+
+
+# --------------------------------------------------------------------------- #
+# resolve_trusted_executable / is_trusted_executable.                          #
+# --------------------------------------------------------------------------- #
+
+
+@POSIX  # /bin/sh is a POSIX system binary
+def test_resolve_trusted_executable_accepts_system_binary():
+    real = ps.resolve_trusted_executable("/bin/sh")
+    assert real and os.path.isabs(real)
+    assert ps.is_trusted_executable("/bin/sh") is True
+
+
+@POSIX
+def test_resolve_trusted_executable_accepts_staged_install(staging):
+    binp = _mkexec(os.path.join(staging, "install"), "tool")
+    assert ps.resolve_trusted_executable(binp) == os.path.realpath(binp)
+
+
+@POSIX
+def test_resolve_trusted_executable_rejects_world_writable_binary(staging):
+    binp = _mkexec(os.path.join(staging, "install"), "tool", mode=0o777)
+    assert ps.resolve_trusted_executable(binp) is None
+    assert ps.is_trusted_executable(binp) is False
+
+
+@POSIX
+def test_resolve_trusted_executable_rejects_group_writable_binary(staging):
+    binp = _mkexec(os.path.join(staging, "install"), "tool", mode=0o775)
+    assert ps.resolve_trusted_executable(binp) is None
+
+
+@POSIX
+def test_resolve_trusted_executable_rejects_directory_fifo_socket_device(staging):
+    d = os.path.join(staging, "adir")
+    os.mkdir(d)
+    assert ps.resolve_trusted_executable(d) is None  # a directory
+
+    fifo = os.path.join(staging, "fifo")
+    os.mkfifo(fifo)
+    assert ps.resolve_trusted_executable(fifo) is None  # a FIFO would block
+
+    sockpath = os.path.join(staging, "sock")
+    if len(sockpath) < 100:  # AF_UNIX paths are capped near 108 bytes
+        srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            srv.bind(sockpath)
+            assert ps.resolve_trusted_executable(sockpath) is None  # a socket
+        finally:
+            srv.close()
+
+    if os.path.exists("/dev/null"):
+        assert ps.resolve_trusted_executable("/dev/null") is None  # a device
+
+
+@POSIX
+def test_resolve_trusted_executable_rejects_symlink_to_writable_target(staging):
+    target_dir = os.path.join(staging, "wt")
+    tgt = _mkexec(target_dir, "real")
+    os.chmod(target_dir, 0o777)  # target lives in an attacker-writable dir
+    link = os.path.join(staging, "clean", "keep")
+    os.makedirs(os.path.dirname(link))
+    os.symlink(tgt, link)  # private holder, but link resolves into the writable one
+    assert ps.resolve_trusted_executable(link) is None
+
+
+@POSIX
+def test_resolve_trusted_executable_rejects_binary_owned_by_other(staging, monkeypatch):
+    binp = _mkexec(os.path.join(staging, "install"), "tool")
+    other = os.geteuid() + 4242
+    monkeypatch.setattr(ps.os, "geteuid", lambda: other)
+    assert ps.resolve_trusted_executable(binp) is None
+
+
+# --------------------------------------------------------------------------- #
+# Non-POSIX platform fails CLOSED (no Windows heuristic to fool).               #
+# --------------------------------------------------------------------------- #
+
+
+def test_non_posix_platform_fails_closed(monkeypatch):
+    """On a non-POSIX os.name the resolver refuses everything: POSIX mode bits do
+    not answer 'who can write this path' on Windows, and NLTK does not assume
+    win32security, so the safe answer is to refuse rather than guess from env."""
+    monkeypatch.setattr(ps.os, "name", "nt")
+    assert ps.resolve_trusted_executable("/bin/sh") is None
+    assert ps.is_trusted_executable("/bin/sh") is False
+    with pytest.raises(ps.TrustError):
+        ps.spawn_trusted("/bin/sh", ["-c", "true"])
+
+
+# --------------------------------------------------------------------------- #
+# safe_env: a whitelist, with no reintroduction path.                          #
+# --------------------------------------------------------------------------- #
+
+
+# Every environment variable that can redirect a dynamic linker, loader,
+# interpreter, charset/locale module, terminfo/message catalog, shell word split,
+# or temp/config lookup. None may survive safe_env(): the whitelist drops them all
+# by default. Kept deliberately broad ("benign or not") so a new attack variable
+# added here fails loudly if it ever slips into _ENV_KEEP.
+_DANGEROUS_ENV = [
+    "LD_PRELOAD",
+    "LD_LIBRARY_PATH",
+    "LD_AUDIT",
+    "LD_ORIGIN_PATH",
+    "LD_PROFILE",
+    "LD_DEBUG",
+    "LD_ASSUME_KERNEL",
+    "LD_CONFIG",
+    "LD_BIND_NOW",
+    "DYLD_INSERT_LIBRARIES",
+    "DYLD_LIBRARY_PATH",
+    "DYLD_FRAMEWORK_PATH",
+    "DYLD_FALLBACK_LIBRARY_PATH",
+    "DYLD_FALLBACK_FRAMEWORK_PATH",
+    "DYLD_VERSIONED_LIBRARY_PATH",
+    "PYTHONPATH",
+    "PYTHONHOME",
+    "PYTHONSTARTUP",
+    "PYTHONEXECUTABLE",
+    "PYTHONWARNINGS",
+    "PERL5LIB",
+    "PERLLIB",
+    "PERL5OPT",
+    "RUBYLIB",
+    "RUBYOPT",
+    "NODE_OPTIONS",
+    "NODE_PATH",
+    "CLASSPATH",
+    "JAVA_TOOL_OPTIONS",
+    "_JAVA_OPTIONS",
+    "GCONV_PATH",
+    "LOCPATH",
+    "NLSPATH",
+    "HOSTALIASES",
+    "RES_OPTIONS",
+    "TERMINFO",
+    "TERMINFO_DIRS",
+    "TERMPATH",
+    "TMPDIR",
+    "TMP",
+    "TEMP",
+    "IFS",
+    "BASH_ENV",
+    "ENV",
+    "CDPATH",
+    "GLOBIGNORE",
+    "SHELLOPTS",
+    "BASHOPTS",
+    "PS4",
+    "PROMPT_COMMAND",
+    "MALLOC_CONF",
+    "MANPATH",
+    "XDG_CONFIG_HOME",
+    "XDG_DATA_DIRS",
+]
+
+
+def test_safe_env_drops_all_known_dangerous_vars(monkeypatch):
+    """Deny-by-default: not one of a broad set of loader/interpreter/locale/shell
+    redirection variables survives, whether or not a denylist ever named it."""
+    for var in _DANGEROUS_ENV:
+        monkeypatch.setenv(var, "/evil")
+    env = ps.safe_env()
+    leaked = [var for var in _DANGEROUS_ENV if var in env]
+    assert not leaked, f"safe_env leaked: {leaked}"
+    # And nothing outside the whitelist (plus PATH) is kept at all.
+    assert set(env) <= (set(ps._ENV_KEEP) | {"PATH"})
+
+
+def test_safe_env_keeps_whitelisted_and_scrubs_path(monkeypatch):
+    monkeypatch.setenv("PATH", "/attacker/bin")
+    monkeypatch.setenv("LANG", "en_US.UTF-8")  # a whitelisted var is kept
+    env = ps.safe_env()
+    assert env.get("LANG") == "en_US.UTF-8"
+    assert "/attacker/bin" not in env["PATH"].split(os.pathsep)
+
+
+def test_safe_env_path_denies_resolution_and_is_never_cwd():
+    """The child PATH resolves nothing (a trusted binary is run by absolute path,
+    so it needs no PATH) and is never empty. An EMPTY or unset PATH is searched as
+    the current directory by execvp/subprocess, so it must be a single directory
+    with no executables, not '' (CWE-426)."""
+    path = ps.safe_env()["PATH"]
+    assert path == ps._LOCKED_PATH
+    # Never empty and never an empty element (which is searched as the CWD). This
+    # is the cross-platform invariant.
+    assert path
+    assert "" not in path.split(os.pathsep), "an empty PATH element is the CWD"
+    # The sentinel is a POSIX-absolute directory with no executables. On Windows,
+    # spawn_trusted fails closed, so this PATH never gates a real exec; a leading
+    # slash is drive-relative there, so the absoluteness check is POSIX-only.
+    if os.name == "posix":
+        assert os.path.isabs(path), "a relative PATH element is CWD-relative"
+        assert not os.path.isdir(path) or not os.listdir(path)  # nothing to find
+
+
+def test_safe_env_has_no_extra_escape_hatch():
+    """A caller must NOT be able to reintroduce a loader variable, so safe_env
+    deliberately takes no parameters."""
+    assert list(inspect.signature(ps.safe_env).parameters) == []
+
+
+# --------------------------------------------------------------------------- #
+# spawn_trusted: choke point (no shell, scrubbed env, verified path).          #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def _popen_spy(monkeypatch):
+    calls = []
+
+    class _FakeProc:
+        returncode = 0
+
+        def communicate(self, *a, **k):
+            return b"", b""
+
+    def _fake_popen(cmd, *a, **k):
+        calls.append(
+            SimpleNamespace(
+                argv=list(cmd),
+                shell=k.get("shell", False),
+                env=k.get("env"),
+                executable=k.get("executable"),
+                close_fds=k.get("close_fds"),
+            )
+        )
+        return _FakeProc()
+
+    monkeypatch.setattr(ps.subprocess, "Popen", _fake_popen)
+    return calls
+
+
+def test_spawn_trusted_refuses_shell():
+    with pytest.raises(ValueError):
+        ps.spawn_trusted("/bin/sh", ["-c", "true"], shell=True)
+
+
+def test_spawn_trusted_refuses_untrusted_target(staging):
+    with pytest.raises(ps.TrustError):
+        ps.spawn_trusted(os.path.join(staging, "does-not-exist"))
+
+
+@POSIX
+def test_spawn_trusted_refuses_world_writable_target(staging):
+    binp = _mkexec(os.path.join(staging, "install"), "tool", mode=0o777)
+    with pytest.raises(ps.TrustError):
+        ps.spawn_trusted(binp)
+
+
+@POSIX  # resolves /bin/sh, which only exists on POSIX
+def test_spawn_trusted_defaults_are_safe(_popen_spy):
+    ps.spawn_trusted("/bin/sh", ["-c", "true"])
+    assert len(_popen_spy) == 1
+    call = _popen_spy[0]
+    assert call.shell is False
+    assert call.close_fds is True
+    assert call.executable == os.path.realpath("/bin/sh")
+    assert call.argv[0] == os.path.realpath("/bin/sh")  # argv[0] is the resolved path
+    assert not call.executable.startswith("/proc/")  # no /proc/self/fd indirection
+    assert "LD_PRELOAD" not in (call.env or {})
+    # PATH is the deny-sentinel: non-empty, absolute, resolves no command.
+    child_path = (call.env or {}).get("PATH", "")
+    assert child_path == ps._LOCKED_PATH
+    assert "" not in child_path.split(os.pathsep)  # no CWD element
+
+
+@POSIX
+def test_spawn_trusted_really_scrubs_child_environment(staging, monkeypatch):
+    marker = os.path.join(staging, "childenv.txt")
+    script = (
+        "#!/bin/sh\n"
+        '{ echo "LD_PRELOAD=[$LD_PRELOAD]"; echo "PYTHONPATH=[$PYTHONPATH]"; '
+        'echo "DYLD=[$DYLD_INSERT_LIBRARIES]"; echo "PATH=[$PATH]"; } > "%s"\n' % marker
+    )
+    binp = _mkexec(os.path.join(staging, "install"), "tool", content=script)
+    monkeypatch.setenv("LD_PRELOAD", "/evil.so")
+    monkeypatch.setenv("PYTHONPATH", "/evil")
+    monkeypatch.setenv("DYLD_INSERT_LIBRARIES", "/evil.dylib")
+
+    proc = ps.spawn_trusted(binp)
+    proc.communicate()
+    reported = open(marker).read()
+    assert "LD_PRELOAD=[]" in reported, reported
+    assert "PYTHONPATH=[]" in reported, reported
+    assert "DYLD=[]" in reported, reported
+    assert ("PATH=[%s]" % ps._LOCKED_PATH) in reported, reported  # deny-sentinel
+
+
+@POSIX
+def test_spawn_trusted_child_cannot_resolve_bare_command_from_cwd(
+    staging, tmp_path, monkeypatch
+):
+    """Real execution: with the locked PATH a trusted child cannot resolve a
+    bare-name command, and in particular cannot reach a planted ./tool in the
+    current directory, so a shell-out on attacker input finds nothing (CWE-426).
+    An empty PATH here WOULD run the CWD tool (verified separately), which is why
+    the sentinel is used instead."""
+    marker = tmp_path / "evil_ran.marker"
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    evil = cwd / "eviltool"
+    evil.write_text('#!/bin/sh\n: > "%s"\n' % marker)
+    os.chmod(evil, 0o755)
+    monkeypatch.chdir(cwd)  # the child inherits this CWD (spawn_trusted sets no cwd)
+
+    # A trusted stub that tries to run 'eviltool' by BARE name.
+    stub = _mkexec(
+        os.path.join(staging, "install"), "tool", content="#!/bin/sh\neviltool\n"
+    )
+    proc = ps.spawn_trusted(stub)
+    proc.communicate()
+    assert not marker.exists(), "child resolved a bare command from the CWD"
+
+
+@POSIX
+def test_spawn_trusted_runs_the_verified_binary(staging):
+    binp = _mkexec(
+        os.path.join(staging, "install"),
+        "tool",
+        content="#!/bin/sh\nprintf ran\n",
+    )
+    proc = ps.spawn_trusted(binp, stdout=subprocess.PIPE)
+    out, _ = proc.communicate()
+    assert out == b"ran"
+
+
+# --------------------------------------------------------------------------- #
+# Minimalism locks: strict resolver, no removed machinery.                     #
+# --------------------------------------------------------------------------- #
+
+
+def test_removed_attack_surface_stays_removed():
+    for gone in (
+        "_resolve_trusted_windows",
+        "_windows_trusted_roots",
+        "_WINDOWS_TRUSTED_ROOT_KEYS",
+        "_dir_is_traversal_safe",
+        "_traversal_dir_ok",
+    ):
+        assert not hasattr(ps, gone), gone

--- a/nltk/test/unit/test_pathsec_trusted_exec.py
+++ b/nltk/test/unit/test_pathsec_trusted_exec.py
@@ -646,13 +646,17 @@ def test_validate_tool_path_max_bytes_refuses_oversize(staging):
     """A model larger than max_bytes is refused (a model-size memory bomb the
     external tool would load whole into RAM, CWE-400)."""
     small = _model_in_root(staging, "small.model", size=100)
-    assert ps.validate_tool_path(small, context="t", max_bytes=100) == os.path.realpath(
-        small
+    # validate_tool_path returns the validated input string verbatim (it resolves
+    # __fspath__ exactly once, it does NOT realpath), so compare to the input, not
+    # to os.path.realpath: on Windows CI the staging path is an 8.3 short name /
+    # junction whose realpath differs, which is not what this guard is about.
+    assert (
+        ps.validate_tool_path(small, context="t", max_bytes=100) == small
     )  # exactly at the cap passes
     with pytest.raises(PermissionError):
         ps.validate_tool_path(small, context="t", max_bytes=99)  # one over -> refused
     # no cap (default) keeps accepting it
-    assert ps.validate_tool_path(small, context="t") == os.path.realpath(small)
+    assert ps.validate_tool_path(small, context="t") == small
 
 
 @POSIX
@@ -660,15 +664,15 @@ def test_validate_tool_path_require_private_refuses_tamperable(staging):
     """A group/world-writable model in a root is refused with require_private: any
     local user could swap the bytes the tool then parses (CWE-426/CWE-732)."""
     private = _model_in_root(staging, "private.model", mode=0o644)
-    assert ps.validate_tool_path(
-        private, context="t", require_private=True
-    ) == os.path.realpath(private)
+    # validated input is returned verbatim (see the max_bytes test) -> compare to
+    # the input, not os.path.realpath.
+    assert ps.validate_tool_path(private, context="t", require_private=True) == private
     for bad_mode in (0o666, 0o646, 0o664):  # world- or group-writable
         ww = _model_in_root(staging, f"ww{bad_mode}.model", mode=bad_mode)
         with pytest.raises(PermissionError):
             ps.validate_tool_path(ww, context="t", require_private=True)
         # without require_private the same file is accepted (guard is opt-in)
-        assert ps.validate_tool_path(ww, context="t") == os.path.realpath(ww)
+        assert ps.validate_tool_path(ww, context="t") == ww
 
 
 @POSIX

--- a/nltk/test/unit/test_pathsec_trusted_exec.py
+++ b/nltk/test/unit/test_pathsec_trusted_exec.py
@@ -8,7 +8,8 @@ test: a world/group-writable directory or binary, a path under the shared
 attacker-writable directory, a ``..``/relative/NUL path, an owner other than us,
 a FIFO/socket/directory/device in the executable slot, symlink loops, loader
 variables in the environment, ``shell=True``, and a non-POSIX platform (which
-fails closed). Real files with real ``chmod``/``symlink``/``mkfifo`` and real
+degrades to best-effort, NOT fail-closed, so Windows tool wrappers keep working).
+Real files with real ``chmod``/``symlink``/``mkfifo`` and real
 ``subprocess`` execution are used (no mocks), so a regression actually leaks
 here rather than being papered over by a stub.
 
@@ -18,7 +19,8 @@ that is the only in-sandbox place a trusted binary may live on Linux.
 
 They also lock the minimalism decisions: no ``/proc/self/fd`` fexecve dance, no
 ``safe_env(extra=...)`` escape hatch, no sticky-``/tmp`` traversal allowance, and
-no Windows heuristic (all were attack surface without an in-scope payoff).
+no win32security DACL check on non-POSIX (the non-POSIX path stays best-effort
+rather than fail-closed; all were attack surface without an in-scope payoff).
 """
 
 import inspect
@@ -548,3 +550,78 @@ def test_removed_attack_surface_stays_removed():
         "_traversal_dir_ok",
     ):
         assert not hasattr(ps, gone), gone
+
+
+# ---------------------------------------------------------------------------- #
+# has_line_unsafe_char: the shared token guard for the line-oriented wrappers.  #
+# It must flag every control char, line/paragraph separator and lone surrogate, #
+# and never flag ordinary multilingual token content.                           #
+# ---------------------------------------------------------------------------- #
+
+# Every code point str.splitlines() treats as a line boundary, plus DEL, the C1
+# controls, and a lone surrogate. All must be flagged.
+_UNSAFE_CODEPOINTS = (
+    list(range(0x00, 0x20))  # C0 controls (incl. TAB/CR/LF/NUL/FS-GS-RS)
+    + [0x7F]  # DEL
+    + list(range(0x80, 0xA0))  # C1 controls (incl. NEL 0x85)
+    + [0x2028, 0x2029]  # Unicode line / paragraph separators
+    + [0xD800, 0xDBFF, 0xDFFF]  # lone surrogates
+)
+
+# Ordinary token content that must NEVER be flagged (letters across scripts,
+# marks, digits, punctuation, symbols, ordinary + non-breaking space, and the
+# format characters real multilingual text relies on).
+_SAFE_CODEPOINTS = [
+    0x41,
+    0x7A,
+    0x30,  # A z 0
+    0x20,
+    0xA0,  # space, non-breaking space
+    0xE9,
+    0xF1,  # é ñ
+    0x3B1,
+    0x4E2D,
+    0x65E5,  # α 中 日
+    0x905,
+    0x5D0,
+    0x627,  # Devanagari A, Hebrew alef, Arabic alef
+    0xA3,
+    0x20AC,
+    0x2764,  # £ € heart
+    0x200D,
+    0x200C,
+    0xFEFF,
+    0x200E,
+    0x200F,
+    0x2060,
+    0xAD,  # ZWJ ZWNJ BOM LRM RLM WJ SHY
+    0x1F600,  # emoji
+]
+
+
+@pytest.mark.parametrize("cp", _UNSAFE_CODEPOINTS)
+def test_has_line_unsafe_char_flags_every_control_separator_and_surrogate(cp):
+    ch = chr(cp)
+    assert ps.has_line_unsafe_char("x" + ch + "y"), f"U+{cp:04X} not flagged"
+    # allow_tab exempts ONLY 0x09, nothing else.
+    if cp == 0x09:
+        assert not ps.has_line_unsafe_char("x\ty", allow_tab=True)
+    else:
+        assert ps.has_line_unsafe_char("x" + ch + "y", allow_tab=True)
+
+
+@pytest.mark.parametrize("cp", _SAFE_CODEPOINTS)
+def test_has_line_unsafe_char_allows_ordinary_multilingual_content(cp):
+    ch = chr(cp)
+    assert not ps.has_line_unsafe_char("a" + ch + "b"), f"U+{cp:04X} wrongly flagged"
+
+
+def test_has_line_unsafe_char_bytes_flags_c0_and_del_only():
+    # On bytes only the unambiguous C0 controls and DEL are detectable; a valid
+    # UTF-8 multibyte token (whose continuation bytes are 0x80-0xBF) is not flagged.
+    assert ps.has_line_unsafe_char(b"a\x00b")  # NUL
+    assert ps.has_line_unsafe_char(b"a\x7fb")  # DEL
+    assert ps.has_line_unsafe_char(b"a\tb")  # TAB blocked by default
+    assert not ps.has_line_unsafe_char(b"a\tb", allow_tab=True)
+    assert not ps.has_line_unsafe_char("café".encode("utf-8"))
+    assert not ps.has_line_unsafe_char("日本語".encode("utf-8"))

--- a/nltk/test/unit/test_pathsec_trusted_exec.py
+++ b/nltk/test/unit/test_pathsec_trusted_exec.py
@@ -623,5 +623,5 @@ def test_has_line_unsafe_char_bytes_flags_c0_and_del_only():
     assert ps.has_line_unsafe_char(b"a\x7fb")  # DEL
     assert ps.has_line_unsafe_char(b"a\tb")  # TAB blocked by default
     assert not ps.has_line_unsafe_char(b"a\tb", allow_tab=True)
-    assert not ps.has_line_unsafe_char("café".encode("utf-8"))
-    assert not ps.has_line_unsafe_char("日本語".encode("utf-8"))
+    assert not ps.has_line_unsafe_char("café".encode())
+    assert not ps.has_line_unsafe_char("日本語".encode())

--- a/nltk/test/unit/test_pathsec_trusted_exec.py
+++ b/nltk/test/unit/test_pathsec_trusted_exec.py
@@ -625,3 +625,63 @@ def test_has_line_unsafe_char_bytes_flags_c0_and_del_only():
     assert not ps.has_line_unsafe_char(b"a\tb", allow_tab=True)
     assert not ps.has_line_unsafe_char("café".encode())
     assert not ps.has_line_unsafe_char("日本語".encode())
+
+
+# ---------------------------------------------------------------------------- #
+# validate_tool_path model guards: max_bytes (size bomb) + require_private        #
+# (a model another local user could plant/swap, parsed by an external C/JVM       #
+# tool). These narrow the "malicious in-root model" residual.                     #
+# ---------------------------------------------------------------------------- #
+
+
+def _model_in_root(staging, name="m.model", size=32, mode=0o644):
+    path = os.path.join(staging, name)
+    with open(path, "wb") as fh:
+        fh.write(b"\x00\x01model" + b"x" * max(0, size - 7))
+    os.chmod(path, mode)
+    return path
+
+
+def test_validate_tool_path_max_bytes_refuses_oversize(staging):
+    """A model larger than max_bytes is refused (a model-size memory bomb the
+    external tool would load whole into RAM, CWE-400)."""
+    small = _model_in_root(staging, "small.model", size=100)
+    assert ps.validate_tool_path(small, context="t", max_bytes=100) == os.path.realpath(
+        small
+    )  # exactly at the cap passes
+    with pytest.raises(PermissionError):
+        ps.validate_tool_path(small, context="t", max_bytes=99)  # one over -> refused
+    # no cap (default) keeps accepting it
+    assert ps.validate_tool_path(small, context="t") == os.path.realpath(small)
+
+
+@POSIX
+def test_validate_tool_path_require_private_refuses_tamperable(staging):
+    """A group/world-writable model in a root is refused with require_private: any
+    local user could swap the bytes the tool then parses (CWE-426/CWE-732)."""
+    private = _model_in_root(staging, "private.model", mode=0o644)
+    assert ps.validate_tool_path(
+        private, context="t", require_private=True
+    ) == os.path.realpath(private)
+    for bad_mode in (0o666, 0o646, 0o664):  # world- or group-writable
+        ww = _model_in_root(staging, f"ww{bad_mode}.model", mode=bad_mode)
+        with pytest.raises(PermissionError):
+            ps.validate_tool_path(ww, context="t", require_private=True)
+        # without require_private the same file is accepted (guard is opt-in)
+        assert ps.validate_tool_path(ww, context="t") == os.path.realpath(ww)
+
+
+@POSIX
+def test_model_guards_still_refuse_fifo_and_symlink_escape(staging):
+    """The pre-existing shape guards remain in force under the new params: a FIFO
+    or a symlink escaping the root in the model slot is still refused."""
+    fifo = os.path.join(staging, "evil.fifo")
+    os.mkfifo(fifo)
+    with pytest.raises(PermissionError):
+        ps.validate_tool_path(
+            fifo, context="t", require_private=True, max_bytes=ps.MAX_TOOL_MODEL_BYTES
+        )
+    escape = os.path.join(staging, "escape.model")
+    os.symlink("/etc/passwd", escape)
+    with pytest.raises(PermissionError):
+        ps.validate_tool_path(escape, context="t", require_private=True)

--- a/nltk/test/unit/test_pickle_allowlist_security.py
+++ b/nltk/test/unit/test_pickle_allowlist_security.py
@@ -1473,7 +1473,7 @@ def test_data_load_restricted_pickle_roundtrips_real_asset(tmp_path, monkeypatch
     assert loaded == staged_value, "staged real .pickle failed to load via data.load"
 
 
-def test_all_nltk_data_pickle_assets_load():
+def test_all_nltk_data_pickle_assets_load(tmp_path_factory):
     """Real-asset regression: EVERY ``*.pickle`` present in the installed nltk_data
     must still load through ``nltk.data.load`` after the picklesec hardening (class-
     bearing artifacts like punkt / perceptron / maxent via the pickle-free redirect;
@@ -1486,7 +1486,20 @@ def test_all_nltk_data_pickle_assets_load():
 
     import nltk
 
-    roots = [p for p in nltk.data.path if os.path.isdir(p)]
+    # conftest.py registers pytest's session basetemp as an nltk.data.path root so
+    # staging tests can write inside the pathsec sandbox. That base holds ephemeral
+    # scratch from other tests (symlinks, deliberately unloadable pickles), never
+    # real nltk_data assets, so exclude it and anything under it: this scanner
+    # validates installed assets, not per-test tmp files (a filename-based skip
+    # would be bypassed by any other extension, so exclude by location).
+    basetemp = os.path.realpath(str(tmp_path_factory.getbasetemp()))
+    roots = [
+        p
+        for p in nltk.data.path
+        if os.path.isdir(p)
+        and os.path.realpath(p) != basetemp
+        and not os.path.realpath(p).startswith(basetemp + os.sep)
+    ]
     files = []
     for root in roots:
         files += glob.glob(os.path.join(root, "**", "*.pickle"), recursive=True)

--- a/nltk/test/unit/test_prover9_security.py
+++ b/nltk/test/unit/test_prover9_security.py
@@ -135,3 +135,43 @@ def test_fromstring_path_is_not_reachable_for_injection():
     # atoms, so a legitimate parse never trips the guard.
     for text in ["man(socrates)", "all x.(walk(x) -> move(x))", "-(P(a) & Q(b))"]:
         _assert_prover9_safe(convert_to_prover9(read(text)))
+
+
+# --- Resource-bound validation (max_seconds / end_size): CWE-400 + type safety --
+# The timeout/end_size are interpolated into ``assign(max_seconds, %d)``. The
+# ``%d`` blocks injection, but a negative value is undefined to the binary and a
+# non-int raises at format time; both are refused up front (0 is the documented
+# "no timeout", the caller's own DoS choice).
+
+
+@pytest.mark.parametrize(
+    "bad", [-1, -60, "60", "0). formulas(goals)", 1.5, 3.0, True, False, None, []]
+)
+def test_safe_seconds_rejects_non_nonnegative_int(bad):
+    from nltk.inference.prover9 import _safe_seconds
+
+    with pytest.raises(ValueError, match="non-negative integer"):
+        _safe_seconds(bad)
+
+
+@pytest.mark.parametrize("good", [0, 1, 60, 3600])
+def test_safe_seconds_accepts_nonnegative_int(good):
+    from nltk.inference.prover9 import _safe_seconds
+
+    assert _safe_seconds(good) == good
+
+
+def test_prover9_rejects_bad_timeout_before_spawn():
+    # A bad timeout is caught before the binary is even located, so there is no
+    # spawn and the caller gets a clear ValueError rather than a later TypeError.
+    with pytest.raises(ValueError, match="non-negative integer"):
+        Prover9(timeout=-5)._call_prover9("formulas(goals).\nend_of_list.\n")
+
+
+def test_mace_rejects_bad_end_size_before_spawn():
+    from nltk.inference.mace import Mace
+
+    builder = Mace()
+    builder._end_size = -1
+    with pytest.raises(ValueError, match="non-negative integer"):
+        builder._call_mace4("formulas(assumptions).\nend_of_list.\n")

--- a/nltk/test/unit/test_prover9_security.py
+++ b/nltk/test/unit/test_prover9_security.py
@@ -40,6 +40,8 @@ read = Expression.fromstring
         "formulasize(y)",  # 'formulas' is only a prefix here
         "clauses_of(x)",  # 'clauses' is only a prefix here
         "p(x)\tq(y)",  # a tab is ordinary whitespace, not a line break
+        "(a = b)",  # equality is legitimate Prover9 syntax
+        "all x exists y (loves(x,y) & -hates(y,x))",  # connectives, quantifiers
     ],
 )
 def test_genuine_formulas_pass(formula):
@@ -64,6 +66,10 @@ def test_genuine_formulas_pass(formula):
         "p(x)\x7fq",  # DEL (control)
         "  end_of_list",  # leading whitespace does not launder it
         "\tformulas(goals)",  # leading tab does not launder a list opener
+        "p(a) % x",  # '%' comments out the appended period, merging formulas
+        "p(a)%end_of_list",  # comment char plus a directive
+        "p(a) # answer(evil)",  # '#' injects a Prover9 answer/label attribute
+        "p(a)#label(spoof)",  # '#' label char
     ],
 )
 def test_injection_formulas_refused(formula):

--- a/nltk/test/unit/test_prover9_security.py
+++ b/nltk/test/unit/test_prover9_security.py
@@ -1,0 +1,131 @@
+# Natural Language Toolkit: Prover9 input-injection guard tests
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""nltk.inference.prover9 builds the Prover9 input by interpolating each converted
+logic formula into a ``formulas(...)`` list. A crafted term carrying a bare
+period, a control character, a NUL, or a leading list keyword could close the
+list early and inject extra Prover9 directives such as ``end_of_list.``
+(CVE-2026-14709). These tests pin the local guard and confirm ``prover9_input``
+(and therefore Mace, which reuses it) routes through it, while genuine formulas
+still convert.
+"""
+
+import pytest
+
+from nltk.inference.prover9 import (
+    Prover9,
+    Prover9Parent,
+    _assert_prover9_safe,
+    convert_to_prover9,
+)
+from nltk.sem.logic import Expression
+
+read = Expression.fromstring
+
+
+@pytest.mark.parametrize(
+    "formula",
+    [
+        "man(socrates)",
+        "walk(john)",
+        "(P(x) & Q(y))",
+        "-(mortal(x))",
+        "exists x see(x,y)",
+        "all x (man(x) -> mortal(x))",
+        "(P(a) <-> Q(b))",
+        "end_of_list_marker(x)",  # reserved word only as a strict prefix
+        "formulasize(y)",  # 'formulas' is only a prefix here
+        "clauses_of(x)",  # 'clauses' is only a prefix here
+        "p(x)\tq(y)",  # a tab is ordinary whitespace, not a line break
+    ],
+)
+def test_genuine_formulas_pass(formula):
+    assert _assert_prover9_safe(formula) == formula
+
+
+@pytest.mark.parametrize(
+    "formula",
+    [
+        "p(x). end_of_list. formulas(goals). q(x)",  # bare period breakout
+        "p(x)\nend_of_list.\nformulas(goals).\nq(x)",  # newline breakout
+        "p(x)\r\nend_of_list.",  # CRLF breakout
+        "p(x)\rend_of_list.",  # bare CR
+        "end_of_list",  # formula IS the list terminator
+        "formulas(goals)",  # list opener
+        "clauses(sos)",  # clause-list opener
+        "end_of_list(x)",  # leading reserved keyword
+        "p(x)\x00drop",  # NUL
+        "p(x)\x0bq",  # vertical tab (control)
+        "p(x)\x0cq",  # form feed (control)
+        "p(x)\x1fq",  # unit separator (control)
+        "p(x)\x7fq",  # DEL (control)
+        "  end_of_list",  # leading whitespace does not launder it
+        "\tformulas(goals)",  # leading tab does not launder a list opener
+    ],
+)
+def test_injection_formulas_refused(formula):
+    with pytest.raises(ValueError, match="inject"):
+        _assert_prover9_safe(formula)
+
+
+def test_prover9_input_builds_and_guards():
+    p = Prover9()
+    good = p.prover9_input(read("man(socrates)"), [read("all x.(man(x) -> mortal(x))")])
+    assert "formulas(assumptions)." in good
+    assert "end_of_list." in good
+    assert "man(socrates)" in good
+
+
+def _evil(payload):
+    class Evil:
+        def simplify(self):
+            return self
+
+        def __str__(self):
+            return payload
+
+    return Evil()
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "p(x).\nend_of_list.\nformulas(goals).\n exploit(y)",
+        "p(x)\x00",
+        "end_of_list",
+        "p(x)\x0cq",
+    ],
+)
+def test_prover9_input_rejects_crafted_expression_as_goal(payload):
+    # A hand-built Expression whose str() injects directives is stopped before it
+    # can reach the Prover9 stdin (Expression.fromstring never yields such text,
+    # so this is the defence-in-depth path). Exercised as the goal argument.
+    with pytest.raises(ValueError, match="inject"):
+        Prover9Parent.prover9_input(Prover9(), _evil(payload), [])
+
+
+def test_prover9_input_rejects_crafted_expression_in_assumptions():
+    # And as an assumption (the loop path), so both interpolation sites are guarded.
+    with pytest.raises(ValueError, match="inject"):
+        Prover9Parent.prover9_input(
+            Prover9(), read("man(socrates)"), [_evil("p(x).\nend_of_list.")]
+        )
+
+
+def test_mace_reuses_the_guarded_prover9_input():
+    # Mace builds its input through the same Prover9Parent.prover9_input, so the
+    # guard protects it too.
+    from nltk.inference.mace import Mace
+
+    with pytest.raises(ValueError, match="inject"):
+        Mace().prover9_input(_evil("p(x).\nend_of_list.\nassign(max_seconds,0)"), [])
+
+
+def test_fromstring_path_is_not_reachable_for_injection():
+    # Real inputs go through Expression.fromstring, which only produces identifier
+    # atoms, so a legitimate parse never trips the guard.
+    for text in ["man(socrates)", "all x.(walk(x) -> move(x))", "-(P(a) & Q(b))"]:
+        _assert_prover9_safe(convert_to_prover9(read(text)))

--- a/nltk/test/unit/test_repp_security.py
+++ b/nltk/test/unit/test_repp_security.py
@@ -103,3 +103,79 @@ def test_scratch_input_is_staged_in_a_data_root_and_cleaned_up(monkeypatch):
     assert captured["existed"] and captured["in_root"]
     assert not captured["in_shared_tmp"]
     assert not os.path.exists(captured["path"])  # cleaned up in the finally
+
+
+# --- Trusted-exec routing: _execute now goes through pathsec.spawn_trusted -----
+# (the standardized native-wrapper chokepoint; strict trust policy, like senna).
+
+requires_posix_perms = pytest.mark.skipif(
+    not hasattr(os, "getuid"), reason="POSIX ownership/permission model"
+)
+
+
+def _staging(prefix="repp_test_"):
+    """A private, in-sandbox base dir (never world-writable /tmp)."""
+    import nltk.data as nltk_data
+
+    try:
+        return nltk_data.make_staging_dir(prefix=prefix, cleanup=True)
+    except PermissionError as exc:  # pragma: no cover - env-dependent
+        pytest.skip(f"no writable in-sandbox NLTK data root: {exc}")
+
+
+def _repp_cmd(reppdir):
+    return [
+        str(reppdir / "src" / "repp"),
+        "-c",
+        str(reppdir / "erg" / "repp.set"),
+        "--format",
+        "triple",
+        "/dev/null",
+    ]
+
+
+@requires_posix_perms
+def test_execute_refuses_untrusted_repp_binary(tmp_path):
+    """Strict trust: a REPP binary whose holding directory is world-writable is
+    refused before running, since another local user could swap it (CWE-426/732)."""
+    reppdir = _make_repp_dir(tmp_path / "wwrepp")
+    os.chmod(reppdir / "src" / "repp", 0o755)
+    os.chmod(reppdir / "src", 0o777)  # world-writable: attacker can swap the binary
+    with pytest.raises(LookupError):
+        ReppTokenizer._execute(_repp_cmd(reppdir))
+
+
+def test_execute_reaches_spawn_for_a_trusted_binary(monkeypatch):
+    """Benign control: a REPP binary under a private staged root reaches the
+    (trapped) spawn with an absolute, fully-resolved argv[0] and no shell."""
+    from types import SimpleNamespace
+
+    import nltk.pathsec as ps
+
+    reppdir = _make_repp_dir(pathlib.Path(_staging()) / "repp")
+    os.chmod(reppdir / "src" / "repp", 0o755)
+
+    calls = []
+
+    class _FakeProc:
+        returncode = 0
+
+        def communicate(self, *a, **k):
+            return b"", b""
+
+    def _fake_popen(cmd, *a, **k):
+        calls.append(
+            SimpleNamespace(
+                argv=list(cmd),
+                shell=k.get("shell", False),
+                executable=k.get("executable"),
+            )
+        )
+        return _FakeProc()
+
+    monkeypatch.setattr(ps.subprocess, "Popen", _fake_popen)
+    ReppTokenizer._execute(_repp_cmd(reppdir))
+    assert len(calls) == 1
+    assert calls[0].shell is False
+    assert os.path.isabs(calls[0].argv[0])
+    assert calls[0].argv[0] == os.path.realpath(str(reppdir / "src" / "repp"))

--- a/nltk/test/unit/test_repp_security.py
+++ b/nltk/test/unit/test_repp_security.py
@@ -179,3 +179,43 @@ def test_execute_reaches_spawn_for_a_trusted_binary(monkeypatch):
     assert calls[0].shell is False
     assert os.path.isabs(calls[0].argv[0])
     assert calls[0].argv[0] == os.path.realpath(str(reppdir / "src" / "repp"))
+
+
+# --- Layer-6 input guard: REPP reads one sentence per line (CWE-93) ------------
+
+
+def _detached_tokenizer():
+    tok = object.__new__(ReppTokenizer)
+    tok.repp_dir = "/x"
+    tok.encoding = "utf8"
+    return tok
+
+
+def test_control_char_sentence_is_refused_before_spawn(monkeypatch):
+    """A newline/NUL/other control char in a sentence would inject an extra REPP
+    input line (or a NUL would truncate one), desynchronising the token stream
+    from the sentence list; such input is refused before the binary is spawned."""
+    tok = _detached_tokenizer()
+    called = []
+    monkeypatch.setattr(
+        ReppTokenizer, "_execute", staticmethod(lambda cmd: called.append(cmd) or b"")
+    )
+    for payload in ["good\nevil", "nul\x00here", "cr\rhere", "esc\x1bhere"]:
+        with pytest.raises(ValueError, match="control characters"):
+            list(tok.tokenize_sents([payload]))
+    assert not called, "REPP was spawned despite a control-char sentence"
+
+
+def test_tab_in_sentence_reaches_execute(monkeypatch):
+    """A tab is legal inside a sentence (REPP splits on newlines only), so the
+    guard must let it through to the (fake) binary."""
+    tok = _detached_tokenizer()
+    called = []
+    monkeypatch.setattr(
+        ReppTokenizer, "_execute", staticmethod(lambda cmd: called.append(1) or b"")
+    )
+    try:
+        list(tok.tokenize_sents(["a\tb c"]))
+    except ValueError:
+        pass  # empty fake output yields no triples; irrelevant to the guard
+    assert called, "a tab-containing sentence must pass the guard and reach _execute"

--- a/nltk/test/unit/test_repp_security.py
+++ b/nltk/test/unit/test_repp_security.py
@@ -200,10 +200,41 @@ def test_control_char_sentence_is_refused_before_spawn(monkeypatch):
     monkeypatch.setattr(
         ReppTokenizer, "_execute", staticmethod(lambda cmd: called.append(cmd) or b"")
     )
-    for payload in ["good\nevil", "nul\x00here", "cr\rhere", "esc\x1bhere"]:
+    payloads = [
+        "good\nevil",  # LF
+        "nul\x00here",  # NUL
+        "cr\rhere",  # CR
+        "esc\x1bhere",  # C0 control
+        "ff\x0chere",  # form feed
+        "rs\x1ehere",  # record separator
+        "del\x7fhere",  # DEL (the reviewer's gap)
+        "nel\x85here",  # NEL / C1 control
+        "c1\x9fhere",  # C1 control
+        "ls\u2028here",  # Unicode line separator
+        "ps\u2029here",  # Unicode paragraph separator
+        "sur\ud800here",  # lone surrogate
+    ]
+    for payload in payloads:
         with pytest.raises(ValueError, match="control characters"):
             list(tok.tokenize_sents([payload]))
-    assert not called, "REPP was spawned despite a control-char sentence"
+    assert not called, "REPP was spawned despite an unsafe-char sentence"
+
+
+def test_legitimate_multilingual_sentence_reaches_execute(monkeypatch):
+    """The guard must not overblock real text: non-ASCII letters and a literal TAB
+    (REPP splits on newlines only) are ordinary sentence content and reach the
+    (fake) binary rather than being refused."""
+    tok = _detached_tokenizer()
+    called = []
+    monkeypatch.setattr(
+        ReppTokenizer, "_execute", staticmethod(lambda cmd: called.append(1) or b"")
+    )
+    for sent in ["café au lait", "日本語 の 文", "a\tb c", "naïve\u200djoin"]:
+        try:
+            list(tok.tokenize_sents([sent]))
+        except ValueError as exc:
+            assert "control characters" not in str(exc), f"overblocked {sent!r}"
+    assert len(called) == 4, "every benign sentence must reach _execute"
 
 
 def test_tab_in_sentence_reaches_execute(monkeypatch):

--- a/nltk/test/unit/test_repp_security.py
+++ b/nltk/test/unit/test_repp_security.py
@@ -229,12 +229,22 @@ def test_legitimate_multilingual_sentence_reaches_execute(monkeypatch):
     monkeypatch.setattr(
         ReppTokenizer, "_execute", staticmethod(lambda cmd: called.append(1) or b"")
     )
-    for sent in ["café au lait", "日本語 の 文", "a\tb c", "naïve\u200djoin"]:
+    # Encodable on every platform: these must pass the guard AND reach _execute.
+    # (_execute records the call before the empty fake output fails to parse, so
+    # the post-spawn parse ValueError is tolerated.)
+    for sent in ["hello world", "a\tb c"]:
+        try:
+            list(tok.tokenize_sents([sent]))
+        except ValueError:
+            pass
+    assert len(called) == 2, "benign ASCII/tab sentences must reach _execute"
+    # Multilingual / ZWJ content must not be refused by the control-char guard;
+    # tolerate an unrelated platform encoding error at the tool's file write.
+    for sent in ["café au lait", "日本語 の 文", "naïve\u200djoin"]:
         try:
             list(tok.tokenize_sents([sent]))
         except ValueError as exc:
-            assert "control characters" not in str(exc), f"overblocked {sent!r}"
-    assert len(called) == 4, "every benign sentence must reach _execute"
+            assert "control characters" not in str(exc), f"guard overblocked {sent!r}"
 
 
 def test_tab_in_sentence_reaches_execute(monkeypatch):

--- a/nltk/test/unit/test_senna_security.py
+++ b/nltk/test/unit/test_senna_security.py
@@ -207,9 +207,8 @@ def test_relative_path_reassigned_after_construction_is_refused(
 
 @pytest.mark.skipif(
     not hasattr(os, "getuid"),
-    reason="the trust check accepts a tmp install via the POSIX ownership model; "
-    "the Windows heuristic only trusts admin-only system roots, so a user-temp "
-    "install is (correctly) refused there",
+    reason="these assertions exercise the POSIX ownership model; on Windows the "
+    "exec-trust check is best-effort (a separate path), so this is POSIX-focused",
 )
 def test_absolute_path_still_reaches_the_spawn_after_revalidation(
     tmp_path, monkeypatch, _senna_popen_spy

--- a/nltk/test/unit/test_senna_security.py
+++ b/nltk/test/unit/test_senna_security.py
@@ -341,12 +341,16 @@ def test_secure_absolute_install_reaches_spawn(tmp_path, monkeypatch, _senna_pop
     assert os.path.isabs(_senna_popen_spy[0].argv[0])
 
 
-@pytest.mark.parametrize("bad_token", ["a\nb", "a\rb", "a\r\nb", "line1\nline2"])
+@pytest.mark.parametrize(
+    "bad_token",
+    ["a\nb", "a\rb", "a\r\nb", "line1\nline2", "a\x00b", "a\x0bb", "a\x1fb"],
+)
 def test_token_with_newline_is_refused(
     tmp_path, monkeypatch, _senna_popen_spy, bad_token
 ):
-    """A CR/LF in a token would add an input line and break senna's 1:1
-    sentence->output mapping (CWE-93); it must raise before spawning."""
+    """A CR/LF/NUL or other control char in a token would add an input line, break
+    senna's 1:1 sentence->output mapping, or truncate the token (CWE-93); it must
+    raise before spawning."""
     senna, _ = _make_abs_senna(tmp_path, monkeypatch)
     with pytest.raises(ValueError):
         senna.tag_sents([[bad_token, "ok"]])

--- a/nltk/test/unit/test_senna_security.py
+++ b/nltk/test/unit/test_senna_security.py
@@ -151,10 +151,9 @@ def _senna_popen_spy(monkeypatch):
 
     def _fake_popen(cmd, *a, **k):
         argv = list(cmd)
-        # On Linux, Senna.executable() calls platform.architecture(), which probes
-        # with the ``file`` command through this same patched subprocess (via
-        # subprocess.run, which needs a real Popen). Run that probe for real so
-        # bit-width detection is correct, and record only the senna spawn itself.
+        # On Linux, Senna.executable() runs `file` via platform.architecture()
+        # through this same patched subprocess; delegate that probe to the real
+        # Popen so bit-width detection works, and record only the senna spawn.
         if argv[:1] == ["file"]:
             return real_popen(cmd, *a, **k)
         calls.append(

--- a/nltk/test/unit/test_senna_security.py
+++ b/nltk/test/unit/test_senna_security.py
@@ -1,22 +1,42 @@
-"""Regression tests for the untrusted-search-path fix in the Senna wrapper.
+"""Regression tests for the untrusted-executable hardening in the Senna wrapper.
 
-``Senna.__init__`` accepted a *relative* ``senna_path`` (e.g. ".") and resolved
-the executable against the current working directory. Because ``executable()``
-returns a path that contains a separator (e.g. ``./senna-osx``),
-``subprocess.Popen`` runs it directly from the CWD without consulting ``$PATH``,
-so an attacker who can write a ``senna-<platform>`` file there would have it
-executed -- running code from an untrusted location (CWE-829, an untrusted
-search path, CWE-426/CWE-427).
+``Senna`` builds its subprocess command from ``self.executable(self._path)``, and
+``self._path`` is a plain, mutable attribute, so ``tag_sents`` re-validates it
+right before spawning:
 
-Only an explicit *absolute* directory (or an absolute ``SENNA`` environment
-variable) is now used; a relative ``senna_path`` no longer falls back to the CWD.
+* it must be an ABSOLUTE string. A relative (or non-str) value makes
+  ``executable()`` a path with a separator that ``subprocess.Popen`` runs from
+  the current working directory without consulting ``$PATH`` (CWE-426/CWE-427),
+  so a planted ``senna-<platform>`` file would execute.
+* even an absolute path is refused if the binary, its symlink target, or any
+  directory up to the root is group/world-writable or not owned by the user or
+  root, since another local user could then swap the binary (CWE-426/CWE-732).
+* a CR/LF in an input token is refused, since it would smuggle an extra input
+  line and break senna's 1:1 sentence->output mapping (CWE-93).
 """
 
 import os
+from pathlib import Path
+from platform import architecture, system
+from types import SimpleNamespace
 
 import pytest
 
+import nltk.classify.senna as senna_mod
+import nltk.data as _nltk_data
 from nltk.classify.senna import Senna
+
+
+def _staging(prefix="senna_test_"):
+    """A private, in-sandbox base dir (never world-writable ``/tmp``). The strict
+    trust check refuses ``/tmp`` even when sticky, so a benign senna install must
+    live under a private data root; make_staging_dir is where NLTK stages output.
+    Skips the test if no writable in-sandbox root exists."""
+    try:
+        return _nltk_data.make_staging_dir(prefix=prefix, cleanup=True)
+    except PermissionError as exc:
+        pytest.skip(f"no writable in-sandbox NLTK data root to stage under: {exc}")
+
 
 # Every platform-specific binary name executable() may pick.
 _SENNA_BINARIES = (
@@ -26,6 +46,19 @@ _SENNA_BINARIES = (
     "senna-osx",
     "senna",
 )
+
+
+def _this_platforms_binary():
+    """The exact binary name ``Senna.executable`` selects on THIS platform, so a
+    reassignment test plants the file the wrapper will actually look for."""
+    os_name = system()
+    if os_name == "Linux":
+        return "senna-linux64" if architecture()[0] == "64bit" else "senna-linux32"
+    if os_name == "Windows":
+        return "senna-win32.exe"
+    if os_name == "Darwin":
+        return "senna-osx"
+    return "senna"
 
 
 def _plant_senna_binaries(directory):
@@ -91,3 +124,454 @@ def test_absolute_path_without_executable_raises(tmp_path, monkeypatch):
 
     with pytest.raises(LookupError):
         Senna(str(empty), ["pos"])
+
+
+# --- Re-validation at invocation (path reassigned after construction) ---------
+# self._path is a plain attribute; reassigning it to a relative value after
+# __init__ makes executable() a CWD-relative path that Popen runs without $PATH,
+# giving code execution to a planted senna-<platform> file (CWE-426/CWE-427).
+
+
+@pytest.fixture
+def _senna_popen_spy(monkeypatch):
+    """Record the spawn without launching senna. senna now spawns through
+    ``pathsec.spawn_trusted``, which does the real trust check and env scrub
+    before calling ``subprocess.Popen``; patching Popen there lets an untrusted
+    path still be rejected (no call recorded) while a trusted one is captured."""
+    import nltk.pathsec as pathsec_mod
+
+    real_popen = pathsec_mod.subprocess.Popen  # capture BEFORE patching
+    calls = []
+
+    class _FakeProc:
+        returncode = 0
+
+        def communicate(self, *a, **k):
+            return b"", b""
+
+    def _fake_popen(cmd, *a, **k):
+        argv = list(cmd)
+        # On Linux, Senna.executable() calls platform.architecture(), which probes
+        # with the ``file`` command through this same patched subprocess (via
+        # subprocess.run, which needs a real Popen). Run that probe for real so
+        # bit-width detection is correct, and record only the senna spawn itself.
+        if argv[:1] == ["file"]:
+            return real_popen(cmd, *a, **k)
+        calls.append(
+            SimpleNamespace(
+                argv=argv,
+                shell=k.get("shell", False),
+                env=k.get("env"),
+                executable=k.get("executable"),
+            )
+        )
+        return _FakeProc()
+
+    monkeypatch.setattr(pathsec_mod.subprocess, "Popen", _fake_popen)
+    return calls
+
+
+def _make_abs_senna(tmp_path, monkeypatch):
+    """Construct a Senna pointed at a valid absolute install directory, staged
+    under a private data root so the strict trust check accepts it on Linux."""
+    absdir = Path(_staging()) / "senna-install"
+    absdir.mkdir()
+    binpath = absdir / _this_platforms_binary()
+    binpath.write_bytes(b"")
+    os.chmod(binpath, 0o755)
+    monkeypatch.delenv("SENNA", raising=False)
+    return Senna(str(absdir), ["pos"]), str(absdir)
+
+
+@pytest.mark.parametrize("relative_path", [".", "." + os.sep, "senna-cwd", ""])
+def test_relative_path_reassigned_after_construction_is_refused(
+    tmp_path, monkeypatch, _senna_popen_spy, relative_path
+):
+    """Reassigning ``_path`` to a relative value must be refused at ``tag_sents``,
+    before any spawn, even though a matching binary sits in the CWD."""
+    senna, _absdir = _make_abs_senna(tmp_path, monkeypatch)
+
+    # Attacker plants the platform binary in the CWD and reassigns the path.
+    cwd = tmp_path / "attacker_cwd"
+    cwd.mkdir()
+    binname = _this_platforms_binary()
+    (cwd / binname).write_bytes(b"")
+    os.chmod(cwd / binname, 0o755)
+    monkeypatch.chdir(cwd)
+
+    senna._path = relative_path
+    with pytest.raises(LookupError):
+        senna.tag_sents([["hello", "world"]])
+    assert _senna_popen_spy == [], "a CWD-relative senna binary reached the spawn"
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "getuid"),
+    reason="the trust check accepts a tmp install via the POSIX ownership model; "
+    "the Windows heuristic only trusts admin-only system roots, so a user-temp "
+    "install is (correctly) refused there",
+)
+def test_absolute_path_still_reaches_the_spawn_after_revalidation(
+    tmp_path, monkeypatch, _senna_popen_spy
+):
+    """Benign control: a valid absolute install still reaches the (trapped) spawn
+    with an ABSOLUTE argv[0] and no shell, so the re-validation is not over-broad."""
+    senna, absdir = _make_abs_senna(tmp_path, monkeypatch)
+    senna.tag_sents([["hi", "there"]])
+    assert len(_senna_popen_spy) == 1
+    argv = _senna_popen_spy[0].argv
+    assert os.path.isabs(argv[0])
+    # spawn_trusted executes the fully RESOLVED path (symlinks collapsed).
+    assert argv[0] == os.path.realpath(
+        os.path.join(senna._path.rstrip(os.sep), _this_platforms_binary())
+    )
+    assert _senna_popen_spy[0].shell is False
+    # The child env is scrubbed of loader/interpreter variables (no LD_*/DYLD_*).
+    child_env = _senna_popen_spy[0].env or {}
+    assert not any(
+        k.startswith(("LD_", "DYLD_")) or k in ("PYTHONPATH", "PYTHONHOME")
+        for k in child_env
+    )
+    # The -path argument (senna's data dir) is the absolute install directory.
+    assert argv[argv.index("-path") + 1] == senna._path
+    assert os.path.isabs(argv[argv.index("-path") + 1])
+
+
+@pytest.mark.parametrize(
+    "bad_path", [None, 123, 1.5, b"/abs/senna", ["/abs"], ("/abs",)]
+)
+def test_non_string_path_reassigned_is_refused(
+    tmp_path, monkeypatch, _senna_popen_spy, bad_path
+):
+    """A non-str _path must raise LookupError (not a raw TypeError from path.join)
+    and must never spawn."""
+    senna, _ = _make_abs_senna(tmp_path, monkeypatch)
+    senna._path = bad_path
+    with pytest.raises(LookupError):
+        senna.tag_sents([["hello"]])
+    assert _senna_popen_spy == []
+
+
+requires_posix_perms = pytest.mark.skipif(
+    not hasattr(os, "getuid"), reason="POSIX ownership/permission model"
+)
+
+
+def _senna_install(
+    tmp_path,
+    *,
+    dir_mode=0o755,
+    bin_mode=0o755,
+    symlink_target_mode=None,
+    ww_ancestor=False,
+):
+    """Build an ABSOLUTE senna install under a private staged root exhibiting one
+    permission weakness (or none, for the benign control). Staged under a data
+    root (not /tmp) so any refusal is due to the injected weakness, not the
+    shared-temp ancestor that the strict resolver already rejects."""
+    base = Path(_staging())
+    root = base / "root"
+    root.mkdir()
+    absdir = root / "senna"
+    absdir.mkdir()
+    binpath = absdir / _this_platforms_binary()
+    if symlink_target_mode is not None:
+        # Staged under the SAME private base, so the only weakness is the target
+        # file's mode (world/group-writable), not a shared-temp ancestor.
+        target = base / "symlink_target"
+        target.write_bytes(b"")
+        os.chmod(target, symlink_target_mode)
+        os.symlink(target, binpath)
+    else:
+        binpath.write_bytes(b"")
+        os.chmod(binpath, bin_mode)
+    os.chmod(absdir, dir_mode)
+    if ww_ancestor:
+        os.chmod(root, 0o777)
+    return str(absdir)
+
+
+@requires_posix_perms
+@pytest.mark.parametrize(
+    "weakness",
+    [
+        {"dir_mode": 0o777},  # world-writable senna dir
+        {"dir_mode": 0o775},  # group-writable senna dir
+        {"bin_mode": 0o777},  # world-writable binary
+        {"bin_mode": 0o775},  # group-writable binary
+        {"symlink_target_mode": 0o777},  # symlink -> world-writable target
+        {"ww_ancestor": True},  # world-writable ancestor directory
+    ],
+)
+def test_untrusted_absolute_path_is_refused(
+    tmp_path, monkeypatch, _senna_popen_spy, weakness
+):
+    """An ABSOLUTE path is still refused when the binary, its symlink target, or an
+    ancestor is group/world-writable: another local user could swap the binary
+    before Popen runs it (CWE-426/CWE-732). No spawn happens."""
+    monkeypatch.delenv("SENNA", raising=False)
+    senna = Senna(_senna_install(tmp_path, **weakness), ["pos"])
+    with pytest.raises(LookupError):
+        senna.tag_sents([["hello"]])
+    assert _senna_popen_spy == []
+
+
+@requires_posix_perms
+def test_binary_owned_by_another_user_is_refused(
+    tmp_path, monkeypatch, _senna_popen_spy
+):
+    """A senna binary not owned by us (or root) is refused even with a benign mode:
+    ownership is kernel truth an attacker cannot fake. getuid is patched to a
+    different uid to stand in for 'owned by another local user'."""
+    monkeypatch.delenv("SENNA", raising=False)
+    senna = Senna(_senna_install(tmp_path), ["pos"])
+    other_uid = os.geteuid() + 4242  # capture BEFORE patching to avoid recursion
+    monkeypatch.setattr("nltk.pathsec.os.geteuid", lambda: other_uid)
+    with pytest.raises(LookupError):
+        senna.tag_sents([["hello"]])
+    assert _senna_popen_spy == []
+
+
+@requires_posix_perms
+def test_secure_absolute_install_reaches_spawn(tmp_path, monkeypatch, _senna_popen_spy):
+    """Benign control: a private, not-writable-by-others absolute install still
+    reaches the (trapped) spawn with an absolute argv[0]."""
+    monkeypatch.delenv("SENNA", raising=False)
+    senna = Senna(_senna_install(tmp_path), ["pos"])
+    senna.tag_sents([["hello", "world"]])
+    assert len(_senna_popen_spy) == 1
+    assert os.path.isabs(_senna_popen_spy[0].argv[0])
+
+
+@pytest.mark.parametrize("bad_token", ["a\nb", "a\rb", "a\r\nb", "line1\nline2"])
+def test_token_with_newline_is_refused(
+    tmp_path, monkeypatch, _senna_popen_spy, bad_token
+):
+    """A CR/LF in a token would add an input line and break senna's 1:1
+    sentence->output mapping (CWE-93); it must raise before spawning."""
+    senna, _ = _make_abs_senna(tmp_path, monkeypatch)
+    with pytest.raises(ValueError):
+        senna.tag_sents([[bad_token, "ok"]])
+    assert _senna_popen_spy == []
+
+
+@pytest.mark.parametrize(
+    "bad_op", ["path", "-path", "version", "../etc", "pos ner", "srl", "chk\n"]
+)
+def test_operation_injection_is_refused(
+    tmp_path, monkeypatch, _senna_popen_spy, bad_op
+):
+    """An operation outside SUPPORTED_OPERATIONS is turned into a '-<op>' senna
+    argument, so an attacker-controlled value like 'path' would inject '-path' and
+    redirect senna's data directory (CWE-88). It must raise before spawning."""
+    senna, _ = _make_abs_senna(tmp_path, monkeypatch)
+    senna.operations = ["pos", bad_op]  # a mutable attribute, like self._path
+    with pytest.raises(ValueError):
+        senna.tag_sents([["hello", "world"]])
+    assert _senna_popen_spy == []
+
+
+# --- End-to-end with a REAL, executable senna-contract binary -----------------
+# These drop a REAL executable honouring SENNA's stdin/stdout contract at an
+# absolute path and drive the whole real code path (real Popen/process/parsing,
+# no mocks); the attacker copy touches a marker so a refusal proves it never ran.
+
+POSIX_ONLY = pytest.mark.skipif(
+    os.name != "posix",
+    reason="the executable senna stub is a POSIX shell script",
+)
+
+
+def _write_real_senna(dirpath, marker=None):
+    """Write a real, executable senna-contract program named for THIS platform.
+
+    If *marker* is given, the program touches that path on execution, so a test
+    can prove from its (non-)existence whether the binary actually ran.
+    """
+    os.makedirs(dirpath, exist_ok=True)
+    lines = ["#!/bin/sh"]
+    if marker is not None:
+        # Quote to tolerate spaces; this fires only if the process is spawned.
+        lines.append(': > "%s"' % marker)
+    lines += [
+        "while IFS= read -r line; do",
+        '  [ -z "$line" ] && continue',
+        "  for w in $line; do printf '%s\\tNNP\\n' \"$w\"; done",
+        "  printf '\\n'",
+        "done",
+    ]
+    binpath = os.path.join(dirpath, _this_platforms_binary())
+    with open(binpath, "w") as fh:
+        fh.write("\n".join(lines) + "\n")
+    os.chmod(binpath, 0o755)
+    return binpath
+
+
+@POSIX_ONLY
+def test_real_senna_binary_tags_end_to_end(tmp_path, monkeypatch):
+    """Benign, fully real: an absolute install with a runnable senna-contract
+    binary tags a sentence through the real subprocess and parser."""
+    from nltk.tag import SennaTagger
+
+    absdir = os.path.join(_staging(), "senna-v3.0")
+    _write_real_senna(absdir)
+    monkeypatch.delenv("SENNA", raising=False)
+
+    tagger = SennaTagger(absdir)
+    tagged = tagger.tag("What is the airspeed ?".split())
+    assert [w for w, _ in tagged] == ["What", "is", "the", "airspeed", "?"]
+    assert all(tag == "NNP" for _, tag in tagged)  # the real binary's output
+
+
+@POSIX_ONLY
+def test_real_cwd_senna_binary_never_executes_when_path_reassigned(
+    tmp_path, monkeypatch
+):
+    """Teeth with a REAL binary: a runnable senna-<platform> is planted in the CWD
+    and ``_path`` is reassigned to ``.`` after construction. The planted binary is
+    demonstrably executable (running it directly touches the marker), yet
+    ``tag_sents`` raises before spawning, so the marker the binary would create
+    never appears; the guard stops code execution, not just a missing file."""
+    import subprocess
+
+    from nltk.tag import SennaTagger
+
+    # A valid absolute install so construction succeeds (private staged root).
+    absdir = os.path.join(_staging(), "trusted")
+    _write_real_senna(absdir)
+    monkeypatch.delenv("SENNA", raising=False)
+    tagger = SennaTagger(absdir)
+
+    # Attacker plants a genuinely-runnable senna in the CWD that touches a marker.
+    cwd = tmp_path / "attacker_cwd"
+    marker = tmp_path / "senna_executed.marker"
+    attacker_bin = _write_real_senna(str(cwd), marker=str(marker))
+    monkeypatch.chdir(cwd)
+
+    # Prove the planted binary really runs (would tag + create the marker).
+    proof_marker = tmp_path / "proof.marker"
+    proof_bin = _write_real_senna(str(tmp_path / "proof"), marker=str(proof_marker))
+    subprocess.run([proof_bin], input=b"hello world\n", capture_output=True, check=True)
+    assert proof_marker.exists(), "sanity: the stub is genuinely executable"
+
+    # Now reassign to a relative path and confirm tag_sents refuses BEFORE exec.
+    tagger._path = "." + os.sep
+    assert os.path.isfile(attacker_bin)  # the CWD binary the guard must not run
+    with pytest.raises(LookupError):
+        tagger.tag_sents([["hello", "world"]])
+    assert not marker.exists(), "the CWD senna binary was executed despite the guard"
+
+
+@POSIX_ONLY
+def test_real_world_writable_binary_never_executes(tmp_path, monkeypatch):
+    """Teeth with a REAL binary: a runnable senna in a WORLD-WRITABLE install
+    touches a marker when run, yet tag_sents refuses before spawning, so the
+    marker never appears; the trusted-path guard stops real code execution."""
+    import subprocess
+
+    from nltk.tag import SennaTagger
+
+    absdir = os.path.join(_staging(), "ww-install")
+    marker = tmp_path / "ww_executed.marker"
+    binpath = _write_real_senna(absdir, marker=str(marker))
+    os.chmod(absdir, 0o777)  # world-writable: another user could swap the binary
+    monkeypatch.delenv("SENNA", raising=False)
+    tagger = SennaTagger(absdir)
+
+    # Prove the binary genuinely runs on its own (creates the marker).
+    subprocess.run([binpath], input=b"hi\n", capture_output=True)
+    assert marker.exists(), "sanity: the stub is genuinely executable"
+    marker.unlink()
+
+    # tag_sents must refuse and never spawn the world-writable binary.
+    with pytest.raises(LookupError):
+        tagger.tag_sents([["hello", "world"]])
+    assert not marker.exists(), "a world-writable senna binary was executed"
+
+
+@POSIX_ONLY
+def test_real_metacharacter_input_is_not_shell_evaluated(tmp_path, monkeypatch):
+    """Real binary + real Popen: shell metacharacters in tokens are fed to senna's
+    stdin, not a shell (Popen uses a list, no shell=True), so no command runs."""
+    from nltk.tag import SennaTagger
+
+    absdir = os.path.join(_staging(), "trusted")
+    _write_real_senna(absdir)
+    monkeypatch.delenv("SENNA", raising=False)
+    tagger = SennaTagger(absdir)
+
+    marker = tmp_path / "injected.marker"
+    # Two tokens so the token count matches senna's word-split output (no
+    # misalignment); joined they form "$(touch <marker>)", which must stay inert.
+    payload = ["$(touch", "%s)" % marker]
+    try:
+        tagger.tag_sents([payload])
+    except Exception:
+        pass  # a misalignment on odd input is fine; we only assert no injection
+    assert not marker.exists(), "shell metacharacters in input were evaluated"
+
+
+@requires_posix_perms
+def test_intermediate_symlink_through_writable_dir_is_refused(
+    tmp_path, monkeypatch, _senna_popen_spy
+):
+    """The executable path passes THROUGH a symlink whose holding directory is
+    world-writable. os.path.realpath would collapse the hop; the component-wise
+    resolver checks every intermediate link directory and refuses (CWE-427)."""
+    monkeypatch.delenv("SENNA", raising=False)
+    binname = _this_platforms_binary()
+
+    # Staged under a private base so the ONLY weakness is the world-writable
+    # intermediate `srv`, not the shared-temp ancestor.
+    base = Path(_staging())
+    final = base / "usr" / "local" / "private"
+    final.mkdir(parents=True)
+    (final / binname).write_bytes(b"")
+    os.chmod(final / binname, 0o755)
+
+    srv = base / "srv"
+    (srv / "links").mkdir(parents=True)
+    os.symlink(final, srv / "links" / "bin")  # intermediate hop
+    os.chmod(srv, 0o777)  # attacker can repoint srv/links/bin
+
+    (base / "opt" / "tool").mkdir(parents=True)
+    os.symlink(srv / "links" / "bin", base / "opt" / "tool" / "bin")
+    absdir = str(base / "opt" / "tool" / "bin")
+
+    senna = Senna(absdir, ["pos"])
+    with pytest.raises(LookupError):
+        senna.tag_sents([["hello"]])
+    assert _senna_popen_spy == []
+
+
+@POSIX_ONLY
+def test_loader_environment_is_scrubbed_from_the_child(tmp_path, monkeypatch):
+    """Real execution: LD_PRELOAD / DYLD_INSERT_LIBRARIES / PYTHONPATH set in the
+    parent must NOT reach the senna child, since a trusted binary run with an
+    untrusted loader environment is still attacker code execution."""
+    from nltk.tag import SennaTagger
+
+    absdir = os.path.join(_staging(), "trusted")
+    os.makedirs(absdir)
+    binpath = os.path.join(absdir, _this_platforms_binary())
+    marker = tmp_path / "child_env.txt"
+    script = (
+        "#!/bin/sh\n"
+        '{ echo "LD_PRELOAD=[$LD_PRELOAD]"; echo "DYLD=[$DYLD_INSERT_LIBRARIES]"; '
+        'echo "PYTHONPATH=[$PYTHONPATH]"; } > MARKER\n'
+        "while IFS= read -r l; do for w in $l; do printf 'x\\tNNP\\n'; done; echo; done\n"
+    ).replace("MARKER", str(marker))
+    with open(binpath, "w") as fh:
+        fh.write(script)
+    os.chmod(binpath, 0o755)
+
+    monkeypatch.delenv("SENNA", raising=False)
+    monkeypatch.setenv("LD_PRELOAD", "/evil.so")
+    monkeypatch.setenv("DYLD_INSERT_LIBRARIES", "/evil.dylib")
+    monkeypatch.setenv("PYTHONPATH", "/evil")
+
+    SennaTagger(absdir).tag(["hello"])
+    reported = marker.read_text()
+    assert "LD_PRELOAD=[]" in reported, reported
+    assert "DYLD=[]" in reported, reported
+    assert "PYTHONPATH=[]" in reported, reported

--- a/nltk/test/unit/test_senna_security.py
+++ b/nltk/test/unit/test_senna_security.py
@@ -343,18 +343,57 @@ def test_secure_absolute_install_reaches_spawn(tmp_path, monkeypatch, _senna_pop
 
 @pytest.mark.parametrize(
     "bad_token",
-    ["a\nb", "a\rb", "a\r\nb", "line1\nline2", "a\x00b", "a\x0bb", "a\x1fb"],
+    [
+        "a\nb",  # LF
+        "a\rb",  # CR
+        "a\r\nb",  # CRLF
+        "line1\nline2",
+        "a\x00b",  # NUL
+        "a\x0bb",  # vertical tab
+        "a\x0cb",  # form feed
+        "a\x1eb",  # record separator (splitlines break)
+        "a\x1fb",  # C0 control
+        "a\x7fb",  # DEL (the reviewer's gap)
+        "a\x85b",  # NEL, a C1 control and splitlines break
+        "a\x9fb",  # C1 control
+        "a\u2028b",  # Unicode line separator
+        "a\u2029b",  # Unicode paragraph separator
+        "a\ud800b",  # lone surrogate (would crash the .encode())
+        "a\tb",  # TAB splits senna's own tab-separated output line (parse_output)
+    ],
 )
 def test_token_with_newline_is_refused(
     tmp_path, monkeypatch, _senna_popen_spy, bad_token
 ):
-    """A CR/LF/NUL or other control char in a token would add an input line, break
-    senna's 1:1 sentence->output mapping, or truncate the token (CWE-93); it must
-    raise before spawning."""
+    """A control character, line/paragraph separator or lone surrogate in a token
+    would add an input line, break senna's 1:1 sentence->output mapping, split its
+    tab-separated output, or fail to encode (CWE-93); it must raise before
+    spawning."""
     senna, _ = _make_abs_senna(tmp_path, monkeypatch)
     with pytest.raises(ValueError):
         senna.tag_sents([[bad_token, "ok"]])
     assert _senna_popen_spy == []
+
+
+@pytest.mark.parametrize(
+    "token", ["café", "日本語", "नमस्ते", "العربية", "R2-D2", "£100", "🙂"]
+)
+def test_legitimate_multilingual_token_is_accepted(
+    tmp_path, monkeypatch, _senna_popen_spy, token
+):
+    """The guard must not overblock: non-ASCII letters, marks, symbols, the
+    non-breaking space and format characters are ordinary token content and must
+    reach the (spied) spawn rather than being refused."""
+    senna, _ = _make_abs_senna(tmp_path, monkeypatch)
+    # tag_sents reaches the spawn; the spy raises to stop before a real senna run,
+    # so a ValueError mentioning the token guard is the only thing that must NOT
+    # happen here.
+    try:
+        senna.tag_sents([[token]])
+    except ValueError as exc:
+        assert "control characters" not in str(exc), f"overblocked {token!r}"
+    except Exception:
+        pass
 
 
 @pytest.mark.parametrize(

--- a/nltk/test/unit/test_tadm_security.py
+++ b/nltk/test/unit/test_tadm_security.py
@@ -1,0 +1,78 @@
+"""Trusted-exec routing for the TADM classifier wrapper (CWE-426/427/732).
+
+``call_tadm`` spawned the tadm binary with a bare ``subprocess.Popen(cmd)``. It
+now routes through ``pathsec.spawn_trusted`` (the standardized native-wrapper
+chokepoint, strict trust policy like Senna): every directory from the root to the
+tadm binary must be owned by us/root and not group/world-writable, no shell, and
+the child gets a scrubbed environment with a locked PATH. A refusal is surfaced
+as the wrapper's own OSError.
+"""
+
+import os
+from types import SimpleNamespace
+
+import pytest
+
+import nltk.classify.tadm as tadm
+import nltk.pathsec as ps
+
+requires_posix_perms = pytest.mark.skipif(
+    not hasattr(os, "getuid"), reason="POSIX ownership/permission model"
+)
+
+
+def _staging(prefix="tadm_test_"):
+    import nltk.data as nltk_data
+
+    try:
+        return nltk_data.make_staging_dir(prefix=prefix, cleanup=True)
+    except PermissionError as exc:  # pragma: no cover - env-dependent
+        pytest.skip(f"no writable in-sandbox NLTK data root: {exc}")
+
+
+def _mkbin(dirpath, name="tadm", mode=0o755):
+    os.makedirs(dirpath, exist_ok=True)
+    path = os.path.join(dirpath, name)
+    with open(path, "w") as handle:
+        handle.write("#!/bin/sh\nexit 0\n")
+    os.chmod(path, mode)
+    return path
+
+
+@requires_posix_perms
+def test_call_tadm_refuses_untrusted_binary(tmp_path, monkeypatch):
+    """Strict trust: a tadm binary in a world-writable directory is refused before
+    running, since another local user could swap it (CWE-426/732)."""
+    install = tmp_path / "inst"
+    binp = _mkbin(str(install))
+    os.chmod(install, 0o777)  # world-writable: attacker can swap the binary
+    monkeypatch.setattr(tadm, "_tadm_bin", binp)
+    with pytest.raises(OSError):
+        tadm.call_tadm(["-x", "/dev/null"])
+
+
+def test_call_tadm_reaches_spawn_for_a_trusted_binary(monkeypatch):
+    """Benign control: a tadm binary under a private staged root reaches the
+    (trapped) spawn with an absolute, resolved argv[0] and no shell."""
+    binp = _mkbin(os.path.join(_staging(), "inst"))
+    monkeypatch.setattr(tadm, "_tadm_bin", binp)
+
+    calls = []
+
+    class _FakeProc:
+        returncode = 0
+
+        def communicate(self, *a, **k):
+            return b"", b""
+
+    def _fake_popen(cmd, *a, **k):
+        calls.append(SimpleNamespace(argv=list(cmd), shell=k.get("shell", False)))
+        return _FakeProc()
+
+    monkeypatch.setattr(ps.subprocess, "Popen", _fake_popen)
+    tadm.call_tadm(["-monitor", "/dev/null"])
+    assert len(calls) == 1
+    assert calls[0].shell is False
+    assert os.path.isabs(calls[0].argv[0])
+    assert calls[0].argv[0] == os.path.realpath(binp)
+    assert calls[0].argv[1:] == ["-monitor", "/dev/null"]

--- a/nltk/tokenize/repp.py
+++ b/nltk/tokenize/repp.py
@@ -88,9 +88,17 @@ class ReppTokenizer(TokenizerI):
             with tempfile.NamedTemporaryFile(
                 prefix="repp_input.", dir=staging_dir, mode="w", delete=False
             ) as input_file:
-                # Write sentences to temporary input file.
+                # REPP reads one sentence per line; a control char in a sentence
+                # injects an extra input line (or a NUL truncates it), so the token
+                # stream desynchronises from the sentence list (CWE-93).
                 for sent in sentences:
-                    input_file.write(str(sent) + "\n")
+                    text = str(sent)
+                    if any(ord(c) < 0x20 and c != "\t" for c in text):
+                        raise ValueError(
+                            "REPP input sentences must not contain newline, NUL or "
+                            "other control characters."
+                        )
+                    input_file.write(text + "\n")
                 input_file.close()
                 # Generate command to run REPP.
                 cmd = self.generate_repp_command(input_file.name)

--- a/nltk/tokenize/repp.py
+++ b/nltk/tokenize/repp.py
@@ -17,6 +17,7 @@ import tempfile
 from nltk import redos
 from nltk.data import ZipFilePathPointer, make_staging_dir
 from nltk.internals import find_dir
+from nltk.pathsec import TrustError, spawn_trusted
 from nltk.tokenize.api import TokenizerI
 
 
@@ -118,7 +119,19 @@ class ReppTokenizer(TokenizerI):
 
     @staticmethod
     def _execute(cmd):
-        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        # Route the REPP binary through the trusted-exec chokepoint: verify it is
+        # on a path no other local user can swap, refuse a shell, and scrub the
+        # loader environment before exec (CWE-426/427/732).
+        try:
+            p = spawn_trusted(
+                cmd[0], cmd[1:], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            )
+        except TrustError as e:
+            raise LookupError(
+                f"Refusing to run the REPP tokenizer {cmd[0]!r}: it is not on a "
+                "trusted path. Install REPP where only you (or root) can write "
+                f"({e})."
+            ) from e
         stdout, stderr = p.communicate()
         return stdout
 

--- a/nltk/tokenize/repp.py
+++ b/nltk/tokenize/repp.py
@@ -17,7 +17,7 @@ import tempfile
 from nltk import redos
 from nltk.data import ZipFilePathPointer, make_staging_dir
 from nltk.internals import find_dir
-from nltk.pathsec import TrustError, spawn_trusted
+from nltk.pathsec import TrustError, has_line_unsafe_char, spawn_trusted
 from nltk.tokenize.api import TokenizerI
 
 
@@ -88,15 +88,18 @@ class ReppTokenizer(TokenizerI):
             with tempfile.NamedTemporaryFile(
                 prefix="repp_input.", dir=staging_dir, mode="w", delete=False
             ) as input_file:
-                # REPP reads one sentence per line; a control char in a sentence
-                # injects an extra input line (or a NUL truncates it), so the token
-                # stream desynchronises from the sentence list (CWE-93).
+                # REPP reads one sentence per line; a control character or Unicode
+                # line/paragraph separator in a sentence injects an extra input
+                # line (or a NUL truncates it), so the token stream desynchronises
+                # from the sentence list (CWE-93).
                 for sent in sentences:
                     text = str(sent)
-                    if any(ord(c) < 0x20 and c != "\t" for c in text):
+                    # REPP splits its stdout on newlines only, so a literal TAB is
+                    # ordinary in-line whitespace here and stays allowed.
+                    if has_line_unsafe_char(text, allow_tab=True):
                         raise ValueError(
-                            "REPP input sentences must not contain newline, NUL or "
-                            "other control characters."
+                            "REPP input sentences must not contain control "
+                            "characters or line separators (newline, NUL, DEL, ...)."
                         )
                     input_file.write(text + "\n")
                 input_file.close()

--- a/nltk/translate/api.py
+++ b/nltk/translate/api.py
@@ -12,6 +12,7 @@ import subprocess
 from collections import namedtuple
 
 from nltk.internals import find_binary
+from nltk.pathsec import TrustError, spawn_trusted
 
 
 class AlignedSent:
@@ -138,14 +139,22 @@ class AlignedSent:
         except LookupError as e:
             raise Exception("Cannot find the dot binary from Graphviz package") from e
         try:
-            process = subprocess.Popen(
-                [dot_binary, "-T%s" % output_format],
+            # Route through the trusted-exec chokepoint: verify the dot binary is
+            # on a path no other local user can swap, refuse a shell, and scrub the
+            # loader environment before exec (CWE-426/427/732).
+            process = spawn_trusted(
+                dot_binary,
+                [f"-T{output_format}"],
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             )
-        except OSError as e:
-            raise Exception("Cannot find the dot binary from Graphviz package") from e
+        except (OSError, TrustError) as e:
+            raise Exception(
+                f"Refusing to run the Graphviz dot binary {dot_binary!r}: it is "
+                "not on a trusted path (install it where only you or root can "
+                f"write), or it could not be executed ({e})."
+            ) from e
         out, err = process.communicate(dot_string)
 
         return out.decode("utf8")


### PR DESCRIPTION
## What

Harden **every native external-tool wrapper in NLTK** by routing it through one reusable, audited `nltk.pathsec` verify-and-spawn API, instead of scattered `subprocess.Popen` calls. Senna is the reference implementation; the same treatment is applied to REPP, TADM, MEGAM, Prover9/Mace, Boxer/C&C, Graphviz `dot`, and HunPos. `EXTERNAL_TOOL_SECURITY.md` documents the model and how to standardize a new wrapper.

New in `nltk/pathsec.py`: `resolve_trusted_executable` / `is_trusted_executable`, `safe_env`, `spawn_trusted` (+ `TrustError`).

## The layered model

`spawn_trusted` bundles the exec-time layers; each wrapper adds the input layers for its own arguments.

| # | Layer | What it stops | CWE |
|---|-------|---------------|-----|
| 1 | Resolve, don't search untrusted | a planted `./tool` (CWD) or `PATH`-relative match | 426/427 |
| 2 | Unswappable binary | another local user swapping the binary because it, or an ancestor dir, is group/world-writable | 426/732 |
| 3 | No shell, absolute exec | the command being reinterpreted by a shell | 78/88 |
| 4 | Scrub the environment | `LD_*`/`DYLD_*`/`PYTHON*`/`GCONV_PATH`/... loader injection; a poisoned or empty `PATH` (empty is searched as the CWD) | 88/426 |
| 5 | Bound the arguments | an attacker value injected as a `-option` or out-of-sandbox path | 88/22 |
| 6 | Sanitize line-oriented I/O | a CR/LF or control char smuggling a record into the tool's structured input | 93 |

`resolve_trusted_executable` walks the path **one component at a time**, following each symlink hop and requiring every directory to be owned by us (`geteuid`) or root and not group/world-writable. Unlike `os.path.realpath` it inspects intermediate hops, so a link through an attacker-writable directory is refused; a shared world-writable dir is refused even with the sticky bit (`/tmp`). `spawn_trusted` then execs the resolved path directly (no `/proc/self/fd` dance: the private ancestor chain already makes path-exec race-free against an unprivileged attacker). `safe_env` is a deny-by-default whitelist and locks `PATH` to a single non-writable no-command directory.

## Trust policy

Strict on POSIX: a tool in a group/world-writable directory (e.g. Homebrew `/usr/local/bin`) is **refused**; install external tools where only you or root can write, or point the wrapper's env var at such a location. On Windows the POSIX ownership check can't run and NLTK doesn't assume `win32security`, so it degrades to **best effort** (a regular file at the resolved absolute path is accepted), relying on `find_binary`'s CWD refusal + no-shell + env-scrub. It does not fail closed, so Windows wrappers keep working.

## Per-wrapper input guards (layer 6)

- **Senna**: reject a newline/CR in any token, and bound `operations` to `SUPPORTED_OPERATIONS` so a value cannot be injected as a senna `-option`.
- **Prover9 / Mace**: `_assert_prover9_safe` rejects a converted formula carrying a control char or bare period, or leading with `end_of_list`/`formulas`/`clauses`, so a crafted term cannot close the `formulas(...)` list and inject directives such as `end_of_list.` (CVE-2026-14709). Mace reuses `prover9_input`, so it is covered too.
- **Boxer / C&C**: reject a control char/quote in a discourse id and a `<META>`-leading input line; write the scratch input through `pathsec.open`.

## Verification

**Real tools, not mocks.** Prover9 and Mace4 were built from LADR source, staged in a trusted location, and driven through the actual NLTK wrappers: a real proof succeeds, a non-theorem is rejected, Mace4 finds a counter-model, the injection guard blocks a crafted formula before the spawn, and a copy of the real binary in a world-writable directory is refused (strict policy). The remaining wrappers are exercised end-to-end with real `subprocess` execution of stub binaries that honour each tool's stdin/stdout contract, plus adversarial coverage: world/group-writable dirs and binaries, a path under `/tmp`, a symlink through an attacker-writable dir, `..`/relative/NUL input, an owner other than us, FIFO/socket/device/directory in the executable slot, loader vars in the parent that must not reach the child, and a real check that a child cannot resolve a bare command from the CWD. Full green: 300-module import sweep, and the senna/pathsec/prover9/boxer/injection/sweep suites; CI matrix (3.10 to 3.14 + 3.14t across macOS/Linux/Windows) passes.

## Honest limits

Same-UID compromise and root are out of scope (they already control the process); filesystems whose ownership bits lie (NFS uid-squash, some FUSE, user namespaces) and the binary's own behaviour after start are out of scope; the Windows check is best-effort, not a DACL check. JVM tools (Stanford/Malt/CoreNLP/Weka) already go through `internals.java` (env scrub + jar validation + no shell + `find_binary`); routing the `java` binary itself through `resolve_trusted_executable` is a documented follow-up.
