### PR TITLE
Give every pathsec refusal the standard Security Violation marker (spawn_trusted + ZIP audit)

### DIFF
--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -353,7 +353,11 @@ def spawn_trusted(target, args=(), **popen_kw):
     out-of-scope race while adding a Linux-only, magic-symlink exec path.
     """
     if popen_kw.get("shell"):
-        raise ValueError("spawn_trusted refuses shell=True")
+        raise ValueError(
+            "Security Violation [spawn_trusted]: shell=True is refused; a shell "
+            "would re-interpret the trusted command on caller-supplied args "
+            "(CWE-78). Pass an argv list and no shell."
+        )
     popen_kw.setdefault("env", safe_env())
     popen_kw.setdefault("close_fds", True)
 

--- a/nltk/pathsec.py
+++ b/nltk/pathsec.py
@@ -600,7 +600,7 @@ def _is_windows_device_name(raw):
     return leaf.split(".", 1)[0].strip().upper() in _WINDOWS_RESERVED_NAMES
 
 
-def _reject_colliding_members(members):
+def _reject_colliding_members(members, context="zip member"):
     """Refuse an archive with two members that collide on a case-insensitive or
     unicode-normalizing filesystem.
 
@@ -619,9 +619,9 @@ def _reject_colliding_members(members):
         key = unicodedata.normalize("NFC", text).casefold()
         if key in seen and seen[key] != text:
             raise ValueError(
-                "Refusing zip: members %r and %r collide on a case-insensitive "
-                "or normalizing filesystem, so one would silently overwrite the "
-                "other (resource poisoning)." % (seen[key], text)
+                f"Security Violation [{context}]: members {seen[key]!r} and "
+                f"{text!r} collide on a case-insensitive or normalizing filesystem, "
+                f"so one would silently overwrite the other (resource poisoning)."
             )
         seen[key] = text
 
@@ -1109,11 +1109,14 @@ def validate_zip_archive(
                 _member_count_guard()(
                     len(members), getattr(zf, "filename", None) or "<archive>"
                 )
-                _reject_colliding_members(members)
+                _reject_colliding_members(members, context)
             for name in members:
                 name_str = name.filename if hasattr(name, "filename") else str(name)
                 if "\0" in name_str:
-                    raise ValueError(f"Null byte in ZIP member: {name_str}")
+                    raise ValueError(
+                        f"Security Violation [{context}]: NUL byte in ZIP member "
+                        f"{name_str!r}"
+                    )
 
                 # ``resolve()`` follows symlinks, catching escapes through a
                 # pre-existing symlinked subpath. The extra component check
@@ -1142,7 +1145,9 @@ def validate_zip_archive(
         raise
     except (OSError, zipfile.BadZipFile):
         if ENFORCE:
-            raise PermissionError("Zip validation failed")
+            raise PermissionError(
+                f"Security Violation [{context}]: Zip validation failed"
+            )
 
 
 @lru_cache(maxsize=256)

--- a/nltk/test/unit/test_pathsec_io_attack_matrix.py
+++ b/nltk/test/unit/test_pathsec_io_attack_matrix.py
@@ -29,7 +29,6 @@ root on macOS).
 
 import os
 import socket
-import tempfile
 import unicodedata
 import zipfile
 

--- a/nltk/test/unit/test_pathsec_io_attack_matrix.py
+++ b/nltk/test/unit/test_pathsec_io_attack_matrix.py
@@ -29,15 +29,19 @@ root on macOS).
 
 import os
 import socket
+import tempfile
 import unicodedata
+import zipfile
 
 import pytest
 
+import nltk.pathsec as _pathsec
 from nltk.pathsec import (
     _reject_colliding_members,
     validate_model_resource,
     validate_tool_dir,
     validate_tool_path,
+    validate_zip_archive,
 )
 
 REFUSALS = (PermissionError, ValueError)
@@ -286,19 +290,43 @@ class TestValidateModelResource:
 # ==========================================================================
 class TestModelFileCollision:
     def test_casefold_collision_is_refused(self):
