### PR TITLE
Extend the no-unsandboxed-open guard to app/draw/twitter and route every open through pathsec.open

### DIFF
--- a/nltk/app/chartparser_app.py
+++ b/nltk/app/chartparser_app.py
@@ -76,32 +76,14 @@ from nltk.parse.chart import (
     TopDownPredictRule,
     TreeEdge,
 )
+from nltk.pathsec import open as pathsec_open
 from nltk.picklesec import AllowlistUnpickler, pickle_dump
 from nltk.tree import Tree
 from nltk.util import in_idle
 
-# A saved chart / grammar ``.pickle`` is loaded from an operator-chosen path via a
-# Tk "Open" dialog, but a ``.pickle`` a user was emailed and opens is a realistic
-# phishing-style RCE, and every other model loader in the tree was hardened, so
-# these loads are routed through an allowlisting unpickler (CWE-502) rather than
-# the warn-only ``pickle_load`` (which warns and then EXECUTES any reduce gadget).
-# Only the exact classes a legitimate chart / grammar / parse tree reconstructs
-# may be built; any other global (``os.system``, ``builtins.eval``,
-# ``subprocess.Popen``, a scientific-stack file sink, ...) raises
-# ``UnpicklingError`` instead of executing. The base
-# :class:`~nltk.picklesec.AllowlistUnpickler` still enforces its denied-module /
-# dotted-name / dunder-name / extension-opcode guards on top.
-#
-# The set was derived empirically: a real CFG, a real chart, a ``(chart, tokens)``
-# tuple, real parse ``Tree`` objects, a ``FeatureGrammar`` and a ``FeatureChart``
-# were each pickled and every ``(module, name)`` their pickle asks ``find_class``
-# to resolve was recorded. The probabilistic / parented / dependency-grammar
-# siblings are added from the class hierarchy so a legitimately saved PCFG,
-# dependency grammar or probabilistic tree also loads. None is a code-execution
-# primitive: they are inert grammar / edge / tree / feature value types with no
-# custom ``__reduce__`` / ``__setstate__`` and no compiled regex, so there is no
-# ReDoS surface to re-derive; hostile BUILD state at worst yields a bounded
-# ``AttributeError`` at use time.
+# Allowlist of the exact ``(module, qualname)`` globals a legitimate pickled chart
+# / grammar / parse tree rebuilds. The File menu loads these pickles through an
+# allowlisting unpickler (CWE-502); any other global raises ``UnpicklingError``.
 _CHART_GRAMMAR_ALLOWED_GLOBALS = (
     # Ordered mapping the chart stores its child-pointer lists in.
     ("nltk.collections", "OrderedDict"),
@@ -873,7 +855,9 @@ class ChartComparer:
         if not filename:
             return
         try:
-            with open(filename, "wb") as outfile:
+            with pathsec_open(
+                filename, "wb", context="ChartComparer.save_chart_dialog"
+            ) as outfile:
                 pickle_dump(self._out_chart, outfile)
         except Exception as e:
             showerror("Error Saving Chart", f"Unable to open file: {filename!r}\n{e}")
@@ -890,7 +874,7 @@ class ChartComparer:
             showerror("Error Loading Chart", f"Unable to open file: {filename!r}\n{e}")
 
     def load_chart(self, filename):
-        with open(filename, "rb") as infile:
+        with pathsec_open(filename, "rb", context="ChartComparer.load_chart") as infile:
             chart = _load_chart_pickle(infile)
         name = os.path.basename(filename)
         if name.endswith(".pickle"):
@@ -2347,7 +2331,9 @@ class ChartParserApp:
         if not filename:
             return
         try:
-            with open(filename, "rb") as infile:
+            with pathsec_open(
+                filename, "rb", context="ChartParserApp.load_chart"
+            ) as infile:
                 chart = _load_chart_pickle(infile)
             self._chart = chart
             self._cv.update(chart)
@@ -2370,7 +2356,9 @@ class ChartParserApp:
         if not filename:
             return
         try:
-            with open(filename, "wb") as outfile:
+            with pathsec_open(
+                filename, "wb", context="ChartParserApp.save_chart"
+            ) as outfile:
                 pickle_dump(self._chart, outfile)
         except Exception as e:
             raise
@@ -2385,10 +2373,14 @@ class ChartParserApp:
             return
         try:
             if filename.endswith(".pickle"):
-                with open(filename, "rb") as infile:
+                with pathsec_open(
+                    filename, "rb", context="ChartParserApp.load_grammar"
+                ) as infile:
                     grammar = _load_chart_pickle(infile)
             else:
-                with open(filename) as infile:
+                with pathsec_open(
+                    filename, context="ChartParserApp.load_grammar"
+                ) as infile:
                     grammar = CFG.fromstring(infile.read())
             self.set_grammar(grammar)
         except Exception as e:
@@ -2402,10 +2394,14 @@ class ChartParserApp:
             return
         try:
             if filename.endswith(".pickle"):
-                with open(filename, "wb") as outfile:
+                with pathsec_open(
+                    filename, "wb", context="ChartParserApp.save_grammar"
+                ) as outfile:
                     pickle_dump((self._chart, self._tokens), outfile)
             else:
-                with open(filename, "w") as outfile:
+                with pathsec_open(
+                    filename, "w", context="ChartParserApp.save_grammar"
+                ) as outfile:
                     prods = self._grammar.productions()
                     start = [p for p in prods if p.lhs() == self._grammar.start()]
                     rest = [p for p in prods if p.lhs() != self._grammar.start()]

--- a/nltk/app/chunkparser_app.py
+++ b/nltk/app/chunkparser_app.py
@@ -38,6 +38,7 @@ from nltk.chunk import ChunkScore, RegexpChunkParser
 from nltk.chunk.regexp import RegexpChunkRule
 from nltk.corpus import conll2000, treebank_chunk
 from nltk.draw.util import ShowText
+from nltk.pathsec import open as pathsec_open
 from nltk.tree import Tree
 from nltk.util import in_idle
 
@@ -1391,7 +1392,9 @@ class RegexpChunkApp:
         else:
             precision = recall = fscore = "Not finished evaluation yet"
 
-        with open(filename, "w") as outfile:
+        with pathsec_open(
+            filename, "w", context="RegexpChunkApp.save_grammar"
+        ) as outfile:
             outfile.write(
                 self.SAVE_GRAMMAR_TEMPLATE
                 % dict(
@@ -1412,7 +1415,7 @@ class RegexpChunkApp:
                 return
         self.grammarbox.delete("1.0", "end")
         self.update()
-        with open(filename) as infile:
+        with pathsec_open(filename, context="RegexpChunkApp.load_grammar") as infile:
             grammar = infile.read()
         grammar = redos.sub(
             r"^\# Regexp Chunk Parsing Grammar[\s\S]*" "F-score:.*\n", "", grammar
@@ -1427,7 +1430,9 @@ class RegexpChunkApp:
             if not filename:
                 return
 
-        with open(filename, "w") as outfile:
+        with pathsec_open(
+            filename, "w", context="RegexpChunkApp.save_history"
+        ) as outfile:
             outfile.write("# Regexp Chunk Parsing Grammar History\n")
             outfile.write("# Saved %s\n" % time.ctime())
             outfile.write("# Development set: %s\n" % self.devset_name)

--- a/nltk/app/wordnet_app.py
+++ b/nltk/app/wordnet_app.py
@@ -66,6 +66,7 @@ from urllib.parse import parse_qs, unquote_plus
 
 from nltk.corpus import wordnet as wn
 from nltk.corpus.reader.wordnet import Lemma, Synset
+from nltk.pathsec import open as pathsec_open
 from nltk.picklesec import RestrictedUnpickler, pickle_dumps
 
 firstClient = True
@@ -134,7 +135,9 @@ class MyServerHandler(BaseHTTPRequestHandler):
             if usp == "NLTK Wordnet Browser Database Info.html":
                 word = "* Database Info *"
                 if os.path.isfile(usp):
-                    with open(usp) as infile:
+                    with pathsec_open(
+                        usp, context="wordnet_app.MyServerHandler"
+                    ) as infile:
                         page = infile.read()
                 else:
                     page = (
@@ -261,7 +264,9 @@ def wnb(port=8000, runBrowser=True, logfilename=None):
     # Setup logging.
     if logfilename:
         try:
-            logfile = open(logfilename, "a", 1)  # 1 means 'line buffering'
+            logfile = pathsec_open(
+                logfilename, "a", buffering=1, context="wordnet_app.wnb"
+            )  # 1 means 'line buffering'
         except OSError as e:
             sys.stderr.write("Couldn't open %s for writing: %s", logfilename, e)
             sys.exit(1)

--- a/nltk/draw/util.py
+++ b/nltk/draw/util.py
@@ -52,6 +52,7 @@ from tkinter import (
 )
 from tkinter.filedialog import asksaveasfilename
 
+from nltk.pathsec import open as pathsec_open
 from nltk.util import in_idle
 
 ##//////////////////////////////////////////////////////
@@ -1867,7 +1868,7 @@ class CanvasFrame:
         )
         # workaround for bug in Tk font handling
         postscript = postscript.replace(" 0 scalefont ", " 9 scalefont ")
-        with open(filename, "wb") as f:
+        with pathsec_open(filename, "wb", context="CanvasFrame.print_to_file") as f:
             f.write(postscript.encode("utf8"))
 
     def scrollregion(self):

--- a/nltk/test/unit/test_app_twitter_open_hardening.py
+++ b/nltk/test/unit/test_app_twitter_open_hardening.py
@@ -1,0 +1,169 @@
+"""Adversarial coverage for the app / draw / twitter opens routed through
+pathsec.open.
+
+The paths these modules open are operator-chosen (a Tk Save/Open dialog, the
+``$TWITTER`` credentials dir, a tweet-output dir), so pathsec.open does not bound
+them to the data roots. It still hardens them, and these tests pin that on the
+actual wrappers: a symlink or hardlink planted at the destination is refused at
+open time (O_NOFOLLOW / st_nlink, CWE-59), a NUL byte or a URL in the path is
+refused (CWE-22), and a freshly written file is created 0600 so a saved chart or
+credentials file is never left group/world readable (CWE-377/378). Legitimate
+operator paths keep working. POSIX only (symlink / hardlink / permission model).
+"""
+
+import os
+import stat
+
+import pytest
+
+from nltk.pathsec import open as pathsec_open
+
+posix_only = pytest.mark.skipif(
+    os.name != "posix", reason="symlink / hardlink / permission model is POSIX"
+)
+
+
+@pytest.fixture
+def sensitive(tmp_path):
+    """A file an attacker would try to redirect a write onto / a read out of."""
+    target = tmp_path / "sensitive"
+    target.write_text("SECRET")
+    return target
+
+
+# --- the shared chokepoint every app/draw/twitter open now goes through --------
+
+
+@posix_only
+@pytest.mark.parametrize("mode", ["w", "wb", "a", "r", "rb"])
+def test_symlink_at_the_path_is_refused(tmp_path, sensitive, mode):
+    link = tmp_path / "dest"
+    link.symlink_to(sensitive)
+    with pytest.raises(PermissionError):
+        pathsec_open(str(link), mode, context="test")
+    assert sensitive.read_text() == "SECRET"  # neither read out nor clobbered
+
+
+@posix_only
+@pytest.mark.parametrize("mode", ["w", "wb", "a"])
+def test_hardlink_at_the_destination_is_refused(tmp_path, sensitive, mode):
+    hard = tmp_path / "hard"
+    os.link(sensitive, hard)
+    with pytest.raises(PermissionError):
+        pathsec_open(str(hard), mode, context="test")
+    assert sensitive.read_text() == "SECRET"
+
+
+@pytest.mark.parametrize("mode", ["w", "wb", "a", "r"])
+def test_nul_byte_in_path_is_refused(tmp_path, mode):
+    with pytest.raises((PermissionError, ValueError, OSError)):
+        pathsec_open(str(tmp_path / "a\x00b"), mode, context="test")
+
+
+@pytest.mark.parametrize("url", ["http://evil.example/x", "file:///etc/passwd"])
+def test_url_as_path_is_refused(url):
+    with pytest.raises((PermissionError, ValueError)):
+        pathsec_open(url, "w", context="test")
+
+
+@posix_only
+def test_new_file_is_not_group_or_world_readable(tmp_path):
+    path = tmp_path / "out.txt"
+    with pathsec_open(str(path), "w", context="test") as handle:
+        handle.write("x")
+    assert stat.S_IMODE(path.stat().st_mode) & 0o077 == 0
+
+
+@posix_only
+def test_legit_operator_path_roundtrips(tmp_path):
+    path = tmp_path / "operator" / "chosen.txt"
+    path.parent.mkdir()
+    with pathsec_open(str(path), "w", context="test") as handle:
+        handle.write("hello")
+    with pathsec_open(str(path), "r", context="test") as handle:
+        assert handle.read() == "hello"
+
+
+# --- per-wrapper attacks on the actual functions -------------------------------
+
+
+@posix_only
+def test_twitter_outf_writer_refuses_symlinked_destination(tmp_path, sensitive):
+    from nltk.twitter.common import _outf_writer
+
+    link = tmp_path / "out.csv"
+    link.symlink_to(sensitive)
+    with pytest.raises(PermissionError):
+        _outf_writer(str(link), "utf-8", "strict", gzip_compress=False)
+    assert sensitive.read_text() == "SECRET"
+
+
+def test_twitter_outf_writer_legit_path_works(tmp_path):
+    from nltk.twitter.common import _outf_writer
+
+    path = tmp_path / "out.csv"
+    writer, handle = _outf_writer(str(path), "utf-8", "strict", gzip_compress=False)
+    writer.writerow(["a", "b"])
+    handle.close()
+    assert path.read_text().strip() == "a,b"
+
+
+@posix_only
+def test_tweetwriter_refuses_symlinked_output(tmp_path, sensitive):
+    pytest.importorskip("twython", reason="twython not installed")
+    from nltk.twitter.twitterclient import TweetWriter
+
+    link = tmp_path / "tweets.json"
+    link.symlink_to(sensitive)
+    writer = object.__new__(TweetWriter)
+    writer.startingup = True
+    writer.gzip_compress = False
+    writer.fname = str(link)
+    with pytest.raises(PermissionError):
+        writer.handle({"id": 1})
+    assert sensitive.read_text() == "SECRET"
+
+
+@posix_only
+def test_chartcomparer_load_refuses_symlinked_source(tmp_path, sensitive):
+    from nltk.app.chartparser_app import ChartComparer
+
+    link = tmp_path / "chart.pickle"
+    link.symlink_to(sensitive)
+    comparer = object.__new__(ChartComparer)
+    with pytest.raises(PermissionError):
+        comparer.load_chart(str(link))
+
+
+@posix_only
+def test_chartparserapp_save_refuses_symlinked_destination(
+    tmp_path, sensitive, monkeypatch
+):
+    import nltk.app.chartparser_app as cpa
+
+    link = tmp_path / "chart.pickle"
+    link.symlink_to(sensitive)
+    monkeypatch.setattr(cpa, "asksaveasfilename", lambda *a, **k: str(link))
+    app = object.__new__(cpa.ChartParserApp)
+    app._chart = "unused: the open is refused before pickling"
+    with pytest.raises(PermissionError):
+        app.save_chart()
+    assert sensitive.read_text() == "SECRET"
+
+
+# --- functional: a real chart pickle still saves and loads through pathsec -----
+
+
+def test_real_chart_pickle_roundtrips_through_pathsec(tmp_path):
+    import nltk.app.chartparser_app as cpa
+    from nltk import CFG
+    from nltk.parse.chart import ChartParser
+    from nltk.picklesec import pickle_dump
+
+    chart = ChartParser(CFG.fromstring("S -> 'a'")).chart_parse(["a"])
+    path = tmp_path / "chart.pickle"
+    with pathsec_open(str(path), "wb", context="test") as handle:
+        pickle_dump(chart, handle)
+    with pathsec_open(str(path), "rb", context="test") as handle:
+        loaded = cpa._load_chart_pickle(handle)  # pathsec + allowlist unpickler
+    assert loaded.num_edges() == chart.num_edges()

--- a/nltk/test/unit/test_output_exposure_security.py
+++ b/nltk/test/unit/test_output_exposure_security.py
@@ -1,0 +1,93 @@
+# Natural Language Toolkit: XSS + secret-exposure regression tests
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""Two file-local weaknesses closed on this branch: the WordNet browser served
+corpus-derived synset text as HTML without escaping (CWE-79), and the Twitter
+creds validator pretty-printed the whole credentials dict (secret values and
+all) into a ValueError that reaches stderr/logs (CWE-532 / CWE-200). These tests
+drive the real code paths."""
+
+import html
+
+import pytest
+
+
+class TestWordnetAppXss:
+    def test_make_lookup_link_escapes_label_and_href(self):
+        from nltk.app.wordnet_app import make_lookup_link
+
+        class Ref:
+            def encode(self):
+                return 'a"onmouseover=alert(1)'
+
+        out = make_lookup_link(Ref(), html.escape("<script>x</script>"))
+        assert "<script>" not in out  # element-content payload neutralised
+        assert '"onmouseover=alert(1)"' not in out  # attribute breakout neutralised
+        assert "&lt;script&gt;" in out and "&quot;" in out
+
+
+class TestTwitterCredsNoLeak:
+    def test_invalid_creds_error_omits_secret_values(self):
+        pytest.importorskip("twython", reason="twython not installed")
+        from nltk.twitter.util import Authenticate
+
+        auth = Authenticate()
+        auth.creds_file = "credentials.txt"
+        auth.oauth = {"app_key": "PUBLIC", "app_secret": "TOP_SECRET_VALUE"}
+        with pytest.raises(ValueError) as exc:
+            auth._validate_creds_file()
+        msg = str(exc.value)
+        assert "TOP_SECRET_VALUE" not in msg  # no secret value leaked
+        assert "app_secret" in msg  # key name is fine
+
+    # Each dict is missing at least one required OAuth key, so validation must
+    # raise; the secret VALUES must never appear in the error while the key
+    # NAMES may (they help an operator fix the file). CWE-532 / CWE-200 / CWE-209.
+    @pytest.mark.parametrize(
+        "oauth",
+        [
+            {"app_key": "PUBLIC", "app_secret": "SEKRIT_APP_SECRET"},
+            {"app_key": "PUBLIC", "app_secret": "S", "oauth_token": "SEKRIT_OAUTH_TOK"},
+            {"app_key": "PUBLIC", "access_token": "SEKRIT_ACCESS_TOK"},
+            {"app_secret": "SEKRIT_ONLY", "oauth_token_secret": "SEKRIT_TS_ONLY"},
+            {},  # nothing at all
+        ],
+    )
+    def test_invalid_creds_never_leak_any_value(self, oauth):
+        pytest.importorskip("twython", reason="twython not installed")
+        from nltk.twitter.util import Authenticate
+
+        auth = Authenticate()
+        auth.creds_file = "credentials.txt"
+        auth.oauth = dict(oauth)
+        with pytest.raises(ValueError) as exc:
+            auth._validate_creds_file()
+        msg = str(exc.value)
+        for key, value in oauth.items():
+            assert key in msg, f"key name {key!r} should be reported for debugging"
+            assert value not in msg, f"secret value for {key!r} leaked into error"
+
+    @pytest.mark.parametrize(
+        "oauth",
+        [
+            {
+                "app_key": "K",
+                "app_secret": "S",
+                "oauth_token": "T",
+                "oauth_token_secret": "TS",
+            },  # complete OAuth 1
+            {"app_key": "K", "app_secret": "S", "access_token": "AT"},  # OAuth 2
+        ],
+    )
+    def test_valid_creds_pass_without_error(self, oauth):
+        pytest.importorskip("twython", reason="twython not installed")
+        from nltk.twitter.util import Authenticate
+
+        auth = Authenticate()
+        auth.creds_file = "credentials.txt"
+        auth.oauth = dict(oauth)
+        # A complete key set must validate silently (no ValueError).
+        auth._validate_creds_file()

--- a/nltk/twitter/common.py
+++ b/nltk/twitter/common.py
@@ -15,6 +15,7 @@ import gzip
 
 from nltk.internals import deprecated
 from nltk.jsontags import safe_json_loads
+from nltk.pathsec import open as pathsec_open
 
 HIER_SEPARATOR = "."
 
@@ -138,9 +139,19 @@ def outf_writer_compat(outfile, encoding, errors, gzip_compress=False):
 
 def _outf_writer(outfile, encoding, errors, gzip_compress=False):
     if gzip_compress:
-        outf = gzip.open(outfile, "wt", newline="", encoding=encoding, errors=errors)
+        # Sandbox the destination, then let gzip wrap the checked handle: the
+        # caller chooses this path, so a bare open is an arbitrary file write.
+        raw = pathsec_open(outfile, "wb", context="twitter._outf_writer")
+        outf = gzip.open(raw, "wt", newline="", encoding=encoding, errors=errors)
     else:
-        outf = open(outfile, "w", newline="", encoding=encoding, errors=errors)
+        outf = pathsec_open(
+            outfile,
+            "w",
+            context="twitter._outf_writer",
+            newline="",
+            encoding=encoding,
+            errors=errors,
+        )
     writer = csv.writer(outf)
     return (writer, outf)
 

--- a/nltk/twitter/twitterclient.py
+++ b/nltk/twitter/twitterclient.py
@@ -33,6 +33,7 @@ import requests
 from twython import Twython, TwythonStreamer
 from twython.exceptions import TwythonError, TwythonRateLimitError
 
+from nltk.pathsec import open as pathsec_open
 from nltk.twitter.api import BasicTweetHandler, TweetHandlerI
 from nltk.twitter.util import credsfromfile, guess_path
 
@@ -518,10 +519,16 @@ class TweetWriter(TweetHandlerI):
         :param data: tweet object returned by Twitter API
         """
         if self.startingup:
+            # self.fname is the operator's own timestamped output file; pathsec.open
+            # validates the path without bounding it to the data roots. For gzip it
+            # sandboxes the raw handle, then gzip wraps the checked file object.
             if self.gzip_compress:
-                self.output = gzip.open(self.fname, "w")
+                raw = pathsec_open(self.fname, "wb", context="twitter.TweetWriter")
+                self.output = gzip.open(raw, "w")
             else:
-                self.output = open(self.fname, "w")
+                self.output = pathsec_open(
+                    self.fname, "w", context="twitter.TweetWriter"
+                )
             print(f"Writing to {self.fname}")
 
         json_data = json.dumps(data)

--- a/nltk/twitter/util.py
+++ b/nltk/twitter/util.py
@@ -11,9 +11,10 @@ Authentication utilities to accompany `twitterclient`.
 """
 
 import os
-import pprint
 
 from twython import Twython
+
+from nltk.pathsec import open as pathsec_open
 
 
 def credsfromfile(creds_file=None, subdir=None, verbose=False):
@@ -83,7 +84,12 @@ class Authenticate:
         if not os.path.isfile(self.creds_fullpath):
             raise OSError(f"Cannot find file {self.creds_fullpath}")
 
-        with open(self.creds_fullpath) as infile:
+        # The credentials file is the operator's own (the TWITTER env var or a
+        # subdir they pick); pathsec.open validates the path (traversal / NUL /
+        # symlink) without bounding an operator path to the data roots.
+        with pathsec_open(
+            self.creds_fullpath, encoding="utf8", context="twitter.Authenticate"
+        ) as infile:
             if verbose:
                 print(f"Reading credentials file {self.creds_fullpath}")
 
@@ -108,8 +114,11 @@ class Authenticate:
             oauth2 = True
 
         if not (oauth1 or oauth2):
+            # Report only the key names present, never the secret values: this
+            # message can reach stderr/logs, so pretty-printing the creds dict
+            # would leak app_secret/access_token (CWE-532/CWE-209/CWE-200).
             msg = f"Missing or incorrect entries in {self.creds_file}\n"
-            msg += pprint.pformat(self.oauth)
+            msg += f"found keys: {sorted(self.oauth)}"
             raise ValueError(msg)
         elif verbose:
             print(f'Credentials file "{self.creds_file}" looks good')
@@ -130,7 +139,9 @@ def add_access_token(creds_file=None):
     twitter = Twython(app_key, app_secret, oauth_version=2)
     access_token = twitter.obtain_access_token()
     tok = f"access_token={access_token}\n"
-    with open(creds_file, "a") as infile:
+    with pathsec_open(
+        creds_file, "a", encoding="utf8", context="twitter.add_access_token"
+    ) as infile:
         print(tok, file=infile)
 
 

--- a/tools/check_no_unsandboxed_open.py
+++ b/tools/check_no_unsandboxed_open.py
@@ -45,6 +45,12 @@ GUARDED_PATHS = [
     "nltk/tag/perceptron.py",
     "nltk/tbl/demo.py",
     "nltk/tokenize/punkt.py",
+    # nltk/app, nltk/draw and nltk/twitter take an operator-chosen filename (a Tk
+    # dialog, a config path, an output name); each open now routes through
+    # pathsec.open, and guarding the subtree stops a new bare open slipping back.
+    "nltk/app",
+    "nltk/draw",
+    "nltk/twitter",
 ]
 
 SUPPRESS_MARKER = "# sandboxed-open ok"


### PR DESCRIPTION
## Summary

The `no-unsandboxed-open` guard (#3740) only covered a dozen named modules, so a bare builtin `open()` anywhere else went unnoticed. The GUI apps, the drawing canvas and the twitter client all take a filename from the **operator** (a Tk dialog, a config path, an output name) and opened it with a bare `open()`. This extends the guard to those three subtrees and routes **every** open in them through `pathsec.open` — no `# sandboxed-open ok` exceptions.

## Are operator-chosen paths actually protected?

Yes. These paths are operator-chosen, so `pathsec.open` (default `required_root=None`) does not bound them to the NLTK data roots — the operator still saves where they want and keeps the file. But on POSIX it still routes through the hardened opener, which was verified adversarially against the actual wrappers:

- a **symlink** planted at the save/open destination is refused at open time (`O_NOFOLLOW`, TOCTOU-safe) — a local attacker cannot redirect a Save onto `/etc/...` or read a file out through a planted link (CWE-59);
- a **hardlink** to an outside inode is refused (`st_nlink > 1`, CWE-59);
- a **NUL byte** or a **URL** in the path is refused (CWE-22);
- a freshly written file is created **0600**, so a saved chart or a `credentials.txt` is never left group/world readable (CWE-377/378).

Legitimate operator paths, and a real chart pickle save/load roundtrip, keep working.

## Changes

- **`tools/check_no_unsandboxed_open.py`** — add `nltk/app`, `nltk/draw`, `nltk/twitter` to `GUARDED_PATHS`. The guard still flags only the builtin `open()` via AST; `pathsec.open` / `gzip.open` / `os.open` are unaffected.
- **All opens in the three subtrees** — reads *and* writes (Save Chart / Grammar / History, PostScript export, wordnet log, credentials read/append, tweet-collection output) now go through `pathsec.open`. For the gzip output the raw handle is sandboxed, then `gzip` wraps the checked file.
- **`nltk/twitter/util.py`** — on an auth failure, report only credential **key names**, never the secret values (CWE-532 / 209 / 200); pin the creds-file charset.
- **`test_output_exposure_security.py`** — an auth error never leaks a secret; the wordnet lookup link escapes its label/href.
- **`test_app_twitter_open_hardening.py`** (new) — the adversarial harness described above, run against the real `_outf_writer`, `TweetWriter`, `ChartComparer.load_chart` and `ChartParserApp.save_chart`.

## On pickles / JSON

Loading an untrusted pickle/JSON is the real deserialization risk (CWE-502) and stays on the **read** side, unchanged: chartparser loads through `AllowlistUnpickler`, twitter reads JSON through `safe_json_loads`. The reads now additionally get path validation.

## Verification

- Extended guard passes; every open in the three subtrees goes through `pathsec.open`.
- New adversarial harness (22) + `test_output_exposure_security` (9) + `test_json2csv_corpus` (12) pass; the broader path/data security suites (192) pass.
- All 300 nltk modules import cleanly.