### PR TITLE
Bound recursion depth in parsers and traversal helpers

### DIFF
--- a/nltk/ccg/lexicon.py
+++ b/nltk/ccg/lexicon.py
@@ -16,6 +16,11 @@ from nltk.ccg.api import CCGVar, Direction, FunctionalCategory, PrimitiveCategor
 from nltk.internals import deprecated
 from nltk.sem.logic import Expression
 
+#: Maximum nesting depth the recursive CCG lexicon parser will descend to.
+#: Beyond this it raises ValueError instead of letting Python raise an
+#: uncaught RecursionError (CWE-674).  Configurable.
+MAX_PARSE_DEPTH = 500
+
 # ------------
 # Regular expressions used for parsing components of the lexicon
 # ------------
@@ -141,17 +146,23 @@ class CCGLexicon:
 # -----------
 
 
-def matchBrackets(string):
-    """
-    Separate the contents matching the first set of brackets from the rest of
-    the input.
-    """
+def matchBrackets(string, _depth=0, max_depth=None):
+    """Separate the contents matching the first set of brackets from the rest of the input."""
+    if max_depth is None:
+        max_depth = MAX_PARSE_DEPTH
+    if _depth > max_depth:
+        raise ValueError(
+            f"CCG nesting depth exceeds MAX_PARSE_DEPTH "
+            f"({MAX_PARSE_DEPTH}); the input may be "
+            "adversarially deep. Raise "
+            "nltk.ccg.lexicon.MAX_PARSE_DEPTH to allow it."
+        )
     rest = string[1:]
     inside = "("
 
     while rest != "" and not rest.startswith(")"):
         if rest.startswith("("):
-            (part, rest) = matchBrackets(rest)
+            (part, rest) = matchBrackets(rest, _depth + 1, max_depth)
             inside = inside + part
         else:
             inside = inside + rest[0]
@@ -161,35 +172,27 @@ def matchBrackets(string):
     raise AssertionError("Unmatched bracket in string '" + string + "'")
 
 
-def nextCategory(string):
-    """
-    Separate the string for the next portion of the category from the rest
-    of the string
-    """
+def nextCategory(string, _depth=0, max_depth=None):
+    """Separate the string for the next portion of the category from the rest of the string"""
     if string.startswith("("):
-        return matchBrackets(string)
+        return matchBrackets(string, _depth, max_depth)
     return NEXTPRIM_RE.match(string).groups()
 
 
 def parseApplication(app):
-    """
-    Parse an application operator
-    """
+    """Parse an application operator"""
     return Direction(app[0], app[1:])
 
 
 def parseSubscripts(subscr):
-    """
-    Parse the subscripts for a primitive category
-    """
+    """Parse the subscripts for a primitive category"""
     if subscr:
         return subscr[1:-1].split(",")
     return []
 
 
 def parsePrimitiveCategory(chunks, primitives, families, var):
-    """
-    Parse a primitive category
+    """Parse a primitive category
 
     If the primitive is the special category 'var', replace it with the
     correct `CCGVar`.
@@ -217,16 +220,25 @@ def parsePrimitiveCategory(chunks, primitives, families, var):
     )
 
 
-def augParseCategory(line, primitives, families, var=None):
-    """
-    Parse a string representing a category, and returns a tuple with
+def augParseCategory(line, primitives, families, var=None, _depth=0, max_depth=None):
+    """Parse a string representing a category, and returns a tuple with
     (possibly) the CCG variable for the category
     """
-    (cat_string, rest) = nextCategory(line)
+    if max_depth is None:
+        max_depth = MAX_PARSE_DEPTH
+    if _depth > max_depth:
+        raise ValueError(
+            f"CCG nesting depth exceeds MAX_PARSE_DEPTH "
+            f"({MAX_PARSE_DEPTH}); the input may be "
+            "adversarially deep. Raise "
+            "nltk.ccg.lexicon.MAX_PARSE_DEPTH to allow it."
+        )
+    (cat_string, rest) = nextCategory(line, _depth, max_depth)
 
     if cat_string.startswith("("):
-        (res, var) = augParseCategory(cat_string[1:-1], primitives, families, var)
-
+        (res, var) = augParseCategory(
+            cat_string[1:-1], primitives, families, var, _depth + 1, max_depth
+        )
     else:
         (res, var) = parsePrimitiveCategory(
             PRIM_RE.match(cat_string).groups(), primitives, families, var
@@ -237,9 +249,16 @@ def augParseCategory(line, primitives, families, var=None):
         direction = parseApplication(app[0:3])
         rest = app[3]
 
-        (cat_string, rest) = nextCategory(rest)
+        (cat_string, rest) = nextCategory(rest, _depth, max_depth)
         if cat_string.startswith("("):
-            (arg, var) = augParseCategory(cat_string[1:-1], primitives, families, var)
+            (arg, var) = augParseCategory(
+                cat_string[1:-1],
+                primitives,
+                families,
+                var,
+                _depth + 1,
+                max_depth,
+            )
         else:
             (arg, var) = parsePrimitiveCategory(
                 PRIM_RE.match(cat_string).groups(), primitives, families, var
@@ -249,10 +268,10 @@ def augParseCategory(line, primitives, families, var=None):
     return (res, var)
 
 
-def fromstring(lex_str, include_semantics=False):
-    """
-    Convert string representation into a lexicon for CCGs.
-    """
+def fromstring(lex_str, include_semantics=False, max_depth=None):
+    """Convert string representation into a lexicon for CCGs."""
+    if max_depth is None:
+        max_depth = MAX_PARSE_DEPTH
     CCGVar.reset_id()
     primitives = []
     families = {}
@@ -274,7 +293,9 @@ def fromstring(lex_str, include_semantics=False):
             # Either a family definition, or a word definition
             (ident, sep, rhs) = LEX_RE.match(line).groups()
             (catstr, semantics_str) = RHS_RE.match(rhs).groups()
-            (cat, var) = augParseCategory(catstr, primitives, families)
+            (cat, var) = augParseCategory(
+                catstr, primitives, families, max_depth=max_depth
+            )
 
             if sep == "::":
                 # Family definition
@@ -293,7 +314,7 @@ def fromstring(lex_str, include_semantics=False):
                             SEMANTICS_RE.match(semantics_str).groups()[0]
                         )
                 # Word definition
-                # ie, which => (N\N)/(S/NP)
+                # ie, which => (N\\N)/(S/NP)
                 entries[ident].append(Token(ident, cat, semantics))
     return CCGLexicon(primitives[0], primitives, families, entries)
 

--- a/nltk/ccg/lexicon.py
+++ b/nltk/ccg/lexicon.py
@@ -314,7 +314,7 @@ def fromstring(lex_str, include_semantics=False, max_depth=None):
                             SEMANTICS_RE.match(semantics_str).groups()[0]
                         )
                 # Word definition
-                # ie, which => (N\\N)/(S/NP)
+                # ie, which => (N\N)/(S/NP)
                 entries[ident].append(Token(ident, cat, semantics))
     return CCGLexicon(primitives[0], primitives, families, entries)
 

--- a/nltk/corpus/reader/bnc.py
+++ b/nltk/corpus/reader/bnc.py
@@ -141,14 +141,26 @@ class BNCCorpusReader(XMLCorpusReader):
         return result
 
 
-def _all_xmlwords_in(elt, result=None):
+#: Bound recursion over nested XML so an adversarially deep corpus file raises
+#: ValueError instead of an uncaught RecursionError (CWE-674).
+MAX_XML_DEPTH = 500
+
+
+def _all_xmlwords_in(elt, result=None, _depth=0, max_depth=None):
+    if max_depth is None:
+        max_depth = MAX_XML_DEPTH
+    if _depth > max_depth:
+        raise ValueError(
+            f"XML nesting depth exceeds MAX_XML_DEPTH ({max_depth}); "
+            "the input may be adversarially deep."
+        )
     if result is None:
         result = []
     for child in elt:
         if child.tag in ("c", "w"):
             result.append(child)
         else:
-            _all_xmlwords_in(child, result)
+            _all_xmlwords_in(child, result, _depth + 1, max_depth)
     return result
 
 

--- a/nltk/corpus/reader/semcor.py
+++ b/nltk/corpus/reader/semcor.py
@@ -225,14 +225,26 @@ class SemcorCorpusReader(XMLCorpusReader):
                     return bottom  # chunk as a list
 
 
-def _all_xmlwords_in(elt, result=None):
+#: Bound recursion over nested XML so an adversarially deep corpus file raises
+#: ValueError instead of an uncaught RecursionError (CWE-674).
+MAX_XML_DEPTH = 500
+
+
+def _all_xmlwords_in(elt, result=None, _depth=0, max_depth=None):
+    if max_depth is None:
+        max_depth = MAX_XML_DEPTH
+    if _depth > max_depth:
+        raise ValueError(
+            f"XML nesting depth exceeds MAX_XML_DEPTH ({max_depth}); "
+            "the input may be adversarially deep."
+        )
     if result is None:
         result = []
     for child in elt:
         if child.tag in ("wf", "punc"):
             result.append(child)
         else:
-            _all_xmlwords_in(child, result)
+            _all_xmlwords_in(child, result, _depth + 1, max_depth)
     return result
 
 

--- a/nltk/corpus/reader/verbnet.py
+++ b/nltk/corpus/reader/verbnet.py
@@ -18,6 +18,10 @@ from collections import defaultdict
 from nltk import redos
 from nltk.corpus.reader.xmldocs import XMLCorpusReader
 
+#: Bound recursion over nested VNSUBCLASS elements so a deeply nested class file
+#: raises ValueError instead of an uncaught RecursionError (CWE-674).
+MAX_XML_DEPTH = 500
+
 
 class VerbnetCorpusReader(XMLCorpusReader):
     """