-        with pytest.raises(ValueError):
+        # Refusal carries the bracketed pathsec marker like every other refusal.
+        with pytest.raises(ValueError, match=r"Security Violation \["):
             _reject_colliding_members(["pkg/Weights.json", "pkg/weights.json"])
 
     def test_unicode_nfc_collision_is_refused(self):
         nfc = unicodedata.normalize("NFC", "café.json")
         nfd = unicodedata.normalize("NFD", "café.json")
         assert nfc != nfd
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r"Security Violation \["):
             _reject_colliding_members([nfc, nfd])
 
     def test_distinct_members_are_allowed(self):
         # Benign control: a legitimate model archive never collides.
         _reject_colliding_members(["weights.json", "tagdict.json", "classes.json"])
+
+    def test_null_byte_member_is_refused_with_marker(self, tmp_path):
+        # A NUL in a member name (C-string truncation) is refused, and the refusal
+        # carries the bracketed pathsec marker like every other refusal.
+        z = tmp_path / "ok.zip"
+        with zipfile.ZipFile(z, "w") as zf:
+            zf.writestr("good.txt", "x")
+
+        class _NulNameZip(zipfile.ZipFile):
+            def namelist(self):
+                return ["good\x00evil.txt"]
+
+        with _NulNameZip(z) as fz:
+            with pytest.raises(ValueError, match=r"Security Violation \["):
+                validate_zip_archive(fz, str(tmp_path))
+
+    def test_corrupt_archive_is_refused_with_marker(self, tmp_path, monkeypatch):
+        # A non-zip / corrupt archive is refused under ENFORCE, with the marker.
+        monkeypatch.setattr(_pathsec, "ENFORCE", True)
+        bad = tmp_path / "not_a.zip"
+        bad.write_bytes(b"NOT A ZIP FILE")
+        with pytest.raises(PermissionError, match=r"Security Violation \["):
+            validate_zip_archive(str(bad), str(tmp_path))
 
 
 # ==========================================================================

--- a/nltk/test/unit/test_pathsec_io_attack_matrix.py
+++ b/nltk/test/unit/test_pathsec_io_attack_matrix.py
@@ -338,6 +338,52 @@ class TestModelFileCollision:
             )
         assert str(excinfo.value).startswith("Security Violation [")
 
+    def test_zip_context_cannot_be_injected_by_archive_name(
+        self, tmp_path, monkeypatch
+    ):
+        # Name the archive with a FAKE marker; extracting a traversal member is still
+        # refused, and the REAL '[ZipAudit]' context leads the message: an attacker
+        # cannot inject or move the marker via the filename (the context param at the
+        # call site is a fixed literal, never attacker data).
+        monkeypatch.setattr(_pathsec, "ENFORCE", True)
+        mal = tmp_path / "Security Violation [pwn].zip"
+        with zipfile.ZipFile(mal, "w") as zf:
+            zf.writestr("../../etc/evil", "x")
+        with pytest.raises((PermissionError, ValueError)) as excinfo:
+            with _pathsec.ZipFile(mal) as zf:
+                zf.extractall(str(tmp_path))
+        msg = str(excinfo.value)
+        assert msg.startswith("Security Violation [ZipAudit]")
+        assert not msg.startswith("Security Violation [pwn")
+
+
+@POSIX_ONLY
+def test_physical_model_guard_refusals_lead_with_marker(restricted_sandbox):
+    # The physical model-file guards (oversize, group/world-writable, non-regular)
+    # also raise a refusal that LEADS with the marker, so the classifier recognizes
+    # them and none can be spoofed. (Name/containment paths are pinned separately.)
+    root = str(restricted_sandbox)
+    big = os.path.join(root, "big.model")
+    with open(big, "wb") as fh:
+        fh.write(b"x" * 4096)
+    with pytest.raises(REFUSALS) as e1:
+        validate_tool_path(big, context="p", must_exist=False, max_bytes=10)
+    assert str(e1.value).startswith("Security Violation [")
+
+    ww = os.path.join(root, "ww.model")
+    with open(ww, "wb") as fh:
+        fh.write(b"x")
+    os.chmod(ww, 0o666)
+    with pytest.raises(REFUSALS) as e2:
+        validate_tool_path(ww, context="p", require_private=True)
+    assert str(e2.value).startswith("Security Violation [")
+
+    fifo = os.path.join(root, "f.fifo")
+    os.mkfifo(fifo)
+    with pytest.raises(REFUSALS) as e3:
+        validate_tool_path(fifo, context="p")
+    assert str(e3.value).startswith("Security Violation [")
+
 
 # ==========================================================================
 # Frozen __fspath__ / hostile str subclass (the guard must not be fooled)

