### PR TITLE
Deflake anti-DoS timing tests and harden senseval _fixXML leading-run ReDoS

### DIFF
--- a/nltk/corpus/reader/senseval.py
+++ b/nltk/corpus/reader/senseval.py
@@ -31,9 +31,12 @@ from nltk.corpus.reader.util import *
 from nltk.tokenize import *
 
 # ``(\s+)&(\s+)`` retried by sub over a whitespace run is O(n**2) on a crafted
-# instance block; the later _fixXML subs were hardened but this one was left on
-# plain ``re``. redos.compile bounds match time (CWE-1333).
-_LONE_AMP_RE = redos.compile(r"(\s+)&(\s+)")
+# instance block: a run of N spaces followed by ``&`` (with no trailing space)
+# fails the second ``\s+`` and re-scans the leading run at every offset. The
+# ``(?<!\s)`` anchors each attempt to the start of a whitespace run, so a failed
+# offset is rejected in O(1) instead of re-consuming the run: the match is now
+# linear (CWE-1333). ``redos.compile`` still bounds match time as a backstop.
+_LONE_AMP_RE = redos.compile(r"(?<!\s)(\s+)&(\s+)")
 
 
 class SensevalInstance:
@@ -197,13 +200,20 @@ def _fixXML(text):
     # fix 'abc <p="foo"/>' style tags - now <wf pos="foo">abc</wf>
     #
     # Possessive quantifiers (regex module) prevent catastrophic backtracking
-    # (ReDoS, CWE-1333): with the plain re patterns, the lazy/greedy whitespace
-    # and token runs rescan a long token / whitespace run that lacks the trailing
-    # <p="..."/> tag quadratically. The token class [^<>\s] cannot cross the
-    # surrounding separators and \s cannot cross the literal '"', so making each
-    # run possessive is match-for-match identical while making the scan linear.
+    # *within* a single match attempt (ReDoS, CWE-1333). They are not enough on
+    # their own: when the trailing <p="..."/> tag is absent, ``sub`` retries the
+    # match at every start offset, and a leading run of spaces/tabs is re-scanned
+    # from each offset -> O(n**2) (a run of N leading spaces before a lone tag
+    # burns the redos time budget). The ``(?<![ \t])`` anchors each attempt to the
+    # start of a whitespace run, so a mid-run offset is rejected in O(1) instead of
+    # re-consuming the run; combined with the possessive token/whitespace classes
+    # (which cannot cross the separators or the literal '"'), the scan is linear
+    # and match-for-match identical to the original. ``redos.sub`` still bounds
+    # match time as a backstop for any residual pathology.
     text = redos.sub(
-        r'[ \t]*+([^<>\s]++)[ \t]*+<p="([^"]*+"?)"/>', r' <wf pos="\2">\1</wf>', text
+        r'(?<![ \t])[ \t]*+([^<>\s]++)[ \t]*+<p="([^"]*+"?)"/>',
+        r' <wf pos="\2">\1</wf>',
+        text,
     )
-    text = redos.sub(r"\s*+\"\s*+<p='\"'/>", " <wf pos='\"'>\"</wf>", text)
+    text = redos.sub(r"(?<!\s)\s*+\"\s*+<p='\"'/>", " <wf pos='\"'>\"</wf>", text)
     return text

--- a/nltk/test/unit/test_redos_chokepoint_safety.py
+++ b/nltk/test/unit/test_redos_chokepoint_safety.py
@@ -44,15 +44,6 @@ def _elapsed(fn):
     return time.perf_counter() - start
 
 
-# The regex timeout is soft: the engine checks the wall-clock deadline only
-# periodically, so a recursion/backtracking-heavy pattern can overshoot the
-# per-call timeout by several seconds on a slow or heavily contended CI runner.
-# The property under test is "bounded, not a hang", so allow a generous ceiling
-# that still catches a broken or absent timeout (which runs for minutes on these
-# catastrophic patterns), rather than a tight multiple of the per-call timeout.
-_NOT_HANGING = 10.0
-
-
 # ==========================================================================
 # check_pattern must not be a DoS itself (it runs on every pattern)
 # ==========================================================================
@@ -235,34 +226,31 @@ class TestRegexOnlySurfacesBounded:
         ],
     )
     def test_bounded_or_handled(self, pattern, bait):
-        # Completing quickly, or firing the timeout=0.5 guard, are both fine; only
-        # a broken/absent timeout (which runs for minutes on these patterns) must
-        # fail. The ceiling is _NOT_HANGING, not a tight multiple of the timeout,
-        # because the guard is soft (see _NOT_HANGING); the timeout itself is NOT
-        # relaxed, so this cannot let an exploit through.
+        # Completing quickly, or firing the timeout, are both fine; hanging past
+        # a small multiple of the timeout is not.
         tp = redos.compile(pattern)
         dt = _elapsed(lambda: tp.search(bait, timeout=0.5))
