### PR TITLE
Harden and complete the CoreNLP server-option allowlist (CWE-88/22/502)

### DIFF
--- a/nltk/parse/corenlp.py
+++ b/nltk/parse/corenlp.py
@@ -33,22 +33,13 @@ class CoreNLPServerError(EnvironmentError):
     """Exceptions associated with the Core NLP server."""
 
 
-# --- corenlp_options allowlist (CWE-88 / CWE-22 / CWE-502) -------------------
+# corenlp_options allowlist (CWE-88 / CWE-22 / CWE-502): these are the CoreNLP
+# server's OWN flags (not JVM launcher flags), many taking a filesystem path or
+# loading a serialized model, so forwarding them unchecked is a read/write escape.
 #
-# corenlp_options is a list of StanfordCoreNLPServer command flags that start()
-# appends to the JVM command AFTER the server class name. Unlike java_options
-# (JVM launcher flags, guarded by internals._validate_java_options), these are the
-# server application's own flags, and CoreNLP has many that take a filesystem
-# path: -serverProperties and -props read an arbitrary file as configuration,
-# -key reads an SSL key, -outputDirectory and -file write or read arbitrary
-# locations, and any -<annotator>.model flag loads a Java-serialized model
-# (deserialization). Forwarding this list unchecked would let whoever populates
-# it read or write files outside the data roots and load an attacker model. So a
-# minimal allowlist is used rather than a denylist (mirroring java_options): only
-# operational flags whose VALUES validate to a safe shape pass; every other flag,
-# path-bearing or simply unknown, is refused without needing enumeration. An
-# application that genuinely needs an unlisted flag builds and starts the JVM
-# itself.
+# An allowlist (mirroring java_options) passes only operational flags whose values
+# validate to a safe shape; any other flag, path-bearing or unknown, is refused
+# without enumeration. A caller needing an unlisted flag runs the JVM itself.
 
 # CoreNLP annotator names permitted as an -annotators / -preload value.
 _CORENLP_ANNOTATORS = frozenset(
@@ -179,12 +170,9 @@ def _validate_corenlp_options(options):
                 _corenlp_reject(raw, "is missing its required value")
             _corenlp_check_scalar(val)
             if flag in _CORENLP_INT_FLAGS:
-                # -maxCharLength reads a non-positive value as "no limit". CoreNLP
-                # only parses a negative in the inline -maxCharLength=-1 form; as
-                # two tokens it reads the "-1" as a separate flag and dies, and a
-                # value starting with '-' is exactly the option-smuggling shape we
-                # refuse elsewhere. So a signed value is accepted inline only; the
-                # two-token form (like every other int flag) must be non-negative.
+                # -maxCharLength takes a signed int only in the inline -flag=-1 form;
+                # as two tokens the "-1" reads as a separate option (the smuggling
+                # shape we refuse), so the two-token form must be non-negative.
                 if flag == "-maxcharlength" and inline is not None:
                     if not _CORENLP_SIGNED_INT_RE.match(val):
                         _corenlp_reject(raw, "requires an integer, got %r" % val)
@@ -202,10 +190,9 @@ def _validate_corenlp_options(options):
                 if not _CORENLP_TOKEN_RE.match(val):
                     _corenlp_reject(raw, "value is not a plain token: %r" % val)
             elif flag in _CORENLP_URI_FLAGS:
-                # ".." is a path-traversal segment, and a leading "//" is a
-                # network-path reference (an empty segment the URL parser may read
-                # as a host); no real context path has either, so refuse both on
-                # top of the safe-charset shape check.
+                # ".." is a traversal segment and a leading "//" is a network-path
+                # reference (a host to the URL parser); no real context path has
+                # either, so refuse both on top of the safe-charset check.
                 if not _CORENLP_URI_RE.match(val) or ".." in val or "//" in val:
                     _corenlp_reject(raw, "value is not a safe uri path: %r" % val)
             i += step
@@ -325,12 +312,9 @@ class CoreNLPServer:
 
         cmd = ["edu.stanford.nlp.pipeline.StanfordCoreNLPServer"]
 
-        # corenlp_options are the CoreNLP server's own flags. Validate them at the
-        # sink against the allowlist (re-validated here, not only at construction,
-        # so a reassignment of self.corenlp_options cannot slip an unchecked flag
-        # past): a path-bearing or unknown flag is refused, closing the argument
-        # injection, arbitrary file read/write and model-deserialization vector
-        # (CWE-88, CWE-22, CWE-502).
+        # Re-validate corenlp_options at the sink (not only at construction), so a
+        # reassignment cannot slip an unchecked flag past: a path-bearing or unknown
+        # flag is refused (CWE-88 / CWE-22 / CWE-502).
         if self.corenlp_options:
             cmd.extend(_validate_corenlp_options(self.corenlp_options))
 

--- a/nltk/parse/corenlp.py
+++ b/nltk/parse/corenlp.py
@@ -13,7 +13,13 @@ import time
 from typing import List, Tuple
 
 from nltk import redos
-from nltk.internals import _java_options, config_java, find_jar_iter, java
+from nltk.internals import (
+    _UNSAFE_OPTION_CHARS,
+    _java_options,
+    config_java,
+    find_jar_iter,
+    java,
+)
 from nltk.parse.api import ParserI
 from nltk.parse.dependencygraph import DependencyGraph
 from nltk.tag.api import TaggerI
@@ -25,6 +31,203 @@ _stanford_url = "https://stanfordnlp.github.io/CoreNLP/"
 
 class CoreNLPServerError(EnvironmentError):
     """Exceptions associated with the Core NLP server."""
+
+
+# --- corenlp_options allowlist (CWE-88 / CWE-22 / CWE-502) -------------------
+#
+# corenlp_options is a list of StanfordCoreNLPServer command flags that start()
+# appends to the JVM command AFTER the server class name. Unlike java_options
+# (JVM launcher flags, guarded by internals._validate_java_options), these are the
+# server application's own flags, and CoreNLP has many that take a filesystem
+# path: -serverProperties and -props read an arbitrary file as configuration,
+# -key reads an SSL key, -outputDirectory and -file write or read arbitrary
+# locations, and any -<annotator>.model flag loads a Java-serialized model
+# (deserialization). Forwarding this list unchecked would let whoever populates
+# it read or write files outside the data roots and load an attacker model. So a
+# minimal allowlist is used rather than a denylist (mirroring java_options): only
+# operational flags whose VALUES validate to a safe shape pass; every other flag,
+# path-bearing or simply unknown, is refused without needing enumeration. An
+# application that genuinely needs an unlisted flag builds and starts the JVM
+# itself.
+
+# CoreNLP annotator names permitted as an -annotators / -preload value.
+_CORENLP_ANNOTATORS = frozenset(
+    {
+        "tokenize",
+        "cleanxml",
+        "ssplit",
+        "mwt",
+        "docdate",
+        "pos",
+        "lemma",
+        "ner",
+        "regexner",
+        "tokensregex",
+        "entitymentions",
+        "parse",
+        "depparse",
+        "coref",
+        "dcoref",
+        "sentiment",
+        "kbp",
+        "quote",
+        "natlog",
+        "openie",
+        "entitylink",
+        "relation",
+        "gender",
+        "truecase",
+        "udfeats",
+        "sutime",
+    }
+)
+
+# Value shapes. Anchored and bounded so nothing rides a prefix. A token value must
+# NOT start with '-' (a value that looks like a flag could be re-read as one by the
+# server arg parser, i.e. option smuggling); only -maxCharLength may be negative.
+_CORENLP_UINT_RE = redos.compile(r"\A[0-9]{1,7}\Z")
+# Only -maxCharLength takes a signed value (CoreNLP reads any non-positive number
+# as "no limit"); a lone leading '-' before digits cannot smuggle a flag.
+_CORENLP_SIGNED_INT_RE = redos.compile(r"\A-?[0-9]{1,7}\Z")
+_CORENLP_TOKEN_RE = redos.compile(r"\A[A-Za-z0-9_.][A-Za-z0-9._-]{0,63}\Z")
+_CORENLP_URI_RE = redos.compile(r"\A/[A-Za-z0-9._/-]{0,127}\Z")
+_CORENLP_BOOL = frozenset({"true", "false"})
+
+# Allowlisted flags (compared case-folded), grouped by the value they take.
+_CORENLP_INT_FLAGS = frozenset(
+    {"-port", "-status_port", "-timeout", "-threads", "-maxcharlength"}
+)
+_CORENLP_ANNOTATOR_FLAGS = frozenset({"-annotators", "-preload"})
+_CORENLP_TOKEN_FLAGS = frozenset({"-server_id", "-username", "-password"})
+_CORENLP_URI_FLAGS = frozenset({"-uricontext"})
+_CORENLP_BARE_FLAGS = frozenset({"-quiet", "-strict", "-ssl", "-stanford", "-srparser"})
+_CORENLP_VALUE_FLAGS = (
+    _CORENLP_INT_FLAGS
+    | _CORENLP_ANNOTATOR_FLAGS
+    | _CORENLP_TOKEN_FLAGS
+    | _CORENLP_URI_FLAGS
+)
+
+_CORENLP_REFUSAL = (
+    "corenlp_options %s: %r. Only a minimal allowlist of operational "
+    "StanfordCoreNLPServer flags with validated values is accepted; path-bearing "
+    "flags (-serverProperties, -props, -key, -outputDirectory, -<annotator>.model "
+    "and the like), argument files and unknown flags are refused so a populated "
+    "option cannot read or write files outside the data roots or load an "
+    "attacker-controlled serialized model (CWE-88, CWE-22, CWE-502)."
+)
+
+
+def _corenlp_reject(entry, why):
+    raise ValueError(_CORENLP_REFUSAL % (why, entry))
+
+
+def _corenlp_check_scalar(entry):
+    """Reject a non-string, an empty string, or one carrying anything outside
+    printable ASCII (whitespace, a C0/C1 control, DEL, or any non-ASCII byte such
+    as a fullwidth digit, homoglyph, bidi override or zero-width character), a
+    shell metacharacter, or a leading Java argument-file prefix.
+
+    Every allowlisted flag and value is plain printable ASCII, so restricting to
+    that here is a name-agnostic gate that closes unicode-confusable and control
+    character bypasses before any per-flag value shape is even consulted."""
+    if not isinstance(entry, str) or not entry:
+        _corenlp_reject(entry, "contains a non-string or empty entry")
+    if any(
+        c.isspace() or ord(c) < 0x20 or ord(c) > 0x7E or c in _UNSAFE_OPTION_CHARS
+        for c in entry
+    ):
+        _corenlp_reject(
+            entry,
+            "contains whitespace, a control character, a non-ASCII or a shell "
+            "metacharacter",
+        )
+    if entry.startswith("@"):
+        _corenlp_reject(entry, "is a Java argument-file reference")
+
+
+def _validate_corenlp_options(options):
+    """Return *options* unchanged when every entry is an allowlisted CoreNLP server
+    flag with a safe value; raise ValueError otherwise (CWE-88/CWE-22/CWE-502).
+
+    Handles both ``-flag value`` (two tokens) and ``-flag=value`` forms, folds the
+    flag name case, and validates each value: integers for port/timeout/threads,
+    a known-annotator comma list for -annotators/-preload, a plain token for
+    -server_id/-username/-password, a safe uri path for -uriContext, and an
+    optional true/false for the bare flags. A value that itself looks like a flag
+    (option smuggling, e.g. ``-port -serverProperties``) fails its value check.
+    """
+    opts = list(options)
+    i, n = 0, len(opts)
+    while i < n:
+        raw = opts[i]
+        _corenlp_check_scalar(raw)
+        if raw.startswith("-") and "=" in raw:
+            name, inline = raw.split("=", 1)
+        else:
+            name, inline = raw, None
+        flag = name.lower()
+        if not flag.startswith("-"):
+            _corenlp_reject(raw, "expected a flag but found a bare value")
+
+        if flag in _CORENLP_VALUE_FLAGS:
+            if inline is not None:
+                val, step = inline, 1
+            elif i + 1 < n:
+                val, step = opts[i + 1], 2
+            else:
+                _corenlp_reject(raw, "is missing its required value")
+            _corenlp_check_scalar(val)
+            if flag in _CORENLP_INT_FLAGS:
+                # -maxCharLength reads a non-positive value as "no limit". CoreNLP
+                # only parses a negative in the inline -maxCharLength=-1 form; as
+                # two tokens it reads the "-1" as a separate flag and dies, and a
+                # value starting with '-' is exactly the option-smuggling shape we
+                # refuse elsewhere. So a signed value is accepted inline only; the
+                # two-token form (like every other int flag) must be non-negative.
+                if flag == "-maxcharlength" and inline is not None:
+                    if not _CORENLP_SIGNED_INT_RE.match(val):
+                        _corenlp_reject(raw, "requires an integer, got %r" % val)
+                elif not _CORENLP_UINT_RE.match(val):
+                    _corenlp_reject(
+                        raw, "requires a non-negative integer, got %r" % val
+                    )
+                elif flag in ("-port", "-status_port") and not 1 <= int(val) <= 65535:
+                    _corenlp_reject(raw, "port is out of range 1..65535: %r" % val)
+            elif flag in _CORENLP_ANNOTATOR_FLAGS:
+                toks = val.split(",")
+                if not val or any(t.lower() not in _CORENLP_ANNOTATORS for t in toks):
+                    _corenlp_reject(raw, "has a token that is not a known annotator")
+            elif flag in _CORENLP_TOKEN_FLAGS:
+                if not _CORENLP_TOKEN_RE.match(val):
+                    _corenlp_reject(raw, "value is not a plain token: %r" % val)
+            elif flag in _CORENLP_URI_FLAGS:
+                # ".." is a path-traversal segment, and a leading "//" is a
+                # network-path reference (an empty segment the URL parser may read
+                # as a host); no real context path has either, so refuse both on
+                # top of the safe-charset shape check.
+                if not _CORENLP_URI_RE.match(val) or ".." in val or "//" in val:
+                    _corenlp_reject(raw, "value is not a safe uri path: %r" % val)
+            i += step
+            continue
+
+        if flag in _CORENLP_BARE_FLAGS:
+            if inline is not None:
+                if inline.lower() not in _CORENLP_BOOL:
+                    _corenlp_reject(raw, "bare flag accepts only true or false")
+                i += 1
+            elif (
+                i + 1 < n
+                and isinstance(opts[i + 1], str)
+                and opts[i + 1].lower() in _CORENLP_BOOL
+            ):
+                i += 2
+            else:
+                i += 1
+            continue
+
+        _corenlp_reject(raw, "is not an allowlisted flag")
+    return opts
 
 
 def try_port(port=0):
@@ -52,6 +255,9 @@ class CoreNLPServer:
     ):
         if corenlp_options is None:
             corenlp_options = ["-preload", "tokenize,ssplit,pos,lemma,parse,depparse"]