--- a/nltk/test/unit/test_pathsec_io_attack_matrix.py
+++ b/nltk/test/unit/test_pathsec_io_attack_matrix.py
@@ -328,6 +328,16 @@ class TestModelFileCollision:
         with pytest.raises(PermissionError, match=r"Security Violation \["):
             validate_zip_archive(str(bad), str(tmp_path))
 
+    def test_attacker_marker_in_member_name_does_not_spoof(self):
+        # A member NAME that embeds a fake "Security Violation [" is still refused,
+        # and the REAL marker leads the message (the injected one only ever appears
+        # mid-message via repr, so it cannot precede or forge the real marker).
+        with pytest.raises(ValueError) as excinfo:
+            _reject_colliding_members(
+                ["Security Violation [x].json", "security violation [x].json"]
+            )
+        assert str(excinfo.value).startswith("Security Violation [")
+
 
 # ==========================================================================
 # Frozen __fspath__ / hostile str subclass (the guard must not be fooled)

--- a/nltk/test/unit/test_pathsec_sweep_tag.py
+++ b/nltk/test/unit/test_pathsec_sweep_tag.py
@@ -643,12 +643,13 @@ _ALL_SINKS = dict(_FILE_SINKS, **_DIR_SINKS)
 
 
 def _is_guard_refusal(exc):
-    """True only for a pathsec refusal, which is ALWAYS raised as the bracketed
-    ``Security Violation [context]: ...`` (pinned by the invariant test below), so
-    a tool raising the same exception type for its own reason is not miscounted."""
-    # Match the bracketed context form, not the bare words: a tool message that
-    # happens to say "security violation" in prose must not read as a guard refusal.
-    return "Security Violation [" in str(exc)
+    """True only for a pathsec refusal, which is ALWAYS raised with the message
+    STARTING ``Security Violation [context]: ...`` (pinned by the invariant test).
+    Anchoring at the start is spoof-proof: attacker-controlled data (a path or zip
+    member) that a tool echoes only ever lands mid-message, so it can never move
+    the leading marker, and a tool that merely mentions the phrase is not a
+    refusal."""
+    return str(exc).startswith("Security Violation [")
 
 
 def _refusal(sink, path):
@@ -815,6 +816,20 @@ def test_is_guard_refusal_distinguishes_guard_from_tool():
     # NOT read as a guard refusal (a tool could mention "security" innocently).
     assert not _is_guard_refusal(ValueError("this triggered a security violation"))
     assert not _is_guard_refusal(RuntimeError("Security Violation: no bracket here"))