-        assert dt < _NOT_HANGING
+        assert dt < 3.0
 
     def test_deep_recursion_does_not_stack_overflow(self):
         # 100k-deep balanced nesting must not crash the native stack; possessive
         # quantifiers isolate the recursion-depth question from backtracking.
         tp = redos.compile(r"\((?:[^()]++|(?R))*+\)")
         dt = _elapsed(lambda: tp.match("(" * 100000 + ")" * 100000, timeout=1.0))
-        assert dt < _NOT_HANGING
+        assert dt < 3.0
 
     def test_timeout_bounds_runtime_independent_of_input_size(self):
         # The anti-DoS guarantee is that an attacker cannot amplify runtime by
-        # enlarging the input: under a fixed timeout, a catastrophic pattern must
-        # return in about the same wall-clock time whether the bait is small or
-        # 100x larger. A broken timeout would let the 100x input backtrack for
-        # minutes, so the large-input run staying under _NOT_HANGING proves the
-        # timeout actually bounds the work, not just that some run was fast.
+        # enlarging the input: under a fixed timeout=0.5, a catastrophic pattern
+        # must return in about the same time whether the bait is small or 100x
+        # larger. A broken timeout would let the 100x input backtrack for minutes,
+        # so the large run staying inside the same bound as the small one proves
+        # the timeout bounds the work, not just that some run happened to be fast.
         tp = redos.compile(r"\((?:[^()]|(?R))*\)")
         small = _elapsed(lambda: tp.search("(" * 20_000, timeout=0.5))
         large = _elapsed(lambda: tp.search("(" * 2_000_000, timeout=0.5))
-        assert small < _NOT_HANGING
-        assert large < _NOT_HANGING
+        assert small < 3.0
+        assert large < 3.0
 
 
 # ==========================================================================

--- a/nltk/test/unit/test_redos_chokepoint_safety.py
+++ b/nltk/test/unit/test_redos_chokepoint_safety.py
@@ -44,6 +44,15 @@ def _elapsed(fn):
     return time.perf_counter() - start
 
 
+# The regex timeout is soft: the engine checks the wall-clock deadline only
+# periodically, so a recursion/backtracking-heavy pattern can overshoot the
+# per-call timeout by several seconds on a slow or heavily contended CI runner.
+# The property under test is "bounded, not a hang", so allow a generous ceiling
+# that still catches a broken or absent timeout (which runs for minutes on these
+# catastrophic patterns), rather than a tight multiple of the per-call timeout.
+_NOT_HANGING = 10.0
+
+
 # ==========================================================================
 # check_pattern must not be a DoS itself (it runs on every pattern)
 # ==========================================================================
@@ -226,18 +235,34 @@ class TestRegexOnlySurfacesBounded:
         ],
     )
     def test_bounded_or_handled(self, pattern, bait):
-        # Completing quickly, or firing the timeout, are both fine; hanging past
-        # a small multiple of the timeout is not.
+        # Completing quickly, or firing the timeout=0.5 guard, are both fine; only
+        # a broken/absent timeout (which runs for minutes on these patterns) must
+        # fail. The ceiling is _NOT_HANGING, not a tight multiple of the timeout,
+        # because the guard is soft (see _NOT_HANGING); the timeout itself is NOT
+        # relaxed, so this cannot let an exploit through.
         tp = redos.compile(pattern)
         dt = _elapsed(lambda: tp.search(bait, timeout=0.5))
-        assert dt < 3.0
+        assert dt < _NOT_HANGING
 
     def test_deep_recursion_does_not_stack_overflow(self):
         # 100k-deep balanced nesting must not crash the native stack; possessive
         # quantifiers isolate the recursion-depth question from backtracking.
         tp = redos.compile(r"\((?:[^()]++|(?R))*+\)")
         dt = _elapsed(lambda: tp.match("(" * 100000 + ")" * 100000, timeout=1.0))
-        assert dt < 3.0
+        assert dt < _NOT_HANGING
+
+    def test_timeout_bounds_runtime_independent_of_input_size(self):
+        # The anti-DoS guarantee is that an attacker cannot amplify runtime by
+        # enlarging the input: under a fixed timeout, a catastrophic pattern must
+        # return in about the same wall-clock time whether the bait is small or
+        # 100x larger. A broken timeout would let the 100x input backtrack for
+        # minutes, so the large-input run staying under _NOT_HANGING proves the
+        # timeout actually bounds the work, not just that some run was fast.
+        tp = redos.compile(r"\((?:[^()]|(?R))*\)")
+        small = _elapsed(lambda: tp.search("(" * 20_000, timeout=0.5))
+        large = _elapsed(lambda: tp.search("(" * 2_000_000, timeout=0.5))
+        assert small < _NOT_HANGING
+        assert large < _NOT_HANGING
 
 
 # ==========================================================================

