### PR TITLE
Open operator-chosen app/twitter paths with an annotated builtin open, not pathsec.open

### DIFF
--- a/nltk/app/chartparser_app.py
+++ b/nltk/app/chartparser_app.py
@@ -76,7 +76,6 @@ from nltk.parse.chart import (
     TopDownPredictRule,
     TreeEdge,
 )
-from nltk.pathsec import open as pathsec_open
 from nltk.picklesec import AllowlistUnpickler, pickle_dump
 from nltk.tree import Tree
 from nltk.util import in_idle
@@ -855,9 +854,9 @@ class ChartComparer:
         if not filename:
             return
         try:
-            with pathsec_open(
-                filename, "wb", context="ChartComparer.save_chart_dialog"
-            ) as outfile:
+            with open(
+                filename, "wb"
+            ) as outfile:  # sandboxed-open ok: operator-chosen GUI file path
                 pickle_dump(self._out_chart, outfile)
         except Exception as e:
             showerror("Error Saving Chart", f"Unable to open file: {filename!r}\n{e}")
@@ -874,7 +873,9 @@ class ChartComparer:
             showerror("Error Loading Chart", f"Unable to open file: {filename!r}\n{e}")
 
     def load_chart(self, filename):
-        with pathsec_open(filename, "rb", context="ChartComparer.load_chart") as infile:
+        with open(
+            filename, "rb"
+        ) as infile:  # sandboxed-open ok: operator-chosen GUI file path
             chart = _load_chart_pickle(infile)
         name = os.path.basename(filename)
         if name.endswith(".pickle"):
@@ -2331,9 +2332,9 @@ class ChartParserApp:
         if not filename:
             return
         try:
-            with pathsec_open(
-                filename, "rb", context="ChartParserApp.load_chart"
-            ) as infile:
+            with open(
+                filename, "rb"
+            ) as infile:  # sandboxed-open ok: operator-chosen GUI file path
                 chart = _load_chart_pickle(infile)
             self._chart = chart
             self._cv.update(chart)
@@ -2356,9 +2357,9 @@ class ChartParserApp:
         if not filename:
             return
         try:
-            with pathsec_open(
-                filename, "wb", context="ChartParserApp.save_chart"
-            ) as outfile:
+            with open(
+                filename, "wb"
+            ) as outfile:  # sandboxed-open ok: operator-chosen GUI file path
                 pickle_dump(self._chart, outfile)
         except Exception as e:
             raise
@@ -2373,14 +2374,14 @@ class ChartParserApp:
             return
         try:
             if filename.endswith(".pickle"):
-                with pathsec_open(
-                    filename, "rb", context="ChartParserApp.load_grammar"
-                ) as infile:
+                with open(
+                    filename, "rb"
+                ) as infile:  # sandboxed-open ok: operator-chosen GUI file path
                     grammar = _load_chart_pickle(infile)
             else:
-                with pathsec_open(
-                    filename, context="ChartParserApp.load_grammar"
-                ) as infile:
+                with open(
+                    filename
+                ) as infile:  # sandboxed-open ok: operator-chosen GUI file path
                     grammar = CFG.fromstring(infile.read())
             self.set_grammar(grammar)
         except Exception as e:
@@ -2394,14 +2395,14 @@ class ChartParserApp:
             return
         try:
             if filename.endswith(".pickle"):
-                with pathsec_open(
-                    filename, "wb", context="ChartParserApp.save_grammar"
-                ) as outfile:
+                with open(
+                    filename, "wb"
+                ) as outfile:  # sandboxed-open ok: operator-chosen GUI file path
                     pickle_dump((self._chart, self._tokens), outfile)
             else:
-                with pathsec_open(
-                    filename, "w", context="ChartParserApp.save_grammar"
-                ) as outfile:
+                with open(
+                    filename, "w"
+                ) as outfile:  # sandboxed-open ok: operator-chosen GUI file path
                     prods = self._grammar.productions()
                     start = [p for p in prods if p.lhs() == self._grammar.start()]
                     rest = [p for p in prods if p.lhs() != self._grammar.start()]

--- a/nltk/app/chunkparser_app.py
+++ b/nltk/app/chunkparser_app.py
@@ -38,7 +38,6 @@ from nltk.chunk import ChunkScore, RegexpChunkParser
 from nltk.chunk.regexp import RegexpChunkRule
 from nltk.corpus import conll2000, treebank_chunk
 from nltk.draw.util import ShowText
-from nltk.pathsec import open as pathsec_open
 from nltk.tree import Tree
 from nltk.util import in_idle
 
