### PR TITLE
Explain negative contingency counts in likelihood ratios

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -319,6 +319,7 @@
 - Nicola <https://github.com/trinik15>
 - medisean <https://github.com/medisean>
 - tandede <https://github.com/tandede>
+- Con-Benksl <https://github.com/Con-Benksl>
 
 ## Others whose work we've taken and included in NLTK, but who didn't directly contribute it:
 

--- a/nltk/metrics/association.py
+++ b/nltk/metrics/association.py
@@ -141,8 +141,17 @@ class NgramAssocMeasures(metaclass=ABCMeta):
 
     @classmethod
     def likelihood_ratio(cls, *marginals):
-        """Scores ngrams using likelihood ratios as in Manning and Schutze 5.3.4."""
+        """Scores ngrams using likelihood ratios as in Manning and Schutze 5.3.4.
+
+        :raises ValueError: If the contingency table contains negative counts.
+        """
         cont = cls._contingency(*marginals)
+        if any(count < 0 for count in cont):
+            raise ValueError(
+                "The contingency table contains negative counts. "
+                "Check the marginal counts; very small samples can make "
+                "collocation approximations invalid."
+            )
         return 2 * sum(
             obs * _ln(obs / (exp + _SMALL) + _SMALL)
             for obs, exp in zip(cont, cls._expected_values(cont))

--- a/nltk/test/unit/test_metrics.py
+++ b/nltk/test/unit/test_metrics.py
@@ -1,5 +1,6 @@
 import unittest
 
+from nltk.collocations import TrigramCollocationFinder
 from nltk.metrics import (
     BigramAssocMeasures,
     QuadgramAssocMeasures,
@@ -21,8 +22,9 @@ class TestLikelihoodRatio(unittest.TestCase):
         self.assertAlmostEqual(
             BigramAssocMeasures.likelihood_ratio(1, (1, 1), 1), 0.0, delta=_DELTA
         )
-        self.assertRaises(
+        self.assertRaisesRegex(
             ValueError,
+            "contingency table contains negative counts",
             BigramAssocMeasures.likelihood_ratio,
             *(0, (2, 2), 2),
         )
@@ -38,8 +40,9 @@ class TestLikelihoodRatio(unittest.TestCase):
             0.0,
             delta=_DELTA,
         )
-        self.assertRaises(
+        self.assertRaisesRegex(
             ValueError,
+            "contingency table contains negative counts",
             TrigramAssocMeasures.likelihood_ratio,
             *(1, (1, 1, 2), (1, 1, 2), 2),
         )
@@ -59,8 +62,17 @@ class TestLikelihoodRatio(unittest.TestCase):
             0.0,
             delta=_DELTA,
         )
-        self.assertRaises(
+        self.assertRaisesRegex(
             ValueError,
+            "contingency table contains negative counts",
             QuadgramAssocMeasures.likelihood_ratio,
             *(1, (1, 1, 1, 1), (1, 1, 1, 1, 1, 2), (1, 1, 1, 1), 1),
         )
+
+    def test_lr_trigram_small_sample(self):
+        finder = TrigramCollocationFinder.from_words(["borrower"] * 6 + ["page"])
+        finder.apply_freq_filter(3)
+        with self.assertRaisesRegex(
+            ValueError, "contingency table contains negative counts"
+        ):
+            finder.nbest(TrigramAssocMeasures.likelihood_ratio, 8)


### PR DESCRIPTION
An inconsistent set of marginal counts currently reaches `math.log` in `NgramAssocMeasures.likelihood_ratio` and raises an unexplained `ValueError: math domain error`. This also happens with the seven-word `TrigramCollocationFinder.nbest` example in #2032.

Validate the derived contingency table before computing the likelihood ratio and explain that negative counts can result from inconsistent marginals or collocation approximations on very small samples. This follows the diagnostic approach suggested in #2032. The exception remains a `ValueError`; valid likelihood-ratio scores and zero-count cells keep their existing behavior. This does not change the small-sample counting approximation.

Related to #2032.

Validation (Python 3.13.13):

- Before the fix, the three existing invalid-count cases and the issue's small-sample reproduction failed the diagnostic assertions: 4 failed.
- `python -m pytest nltk/test/unit/test_metrics.py nltk/test/unit/test_collocations.py nltk/test/metrics.doctest -q`: 8 passed. The existing bigram, trigram, and quadgram numerical checks remain covered.
- `python -m doctest nltk/metrics/association.py`: passed.
- `pre-commit run --all-files`: all 13 hooks passed; `git diff --check` passed.

No corpus downloads were needed; the full corpus-dependent test suite was not run. OpenAI Codex implemented and tested this change, with a separate agent performing an independent code review.