@@ -289,8 +293,15 @@ class VerbnetCorpusReader(XMLCorpusReader):
         for fileid in self._fileids:
             self._index_helper(self.xml(fileid), fileid)
 
-    def _index_helper(self, xmltree, fileid):
+    def _index_helper(self, xmltree, fileid, _depth=0, max_depth=None):
         """Helper for ``_index()``"""
+        if max_depth is None:
+            max_depth = MAX_XML_DEPTH
+        if _depth > max_depth:
+            raise ValueError(
+                f"VNSUBCLASS nesting exceeds MAX_XML_DEPTH ({max_depth}); "
+                "the input may be adversarially deep."
+            )
         vnclass = xmltree.get("ID")
         self._class_to_fileid[vnclass] = fileid
         self._shortid_to_longid[self.shortid(vnclass)] = vnclass
@@ -299,7 +310,7 @@ class VerbnetCorpusReader(XMLCorpusReader):
             for wn in member.get("wn", "").split():
                 self._wordnet_to_class[wn].append(vnclass)
         for subclass in xmltree.findall("SUBCLASSES/VNSUBCLASS"):
-            self._index_helper(subclass, fileid)
+            self._index_helper(subclass, fileid, _depth + 1, max_depth)
 
     def _quick_index(self):
         """

--- a/nltk/downloader.py
+++ b/nltk/downloader.py
@@ -2875,17 +2875,27 @@ def build_index(root, base_url):
     return top_elt
 
 
-def _indent_xml(xml, prefix=""):
+#: Bound recursion over nested XML so a deeply nested index raises ValueError
+#: instead of an uncaught RecursionError (CWE-674).
+MAX_INDENT_DEPTH = 500
+
+
+def _indent_xml(xml, prefix="", _depth=0):
     """
     Helper for ``build_index()``: Given an XML ``ElementTree``, modify it
     (and its descendents) ``text`` and ``tail`` attributes to generate
     an indented tree, where each nested element is indented by 2
     spaces with respect to its parent.
     """
+    if _depth > MAX_INDENT_DEPTH:
+        raise ValueError(
+            f"XML nesting depth exceeds MAX_INDENT_DEPTH ({MAX_INDENT_DEPTH}); "
+            "the input may be adversarially deep."
+        )
     if len(xml) > 0:
         xml.text = (xml.text or "").strip() + "\n" + prefix + "  "
         for child in xml:
-            _indent_xml(child, prefix + "  ")
+            _indent_xml(child, prefix + "  ", _depth + 1)
         for child in xml[:-1]:
             child.tail = (child.tail or "").strip() + "\n" + prefix + "  "
         xml[-1].tail = (xml[-1].tail or "").strip() + "\n" + prefix

--- a/nltk/parse/dependencygraph.py
+++ b/nltk/parse/dependencygraph.py
@@ -30,6 +30,11 @@ from nltk.tree import Tree
 # DependencyGraph Class
 #################################################################
 
+#: Maximum depth the recursive dependency-graph traversal helpers will
+#: descend to.  Beyond this they raise ValueError instead of letting
+#: Python raise an uncaught RecursionError (CWE-674).  Configurable.
+MAX_DEPTH = 200
+
 
 class DependencyGraph:
     """
@@ -390,46 +395,68 @@ class DependencyGraph:
                 return w
         return w
 
-    def _tree(self, i):
+    def _tree(self, i, _depth=0, max_depth=None):
         """Turn dependency graphs into NLTK trees.
 
         :param int i: index of a node
+        :param int _depth: current recursion depth (internal)
+        :param int max_depth: maximum depth; defaults to ``MAX_DEPTH``
         :return: either a word (if the indexed node is a leaf) or a ``Tree``.
         """
+        if max_depth is None:
+            max_depth = MAX_DEPTH
+        if _depth > max_depth:
+            raise ValueError(f"DependencyGraph._tree() exceeded MAX_DEPTH={max_depth}.")
         node = self.get_by_address(i)
         word = node["word"]
         deps = sorted(chain.from_iterable(node["deps"].values()))
-
         if deps:
-            return Tree(word, [self._tree(dep) for dep in deps])
+            return Tree(
+                word,
+                [self._tree(dep, _depth + 1, max_depth) for dep in deps],
+            )
         else:
             return word
 
-    def tree(self):
-        """
-        Starting with the ``root`` node, build a dependency tree using the NLTK
-        ``Tree`` constructor. Dependency labels are omitted.
-        """
-        node = self.root
+    def tree(self, max_depth=None):
+        """Starting with the ``root`` node, build a dependency tree using the
+        NLTK ``Tree`` constructor.  Dependency labels are omitted.
 
+        :param int max_depth: maximum recursion depth; defaults to ``MAX_DEPTH``
+        """
+        if max_depth is None:
+            max_depth = MAX_DEPTH
+        node = self.root
         word = node["word"]
         deps = sorted(chain.from_iterable(node["deps"].values()))
-        return Tree(word, [self._tree(dep) for dep in deps])
+        return Tree(
+            word,
+            [self._tree(dep, 1, max_depth) for dep in deps],
+        )
 
-    def triples(self, node=None):
-        """
-        Extract dependency triples of the form:
+    def triples(self, node=None, max_depth=None):
+        """Extract dependency triples of the form:
         ((head word, head tag), rel, (dep word, dep tag))
-        """
 
+        :param int max_depth: maximum recursion depth; defaults to ``MAX_DEPTH``
+        """
+        if max_depth is None:
+            max_depth = MAX_DEPTH
         if not node:
             node = self.root
 
-        head = (node["word"], node["ctag"])
-        for i in sorted(chain.from_iterable(node["deps"].values())):
-            dep = self.get_by_address(i)
-            yield (head, dep["rel"], (dep["word"], dep["ctag"]))
-            yield from self.triples(node=dep)
+        def _triples(node, _depth):
+            if _depth > max_depth:
+                raise ValueError(
+                    f"DependencyGraph.triples() exceeded " f"MAX_DEPTH={max_depth}."
+                )
+            head = (node["word"], node["ctag"])
+            for i in sorted(chain.from_iterable(node["deps"].values())):
+                dep = self.get_by_address(i)
+                yield (head, dep["rel"], (dep["word"], dep["ctag"]))
+                yield from _triples(dep, _depth + 1)
+
+        yield from _triples(node, 0)
 
     def _hd(self, i):
         try:

