### PR TITLE
[WIP] Extend the tool model-file guards to crf, stanford tagger and segmenter

### DIFF
--- a/nltk/tag/crf.py
+++ b/nltk/tag/crf.py
@@ -14,7 +14,7 @@ import unicodedata
 import warnings
 
 from nltk import redos
-from nltk.pathsec import validate_tool_path
+from nltk.pathsec import MAX_TOOL_MODEL_BYTES, validate_tool_path
 from nltk.tag.api import TaggerI
 
 try:
@@ -131,7 +131,15 @@ class CRFTagger(TaggerI):
         C extension does its own open, so containment is the check that can be
         applied; a symlink swapped in after it is not covered.
         """
-        validate_tool_path(model_file, context="CRFTagger.set_model_file")
+        # crfsuite (C) opens and parses the whole model itself; beyond
+        # containment, refuse a model another local user could plant/swap
+        # (require_private) or an oversized memory bomb (max_bytes).
+        validate_tool_path(
+            model_file,
+            context="CRFTagger.set_model_file",
+            max_bytes=MAX_TOOL_MODEL_BYTES,
+            require_private=True,
+        )
         self._model_file = model_file
         self._tagger.open(self._model_file)
 

--- a/nltk/tag/stanford.py
+++ b/nltk/tag/stanford.py
@@ -24,7 +24,7 @@ from subprocess import PIPE
 
 from nltk.data import staging_tempdir
 from nltk.internals import find_file, find_jar, java
-from nltk.pathsec import validate_tool_path
+from nltk.pathsec import MAX_TOOL_MODEL_BYTES, validate_tool_path
 from nltk.tag.api import TaggerI
 
 _stanford_url = "https://nlp.stanford.edu/software"
@@ -78,7 +78,12 @@ class StanfordTagger(TaggerI):
         )
         # Fail fast: the model is a JVM subprocess argument, so bound it here as
         # well as at the hand-off, and never keep an out-of-sandbox path around.
-        validate_tool_path(self._stanford_model, context=f"{type(self).__name__}")
+        validate_tool_path(
+            self._stanford_model,
+            context=f"{type(self).__name__}",
+            max_bytes=MAX_TOOL_MODEL_BYTES,
+            require_private=True,
+        )
 
         self._encoding = encoding
         self.java_options = java_options
@@ -118,7 +123,12 @@ class StanfordTagger(TaggerI):
 
             # ``self._stanford_model`` (from find_file) is handed to the JVM subprocess
             # pathsec.open cannot wrap; bound it before spawning (GHSA-8mgp-746c-j5xp).
-            validate_tool_path(self._stanford_model, context="StanfordTagger.tag_sents")
+            validate_tool_path(
+                self._stanford_model,
+                context="StanfordTagger.tag_sents",
+                max_bytes=MAX_TOOL_MODEL_BYTES,
+                require_private=True,
+            )
 
             # Run the tagger and get the output
             stanpos_output, _stderr = java(

--- a/nltk/test/unit/test_crf.py
+++ b/nltk/test/unit/test_crf.py
@@ -2,6 +2,8 @@
 Regression tests for ``nltk.tag.crf.CRFTagger``.
 """
 
+import os
+
 import pytest
 
 pytest.importorskip("pycrfsuite")
@@ -123,3 +125,39 @@ def test_train_tag_round_trip(tmp_path):
     reloaded = CRFTagger()
     reloaded.set_model_file(str(model_file))
     assert reloaded.tag(_SAMPLE_SENT) == tagged
+
+
+@pytest.mark.skipif(not hasattr(os, "getuid"), reason="POSIX ownership model")
+def test_set_model_file_refuses_group_or_world_writable_model(tmp_path):
+    """A group/world-writable model another local user could swap is refused
+    before crfsuite (C) parses it (require_private, CWE-426/CWE-732)."""
+    model = tmp_path / "model.crf.tagger"
+    CRFTagger().train(_TRAIN, str(model))
+    os.chmod(model, 0o666)
+    with pytest.raises(PermissionError):
+        CRFTagger().set_model_file(str(model))
+
+
+def test_set_model_file_refuses_oversize_model(tmp_path, monkeypatch):
+    """A model over MAX_TOOL_MODEL_BYTES is refused (a memory bomb crfsuite would
+    load whole, CWE-400); a tiny monkeypatched cap avoids needing a giant file."""
+    import nltk.tag.crf as crf_mod
+
+    model = tmp_path / "model.crf.tagger"
+    CRFTagger().train(_TRAIN, str(model))
+    assert model.stat().st_size > 8
+    monkeypatch.setattr(crf_mod, "MAX_TOOL_MODEL_BYTES", 8)
+    with pytest.raises(PermissionError):
+        CRFTagger().set_model_file(str(model))
+
+
+def test_legit_private_model_still_loads_and_tags(tmp_path):
+    """Control: a normal (private, in-size) trained model still loads through the
+    guard and tags, so the new checks do not over-block real usage."""
+    model = tmp_path / "model.crf.tagger"
+    CRFTagger().train(_TRAIN, str(model))
+    ct = CRFTagger()
+    ct.set_model_file(str(model))
+    tagged = ct.tag_sents([_SAMPLE_SENT])[0]
+    assert [w for w, _ in tagged] == _SAMPLE_SENT
+    assert all(t in _TAGS for _, t in tagged)