@@ -1392,9 +1391,9 @@ class RegexpChunkApp:
         else:
             precision = recall = fscore = "Not finished evaluation yet"
 
-        with pathsec_open(
-            filename, "w", context="RegexpChunkApp.save_grammar"
-        ) as outfile:
+        with open(
+            filename, "w"
+        ) as outfile:  # sandboxed-open ok: operator-chosen GUI file path
             outfile.write(
                 self.SAVE_GRAMMAR_TEMPLATE
                 % dict(
@@ -1415,7 +1414,9 @@ class RegexpChunkApp:
                 return
         self.grammarbox.delete("1.0", "end")
         self.update()
-        with pathsec_open(filename, context="RegexpChunkApp.load_grammar") as infile:
+        with open(
+            filename
+        ) as infile:  # sandboxed-open ok: operator-chosen GUI file path
             grammar = infile.read()
         grammar = redos.sub(
             r"^\# Regexp Chunk Parsing Grammar[\s\S]*" "F-score:.*\n", "", grammar
@@ -1430,9 +1431,9 @@ class RegexpChunkApp:
             if not filename:
                 return
 
-        with pathsec_open(
-            filename, "w", context="RegexpChunkApp.save_history"
-        ) as outfile:
+        with open(
+            filename, "w"
+        ) as outfile:  # sandboxed-open ok: operator-chosen GUI file path
             outfile.write("# Regexp Chunk Parsing Grammar History\n")
             outfile.write("# Saved %s\n" % time.ctime())
             outfile.write("# Development set: %s\n" % self.devset_name)

--- a/nltk/app/wordnet_app.py
+++ b/nltk/app/wordnet_app.py
@@ -66,7 +66,6 @@ from urllib.parse import parse_qs, unquote_plus
 
 from nltk.corpus import wordnet as wn
 from nltk.corpus.reader.wordnet import Lemma, Synset
-from nltk.pathsec import open as pathsec_open
 from nltk.picklesec import RestrictedUnpickler, pickle_dumps
 
 firstClient = True
@@ -135,9 +134,9 @@ class MyServerHandler(BaseHTTPRequestHandler):
             if usp == "NLTK Wordnet Browser Database Info.html":
                 word = "* Database Info *"
                 if os.path.isfile(usp):
-                    with pathsec_open(
-                        usp, context="wordnet_app.MyServerHandler"
-                    ) as infile:
+                    with open(
+                        usp
+                    ) as infile:  # sandboxed-open ok: fixed db-info filename (exact-string gated)
                         page = infile.read()
                 else:
                     page = (
@@ -264,9 +263,9 @@ def wnb(port=8000, runBrowser=True, logfilename=None):
     # Setup logging.
     if logfilename:
         try:
-            logfile = pathsec_open(
-                logfilename, "a", buffering=1, context="wordnet_app.wnb"
-            )  # 1 means 'line buffering'
+            logfile = open(
+                logfilename, "a", buffering=1
+            )  # sandboxed-open ok: operator log path
         except OSError as e:
             sys.stderr.write("Couldn't open %s for writing: %s", logfilename, e)
             sys.exit(1)

--- a/nltk/draw/util.py
+++ b/nltk/draw/util.py
@@ -52,7 +52,6 @@ from tkinter import (
 )
 from tkinter.filedialog import asksaveasfilename
 
-from nltk.pathsec import open as pathsec_open
 from nltk.util import in_idle
 
 ##//////////////////////////////////////////////////////
@@ -1868,7 +1867,9 @@ class CanvasFrame:
         )
         # workaround for bug in Tk font handling
         postscript = postscript.replace(" 0 scalefont ", " 9 scalefont ")
-        with pathsec_open(filename, "wb", context="CanvasFrame.print_to_file") as f:
+        with open(
+            filename, "wb"
+        ) as f:  # sandboxed-open ok: operator-chosen GUI file path
             f.write(postscript.encode("utf8"))
 
     def scrollregion(self):

--- a/nltk/test/unit/test_app_twitter_open_hardening.py
+++ b/nltk/test/unit/test_app_twitter_open_hardening.py
@@ -1,14 +1,17 @@
-"""Adversarial coverage for the app / draw / twitter opens routed through
-pathsec.open.
+"""pathsec.open write-side hardening, plus the twitter writer functional path.
 
-The paths these modules open are operator-chosen (a Tk Save/Open dialog, the
-``$TWITTER`` credentials dir, a tweet-output dir), so pathsec.open does not bound
-them to the data roots. It still hardens them, and these tests pin that on the
-actual wrappers: a symlink or hardlink planted at the destination is refused at
-open time (O_NOFOLLOW / st_nlink, CWE-59), a NUL byte or a URL in the path is
-refused (CWE-22), and a freshly written file is created 0600 so a saved chart or
-credentials file is never left group/world readable (CWE-377/378). Legitimate
-operator paths keep working. POSIX only (symlink / hardlink / permission model).
+The app / draw / twitter *operator* opens (a Tk Save/Open dialog, the ``$TWITTER``
+credentials/output paths) take an operator-chosen path that legitimately lives
+outside the NLTK data roots, so they use an annotated builtin ``open`` -- NOT
+``pathsec.open`` -- because confining them would reject a normal Save/credentials
+destination. Their behaviour is pinned in ``test_operator_path_opens_regression``.
+
+These tests instead cover ``pathsec.open``'s own write-side hardening, which the
+corpus/model loaders and the twitter writer's in-root paths still rely on: a
+symlink or hardlink planted at the destination is refused (O_NOFOLLOW / st_nlink,
+CWE-59), a NUL byte or a URL is refused (CWE-22), and a new file is created 0600
+(CWE-377/378); plus a legitimate write round-trips. POSIX only for the sym/hard
+link and permission cases.
 """
 
 import os
@@ -29,9 +32,6 @@ def sensitive(tmp_path):
     target = tmp_path / "sensitive"
     target.write_text("SECRET")
     return target
-
-
-# --- the shared chokepoint every app/draw/twitter open now goes through --------
 
 
 @posix_only
@@ -84,20 +84,6 @@ def test_legit_operator_path_roundtrips(tmp_path):
         assert handle.read() == "hello"
 
 
-# --- per-wrapper attacks on the actual functions -------------------------------
-
-
-@posix_only
-def test_twitter_outf_writer_refuses_symlinked_destination(tmp_path, sensitive):
-    from nltk.twitter.common import _outf_writer
-
-    link = tmp_path / "out.csv"
-    link.symlink_to(sensitive)
-    with pytest.raises(PermissionError):
-        _outf_writer(str(link), "utf-8", "strict", gzip_compress=False)
-    assert sensitive.read_text() == "SECRET"
-
-
 def test_twitter_outf_writer_legit_path_works(tmp_path):
     from nltk.twitter.common import _outf_writer
 
@@ -106,52 +92,6 @@ def test_twitter_outf_writer_legit_path_works(tmp_path):
     writer.writerow(["a", "b"])
     handle.close()
     assert path.read_text().strip() == "a,b"
-
-
-@posix_only
-def test_tweetwriter_refuses_symlinked_output(tmp_path, sensitive):
-    pytest.importorskip("twython", reason="twython not installed")
-    from nltk.twitter.twitterclient import TweetWriter
-
-    link = tmp_path / "tweets.json"
-    link.symlink_to(sensitive)
-    writer = object.__new__(TweetWriter)
-    writer.startingup = True
-    writer.gzip_compress = False
-    writer.fname = str(link)
-    with pytest.raises(PermissionError):
-        writer.handle({"id": 1})
-    assert sensitive.read_text() == "SECRET"
-
-
-@posix_only
-def test_chartcomparer_load_refuses_symlinked_source(tmp_path, sensitive):
-    from nltk.app.chartparser_app import ChartComparer
-
-    link = tmp_path / "chart.pickle"
-    link.symlink_to(sensitive)
-    comparer = object.__new__(ChartComparer)
-    with pytest.raises(PermissionError):
-        comparer.load_chart(str(link))
-
-
-@posix_only
-def test_chartparserapp_save_refuses_symlinked_destination(
-    tmp_path, sensitive, monkeypatch
-):
-    import nltk.app.chartparser_app as cpa
-
-    link = tmp_path / "chart.pickle"
-    link.symlink_to(sensitive)
-    monkeypatch.setattr(cpa, "asksaveasfilename", lambda *a, **k: str(link))
-    app = object.__new__(cpa.ChartParserApp)
-    app._chart = "unused: the open is refused before pickling"
-    with pytest.raises(PermissionError):
-        app.save_chart()
-    assert sensitive.read_text() == "SECRET"
-
-
-# --- functional: a real chart pickle still saves and loads through pathsec -----
 
 
 def test_real_chart_pickle_roundtrips_through_pathsec(tmp_path):

--- a/nltk/test/unit/test_operator_path_opens_regression.py
+++ b/nltk/test/unit/test_operator_path_opens_regression.py
@@ -1,0 +1,149 @@
+"""Operator-chosen file opens must not be confined to the NLTK data roots.
+
+The Tk Save/Open dialogs, the ``$TWITTER`` credentials/output paths, and the
+wordnet browser log are chosen by the operator and legitimately live OUTSIDE the
+data roots (a chart saved to ``~/mychart.pickle``, tweets collected to
+``./twitter-files/``). #3861 briefly routed these through ``pathsec.open``, which
+confines to the data roots and so rejected every such path with
+``PermissionError: Unauthorized path``. They are now plain builtin opens
+annotated for the no-unsandboxed-open guard.
+
+These paths are operator-controlled, not attacker input, so the annotated bare
+open is not an exploit point: the GUI dialogs return an operator-picked path, the
+twitter paths come from operator config, and the only HTTP-facing case (the
+wordnet browser) is proven traversal-safe below. The functional tests pin that an
+outside-roots operator path works, so re-confining these would fail immediately.
+"""
+
+import os
+
+import pytest
+
+# --- wordnet HTTP surface: no arbitrary-file read (attack) --------------------
+
+
+@pytest.mark.parametrize(
+    "evil",
+    [
+        "../../../../etc/passwd",
+        "/etc/passwd",
+        "..%2f..%2fetc%2fpasswd",
+        "....//....//etc/passwd",
+        "\\..\\..\\windows\\win.ini",
+        "index.rdf/../../../etc/passwd",
+        "arbitrary.html",
+    ],
+)
+def test_wordnet_static_page_dispatch_never_reads_arbitrary_files(evil):
+    """The wordnet browser serves static pages by dispatching a fixed set of known
+    paths; an unknown or traversal path raises FileNotFoundError and opens nothing,
+    so the HTTP-facing route cannot be turned into an arbitrary file read (CWE-22).
+    """
+    from nltk.app.wordnet_app import get_static_page_by_path
+
+    with pytest.raises(FileNotFoundError):
+        get_static_page_by_path(evil)
+
+
+def test_wordnet_dbinfo_open_is_exact_string_gated():
+    """The one file the request handler opens is gated by exact equality to a fixed
+    name, so a crafted request path can never reach that open."""
+    import inspect
+
+    from nltk.app import wordnet_app
+
+    src = inspect.getsource(wordnet_app.MyServerHandler.do_GET)
+    assert '== "NLTK Wordnet Browser Database Info.html"' in src
+
+
+# --- functional: operator opens work OUTSIDE the data roots -------------------
+
+
+@pytest.fixture
+def outside_roots(monkeypatch, tmp_path):
+    """An operator directory confirmed OUTSIDE every allowed data root, so a
+    confining open rejects it. Skips where the platform authorizes the temp base
+    (there the confinement regression cannot be observed)."""
+    import nltk.data as _data
+    from nltk import pathsec
+    from nltk.pathsec import open as pathsec_open
+
+    data_root = tmp_path / "dataroot"
+    data_root.mkdir()
+    operator = tmp_path / "operator_home"
+    operator.mkdir()
+    monkeypatch.setattr(_data, "path", [str(data_root)])
+    monkeypatch.setenv("NLTK_DATA", str(data_root))
+    monkeypatch.setattr(pathsec, "_ALLOWED_ROOTS_CACHE", None, raising=False)
+    monkeypatch.setattr(pathsec, "_LAST_DATA_PATHS", None, raising=False)
+    try:
+        with pathsec_open(str(operator / ".probe"), "w"):
+            pass
+        pytest.skip("temp base is authorized here; confinement is not observable")
+    except PermissionError:
+        pass
+    return operator
+
+
+def _open_not_confined(fn):
+    """Run an operator open; fail ONLY if it was confined to the data roots.
+
+    The open is what this pins; any later error from an incompletely initialised
+    Tk widget / tweet handler is downstream of the open and irrelevant here.
+    """
+    try:
+        fn()
+    except PermissionError as exc:
+        if "Unauthorized" in str(exc):
+            pytest.fail(f"operator open was confined to the data roots: {exc}")
+        raise  # a genuine OS permission error is a real failure
+    except Exception:
+        pass  # post-open handler/widget state, not the open
+
+
+def test_twitter_outf_writer_works_outside_data_roots(outside_roots):
+    from nltk.twitter.common import _outf_writer
+
+    path = str(outside_roots / "tweets.csv")
+    writer, handle = _outf_writer(path, "utf-8", "strict", gzip_compress=False)
+    writer.writerow(["a", "b"])
+    handle.close()
+    assert os.path.exists(path)
+
+
+def test_tweetwriter_output_works_outside_data_roots(outside_roots):
+    from nltk.twitter.twitterclient import TweetWriter
+
+    writer = object.__new__(TweetWriter)
+    writer.startingup = True
+    writer.gzip_compress = False
+    writer.fname = str(outside_roots / "tweets.json")
+    _open_not_confined(lambda: writer.handle({"id": 1}))
+    assert os.path.exists(writer.fname)  # the open + first write happened
+
+
+def test_chart_load_works_outside_data_roots(outside_roots):
+    import nltk.app.chartparser_app as cpa
+    from nltk import CFG
+    from nltk.parse.chart import ChartParser
+    from nltk.picklesec import pickle_dump
+
+    chart = ChartParser(CFG.fromstring("S -> 'a'")).chart_parse(["a"])
+    path = str(outside_roots / "chart.pickle")
+    with open(path, "wb") as handle:  # test writer; nltk/test is not guarded
+        pickle_dump(chart, handle)
+    comparer = object.__new__(cpa.ChartComparer)
+    comparer._charts = {}
+    _open_not_confined(lambda: comparer.load_chart(path))  # operator Open
+
+
+def test_twitter_creds_read_outside_data_roots(outside_roots):
+    """Authenticate reads the operator's credentials file from a path outside the
+    data roots (the regression that failed CI)."""
+    from nltk.twitter.util import Authenticate
+
+    creds = outside_roots / "credentials.txt"
+    creds.write_text("app_key=a\napp_secret=b\noauth_token=c\noauth_token_secret=d\n")
+    auth = Authenticate()
+    result = auth.load_creds(creds_file="credentials.txt", subdir=str(outside_roots))
+    assert result.get("app_key") == "a"

--- a/nltk/twitter/common.py
+++ b/nltk/twitter/common.py
@@ -15,7 +15,6 @@ import gzip
 
 from nltk.internals import deprecated
 from nltk.jsontags import safe_json_loads
-from nltk.pathsec import open as pathsec_open
 
 HIER_SEPARATOR = "."
 
@@ -139,19 +138,13 @@ def outf_writer_compat(outfile, encoding, errors, gzip_compress=False):
 
 def _outf_writer(outfile, encoding, errors, gzip_compress=False):
     if gzip_compress:
-        # Sandbox the destination, then let gzip wrap the checked handle: the
-        # caller chooses this path, so a bare open is an arbitrary file write.
-        raw = pathsec_open(outfile, "wb", context="twitter._outf_writer")
-        outf = gzip.open(raw, "wt", newline="", encoding=encoding, errors=errors)
+        outf = gzip.open(
+            outfile, "wt", newline="", encoding=encoding, errors=errors
+        )  # sandboxed-open ok: operator output path
     else:
-        outf = pathsec_open(
-            outfile,
-            "w",
-            context="twitter._outf_writer",
-            newline="",
-            encoding=encoding,
-            errors=errors,
-        )
+        outf = open(
+            outfile, "w", newline="", encoding=encoding, errors=errors
+        )  # sandboxed-open ok: operator output path
     writer = csv.writer(outf)
     return (writer, outf)
 

--- a/nltk/twitter/twitterclient.py
+++ b/nltk/twitter/twitterclient.py
@@ -33,7 +33,6 @@ import requests
 from twython import Twython, TwythonStreamer
 from twython.exceptions import TwythonError, TwythonRateLimitError
 
-from nltk.pathsec import open as pathsec_open
 from nltk.twitter.api import BasicTweetHandler, TweetHandlerI
 from nltk.twitter.util import credsfromfile, guess_path
 
@@ -519,16 +518,14 @@ class TweetWriter(TweetHandlerI):
         :param data: tweet object returned by Twitter API
         """
         if self.startingup:
-            # self.fname is the operator's own timestamped output file; pathsec.open
-            # validates the path without bounding it to the data roots. For gzip it
-            # sandboxes the raw handle, then gzip wraps the checked file object.
             if self.gzip_compress:
-                raw = pathsec_open(self.fname, "wb", context="twitter.TweetWriter")
-                self.output = gzip.open(raw, "w")
+                self.output = gzip.open(
+                    self.fname, "w"
+                )  # sandboxed-open ok: operator output path
             else:
-                self.output = pathsec_open(
-                    self.fname, "w", context="twitter.TweetWriter"
-                )
+                self.output = open(
+                    self.fname, "w"
+                )  # sandboxed-open ok: operator output path
             print(f"Writing to {self.fname}")
 
         json_data = json.dumps(data)

--- a/nltk/twitter/util.py
+++ b/nltk/twitter/util.py
@@ -14,8 +14,6 @@ import os
 
 from twython import Twython
 
-from nltk.pathsec import open as pathsec_open
-
 
 def credsfromfile(creds_file=None, subdir=None, verbose=False):
     """
@@ -84,12 +82,9 @@ class Authenticate:
         if not os.path.isfile(self.creds_fullpath):
             raise OSError(f"Cannot find file {self.creds_fullpath}")
 
-        # The credentials file is the operator's own (the TWITTER env var or a
-        # subdir they pick); pathsec.open validates the path (traversal / NUL /
-        # symlink) without bounding an operator path to the data roots.
-        with pathsec_open(
-            self.creds_fullpath, encoding="utf8", context="twitter.Authenticate"
-        ) as infile:
+        with open(
+            self.creds_fullpath, encoding="utf8"
+        ) as infile:  # sandboxed-open ok: operator credentials path, not attacker input
             if verbose:
                 print(f"Reading credentials file {self.creds_fullpath}")
 
@@ -139,9 +134,9 @@ def add_access_token(creds_file=None):
     twitter = Twython(app_key, app_secret, oauth_version=2)
     access_token = twitter.obtain_access_token()
     tok = f"access_token={access_token}\n"
-    with pathsec_open(
-        creds_file, "a", encoding="utf8", context="twitter.add_access_token"
-    ) as infile:
+    with open(
+        creds_file, "a", encoding="utf8"
+    ) as infile:  # sandboxed-open ok: operator credentials path, not attacker input
         print(tok, file=infile)
 
 


### PR DESCRIPTION
## Problem (develop CI regression)

develop's ci-workflow fails on exactly **1 test** — `test_output_exposure_security.py::TestTwitterCredsNoLeak` — with:
```
PermissionError: Security Violation [twitter.Authenticate]: Unauthorized path .../credentials.txt
```
`pathsec.open` confines every path to the NLTK **data roots** (unconditionally — even `required_root=None`). #3861 routed the app/draw/twitter **operator-chosen** opens through it, but a credentials file, a Tk *Save/Open* destination, a tweet-output dir, or a PostScript export legitimately lives **outside** the data roots, so `pathsec.open` rejects them. The twitter creds path is the only one with a test that loads a real path; the rest (chart Save/Open, tweet output, json2csv, wordnet log/db-info) are the **same latent break** (verified: each rejects an outside-roots path).

## Fix

Revert those operator opens to a **builtin `open()`** annotated `# sandboxed-open ok:` for the no-unsandboxed-open guard (7 files). These paths are **operator-controlled, not attacker input**, so confinement is wrong for them and a plain annotated open is correct. The guard still covers the subtree; the `pathsec.open` import is removed where unused.

## Is the annotated bare open an exploit point? (verified)

- **Path source is operator-controlled**: Tk `asksaveasfilename`/`askopenfilename` (operator picks), `$TWITTER` config, operator CLI log arg.
- **The one HTTP-facing case (wordnet) is traversal-safe**: `get_static_page_by_path` raises `FileNotFoundError` (opens nothing) for **every** traversal/arbitrary path, and the db-info open is **exact-string gated**. Pinned in `test_operator_path_opens_regression.py`.
- **Tradeoff, accepted**: a bare open no longer refuses a *planted symlink* at the destination (the O_NOFOLLOW TOCTOU protection `pathsec.open` gave). These are operator-private paths, so the local symlink-swap surface is marginal. The four per-wrapper symlink-refusal tests are dropped; `pathsec.open`'s own write-side hardening (symlink/hardlink/NUL/URL/0600) is still tested.

## Tests

- `test_operator_path_opens_regression.py` (new): wordnet traversal-safety (attack) + functional round-trips proving each operator open **works** outside the data roots (so re-confining fails a test).
- `test_app_twitter_open_hardening.py`: refit to pin `pathsec.open`'s own hardening.

## Verification
- `test_output_exposure_security.py` (9), `test_json2csv_corpus.py` (12), `test_pickle_allowlist_security.py`, `test_app_twitter_open_hardening.py`, `test_operator_path_opens_regression.py` — all pass (188 passed, 6 skipped, 0 failed).
- `check_no_unsandboxed_open.py`: OK. All 300 nltk modules import. pre-commit clean.