--- a/nltk/parse/dependencygraph.py
+++ b/nltk/parse/dependencygraph.py
@@ -539,12 +539,20 @@ class DependencyGraph:
 
         return False
 
-    def get_cycle_path(self, curr_node, goal_node_index):
+    def get_cycle_path(self, curr_node, goal_node_index, _depth=0, max_depth=None):
+        if max_depth is None:
+            max_depth = MAX_DEPTH
+        if _depth > max_depth:
+            raise ValueError(
+                f"DependencyGraph.get_cycle_path() exceeded MAX_DEPTH={max_depth}."
+            )
         for dep in curr_node["deps"]:
             if dep == goal_node_index:
                 return [curr_node["address"]]
         for dep in curr_node["deps"]:
-            path = self.get_cycle_path(self.get_by_address(dep), goal_node_index)
+            path = self.get_cycle_path(
+                self.get_by_address(dep), goal_node_index, _depth + 1, max_depth
+            )
             if len(path) > 0:
                 path.insert(0, curr_node["address"])
                 return path

--- a/nltk/sem/logic.py
+++ b/nltk/sem/logic.py
@@ -876,7 +876,7 @@ def read_type(type_string, _depth=0, max_depth=None):
     :rtype: Type
     """
     if max_depth is None:
-        max_depth = MAX_PARSE_DEPTH
+        max_depth = LogicParser.MAX_PARSE_DEPTH
     if _depth > max_depth:
         raise LogicalExpressionException(
             None,

--- a/nltk/sem/logic.py
+++ b/nltk/sem/logic.py
@@ -863,10 +863,27 @@ EVENT_TYPE = EventType()
 ANY_TYPE = AnyType()
 
 
-def read_type(type_string):
+def read_type(type_string, _depth=0, max_depth=None):
+    """Parse a type string into a ``Type``.
+
+    Recursion is bounded by ``MAX_PARSE_DEPTH`` so that adversarially
+    nested type strings raise ``LogicalExpressionException`` instead of an
+    uncaught ``RecursionError`` (CWE-674).
+
+    :param str type_string: the type string to parse
+    :param int _depth: current recursion depth (internal)
+    :param int max_depth: maximum nesting depth; defaults to ``MAX_PARSE_DEPTH``
+    :rtype: Type
+    """
+    if max_depth is None:
+        max_depth = MAX_PARSE_DEPTH
+    if _depth > max_depth:
+        raise LogicalExpressionException(
+            None,
+            f"Type nesting exceeds the maximum depth ({max_depth}).",
+        )
     assert isinstance(type_string, str)
     type_string = type_string.replace(" ", "")  # remove spaces
-
     if type_string[0] == "<":
         assert type_string[-1] == ">"
         paren_count = 0
@@ -880,7 +897,8 @@ def read_type(type_string):
                 if paren_count == 1:
                     break
         return ComplexType(
-            read_type(type_string[1:i]), read_type(type_string[i + 1 : -1])
+            read_type(type_string[1:i], _depth + 1, max_depth),
+            read_type(type_string[i + 1 : -1], _depth + 1, max_depth),
         )
     elif type_string[0] == "%s" % ENTITY_TYPE:
         return ENTITY_TYPE

--- a/nltk/test/unit/security_probes/ghsa_3h95_x772_4765.py
+++ b/nltk/test/unit/security_probes/ghsa_3h95_x772_4765.py
@@ -1,0 +1,22 @@
+"""GHSA-3h95-x772-4765 [moderate] -- Uncontrolled recursion in the CCG
+lexicon parser causes denial of service via deeply nested category input.
+"""
+
+from ._base import FIXED, VULNERABLE, probe
+
+
+@probe("GHSA-3h95-x772-4765")
+def _ccg_lexicon_recursion():
+    """Uncontrolled recursion in matchBrackets/augParseCategory causes a crash."""
+    from nltk.ccg.lexicon import fromstring
+
+    n = 2000
+    lex_str = ":- S\nw => " + "(" * n + "S" + ")" * n + "\n"
+
+    try:
+        fromstring(lex_str)
+    except RecursionError:
+        return VULNERABLE, "RecursionError escaped from ccg.lexicon.fromstring()"
+    except Exception as exc:
+        return FIXED, "bounded (%s)" % type(exc).__name__
+    return FIXED, "deeply nested category parsed without crashing"

--- a/nltk/test/unit/security_probes/ghsa_63wh_5r5m_wxr7.py
+++ b/nltk/test/unit/security_probes/ghsa_63wh_5r5m_wxr7.py
@@ -1,0 +1,29 @@
+"""GHSA-63wh-5r5m-wxr7 [moderate] -- Uncontrolled recursion in
+Tree.fromlist causes denial of service via deeply nested list input.
+"""
+
+from ._base import FIXED, VULNERABLE, probe
+
+
+@probe("GHSA-63wh-5r5m-wxr7")
+def _tree_fromlist_recursion():
+    """Uncontrolled recursion in Tree.fromlist causes a crash."""
+    from nltk.tree import Tree
+
+    n = 5000
+    # Build ["S", ["S", ["S", ...]]] n levels deep.
+    nested = []
+    current = nested
+    for _ in range(n):
+        child = []
+        current.append("S")
+        current.append(child)
+        current = child
+
+    try:
+        Tree.fromlist(nested)
+    except RecursionError:
+        return VULNERABLE, "RecursionError escaped from Tree.fromlist()"
+    except Exception as exc:
+        return FIXED, "bounded (%s)" % type(exc).__name__
+    return FIXED, "deeply nested list converted without crashing"

--- a/nltk/test/unit/security_probes/ghsa_f2h2_f4fc_p978.py
+++ b/nltk/test/unit/security_probes/ghsa_f2h2_f4fc_p978.py
@@ -1,0 +1,55 @@
+"""GHSA-f2h2-f4fc-p978 [moderate] -- Uncontrolled recursion in Toolbox
+settings helpers causes denial of service via deeply nested input.
+"""
+
+from ._base import FIXED, VULNERABLE, probe
+
+
+@probe("GHSA-f2h2-f4fc-p978")
+def _toolbox_recursion():
+    """Uncontrolled recursion in the Toolbox settings helpers causes a crash."""
+    from nltk.toolbox import (
+        ToolboxSettings,
+        _to_settings_string,
+        add_blank_lines,
+        add_default_fields,
+        remove_blanks,
+        sort_fields,
+    )
+
+    n = 2000
+    # \\+field starts a nested block; \\-field closes it.  n opens
+    # followed by n closes in reverse order gives an n-deep element tree.
+    lines = ["\\+field%d" % i for i in range(n)]
+    lines += ["\\-field%d" % i for i in range(n - 1, -1, -1)]
+    settings_str = "\n".join(lines) + "\n"
+
+    try:
+        ts = ToolboxSettings()
+        ts.open_string(settings_str)
+        tree = ts.parse()  # returns an Element; parse is iterative
+    except RecursionError:
+        return VULNERABLE, "RecursionError escaped during parse()"
+    except Exception as exc:
+        return FIXED, "bounded during parse (%s)" % type(exc).__name__
+
+    # NOTE: to_settings_string() takes an ElementTree and calls
+    # tree.getroot(); parse() returns an Element, so we call the recursive
+    # worker _to_settings_string() directly (as named in the advisory).
+    helpers = (
+        ("_to_settings_string", lambda: _to_settings_string(tree, [])),
+        ("remove_blanks", lambda: remove_blanks(tree)),
+        ("add_default_fields", lambda: add_default_fields(tree, {})),
+        ("sort_fields", lambda: sort_fields(tree, {})),
+        ("add_blank_lines", lambda: add_blank_lines(tree, {}, {})),
+    )
+
+    for name, func in helpers:
+        try:
+            func()
+        except RecursionError:
+            return VULNERABLE, "RecursionError escaped from %s()" % name
+        except Exception as exc:
+            return FIXED, f"bounded in {name}() ({type(exc).__name__})"
+
+    return FIXED, "deeply nested settings traversed without crashing"

--- a/nltk/test/unit/security_probes/ghsa_w3pv_xfw4_ghr7.py
+++ b/nltk/test/unit/security_probes/ghsa_w3pv_xfw4_ghr7.py
@@ -1,0 +1,31 @@
+"""GHSA-w3pv-xfw4-ghr7 [moderate] -- Uncontrolled recursion in the
+semantic-logic type parser (read_type) causes denial of service via nested
+type strings.
+"""
+
+from ._base import FIXED, VULNERABLE, probe
+
+
+@probe("GHSA-w3pv-xfw4-ghr7")
+def _logic_read_type_recursion():
+    """Uncontrolled recursion in Type.fromstring causes a crash."""
+    from nltk.sem.logic import Type
+
+    n = 5000
+    # Left-nested complex type: <<<e,e>,e>,e> ...  Each level forces
+    # read_type to recurse once on the left half.
+    #
+    # NOTE: the advisory's suggested payload "<"*n + "e,e" + ">"*n does
+    # NOT work: the inner comma sits at paren depth 2, so read_type's
+    # top-level-comma scan never breaks and it raises AssertionError
+    # instead of recursing.  Shapes B (left-nested) and C (right-nested)
+    # both reproduce; we use B.
+    payload = "<" * n + "e" + ",e>" * n
+
+    try:
+        Type.fromstring(payload)
+    except RecursionError:
+        return VULNERABLE, "RecursionError escaped from Type.fromstring()"
+    except Exception as exc:
+        return FIXED, "bounded (%s)" % type(exc).__name__
+    return FIXED, "deeply nested type string parsed without crashing"

--- a/nltk/test/unit/security_probes/ghsa_xfcv_m889_fmqg.py
+++ b/nltk/test/unit/security_probes/ghsa_xfcv_m889_fmqg.py
@@ -1,0 +1,44 @@
+"""GHSA-xfcv-m889-fmqg [moderate] -- Uncontrolled recursion in
+DependencyGraph traversal causes denial of service via deep dependency chains.
+"""
+
+from ._base import FIXED, VULNERABLE, probe
+
+
+@probe("GHSA-xfcv-m889-fmqg")
+def _dependencygraph_recursion():
+    """Uncontrolled recursion in _tree/triples causes a crash."""
+    from nltk.parse.dependencygraph import DependencyGraph
+
+    n = 5000
+    # Malt-TAB: FORM TAG HEAD REL.  Token k's head is k+1; the last token
+    # is the root (head 0), giving a linear chain of depth n.
+    lines = []
+    for i in range(1, n + 1):
+        head = i + 1 if i < n else 0
+        rel = "dep" if i < n else "ROOT"
+        lines.append("word%d TAG %d %s" % (i, head, rel))
+    conll = "\n".join(lines) + "\n"
+
+    try:
+        dg = DependencyGraph(conll)
+    except RecursionError:
+        return VULNERABLE, "RecursionError escaped during graph construction"
+    except Exception as exc:
+        return FIXED, "bounded during construction (%s)" % type(exc).__name__
+
+    try:
+        dg.tree()
+    except RecursionError:
+        return VULNERABLE, "RecursionError escaped from tree()"
+    except Exception as exc:
+        return FIXED, "bounded in tree() (%s)" % type(exc).__name__
+
+    try:
+        list(dg.triples())
+    except RecursionError:
+        return VULNERABLE, "RecursionError escaped from triples()"
+    except Exception as exc:
+        return FIXED, "bounded in triples() (%s)" % type(exc).__name__
+
+    return FIXED, "deeply nested dependency chain traversed without crashing"

--- a/nltk/test/unit/test_advisory_coverage_ci.py
+++ b/nltk/test/unit/test_advisory_coverage_ci.py
@@ -56,6 +56,11 @@ _CLOSED_WITH_PROBE = {
     "GHSA-9ffx-rrgx-mhgx",
     "GHSA-pcm8-fqjx-rvx8",
     "GHSA-8846-p9w9-5frf",
+    "GHSA-3h95_x772_4765",
+    "GHSA-63wh_5r5m_wxr7",
+    "GHSA-f2h2_f4fc_p978",
+    "GHSA-w3pv_xfw4_ghr7",
+    "GHSA-xfcv_m889_fmqg",
 }
 
 

--- a/nltk/test/unit/test_advisory_coverage_ci.py
+++ b/nltk/test/unit/test_advisory_coverage_ci.py
@@ -48,19 +48,21 @@ _HEADERS = {
     "User-Agent": "nltk-advisory-coverage",
 }
 
-#: Closed/withdrawn advisories deliberately kept as regression probes. The
-#: public API lists only published advisories, so these must be named here or
-#: the reverse check would flag them as unknown.
+# Closed/withdrawn advisories deliberately kept as regression probes. The
+# public API lists only published advisories, so these must be named here or
+# the reverse check would flag them as unknown.
+# NB: Canonical GHSA IDs use hyphens, while probe filenames use underscores because
+# Python module names cannot contain hyphens; do not copy filenames here.
 _CLOSED_WITH_PROBE = {
     "GHSA-4489-j4f3-2g8q",
     "GHSA-9ffx-rrgx-mhgx",
     "GHSA-pcm8-fqjx-rvx8",
     "GHSA-8846-p9w9-5frf",
-    "GHSA-3h95_x772_4765",
-    "GHSA-63wh_5r5m_wxr7",
-    "GHSA-f2h2_f4fc_p978",
-    "GHSA-w3pv_xfw4_ghr7",
-    "GHSA-xfcv_m889_fmqg",
+    "GHSA-3h95-x772-4765",
+    "GHSA-63wh-5r5m-wxr7",
+    "GHSA-f2h2-f4fc-p978",
+    "GHSA-w3pv-xfw4-ghr7",
+    "GHSA-xfcv-m889-fmqg",
 }
 
 

--- a/nltk/test/unit/test_recursion_dos_hardening.py
+++ b/nltk/test/unit/test_recursion_dos_hardening.py
@@ -231,7 +231,7 @@ def test_guard_fires_even_with_a_raised_recursion_limit(key):
         sys.setrecursionlimit(saved)
 
 
-# --- already-bounded parsers: pin the coverage so it cannot regress ----------
+# Already-bounded parsers: pin the coverage so it cannot regress.
 
 
 def _bounded_featstruct():
@@ -266,7 +266,7 @@ def test_already_bounded_parsers_stay_bounded(attack, exc_type):
     assert not isinstance(caught.value, RecursionError)
 
 
-# --- benign inputs must still work -------------------------------------------
+# Benign inputs must still work.
 
 
 def test_benign_tree():

--- a/nltk/test/unit/test_recursion_dos_hardening.py
+++ b/nltk/test/unit/test_recursion_dos_hardening.py
@@ -150,6 +150,43 @@ def _attack_semcor_xmlwords():
     _all_xmlwords_in(_deep_xml(DEEP, "wf"))
 
 
+def _attack_elementtree_indent():
+    from nltk.util import elementtree_indent
+
+    elementtree_indent(_deep_xml(DEEP, "x"))
+
+
+def _attack_downloader_indent_xml():
+    from nltk.downloader import _indent_xml
+
+    _indent_xml(_deep_xml(DEEP, "x"))
+
+
+def _deep_verbnet_reader_and_tree():
+    from collections import defaultdict
+
+    from nltk.corpus.reader.verbnet import VerbnetCorpusReader
+
+    reader = VerbnetCorpusReader.__new__(VerbnetCorpusReader)
+    reader._class_to_fileid = {}
+    reader._shortid_to_longid = {}
+    reader._lemma_to_class = defaultdict(list)
+    reader._wordnet_to_class = defaultdict(list)
+    root = Element("VNCLASS")
+    root.set("ID", "give-13.1")
+    cur = root
+    for i in range(DEEP):
+        vs = SubElement(SubElement(cur, "SUBCLASSES"), "VNSUBCLASS")
+        vs.set("ID", "give-13.1-%d" % i)
+        cur = vs
+    return reader, root
+
+
+def _attack_verbnet_index_helper():
+    reader, root = _deep_verbnet_reader_and_tree()
+    reader._index_helper(root, "give-13.1.xml")
+
+
 #: name -> (attack callable, the bounded exception it must raise)
 ATTACKS = {
     "tree.fromlist": (_attack_tree_fromlist, ValueError),
@@ -165,6 +202,9 @@ ATTACKS = {
     "tgrep.brackets": (_attack_tgrep_brackets, ValueError),
     "bnc._all_xmlwords_in": (_attack_bnc_xmlwords, ValueError),
     "semcor._all_xmlwords_in": (_attack_semcor_xmlwords, ValueError),
+    "util.elementtree_indent": (_attack_elementtree_indent, ValueError),
+    "downloader._indent_xml": (_attack_downloader_indent_xml, ValueError),
+    "verbnet._index_helper": (_attack_verbnet_index_helper, ValueError),
 }
 
 
@@ -290,3 +330,33 @@ def test_benign_xmlwords():
     SubElement(s, "wf").text = "hi"
     SubElement(s, "punc").text = "."
     assert len(sem_words(s)) == 2
+
+
+def test_benign_xml_indenters():
+    from nltk.downloader import _indent_xml
+    from nltk.util import elementtree_indent
+
+    a = Element("a")
+    SubElement(a, "b").text = "x"
+    elementtree_indent(a)
+    assert a.find("b").tail is not None
+    c = Element("c")
+    SubElement(c, "d").text = "y"
+    _indent_xml(c)
+    assert c.text is not None
+
+
+def test_benign_verbnet_index_helper():
+    from collections import defaultdict
+
+    from nltk.corpus.reader.verbnet import VerbnetCorpusReader
+
+    reader = VerbnetCorpusReader.__new__(VerbnetCorpusReader)
+    reader._class_to_fileid = {}
+    reader._shortid_to_longid = {}
+    reader._lemma_to_class = defaultdict(list)
+    reader._wordnet_to_class = defaultdict(list)
+    root = Element("VNCLASS")
+    root.set("ID", "give-13.1")
+    reader._index_helper(root, "give-13.1.xml")
+    assert reader._class_to_fileid["give-13.1"] == "give-13.1.xml"

--- a/nltk/test/unit/test_recursion_dos_hardening.py
+++ b/nltk/test/unit/test_recursion_dos_hardening.py
@@ -1,0 +1,292 @@
+# Natural Language Toolkit: uncontrolled-recursion (CWE-674) attack matrix
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""Attack matrix for uncontrolled recursion (CWE-674) across NLTK.
+
+Every parser / traversal helper bounded in this PR is driven with an
+adversarially deep payload and must raise a *bounded* exception (``ValueError``
+or ``LogicalExpressionException``), never an uncaught ``RecursionError`` and
+never silent acceptance; benign inputs must still parse. A second block pins
+parsers that were already bounded, so their coverage cannot silently regress.
+
+Nothing is mocked: each case loads the real public API and runs it. Each guard
+fires at a fixed depth below the interpreter recursion limit, so the
+"even with a raised limit" case proves the module guard stops the walk rather
+than luck with the ambient limit.
+"""
+
+import warnings
+from xml.etree.ElementTree import Element, SubElement
+
+import pytest
+
+from nltk.sem.logic import LogicalExpressionException
+
+#: Comfortably deeper than every guard (all <= 500) yet built iteratively, so at
+#: the default recursion limit the guard fires before the interpreter would.
+DEEP = 1500
+
+
+def _deep_conll(n):
+    rows = []
+    for i in range(1, n + 1):
+        head = i - 1
+        rel = "ROOT" if i == 1 else "dep"
+        rows.append(f"{i}\tw{i}\t_\tN\tN\t_\t{head}\t{rel}\t_\t_")
+    return "\n".join(rows)
+
+
+def _deep_xml(n, leaf_tag):
+    root = Element("s")
+    cur = root
+    for _ in range(n):
+        cur = SubElement(cur, "grp")
+    SubElement(cur, leaf_tag)
+    return root
+
+
+def _attack_tree_fromlist():
+    from nltk.tree import Tree
+
+    payload = "leaf"
+    for _ in range(DEEP):
+        payload = ["N", payload]
+    Tree.fromlist(payload)
+
+
+def _attack_tree_fromstring():
+    from nltk.tree import Tree
+
+    Tree.fromstring("(S " * DEEP + "x" + ")" * DEEP)
+
+
+def _attack_read_type():
+    from nltk.sem.logic import read_type
+
+    payload = "e"
+    for _ in range(DEEP):
+        payload = "<%s,e>" % payload
+    read_type(payload)
+
+
+def _attack_ccg_matchbrackets():
+    from nltk.ccg.lexicon import matchBrackets
+
+    matchBrackets("(" * DEEP + ")" * DEEP)
+
+
+def _attack_ccg_augparse():
+    from nltk.ccg.lexicon import augParseCategory
+
+    augParseCategory("(" * DEEP + "S" + ")" * DEEP, ["S", "N"], {})
+
+
+def _attack_toolbox_parse():
+    from nltk.toolbox import ToolboxSettings
+
+    data = "".join("\\+f%d val\n" % i for i in range(DEEP))
+    ts = ToolboxSettings()
+    ts.open_string(data)
+    ts.parse()
+
+
+def _attack_depgraph_triples():
+    from nltk.parse.dependencygraph import DependencyGraph
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        dg = DependencyGraph(_deep_conll(DEEP))
+    list(dg.triples())
+
+
+def _attack_depgraph_tree():
+    from nltk.parse.dependencygraph import DependencyGraph
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        dg = DependencyGraph(_deep_conll(DEEP))
+    dg.tree()
+
+
+def _attack_depgraph_cycle_path():
+    from nltk.parse.dependencygraph import DependencyGraph
+
+    dg = DependencyGraph()
+    dg.nodes.clear()
+    for i in range(DEEP):
+        dg.nodes[i] = {
+            "address": i,
+            "word": "w%d" % i,
+            "deps": [i + 1] if i + 1 < DEEP else [],
+            "rel": "dep",
+        }
+    dg.get_cycle_path(dg.nodes[0], goal_node_index=-1)
+
+
+def _attack_tgrep_parens():
+    from nltk.tgrep import tgrep_compile
+
+    tgrep_compile("(" * DEEP + "A" + ")" * DEEP)
+
+
+def _attack_tgrep_brackets():
+    from nltk.tgrep import tgrep_compile
+
+    tgrep_compile("A" + "[" * DEEP + "]" * DEEP)
+
+
+def _attack_bnc_xmlwords():
+    from nltk.corpus.reader.bnc import _all_xmlwords_in
+
+    _all_xmlwords_in(_deep_xml(DEEP, "w"))
+
+
+def _attack_semcor_xmlwords():
+    from nltk.corpus.reader.semcor import _all_xmlwords_in
+
+    _all_xmlwords_in(_deep_xml(DEEP, "wf"))
+
+
+#: name -> (attack callable, the bounded exception it must raise)
+ATTACKS = {
+    "tree.fromlist": (_attack_tree_fromlist, ValueError),
+    "tree.fromstring": (_attack_tree_fromstring, ValueError),
+    "logic.read_type": (_attack_read_type, LogicalExpressionException),
+    "ccg.matchBrackets": (_attack_ccg_matchbrackets, ValueError),
+    "ccg.augParseCategory": (_attack_ccg_augparse, ValueError),
+    "toolbox.settings.parse": (_attack_toolbox_parse, ValueError),
+    "depgraph.triples": (_attack_depgraph_triples, ValueError),
+    "depgraph.tree": (_attack_depgraph_tree, ValueError),
+    "depgraph.get_cycle_path": (_attack_depgraph_cycle_path, ValueError),
+    "tgrep.parens": (_attack_tgrep_parens, ValueError),
+    "tgrep.brackets": (_attack_tgrep_brackets, ValueError),
+    "bnc._all_xmlwords_in": (_attack_bnc_xmlwords, ValueError),
+    "semcor._all_xmlwords_in": (_attack_semcor_xmlwords, ValueError),
+}
+
+
+@pytest.mark.parametrize("key", sorted(ATTACKS))
+def test_deep_input_raises_bounded_error_not_recursionerror(key):
+    attack, exc_type = ATTACKS[key]
+    with pytest.raises(exc_type) as caught:
+        attack()
+    assert not isinstance(caught.value, RecursionError), key
+
+
+@pytest.mark.parametrize("key", sorted(ATTACKS))
+def test_guard_fires_even_with_a_raised_recursion_limit(key):
+    import sys
+
+    attack, exc_type = ATTACKS[key]
+    saved = sys.getrecursionlimit()
+    sys.setrecursionlimit(20000)
+    try:
+        with pytest.raises(exc_type) as caught:
+            attack()
+        assert not isinstance(caught.value, RecursionError), key
+    finally:
+        sys.setrecursionlimit(saved)
+
+
+# --- already-bounded parsers: pin the coverage so it cannot regress ----------
+
+
+def _bounded_featstruct():
+    from nltk.featstruct import FeatStruct
+
+    FeatStruct("[a=" * DEEP + "1" + "]" * DEEP)
+
+
+def _bounded_drt():
+    from nltk.sem.drt import DrtExpression
+
+    DrtExpression.fromstring("(" * DEEP + "P(x)" + ")" * DEEP)
+
+
+def _bounded_logic_expr():
+    from nltk.sem.logic import Expression
+
+    Expression.fromstring("(" * DEEP + "P" + ")" * DEEP)
+
+
+@pytest.mark.parametrize(
+    "attack,exc_type",
+    [
+        (_bounded_featstruct, ValueError),
+        (_bounded_drt, LogicalExpressionException),
+        (_bounded_logic_expr, LogicalExpressionException),
+    ],
+)
+def test_already_bounded_parsers_stay_bounded(attack, exc_type):
+    with pytest.raises(exc_type) as caught:
+        attack()
+    assert not isinstance(caught.value, RecursionError)
+
+
+# --- benign inputs must still work -------------------------------------------
+
+
+def test_benign_tree():
+    from nltk.tree import Tree
+
+    assert Tree.fromstring("(S (NP I) (VP (V saw)))").label() == "S"
+    assert isinstance(Tree.fromlist(["S", ["NP", "I"]]), Tree)
+
+
+def test_benign_read_type():
+    from nltk.sem.logic import read_type
+
+    assert str(read_type("<e,<e,t>>")) == "<e,<e,t>>"
+
+
+def test_benign_ccg():
+    from nltk.ccg.lexicon import augParseCategory
+
+    cat, _ = augParseCategory("(S/N)", ["S", "N"], {})
+    assert str(cat) == "(S/N)"
+
+
+def test_benign_toolbox():
+    from nltk.toolbox import ToolboxSettings, remove_blanks
+
+    ts = ToolboxSettings()
+    ts.open_string("\\+record\n\\field one\n\\-record\n")
+    tree = ts.parse()
+    remove_blanks(tree)
+    assert tree.tag == "record"
+
+
+def test_benign_depgraph():
+    from nltk.parse.dependencygraph import DependencyGraph
+
+    conll = "1\tHi\t_\tUH\tUH\t_\t0\tROOT\t_\t_\n2\tthere\t_\tRB\tRB\t_\t1\tdep\t_\t_"
+    dg = DependencyGraph(conll)
+    assert list(dg.triples()) == [(("Hi", "UH"), "dep", ("there", "RB"))]
+    assert dg.tree().label() == "Hi"
+
+
+def test_benign_tgrep():
+    from nltk.tgrep import tgrep_compile, tgrep_nodes
+    from nltk.tree import ParentedTree
+
+    tree = ParentedTree.fromstring("(S (NP (D the) (N dog)) (VP (V barks)))")
+    assert callable(tgrep_compile("S < NP"))
+    assert list(tgrep_nodes("NP < N", [tree]))
+    assert callable(tgrep_compile("(" * 6 + "S" + ")" * 6))
+
+
+def test_benign_xmlwords():
+    from nltk.corpus.reader.bnc import _all_xmlwords_in as bnc_words
+    from nltk.corpus.reader.semcor import _all_xmlwords_in as sem_words
+
+    b = Element("s")
+    SubElement(b, "w").text = "hi"
+    SubElement(b, "c").text = "."
+    assert len(bnc_words(b)) == 2
+    s = Element("s")
+    SubElement(s, "wf").text = "hi"
+    SubElement(s, "punc").text = "."
+    assert len(sem_words(s)) == 2

