### PR TITLE
Bound the WekaClassifier model path to the pathsec data roots

### DIFF
--- a/nltk/classify/weka.py
+++ b/nltk/classify/weka.py
@@ -369,9 +369,11 @@ class ARFF_Formatter:
         # Relation name
         s += "@RELATION rel\n\n"
 
-        # Input attribute specifications
+        # Input attribute specifications. fname is repr'd (a control char in it is
+        # escaped), but ftype is interpolated raw, so a newline in a caller-supplied
+        # type would inject a new @ATTRIBUTE/@DATA line (CWE-1236); refuse it.
         for fname, ftype in self._features:
-            s += "@ATTRIBUTE %-30r %s\n" % (fname, ftype)
+            s += "@ATTRIBUTE %-30r %s\n" % (fname, self._check_arff_ftype(ftype))
 
         # Label attribute specification – labels are already sanitized.
         # Wrap each label in single quotes and join with commas.
@@ -419,6 +421,23 @@ class ARFF_Formatter:
             return "%r" % fval
         else:
             return "%r" % fval
+
+    @staticmethod
+    def _check_arff_ftype(ftype):
+        """Refuse an ARFF attribute type carrying a control character.
+
+        ``from_train`` only ever emits the fixed enum (NUMERIC / STRING /
+        ``{True, False}``), but a caller may build an ``ARFF_Formatter`` directly;
+        a newline or other C0 control in the type would break out of the
+        ``@ATTRIBUTE`` line and inject a new attribute or ``@DATA`` section
+        (CWE-1236). Any legitimate ARFF type is control-character free.
+        """
+        text = str(ftype)
+        if any(ord(ch) < 0x20 for ch in text):
+            raise ValueError(
+                f"ARFF attribute type must not contain control characters: {ftype!r}"
+            )
+        return text
 
     @staticmethod
     def _sanitize_arff_label(label):

--- a/nltk/classify/weka.py
+++ b/nltk/classify/weka.py
@@ -22,7 +22,7 @@ from nltk.data import make_staging_dir
 from nltk.internals import config_java, java
 from nltk.pathsec import ZipFile as SecureZipFile
 from nltk.pathsec import open as pathsec_open
-from nltk.pathsec import validate_path
+from nltk.pathsec import validate_path, validate_tool_path
 from nltk.probability import DictionaryProbDist
 
 _weka_classpath = None
@@ -107,6 +107,10 @@ def _check_weka_version(jar):
 class WekaClassifier(ClassifierI):
     def __init__(self, formatter, model_filename):
         self._formatter = formatter
+        # Bound the caller-controlled model path to the pathsec data roots before
+        # it reaches the weka JVM as a -l read target, closing the model-artifact
+        # containment gap weka.py was left out of (GHSA-j456-xh4h-cpf2).
+        validate_tool_path(model_filename, context="WekaClassifier", must_exist=False)
         self._model = model_filename
 
     def prob_classify_many(self, featuresets):
@@ -116,6 +120,12 @@ class WekaClassifier(ClassifierI):
         return self._classify_many(featuresets, ["-p", "0"])
 
     def _classify_many(self, featuresets, options):
+        # Re-bound the model path in case _model was reassigned after construction;
+        # weka reads it via -l (GHSA-j456-xh4h-cpf2). Containment, not existence, is
+        # the security property, so must_exist stays False.
+        validate_tool_path(
+            self._model, context="WekaClassifier._classify_many", must_exist=False
+        )
         # Make sure we can find java & weka.
         config_weka()
 
@@ -233,6 +243,15 @@ class WekaClassifier(ClassifierI):
         options=[],
         quiet=True,
     ):
+        # Bound the caller-controlled model path before weka writes to it via -d
+        # (GHSA-j456-xh4h-cpf2); it need not exist yet, and validating before any
+        # weka lookup refuses an out-of-root path early.
+        validate_tool_path(
+            model_filename,
+            context="WekaClassifier.train",
+            for_write=True,
+            must_exist=False,
+        )
         # Make sure we can find java & weka.
         config_weka()
 