+        # Reject a hostile corenlp_options before doing any other work; start()
+        # re-validates the final list (including the port we append) at the sink.
+        _validate_corenlp_options(corenlp_options)
 
         jars = list(
             find_jar_iter(
@@ -119,8 +325,14 @@ class CoreNLPServer:
 
         cmd = ["edu.stanford.nlp.pipeline.StanfordCoreNLPServer"]
 
+        # corenlp_options are the CoreNLP server's own flags. Validate them at the
+        # sink against the allowlist (re-validated here, not only at construction,
+        # so a reassignment of self.corenlp_options cannot slip an unchecked flag
+        # past): a path-bearing or unknown flag is refused, closing the argument
+        # injection, arbitrary file read/write and model-deserialization vector
+        # (CWE-88, CWE-22, CWE-502).
         if self.corenlp_options:
-            cmd.extend(self.corenlp_options)
+            cmd.extend(_validate_corenlp_options(self.corenlp_options))
 
         # Configure java.
         default_options = " ".join(_java_options)

--- a/nltk/parse/corenlp.py
+++ b/nltk/parse/corenlp.py
@@ -114,7 +114,8 @@ def _corenlp_reject(entry, why):
 
 
 def _corenlp_check_scalar(entry):
-    """Reject a non-string, an empty string, or one carrying anything outside
+    """Reject a non-string (including a str subclass, whose methods could lie),
+    an empty string, or one carrying anything outside
     printable ASCII (whitespace, a C0/C1 control, DEL, or any non-ASCII byte such
     as a fullwidth digit, homoglyph, bidi override or zero-width character), a
     shell metacharacter, or a leading Java argument-file prefix.
@@ -122,7 +123,7 @@ def _corenlp_check_scalar(entry):
     Every allowlisted flag and value is plain printable ASCII, so restricting to
     that here is a name-agnostic gate that closes unicode-confusable and control
     character bypasses before any per-flag value shape is even consulted."""
-    if not isinstance(entry, str) or not entry:
+    if type(entry) is not str or not entry:
         _corenlp_reject(entry, "contains a non-string or empty entry")
     if any(
         c.isspace() or ord(c) < 0x20 or ord(c) > 0x7E or c in _UNSAFE_OPTION_CHARS
@@ -148,7 +149,13 @@ def _validate_corenlp_options(options):
     optional true/false for the bare flags. A value that itself looks like a flag
     (option smuggling, e.g. ``-port -serverProperties``) fails its value check.
     """
+    # Hard-reject str subclasses (and non-str): a subclass could override
+    # startswith/split/lower/__iter__ to validate benign while its real chars
+    # smuggle a hostile flag into the JVM argv (CWE-88). Refuse, do not coerce.
     opts = list(options)
+    for entry in opts:
+        if type(entry) is not str:
+            _corenlp_reject(entry, "is not a plain str (str subclasses are refused)")
     i, n = 0, len(opts)
     while i < n:
         raw = opts[i]

--- a/nltk/test/unit/test_corenlp_options_security.py
+++ b/nltk/test/unit/test_corenlp_options_security.py
@@ -24,13 +24,9 @@ import pytest
 
 from nltk.parse.corenlp import CoreNLPServer, _validate_corenlp_options
 
-# Reuse the adversarial JVM / external-tool payload corpora already written for the
-# java() and tool-wrapper guards. None of these is an allowlisted CoreNLP server
-# flag, so corenlp_options must refuse every one of them too. This piggybacks the
-# corenlp allowlist onto ~115 existing hostile vectors (JVM agents, @argfile,
-# -XX:OnError, bootclasspath / module-path / class-path, codebase, metacharacter /
-# NUL / unicode-whitespace / DEL smuggling, concatenated flags, tool program flags
-# and hostile model paths) rather than re-authoring them.
+# Reuse the ~115 adversarial JVM / tool-wrapper payload corpora (agents, @argfile,
+# -XX:OnError, class/module path, NUL/unicode/DEL smuggling, hostile model paths):
+# none is an allowlisted CoreNLP server flag, so corenlp_options must refuse each.
 from nltk.test.unit.test_attack_java_tool_expanded import (
     _HOSTILE_HUNPOS_MODELS,
     _TOOL_FLAGS,
@@ -64,7 +60,7 @@ _REUSED_HOSTILE = [
     if opts
 ]
 
-# --- BENIGN: normal operational usage that MUST keep working ------------------
+# BENIGN: normal operational usage that MUST keep working.
 BENIGN = [
     ["-preload", "tokenize,ssplit,pos,lemma,parse,depparse"],  # the NLTK default
     ["-port", "9000"],
@@ -105,7 +101,7 @@ BENIGN = [
     [],
 ]
 
-# --- MALICIOUS: every candidate must be refused -------------------------------
+# MALICIOUS: every candidate must be refused.
 # Arbitrary file READ via a config/properties/key/blocklist path flag.
 FILE_READ = [
     ["-serverProperties", "/etc/passwd"],
@@ -208,10 +204,9 @@ NON_STRING = [
     [b"-port", b"9000"],
     ["-port", 9000],  # int value where a string is required
 ]
-# Adversarial sneak-through attempts found by probing the allowlist: consumption
-# desync (a bare flag must not swallow a following dangerous flag as its value),
-# double-dash spellings, glued forms, homoglyph and fullwidth digits, oversize
-# values, path/model tokens hidden in an annotator list, and uriContext traversal.
+# Adversarial sneak-through attempts probing the allowlist: consumption desync (a
+# bare flag swallowing the next as its value), double-dash/glued spellings, homoglyph
+# and fullwidth digits, oversize values, hidden path/model tokens, uriContext traversal.
 ADVERSARIAL = [
     ["-uriContext", "/../../etc/passwd"],  # traversal inside a URI context
     ["-uriContext", "/..%2f..%2fetc"],
@@ -281,9 +276,8 @@ class TestValidatorMalicious:
 
 class TestReusedAdversarialCorpora:
     # ~115 hostile vectors reused from the java()/tool-wrapper attack suites; the
-    # corenlp_options allowlist must refuse every one (none is an allowlisted
-    # server flag). Proves the guard piggybacks the existing corpus, not just the
-    # cases written by hand for it.
+    # corenlp_options allowlist must refuse every one (none is an allowlisted server
+    # flag), proving the guard piggybacks the existing corpus, not just hand cases.
     @pytest.mark.parametrize("opts", _REUSED_HOSTILE)
     def test_reused_jvm_and_tool_payloads_are_refused(self, opts):
         with pytest.raises((ValueError, TypeError)):

--- a/nltk/test/unit/test_corenlp_options_security.py
+++ b/nltk/test/unit/test_corenlp_options_security.py
@@ -83,6 +83,9 @@ BENIGN = [
     ["-srparser", "true"],
     ["-srparser=false"],
     ["-server_id", "my_server-1"],
+    ["-username", "corenlp"],  # basic-auth token flags: plain-token shape
+    ["-password", "s3cr3t.pass_ok"],
+    ["-username=corenlp"],
     ["-uriContext", "/corenlp"],
     ["-uriContext", "/corenlp/api/"],  # multi-segment context still valid
     ["-uriContext", "/"],
@@ -116,6 +119,14 @@ FILE_READ = [
     ["-fileList", "/etc/shadow"],
     ["-filelist", "/etc/shadow"],
     ["-inputDirectory", "/root"],
+    ["-keystore", "/etc/ssl/keystore.jks"],
+    ["-whitelist", "/etc/passwd"],
+    ["-inputFiles", "/etc/passwd"],
+    ["-textFile", "/etc/passwd"],
+    ["-loadClassifier", "/tmp/evil.ser.gz"],
+    ["-regexner.mapping", "/tmp/evil.tab"],
+    ["-tokensregex.rules", "/tmp/evil.rules"],
+    ["-sutime.rules", "/tmp/evil.rules"],
     ["-ServerProperties", "/etc/passwd"],  # case variant of a dangerous flag
     ["-SERVERPROPERTIES", "/etc/passwd"],
 ]
@@ -134,6 +145,9 @@ MODEL_DESER = [
     ["-sentiment.model", "/tmp/evil.ser.gz"],
     ["-truecase.model", "/tmp/evil.ser.gz"],
     ["-tokenize.model", "/tmp/evil.ser.gz"],
+    ["-kbp.model", "/tmp/evil.ser.gz"],
+    ["-lemma.model", "/tmp/evil.ser.gz"],
+    ["-ner.additional.regexner.mapping", "/tmp/evil.tab"],
 ]
 # JVM/launcher flags that do not belong on the server command at all.
 JVM_SMUGGLE = [
@@ -144,6 +158,8 @@ JVM_SMUGGLE = [
     ["-javaagent:/tmp/evil.jar"],
     ["-cp", "/tmp/evil.jar"],
     ["-classpath", "/tmp/evil.jar"],
+    ["-agentlib:jdwp=transport=dt_socket"],
+    ["-Xmx4g"],
     ["@/tmp/argfile"],
     ["-preload", "@/tmp/argfile"],
 ]
@@ -406,13 +422,9 @@ def _make_corenlp_server(corenlp_options, port=None):
 
 @pytest.fixture(scope="module")
 def live_server():
-    # One real server shared by every wrapper-function test. Bind an ephemeral
-    # free port, never the default 9000: the mock suite in test_corenlp.py starts
-    # its own server on 9000, and under xdist two modules both binding 9000 race
-    # to "Address already in use", so this module stays off that port entirely.
-    # The options preload the full annotator set (so parse/depparse/ner all work)
-    # and include the allowlisted -srparser and inline -maxCharLength=-1: the
-    # server coming up at all proves CoreNLP's own arg parser accepts them.
+    # One real server for every wrapper-function test, on an ephemeral port (never
+    # the default 9000, which test_corenlp.py binds and races under xdist); the
+    # preloaded annotators + allowlisted -srparser/-maxCharLength=-1 must start clean.
     pytest.importorskip("requests")
     srv = _make_corenlp_server(
         [
@@ -482,6 +494,9 @@ class TestRealServerLaunch:
         assert list(next(d.parse("The dog barks .".split())).triples())
         batch = list(d.parse_sents([["The", "dog", "barks", "."]]))
         assert list(next(iter(batch[0])).triples())
+        # ParserI wrappers over parse() on the dependency parser.
+        assert list(d.parse_one("The dog barks .".split()).triples())
+        assert d.parse_all("The dog barks .".split())
 
     def test_real_api_call(self, live_server):
         from nltk.parse.corenlp import CoreNLPParser
@@ -490,6 +505,41 @@ class TestRealServerLaunch:
             "The dog barks.", properties={"annotators": "tokenize,ssplit,pos"}
         )
         assert "sentences" in resp
+
+    def test_real_parse_all_and_make_tree(self, live_server):
+        from nltk.parse.corenlp import CoreNLPParser
+
+        p = CoreNLPParser(url=live_server.url)
+        # parse_all (ParserI) returns every parse for the sentence.
+        trees = list(p.parse_all("The dog barks .".split()))
+        assert trees and all(t.label() == "ROOT" for t in trees)
+        # make_tree is the transformer parse() feeds; drive it directly here.
+        resp = p.api_call(
+            "The dog barks.", properties={"annotators": "tokenize,ssplit,pos,parse"}
+        )
+        assert p.make_tree(resp["sentences"][0]).label() == "ROOT"
+
+    def test_real_dependency_make_tree(self, live_server):
+        from nltk.parse.corenlp import CoreNLPDependencyParser
+
+        d = CoreNLPDependencyParser(url=live_server.url)
+        # The dependency make_tree needs the lemma field the depparse run adds.
+        resp = d.api_call(
+            "The dog barks.",
+            properties={"annotators": "tokenize,ssplit,pos,lemma,depparse"},
+        )
+        assert list(d.make_tree(resp["sentences"][0]).triples())
+
+    def test_real_server_context_manager(self):
+        # The documented "with CoreNLPServer(...) as server" form starts the server
+        # on __enter__ and stops it on __exit__ (its own ephemeral port).
+        pytest.importorskip("requests")
+        from nltk.parse.corenlp import CoreNLPParser
+
+        srv = _make_corenlp_server(["-preload", "tokenize,ssplit"], port=try_port())
+        with srv as server:
+            toks = list(CoreNLPParser(url=server.url).tokenize("The dog barks."))
+            assert toks[:3] == ["The", "dog", "barks"], toks
 
     def test_malicious_options_never_reach_a_real_launch(self):
         # Even with a real install present, a path-bearing or unknown option is

--- a/nltk/test/unit/test_corenlp_options_security.py
+++ b/nltk/test/unit/test_corenlp_options_security.py
@@ -397,17 +397,23 @@ def _real_corenlp_available():
         from nltk.internals import find_jar_iter
         from nltk.parse.corenlp import _stanford_url
 
-        list(
-            find_jar_iter(
-                CoreNLPServer._JAR,
-                None,
-                env_vars=("CORENLP",),
-                searchpath=(),
-                url=_stanford_url,
-                verbose=False,
-                is_regex=True,
+        # Both jars must be discoverable, or CoreNLPServer's model-jar lookup
+        # fails at start() and the real tests error instead of skipping.
+        for pattern, env in (
+            (CoreNLPServer._JAR, "CORENLP"),
+            (CoreNLPServer._MODEL_JAR_PATTERN, "CORENLP_MODELS"),
+        ):
+            list(
+                find_jar_iter(
+                    pattern,
+                    None,
+                    env_vars=(env,),
+                    searchpath=(),
+                    url=_stanford_url,
+                    verbose=False,
+                    is_regex=True,
+                )
             )
-        )
         return True
     except Exception:
         return False
@@ -440,11 +446,14 @@ def live_server():
         ],
         port=try_port(),
     )
-    srv.start()
+    # start() inside the try: a readiness failure raises but leaves the JVM
+    # running, so stop() must run if the process was ever launched.
     try:
+        srv.start()
         yield srv
     finally:
-        srv.stop()
+        if getattr(srv, "popen", None) is not None:
+            srv.stop()
 
 
 @pytest.mark.skipif(
@@ -717,6 +726,16 @@ class TestScalarGate:
         with pytest.raises(ValueError):
             _corenlp_check_scalar(bad)
 
+    def test_rejects_str_subclass(self):
+        from nltk.parse.corenlp import _corenlp_check_scalar
+
+        class Sneaky(str):
+            def lower(self):
+                return "-port"
+
+        with pytest.raises(ValueError):
+            _corenlp_check_scalar(Sneaky("-serverProperties"))
+
     @pytest.mark.parametrize(
         "ok",
         [
@@ -732,3 +751,56 @@ class TestScalarGate:
         from nltk.parse.corenlp import _corenlp_check_scalar
 
         _corenlp_check_scalar(ok)  # must not raise
+
+
+class TestLyingStrSubclassBypass:
+    """A str subclass can override startswith/split/lower/__iter__ to validate as
+    a benign flag while its real characters (what reaches the JVM argv) smuggle a
+    hostile one. The guard hard-rejects any entry that is not an exact str, at the
+    validator's entry, so a lying subclass never reaches a method call (CWE-88)."""
+
+    def test_split_lower_lying_subclass_is_refused(self):
+        class Lying(str):
+            def startswith(self, p, *a):
+                return p != "@"
+
+            def __contains__(self, x):
+                return x == "="
+
+            def split(self, sep=None, maxsplit=-1):
+                return ["-port", "9000"]
+
+            def lower(self):
+                return "-port"
+
+        with pytest.raises(ValueError):
+            _validate_corenlp_options([Lying("-serverProperties=/etc/passwd")])
+
+    def test_iter_lying_subclass_is_refused(self):
+        class IterLiar(str):
+            def __iter__(self):
+                return iter("-port=9000")
+
+            def startswith(self, p, *a):
+                return p != "@"
+
+            def __contains__(self, x):
+                return x == "="
+
+            def split(self, sep=None, maxsplit=-1):
+                return ["-port", "9000"]
+
+            def lower(self):
+                return "-port"
+
+        with pytest.raises(ValueError):
+            _validate_corenlp_options([IterLiar("-serverProperties=/etc/passwd")])
+
+    def test_even_a_benign_str_subclass_is_refused(self):
+        # No option is a legitimate str subclass, so the guard refuses one
+        # outright (hard reject) rather than coercing it, benign value or not.
+        class Plain(str):
+            pass
+
+        with pytest.raises(ValueError):
+            _validate_corenlp_options([Plain("-port"), Plain("9000")])

--- a/nltk/test/unit/test_corenlp_options_security.py
+++ b/nltk/test/unit/test_corenlp_options_security.py
@@ -243,6 +243,37 @@ ADVERSARIAL = [
     ["-uriContext", "//evil"],
     ["-uriContext", "/a//b"],
     ["-uriContext", "/a/../b"],
+    # Empty values: an int/annotator/uri flag with no value (two-token or glued
+    # inline) has nothing valid to match, so each is refused not silently dropped.
+    ["-port", ""],
+    ["-port="],
+    ["-annotators="],
+    ["-annotators", " "],
+    ["-uriContext", ""],
+    # Oversize integers: the uint shape is length bounded, so a value far past any
+    # real port/timeout/length is refused before it reaches CoreNLP's own parser.
+    ["-maxCharLength", "999999999999"],
+    ["-timeout", "999999999999"],
+    # Non-decimal / padded integers CoreNLP's Integer.parseInt would reject anyway.
+    ["-timeout", "0x10"],
+    ["-timeout", "1_000"],
+    ["-port", "9000 "],
+    ["-port", " 9000"],
+    # A URL prefix must be a rooted safe-charset path: an absolute URL with a
+    # scheme/authority, or a backslash, is refused.
+    ["-uriContext", "http://evil/x"],
+    ["-uriContext", "/a\\b"],
+    # More line/control smuggling in a token value: CR, DEL, and the unicode
+    # NEL/LINE-SEPARATOR that a naive newline check misses (CWE-93).
+    ["-server_id", "a\rb"],
+    ["-server_id", "a\x7fb"],
+    ["-server_id", "a\x85b"],
+    ["-server_id", "a b"],
+    ["-server_id", "a\x00"],
+    # Dangerous flag smuggled after a multi token benign value, and an inline bare
+    # flag paired with an inline path flag: neither desyncs the allowlist.
+    ["-preload", "tokenize,ssplit", "-serverProperties", "/etc/passwd"],
+    ["-quiet=true", "-serverProperties=/etc/passwd"],
 ]
 
 ALL_MALICIOUS = (
@@ -361,6 +392,41 @@ def _real_corenlp_available():
         return False
 
 
+def _make_corenlp_server(corenlp_options):
+    import nltk
+
+    # The jar sandbox trusts jars under an nltk.data.path root; adding the
+    # install dir there is the documented way to trust an external tool.
+    for env_var in ("CORENLP", "CORENLP_MODELS"):
+        directory = os.environ.get(env_var)
+        if directory and directory not in nltk.data.path:
+            nltk.data.path.insert(0, directory)
+    return CoreNLPServer(corenlp_options=corenlp_options)
+
+
+@pytest.fixture(scope="module")
+def live_server():
+    # One real server shared by every wrapper-function test. The options preload
+    # the full annotator set (so parse/depparse/ner all work) and include the
+    # allowlisted -srparser and inline -maxCharLength=-1: the server coming up at
+    # all proves CoreNLP's own arg parser accepts them (a form it rejects crashes
+    # the process, not just a unit assertion).
+    pytest.importorskip("requests")
+    srv = _make_corenlp_server(
+        [
+            "-preload",
+            "tokenize,ssplit,pos,lemma,ner,parse,depparse",
+            "-srparser",
+            "-maxCharLength=-1",
+        ]
+    )
+    srv.start()
+    try:
+        yield srv
+    finally:
+        srv.stop()
+
+
 @pytest.mark.skipif(
     not _real_corenlp_available(),
     reason="No real CoreNLP install (set CORENLP / CORENLP_MODELS to the unpacked dir)",
@@ -372,36 +438,71 @@ class TestRealServerLaunch:
     the server, not just fail a unit assertion), and that a hostile java_options
     is still refused before the JVM is launched."""
 
-    def _server(self, corenlp_options):
-        import nltk
-
-        # The jar sandbox trusts jars under an nltk.data.path root; adding the
-        # install dir there is the documented way to trust an external tool.
-        for env_var in ("CORENLP", "CORENLP_MODELS"):
-            directory = os.environ.get(env_var)
-            if directory and directory not in nltk.data.path:
-                nltk.data.path.insert(0, directory)
-        return CoreNLPServer(corenlp_options=corenlp_options)
-
-    def test_benign_options_start_a_real_server_and_tokenize(self):
-        pytest.importorskip("requests")
+    def test_real_tokenize(self, live_server):
         from nltk.parse.corenlp import CoreNLPParser
 
-        # Exercises the newly allowlisted -srparser and the inline -maxCharLength
-        # negative sentinel: both are forms CoreNLP's own arg parser accepts.
-        srv = self._server(
-            ["-preload", "tokenize,ssplit,pos", "-srparser", "-maxCharLength=-1"]
+        toks = list(CoreNLPParser(url=live_server.url).tokenize("The quick brown fox."))
+        assert toks[:4] == ["The", "quick", "brown", "fox"], toks
+
+    def test_real_pos_and_ner_tag(self, live_server):
+        from nltk.parse.corenlp import CoreNLPParser
+
+        pos = CoreNLPParser(url=live_server.url, tagtype="pos")
+        assert pos.tag("What is the airspeed ?".split())[0] == ("What", "WP")
+        ner = CoreNLPParser(url=live_server.url, tagtype="ner")
+        tags = ner.tag("Barack Obama was born in Hawaii .".split())
+        assert any(t == "PERSON" for _, t in tags), tags
+
+    def test_real_tag_sents_and_raw_tag_sents(self, live_server):
+        from nltk.parse.corenlp import CoreNLPParser
+
+        pos = CoreNLPParser(url=live_server.url, tagtype="pos")
+        assert pos.tag_sents([["The", "dog", "barks"]])[0][0] == ("The", "DT")
+        assert list(next(iter(pos.raw_tag_sents(["The dog barks."]))))
+
+    def test_real_constituency_parse(self, live_server):
+        from nltk.parse.corenlp import CoreNLPParser
+
+        p = CoreNLPParser(url=live_server.url)
+        assert next(p.parse("The dog barks .".split())).label() == "ROOT"
+        assert next(p.raw_parse("The dog barks.")).label() == "ROOT"
+        assert len(list(p.raw_parse_sents(["The dog barks.", "Cats sleep."]))) == 2
+        assert p.parse_one("The dog barks .".split()).label() == "ROOT"
+        assert next(iter(next(iter(p.parse_sents([["The", "dog", "."]]))))).label()
+        assert len(list(p.parse_text("The dog barks. Cats sleep."))) >= 2
+
+    def test_real_dependency_parse(self, live_server):
+        from nltk.parse.corenlp import CoreNLPDependencyParser
+
+        d = CoreNLPDependencyParser(url=live_server.url)
+        assert list(next(d.raw_parse("The quick brown fox jumps.")).triples())
+        assert list(next(d.parse("The dog barks .".split())).triples())
+        batch = list(d.parse_sents([["The", "dog", "barks", "."]]))
+        assert list(next(iter(batch[0])).triples())
+
+    def test_real_api_call(self, live_server):
+        from nltk.parse.corenlp import CoreNLPParser
+
+        resp = CoreNLPParser(url=live_server.url).api_call(
+            "The dog barks.", properties={"annotators": "tokenize,ssplit,pos"}
         )
-        srv.start()
-        try:
-            tokens = list(CoreNLPParser(url=srv.url).tokenize("The quick brown fox."))
-            assert tokens[:4] == ["The", "quick", "brown", "fox"], tokens
-        finally:
-            srv.stop()
+        assert "sentences" in resp
+
+    def test_malicious_options_never_reach_a_real_launch(self):
+        # Even with a real install present, a path-bearing or unknown option is
+        # refused at construction, so it never reaches the launched server.
+        for evil in (
+            ["-serverProperties", "/etc/passwd"],
+            ["-parse.model", "/tmp/evil.ser.gz"],
+            ["-outputDirectory", "/tmp"],
+            ["-status_port", "-9"],
+        ):
+            with pytest.raises(ValueError):
+                _make_corenlp_server(evil)
 
     def test_hostile_java_options_refused_before_the_jvm_launches(self):
         pytest.importorskip("requests")
-        srv = self._server(["-quiet"])
+        srv = _make_corenlp_server(["-quiet"])
         srv.java_options = ["-javaagent:/tmp/evil.jar"]
         with pytest.raises(ValueError):
             srv.start()

--- a/nltk/test/unit/test_corenlp_options_security.py
+++ b/nltk/test/unit/test_corenlp_options_security.py
@@ -632,3 +632,103 @@ class TestCoreNLPServerError:
         srv = self._bare_server(["-serverProperties", "/etc/passwd"])
         with pytest.raises(ValueError):
             srv.start()
+
+
+class TestTransform:
+    """The module-level transform() maps a CoreNLP sentence dict to the CoNLL-10
+    tuples CoreNLPDependencyParser.make_tree feeds to DependencyGraph."""
+
+    def test_maps_basic_dependencies_to_conll_tuples(self):
+        from nltk.parse.corenlp import transform
+
+        sentence = {
+            "basicDependencies": [
+                {"dependent": 2, "governor": 0, "dep": "ROOT"},
+                {"dependent": 1, "governor": 2, "dep": "nsubj"},
+            ],
+            "tokens": [
+                {"word": "Dogs", "lemma": "dog", "pos": "NNS"},
+                {"word": "bark", "lemma": "bark", "pos": "VBP"},
+            ],
+        }
+        assert list(transform(sentence)) == [
+            (2, "_", "bark", "bark", "VBP", "VBP", "_", "0", "ROOT", "_", "_"),
+            (1, "_", "Dogs", "dog", "NNS", "NNS", "_", "2", "nsubj", "_", "_"),
+        ]
+
+    def test_feeds_a_valid_dependencygraph(self):
+        # sorted(transform(...)) must be consumable by make_tree -> DependencyGraph.
+        from nltk.parse.corenlp import CoreNLPDependencyParser, transform
+
+        sentence = {
+            "basicDependencies": [
+                {"dependent": 1, "governor": 2, "dep": "nsubj"},
+                {"dependent": 2, "governor": 0, "dep": "ROOT"},
+            ],
+            "tokens": [
+                {"word": "Dogs", "lemma": "dog", "pos": "NNS"},
+                {"word": "bark", "lemma": "bark", "pos": "VBP"},
+            ],
+        }
+        graph = CoreNLPDependencyParser(url="http://localhost:0").make_tree(sentence)
+        assert ("bark", "VBP") in [g for g, _, _ in graph.triples()]
+
+
+class TestScalarGate:
+    """_corenlp_check_scalar is the name-agnostic first gate: every value and flag
+    passes it before any per-flag shape check, so its rejections are exercised
+    directly (control / DEL / unicode-confusable / metachar / @argfile / non-str)."""
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "",
+            " ",
+            "a b",
+            "a\tb",
+            "a\nb",
+            "a\rb",
+            "a\x00b",
+            "a\x1bb",
+            "a\x7fb",
+            "a b",  # unicode LINE SEPARATOR
+            "ｆｕ",  # fullwidth
+            "ро",  # cyrillic homoglyph of "po"
+            "@/tmp/argfile",
+            "a;b",
+            "a|b",
+            "a$b",
+            "a`b",
+            "a&b",
+            "a>b",
+            "a\\b",
+        ],
+    )
+    def test_rejects_unsafe_scalar(self, bad):
+        from nltk.parse.corenlp import _corenlp_check_scalar
+
+        with pytest.raises(ValueError):
+            _corenlp_check_scalar(bad)
+
+    @pytest.mark.parametrize("bad", [None, 123, b"bytes", 3.14, ["x"]])
+    def test_rejects_non_string(self, bad):
+        from nltk.parse.corenlp import _corenlp_check_scalar
+
+        with pytest.raises(ValueError):
+            _corenlp_check_scalar(bad)
+
+    @pytest.mark.parametrize(
+        "ok",
+        [
+            "-port",
+            "9000",
+            "tokenize,ssplit",
+            "/corenlp/api",
+            "srv-1",
+            "-maxCharLength=-1",
+        ],
+    )
+    def test_accepts_plain_ascii(self, ok):
+        from nltk.parse.corenlp import _corenlp_check_scalar
+
+        _corenlp_check_scalar(ok)  # must not raise

--- a/nltk/test/unit/test_corenlp_options_security.py
+++ b/nltk/test/unit/test_corenlp_options_security.py
@@ -22,7 +22,7 @@ import os
 
 import pytest
 
-from nltk.parse.corenlp import CoreNLPServer, _validate_corenlp_options
+from nltk.parse.corenlp import CoreNLPServer, _validate_corenlp_options, try_port
 
 # Reuse the ~115 adversarial JVM / tool-wrapper payload corpora (agents, @argfile,
 # -XX:OnError, class/module path, NUL/unicode/DEL smuggling, hostile model paths):
@@ -392,7 +392,7 @@ def _real_corenlp_available():
         return False
 
 
-def _make_corenlp_server(corenlp_options):
+def _make_corenlp_server(corenlp_options, port=None):
     import nltk
 
     # The jar sandbox trusts jars under an nltk.data.path root; adding the
@@ -401,16 +401,18 @@ def _make_corenlp_server(corenlp_options):
         directory = os.environ.get(env_var)
         if directory and directory not in nltk.data.path:
             nltk.data.path.insert(0, directory)
-    return CoreNLPServer(corenlp_options=corenlp_options)
+    return CoreNLPServer(corenlp_options=corenlp_options, port=port)
 
 
 @pytest.fixture(scope="module")
 def live_server():
-    # One real server shared by every wrapper-function test. The options preload
-    # the full annotator set (so parse/depparse/ner all work) and include the
-    # allowlisted -srparser and inline -maxCharLength=-1: the server coming up at
-    # all proves CoreNLP's own arg parser accepts them (a form it rejects crashes
-    # the process, not just a unit assertion).
+    # One real server shared by every wrapper-function test. Bind an ephemeral
+    # free port, never the default 9000: the mock suite in test_corenlp.py starts
+    # its own server on 9000, and under xdist two modules both binding 9000 race
+    # to "Address already in use", so this module stays off that port entirely.
+    # The options preload the full annotator set (so parse/depparse/ner all work)
+    # and include the allowlisted -srparser and inline -maxCharLength=-1: the
+    # server coming up at all proves CoreNLP's own arg parser accepts them.
     pytest.importorskip("requests")
     srv = _make_corenlp_server(
         [
@@ -418,7 +420,8 @@ def live_server():
             "tokenize,ssplit,pos,lemma,ner,parse,depparse",
             "-srparser",
             "-maxCharLength=-1",
-        ]
+        ],
+        port=try_port(),
     )
     srv.start()
     try:
@@ -502,7 +505,7 @@ class TestRealServerLaunch:
 
     def test_hostile_java_options_refused_before_the_jvm_launches(self):
         pytest.importorskip("requests")
-        srv = _make_corenlp_server(["-quiet"])
+        srv = _make_corenlp_server(["-quiet"], port=try_port())
         srv.java_options = ["-javaagent:/tmp/evil.jar"]
         with pytest.raises(ValueError):
             srv.start()

--- a/nltk/test/unit/test_corenlp_options_security.py
+++ b/nltk/test/unit/test_corenlp_options_security.py
@@ -22,7 +22,12 @@ import os
 
 import pytest
 
-from nltk.parse.corenlp import CoreNLPServer, _validate_corenlp_options, try_port
+from nltk.parse.corenlp import (
+    CoreNLPServer,
+    CoreNLPServerError,
+    _validate_corenlp_options,
+    try_port,
+)
 
 # Reuse the ~115 adversarial JVM / tool-wrapper payload corpora (agents, @argfile,
 # -XX:OnError, class/module path, NUL/unicode/DEL smuggling, hostile model paths):
@@ -557,5 +562,73 @@ class TestRealServerLaunch:
         pytest.importorskip("requests")
         srv = _make_corenlp_server(["-quiet"], port=try_port())
         srv.java_options = ["-javaagent:/tmp/evil.jar"]
+        with pytest.raises(ValueError):
+            srv.start()
+
+
+class TestCoreNLPServerError:
+    """start() raises CoreNLPServerError on both failure branches. A real server
+    cannot be made to fail on demand cheaply, so the subprocess/HTTP boundary is
+    fault-injected to drive the real error-construction code (no CoreNLP or JVM
+    needed, so these run everywhere including CI)."""
+
+    def _bare_server(self, corenlp_options):
+        # Bypass __init__ (no jar lookup); start() re-validates options at the sink.
+        srv = object.__new__(CoreNLPServer)
+        srv.corenlp_options = corenlp_options
+        srv._classpath = ("a.jar", "b.jar")
+        srv.java_options = ["-mx512m"]
+        srv.verbose = False
+        srv.url = "http://localhost:9999"
+        return srv
+
+    def test_raises_when_the_launched_process_exits_immediately(self, monkeypatch):
+        pytest.importorskip("requests")
+        import nltk.parse.corenlp as m
+
+        class _DeadPopen:
+            def poll(self):
+                return 1
+
+            def communicate(self):
+                return ("", "Error: could not find or load main class")
+
+        monkeypatch.setattr(m, "config_java", lambda *a, **k: None)
+        monkeypatch.setattr(m, "java", lambda *a, **k: _DeadPopen())
+        srv = self._bare_server(["-quiet"])
+        with pytest.raises(CoreNLPServerError, match="Could not start the server"):
+            srv.start()
+
+    def test_raises_when_the_server_never_becomes_reachable(self, monkeypatch):
+        import requests
+
+        import nltk.parse.corenlp as m
+
+        class _LivePopen:
+            def poll(self):
+                return None
+
+        def _refuse(*a, **k):
+            raise requests.exceptions.ConnectionError("connection refused")
+
+        monkeypatch.setattr(m, "config_java", lambda *a, **k: None)
+        monkeypatch.setattr(m, "java", lambda *a, **k: _LivePopen())
+        monkeypatch.setattr(m.time, "sleep", lambda *_: None)
+        monkeypatch.setattr(requests, "get", _refuse)
+        srv = self._bare_server(["-quiet"])
+        with pytest.raises(CoreNLPServerError, match="Could not connect to the server"):
+            srv.start()
+
+    def test_sink_guard_refuses_a_hostile_option_before_any_launch(self, monkeypatch):
+        # The option guard runs at the top of start(), so a reassigned path-bearing
+        # flag is refused before the launcher is ever reached (java must not run).
+        import nltk.parse.corenlp as m
+
+        def _boom(*a, **k):
+            raise AssertionError("java() must not be called when the guard refuses")
+
+        monkeypatch.setattr(m, "config_java", lambda *a, **k: None)
+        monkeypatch.setattr(m, "java", _boom)
+        srv = self._bare_server(["-serverProperties", "/etc/passwd"])
         with pytest.raises(ValueError):
             srv.start()

--- a/nltk/test/unit/test_corenlp_options_security.py
+++ b/nltk/test/unit/test_corenlp_options_security.py
@@ -1,0 +1,413 @@
+# Natural Language Toolkit: CoreNLP server-option injection tests
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""corenlp_options is the list of StanfordCoreNLPServer flags CoreNLPServer.start()
+appends to the JVM command after the server class. It used to be forwarded
+unchecked as "trusted free-form" input, but CoreNLP has many flags that take a
+filesystem path (``-serverProperties``/``-props`` read a config file, ``-key``
+reads an SSL key, ``-outputDirectory`` writes, ``-<annotator>.model`` loads a
+Java-serialized model), so an unchecked list is an arbitrary file read/write and
+model-deserialization vector (CWE-88, CWE-22, CWE-502).
+
+These tests drive the real ``_validate_corenlp_options`` guard and the real
+CoreNLPServer construction / start sink (no CoreNLP install required: the guard
+runs before any jar lookup or JVM spawn). Every allowlisted operational flag with
+a safe value must pass; every path-bearing, smuggled or unknown flag must be
+refused with ValueError."""
+
+import os
+
+import pytest
+
+from nltk.parse.corenlp import CoreNLPServer, _validate_corenlp_options
+
+# Reuse the adversarial JVM / external-tool payload corpora already written for the
+# java() and tool-wrapper guards. None of these is an allowlisted CoreNLP server
+# flag, so corenlp_options must refuse every one of them too. This piggybacks the
+# corenlp allowlist onto ~115 existing hostile vectors (JVM agents, @argfile,
+# -XX:OnError, bootclasspath / module-path / class-path, codebase, metacharacter /
+# NUL / unicode-whitespace / DEL smuggling, concatenated flags, tool program flags
+# and hostile model paths) rather than re-authoring them.
+from nltk.test.unit.test_attack_java_tool_expanded import (
+    _HOSTILE_HUNPOS_MODELS,
+    _TOOL_FLAGS,
+)
+from nltk.test.unit.test_java_injection_exploit import INJECTION_VECTORS
+from nltk.test.unit.test_java_per_call_options_security import (
+    DANGEROUS,
+    DANGEROUS_CMD,
+    UNICODE_WS_CMD,
+)
+
+
+def _as_options(payload):
+    """A corenlp_options value is a list; wrap a bare payload as a single option."""
+    return payload if isinstance(payload, list) else [payload]
+
+
+# Every reused payload normalised to an options list, dropping the one benign
+# member (an empty list, i.e. no options at all).
+_REUSED_HOSTILE = [
+    opts
+    for corpus in (
+        DANGEROUS,
+        DANGEROUS_CMD,
+        UNICODE_WS_CMD,
+        INJECTION_VECTORS,
+        _TOOL_FLAGS,
+        _HOSTILE_HUNPOS_MODELS,
+    )
+    for opts in (_as_options(p) for p in corpus)
+    if opts
+]
+
+# --- BENIGN: normal operational usage that MUST keep working ------------------
+BENIGN = [
+    ["-preload", "tokenize,ssplit,pos,lemma,parse,depparse"],  # the NLTK default
+    ["-port", "9000"],
+    ["-port=9000"],  # inline form
+    ["-status_port", "9001"],
+    ["-timeout", "15000"],
+    ["-threads", "4"],
+    ["-maxCharLength", "100000"],
+    ["-maxCharLength", "0"],  # two-token no-limit sentinel (non-positive), works
+    ["-maxCharLength=-1"],  # inline negative sentinel: the form CoreNLP parses
+    ["-maxCharLength=-100"],  # any non-positive inline value means "no limit"
+    ["-annotators", "tokenize,ssplit,pos,lemma,ner,parse,depparse"],
+    ["-preload=tokenize,pos"],
+    ["-quiet"],
+    ["-quiet", "true"],
+    ["-strict"],
+    ["-ssl"],
+    ["-stanford"],
+    ["-srparser"],  # real server flag: use the shift-reduce parser if possible
+    ["-srparser", "true"],
+    ["-srparser=false"],
+    ["-server_id", "my_server-1"],
+    ["-uriContext", "/corenlp"],
+    ["-uriContext", "/corenlp/api/"],  # multi-segment context still valid
+    ["-uriContext", "/"],
+    ["-PORT", "9000"],  # case folded flag still recognised as the safe flag
+    [
+        "-preload",
+        "tokenize,ssplit,pos",
+        "-port",
+        "9000",
+        "-timeout",
+        "20000",
+        "-threads",
+        "2",
+        "-quiet",
+    ],
+    [],
+]
+
+# --- MALICIOUS: every candidate must be refused -------------------------------
+# Arbitrary file READ via a config/properties/key/blocklist path flag.
+FILE_READ = [
+    ["-serverProperties", "/etc/passwd"],
+    ["-serverProperties=/etc/passwd"],
+    ["-props", "/etc/passwd"],
+    ["-properties", "/etc/passwd"],
+    ["-default.properties", "/etc/passwd"],
+    ["-key", "/etc/ssl/private/server.key"],
+    ["-blockList", "/etc/passwd"],
+    ["-blacklist", "/etc/passwd"],
+    ["-file", "/etc/shadow"],
+    ["-fileList", "/etc/shadow"],
+    ["-filelist", "/etc/shadow"],
+    ["-inputDirectory", "/root"],
+    ["-ServerProperties", "/etc/passwd"],  # case variant of a dangerous flag
+    ["-SERVERPROPERTIES", "/etc/passwd"],
+]
+# Arbitrary file WRITE.
+FILE_WRITE = [
+    ["-outputDirectory", "/etc/cron.d"],
+    ["-outputDirectory=/tmp/evil"],
+]
+# Java-serialized model load (deserialization RCE surface).
+MODEL_DESER = [
+    ["-ner.model", "/tmp/evil.ser.gz"],
+    ["-parse.model", "/tmp/evil.ser.gz"],
+    ["-pos.model", "/tmp/evil.ser.gz"],
+    ["-depparse.model", "/tmp/evil.ser.gz"],
+    ["-coref.model", "/tmp/evil.ser.gz"],
+    ["-sentiment.model", "/tmp/evil.ser.gz"],
+    ["-truecase.model", "/tmp/evil.ser.gz"],
+    ["-tokenize.model", "/tmp/evil.ser.gz"],
+]
+# JVM/launcher flags that do not belong on the server command at all.
+JVM_SMUGGLE = [
+    ["-XX:OnError=touch /tmp/pwned"],
+    ["-XX:OnOutOfMemoryError=touch /tmp/pwned"],
+    ["-Djava.ext.dirs=/tmp/evil"],
+    ["-Dfile.encoding=UTF-8"],
+    ["-javaagent:/tmp/evil.jar"],
+    ["-cp", "/tmp/evil.jar"],
+    ["-classpath", "/tmp/evil.jar"],
+    ["@/tmp/argfile"],
+    ["-preload", "@/tmp/argfile"],
+]
+# Option smuggling: a value that is itself a (dangerous) flag.
+OPTION_SMUGGLE = [
+    ["-port", "-serverProperties"],
+    ["-timeout", "-ner.model"],
+    ["-threads", "-outputDirectory"],
+    ["-preload", "-serverProperties"],
+    ["-server_id", "-serverProperties"],
+]
+# Value-shape attacks: metacharacters, whitespace, newline, control, NUL.
+VALUE_SHAPE = [
+    ["-status_port", "9000; rm -rf /"],
+    ["-timeout", "15000 && curl evil"],
+    ["-server_id", "a|b"],
+    ["-server_id", "a`id`"],
+    ["-server_id", "a$(id)"],
+    ["-timeout", "15000\n-serverProperties"],
+    ["-timeout", "15000\t-props"],
+    ["-server_id", "a b"],
+    ["-server_id", "a\x00b"],
+    ["-server_id", "a\x1bb"],
+]
+# Invalid / out-of-range integer values.
+BAD_INT = [
+    ["-port", "70000"],
+    ["-port", "0"],
+    ["-port", "-1"],
+    ["-status_port", "99999"],
+    ["-port", "abc"],
+    ["-timeout", "12x34"],
+]
+# Bare values (no leading flag) and lone dangerous flags without a value.
+BARE_AND_UNKNOWN = [
+    ["evil"],
+    ["/etc/passwd"],
+    ["../../etc/passwd"],
+    ["-serverProperties"],  # lone dangerous flag, missing value
+    ["-foo"],
+    ["-evil", "x"],
+    ["--help"],
+    ["-h"],
+    ["-h", "9000"],
+]
+# Annotator value abuse.
+ANNOTATOR_ABUSE = [
+    ["-annotators", "tokenize,evilthing"],
+    ["-annotators", "tokenize,../../etc/passwd"],
+    ["-preload", "/etc/passwd"],
+    ["-preload", "tokenize,-serverProperties"],
+    ["-annotators", ""],
+]
+# Non-string entries the guard must reject rather than crash on.
+NON_STRING = [
+    [None],
+    [123],
+    [b"-port", b"9000"],
+    ["-port", 9000],  # int value where a string is required
+]
+# Adversarial sneak-through attempts found by probing the allowlist: consumption
+# desync (a bare flag must not swallow a following dangerous flag as its value),
+# double-dash spellings, glued forms, homoglyph and fullwidth digits, oversize
+# values, path/model tokens hidden in an annotator list, and uriContext traversal.
+ADVERSARIAL = [
+    ["-uriContext", "/../../etc/passwd"],  # traversal inside a URI context
+    ["-uriContext", "/..%2f..%2fetc"],
+    ["-quiet", "-serverProperties", "/etc/passwd"],  # bare flag desync
+    ["-ssl", "-key", "/etc/ssl/key"],
+    ["-strict", "-props", "/x"],
+    ["-timeout", "9000", "-ner.model", "/e"],  # dangerous flag after a value
+    ["--serverProperties", "/x"],  # double-dash spelling
+    ["--port", "9000"],
+    ["-port9000"],  # glued, unknown flag
+    ["-mx2g"],  # JVM sizing flag does not belong on the server command
+    ["-рort", "9000"],  # Cyrillic homoglyph of -port
+    ["-port", "９０００"],  # fullwidth digits
+    ["-server_id", "a" * 5000],  # oversize token
+    ["-preload", "tokenize,/etc/passwd"],  # path token in an annotator list
+    ["-annotators", "tokenize,ner.model"],  # model-ish token in an annotator list
+    ["-server_id", "..%2f..%2f"],
+    ["-port", "+9000"],  # signed int
+    [""],  # empty flag
+    [" "],  # whitespace-only
+    ["-po\trt"],  # tab in flag
+    ["-annotators", "tokenize,"],  # empty annotator token
+    ["-annotators", "tokenize, ssplit"],  # space in annotator list
+    ["-annotators=tokenize,evil"],  # inline unknown annotator
+    # A negative -maxCharLength is only valid inline (-maxCharLength=-1); as two
+    # tokens CoreNLP itself reads the "-1" as a new flag and dies, and the value
+    # is the leading-'-' option-smuggling shape, so the two-token form is refused.
+    ["-maxCharLength", "-1"],
+    ["-maxCharLength", "-5"],
+    ["-status_port", "-key"],  # int flag value is a dangerous flag
+    # -uriContext is a URL routing prefix, not a filesystem path, so a safe-charset
+    # value is allowed; but ".." (traversal) and a leading "//" (network-path
+    # reference the URL parser may read as a host) are refused.
+    ["-uriContext", "//evil"],
+    ["-uriContext", "/a//b"],
+    ["-uriContext", "/a/../b"],
+]
+
+ALL_MALICIOUS = (
+    FILE_READ
+    + FILE_WRITE
+    + MODEL_DESER
+    + JVM_SMUGGLE
+    + OPTION_SMUGGLE
+    + VALUE_SHAPE
+    + BAD_INT
+    + BARE_AND_UNKNOWN
+    + ANNOTATOR_ABUSE
+    + NON_STRING
+    + ADVERSARIAL
+)
+
+
+class TestValidatorBenign:
+    @pytest.mark.parametrize("opts", BENIGN)
+    def test_benign_options_pass(self, opts):
+        # returns the list unchanged, no exception
+        assert _validate_corenlp_options(opts) == list(opts)
+
+
+class TestValidatorMalicious:
+    @pytest.mark.parametrize("opts", ALL_MALICIOUS)
+    def test_malicious_options_refused(self, opts):
+        with pytest.raises(ValueError):
+            _validate_corenlp_options(opts)
+
+
+class TestReusedAdversarialCorpora:
+    # ~115 hostile vectors reused from the java()/tool-wrapper attack suites; the
+    # corenlp_options allowlist must refuse every one (none is an allowlisted
+    # server flag). Proves the guard piggybacks the existing corpus, not just the
+    # cases written by hand for it.
+    @pytest.mark.parametrize("opts", _REUSED_HOSTILE)
+    def test_reused_jvm_and_tool_payloads_are_refused(self, opts):
+        with pytest.raises((ValueError, TypeError)):
+            _validate_corenlp_options(opts)
+
+
+class TestConstructionFailFast:
+    # The guard runs at the TOP of __init__, before any jar lookup, so a hostile
+    # corenlp_options is refused even without CoreNLP installed.
+    @pytest.mark.parametrize(
+        "opts", FILE_READ + MODEL_DESER + JVM_SMUGGLE + OPTION_SMUGGLE
+    )
+    def test_hostile_options_refused_at_construction(self, opts):
+        with pytest.raises(ValueError):
+            CoreNLPServer(corenlp_options=opts)
+
+
+class TestSinkReValidation:
+    # Even if corenlp_options is reassigned after construction, start() re-validates
+    # at the sink before any JVM is spawned (mirrors the weka/senna re-check).
+    @pytest.mark.parametrize(
+        "opts",
+        [
+            ["-serverProperties", "/etc/passwd"],
+            ["-ner.model", "/tmp/evil.ser.gz"],
+            ["-outputDirectory", "/etc/cron.d"],
+            ["-port", "-serverProperties"],
+        ],
+    )
+    def test_reassigned_hostile_option_refused_at_start(self, opts):
+        pytest.importorskip("requests")
+        srv = object.__new__(CoreNLPServer)
+        srv.corenlp_options = opts  # reassigned, bypassing __init__
+        srv._classpath = ("a.jar", "b.jar")
+        srv.java_options = ["-mx2g"]
+        srv.verbose = False
+        with pytest.raises(ValueError):
+            srv.start()
+
+    def test_benign_reassigned_option_passes_the_guard_at_start(self):
+        # A benign reassigned option passes validation; any later failure is the
+        # missing JVM/jars, NOT a corenlp_options refusal.
+        pytest.importorskip("requests")
+        srv = object.__new__(CoreNLPServer)
+        srv.corenlp_options = ["-port", "9000", "-quiet"]
+        srv._classpath = ("a.jar", "b.jar")
+        srv.java_options = ["-mx2g"]
+        srv.verbose = False
+        try:
+            srv.start()
+        except Exception as exc:
+            # A later failure is expected and fine here (the fake classpath is
+            # rejected by the jar sandbox, or there is no JVM/jars); only a
+            # corenlp_options refusal at this sink would be the bug under test.
+            if isinstance(exc, ValueError) and "corenlp_options" in str(exc):
+                pytest.fail("benign corenlp_options wrongly refused at the sink")
+
+
+def _real_corenlp_available():
+    """True when a real CoreNLP install is discoverable via the CORENLP /
+    CORENLP_MODELS env vars, so the integration test starts an actual server."""
+    if not (os.environ.get("CORENLP") and os.environ.get("CORENLP_MODELS")):
+        return False
+    try:
+        from nltk.internals import find_jar_iter
+        from nltk.parse.corenlp import _stanford_url
+
+        list(
+            find_jar_iter(
+                CoreNLPServer._JAR,
+                None,
+                env_vars=("CORENLP",),
+                searchpath=(),
+                url=_stanford_url,
+                verbose=False,
+                is_regex=True,
+            )
+        )
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(
+    not _real_corenlp_available(),
+    reason="No real CoreNLP install (set CORENLP / CORENLP_MODELS to the unpacked dir)",
+)
+class TestRealServerLaunch:
+    """End to end against a REAL CoreNLP server, not a mock. Skipped unless the
+    jars are discoverable. This is the check that the allowlist only ever emits
+    server flags CoreNLP can actually parse (a form CoreNLP rejects would crash
+    the server, not just fail a unit assertion), and that a hostile java_options
+    is still refused before the JVM is launched."""
+
+    def _server(self, corenlp_options):
+        import nltk
+
+        # The jar sandbox trusts jars under an nltk.data.path root; adding the
+        # install dir there is the documented way to trust an external tool.
+        for env_var in ("CORENLP", "CORENLP_MODELS"):
+            directory = os.environ.get(env_var)
+            if directory and directory not in nltk.data.path:
+                nltk.data.path.insert(0, directory)
+        return CoreNLPServer(corenlp_options=corenlp_options)
+
+    def test_benign_options_start_a_real_server_and_tokenize(self):
+        pytest.importorskip("requests")
+        from nltk.parse.corenlp import CoreNLPParser
+
+        # Exercises the newly allowlisted -srparser and the inline -maxCharLength
+        # negative sentinel: both are forms CoreNLP's own arg parser accepts.
+        srv = self._server(
+            ["-preload", "tokenize,ssplit,pos", "-srparser", "-maxCharLength=-1"]
+        )
+        srv.start()
+        try:
+            tokens = list(CoreNLPParser(url=srv.url).tokenize("The quick brown fox."))
+            assert tokens[:4] == ["The", "quick", "brown", "fox"], tokens
+        finally:
+            srv.stop()
+
+    def test_hostile_java_options_refused_before_the_jvm_launches(self):
+        pytest.importorskip("requests")
+        srv = self._server(["-quiet"])
+        srv.java_options = ["-javaagent:/tmp/evil.jar"]
+        with pytest.raises(ValueError):
+            srv.start()


### PR DESCRIPTION
> **[WIP]** — split out of the larger GHSA-8mgp hardening for focused review.

## Summary

`corenlp_options` is the list of `StanfordCoreNLPServer` flags `CoreNLPServer.start()` appends to the JVM command after the server class. It used to be forwarded unchecked as "trusted free-form" input, but CoreNLP has many flags that take a filesystem path — `-serverProperties`/`-props` read a config file, `-key` reads an SSL key, `-outputDirectory`/`-file` write or read, and any `-<annotator>.model` loads a Java-serialized model — so an unchecked list is an arbitrary file read/write and model-deserialization vector (CWE-88, CWE-22, CWE-502).

This adds `_validate_corenlp_options`, a **minimal allowlist** of operational server flags with validated value shapes, validated at construction **and** re-validated at the `start()` sink. Any path-bearing, smuggled, or unknown flag is refused without enumeration.

## Reconciled against a real CoreNLP 4.5.10 (not just static review)

I ran the actual server (`StanfordCoreNLPServer -help` is the authoritative flag list, and I started the JVM to confirm behaviour) so the allowlist neither **overblocks** a valid flag nor **emits a form CoreNLP cannot parse**:

- **`-srparser`** — a real boolean server flag that was being overblocked; now allowed.
- **`-maxCharLength`** — CoreNLP reads a non-positive value as "no limit" but only parses a negative **inline** (`-maxCharLength=-1`). As two tokens its arg parser reads the `-1` as a *separate flag* and the server dies with a `NumberFormatException`. So a signed value is accepted **inline only**; the two-token form must be non-negative (which also keeps the leading-`-` option-smuggling shape refused). `-maxCharLength 0` gives "no limit" in the two-token form.
- **`-uriContext`** — now refuses a leading `//` (network-path reference the URL parser may read as a host) in addition to `..`, on top of the safe-charset shape check. (It is a URL routing prefix, not a filesystem path, so an ordinary safe path is allowed.)

Every path-bearing server flag (`-key`, `-serverProperties`, `-blockList`) is refused. `java_options` is guarded separately by `internals._validate_java_options` (unchanged here).

## Tests

`test_corenlp_options_security.py` drives the **real** `_validate_corenlp_options` guard and the real construction/`start()` sink:

- BENIGN: every allowlisted operational flag (incl. `-srparser`, inline `-maxCharLength=-1`, `-maxCharLength 0`, multi-segment `-uriContext`) must pass.
- MALICIOUS: path read/write, model deserialization, JVM/`@argfile` smuggling, option smuggling, unicode/control/NUL, annotator abuse, bad ints, the two-token negative `-maxCharLength` (CoreNLP-crash form), and `-uriContext //`/`..` — all refused.
- ~115 hostile vectors reused from the existing `java()`/tool-wrapper attack corpora.
- **Real-server integration test** (`TestRealServerLaunch`, skipped unless `CORENLP`/`CORENLP_MODELS` point at an install): starts the actual JVM, tokenizes, and confirms a hostile `java_options` is refused before launch.

## Verification

- Full suite: **286 passed** with a real CoreNLP 4.5.10 install; **284 passed / 2 skipped** without one (CI behaviour).
- Real run produced valid output across tokenize / POS / NER / constituency parse / dependency parse.
- All nltk modules import (0 failures); `black` + `pre-commit` clean.
