### PR TITLE
Fix resolution paths that cancel distinct literals

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -178,6 +178,7 @@
 - Louis Tiao
 - Steven Tomcavage
 - Tiago Tresoldi
+- UnbearableFate
 - Marcus Uneson
 - Yu Usami
 - Petro Verkhogliad

--- a/nltk/inference/resolution.py
+++ b/nltk/inference/resolution.py
@@ -539,6 +539,29 @@ def _unify_terms(a, b, bindings=None, used=None):
 
 def _complete_unify_path(first, second, bindings, used, skipped, debug):
     if used[0] or used[1]:  # if bindings were made along the path
+        # Resolution may remove several literals only if they factor to the
+        # same literal. Removing distinct complementary pairs is unsound:
+        # {P, Q} and {-P, -Q} do not imply the empty clause.
+        # Equality literals are consumed by demodulation, not resolution.
+        resolved = [
+            atom for atom in used[0] if not isinstance(atom, EqualityExpression)
+        ]
+        if resolved:
+            pivot = resolved[0]
+            for atom in resolved[1:]:
+                if isinstance(pivot, NegatedExpression) != isinstance(
+                    atom, NegatedExpression
+                ):
+                    return []
+                left = pivot.term if isinstance(pivot, NegatedExpression) else pivot
+                right = atom.term if isinstance(atom, NegatedExpression) else atom
+                try:
+                    bindings = bindings + most_general_unification(
+                        left.substitute_bindings(bindings),
+                        right.substitute_bindings(bindings),
+                    )
+                except BindingException:
+                    return []
         newclause = Clause(skipped[0] + skipped[1] + first + second)
         debug.line("  -> New Clause: %s" % newclause)
         return [newclause.substitute_bindings(bindings)]

--- a/nltk/test/resolution.doctest
+++ b/nltk/test/resolution.doctest
@@ -56,7 +56,7 @@ Test unify()
     >>> print(Clause([P(A), Q(x), R(x,y)]).unify(Clause([-P(x), Q(y)])))
     [{Q(y), Q(A), R(A,y)}]
     >>> print(Clause([P(A), -Q(y)]).unify(Clause([-P(x), Q(B)])))
-    [{}]
+    [{Q(B), -Q(y)}, {-P(x), P(A)}]
     >>> print(Clause([P(x), Q(x)]).unify(Clause([-P(A), -Q(B)])))
     [{-Q(B), Q(A)}, {-P(A), P(B)}]
     >>> print(Clause([P(x,x), Q(x), R(x)]).unify(Clause([-P(A,z), -Q(B)])))

--- a/nltk/test/unit/test_resolution.py
+++ b/nltk/test/unit/test_resolution.py
@@ -1,0 +1,74 @@
+"""Soundness regressions for resolution (issue #2699)."""
+
+from itertools import combinations, product
+
+import pytest
+
+from nltk.inference.resolution import Clause, ResolutionProver
+from nltk.sem.logic import Expression
+
+read = Expression.fromstring
+
+
+def test_biconditional_does_not_prove_unrelated_goal():
+    assumption = read("all x.all y.(parentof(y,x) <-> childof(x,y))")
+    assert not ResolutionProver().prove(read("foo(Bar)"), [assumption])
+
+
+@pytest.mark.parametrize(
+    "left,right",
+    [
+        (["P(Adam)", "Q(Adam)"], ["-P(Adam)", "-Q(Adam)"]),
+        (["P(Adam)", "P(Bob)"], ["-P(Adam)", "-P(Bob)"]),
+        (["P(x)", "Q(x)"], ["-P(Adam)", "-Q(Adam)"]),
+        (["P(Adam)", "-Q(y)"], ["-P(x)", "Q(Bob)"]),
+        (["P(Adam)", "-P(Bob)"], ["-P(Adam)", "P(Bob)"]),
+    ],
+)
+def test_distinct_pivots_do_not_produce_empty_clause(left, right):
+    resolvents = Clause(map(read, left)).unify(Clause(map(read, right)))
+    assert resolvents
+    assert all(resolvents)
+
+
+@pytest.mark.parametrize(
+    "left,right",
+    [
+        (["P(Adam)", "P(Adam)"], ["-P(Adam)", "-P(Adam)"]),
+        (["P(x)", "P(y)"], ["-P(Adam)", "-P(Adam)"]),
+        (["P(x)", "P(y)"], ["-P(u)", "-P(v)"]),
+        (["-P(x)", "-P(y)"], ["P(u)", "P(v)"]),
+    ],
+)
+def test_factoring_still_produces_empty_clause(left, right):
+    assert Clause(map(read, left)).unify(Clause(map(read, right))) == [Clause([])]
+
+
+def test_factoring_substitutes_remaining_literals():
+    left = Clause(map(read, ["P(x)", "P(y)", "R(x,y)"]))
+    right = Clause(map(read, ["-P(u)", "-P(v)"]))
+    resolvents = left.unify(right)
+    assert len(resolvents) == 1
+    assert len(resolvents[0]) == 1
+    predicate, arguments = resolvents[0][0].uncurry()
+    assert predicate == read("R")
+    assert len(arguments) == 2
+    assert arguments[0] == arguments[1]
+
+
+def test_ground_resolvents_follow_from_their_parents():
+    """Check the resolution rule against truth assignments, independently of MGU."""
+    atoms = list(map(read, ["P(Adam)", "P(Bob)", "Q(Adam)"]))
+    literals = atoms + [-atom for atom in atoms]
+    clauses = [Clause(pair) for pair in combinations(literals, 2)]
+    for left, right in combinations(clauses, 2):
+        resolvents = left.unify(right)
+        for values in product([False, True], repeat=len(atoms)):
+            assignment = dict(zip(atoms, values))
+            assignment.update({-atom: not value for atom, value in zip(atoms, values)})
+            if all(
+                any(assignment[term] for term in clause) for clause in (left, right)
+            ):
+                assert all(
+                    any(assignment[term] for term in clause) for clause in resolvents
+                ), (left, right, resolvents, assignment)


### PR DESCRIPTION
`ResolutionProver` currently proves `foo(Bar)` from only `all x.all y.(parentof(y,x) <-> childof(x,y))`. A unification path can remove several distinct complementary pairs: `{P, Q}` and `{-P, -Q}` incorrectly produce the empty clause even though both parents can be true.

Require the removed resolution literals to factor to one common literal with the same polarity before emitting a resolvent. Apply the factoring bindings to the remaining literals. This preserves valid factoring and leaves the shared subsumption traversal and equality demodulation intact. Also correct the existing doctest that expected a false contradiction.

Fixes #2699.

Validation on Python 3.13.14:
- Regression tests cover the reported public proof, distinct predicates/arguments/polarities, duplicate literals, variable factoring, and substitution into remaining literals. An independent truth-table check verifies ground resolvents against their parents. The final regression file has 8 failures and 4 passes on unchanged upstream production code; all 12 pass with the fix.
- Resolution/logic doctests and related unit/security tests: 27 passed, 2 skipped because `mace4` is unavailable.
- Module examples in `resolution.py` and `logic.py`: 2 passed.
- An additional check of `tableau.py::testHigherOrderTableauProver` fails with a parser error on both this branch and a pristine archive of the base revision. No changes to that unrelated example.

All applicable pre-commit hooks passed on the changed files, including Black, isort, Ruff, pyupgrade, and the repository-wide security guard checks; `git diff --check` passed. The full cross-platform CI matrix was not run locally.