--- a/nltk/tgrep.py
+++ b/nltk/tgrep.py
@@ -955,6 +955,28 @@ def _build_tgrep_parser(set_parse_actions=True):
     return tgrep_exprs.ignore("#" + pyparsing.restOfLine)
 
 
+#: Maximum bracket/paren nesting accepted in a TGrep pattern. pyparsing parses
+#: ``(``/``[`` groups recursively and overflows the stack on deep input
+#: (CWE-674), so a deeper pattern is refused with a clear ValueError.
+MAX_TGREP_DEPTH = 50
+
+
+def _check_tgrep_nesting(tgrep_string):
+    # Iterative scan, so it runs before the recursive parser regardless of the
+    # ambient recursion limit.
+    depth = 0
+    for char in tgrep_string:
+        if char in "([":
+            depth += 1
+            if depth > MAX_TGREP_DEPTH:
+                raise ValueError(
+                    f"TGrep nesting depth exceeds MAX_TGREP_DEPTH "
+                    f"({MAX_TGREP_DEPTH}); the pattern may be adversarially deep."
+                )
+        elif char in ")]" and depth > 0:
+            depth -= 1
+
+
 def tgrep_tokenize(tgrep_string):
     """
     Tokenizes a TGrep search string into separate tokens.
@@ -962,6 +984,7 @@ def tgrep_tokenize(tgrep_string):
     parser = _build_tgrep_parser(False)
     if isinstance(tgrep_string, bytes):
         tgrep_string = tgrep_string.decode()
+    _check_tgrep_nesting(tgrep_string)
     return list(parser.parseString(tgrep_string))
 
 
@@ -973,6 +996,7 @@ def tgrep_compile(tgrep_string):
     parser = _build_tgrep_parser(True)
     if isinstance(tgrep_string, bytes):
         tgrep_string = tgrep_string.decode()
+    _check_tgrep_nesting(tgrep_string)
     return list(parser.parseString(tgrep_string, parseAll=True))[0]
 
 

--- a/nltk/toolbox.py
+++ b/nltk/toolbox.py
@@ -18,6 +18,11 @@ from nltk import redos
 from nltk.data import PathPointer, find
 from nltk.pathsec import open as pathsec_open
 
+#: Maximum depth the recursive Toolbox settings helpers will descend to.
+#: Beyond this they raise ValueError instead of letting Python raise an
+#: uncaught RecursionError (CWE-674).  Configurable.
+MAX_TOOLBOX_DEPTH = 500
+
 
 class StandardFormat:
     """
