### PR TITLE
Don't miscount a python-crfsuite Windows failure as a pathsec over-block (tag sweep)

### DIFF
--- a/nltk/test/unit/test_pathsec_sweep_tag.py
+++ b/nltk/test/unit/test_pathsec_sweep_tag.py
@@ -752,6 +752,15 @@ _BENIGN_UNICODE_NAMES = [
     ("emoji", "robot_\U0001f916.model"),
     ("zwj", "co‍op.model"),  # zero-width joiner inside the name
     ("mixed-space", "my café 模型.model"),
+    ("bidi-rlo", "file\u202edoc.model"),  # right-to-left override, a valid char
+    ("fullwidth-solidus", "a\uff0fb.model"),  # U+FF0F is NOT a path separator
+    # DEL, the C1 control NEL and the Unicode line separator are line-injection
+    # vectors on a tool's STDIN (blocked by has_line_unsafe_char), but this guard
+    # bounds a PATH argument in argv, where there is no line to inject into, so
+    # they are legitimate filename bytes here and must not be over-blocked.
+    ("del-0x7f", "mod\x7fel.model"),
+    ("c1-nel-0x85", "mod\x85el.model"),
+    ("line-separator-2028", "mod\u2028el.model"),
 ]
 
 
@@ -782,6 +791,9 @@ _UNICODE_ATTACKS = [
     ("trailing-dot-unicode", "модель."),
     ("trailing-space-unicode", "模型 "),
     ("newline-in-unicode", "模型\nevil.model"),
+    ("cr-in-unicode", "\u6a21\u578b\rx.model"),
+    ("vtab-in-unicode", "\u6a21\u578b\x0bx.model"),
+    ("formfeed-in-unicode", "\u6a21\u578b\x0cx.model"),
 ]
 
 