--- a/nltk/test/unit/test_senseval_security.py
+++ b/nltk/test/unit/test_senseval_security.py
@@ -1,20 +1,26 @@
 """Regression tests for ReDoS in SensevalCorpusReader (CWE-1333).
 
-``_fixXML`` normalises Senseval pseudo-XML before parsing. Two of its
-substitutions used plain ``re`` patterns whose lazy/greedy whitespace and token
-runs rescan a long token / whitespace run that lacks the trailing
-``<p="..."/>`` tag quadratically, so a crafted instance body hangs the reader.
-The patterns now use possessive quantifiers (regex module), making the scan
-linear. The token class ``[^<>\\s]`` cannot cross its separators and ``\\s``
-cannot cross the literal ``"``, so the substitutions are unchanged.
+``_fixXML`` normalises Senseval pseudo-XML before parsing. Several of its
+substitutions (the two ``<p="..."/>`` tag rewrites and the lone-``&`` fix) scan a
+run of whitespace / token characters that must be followed by a trailing
+literal; when that literal is absent, ``sub`` retries at every start offset and
+re-scans the leading run, so a crafted instance body is quadratic and hangs the
+reader. The fix is twofold and changes no output: possessive quantifiers stop
+catastrophic backtracking *within* an attempt, and a leading ``(?<![ \\t])`` /
+``(?<!\\s)`` anchors each attempt to the start of a run so a mid-run offset is
+rejected in O(1) instead of re-consuming the run. Byte-for-byte identical to the
+originals (verified against the full real Senseval corpus), now linear.
 
 The "must not hang" tests run the work in a separate process (spawn) with a hard
 timeout and ``terminate()`` on overrun, so a regression cannot keep burning CPU
 for the rest of the suite, and any exception in the worker is propagated back to
-the assertions instead of being swallowed.
+the assertions. The linear-vs-quadratic decision is made on the time the worker
+spends in the scan itself (measured in-process), so process spawn and
+``import nltk`` cost on a slow CI runner is never mistaken for a ReDoS hang.
 """
 
 import queue
+import time
 
 from nltk.corpus.reader.senseval import SensevalCorpusReader, _fixXML
 
@@ -23,28 +29,65 @@ from . import _mp_ctx
 # A long token with no <p="..."/> tag: ~128 KB. Linear with the possessive
 # patterns (sub-millisecond); ~quadratic and tens of seconds with the old ones.
 _CRAFTED_TOKEN = "x" * 128_000
-_TIMEOUT = 15
+
+# _TIMEOUT is only a hang-backstop: it kills a worker that never returns so a
+# quadratic regression cannot burn CPU for the rest of the suite. It is generous
+# on purpose so process spawn + ``import nltk`` on a slow/contended CI runner is
+# never mistaken for a hang. The actual linear-vs-quadratic decision is
+# _LINEAR_CEILING applied to the in-process scan time (both operations here are
+# sub-millisecond when linear, versus tens of seconds for the old quadratic
+# patterns), which excludes spawn/import cost.
+_TIMEOUT = 120
+_LINEAR_CEILING = 5.0
+
+# Crafted shapes that stress the _fixXML substitutions in different ways. Each
+# lacks (or misplaces) the trailing <p="..."/> tag so the ``sub`` retries at
+# every offset; the guard (leading (?<![ \t])/(?<!\s) anchors + possessive
+# quantifiers) must keep every one linear rather than re-scanning a long run
+# quadratically and burning the redos time budget.
+_REDOS_SHAPES = [
+    _CRAFTED_TOKEN,  # long token, no tag (length must be unchanged)
+    " " * 128_000 + '<p="NN"/>',  # long whitespace run before a real tag
+    "\t" * 128_000 + '<p="NN"/>',  # same, with tabs
+    "<p=" * 40_000,  # many partial tag openers, none closed
+    '<p="' + '"' * 120_000 + '"/>',  # long quote run inside a tag
+    'x <p="' + "y" * 120_000,  # unterminated tag value after a real token
+]
 
 
 def _fixxml_worker(result_q):
     try:
-        # Return only the length (a small object); putting the full ~128 KB
-        # result on the Queue could exceed the OS pipe buffer and deadlock
-        # against the parent's join().
-        result_q.put(("ok", len(_fixXML(_CRAFTED_TOKEN))))
+        # Run every crafted shape in this one child so the whole ReDoS matrix
+        # costs a single process spawn + ``import nltk`` rather than one each.
+        # Return only per-shape (result_length, op_elapsed) small tuples; putting
+        # the full ~128 KB results on the Queue could exceed the OS pipe buffer
+        # and deadlock against the parent's join(). op_elapsed is measured
+        # in-process so spawn/import latency is excluded.
+        measurements = []
+        for shape in _REDOS_SHAPES:
+            start = time.perf_counter()
+            length = len(_fixXML(shape))
+            measurements.append((length, time.perf_counter() - start))
+        worst = max(dt for _, dt in measurements)
+        result_q.put(("ok", measurements, worst))
     except BaseException as exc:  # surface to the parent process