--- a/nltk/classify/weka.py
+++ b/nltk/classify/weka.py
@@ -9,6 +9,7 @@
 Classifiers that make use of the external 'Weka' package.
 """
 
+import numbers
 import os
 import subprocess
 import tempfile
@@ -177,6 +178,17 @@ class WekaClassifier(ClassifierI):
         probs = dict(zip(self._formatter.labels(), probs))
         return DictionaryProbDist(probs)
 
+    @staticmethod
+    def _weka_predicted_class(line):
+        # A weka -p line is "<inst> <actual> <idx>:<class> <error> <prob>". The
+        # stdout is only as trustworthy as the model weka just loaded, so guard the
+        # shape and raise a clear error instead of an opaque IndexError on a
+        # truncated or malformed line.
+        toks = line.split()
+        if len(toks) < 3 or ":" not in toks[2]:
+            raise ValueError("Malformed weka prediction line: %r" % line)
+        return toks[2].split(":", 1)[1]
+
     def parse_weka_output(self, lines):
         # Strip unwanted text from stdout
         for i, line in enumerate(lines):
@@ -184,8 +196,13 @@ class WekaClassifier(ClassifierI):
                 lines = lines[i:]
                 break
 
+        if not lines:
+            raise ValueError("No weka output to parse")
+
         if lines[0].split() == ["inst#", "actual", "predicted", "error", "prediction"]:
-            return [line.split()[2].split(":")[1] for line in lines[1:] if line.strip()]
+            return [
+                self._weka_predicted_class(line) for line in lines[1:] if line.strip()
+            ]
         elif lines[0].split() == [
             "inst#",
             "actual",
@@ -350,7 +367,10 @@ class ARFF_Formatter:
                 elif fval is None:
                     continue  # can't tell the type.
                 else:
-                    raise ValueError("Unsupported value type %r" % ftype)
+                    # Report the offending type, not the undefined ftype (which
+                    # raised an opaque UnboundLocalError here). type() is safe to
+                    # format; a hostile __repr__ on the value never runs.
+                    raise ValueError("Unsupported value type %r" % type(fval))
                 if features.get(fname, ftype) != ftype:
                     raise ValueError("Inconsistent type for %s" % fname)
                 features[fname] = ftype
@@ -369,11 +389,16 @@ class ARFF_Formatter:
         # Relation name
         s += "@RELATION rel\n\n"
 
-        # Input attribute specifications. fname is repr'd (a control char in it is
-        # escaped), but ftype is interpolated raw, so a newline in a caller-supplied
-        # type would inject a new @ATTRIBUTE/@DATA line (CWE-1236); refuse it.
+        # Input attribute specifications. fname goes through _safe_str_repr (the
+        # built-in str repr of its characters, so a str subclass overriding
+        # __repr__ cannot smuggle a newline), and ftype is refused if it carries a
+        # control char; either would otherwise inject a new @ATTRIBUTE/@DATA line
+        # (CWE-1236).
         for fname, ftype in self._features:
-            s += "@ATTRIBUTE %-30r %s\n" % (fname, self._check_arff_ftype(ftype))
+            s += "@ATTRIBUTE %-30s %s\n" % (
+                self._safe_str_repr(fname),
+                self._check_arff_ftype(ftype),
+            )
 
         # Label attribute specification – labels are already sanitized.
         # Wrap each label in single quotes and join with commas.
@@ -412,15 +437,31 @@ class ARFF_Formatter:
                 s += "%s\n" % self._fmt_arff_val(safe_label)
         return s
 
+    @staticmethod
+    def _safe_str_repr(value):
+        # Return the built-in str repr of value's characters. str.__repr__ always
+        # escapes control chars (a newline becomes a literal \n), so routing every
+        # string-like ARFF token through it means a str subclass overriding
+        # __repr__/__str__, or any object with a hostile __str__, cannot break out
+        # of its field to forge an @ATTRIBUTE/@DATA line (CWE-1236).
+        s = value if isinstance(value, str) else str(value)
+        return str.__repr__(s)
+
     def _fmt_arff_val(self, fval):
+        # Numerics are formatted from their numeric VALUE, not str()/repr(): int()
+        # and float() strip any subclass whose __str__/__repr__ could otherwise
+        # inject a newline, and the resulting text is digits/./e/+/-/inf/nan only.
+        # Everything else is escaped through _safe_str_repr. So no feature value,
+        # whatever its type, can smuggle an ARFF directive into the data section.
         if fval is None:
             return "?"
-        elif isinstance(fval, (bool, int)):
-            return "%s" % fval
-        elif isinstance(fval, float):
-            return "%r" % fval
-        else:
-            return "%r" % fval
+        if isinstance(fval, bool):
+            return "True" if fval else "False"
+        if isinstance(fval, numbers.Integral):
+            return "%d" % int(fval)
+        if isinstance(fval, numbers.Real):
+            return repr(float(fval))
+        return self._safe_str_repr(fval)
 
     @staticmethod
     def _check_arff_ftype(ftype):

--- a/nltk/test/unit/test_weka_jvm_arff_hardening.py
+++ b/nltk/test/unit/test_weka_jvm_arff_hardening.py
@@ -27,6 +27,7 @@ loading an attacker-authored in-root model safe.
 """
 
 import os
+import zipfile
 
 import pytest
 
@@ -122,6 +123,29 @@ def test_unknown_classifier_class_is_refused(trusted_weka):
     model = os.path.join(root, "m.model")
     with pytest.raises(ValueError, match="Unknown classifier"):
         WekaClassifier.train(model, FEATS, classifier="weka.evil.RuntimeExec")