@@ -798,6 +810,31 @@ def test_validate_tool_path_refuses_unicode_disguised_attacks(restricted_sandbox
     with pytest.raises((PermissionError, ValueError)) as excinfo:
         pathsec.validate_tool_path(path, context="unicode-attack", must_exist=False)
     assert _is_guard_refusal(excinfo.value)
+
+
+def test_is_guard_refusal_distinguishes_guard_from_tool():
+    """Lock the refusal classifier: only a pathsec Security Violation is a guard
+    refusal. A tool raising the same exception type for its OWN reason must not be
+    miscounted as an over-block, and a real guard refusal must not be miscounted as
+    a tolerated tool failure (which would let a real escape leak)."""
+    assert _is_guard_refusal(PermissionError("Security Violation [ctx]: nope"))
+    assert _is_guard_refusal(ValueError("Security Violation [ctx]: bad name"))
+    assert not _is_guard_refusal(ValueError("crfsuite: cannot open the output file"))
+    assert not _is_guard_refusal(PermissionError("[Errno 13] Permission denied: x"))
+    assert not _is_guard_refusal(FileNotFoundError("[WinError 2] cannot find m.model"))
+    assert not _is_guard_refusal(OSError("disk full"))
+
+
+@pytest.mark.parametrize("sink", sorted(_FILE_SINKS))
+def test_file_sinks_refuse_outside_unicode_path_at_the_guard(pathsec_sandbox, sink):
+    """No-leak proof for the tolerance: an OUTSIDE path with a unicode name must be
+    refused by the GUARD (a Security Violation raised before the tool ever runs),
+    never merely by a downstream tool failure. _refusal returns None only for a
+    guard refusal, so this asserts the escape is stopped by containment itself."""
+    root, outside = pathsec_sandbox
+    target = str(outside / "\u043c\u043e\u0434\u0435\u043b\u044c_\u6a21\u578b.model")
+    outcome = _refusal(sink, target)
+    assert outcome is None, f"{sink} did not refuse an outside unicode path (leak?)"
 
 
 def test_benign_vectors_are_not_expanded_or_decoded(pathsec_sandbox):

--- a/nltk/test/unit/test_pathsec_sweep_tag.py
+++ b/nltk/test/unit/test_pathsec_sweep_tag.py
@@ -643,24 +643,18 @@ _ALL_SINKS = dict(_FILE_SINKS, **_DIR_SINKS)
 
 
 def _is_guard_refusal(exc):
-    """True only for a pathsec refusal, not any exception of the same type.
-
-    Every pathsec refusal is raised as ``Security Violation [context]: ...``, so
-    the marker distinguishes the guard from a tool that raises the same exception
-    type for its own reason. Without this, a real-tool sink that fails for a
-    reason unrelated to containment (e.g. python-crfsuite cannot create a
-    CJK-named output file on Windows, which surfaces as ValueError/OSError) would
-    be miscounted as the GUARD refusing a contained path, i.e. a false over-block.
-    """
-    return "Security Violation" in str(exc)
+    """True only for a pathsec refusal, which is ALWAYS raised as the bracketed
+    ``Security Violation [context]: ...`` (pinned by the invariant test below), so
+    a tool raising the same exception type for its own reason is not miscounted."""
+    # Match the bracketed context form, not the bare words: a tool message that
+    # happens to say "security violation" in prose must not read as a guard refusal.
+    return "Security Violation [" in str(exc)
 
 
 def _refusal(sink, path):
-    """Run *sink* on *path*; return None if the GUARD refused it, else the
-    exception (or None-as-success) that proves it got past the guard. Only a
-    pathsec ``Security Violation`` counts as a refusal; a tool failing for its own
-    reason is past-guard, which is exactly the "allowed to fail for its own
-    unrelated reason" case the false-positive control tolerates."""
+    """Run *sink* on *path*; return None only if the GUARD refused it (a pathsec
+    Security Violation), else the exception/None-as-success proving it got past
+    the guard. A tool failing for its own reason is past-guard, not a refusal."""
     try:
         _ALL_SINKS[sink](path)
     except (PermissionError, ValueError) as exc:
@@ -735,14 +729,9 @@ def test_file_sinks_do_not_over_block_contained_paths(pathsec_sandbox, sink, vec
         _cleanup(registry)
 
 
-# Legitimate non-ASCII filenames. validate_tool_path must ACCEPT every one when it
-# is contained (a guard that refused these would break real model paths for
-# non-ASCII users, e.g. a CJK/Cyrillic/Arabic model name or an NFD spelling from a
-# macOS filesystem). These probe the GUARD directly, so they do not depend on any
-# external tool's own unicode handling (python-crfsuite, for one, cannot even
-# create a CJK-named file on Windows; that is the tool's limitation, not the
-# guard's, and is why the file-sink control above tolerates a non-Security-
-# Violation failure). validate_tool_path returns the validated input verbatim.
+# Legitimate non-ASCII filenames validate_tool_path must ACCEPT (returned
+# verbatim) when contained; refusing them would break real model paths for
+# non-ASCII users. Probes the GUARD directly, not any tool's own unicode handling.
 _BENIGN_UNICODE_NAMES = [
     ("nfc-precomposed", "modéle.model"),  # e-acute as one code point
     ("nfd-decomposed", "modéle.model"),  # e + combining acute
@@ -754,10 +743,9 @@ _BENIGN_UNICODE_NAMES = [
     ("mixed-space", "my café 模型.model"),
     ("bidi-rlo", "file\u202edoc.model"),  # right-to-left override, a valid char
     ("fullwidth-solidus", "a\uff0fb.model"),  # U+FF0F is NOT a path separator
-    # DEL, the C1 control NEL and the Unicode line separator are line-injection
-    # vectors on a tool's STDIN (blocked by has_line_unsafe_char), but this guard
-    # bounds a PATH argument in argv, where there is no line to inject into, so
-    # they are legitimate filename bytes here and must not be over-blocked.
+    # DEL / C1 NEL / Unicode line separator are stdin line-injection vectors
+    # (blocked by has_line_unsafe_char) but legitimate bytes in an argv PATH, which
+    # has no line to inject into, so this guard must not over-block them.
     ("del-0x7f", "mod\x7fel.model"),
     ("c1-nel-0x85", "mod\x85el.model"),
     ("line-separator-2028", "mod\u2028el.model"),
@@ -813,24 +801,55 @@ def test_validate_tool_path_refuses_unicode_disguised_attacks(restricted_sandbox
 
 
 def test_is_guard_refusal_distinguishes_guard_from_tool():
-    """Lock the refusal classifier: only a pathsec Security Violation is a guard
-    refusal. A tool raising the same exception type for its OWN reason must not be
-    miscounted as an over-block, and a real guard refusal must not be miscounted as
-    a tolerated tool failure (which would let a real escape leak)."""
+    """Lock the classifier: only pathsec's bracketed Security Violation is a guard
+    refusal, so a tool raising the same exception type for its own reason is not
+    miscounted (nor a real refusal miscounted as a tolerated tool failure)."""
     assert _is_guard_refusal(PermissionError("Security Violation [ctx]: nope"))
     assert _is_guard_refusal(ValueError("Security Violation [ctx]: bad name"))
+    # Tool failures with no bracketed pathsec marker are NOT guard refusals.
     assert not _is_guard_refusal(ValueError("crfsuite: cannot open the output file"))
     assert not _is_guard_refusal(PermissionError("[Errno 13] Permission denied: x"))
     assert not _is_guard_refusal(FileNotFoundError("[WinError 2] cannot find m.model"))
     assert not _is_guard_refusal(OSError("disk full"))
+    # Adversarial: the bare words in prose, or without the '[context]' bracket, must
+    # NOT read as a guard refusal (a tool could mention "security" innocently).
+    assert not _is_guard_refusal(ValueError("this triggered a security violation"))
+    assert not _is_guard_refusal(RuntimeError("Security Violation: no bracket here"))
+
+
+_GUARD_REFUSAL_TRIGGERS = [
+    ("empty", ""),
+    ("nul", "a\x00b.model"),
+    ("newline", "a\nb.model"),
+    ("option-dash", "-rf.model"),
+    ("url", "http://evil/x.model"),
+    ("tilde", "~/x.model"),
+    ("dotdot", os.path.join("..", "..", "etc", "passwd")),
+    ("absolute-outside", "/etc/passwd" if _POSIX else "C:\\Windows\\win.ini"),
+]
+
+
+@pytest.mark.parametrize(
+    "val",
+    [v for _, v in _GUARD_REFUSAL_TRIGGERS],
+    ids=[i for i, _ in _GUARD_REFUSAL_TRIGGERS],
+)
+def test_every_guard_refusal_carries_the_bracketed_marker(restricted_sandbox, val):
+    """Pin the classifier's premise: EVERY validate_tool_path refusal is raised as
+    PermissionError/ValueError carrying 'Security Violation ['. If a future pathsec
+    change drops the marker on any path, _is_guard_refusal breaks, so fail loudly."""
+    with pytest.raises((PermissionError, ValueError)) as excinfo:
+        pathsec.validate_tool_path(val, context="invariant", must_exist=False)
+    assert _is_guard_refusal(
+        excinfo.value
+    ), f"refusal without marker: {excinfo.value!r}"
 
 
 @pytest.mark.parametrize("sink", sorted(_FILE_SINKS))
 def test_file_sinks_refuse_outside_unicode_path_at_the_guard(pathsec_sandbox, sink):
-    """No-leak proof for the tolerance: an OUTSIDE path with a unicode name must be
-    refused by the GUARD (a Security Violation raised before the tool ever runs),
-    never merely by a downstream tool failure. _refusal returns None only for a
-    guard refusal, so this asserts the escape is stopped by containment itself."""
+    """No-leak proof: an OUTSIDE unicode-named path must be refused by the GUARD
+    (a Security Violation before the tool runs), not merely by a tool failure.
+    _refusal returns None only for a guard refusal, so the escape is stopped here."""
     root, outside = pathsec_sandbox
     target = str(outside / "\u043c\u043e\u0434\u0435\u043b\u044c_\u6a21\u578b.model")
     outcome = _refusal(sink, target)

--- a/nltk/test/unit/test_pathsec_sweep_tag.py
+++ b/nltk/test/unit/test_pathsec_sweep_tag.py
@@ -608,13 +608,29 @@ _DIR_SINKS = {
 _ALL_SINKS = dict(_FILE_SINKS, **_DIR_SINKS)
 
 
+def _is_guard_refusal(exc):
+    """True only for a pathsec refusal, not any exception of the same type.
+
+    Every pathsec refusal is raised as ``Security Violation [context]: ...``, so
+    the marker distinguishes the guard from a tool that raises the same exception
+    type for its own reason. Without this, a real-tool sink that fails for a
+    reason unrelated to containment (e.g. python-crfsuite cannot create a
+    CJK-named output file on Windows, which surfaces as ValueError/OSError) would
+    be miscounted as the GUARD refusing a contained path, i.e. a false over-block.
+    """
+    return "Security Violation" in str(exc)
+
+
 def _refusal(sink, path):
-    """Run *sink* on *path*; return None if it refused, else the exception (or
-    None-as-success) that proves it got past the guard."""
+    """Run *sink* on *path*; return None if the GUARD refused it, else the
+    exception (or None-as-success) that proves it got past the guard. Only a
+    pathsec ``Security Violation`` counts as a refusal; a tool failing for its own
+    reason is past-guard, which is exactly the "allowed to fail for its own
+    unrelated reason" case the false-positive control tolerates."""
     try:
         _ALL_SINKS[sink](path)
-    except (PermissionError, ValueError):
-        return None
+    except (PermissionError, ValueError) as exc:
+        return None if _is_guard_refusal(exc) else exc
     except _ReachedSink as exc:
         return exc
     except Exception as exc:  # noqa: BLE001 - any other failure is "past the guard"
@@ -683,6 +699,71 @@ def test_file_sinks_do_not_over_block_contained_paths(pathsec_sandbox, sink, vec
         assert outcome is not None, f"{sink} unexpectedly refused {vector}"
     finally:
         _cleanup(registry)
+
+
+# Legitimate non-ASCII filenames. validate_tool_path must ACCEPT every one when it
+# is contained (a guard that refused these would break real model paths for
+# non-ASCII users, e.g. a CJK/Cyrillic/Arabic model name or an NFD spelling from a
+# macOS filesystem). These probe the GUARD directly, so they do not depend on any
+# external tool's own unicode handling (python-crfsuite, for one, cannot even
+# create a CJK-named file on Windows; that is the tool's limitation, not the
+# guard's, and is why the file-sink control above tolerates a non-Security-
+# Violation failure). validate_tool_path returns the validated input verbatim.
+_BENIGN_UNICODE_NAMES = [
+    ("nfc-precomposed", "modéle.model"),  # e-acute as one code point
+    ("nfd-decomposed", "modéle.model"),  # e + combining acute
+    ("cjk", "模型.model"),  # CJK
+    ("cyrillic", "модель.model"),
+    ("arabic-rtl", "نموذج.model"),
+    ("emoji", "robot_\U0001f916.model"),
+    ("zwj", "co‍op.model"),  # zero-width joiner inside the name
+    ("mixed-space", "my café 模型.model"),
+]
+
+
+@pytest.mark.parametrize(
+    "name",
+    [n for _, n in _BENIGN_UNICODE_NAMES],
+    ids=[i for i, _ in _BENIGN_UNICODE_NAMES],
+)
+def test_validate_tool_path_accepts_benign_unicode(restricted_sandbox, name):
+    """A contained path with any legitimate non-ASCII leaf must be accepted and
+    returned verbatim, never over-blocked."""
+    path = os.path.join(str(restricted_sandbox), name)
+    result = pathsec.validate_tool_path(
+        path, context="unicode-benign", must_exist=False
+    )
+    assert result == path  # no normalization, no over-block
+
+
+# Attacks that wear a unicode disguise but are still a real escape or a
+# Windows-ambiguous name: the guard must refuse EVERY one, with a Security
+# Violation (proving the tolerance added above does not open a hole).
+_UNICODE_ATTACKS = [
+    ("nul-after-unicode", "модель\x00.model"),
+    (
+        "traversal-through-unicode",
+        os.path.join("..", "模型", "..", "..", "etc", "passwd"),
+    ),
+    ("trailing-dot-unicode", "модель."),
+    ("trailing-space-unicode", "模型 "),
+    ("newline-in-unicode", "模型\nevil.model"),
+]
+
+
+@pytest.mark.parametrize(
+    "name", [n for _, n in _UNICODE_ATTACKS], ids=[i for i, _ in _UNICODE_ATTACKS]
+)
+def test_validate_tool_path_refuses_unicode_disguised_attacks(restricted_sandbox, name):
+    """A unicode disguise must not smuggle a NUL, a traversal, a Windows-stripped
+    trailing dot/space, or a control character past the guard."""
+    if os.path.isabs(name):
+        path = name
+    else:
+        path = os.path.join(str(restricted_sandbox), name)
+    with pytest.raises((PermissionError, ValueError)) as excinfo:
+        pathsec.validate_tool_path(path, context="unicode-attack", must_exist=False)
+    assert _is_guard_refusal(excinfo.value)
 
 
 def test_benign_vectors_are_not_expanded_or_decoded(pathsec_sandbox):
@@ -833,8 +914,10 @@ def test_each_guard_is_load_bearing(
 def _refusal_for(driver, path):
     try:
         driver(path)
-    except (PermissionError, ValueError):
-        return "refused"
+    except (PermissionError, ValueError) as exc:
+        # Only a pathsec Security Violation is a guard refusal; a tool raising the
+        # same type for its own reason is past-guard (see _is_guard_refusal).
+        return "refused" if _is_guard_refusal(exc) else "past-guard"
     except Exception:
         return "past-guard"
     return "landed"


### PR DESCRIPTION
## TL;DR

`test_file_sinks_do_not_over_block_contained_paths[unicode-name-CRFTagger.train]`
fails on Windows **when python-crfsuite is installed**. I traced it on a real
Windows runner: **the pathsec guard is correct and is NOT over-blocking.** The
test's own classifier was miscounting a python-crfsuite tool failure as a guard
refusal. This is a **test-only fix; `pathsec.py` is untouched** (no guard
relaxed, no exploit surface changed).

## What actually happens (verified on a Windows runner)

For the contained path `<root>/modelé_模型.json` (`must_exist=False`):

1. `validate_tool_path(...)` → **PASSES** (guard accepts the contained CJK path;
   `resolve()` + `is_relative_to(root)` are both fine).
2. `pycrfsuite.Trainer.train(...)` → **cannot create the CJK-named file on
   Windows** (the C extension mangles the path in the active code page). It either
   silently mis-writes (then `CRFTagger.set_model_file` raises `FileNotFoundError`)
   or raises `ValueError` under the full suite.
3. `_refusal` caught *any* `PermissionError`/`ValueError` as a guard refusal, so
   step 2's tool-level `ValueError` was miscounted as "the guard refused a benign
   path" and the false-positive control failed.

The main CI never sees this because it does not install python-crfsuite, so
`CRFTagger()` raises `ImportError` and the sink fails "for its own unrelated
reason" (which the control already tolerates).

## The fix

A pathsec refusal is always raised as `Security Violation [context]: ...`, so a
new `_is_guard_refusal(exc)` treats **only** exceptions carrying that marker as a
guard refusal. `_refusal` and `_refusal_for` use it, so a tool that fails for its
own reason is correctly "past guard" — exactly the case the control's docstring
says it must tolerate. Over-block detection is preserved: a real over-block still
raises a Security Violation, so the control still catches it.

## Harness expansion (probes the guard directly, no tool involved)

- `test_validate_tool_path_accepts_benign_unicode` — a contained path whose leaf
  is NFC / NFD / CJK / Cyrillic / Arabic / emoji / ZWJ / mixed must be **accepted
  and returned verbatim** (no over-block, no normalization).
- `test_validate_tool_path_refuses_unicode_disguised_attacks` — a NUL, a
  traversal, a Windows-stripped trailing dot/space, or a control character wearing
  a unicode disguise is still **refused with a Security Violation** (no leak).

## Verification

- **Windows runner, full `test_pathsec_sweep_tag.py` with crfsuite installed:
  597 passed, 0 failed** (was 1 failed before this change). ubuntu: green.
- Local: 764 passed in the sweep; the adjacent pathsec attack suites
  (`test_pathsec.py`, `test_pathsec_io_attack_matrix.py`, `test_pathsec_sweep_wrappers.py`)
  290 passed / 15 skipped; a real `CRFTagger` train + tag + reload works; all 300
  nltk modules import.
- `black` (25.11.0) / `isort` clean.

## Not in scope (noted)

python-crfsuite's inability to write a CJK-named file on Windows is an upstream
limitation of that C extension, not an NLTK bug; `CRFTagger` passes the path
through unchanged. The pathsec 8.3-short-name refusal
(`test_windows_short_name_is_refused`) is a deliberate defense and is left as-is.
