### PR TITLE
Avoid projecting cluster assignment vectors twice

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -319,6 +319,7 @@
 - Nicola <https://github.com/trinik15>
 - medisean <https://github.com/medisean>
 - tandede <https://github.com/tandede>
+- vzer200 <https://github.com/vzer200>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 

--- a/nltk/cluster/util.py
+++ b/nltk/cluster/util.py
@@ -39,6 +39,7 @@ class VectorSpaceClusterer(ClusterI):
 
     def cluster(self, vectors, assign_clusters=False, trace=False):
         assert len(vectors) > 0
+        original_vectors = vectors
 
         # normalise the vectors
         if self._should_normalise:
@@ -60,7 +61,8 @@ class VectorSpaceClusterer(ClusterI):
 
         # assign the vectors to clusters
         if assign_clusters:
-            return [self.classify(vector) for vector in vectors]
+            # classify() applies normalisation and dimensionality reduction.
+            return [self.classify(vector) for vector in original_vectors]
 
     @abstractmethod
     def cluster_vectorspace(self, vectors, trace):

--- a/nltk/test/unit/test_cluster.py
+++ b/nltk/test/unit/test_cluster.py
@@ -1,0 +1,59 @@
+import random
+
+import pytest
+
+from nltk.cluster import EMClusterer, GAAClusterer, KMeansClusterer, euclidean_distance
+
+np = pytest.importorskip("numpy")
+
+
+@pytest.mark.parametrize("normalise", [False, True])
+@pytest.mark.parametrize("svd_dimensions", [None, 1, 2])
+@pytest.mark.parametrize("assign_clusters", [False, True])
+@pytest.mark.parametrize("algorithm", ["kmeans", "em"])
+def test_cluster_assignments_after_preprocessing(
+    normalise, svd_dimensions, assign_clusters, algorithm
+):
+    vectors = np.array(
+        [[3.0, 1.0, 0.0], [4.0, 1.0, 0.0], [-3.0, -1.0, 0.0], [-4.0, -1.0, 0.0]]
+    )
+    original_vectors = vectors.copy()
+    if algorithm == "kmeans":
+        clusterer = KMeansClusterer(
+            2,
+            euclidean_distance,
+            normalise=normalise,
+            svd_dimensions=svd_dimensions,
+            rng=random.Random(0),
+        )
+    else:
+        means = np.zeros((2, svd_dimensions or vectors.shape[1]))
+        means[:, 0] = [1.0, -1.0]
+        clusterer = EMClusterer(
+            means, normalise=normalise, svd_dimensions=svd_dimensions
+        )
+
+    assignments = clusterer.cluster(vectors, assign_clusters=assign_clusters)
+    classifications = [clusterer.classify(vector) for vector in vectors]
+
+    assert classifications[0] == classifications[1]
+    assert classifications[2] == classifications[3]
+    assert classifications[0] != classifications[2]
+    if assign_clusters:
+        assert assignments == classifications
+    else:
+        assert assignments is None
+    np.testing.assert_array_equal(vectors, original_vectors)
+
+
+@pytest.mark.parametrize("normalise", [False, True])
+def test_gaac_cluster_assignments(normalise):
+    vectors = np.array([[3.0, 1.0], [4.0, 1.0], [-3.0, -1.0], [-4.0, -1.0]])
+    clusterer = GAAClusterer(2, normalise=normalise)
+
+    assignments = clusterer.cluster(vectors, assign_clusters=True)
+
+    assert assignments == [clusterer.classify(vector) for vector in vectors]
+    assert assignments[0] == assignments[1]
+    assert assignments[2] == assignments[3]
+    assert assignments[0] != assignments[2]


### PR DESCRIPTION
With SVD enabled, `VectorSpaceClusterer.cluster(..., assign_clusters=True)` passes already-reduced vectors to `classify()`, which applies the projection again and raises a dimension mismatch. This affects both KMeans and EM clustering.

Retain the original input vectors for label assignment so each `classify()` call performs preprocessing once. This preserves the existing classification entry point and leaves fitting unchanged.

Fixes #2339.

Validation: 26 cluster tests pass on Windows with Python 3.12.14 and NumPy 2.5.3; the same regression matrix has 8 failures on the original implementation. Tests cover SVD sizes 1 and 2, normalization, optional label assignment, consistent later classification, unchanged inputs, and GAA assignment without SVD. All applicable pre-commit hooks and `git diff --check` pass. The full NLTK corpus/external-tool suite was not run.

AI-assisted implementation, independently reviewed by a second coding agent.