+    # Spoofing: attacker data a tool echoes lands MID-message. Anchoring the marker
+    # at the START means a forged marker inside a tool error cannot pass as a guard
+    # refusal, even though the substring is present.
+    assert not _is_guard_refusal(
+        ValueError("crfsuite: cannot open 'Security Violation [x]: pwned'")
+    )
+    assert not _is_guard_refusal(
+        FileNotFoundError("No such file: /tmp/Security Violation [evil]/m.crf")
+    )
+    # But a genuine refusal that QUOTES an attacker's fake marker mid-message is
+    # still a refusal, because the REAL marker still leads.
+    assert _is_guard_refusal(
+        ValueError("Security Violation [ZipAudit]: member 'Security Violation [x]'")
+    )
 
 
 _GUARD_REFUSAL_TRIGGERS = [

--- a/nltk/test/unit/test_pathsec_sweep_tag.py
+++ b/nltk/test/unit/test_pathsec_sweep_tag.py
@@ -807,8 +807,20 @@ def test_is_guard_refusal_distinguishes_guard_from_tool():
     miscounted (nor a real refusal miscounted as a tolerated tool failure)."""
     assert _is_guard_refusal(PermissionError("Security Violation [ctx]: nope"))
     assert _is_guard_refusal(ValueError("Security Violation [ctx]: bad name"))
-    # Tool failures with no bracketed pathsec marker are NOT guard refusals.
+    # Real sinks run past the guard for MANY tools, not just crfsuite: the
+    # pure-Python perceptron / maxent save-load sinks and an AttributeError from
+    # CRFTagger.set_model_file all reach real code. None of their error shapes may
+    # read as a refusal (only Stanford/Hunpos are mocked with _ReachedSink).
     assert not _is_guard_refusal(ValueError("crfsuite: cannot open the output file"))
+    assert not _is_guard_refusal(  # perceptron json load
+        ValueError("Expecting value: line 1 column 1 (char 0)")
+    )
+    assert not _is_guard_refusal(ValueError("invalid load key, 'x'."))  # pickle
+    assert not _is_guard_refusal(  # CRFTagger.set_model_file on object.__new__
+        AttributeError("'CRFTagger' object has no attribute '_tagger'")
+    )
+    assert not _is_guard_refusal(OSError("[Errno 2] No such file or directory: 'java'"))
+    assert not _is_guard_refusal(ValueError("MaltParser: could not open the model"))
     assert not _is_guard_refusal(PermissionError("[Errno 13] Permission denied: x"))
     assert not _is_guard_refusal(FileNotFoundError("[WinError 2] cannot find m.model"))
     assert not _is_guard_refusal(OSError("disk full"))

--- a/nltk/test/unit/test_pathsec_trusted_exec.py
+++ b/nltk/test/unit/test_pathsec_trusted_exec.py
@@ -443,7 +443,9 @@ def _popen_spy(monkeypatch):
 
 
 def test_spawn_trusted_refuses_shell():
-    with pytest.raises(ValueError):
+    # The refusal carries the bracketed "Security Violation [context]:" marker like
+    # every other pathsec refusal, so a marker-based classifier reads it correctly.
+    with pytest.raises(ValueError, match=r"Security Violation \[spawn_trusted\]"):
         ps.spawn_trusted("/bin/sh", ["-c", "true"], shell=True)
 
 


### PR DESCRIPTION
Follow-up to the merged exec-trust PR #3858: make **every** `nltk.pathsec`
refusal carry the standard bracketed `Security Violation [context]: ...` form.

An AST audit of `pathsec.py` found the only refusals raised *without* the marker
were `spawn_trusted`'s `shell=True` guard and the three ZIP-audit refusals. That
inconsistency means a marker-based check (anything keying on the `Security
Violation [` form pathsec otherwise guarantees) would not recognize them.

## Changes (all message-only; no logic or exception-type change)
- `spawn_trusted(shell=True)` -> `Security Violation [spawn_trusted]: ... (CWE-78)`.
- `_reject_colliding_members` (member collision / resource poisoning) now takes a
  `context` and raises with the marker.
- `validate_zip_archive`'s NUL-byte-member and corrupt-archive refusals carry the
  marker and the context.

After this, an AST audit shows **zero** pathsec refusals without the bracketed
marker.

## Tests
- `spawn_trusted` shell refusal asserts the marker (`match=`).
- Collision, NUL-byte-member and corrupt-archive refusals assert the marker.

## Verified (real, not mock)
- Full exec-trust suite + zip/pathsec attack matrix: 501+ pass, no leaks; every
  attack (world-writable binary, shell=True, zip-slip, collision, NUL, corrupt)
  still refused, now with the bracketed marker.
- Real Senna (`USSR->NNP`) and HunPos (`the->DT`) still spawn and tag through
  `spawn_trusted` (no regression; they pass argv, not shell).
- 300 nltk modules import; `black`/`isort` clean.