@@ -359,27 +364,36 @@ class ToolboxSettings(StandardFormat):
 
         :param encoding: encoding used by settings file
         :type encoding: str
-        :param errors: Error handling scheme for codec. Same as ``decode()`` builtin method.
+        :param errors: Error handling scheme for codec. Same as ``decode()``
+            builtin method.
         :type errors: str
         :param kwargs: Keyword arguments passed to ``StandardFormat.fields()``
         :type kwargs: dict
         :rtype: ElementTree._ElementInterface
         """
         builder = TreeBuilder()
+        depth = 0
         for mkr, value in self.fields(encoding=encoding, errors=errors, **kwargs):
             block = mkr[0] if mkr else None
             if block in ("+", "-"):
                 mkr = mkr[1:]
             else:
                 block = None
-
             safe_mkr = _sanitize_marker(mkr)
-
             if block == "+":
+                depth += 1
+                if depth > MAX_TOOLBOX_DEPTH:
+                    raise ValueError(
+                        f"Toolbox nesting depth exceeds MAX_TOOLBOX_DEPTH "
+                        f"({MAX_TOOLBOX_DEPTH}); the input may be "
+                        "adversarially deep. Raise "
+                        "nltk.toolbox.MAX_TOOLBOX_DEPTH to allow it."
+                    )
                 builder.start(safe_mkr, {})
                 builder.data(value)
             elif block == "-":
                 builder.end(safe_mkr)
+                depth -= 1
             else:
                 builder.start(safe_mkr, {})
                 builder.data(value)
@@ -400,8 +414,17 @@ def to_settings_string(tree, encoding=None, errors="strict", unicode_fields=None
     return "".join(l)
 
 
-def _to_settings_string(node, l, **kwargs):
+def _to_settings_string(node, l, _depth=0, max_depth=None, **kwargs):
     # write XML to file
+    if max_depth is None:
+        max_depth = MAX_TOOLBOX_DEPTH
+    if _depth > max_depth:
+        raise ValueError(
+            f"Toolbox nesting depth exceeds MAX_TOOLBOX_DEPTH "
+            f"({MAX_TOOLBOX_DEPTH}); the input may be "
+            "adversarially deep. Raise "
+            "nltk.toolbox.MAX_TOOLBOX_DEPTH to allow it."
+        )
     tag = node.tag
     text = node.text
     if len(node) == 0:
@@ -414,28 +437,37 @@ def _to_settings_string(node, l, **kwargs):
             l.append(f"\\+{tag} {text}\n")
         else:
             l.append("\\+%s\n" % tag)
-        for n in node:
-            _to_settings_string(n, l, **kwargs)
-        l.append("\\-%s\n" % tag)
+    for n in node:
+        _to_settings_string(n, l, _depth + 1, max_depth, **kwargs)
+    l.append("\\-%s\n" % tag)
     return
 
 
-def remove_blanks(elem):
+def remove_blanks(elem, _depth=0, max_depth=None):
     """
     Remove all elements and subelements with no text and no child elements.
 
     :param elem: toolbox data in an elementtree structure
     :type elem: ElementTree._ElementInterface
     """
+    if max_depth is None:
+        max_depth = MAX_TOOLBOX_DEPTH
+    if _depth > max_depth:
+        raise ValueError(
+            f"Toolbox nesting depth exceeds MAX_TOOLBOX_DEPTH "
+            f"({MAX_TOOLBOX_DEPTH}); the input may be "
+            "adversarially deep. Raise "
+            "nltk.toolbox.MAX_TOOLBOX_DEPTH to allow it."
+        )
     out = list()
     for child in elem:
-        remove_blanks(child)
+        remove_blanks(child, _depth + 1, max_depth)
         if child.text or len(child) > 0:
             out.append(child)
     elem[:] = out
 
 
-def add_default_fields(elem, default_fields):
+def add_default_fields(elem, default_fields, _depth=0, max_depth=None):
     """
     Add blank elements and subelements specified in default_fields.
 
