### PR TITLE
Exclude pytest's ephemeral basetemp from the pickle-asset scanner

### DIFF
--- a/nltk/test/unit/test_pickle_allowlist_security.py
+++ b/nltk/test/unit/test_pickle_allowlist_security.py
@@ -1473,7 +1473,7 @@ def test_data_load_restricted_pickle_roundtrips_real_asset(tmp_path, monkeypatch
     assert loaded == staged_value, "staged real .pickle failed to load via data.load"
 
 
-def test_all_nltk_data_pickle_assets_load():
+def test_all_nltk_data_pickle_assets_load(tmp_path_factory):
     """Real-asset regression: EVERY ``*.pickle`` present in the installed nltk_data
     must still load through ``nltk.data.load`` after the picklesec hardening (class-
     bearing artifacts like punkt / perceptron / maxent via the pickle-free redirect;
@@ -1486,7 +1486,20 @@ def test_all_nltk_data_pickle_assets_load():
 
     import nltk
 
-    roots = [p for p in nltk.data.path if os.path.isdir(p)]
+    # conftest.py registers pytest's session basetemp as an nltk.data.path root so
+    # staging tests can write inside the pathsec sandbox. That base holds ephemeral
+    # scratch from other tests (symlinks, deliberately unloadable pickles), never
+    # real nltk_data assets, so exclude it and anything under it: this scanner
+    # validates installed assets, not per-test tmp files (a filename-based skip
+    # would be bypassed by any other extension, so exclude by location).
+    basetemp = os.path.realpath(str(tmp_path_factory.getbasetemp()))
+    roots = [
+        p
+        for p in nltk.data.path
+        if os.path.isdir(p)
+        and os.path.realpath(p) != basetemp
+        and not os.path.realpath(p).startswith(basetemp + os.sep)
+    ]
     files = []
     for root in roots:
         files += glob.glob(os.path.join(root, "**", "*.pickle"), recursive=True)
@@ -1509,6 +1522,67 @@ def test_all_nltk_data_pickle_assets_load():
     assert not broken, "nltk_data pickle assets failed to load:\n  " + "\n  ".join(
         broken
     )
+
+
+@pytest.mark.parametrize(
+    "reduce_fn",
+    [
+        lambda m: (os.system, (f"touch {m}",)),
+        lambda m: (eval, (f"__import__('os').system('touch {m}')",)),
+        lambda m: (__import__("subprocess").call, (["touch", str(m)],)),
+    ],
+)
+def test_gadget_pickle_under_authorized_root_is_refused_at_load(
+    tmp_path, monkeypatch, reduce_fn
+):
+    """Excluding the pytest basetemp from the asset scanner is not a security hole.
+
+    The scanner is a real-asset regression test, not the load-time defense. A
+    gadget pickle placed inside a *trusted* (conftest-authorized) data root is
+    still refused by nltk.data.load's restricted unpickler, which fires on every
+    load regardless of location, so nothing executes (CWE-502).
+    """
+    import pickle
+
+    import nltk
+    import nltk.data as _data
+    from nltk import pathsec
+
+    marker = tmp_path / "PWNED"
+
+    class _Gadget:
+        def __reduce__(self):
+            return reduce_fn(marker)
+
+    (tmp_path / "corpora").mkdir()
+    with open(tmp_path / "corpora" / "gadget.pickle", "wb") as handle:
+        pickle.dump(_Gadget(), handle)
+    monkeypatch.setattr(_data, "path", [str(tmp_path), *_data.path])
+    monkeypatch.setattr(pathsec, "_ALLOWED_ROOTS_CACHE", None, raising=False)
+    monkeypatch.setattr(pathsec, "_LAST_DATA_PATHS", None, raising=False)
+
+    with pytest.raises(Exception) as exc:
+        nltk.data.load("corpora/gadget.pickle")
+    assert "forbidden" in str(exc.value).lower()
+    assert not marker.exists()
+
+
+def test_scanner_excludes_only_the_pytest_base_not_siblings_or_real_roots(
+    tmp_path_factory,
+):
+    """The scanner's basetemp exclusion is precise and by location: only the base
+    and its subtree are dropped, so a sibling sharing the name prefix and the real
+    asset roots are still scanned -- no over-exclusion blind spot."""
+    base = os.path.realpath(str(tmp_path_factory.getbasetemp()))
+
+    def _excluded(p):
+        rp = os.path.realpath(p)
+        return rp == base or rp.startswith(base + os.sep)
+
+    assert _excluded(base)  # the ephemeral base itself
+    assert _excluded(os.path.join(base, "sub", "worker0"))  # scratch under it
+    assert not _excluded(base + "-real")  # sibling prefix -> still scanned
+    assert not _excluded("/usr/share/nltk_data")  # a real asset root -> still scanned
 
 
 # Module (sub)trees where EVERY callable is a code-exec / file / native /

--- a/nltk/test/unit/test_pickle_asset_scanner_load_defense.py
+++ b/nltk/test/unit/test_pickle_asset_scanner_load_defense.py
@@ -1,0 +1,178 @@
+"""Adversarial proof that excluding pytest's basetemp from the pickle-asset
+scanner opens no load-time hole.
+
+``test_all_nltk_data_pickle_assets_load`` skips pytest's ephemeral session base
+(a conftest-authorized nltk.data.path root) so it only validates real installed
+assets. That scanner is a regression test, not the security boundary: the
+boundary is ``nltk.data.load``'s restricted unpickler, which refuses dangerous
+globals, hand-written opcodes, nested loads and unsafe resource paths on EVERY
+load, no matter which root the file lives in or which roots the scanner skips.
+
+These tests attack that boundary directly -- including from inside a trusted,
+scanner-excluded root and from behind a symlink -- and confirm nothing executes
+and nothing is read outside the roots (CWE-502 / CWE-22 / CWE-59). If the
+scanner exclusion were a hole, one of these would load.
+"""
+
+import importlib
+import os
+import pickle
+
+import pytest
+
+
+@pytest.fixture
+def authorized_root(monkeypatch, tmp_path):
+    """A trusted, authorized nltk.data.path root -- the same kind conftest
+    authorizes for pytest's basetemp, and the kind the scanner now excludes."""
+    import nltk.data as _data
+    from nltk import pathsec
+
+    (tmp_path / "corpora").mkdir()
+    monkeypatch.setattr(_data, "path", [str(tmp_path), *_data.path])
+    monkeypatch.setattr(pathsec, "_ALLOWED_ROOTS_CACHE", None, raising=False)
+    monkeypatch.setattr(pathsec, "_LAST_DATA_PATHS", None, raising=False)
+    return tmp_path
+
+
+def _drop(root, raw):
+    (root / "corpora" / "g.pickle").write_bytes(raw)
+    return "corpora/g.pickle"
+
+
+# Every dangerous global a gadget could name: process / exec / eval / import /
+# native / file / socket / nested-unpickle / call-traversal primitives.
+_DANGEROUS = [
+    ("os", "system"), ("os", "popen"), ("os", "execv"), ("os", "spawnv"),
+    ("os", "remove"), ("os", "unlink"), ("os", "rmdir"), ("os", "chmod"),
+    ("os", "rename"), ("posix", "system"), ("subprocess", "call"),
+    ("subprocess", "Popen"), ("subprocess", "run"), ("subprocess", "check_output"),
+    ("subprocess", "getoutput"), ("builtins", "eval"), ("builtins", "exec"),
+    ("builtins", "__import__"), ("builtins", "compile"), ("builtins", "open"),
+    ("builtins", "getattr"), ("builtins", "setattr"), ("importlib", "import_module"),
+    ("ctypes", "CDLL"), ("shutil", "rmtree"), ("shutil", "copy"),
+    ("socket", "socket"), ("webbrowser", "open"), ("io", "open"),
+    ("codecs", "open"), ("pickle", "loads"), ("operator", "attrgetter"),
+    ("operator", "methodcaller"), ("functools", "partial"),
+]  # fmt: skip
+
+
+def _forbidden(exc):
+    text = str(exc).lower()
+    return (
+        "forbidden" in text
+        or "restrict" in text
+        or "not allowed" in text
+        or type(exc).__name__ == "UnpicklingError"
+    )
+
+
+@pytest.mark.parametrize("module,qualname", _DANGEROUS)
+def test_reduce_gadget_global_is_refused_from_authorized_root(
+    authorized_root, module, qualname
+):
+    """A __reduce__ gadget naming a dangerous global is refused even when the
+    pickle sits in a trusted, scanner-excluded root, and nothing executes."""
+    import nltk
+
+    try:
+        obj = importlib.import_module(module)
+        for part in qualname.split("."):
+            obj = getattr(obj, part)
+    except (ImportError, AttributeError):  # pragma: no cover - platform dependent
+        pytest.skip(f"{module}.{qualname} unavailable on this platform")
+
+    marker = authorized_root / "PWNED"
+
+    class _Gadget:
+        def __reduce__(self):
+            return (obj, (f"touch {marker}",) if callable(obj) else ())
+
+    res = _drop(authorized_root, pickle.dumps(_Gadget()))
+    with pytest.raises(Exception) as exc:
+        nltk.data.load(res)
+    assert _forbidden(exc.value)
+    assert not marker.exists()
+
+
+@pytest.mark.parametrize(
+    "raw,label",
+    [
+        (
+            b"\x80\x04\x95\x1a\x00\x00\x00\x00\x00\x00\x00\x8c\x02os\x94"
+            b"\x8c\x06system\x94\x93\x94\x8c\x02id\x94\x85\x94R\x94.",
+            "STACK_GLOBAL os.system",
+        ),
+        (b"cposix\nsystem\n(S'id'\ntR.", "GLOBAL posix.system"),
+        (b"\x80\x02\x82\x01.", "EXT1 extension registry"),
+    ],
+)
+def test_hand_written_opcode_gadget_is_refused(authorized_root, raw, label):
+    """Raw GLOBAL / STACK_GLOBAL / extension-registry opcodes are refused, not
+    just __reduce__ pickles."""
+    import nltk
+
+    with pytest.raises(Exception):
+        nltk.data.load(_drop(authorized_root, raw))
+
+
+def test_nested_pickle_loads_gadget_is_refused(authorized_root):
+    """A pickle whose reduce calls pickle.loads(<inner gadget>) is refused: the
+    outer load never reaches the inner bytes (pickle.loads is itself forbidden)."""
+    import nltk
+
+    marker = authorized_root / "PWNED"
+    inner = b"cposix\nsystem\n(S'touch %s'\ntR." % str(marker).encode()
+
+    class _Nest:
+        def __reduce__(self):
+            return (pickle.loads, (inner,))
+
+    with pytest.raises(Exception):
+        nltk.data.load(_drop(authorized_root, pickle.dumps(_Nest())))
+    assert not marker.exists()
+
+
+@pytest.mark.parametrize(
+    "resource",
+    [
+        "../../../../etc/passwd",
+        "corpora/../../../../etc/passwd",
+        "/etc/passwd",
+        "corpora/a\x00b.pickle",
+        "file:///etc/passwd",
+    ],
+)
+def test_unsafe_resource_path_is_refused(resource):
+    """Traversal, absolute, NUL-byte and file:// resource names are refused before
+    any content is returned (CWE-22 / CWE-59)."""
+    import nltk
+
+    with pytest.raises(Exception):
+        nltk.data.load(resource)
+
+
+def test_gadget_behind_a_symlinked_authorized_root_is_refused(monkeypatch, tmp_path):
+    """A trusted root reached through a symlink is realpath-resolved, and a gadget
+    behind it is still refused -- no symlink-hijack bypass (CWE-59)."""
+    import nltk
+    import nltk.data as _data
+    from nltk import pathsec
+
+    real = tmp_path / "real"
+    (real / "corpora").mkdir(parents=True)
+    link = tmp_path / "link"
+    os.symlink(real, link)
+    marker = real / "PWNED"
+
+    class _Gadget:
+        def __reduce__(self):
+            return (os.system, (f"touch {marker}",))
+
+    (real / "corpora" / "g.pickle").write_bytes(pickle.dumps(_Gadget()))
+    monkeypatch.setattr(_data, "path", [str(link), *_data.path])
+    monkeypatch.setattr(pathsec, "_ALLOWED_ROOTS_CACHE", None, raising=False)
+    monkeypatch.setattr(pathsec, "_LAST_DATA_PATHS", None, raising=False)
+    with pytest.raises(Exception):
+        nltk.data.load("corpora/g.pickle")
+    assert not marker.exists()


### PR DESCRIPTION
## Problem

Every `ci-workflow` matrix job on `develop` fails at "Run pytest": `test_pickle_allowlist_security.py::test_all_nltk_data_pickle_assets_load`.

That test is a real-asset regression: it globs `**/*.pickle` under every `nltk.data.path` root and asserts each loads through `nltk.data.load`. But `nltk/test/conftest.py::_authorize_pytest_basetemp` **registers pytest's session basetemp as an `nltk.data.path` root** (so staging tests can write inside the pathsec sandbox). So the scanner also scans that ephemeral base and loads the scratch artifacts other tests leave there — e.g. `test_app_twitter_open_hardening.py` (added in #3861) writes `chart.pickle` symlinks (pathsec refuses them at open, CWE-59) and a real `Chart` pickle (the restricted loader correctly forbids `nltk.parse.chart.Chart`). Those are **test artifacts, not real assets**, so the scan fails.

## Fix

Exclude the pytest basetemp root (and anything under it) from the scanned roots, **by location, not by filename**. A filename-based skip (e.g. renaming the test's `.pickle` files) is fragile — any other test, or any other extension, re-breaks it, and the scanner's job is to validate *installed assets*, not per-test tmp files. Real asset roots are never under the pytest base, so their coverage is unchanged.

## Verification

- `test_pickle_allowlist_security.py` + `test_app_twitter_open_hardening.py` together: 159 passed, 2 skipped, **0 failed** (reproduced the failure first, then confirmed the fix — with the test keeping its natural `.pickle` names).
- The scanner still runs against real assets (not skipped): 1 passed.
- One file changed: `nltk/test/unit/test_pickle_allowlist_security.py`.