### PR TITLE
Preserve sentence boundaries in MaltParser batches

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -37,6 +37,7 @@
 - Graham Christensen
 - Trevor Cohn
 - David Coles
+- Con-Benksl
 - Tom Conroy <https://github.com/tconroy>
 - Claude Coulombe
 - Lucas Cooper

--- a/nltk/parse/malt.py
+++ b/nltk/parse/malt.py
@@ -259,6 +259,8 @@ class MaltParser(ParserI):
                     output_file_name, context="MaltParser.parse_tagged_sents"
                 ) as infile:
                     for tree_str in infile.read().split("\n\n"):
+                        if not tree_str.strip():
+                            continue
                         yield (
                             iter(
                                 [

--- a/nltk/parse/util.py
+++ b/nltk/parse/util.py
@@ -106,8 +106,8 @@ def taggedsents_to_conll(sentences):
     """
     A module to convert the a POS tagged document stream
     (i.e. list of list of tuples, a list of sentences) and yield lines
-    in CONLL format. This module yields one line per word and two newlines
-    for end of sentence.
+    in CONLL format. This module yields one line per word and one blank line
+    at the end of each sentence.
 
     >>> from nltk import word_tokenize, sent_tokenize, pos_tag
     >>> text = "This is a foobar sentence. Is that right?"
@@ -122,12 +122,10 @@ def taggedsents_to_conll(sentences):
     5	sentence	_	NN	NN	_	0	a	_	_
     6	.		_	.	.	_	0	a	_	_
     <BLANKLINE>
-    <BLANKLINE>
     1	Is	_	VBZ	VBZ	_	0	a	_	_
     2	that	_	IN	IN	_	0	a	_	_
     3	right	_	NN	NN	_	0	a	_	_
     4	?	_	.	.	_	0	a	_	_
-    <BLANKLINE>
     <BLANKLINE>
 
     :param sentences: Input sentences to parse
@@ -137,7 +135,7 @@ def taggedsents_to_conll(sentences):
     """
     for sentence in sentences:
         yield from taggedsent_to_conll(sentence)
-        yield "\n\n"
+        yield "\n"
 
 
 ######################################################################

--- a/nltk/test/unit/test_malt.py
+++ b/nltk/test/unit/test_malt.py
@@ -5,6 +5,15 @@ import pytest
 
 import nltk.parse.malt as malt
 from nltk.parse.malt import MaltParser
+from nltk.parse.util import taggedsents_to_conll
+
+
+def test_tagged_sents_to_conll_separates_sentences():
+    sentences = iter([[("hello", "NN")], [("world", "NN")]])
+    assert "".join(taggedsents_to_conll(sentences)) == (
+        "1\thello\t_\tNN\tNN\t_\t0\ta\t_\t_\n\n"
+        "1\tworld\t_\tNN\tNN\t_\t0\ta\t_\t_\n\n"
+    )
 
 
 def _minimal_malt_parser(tmp_path, monkeypatch):
@@ -41,6 +50,29 @@ def _write_minimal_parse(cmd):
         "1\thello\t_\tNN\tNN\t_\t0\tnull\t_\t_\n",
         encoding="utf-8",
     )
+
+
+@pytest.mark.parametrize("words", [[], ["hello"], ["hello", "world"]])
+def test_malt_parse_ignores_empty_output_blocks(monkeypatch, tmp_path, words):
+    parser, _ = _minimal_malt_parser(tmp_path, monkeypatch)
+
+    def fake_execute(cmd, verbose=False):
+        output_path = Path(cmd[cmd.index("-o") + 1])
+        output_path.write_text(
+            "".join(f"1\t{word}\t_\tNN\tNN\t_\t0\tnull\t_\t_\n\n" for word in words),
+            encoding="utf-8",
+        )
+        return 0
+
+    parser._execute = fake_execute
+    parses = [
+        next(trees)
+        for trees in parser.parse_tagged_sents([[(word, "NN")] for word in words])
+    ]
+    assert [
+        [node["word"] for address, node in sorted(graph.nodes.items()) if address]
+        for graph in parses
+    ] == [[word] for word in words]
 
 
 def test_malt_parse_passes_model_dir_via_w_without_changing_process_cwd(


### PR DESCRIPTION
`parse_tagged_sents` stops after the first sentence because `taggedsents_to_conll` emits three newline characters between sentences. MaltParser treats the resulting extra empty sentence as the end of input.

Emit the single blank-line separator expected by CoNLL and update the example accordingly. Also ignore empty output blocks so MaltParser's normal trailing separator does not produce a spurious empty `DependencyGraph`.

Fixes #2373.

Validation:

- The four new regression cases failed on the unchanged code. They check exact serialized boundaries and zero/one/multiple output sentences independently.
- Related Malt and wrapper-security tests: **46 passed, 3 skipped**. The skipped cases require Stanford Parser, which was not installed. The existing real Malt training test ran successfully.
- Real MaltParser 1.9.2 with Corretto 11.0.31: trained a 5.5 KB model from three synthetic sentences. Before the fix, batch parsing returned only the first sentence plus an empty graph; afterward, it returned all three sentences exactly once. Generator batches of zero/one/three sentences, `parse_sents`, and `parse_one` were also checked.
- All 13 repository pre-commit checks and `git diff --check` passed on Python 3.13.13.

The real parser checks used the official MaltParser distribution and a locally trained toy model, with no pretrained-model or corpus downloads. The full corpus-dependent NLTK suite and tokenizer/tagger-dependent inline examples were not run.

OpenAI Codex implemented and verified this change autonomously. A separate agent reviewed the final diff, callers, MaltParser's reader/writer contract, and validation evidence.