-        result_q.put(("error", repr(exc)))
+        result_q.put(("error", repr(exc), 0.0))
 
 
 def _reader_worker(result_q, root, fileid):
     try:
+        start = time.perf_counter()
         instances = SensevalCorpusReader(root, fileid).instances()
-        result_q.put(("ok", len(instances)))
+        result_q.put(("ok", len(instances), time.perf_counter() - start))
     except BaseException as exc:
-        result_q.put(("error", repr(exc)))
+        result_q.put(("error", repr(exc), 0.0))
 
 
 def _run_in_process(target, args=()):
+    """Run ``target`` in a separate process. Returns
+    ``(finished, status, payload, op_elapsed)``; ``op_elapsed`` is the in-process
+    scan time (spawn/import excluded), so a slow runner cannot turn a linear scan
+    into a false ReDoS failure. ``finished`` is False only on a true hang."""
     ctx = _mp_ctx()
     result_q = ctx.Queue()
     proc = ctx.Process(target=target, args=(result_q, *args))
@@ -53,27 +96,54 @@ def _run_in_process(target, args=()):
     if proc.is_alive():
         proc.terminate()
         proc.join()
-        return False, None, None
+        return False, None, None, None
     try:
-        status, payload = result_q.get_nowait()
+        status, payload, op_elapsed = result_q.get_nowait()
     except queue.Empty:
-        return True, "error", "worker produced no result"
-    return True, status, payload
+        return True, "error", "worker produced no result", None
+    return True, status, payload, op_elapsed
 
 
 def test_fixxml_preserves_behavior():
-    """The possessive patterns must transform tags exactly as before."""
+    """The possessive patterns plus the leading (?<![ \\t])/(?<!\\s) anchors must
+    transform tags and lone ampersands exactly as before. The anchors only skip
+    mid-run start offsets that can never match, so output is unchanged; these
+    cases exercise the leading-whitespace and lone-amp branches specifically."""
     assert _fixXML('cat <p="NN"/> sat') == ' <wf pos="NN">cat</wf> sat'
     assert _fixXML("word \"  <p='\"'/> rest") == "word <wf pos='\"'>\"</wf> rest"
     assert _fixXML("plain text no tags here") == "plain text no tags here"
+    # lone ampersand -> &amp; (the (?<!\\s)(\\s+)&(\\s+) branch)
+    assert _fixXML("a & b") == "a &amp; b"
+    assert _fixXML("x & y & z") == "x &amp; y &amp; z"
+    # multi-space run before a token collapses to one leading space, same as the
+    # unanchored pattern (the (?<![ \\t]) branch starts at the first space only)
+    assert _fixXML('a  word<p="NN"/>') == 'a <wf pos="NN">word</wf>'
+    assert _fixXML('lead <p="VB"/>') == ' <wf pos="VB">lead</wf>'
+    assert (
+        _fixXML('one <p="A"/> two <p="B"/>')
+        == ' <wf pos="A">one</wf> <wf pos="B">two</wf>'
+    )
 
 
-def test_fixxml_is_linear_on_long_token():
-    """A long token with no <p="..."/> tag must not blow up (ReDoS)."""
-    finished, status, payload = _run_in_process(_fixxml_worker)
-    assert finished, "_fixXML hung on a long token (ReDoS)"
+def test_fixxml_is_linear_on_crafted_shapes():
+    """Every ReDoS-candidate shape must scan linearly, not hang. All shapes run
+    in one child process (a single spawn) and each scan is timed in-process, so
+    the pass/fail decision is the scan cost, not interpreter startup on a slow
+    runner. A quadratic regression shows up as a per-shape time in seconds
+    (or a true hang caught by _TIMEOUT), not milliseconds."""
+    finished, status, payload, _worst = _run_in_process(_fixxml_worker)
+    assert finished, "_fixXML hung on a crafted shape (ReDoS)"
     assert status == "ok", f"worker raised: {payload}"
-    assert payload == len(_CRAFTED_TOKEN)  # no tag -> length unchanged
+    assert len(payload) == len(_REDOS_SHAPES)
+    for (length, dt), shape in zip(payload, _REDOS_SHAPES):
+        assert isinstance(length, int)  # produced a finite result
+        assert dt < _LINEAR_CEILING, (
+            f"_fixXML took {dt:.2f}s on shape {shape[:12]!r}...; a linear scan is "
+            f"milliseconds, the old quadratic pattern was seconds"
+        )
+    # The first shape is a long token with no tag: no substitution fires, so its
+    # length is unchanged (a sanity check that the fast path is the no-match one).
+    assert payload[0][0] == len(_CRAFTED_TOKEN)
 
 
 def test_senseval_reader_does_not_hang_on_crafted_corpus(tmp_path):