+
+
+# --- decompression bomb in the jar's version.txt (CWE-409) --------------------
+
+
+def test_weka_version_txt_decompression_bomb_is_refused():
+    """A hostile weka.jar whose ``weka/core/version.txt`` expands far past its
+    compressed size must be cut off, not read into RAM: ``_check_weka_version``
+    reads it through the pathsec ``SecureZipFile``, whose streaming reader refuses
+    the bomb mid-member (CWE-409). A legitimate small version still reads back."""
+    root = _staged_root()
+    bomb = os.path.join(root, "bomb.jar")
+    with zipfile.ZipFile(bomb, "w", zipfile.ZIP_DEFLATED) as zf:
+        # ~48 MiB of zeros compresses to ~48 KiB: past MAX_UNZIP_ACTIVATION and
+        # above MAX_UNZIP_RATIO, so the read is cut off before it exhausts memory.
+        zf.writestr("weka/core/version.txt", b"0" * (48 * 1024 * 1024))
+    with pytest.raises(ValueError, match="zip bomb"):
+        weka._check_weka_version(bomb)
+
+    good = os.path.join(root, "good.jar")
+    with zipfile.ZipFile(good, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("weka/core/version.txt", b"3.8.6")
+    assert weka._check_weka_version(good) == b"3.8.6"
 
 
 # --- ARFF structural injection (CWE-1236) -------------------------------------

--- a/nltk/test/unit/test_weka_jvm_arff_hardening.py
+++ b/nltk/test/unit/test_weka_jvm_arff_hardening.py
@@ -1,0 +1,186 @@
+"""Adversarial coverage for the WekaClassifier JVM-subprocess and ARFF surfaces.
+
+WekaClassifier drives the weka JVM through ``nltk.internals.java`` and writes ARFF
+files the JVM reads. Beyond the model-path containment already pinned in
+test_weka_model_path_security (GHSA-j456-xh4h-cpf2), a Python wrapper around a JVM
+tool is exposed to the vector classes seen across the ecosystem:
+
+- JVM argument injection through the caller option list or the model path
+  (``@argfile`` / ``-javaagent``, CVE-2026-12841 / CWE-88);
+- an untrusted classpath jar, an out-of-root ``WEKAHOME`` or a current-directory
+  ``weka.jar`` (CWE-426 / CWE-427 / CWE-494);
+- a decompression bomb in the jar's ``version.txt`` (CWE-409);
+- ARFF structural injection through a feature value, a class label, or a feature
+  type (CWE-1236);
+- classifier-class injection (only the known weka classes may run).
+
+Nothing is mocked at the security boundary: the guards that fire are the real
+``internals.java`` / ``pathsec`` / ARFF checks. ``config_weka`` is stubbed only so
+the flow can reach ``internals.java`` without a local weka install, and the
+classpath is a real file staged inside a trusted data root.
+
+Residual, out of Python's reach: weka's ``-l`` deserializes a Java-serialized
+model, so a *malicious model already inside a data root* could still trigger
+Java-side deserialization (CWE-502). Containment (the model path must resolve
+inside a data root) is the mitigation this layer can provide; it does not make
+loading an attacker-authored in-root model safe.
+"""
+
+import os
+
+import pytest
+
+import nltk
+from nltk.classify import weka
+from nltk.classify.weka import ARFF_Formatter, WekaClassifier
+from nltk.internals import UntrustedJarError
+
+FEATS = [({"a": 1}, "x"), ({"a": 2}, "y")]
+
+
+def _staged_root(prefix="weka_sec_"):
+    try:
+        return nltk.data.make_staging_dir(prefix=prefix, cleanup=True)
+    except PermissionError as exc:  # pragma: no cover - env-dependent
+        pytest.skip(f"no writable in-sandbox NLTK data root: {exc}")
+
+
+@pytest.fixture
+def trusted_weka(monkeypatch):
+    """A trusted-path weka.jar in a data root plus a no-op config_weka, so the
+    flow reaches internals.java (which owns the @argfile / classpath guards)."""
+    root = _staged_root()
+    jar = os.path.join(root, "weka.jar")
+    with open(jar, "wb") as handle:
+        handle.write(b"PK\x03\x04")  # zip magic; path trust is what is exercised
+    monkeypatch.setattr(weka, "config_weka", lambda *a, **k: None)
+    monkeypatch.setattr(weka, "_weka_classpath", jar)
+    return root, jar
+
+
+# --- JVM argument injection (CVE-2026-12841 / CWE-88) --------------------------
+
+
+@pytest.mark.parametrize("evil", ["@/etc/passwd", "@argfile", "\t@sneaky"])
+def test_train_option_argfile_is_refused(trusted_weka, evil):
+    """A caller weka option that is an @argfile token must be refused: the Java
+    launcher expands @argfiles anywhere on the line, injecting JVM arguments."""
+    root, _ = trusted_weka
+    model = os.path.join(root, "m.model")
+    with pytest.raises(ValueError, match="argfile"):
+        WekaClassifier.train(model, FEATS, options=[evil])
+
+
+def test_classify_option_argfile_is_refused(trusted_weka):
+    root, _ = trusted_weka
+    model = os.path.join(root, "m.model")
+    clf = WekaClassifier(ARFF_Formatter.from_train(FEATS), model)
+    with pytest.raises(ValueError, match="argfile"):
+        clf._classify_many([{"a": 1}], ["-p", "0", "@/etc/passwd"])
+
+
+# --- untrusted classpath jar (CWE-494) ----------------------------------------
+
+
+def test_untrusted_classpath_jar_is_refused(monkeypatch):
+    """internals.java refuses a classpath jar that resolves outside the trusted
+    data roots, so a planted weka.jar cannot load arbitrary Java classes."""
+    monkeypatch.setattr(weka, "config_weka", lambda *a, **k: None)
+    monkeypatch.setattr(weka, "_weka_classpath", "/tmp/evil-weka.jar")
+    root = _staged_root()
+    model = os.path.join(root, "m.model")
+    with pytest.raises(UntrustedJarError):
+        WekaClassifier.train(model, FEATS)
+
+
+def test_current_directory_is_not_a_weka_search_path():
+    """A weka.jar in the CWD must never be picked up (CWE-426/427/494)."""
+    assert "." not in weka._weka_search
+    assert os.curdir not in weka._weka_search
+    assert not any(os.path.abspath(p) == os.getcwd() for p in weka._weka_search)
+
+
+# --- WEKAHOME containment (CWE-426) -------------------------------------------
+
+
+def test_wekahome_outside_roots_is_ignored(monkeypatch):
+    """An attacker-influenceable WEKAHOME pointing outside the trusted roots is
+    dropped with a warning, not added to the classpath search."""
+    monkeypatch.setattr(weka, "_weka_classpath", None)
+    monkeypatch.setattr(weka, "config_java", lambda *a, **k: None)
+    monkeypatch.setenv("WEKAHOME", "/tmp/evil-weka")
+    with pytest.warns(UserWarning, match="outside the trusted"):
+        with pytest.raises(LookupError):  # nothing found in the trusted dirs
+            weka.config_weka()
+
+
+# --- classifier-class allowlist ------------------------------------------------
+
+
+def test_unknown_classifier_class_is_refused(trusted_weka):
+    root, _ = trusted_weka
+    model = os.path.join(root, "m.model")
+    with pytest.raises(ValueError, match="Unknown classifier"):
+        WekaClassifier.train(model, FEATS, classifier="weka.evil.RuntimeExec")
+
+
+# --- ARFF structural injection (CWE-1236) -------------------------------------
+
+
+@pytest.mark.parametrize(
+    "hostile",
+    ["x\n@ATTRIBUTE evil NUMERIC", "a\r\n@DATA", "lbl,inject", "a'b", "%comment"],
+)
+def test_arff_label_injection_is_sanitized(hostile):
+    """A class label cannot introduce a newline, an ARFF separator, or an
+    unescaped quote into the header or data section."""
+    out = ARFF_Formatter._sanitize_arff_label(hostile)
+    assert "\n" not in out and "\r" not in out and "\t" not in out
+    assert "," not in out
+    assert out.count("'") % 2 == 0  # quotes are doubled, never left dangling
+
+
+def test_arff_feature_value_injection_is_escaped():
+    """A string feature value carrying a newline and ARFF directives must not
+    inject a new @ATTRIBUTE/@DATA line; repr escapes the newline to a literal."""
+    fmt = ARFF_Formatter(["x", "y"], [("f", "STRING")])
+    payload = "v\n@ATTRIBUTE evil NUMERIC\n@DATA\n0"
+    data = fmt.data_section([({"f": payload}, "x")])
+    body = data.split("@DATA", 1)[1]
+    assert "\n@ATTRIBUTE" not in body
+    assert "\n@DATA" not in body
+
+
+@pytest.mark.parametrize(
+    "bad", ["STRING\n@ATTRIBUTE evil NUMERIC", "NUMERIC\t}", "a\r"]
+)
+def test_arff_feature_type_control_char_is_refused(bad):
+    """A caller-supplied feature TYPE with a control character would break out of
+    the @ATTRIBUTE line, so building the header refuses it."""
+    fmt = ARFF_Formatter(["x"], [("f", bad)])
+    with pytest.raises(ValueError, match="control characters"):
+        fmt.header_section()
+
+
+# --- functionality: a legitimate corpus still formats and round-trips ----------
+
+
+def test_legit_arff_still_formats():
+    """The guards must not disturb ordinary ARFF generation."""
+    toks = [({"a": 1, "s": "hi"}, "pos"), ({"a": 2, "s": "bye"}, "neg")]
+    fmt = ARFF_Formatter.from_train(toks)
+    text = fmt.format(toks)
+    assert "@RELATION" in text and "@DATA" in text
+    assert sorted(fmt.labels()) == ["neg", "pos"]
+    assert [t for _, t in fmt._features] == ["NUMERIC", "STRING"]
+
+
+def test_legit_model_path_write_roundtrips(tmp_path):
+    """A legitimate in-root model path and ARFF file still work end to end at the
+    boundary (up to the point weka itself would be invoked)."""
+    root = _staged_root()
+    fmt = ARFF_Formatter.from_train(FEATS)
+    arff = os.path.join(root, "train.arff")
+    fmt.write(arff, FEATS)
+    with open(arff) as handle:
+        assert "@DATA" in handle.read()

--- a/nltk/test/unit/test_weka_jvm_arff_hardening.py
+++ b/nltk/test/unit/test_weka_jvm_arff_hardening.py
@@ -186,6 +186,112 @@ def test_arff_feature_type_control_char_is_refused(bad):
         fmt.header_section()
 
 
+# --- value/name type-confusion injection (CWE-1236, defence in depth) ----------
+
+
+def _real_directives(text):
+    """The @-directive lines that are actually newline-anchored (i.e. real ARFF
+    structure), so an escaped payload sitting inside a quoted field does not
+    count as an injected directive."""
+    return [ln for ln in text.split("\n") if ln.lstrip().startswith("@")]
+
+
+def test_numeric_value_subclass_cannot_inject_via_repr_or_str():
+    """A NUMERIC-typed value that is an int/float SUBCLASS whose __str__/__repr__
+    emits ARFF directives must be formatted from its numeric value, not its text,
+    so it cannot smuggle a new @ATTRIBUTE/@DATA line."""
+
+    class EvilFloat(float):
+        def __repr__(self):
+            return "1\n@ATTRIBUTE evil NUMERIC\n@DATA\n9"
+
+    class EvilInt(int):
+        def __str__(self):
+            return "1\n@DATA\n9"
+
+        __repr__ = __str__
+
+    fmt = ARFF_Formatter(["A"], [("f", "NUMERIC")])
+    assert fmt._fmt_arff_val(EvilFloat(1.5)) == "1.5"
+    assert fmt._fmt_arff_val(EvilInt(7)) == "7"
+
+
+def test_string_value_and_feature_name_subclass_cannot_inject():
+    """A str SUBCLASS overriding __repr__, whether used as a feature value or a
+    feature NAME, is escaped through the built-in str repr, so the override cannot
+    forge a directive in the data row or the header."""
+
+    class EvilStr(str):
+        def __repr__(self):
+            return "'x'\n@ATTRIBUTE injected NUMERIC\n@DATA\n9"
+
+    fmt = ARFF_Formatter(["A"], [(EvilStr("n"), "STRING")])
+    # value in the data row
+    row = fmt.data_section([({EvilStr("n"): EvilStr("v")}, "A")])
+    assert not any("injected" in d for d in _real_directives(row))
+    # name in the header
+    hdr = fmt.header_section()
+    assert not any("injected" in d for d in _real_directives(hdr))
+    assert _real_directives(hdr)[1].startswith("@ATTRIBUTE 'n'")
+
+
+def test_arbitrary_object_value_is_escaped_not_injected():
+    """A directly-built formatter handed an arbitrary object as a value (bypassing
+    from_train's type check) must escape it, never interpolate its raw __repr__."""
+
+    class Evil:
+        def __repr__(self):
+            return "0\n@ATTRIBUTE evil NUMERIC\n@DATA\n9"
+
+    fmt = ARFF_Formatter(["A"], [("f", "STRING")])
+    row = fmt.data_section([({"f": Evil()}, "A")])
+    assert _real_directives(row) == ["@DATA"]  # no injected directive
+
+
+def test_from_train_rejects_non_scalar_value_cleanly():
+    """from_train on an unsupported value type raises a clear ValueError naming the
+    type, not the opaque UnboundLocalError the old error message produced."""
+
+    class Evil:
+        def __repr__(self):
+            return "0\n@ATTRIBUTE evil NUMERIC"
+
+    with pytest.raises(ValueError, match="Unsupported value type"):
+        ARFF_Formatter.from_train([({"f": Evil()}, "A")])
+
+
+# --- untrusted JVM stdout parsing (robustness against a hostile model) ---------
+
+
+@pytest.mark.parametrize(
+    "lines",
+    [
+        ["inst# actual predicted error prediction", "x"],  # too few tokens
+        ["inst# actual predicted error prediction", "0 a b c d"],  # no ':' in col 3
+        [],  # nothing to parse
+    ],
+)
+def test_parse_weka_output_refuses_malformed_lines(lines):
+    """weka's -p stdout is only as trustworthy as the model it just loaded, so a
+    truncated or malformed line must raise a clear ValueError, not an IndexError."""
+    clf = object.__new__(WekaClassifier)
+    clf._formatter = ARFF_Formatter(["pos", "neg"], [("a", "NUMERIC")])
+    with pytest.raises(ValueError):
+        clf.parse_weka_output(list(lines))
+
+
+def test_parse_weka_output_happy_path_still_parses():
+    """A well-formed prediction block still yields the predicted classes."""
+    clf = object.__new__(WekaClassifier)
+    clf._formatter = ARFF_Formatter(["pos", "neg"], [("a", "NUMERIC")])
+    lines = [
+        "inst# actual predicted error prediction",
+        "1 1:pos 2:neg + 0.9",
+        "2 1:pos 1:pos + 0.8",
+    ]
+    assert clf.parse_weka_output(lines) == ["neg", "pos"]
+
+
 # --- functionality: a legitimate corpus still formats and round-trips ----------
 
 

--- a/nltk/test/unit/test_weka_model_path_security.py
+++ b/nltk/test/unit/test_weka_model_path_security.py
@@ -1,0 +1,176 @@
+# Natural Language Toolkit: WekaClassifier model-path containment tests
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""GHSA-j456-xh4h-cpf2: WekaClassifier passed a caller-controlled model path to
+the weka JVM (``-d`` write on train, ``-l`` read on classify) with no pathsec
+validation, a variant of the GHSA-8mgp-746c-j5xp / CVE-2026-81726 model-artifact
+containment class weka.py was left out of. These tests drive the real code paths: the validation
+runs before any weka/config lookup, so an out-of-root path is refused with
+PermissionError even without weka installed, while a legitimate in-root staged
+path still passes. Nothing is mocked."""
+
+import os
+
+import pytest
+
+import nltk.pathsec as ps
+from nltk.classify.weka import WekaClassifier
+from nltk.data import make_staging_dir
+
+OUT_OF_ROOT = [
+    "/tmp/outside_sandbox/evil.model",  # absolute, outside any data root
+    "/etc/cron.d/evil",  # absolute write to a sensitive dir
+    "../../../home/victim/.ssh/authorized_keys",  # relative traversal
+    "/home/victim/secret.model",  # absolute read oracle
+    "/etc/passwd",  # absolute read of a sensitive file
+    "..\\..\\windows\\system32\\x",  # backslash traversal
+]
+
+FEATS = [({"a": 1}, "pos"), ({"a": 0}, "neg")]
+
+
+@pytest.fixture(autouse=True)
+def _enforce():
+    old = ps.ENFORCE
+    ps.ENFORCE = True
+    try:
+        yield
+    finally:
+        ps.ENFORCE = old
+
+
+class TestWekaWriteContainment:
+    @pytest.mark.parametrize("path", OUT_OF_ROOT)
+    def test_train_refuses_out_of_root_model(self, path):
+        # -d write target: refused before config_weka() / java() is reached.
+        with pytest.raises((PermissionError, ValueError)):
+            WekaClassifier.train(path, FEATS)
+
+
+class TestWekaReadContainment:
+    @pytest.mark.parametrize("path", OUT_OF_ROOT)
+    def test_construct_refuses_out_of_root_model(self, path):
+        # -l read target is bounded at construction.
+        with pytest.raises((PermissionError, ValueError)):
+            WekaClassifier(None, path)
+
+    @pytest.mark.parametrize("path", OUT_OF_ROOT)
+    def test_classify_rechecks_reassigned_model(self, path):
+        # even if _model is swapped after construction, classify re-validates.
+        clf = object.__new__(WekaClassifier)
+        clf._formatter = None
+        clf._model = path
+        with pytest.raises((PermissionError, ValueError)):
+            clf.classify_many([{"a": 1}])
+
+
+class TestWekaSymlinkEscape:
+    def test_construct_refuses_symlink_escaping_the_root(self, tmp_path):
+        # a symlink that lives inside a data root but points outside must not be
+        # a bypass; validate_tool_path resolves the link before the containment
+        # check.
+        root = make_staging_dir(prefix="nltk_weka_symtest_")
+        link = os.path.join(root, "escape.model")
+        try:
+            os.symlink("/etc/passwd", link)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unavailable")
+        with pytest.raises((PermissionError, ValueError)):
+            WekaClassifier(None, link)
+
+
+SYNTACTICALLY_HOSTILE = [
+    "model\x00.bin",  # NUL truncates the path in the JVM's native layer
+    "-loadModel",  # option-shaped: would smuggle a second weka flag
+    "--outputFormat",  # option-shaped (long form)
+    "http://evil.example/model",  # URL, not a local path
+    "file:///etc/passwd",  # file URL
+]
+
+
+class TestWekaSyntacticallyHostileModel:
+    @pytest.mark.parametrize("path", SYNTACTICALLY_HOSTILE)
+    def test_construct_refuses_syntactically_hostile_model(self, path):
+        # A NUL/option-shaped/URL model is refused at construction (-l read), by
+        # the shared name checks, before any weka/config lookup.
+        with pytest.raises((PermissionError, ValueError)):
+            WekaClassifier(None, path)
+
+    @pytest.mark.parametrize("path", SYNTACTICALLY_HOSTILE)
+    def test_train_refuses_syntactically_hostile_model(self, path):
+        # Same value as a -d write target: refused before config_weka()/java().
+        with pytest.raises((PermissionError, ValueError)):
+            WekaClassifier.train(path, FEATS)
+
+
+def _escapes_all_data_roots(path):
+    """True if ``path`` resolves outside every pathsec-allowed data root.
+
+    The symlink-escape vector only exists when the link genuinely resolves outside
+    the sandbox; on a platform/layout where the chosen "outside" location happens
+    to sit inside a data root (some Windows temp setups place pytest's tmp under a
+    directory that is also a data root), there is nothing for the guard to refuse.
+    Verifying the escape here keeps the assertion honest: where the link truly
+    escapes the refusal is still required, so a real gap cannot hide behind a
+    platform skip; where it does not escape the test skips instead of asserting a
+    refusal that cannot apply.
+    """
+    resolved = os.path.realpath(path)
+    for root in ps._get_allowed_roots():
+        try:
+            root_resolved = os.path.realpath(str(root))
+            # commonpath raises ValueError on different Windows drives / mixed
+            # absoluteness, i.e. genuinely not contained -> treat as "outside".
+            if os.path.commonpath([resolved, root_resolved]) == root_resolved:
+                return False
+        except (OSError, ValueError):
+            continue
+    return True
+
+
+class TestWekaWriteSymlinkEscape:
+    def test_train_refuses_symlink_write_target_escaping_the_root(self, tmp_path):
+        # A -d WRITE target that is an in-root symlink to an outside file must be
+        # refused: for_write hardening resolves the link before the containment
+        # check, so weka cannot be steered into overwriting an outside file.
+        root = make_staging_dir(prefix="nltk_weka_wsym_")
+        outside = tmp_path / "outside.model"
+        outside.write_bytes(b"")
+        link = os.path.join(root, "out.model")
+        try:
+            os.symlink(str(outside), link)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unavailable")
+        if not _escapes_all_data_roots(link):
+            pytest.skip("symlink target does not resolve outside a data root here")
+        with pytest.raises((PermissionError, ValueError)):
+            WekaClassifier.train(link, FEATS)
+
+
+class TestWekaLegitimatePathsPass:
+    def test_in_root_model_passes_at_construction(self):
+        model = os.path.join(make_staging_dir(prefix="nltk_weka_ok_"), "name.model")
+        clf = WekaClassifier(None, model)  # in-root -> validation passes
+        assert clf._model == model
+
+    def test_in_root_model_that_does_not_exist_yet_is_accepted(self):
+        # must_exist=False: a not-yet-written in-root model validates (containment,
+        # not existence, is the property), so a fresh train destination is allowed.
+        model = os.path.join(make_staging_dir(prefix="nltk_weka_new_"), "fresh.model")
+        assert not os.path.exists(model)
+        clf = WekaClassifier(None, model)
+        assert clf._model == model
+
+    def test_in_root_train_path_is_not_refused_by_containment(self):
+        model = os.path.join(make_staging_dir(prefix="nltk_weka_ok_"), "name.model")
+        # validation passes for an in-root path; any subsequent failure is
+        # weka-not-installed, NOT a containment refusal.
+        try:
+            WekaClassifier.train(model, FEATS)
+        except PermissionError:
+            pytest.fail("in-root model path wrongly refused by containment")
+        except Exception:
+            pass  # config_weka()/java() failing (no weka) is fine: validation passed


### PR DESCRIPTION
> **[WIP]** — split out of the larger GHSA-8mgp hardening for focused review.

## Summary

Hardens `WekaClassifier` — a Python wrapper that drives the weka JVM and writes ARFF the JVM reads — against the known JVM-wrapper vulnerability classes, and adds an unmocked adversarial harness for the whole surface.

## 1. Model-path containment (GHSA-j456-xh4h-cpf2)

`WekaClassifier` passed a caller-controlled model filename straight to the JVM (`-l` read, `-d` write) with no containment check. `validate_tool_path` now bounds it at `__init__`, `_classify_many` (re-checked in case `_model` was reassigned), and `train` (`for_write=True`). `must_exist=False` — containment, not existence, is the property. Out-of-root, symlink-escaping and hostile paths are refused before `config_weka()`/`java()`.

## 2. JVM / ARFF surface audit + fixes

I audited every way attacker-influenced data reaches the JVM or the ARFF, against the ecosystem's JVM-wrapper CVEs:

| Vector | Status |
|---|---|
| JVM arg injection via options / model path (`@argfile`, `-javaagent`, CVE-2026-12841 / CWE-88) | already refused by `internals.java` (rejects any `@argfile` token in the command) |
| Untrusted classpath jar / CWD `weka.jar` (CVE-2026-0848, CVE-2026-12252 class; CWE-426/427/494) | already refused (`internals.java` classpath trust; CWD not in `_weka_search`) |
| Out-of-root `WEKAHOME` (CWE-426) | already dropped with a warning |
| Decompression bomb in the jar's `version.txt` (CWE-409) | already capped — `_check_weka_version` reads through the pathsec `SecureZipFile`, whose streaming reader enforces `MAX_UNZIP_RATIO` / `MAX_UNZIP_ACTIVATION`; **now pinned by a test** |
| Classifier-class injection | already allowlisted (`_CLASSIFIER_CLASS`) |
| ARFF **label** injection (CWE-1236) | already sanitised (`_sanitize_arff_label`) |
| ARFF feature **type** injection | **fixed here** — a caller-supplied `ftype` was interpolated raw, so a newline injected a new `@ATTRIBUTE`/`@DATA` line; `_check_arff_ftype` now refuses a control char in a type |
| ARFF **value / feature-name** type-confusion (CWE-1236) | **fixed here** — the formatter trusted the caller's `__str__`/`__repr__`, so an int/float **subclass** with a hostile `__str__`/`__repr__`, a `str` subclass overriding `__repr__`, or an arbitrary object handed to a directly-built formatter could emit a raw newline and forge a directive. Values are now formatted from their numeric value (`int()`/`float()` strip the subclass) and every string-like token goes through `_safe_str_repr` (the built-in `str` repr, which always escapes control chars) |

These value/name vectors need object-type control, so they are defence in depth — but the formatter's contract is to emit safe ARFF for **any** input, so it must never interpolate an untrusted `__repr__`. Output for ordinary `bool`/`int`/`float`/`str` values is byte-identical.

## 3. Robustness fixes on untrusted paths

- `from_train` raised an opaque `UnboundLocalError` (it formatted the undefined `ftype`) when handed an unsupported value type; it now raises a clear `ValueError` naming the type.
- `parse_weka_output` raised a raw `IndexError` on truncated/malformed weka `-p` stdout — which is only as trustworthy as the model weka just loaded — instead of a clear error; `_weka_predicted_class` now validates the line shape and raises a descriptive `ValueError`, and an empty output block is rejected explicitly.

### ARFF write is confined by design

`ARFF_Formatter.write(path, ...)` routes the path through the pathsec sandbox, so the scratch ARFF weka reads stays inside the data roots (it is written under a private staging dir). A caller who genuinely wants to export ARFF to an operator-chosen path outside the roots passes a **file object** instead of a path — that bypasses the path open and is not confined. This is deliberate; `test_weka_save_security.py` pins it, so please do not "relax" the write to a bare `open()`.

## Tests

- `test_weka_model_path_security.py` — model-path containment (unmocked).
- `test_weka_jvm_arff_hardening.py` (new) — @argfile in options, untrusted classpath, out-of-root WEKAHOME, CWD exclusion, `version.txt` decompression bomb (CWE-409), classifier allowlist, ARFF label/value/type injection, numeric-subclass and str-subclass and arbitrary-object value/name injection, `from_train` non-scalar rejection, and `parse_weka_output` malformed-line rejection + happy-path parse, plus legitimate-formatting round-trips. The real `internals.java` / `pathsec` / ARFF guards fire; `config_weka` is stubbed only so the flow reaches `internals.java` without a local weka install.
- `test_weka_security.py` / `test_weka_save_security.py` / `test_weka_arff_injection.py` — CWD search-path exclusion, WEKAHOME containment, scratch-ARFF-stays-in-root, ARFF directive-injection, write confinement.

## Residual (documented, out of Python's reach)

weka's `-l` **deserializes a Java-serialized model**, so a malicious model *already inside a data root* remains a Java-side deserialization risk (CWE-502). Path containment reduces the attack surface (an attacker needs write access to a data root) but does not make loading an attacker-authored in-root model safe. Jar integrity beyond path trust (a trusted-path but tampered `weka.jar`) is likewise out of scope for this layer.

## Verification

- Full weka suite: **77 passed, 2 skipped** (real-weka integration + a macOS temp-authorized case skip).
- All nltk modules import with 0 hard failures; real `from_train` → ARFF formatting round-trips (in-root path write and operator file-object write both work); pre-commit clean (sandbox-open / redos / picklesec guards included).