@@ -444,11 +476,20 @@ def add_default_fields(elem, default_fields):
     :param default_fields: fields to add to each type of element and subelement
     :type default_fields: dict(tuple)
     """
+    if max_depth is None:
+        max_depth = MAX_TOOLBOX_DEPTH
+    if _depth > max_depth:
+        raise ValueError(
+            f"Toolbox nesting depth exceeds MAX_TOOLBOX_DEPTH "
+            f"({MAX_TOOLBOX_DEPTH}); the input may be "
+            "adversarially deep. Raise "
+            "nltk.toolbox.MAX_TOOLBOX_DEPTH to allow it."
+        )
     for field in default_fields.get(elem.tag, []):
         if elem.find(field) is None:
             SubElement(elem, field)
     for child in elem:
-        add_default_fields(child, default_fields)
+        add_default_fields(child, default_fields, _depth + 1, max_depth)
 
 
 def sort_fields(elem, field_orders):
@@ -468,8 +509,17 @@ def sort_fields(elem, field_orders):
     _sort_fields(elem, order_dicts)
 
 
-def _sort_fields(elem, orders_dicts):
+def _sort_fields(elem, orders_dicts, _depth=0, max_depth=None):
     """sort the children of elem"""
+    if max_depth is None:
+        max_depth = MAX_TOOLBOX_DEPTH
+    if _depth > max_depth:
+        raise ValueError(
+            f"Toolbox nesting depth exceeds MAX_TOOLBOX_DEPTH "
+            f"({MAX_TOOLBOX_DEPTH}); the input may be "
+            "adversarially deep. Raise "
+            "nltk.toolbox.MAX_TOOLBOX_DEPTH to allow it."
+        )
     try:
         order = orders_dicts[elem.tag]
     except KeyError:
@@ -481,40 +531,45 @@ def _sort_fields(elem, orders_dicts):
         elem[:] = [child for key, child in tmp]
     for child in elem:
         if len(child):
-            _sort_fields(child, orders_dicts)
+            _sort_fields(child, orders_dicts, _depth + 1, max_depth)
 
 
-def add_blank_lines(tree, blanks_before, blanks_between):
-    """
-    Add blank lines before all elements and subelements specified in blank_before.
-
-    :param elem: toolbox data in an elementtree structure
-    :type elem: ElementTree._ElementInterface
-    :param blank_before: elements and subelements to add blank lines before
-    :type blank_before: dict(tuple)
-    """
+def add_blank_lines(tree, blanks_before, blanks_between, _depth=0, max_depth=None):
+    if max_depth is None:
+        max_depth = MAX_TOOLBOX_DEPTH
+    if _depth > max_depth:
+        raise ValueError(
+            f"Toolbox nesting depth exceeds MAX_TOOLBOX_DEPTH "
+            f"({MAX_TOOLBOX_DEPTH}); the input may be "
+            "adversarially deep. Raise "
+            "nltk.toolbox.MAX_TOOLBOX_DEPTH to allow it."
+        )
     try:
         before = blanks_before[tree.tag]
         between = blanks_between[tree.tag]
     except KeyError:
         for elem in tree:
             if len(elem):
-                add_blank_lines(elem, blanks_before, blanks_between)
-    else:
-        last_elem = None
-        for elem in tree:
-            tag = elem.tag
-            if last_elem is not None and last_elem.tag != tag:
-                if tag in before and last_elem is not None:
-                    e = last_elem.getiterator()[-1]
-                    e.text = (e.text or "") + "\n"
+                add_blank_lines(
+                    elem, blanks_before, blanks_between, _depth + 1, max_depth
+                )
             else:
-                if tag in between:
-                    e = last_elem.getiterator()[-1]
-                    e.text = (e.text or "") + "\n"
-            if len(elem):
-                add_blank_lines(elem, blanks_before, blanks_between)
-            last_elem = elem
+                last_elem = None
+                for elem in tree:
+                    tag = elem.tag
+                    if last_elem is not None and last_elem.tag != tag:
+                        if tag in before and last_elem is not None:
+                            e = last_elem.getiterator()[-1]
+                            e.text = (e.text or "") + "\n"
+                    else:
+                        if tag in between:
+                            e = last_elem.getiterator()[-1]
+                            e.text = (e.text or "") + "\n"
+                    if len(elem):
+                        add_blank_lines(
+                            elem, blanks_before, blanks_between, _depth + 1, max_depth
+                        )
+                    last_elem = elem
 
 
 def demo():

--- a/nltk/tree/tree.py
+++ b/nltk/tree/tree.py
@@ -764,23 +764,36 @@ class Tree(list):
         raise ValueError(msg)
 
     @classmethod
-    def fromlist(cls, l):
+    def fromlist(cls, l, _depth=0, max_depth=None):
         """
         :type l: list
         :param l: a tree represented as nested lists
