### PR TITLE
Optimize CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,11 @@ name: ci-workflow
 
 on: [push, pull_request, workflow_dispatch]
 
+# Automatically cancel in-progress jobs when new commits are pushed to the same PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -18,6 +23,25 @@ env:
   MALT_PARSER: ${{ github.workspace }}/third/maltparser
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**/*.py'
+              - 'requirements*.txt'
+              - 'setup.py'
+              - '.github/workflows/**'
+              - 'tools/github_actions/**'
+
   pre-commit:
     name: pre-commit
     runs-on: ubuntu-latest
@@ -37,6 +61,8 @@ jobs:
 
   minimal_download_test:
     name: Minimal NLTK Download Test
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -66,16 +92,31 @@ jobs:
         run: |
           python -c "import os, nltk; d = os.environ['NLTK_DATA']; import pathlib; pathlib.Path(d).mkdir(parents=True, exist_ok=True); nltk.download('wordnet', download_dir=d)"
 
+  setup-matrix:
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
+    outputs:
+      python_versions: ${{ steps.set-matrix.outputs.python_versions }}
+    steps:
+      - id: set-matrix
+        run: |
+          if [[ "${{ github.event_name }}" == "merge_group" || contains(github.event.pull_request.labels.*.name, 'full-matrix') || "${{ github.ref }}" == "refs/heads/develop" ]]; then
+            echo 'python_versions=["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]' >> $GITHUB_OUTPUT
+          else
+            echo 'python_versions=["3.14", "3.14t"]' >> $GITHUB_OUTPUT
+          fi
+
   test:
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     # Gate on pre-commit only. Depending on minimal_download_test blocked the
     # whole matrix whenever its macos-latest leg could not acquire a hosted
     # runner (it sits queued ~26m then errors), so the full suite never ran.
     # minimal_download_test still runs and reports on its own.
-    needs: [pre-commit]
+    needs: [pre-commit, setup-matrix]
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
+        python-version: ${{ fromJSON(needs.setup-matrix.outputs.python_versions) }}
         os: [ubuntu-latest, macos-latest, windows-latest]
         exclude:
           - os: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,8 +100,9 @@ jobs:
       python_versions: ${{ steps.set-matrix.outputs.python_versions }}
     steps:
       - id: set-matrix
+        shell: bash
         run: |
-          if [[ "${{ github.event_name }}" == "merge_group" || contains(github.event.pull_request.labels.*.name, 'full-matrix') || "${{ github.ref }}" == "refs/heads/develop" ]]; then
+          if [[ "${{ github.event_name }}" == "merge_group" ]] || [[ "${{ contains(github.event.pull_request.labels.*.name, 'full-matrix') }}" == "true" ]] || [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
             echo 'python_versions=["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]' >> $GITHUB_OUTPUT
           else
             echo 'python_versions=["3.14", "3.14t"]' >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,15 @@
 name: ci-workflow
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+  workflow_dispatch:
+  merge_group:
 
 # Automatically cancel in-progress jobs when new commits are pushed to the same PR
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -26,6 +31,7 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: read
     outputs:
       code: ${{ steps.filter.outputs.code }}
@@ -293,6 +299,8 @@ jobs:
     # already runs the PR's code. It fails only on a real coverage gap and
     # skips if the fetch cannot be made. `permissions: {}` is intentional and
     # sufficient: checking out a public repo needs no token scope.
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     permissions: {}
     steps:


### PR DESCRIPTION
**Description:**
This PR significantly reduces CI queue times and runner consumption for routine pull requests while maintaining rigorous full-suite validation before merging.

* **Dynamic Test Matrix:** Normal PR commits now only run against Python 3.14 and 3.14t across all three OSes (respecting existing platform exclusions). The full version matrix (3.10 through 3.14t) triggers automatically for merge queues, direct pushes to `develop`, or PRs tagged with the `full-matrix` label.
* **Smart Path Filtering:** Bypasses the main test suite and third-party downloads entirely for docs-only changes. Tests only trigger if Python files, dependency lists, or workflow configs are modified. The `pre-commit` job still runs universally to enforce markdown and file formatting.
* **Auto-Canceling Redundant Runs:** Implements workflow concurrency limits. If a contributor pushes a new commit to an open PR, any currently executing jobs from their previous commit are instantly canceled.

*Result:* Faster feedback loops for contributors and zero wasted GitHub Actions minutes on obsolete commits or README typos.