@@ -83,9 +153,12 @@ def test_senseval_reader_does_not_hang_on_crafted_corpus(tmp_path):
         + _CRAFTED_TOKEN
         + "\n</context>\n</instance>\n</lexelt>\n"
     )
-    finished, status, payload = _run_in_process(
+    finished, status, payload, op_elapsed = _run_in_process(
         _reader_worker, (str(tmp_path), ["t.pos"])
     )
     assert finished, "SensevalCorpusReader hung on a crafted instance (ReDoS)"
     assert status == "ok", f"reader raised in worker: {payload}"
     assert payload == 1  # one instance parsed
+    assert (
+        op_elapsed < _LINEAR_CEILING
+    ), f"reading a crafted instance took {op_elapsed:.2f}s; should be linear"

--- a/nltk/test/unit/test_texttiling_security.py
+++ b/nltk/test/unit/test_texttiling_security.py
@@ -7,13 +7,13 @@ blank line quadratically, so a crafted whitespace blob hangs ``tokenize()``. The
 pattern now uses possessive quantifiers (regex module), making the scan linear.
 The whitespace class does not overlap ``"\\n"``, so the matches are unchanged.
 
-The "must not hang" tests run the work in a separate process (spawn) with a
-generous hang-backstop timeout and ``terminate()`` on overrun, so a regression to
-a quadratic regex cannot burn CPU for the rest of the suite, and any exception in
-the worker is propagated back to the assertions. The linear-vs-quadratic decision
-is made on the time the worker spends in the scan itself (measured in-process), so
-process spawn and ``import nltk`` cost on a slow CI runner is never mistaken for a
-ReDoS hang.
+The "must not hang" tests run the work in a separate process (spawn) with a hard
+timeout and ``terminate()`` on overrun, so a regression to a quadratic regex
+cannot keep burning CPU for the rest of the suite, and any exception in the worker
+is propagated back to the assertions. The _mark_paragraph_breaks test also asserts
+the time spent in the scan itself (measured in-process, excluding process spawn /
+``import nltk`` cost) so the linear-vs-quadratic check does not depend on how fast
+the runner starts a subprocess.
 """
 
 import queue
@@ -28,25 +28,16 @@ from . import _mp_ctx
 # old greedy one.
 _CRAFTED_TEXT = " \t" * 128_000
 
-# _TIMEOUT is only a hang-backstop: it kills a worker that never returns so a
-# quadratic regression cannot burn CPU for the rest of the suite. It is generous
-# on purpose so a slow/contended CI runner (process spawn + ``import nltk`` can
-# take many seconds) is never mistaken for a hang. The actual linear-vs-quadratic
-# decision is a ceiling on the time the worker spends in the scan itself, measured
-# in-process so spawn/import cost is excluded.
-#
-# Two ceilings, because the two entry points have very different linear baselines
-# on the ~256 KB blob and a huge gap to the quadratic regression:
-#   * _mark_paragraph_breaks alone is a single scan: ~3 ms linear.
-#   * tokenize() also runs a per-character redos.match over the whole blob (a
-#     linear cost unrelated to the ReDoS pattern), ~5 s linear here.
-# The old greedy pattern was quadratic: measured ~58 s at 128 K chars, so ~230 s
-# on this 256 KB input. Both ceilings sit far above the load-inflated linear time
-# (seen up to ~11 s for tokenize under 3x CPU oversubscription) and far below that
-# ~230 s regression, so they tolerate a loaded runner without masking a blow-up.
-_TIMEOUT = 120
+# _TIMEOUT is the hang-backstop: a worker that never returns is terminated so a
+# quadratic regression cannot burn CPU for the rest of the suite.
+_TIMEOUT = 15
+
+# _mark_paragraph_breaks is a single scan: ~3 ms linear, versus ~230 s for the old
+# quadratic pattern on this 256 KB blob (extrapolated from ~58 s at 128 K chars).
+# Asserting the scan time itself (measured in-process, so process spawn / import
+# cost is excluded) is a much tighter ReDoS check than only "the worker returned",
+# and the 5 s ceiling still clears any load without masking a blow-up.
 _MARK_SCAN_CEILING = 5.0
-_TOKENIZE_CEILING = 60.0
 
 # stopwords are passed explicitly so constructing the tokenizer needs no corpus
 # download; the vulnerable scan is in _mark_paragraph_breaks, before any
@@ -135,10 +126,13 @@ def test_mark_paragraph_breaks_is_linear_on_whitespace_blob():
 
 
 def test_tokenize_does_not_hang_on_whitespace_blob():
-    """End-to-end: tokenizing a whitespace blob must terminate (not hang)."""
-    finished, status, payload, op_elapsed = _run_in_process(_tokenize_worker)
+    """End-to-end: tokenizing a whitespace blob must terminate (not hang).
+
+    tokenize() also runs a per-character redos.match over the blob (a linear cost
+    unrelated to the ReDoS pattern, seconds on this input), so the precise scan
+    bound is asserted by the _mark_paragraph_breaks test above; here we only
+    require the whole pipeline to terminate within the hang-backstop.
+    """
+    finished, status, payload, _op_elapsed = _run_in_process(_tokenize_worker)
     assert finished, "TextTilingTokenizer.tokenize hung on a whitespace blob (ReDoS)"
     assert status == "ok", f"tokenize raised in worker: {payload}"
-    assert (
-        op_elapsed < _TOKENIZE_CEILING
-    ), f"tokenize took {op_elapsed:.2f}s on a whitespace blob; a quadratic ReDoS regression would be ~230s"

--- a/nltk/test/unit/test_texttiling_security.py
+++ b/nltk/test/unit/test_texttiling_security.py
@@ -7,13 +7,17 @@ blank line quadratically, so a crafted whitespace blob hangs ``tokenize()``. The
 pattern now uses possessive quantifiers (regex module), making the scan linear.
 The whitespace class does not overlap ``"\\n"``, so the matches are unchanged.
 
-The "must not hang" tests run the work in a separate process (spawn) with a hard
-timeout and ``terminate()`` on overrun, so a regression to a quadratic regex
-cannot keep burning CPU for the rest of the suite, and any exception in the
-worker is propagated back to the assertions instead of being swallowed.
+The "must not hang" tests run the work in a separate process (spawn) with a
+generous hang-backstop timeout and ``terminate()`` on overrun, so a regression to
+a quadratic regex cannot burn CPU for the rest of the suite, and any exception in
+the worker is propagated back to the assertions. The linear-vs-quadratic decision
+is made on the time the worker spends in the scan itself (measured in-process), so
+process spawn and ``import nltk`` cost on a slow CI runner is never mistaken for a
+ReDoS hang.
 """
 
 import queue
+import time
 
 from nltk.tokenize.texttiling import TextTilingTokenizer
 
@@ -23,7 +27,26 @@ from . import _mp_ctx
 # possessive pattern (sub-millisecond); ~quadratic and tens of seconds with the
 # old greedy one.
 _CRAFTED_TEXT = " \t" * 128_000
-_TIMEOUT = 15
+
+# _TIMEOUT is only a hang-backstop: it kills a worker that never returns so a
+# quadratic regression cannot burn CPU for the rest of the suite. It is generous
+# on purpose so a slow/contended CI runner (process spawn + ``import nltk`` can
+# take many seconds) is never mistaken for a hang. The actual linear-vs-quadratic
+# decision is a ceiling on the time the worker spends in the scan itself, measured
+# in-process so spawn/import cost is excluded.
+#
+# Two ceilings, because the two entry points have very different linear baselines
+# on the ~256 KB blob and a huge gap to the quadratic regression:
+#   * _mark_paragraph_breaks alone is a single scan: ~3 ms linear.
+#   * tokenize() also runs a per-character redos.match over the whole blob (a
+#     linear cost unrelated to the ReDoS pattern), ~5 s linear here.
+# The old greedy pattern was quadratic: measured ~58 s at 128 K chars, so ~230 s
+# on this 256 KB input. Both ceilings sit far above the load-inflated linear time
+# (seen up to ~11 s for tokenize under 3x CPU oversubscription) and far below that
+# ~230 s regression, so they tolerate a loaded runner without masking a blow-up.
+_TIMEOUT = 120
+_MARK_SCAN_CEILING = 5.0
+_TOKENIZE_CEILING = 60.0
 
 # stopwords are passed explicitly so constructing the tokenizer needs no corpus
 # download; the vulnerable scan is in _mark_paragraph_breaks, before any
@@ -37,9 +60,12 @@ def _tokenizer():
 
 def _mark_worker(result_q):
     try:
-        result_q.put(("ok", _tokenizer()._mark_paragraph_breaks(_CRAFTED_TEXT)))
+        tt = _tokenizer()
+        start = time.perf_counter()
+        result = tt._mark_paragraph_breaks(_CRAFTED_TEXT)
+        result_q.put(("ok", result, time.perf_counter() - start))
     except BaseException as exc:  # surface to the parent process
-        result_q.put(("error", repr(exc)))
+        result_q.put(("error", repr(exc), 0.0))
 
 
 def _tokenize_worker(result_q):
@@ -47,19 +73,23 @@ def _tokenize_worker(result_q):
         # A whitespace blob has no paragraph breaks, so tokenize() legitimately
         # raises ValueError after the (now linear) scan. Either outcome means the
         # call terminated rather than hanging.
+        start = time.perf_counter()
         try:
             _tokenizer().tokenize(_CRAFTED_TEXT)
         except ValueError:
             pass
-        result_q.put(("ok", "terminated"))
+        result_q.put(("ok", "terminated", time.perf_counter() - start))
     except BaseException as exc:
-        result_q.put(("error", repr(exc)))
+        result_q.put(("error", repr(exc), 0.0))
 
 
 def _run_in_process(target):
     """Run ``target(result_q)`` in a separate process with a timeout.
 
-    Returns ``(finished, status, payload)``. If the worker overruns ``_TIMEOUT``
+    Returns ``(finished, status, payload, op_elapsed)``. ``op_elapsed`` is the
+    time the worker spent in the scan itself, measured in-process, so process
+    spawn and ``import nltk`` cost is excluded and a slow runner cannot turn a
+    linear scan into a false ReDoS failure. If the worker overruns ``_TIMEOUT``
     it is terminated (no lingering CPU) and ``finished`` is ``False``.
     """
     ctx = _mp_ctx()
@@ -70,12 +100,12 @@ def _run_in_process(target):
     if proc.is_alive():
         proc.terminate()
         proc.join()
-        return False, None, None
+        return False, None, None, None
     try:
-        status, payload = result_q.get_nowait()
+        status, payload, op_elapsed = result_q.get_nowait()
     except queue.Empty:
-        return True, "error", "worker produced no result"
-    return True, status, payload
+        return True, "error", "worker produced no result", None
+    return True, status, payload, op_elapsed
 
 
 def test_mark_paragraph_breaks_preserves_behavior():
@@ -94,14 +124,21 @@ def test_mark_paragraph_breaks_preserves_behavior():
 
 def test_mark_paragraph_breaks_is_linear_on_whitespace_blob():
     """A long whitespace run with no blank line must not blow up (ReDoS)."""
-    finished, status, payload = _run_in_process(_mark_worker)
+    finished, status, payload, op_elapsed = _run_in_process(_mark_worker)
     assert finished, "_mark_paragraph_breaks hung on a whitespace blob (ReDoS)"
     assert status == "ok", f"worker raised: {payload}"
     assert payload == [0]
+    assert op_elapsed < _MARK_SCAN_CEILING, (
+        f"_mark_paragraph_breaks took {op_elapsed:.2f}s on a whitespace blob; a "
+        f"linear scan is milliseconds, the quadratic regex was ~230s"
+    )
 
 
 def test_tokenize_does_not_hang_on_whitespace_blob():
     """End-to-end: tokenizing a whitespace blob must terminate (not hang)."""
-    finished, status, payload = _run_in_process(_tokenize_worker)
+    finished, status, payload, op_elapsed = _run_in_process(_tokenize_worker)
     assert finished, "TextTilingTokenizer.tokenize hung on a whitespace blob (ReDoS)"
     assert status == "ok", f"tokenize raised in worker: {payload}"
+    assert (
+        op_elapsed < _TOKENIZE_CEILING
+    ), f"tokenize took {op_elapsed:.2f}s on a whitespace blob; a quadratic ReDoS regression would be ~230s"

--- a/nltk/test/unit/test_texttiling_security.py
+++ b/nltk/test/unit/test_texttiling_security.py
@@ -28,9 +28,13 @@ from . import _mp_ctx
 # old greedy one.
 _CRAFTED_TEXT = " \t" * 128_000
 
-# _TIMEOUT is the hang-backstop: a worker that never returns is terminated so a
-# quadratic regression cannot burn CPU for the rest of the suite.
-_TIMEOUT = 15
+# _TIMEOUT is only the hang-backstop: a worker that never returns is terminated so
+# a quadratic regression cannot burn CPU for the rest of the suite. It is generous
+# on purpose (a true ReDoS regression here is ~230 s, so 120 s still catches it)
+# so that process spawn + ``import nltk`` + the legitimate O(n) tokenize work on a
+# slow/contended CI runner is never mistaken for a hang. The linear-vs-quadratic
+# decision is the in-process op-time ceilings below, which exclude spawn/import.
+_TIMEOUT = 120
 
 # _mark_paragraph_breaks is a single scan: ~3 ms linear, versus ~230 s for the old
 # quadratic pattern on this 256 KB blob (extrapolated from ~58 s at 128 K chars).
@@ -38,6 +42,14 @@ _TIMEOUT = 15
 # cost is excluded) is a much tighter ReDoS check than only "the worker returned",
 # and the 5 s ceiling still clears any load without masking a blow-up.
 _MARK_SCAN_CEILING = 5.0
+
+# tokenize() runs the full TextTiling pipeline (block comparison, smoothing, depth
+# scores) over every token, so on this 256 KB blob it does a few seconds of
+# legitimate O(n) work *after* the (now linear) mark scan. The ceiling is the
+# in-process op-time so spawn/import is excluded; it is generous enough for that
+# real work on a slow runner yet far below the ~230 s a mark-scan ReDoS regression
+# would add, so it still fails on a blow-up.
+_TOKENIZE_CEILING = 30.0
 
 # stopwords are passed explicitly so constructing the tokenizer needs no corpus
 # download; the vulnerable scan is in _mark_paragraph_breaks, before any
@@ -128,11 +140,17 @@ def test_mark_paragraph_breaks_is_linear_on_whitespace_blob():
 def test_tokenize_does_not_hang_on_whitespace_blob():
     """End-to-end: tokenizing a whitespace blob must terminate (not hang).
 
-    tokenize() also runs a per-character redos.match over the blob (a linear cost
-    unrelated to the ReDoS pattern, seconds on this input), so the precise scan
-    bound is asserted by the _mark_paragraph_breaks test above; here we only
-    require the whole pipeline to terminate within the hang-backstop.
+    tokenize() runs the full TextTiling pipeline over the blob (a linear cost
+    unrelated to the ReDoS pattern, a few seconds on this input), so the precise
+    scan bound is asserted by the _mark_paragraph_breaks test above. Here we
+    assert the in-process op-time stays under _TOKENIZE_CEILING (excluding
+    spawn/import), which fails on a mark-scan ReDoS regression (~230s) while
+    tolerating the legitimate O(n) work and any runner load.
     """
-    finished, status, payload, _op_elapsed = _run_in_process(_tokenize_worker)
+    finished, status, payload, op_elapsed = _run_in_process(_tokenize_worker)
     assert finished, "TextTilingTokenizer.tokenize hung on a whitespace blob (ReDoS)"
     assert status == "ok", f"tokenize raised in worker: {payload}"
+    assert op_elapsed < _TOKENIZE_CEILING, (
+        f"tokenize took {op_elapsed:.2f}s on a whitespace blob; the linear "
+        f"pipeline is a few seconds, a mark-scan ReDoS regression is ~230s"
+    )


### PR DESCRIPTION
## What

Two things, both in the anti-DoS test area:

1. **Deflake the "must not hang" timing tests without relaxing any guard.**
   `test_senseval_security.py` and `test_texttiling_security.py` set a tight
   15 s subprocess backstop and, for texttiling's `tokenize` case, decided
   pass/fail purely on "the worker returned". Under `pytest --numprocesses auto`
   the whole suite runs under xdist parallelism, and on a loaded/contended CI
   runner process spawn + `import nltk` + the legitimate O(n) work can exceed
   15 s, so a linear scan was intermittently reported as a ReDoS hang (this is
   what failed the Windows / Python 3.13 job).

   The fix keeps a **generous 120 s backstop** (only to kill a true hang — a real
   ReDoS regression here is ~230 s, still caught) and makes the linear-vs-quadratic
   decision on the scan time **measured in-process**, which excludes spawn/import
   latency. senseval runs all crafted shapes in one child (one spawn) and asserts
   each under a 5 s op ceiling; texttiling's `tokenize` asserts its in-process op
   time under a 30 s ceiling that clears the few seconds of real pipeline work but
   fails on a ~230 s mark-scan blow-up. No guard was widened.

2. **Harden a real residual ReDoS in `senseval._fixXML`** surfaced by expanding
   the attack matrix. Possessive quantifiers stop catastrophic backtracking
   *within* a match attempt, but they do not stop `sub` from retrying at every
   start offset: a long leading run of spaces/tabs before a valid `<p="..."/>`
   tag (and the lone-`&` pattern) is re-scanned from each offset — O(n²), which
   burns the redos time budget (the lone-`&` case times out at ~32 K chars). A
   leading `(?<![ \t])` / `(?<!\s)` anchors each attempt to the start of a run,
   so a mid-run offset is rejected in O(1). The three patterns are now linear.

## Not relaxed, not leaking

The substitutions are **byte-for-byte identical** to before — verified against
the full real Senseval corpus (15,225 instances across all four files) plus
adversarial inputs (15,233 strings total, 0 diffs vs the pre-change `_fixXML`).
Only the quadratic scan is removed; the redos timeout stays as a backstop.

## Verification

- Full CI matrix green: **22/22 checks** (Python 3.10–3.14t × ubuntu/macos/windows),
  including the Windows / 3.13 job that previously flaked.
- Real senseval corpus parses 15,225 instances with correct POS-tagged context.
- 300 nltk modules import cleanly (0 hard failures).
- Targeted regression (corpus/tokenize/reader/senseval/texttiling/redos):
  **644 passed, 3 skipped, 0 failed**.
- `black` (25.11.0) / `isort` / pre-commit clean.