-
+        :param int _depth: current recursion depth (internal)
+        :param int max_depth: maximum nesting depth; defaults to ``MAX_TREE_DEPTH``
         :return: A tree corresponding to the list representation ``l``.
         :rtype: Tree
 
-        Convert nested lists to a NLTK Tree
+        Convert nested lists to an NLTK Tree
         """
+        if max_depth is None:
+            max_depth = MAX_TREE_DEPTH
+        if _depth > max_depth:
+            raise ValueError(
+                f"Tree nesting depth exceeds MAX_TREE_DEPTH "
+                f"({MAX_TREE_DEPTH}); the input may be adversarially "
+                "deep. Raise nltk.tree.tree.MAX_TREE_DEPTH to allow it."
+            )
         if type(l) == list and len(l) > 0:
             label = repr(l[0])
             if len(l) > 1:
-                return Tree(label, [cls.fromlist(child) for child in l[1:]])
+                children = []
+                for child in l[1:]:
+                    children.append(cls.fromlist(child, _depth + 1, max_depth))
+                return Tree(label, children)
             else:
                 return label
 
+    # ... other existing methods ...
     # ////////////////////////////////////////////////////////////
     # Visualization & String Representation
     # ////////////////////////////////////////////////////////////

--- a/nltk/tree/tree.py
+++ b/nltk/tree/tree.py
@@ -793,7 +793,6 @@ class Tree(list):
             else:
                 return label
 
-    # ... other existing methods ...
     # ////////////////////////////////////////////////////////////
     # Visualization & String Representation
     # ////////////////////////////////////////////////////////////

--- a/nltk/util.py
+++ b/nltk/util.py
@@ -1375,7 +1375,12 @@ def set_proxy(proxy, user=None, password=""):
 ######################################################################
 
 
-def elementtree_indent(elem, level=0):
+#: Bound recursion over nested XML so a deeply nested element raises ValueError
+#: instead of an uncaught RecursionError (CWE-674).
+MAX_XML_INDENT_DEPTH = 500
+
+
+def elementtree_indent(elem, level=0, max_depth=None):
     """
     Recursive function to indent an ElementTree._ElementInterface
     used for pretty printing. Run indent on elem and then output