--- a/nltk/test/unit/test_tokenize_stanford_pathsec.py
+++ b/nltk/test/unit/test_tokenize_stanford_pathsec.py
@@ -253,3 +253,49 @@ def test_stanford_tokenizer_input_file_staged_in_data_root(
 
     staged = os.path.realpath(sink["cmd"][-1])
     assert staged.startswith(os.path.realpath(str(root)) + os.sep)
+
+
+# --- StanfordSegmenter model-file guards: require_private + max_bytes -----------
+# The primary model/dict are files the JVM loads whole and parses, so they get the
+# same tamper/size guards as any tool model (parity with the POS tagger).
+
+_requires_posix = pytest.mark.skipif(
+    not hasattr(os, "getuid"), reason="POSIX ownership/permission model"
+)
+
+
+@_requires_posix
+def test_segmenter_model_refuses_group_or_world_writable(pathsec_sandbox, monkeypatch):
+    """A group/world-writable model another local user could swap is refused
+    before the JVM parses it (require_private, CWE-426/CWE-732)."""
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, _ = pathsec_sandbox
+    _trap_java(monkeypatch, seg, {})
+    model = root / "pku.gz"
+    model.write_bytes(b"\x1f\x8bmodel")
+    os.chmod(model, 0o666)
+    inside = str(root / "in.txt")
+    with pathsec.open(inside, "w", encoding="utf-8") as handle:
+        handle.write("中文")
+    tool = _segmenter(monkeypatch, str(root), model=str(model))
+    with pytest.raises(PermissionError):
+        tool.segment_file(inside)
+
+
+def test_segmenter_model_refuses_oversize(pathsec_sandbox, monkeypatch):
+    """A model over MAX_TOOL_MODEL_BYTES is refused (a memory bomb the JVM would
+    load whole, CWE-400); a tiny monkeypatched cap avoids needing a giant file."""
+    import nltk.tokenize.stanford_segmenter as seg
+
+    root, _ = pathsec_sandbox
+    _trap_java(monkeypatch, seg, {})
+    model = root / "pku.gz"
+    model.write_bytes(b"\x1f\x8b" + b"x" * 4096)
+    monkeypatch.setattr(seg, "MAX_TOOL_MODEL_BYTES", 1024)
+    inside = str(root / "in.txt")
+    with pathsec.open(inside, "w", encoding="utf-8") as handle:
+        handle.write("中文")
+    tool = _segmenter(monkeypatch, str(root), model=str(model))
+    with pytest.raises(PermissionError):
+        tool.segment_file(inside)

--- a/nltk/tokenize/stanford_segmenter.py
+++ b/nltk/tokenize/stanford_segmenter.py
@@ -24,8 +24,15 @@ from nltk.internals import (
     find_jar,
     java,
 )
+from nltk.pathsec import (
+    MAX_TOOL_MODEL_BYTES,
+)
 from nltk.pathsec import open as pathsec_open
-from nltk.pathsec import validate_path, validate_tool_dir, validate_tool_path
+from nltk.pathsec import (
+    validate_path,
+    validate_tool_dir,
+    validate_tool_path,
+)
 from nltk.tokenize.api import TokenizerI
 
 _stanford_url = "https://nlp.stanford.edu/software"
@@ -60,8 +67,13 @@ def _validated_options(options):
         if isinstance(value, str) and (
             os.path.isabs(value) or "/" in value or "\\" in value
         ):
+            # A path-valued segmenter option is a model/dictionary/classifier
+            # the JVM reads; refuse a tamperable or oversized one too.
             value = validate_tool_path(
-                value, context=f"StanfordSegmenter options[{name}]"
+                value,
+                context=f"StanfordSegmenter options[{name}]",
+                max_bytes=MAX_TOOL_MODEL_BYTES,
+                require_private=True,
             )
         validated[name] = value
     return validated
@@ -404,17 +416,22 @@ class StanfordSegmenter(TokenizerI):
         :return: the validated (model, dictionary, sihan corpora dict) strings,
             each None when it was unset
         """
+        # The model and dictionary are files the JVM loads whole and parses, so
+        # they get the same guards as any tool model: refuse one another local
+        # user could plant/swap (require_private) or an oversized memory bomb
+        # (max_bytes). The Sihan corpora dict is a DIRECTORY, so it uses the
+        # directory guard (validate_tool_path requires a regular file) and those
+        # file-only kwargs do not apply.
+        _model_kw = {"max_bytes": MAX_TOOL_MODEL_BYTES, "require_private": True}
         validated = []
-        for attribute, label, guard in (
-            ("_model", "model", validate_tool_path),
-            ("_dict", "dictionary", validate_tool_path),
-            # The Sihan corpora dict is a DIRECTORY, so it needs the directory
-            # guard: validate_tool_path requires a regular file.
-            ("_sihan_corpora_dict", "sihan corpora dict", validate_tool_dir),
+        for attribute, label, guard, guard_kw in (
+            ("_model", "model", validate_tool_path, _model_kw),
+            ("_dict", "dictionary", validate_tool_path, _model_kw),
+            ("_sihan_corpora_dict", "sihan corpora dict", validate_tool_dir, {}),
         ):
             value = getattr(self, attribute)
             if value:
-                value = guard(value, context=f"StanfordSegmenter {label}")
+                value = guard(value, context=f"StanfordSegmenter {label}", **guard_kw)
                 setattr(self, attribute, value)
             validated.append(value)
         return tuple(validated)


### PR DESCRIPTION
> **[WIP]** — stacked on #3858 (harden-senna-cwd-exec). It uses the
> `validate_tool_path(..., require_private=, max_bytes=)` capability added there,
> so it depends on #3858; until #3858 merges, this PR's diff includes #3858's
> commits. Review the top commit ("Extend the model-file guards…") for the new
> work.

## Summary

#3858 gave the **hunpos** model file two guards against a malicious model an
attacker planted inside a data root (which the external tool then parses):
`require_private` (refuse a group/world-writable or non-owner model) and
`max_bytes` (refuse an oversized memory-bomb model). The same residual applies to
every other tool that hands a **model file** to a native/JVM parser. This extends
the guard for parity:

| Tool | Parser | Guarded call-site |
|---|---|---|
| `CRFTagger.set_model_file` | crfsuite (C) | `require_private` + `max_bytes` |
| `StanfordTagger` (`__init__`, `tag_sents`) | JVM | `require_private` + `max_bytes` |
| `StanfordSegmenter._validate_model_paths` | JVM | `require_private` + `max_bytes` on the model + dictionary files (the Sihan corpora **dir** keeps the directory guard) |

`max_bytes` stays `MAX_TOOL_MODEL_BYTES` (512 MiB), verified far above every real
model. `require_private` is POSIX (best-effort on Windows, like the exec-trust).

## Real tools, not mocks

All three were exercised on the actual binaries/models (installed persistently
under `~/nltk_tools/`):

- **crf** — trained a real `pycrfsuite` model, loaded + tagged through the guard (`dog→Noun`), world-writable and oversized copies refused.
- **Stanford POS tagger** — `stanford-tagger-4.2.0`, real output `What→WP is→VBZ …`; largest model 68 MiB (under the cap); world-writable copy refused.
- **Stanford segmenter** — `stanford-segmenter-4.2.0`, real Chinese output `这 是 斯坦福 中文 分词器 测试`; models 114–122 MiB (under the cap); world-writable copy refused. (A real run first exposed that the segmenter's *primary* model path validated **without** the guards — only the `options=` dict was covered — so the guard was moved to `_validate_model_paths`, the actual sink, and re-verified.)

## Verification

- crf/stanford/segmenter guard tests (world/group-writable + oversize refused; legit private model still loads/tags/segments).
- Affected suites: **985 passed / 4 skipped**. All nltk modules import (0 failures). `black`/`isort`/pre-commit clean.
- The tagger source-audit was made formatting-tolerant so black-wrapping the (now multi-arg) `validate_tool_path` calls does not break it.

## Out of scope (correctly)

The senna/boxer/mace/prover9/tadm/megam/repp/translate wrappers do **not** hand a caller-provided model *file* to the external tool (they feed tokens, logic, generated feature data, install dirs, or a generated DOT string), so `max_bytes`/`require_private` do not apply there — their guards are the input-appropriate ones (control-char, timeout, numeric-injection) plus exec-trust.