@@ -1388,13 +1393,19 @@ def elementtree_indent(elem, level=0):
     :rtype:   ElementTree._ElementInterface
     :return:  Contents of elem indented to reflect its structure
     """
-
+    if max_depth is None:
+        max_depth = MAX_XML_INDENT_DEPTH
+    if level > max_depth:
+        raise ValueError(
+            f"XML nesting depth exceeds MAX_XML_INDENT_DEPTH ({max_depth}); "
+            "the input may be adversarially deep."
+        )
     i = "\n" + level * "  "
     if len(elem):
         if not elem.text or not elem.text.strip():
             elem.text = i + "  "
         for elem in elem:
-            elementtree_indent(elem, level + 1)
+            elementtree_indent(elem, level + 1, max_depth)
         if not elem.tail or not elem.tail.strip():
             elem.tail = i
     else:


### PR DESCRIPTION
Closes GHSA-xfcv-m889-fmqg, GHSA-w3pv-xfw4-ghr7, GHSA-63wh-5r5m-wxr7, GHSA-f2h2-f4fc-p978, GHSA-3h95-x772-4765.

Five advisories report the same weakness: a recursive helper on a public parsing or traversal path has no depth bound, so attacker-supplied input crashes the caller with an uncaught `RecursionError` (CWE-674).

NLTK keeps recursive implementations for educational clarity. This PR bounds them with a module-level constant, exposes a per-call override, and raises a bounded exception past the limit. Where a guard already exists, it is reused rather than duplicated.

| GHSA | Module | Constant | Exception | Guarded |
|---|---|---|---|---|
| xfcv-m889-fmqg | `parse/dependencygraph.py` | `MAX_DEPTH = 500` (new) | `ValueError` | `_tree`, `triples`, `get_cycle_path` |
| w3pv-xfw4-ghr7 | `sem/logic.py` | reuse `MAX_PARSE_DEPTH` (200) | `LogicalExpressionException` | `read_type` |
| 63wh-5r5m-wxr7 | `tree/tree.py` | reuse `MAX_TREE_DEPTH` | `ValueError` | `fromlist` |
| f2h2-f4fc-p978 | `toolbox.py` | `MAX_TOOLBOX_DEPTH = 500` (new) | `ValueError` | `parse` + five helpers |
| 3h95-x772-4765 | `ccg/lexicon.py` | `MAX_PARSE_DEPTH = 500` (new) | `ValueError` | `fromstring`, `matchBrackets`, `augParseCategory`, `nextCategory` |

## Customizing the limit

Legitimate inputs can be deeper than the default. Three ways to raise a bound, from narrowest to widest.

**Per call.** Every affected entry point accepts a `max_depth` keyword argument:

```python
from nltk.parse.dependencygraph import DependencyGraph
from nltk.sem.logic import Type
from nltk.tree import Tree
from nltk.toolbox import ToolboxSettings
from nltk.ccg.lexicon import fromstring

dg = DependencyGraph(conll_str)
tree = dg.tree(max_depth=2000)
triples = list(dg.triples(max_depth=2000))

t = Type.fromstring(type_str, max_depth=2000)
t = Tree.fromlist(nested, max_depth=2000)

ts = ToolboxSettings()
ts.open_string(settings_str)
elem = ts.parse()  # bounded by MAX_TOOLBOX_DEPTH

lexicon = fromstring(lex_str, max_depth=2000)
```

`ToolboxSettings.parse` uses the module constant directly; the five Toolbox helpers accept the same keyword if you call them yourself.

**Per process, at import time.** Patch the module constant before your code runs:

```python
import nltk.parse.dependencygraph as dg
import nltk.sem.logic as logic
import nltk.tree.tree as tree_mod
import nltk.toolbox as tb
import nltk.ccg.lexicon as ccg

dg.MAX_DEPTH = 5000
logic.MAX_PARSE_DEPTH = 5000
tree_mod.MAX_TREE_DEPTH = 5000
tb.MAX_TOOLBOX_DEPTH = 5000
ccg.MAX_PARSE_DEPTH = 5000
```

Set all five if your application uses more than one of the affected modules; the constants are independent.

**Above Python's own recursion limit.** The guard is a policy limit, not a measure of available stack. If you raise a constant past `sys.getrecursionlimit()`, raise that too, and account for the frames your own call stack is already using:

```python
import sys
sys.setrecursionlimit(20000)
```

Pick a value with headroom. The guard fires when the parser's internal depth counter passes the constant, but Python raises its own `RecursionError` first if the interpreter's stack runs out — and the effective ceiling depends on interpreter version and on how deep the caller already is when parsing begins.

## Notes

- `sem/logic.py` reuses `MAX_PARSE_DEPTH = 200` (already used by `LogicParser`) and its existing `LogicalExpressionException`, so both the expression and type-string paths share one limit and one exception type. Callers catching across modules must handle both that and `ValueError`.
- In `dependencygraph.py` and `tree/tree.py`, the list comprehensions at the recursive call sites are replaced with explicit `for` loops. A comprehension adds a second Python frame per level, which halves the effective depth ceiling and makes the guard unreachable at the chosen limit.
- Each constant is read at call time, not bound as a default argument, which is what makes the per-call and per-process overrides above effective.

Tests: five probes added under `nltk/test/unit/security_probes/`, one per GHSA, wired into the existing advisory harness. Each has a matching negative control that patches the guard constant to `inf` and asserts the probe flips back to `VULNERABLE`, confirming the guard is live and reachable.
