### PR TITLE
Bound recursion depth and harden tool search path and DB path containment

### DIFF
--- a/nltk/ccg/lexicon.py
+++ b/nltk/ccg/lexicon.py
@@ -140,18 +140,30 @@ class CCGLexicon:
 # Parsing lexicons
 # -----------
 
+#: Maximum bracket-nesting depth accepted when parsing a CCG category string.
+#: matchBrackets and augParseCategory recurse once per ``(`` level, so an
+#: arbitrarily deep category would raise an uncaught ``RecursionError``
+#: (CWE-674); past this depth a clear ``ValueError`` is raised instead.
+MAX_CATEGORY_DEPTH = 200
 
-def matchBrackets(string):
+
+def matchBrackets(string, _depth=0):
     """
     Separate the contents matching the first set of brackets from the rest of
     the input.
     """
+    # Bound nesting depth (CWE-674); ``_depth`` is internal (callers never pass it).
+    if _depth > MAX_CATEGORY_DEPTH:
+        raise ValueError(
+            "Category bracket nesting exceeds MAX_CATEGORY_DEPTH (%d); the input "
+            "may be adversarially deep." % MAX_CATEGORY_DEPTH
+        )
     rest = string[1:]
     inside = "("
 
     while rest != "" and not rest.startswith(")"):
         if rest.startswith("("):
-            (part, rest) = matchBrackets(rest)
+            (part, rest) = matchBrackets(rest, _depth + 1)
             inside = inside + part
         else:
             inside = inside + rest[0]
@@ -217,15 +229,23 @@ def parsePrimitiveCategory(chunks, primitives, families, var):
     )
 
 
-def augParseCategory(line, primitives, families, var=None):
+def augParseCategory(line, primitives, families, var=None, _depth=0):
     """
     Parse a string representing a category, and returns a tuple with
     (possibly) the CCG variable for the category
     """
+    # Bound nesting depth (CWE-674); ``_depth`` is internal (callers never pass it).
+    if _depth > MAX_CATEGORY_DEPTH:
+        raise ValueError(
+            "Category nesting exceeds MAX_CATEGORY_DEPTH (%d); the input may be "
+            "adversarially deep." % MAX_CATEGORY_DEPTH
+        )
     (cat_string, rest) = nextCategory(line)
 
     if cat_string.startswith("("):
-        (res, var) = augParseCategory(cat_string[1:-1], primitives, families, var)
+        (res, var) = augParseCategory(
+            cat_string[1:-1], primitives, families, var, _depth + 1
+        )
 
     else:
         (res, var) = parsePrimitiveCategory(
@@ -239,7 +259,9 @@ def augParseCategory(line, primitives, families, var=None):
 
         (cat_string, rest) = nextCategory(rest)
         if cat_string.startswith("("):
-            (arg, var) = augParseCategory(cat_string[1:-1], primitives, families, var)
+            (arg, var) = augParseCategory(
+                cat_string[1:-1], primitives, families, var, _depth + 1
+            )
         else:
             (arg, var) = parsePrimitiveCategory(
                 PRIM_RE.match(cat_string).groups(), primitives, families, var

--- a/nltk/classify/megam.py
+++ b/nltk/classify/megam.py
@@ -26,7 +26,7 @@ import math
 import numbers
 import subprocess
 
-from nltk.internals import find_binary
+from nltk.internals import find_binary_absolute
 from nltk.pathsec import TrustError, spawn_trusted
 
 try:
@@ -52,7 +52,9 @@ def config_megam(bin=None):
     :type bin: str
     """
     global _megam_bin
-    _megam_bin = find_binary(
+    # Accept only an absolute binary: a relative ``bin`` resolves against the CWD
+    # and would be executed from there (untrusted search path, CWE-426/CWE-427).
+    _megam_bin = find_binary_absolute(
         "megam",
         bin,
         env_vars=["MEGAM"],

--- a/nltk/classify/tadm.py
+++ b/nltk/classify/tadm.py
@@ -9,7 +9,7 @@ import math
 import numbers
 import sys
 
-from nltk.internals import find_binary
+from nltk.internals import find_binary_absolute
 from nltk.pathsec import TrustError, spawn_trusted
 
 try:
@@ -22,7 +22,9 @@ _tadm_bin = None
 
 def config_tadm(bin=None):
     global _tadm_bin
-    _tadm_bin = find_binary(
+    # Accept only an absolute binary: a relative ``bin`` resolves against the CWD
+    # and would be executed from there (untrusted search path, CWE-426/CWE-427).
+    _tadm_bin = find_binary_absolute(
         "tadm", bin, env_vars=["TADM"], binary_names=["tadm"], url="http://tadm.sf.net"
     )
 

--- a/nltk/inference/prover9.py
+++ b/nltk/inference/prover9.py
@@ -126,7 +126,11 @@ class Prover9Parent:
             self._prover9_bin = None
         else:
             name = "prover9"
-            self._prover9_bin = nltk.internals.find_binary(
+            # Accept only an absolute binary: a relative binary_location yields a
+            # CWD-relative path that _call()'s Popen would execute without
+            # consulting $PATH, so a planted "prover9" there would run (untrusted
+            # search path, CWE-426/CWE-427). Boxer/Malt/REPP refuse it the same way.
+            self._prover9_bin = nltk.internals.find_binary_absolute(
                 name,
                 path_to_bin=binary_location,
                 env_vars=["PROVER9"],

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -1062,6 +1062,41 @@ def find_binary(
     )
 
 
+def find_binary_absolute(
+    name,
+    path_to_bin=None,
+    env_vars=(),
+    searchpath=(),
+    binary_names=None,
+    url=None,
+    verbose=False,
+):
+    """Like :func:`find_binary`, but return only an *absolute* match.
+
+    A relative match resolves against the current working directory, so a
+    wrapper that runs the result through ``subprocess.Popen`` would execute a
+    binary planted in an attacker-writable directory (an untrusted search path,
+    CWE-426 / CWE-427). ``find_binary_iter`` already refuses a bare name that
+    resolves only in the CWD, but an explicit *relative* ``path_to_bin`` (e.g.
+    ``"tools/prover9"``) is honored there as the caller's choice, which is unsafe
+    for something about to be executed. Tool wrappers (prover9/mace, megam, tadm;
+    cf. Boxer/Malt/REPP) therefore accept only an absolute location: an absolute
+    ``path_to_bin``, an env var, or a ``$PATH`` lookup, none of which resolve
+    against the CWD.
+    """
+    for path in find_binary_iter(
+        name, path_to_bin, env_vars, searchpath, binary_names, url, verbose
+    ):
+        if os.path.isabs(path):
+            return path
+    raise LookupError(
+        f"No absolute {name!r} binary found; a binary found relative to the "
+        "current working directory is refused (untrusted search path). Pass an "
+        "absolute path_to_bin, or set the tool's env var / searchpath to an "
+        "absolute location."
+    )
+
+
 def find_jar_iter(
     name_pattern,
     path_to_jar=None,

--- a/nltk/parse/dependencygraph.py
+++ b/nltk/parse/dependencygraph.py
@@ -26,6 +26,13 @@ from nltk.internals import find_binary
 from nltk.pathsec import open as _secure_open
 from nltk.tree import Tree
 
+#: Maximum dependency-chain depth walked by the recursive graph traversals
+#: (_tree, triples, get_cycle_path). A crafted graph with a long chain of
+#: dependents would otherwise recurse until Python raises an uncaught
+#: ``RecursionError`` (CWE-674); past this depth a clear ``ValueError`` is
+#: raised instead. Configurable.
+MAX_GRAPH_DEPTH = 500
+
 #################################################################
 # DependencyGraph Class
 #################################################################
@@ -390,18 +397,25 @@ class DependencyGraph:
                 return w
         return w
 
-    def _tree(self, i):
+    def _tree(self, i, _depth=0):
         """Turn dependency graphs into NLTK trees.
 
         :param int i: index of a node
         :return: either a word (if the indexed node is a leaf) or a ``Tree``.
         """
+        # Bound recursion over the dependency chain (CWE-674); ``_depth`` is
+        # internal (callers never pass it).
+        if _depth > MAX_GRAPH_DEPTH:
+            raise ValueError(
+                "Dependency nesting exceeds MAX_GRAPH_DEPTH (%d); the graph may "
+                "be adversarially deep." % MAX_GRAPH_DEPTH
+            )
         node = self.get_by_address(i)
         word = node["word"]
         deps = sorted(chain.from_iterable(node["deps"].values()))
 
         if deps:
-            return Tree(word, [self._tree(dep) for dep in deps])
+            return Tree(word, [self._tree(dep, _depth + 1) for dep in deps])
         else:
             return word
 
@@ -416,11 +430,18 @@ class DependencyGraph:
         deps = sorted(chain.from_iterable(node["deps"].values()))
         return Tree(word, [self._tree(dep) for dep in deps])
 
-    def triples(self, node=None):
+    def triples(self, node=None, _depth=0):
         """
         Extract dependency triples of the form:
         ((head word, head tag), rel, (dep word, dep tag))
         """
+        # Bound recursion over the dependency chain (CWE-674); ``_depth`` is
+        # internal (callers never pass it).
+        if _depth > MAX_GRAPH_DEPTH:
+            raise ValueError(
+                "Dependency nesting exceeds MAX_GRAPH_DEPTH (%d); the graph may "
+                "be adversarially deep." % MAX_GRAPH_DEPTH
+            )
 
         if not node:
             node = self.root
@@ -429,7 +450,7 @@ class DependencyGraph:
         for i in sorted(chain.from_iterable(node["deps"].values())):
             dep = self.get_by_address(i)
             yield (head, dep["rel"], (dep["word"], dep["ctag"]))
-            yield from self.triples(node=dep)
+            yield from self.triples(node=dep, _depth=_depth + 1)
 
     def _hd(self, i):
         try:
@@ -512,12 +533,21 @@ class DependencyGraph:
 
         return False
 
-    def get_cycle_path(self, curr_node, goal_node_index):
+    def get_cycle_path(self, curr_node, goal_node_index, _depth=0):
+        # Bound recursion over the dependency chain (CWE-674); ``_depth`` is
+        # internal (callers never pass it).
+        if _depth > MAX_GRAPH_DEPTH:
+            raise ValueError(
+                "Dependency nesting exceeds MAX_GRAPH_DEPTH (%d); the graph may "
+                "be adversarially deep." % MAX_GRAPH_DEPTH
+            )
         for dep in curr_node["deps"]:
             if dep == goal_node_index:
                 return [curr_node["address"]]
         for dep in curr_node["deps"]:
-            path = self.get_cycle_path(self.get_by_address(dep), goal_node_index)
+            path = self.get_cycle_path(
+                self.get_by_address(dep), goal_node_index, _depth + 1
+            )
             if len(path) > 0:
                 path.insert(0, curr_node["address"])
                 return path

--- a/nltk/sem/chat80.py
+++ b/nltk/sem/chat80.py
@@ -511,6 +511,10 @@ def sql_query(dbname, query):
     """
     import sqlite3
 
+    # ``dbname`` names a persistent store opened by sqlite3; validate it stays
+    # inside a trusted data root with no symlink/traversal escape before opening
+    # (CWE-59), matching cities2table / val_dump / val_load.
+    validate_path(dbname, context="chat80.sql_query")
     try:
         path = nltk.data.find(dbname)
         connection = sqlite3.connect(str(path))

--- a/nltk/sem/logic.py
+++ b/nltk/sem/logic.py
@@ -863,8 +863,24 @@ EVENT_TYPE = EventType()
 ANY_TYPE = AnyType()
 
 
-def read_type(type_string):
+#: Maximum nesting depth for a type string parsed by :func:`read_type`. A type
+#: like ``<e,<e,<e,t>>>`` recurses once per ``<``; unbounded nesting would raise
+#: an uncaught ``RecursionError`` (CWE-674), so past this depth a normal
+#: ``LogicalExpressionException`` is raised instead. Configurable.
+MAX_TYPE_DEPTH = 200
+
+
+def read_type(type_string, _depth=0):
     assert isinstance(type_string, str)
+    # Bound nesting depth: read_type recurses once per ``<`` level, so an
+    # arbitrarily deep type string would otherwise crash with RecursionError
+    # (CWE-674). ``_depth`` is internal (callers never pass it).
+    if _depth > MAX_TYPE_DEPTH:
+        raise LogicalExpressionException(
+            None,
+            "Type nesting depth exceeds MAX_TYPE_DEPTH (%d); the input may be "
+            "adversarially deep." % MAX_TYPE_DEPTH,
+        )
     type_string = type_string.replace(" ", "")  # remove spaces
 
     if type_string[0] == "<":
@@ -880,7 +896,8 @@ def read_type(type_string):
                 if paren_count == 1:
                     break
         return ComplexType(
-            read_type(type_string[1:i]), read_type(type_string[i + 1 : -1])
+            read_type(type_string[1:i], _depth + 1),
+            read_type(type_string[i + 1 : -1], _depth + 1),
         )
     elif type_string[0] == "%s" % ENTITY_TYPE:
         return ENTITY_TYPE

--- a/nltk/test/unit/security_probes/ghsa_3h95_x772_4765.py
+++ b/nltk/test/unit/security_probes/ghsa_3h95_x772_4765.py
@@ -1,0 +1,25 @@
+"""GHSA-3h95-x772-4765 [medium] -- Uncontrolled recursion in CCG lexicon parser causes denial of service via deeply nested category input (CWE-674)"""
+
+from ._base import FIXED, VULNERABLE, probe
+
+
+@probe("GHSA-3h95-x772-4765")
+def _ccg_category_recursion():
+    """Parse a deeply parenthesised CCG category string.
+
+    ``matchBrackets`` (reached from ``augParseCategory`` / lexicon
+    ``fromstring``) recursed once per ``(`` with no bound, so a category like
+    ``(((...)))`` crashed with an uncaught ``RecursionError`` (a DoS). It must
+    now reject the input with a bounded ``ValueError``.
+    """
+    from nltk.ccg.lexicon import MAX_CATEGORY_DEPTH, matchBrackets
+
+    n = MAX_CATEGORY_DEPTH + 200
+    payload = "(" * n + ")" * n
+    try:
+        matchBrackets(payload)
+    except RecursionError:
+        return VULNERABLE, "matchBrackets recursed to RecursionError (uncontrolled)"
+    except ValueError as exc:
+        return FIXED, "deeply nested category rejected: %s" % str(exc)[:50]
+    return VULNERABLE, "matchBrackets accepted an adversarially deep category"

--- a/nltk/test/unit/security_probes/ghsa_63wh_5r5m_wxr7.py
+++ b/nltk/test/unit/security_probes/ghsa_63wh_5r5m_wxr7.py
@@ -1,0 +1,27 @@
+"""GHSA-63wh-5r5m-wxr7 [medium] -- Uncontrolled recursion in Tree.fromlist causes denial of service via deeply nested list input (CWE-674)"""
+
+from ._base import FIXED, VULNERABLE, probe
+
+
+@probe("GHSA-63wh-5r5m-wxr7")
+def _tree_fromlist_recursion():
+    """Convert a deeply nested list with ``Tree.fromlist``.
+
+    ``fromstring`` bounds bracket depth with ``MAX_TREE_DEPTH``, but ``fromlist``
+    recursed once per level with no bound, so a crafted nested list crashed with
+    an uncaught ``RecursionError`` (a DoS). It must now reject the input with a
+    bounded ``ValueError`` before reaching that depth.
+    """
+    from nltk.tree import Tree
+    from nltk.tree.tree import MAX_TREE_DEPTH
+
+    payload = "leaf"
+    for _ in range(MAX_TREE_DEPTH + 200):
+        payload = ["N", payload]
+    try:
+        Tree.fromlist(payload)
+    except RecursionError:
+        return VULNERABLE, "Tree.fromlist recursed to RecursionError (uncontrolled)"
+    except ValueError as exc:
+        return FIXED, "deep nested list rejected: %s" % str(exc)[:56]
+    return VULNERABLE, "Tree.fromlist accepted an adversarially deep list"

--- a/nltk/test/unit/security_probes/ghsa_cc5r_64rf_75hg.py
+++ b/nltk/test/unit/security_probes/ghsa_cc5r_64rf_75hg.py
@@ -1,0 +1,44 @@
+"""GHSA-cc5r-64rf-75hg [high] -- Untrusted search path in prover9/mace4 config allows local code execution via relative binary_location (CWE-426, CWE-427)"""
+
+import os
+import shutil
+import stat
+import tempfile
+
+from ._base import FIXED, VULNERABLE, probe
+
+
+@probe("GHSA-cc5r-64rf-75hg")
+def _prover9_relative_binary_location():
+    """Plant ``./prover9`` and ``./sub/prover9`` in the CWD, then configure the
+    prover with relative locations.
+
+    ``config_prover9`` forwarded ``binary_location`` straight to ``find_binary``,
+    which honors an explicit relative path, so a planted CWD binary would be run
+    by ``_call``'s ``Popen`` (an untrusted search path). It now resolves through
+    ``find_binary_absolute`` and accepts only an absolute location, like
+    Boxer/Malt/REPP; every relative form must be refused. Mace4 inherits the
+    same ``config_prover9``.
+    """
+    from nltk.inference.prover9 import Prover9
+
+    box = tempfile.mkdtemp()
+    for rel in ("prover9", "sub/prover9"):
+        target = os.path.join(box, rel)
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        with open(target, "w", encoding="utf-8") as fh:
+            fh.write("#!/bin/sh\necho PWNED\n")
+        os.chmod(target, os.stat(target).st_mode | stat.S_IEXEC)
+    old = os.getcwd()
+    try:
+        os.chdir(box)
+        for loc in (".", "./prover9", "sub/prover9"):
+            try:
+                Prover9().config_prover9(loc)
+            except LookupError:
+                continue
+            return VULNERABLE, "config_prover9(%r) took a CWD-relative binary" % loc
+        return FIXED, "every relative binary_location refused (absolute-only)"
+    finally:
+        os.chdir(old)
+        shutil.rmtree(box, ignore_errors=True)

--- a/nltk/test/unit/security_probes/ghsa_f2h2_f4fc_p978.py
+++ b/nltk/test/unit/security_probes/ghsa_f2h2_f4fc_p978.py
@@ -1,0 +1,29 @@
+"""GHSA-f2h2-f4fc-p978 [medium] -- Uncontrolled recursion in Toolbox settings helpers causes denial of service via deeply nested input (CWE-674)"""
+
+from ._base import FIXED, VULNERABLE, probe
+
+
+@probe("GHSA-f2h2-f4fc-p978")
+def _toolbox_settings_recursion():
+    """Parse a settings string whose ``\\+field`` markers nest without closing.
+
+    Each ``\\+`` opens an element-tree level walked later by recursive helpers
+    (``remove_blanks``, ``add_default_fields``, ``_sort_fields``,
+    ``add_blank_lines``, ``_to_settings_string``), so a string with thousands of
+    open markers built an arbitrarily deep tree and crashed those walks with an
+    uncaught ``RecursionError`` (a DoS). ``parse`` must now bound the nesting
+    with a ``ValueError`` at read time.
+    """
+    from nltk.toolbox import MAX_TOOLBOX_DEPTH, ToolboxSettings
+
+    n = MAX_TOOLBOX_DEPTH + 200
+    data = "".join("\\+f%d val\n" % i for i in range(n))
+    ts = ToolboxSettings()
+    ts.open_string(data)
+    try:
+        ts.parse()
+    except RecursionError:
+        return VULNERABLE, "toolbox parse recursed to RecursionError (uncontrolled)"
+    except ValueError as exc:
+        return FIXED, "deeply nested settings rejected: %s" % str(exc)[:48]
+    return VULNERABLE, "ToolboxSettings.parse accepted adversarially deep nesting"

--- a/nltk/test/unit/security_probes/ghsa_j456_xh4h_cpf2.py
+++ b/nltk/test/unit/security_probes/ghsa_j456_xh4h_cpf2.py
@@ -1,0 +1,27 @@
+"""GHSA-j456-xh4h-cpf2 [high] -- WekaClassifier passes an unvalidated caller-controlled model path to the weka JVM, bypassing nltk.pathsec containment (CWE-22, CWE-73)"""
+
+from ._base import FIXED, STATIC, VULNERABLE, is_security_rejection, probe
+
+
+@probe("GHSA-j456-xh4h-cpf2")
+def _weka_model_path_containment():
+    """Construct a ``WekaClassifier`` with a model path outside the data roots.
+
+    The model filename is handed to the weka JVM classpath; an unvalidated
+    caller path (absolute escape or traversal) could point outside the pathsec
+    data roots. ``__init__`` (and ``classify_many`` / ``train``) now route it
+    through ``validate_tool_path``, so an out-of-root path is security-rejected
+    before it can reach the JVM.
+    """
+    from nltk.classify.weka import WekaClassifier
+
+    attempts = ("/etc/passwd", "../" * 10 + "etc/passwd")
+    for path in attempts:
+        try:
+            WekaClassifier(None, path)
+        except Exception as exc:
+            if is_security_rejection(exc):
+                continue
+            return STATIC, "%s rejected non-securely (%s)" % (path, type(exc).__name__)
+        return VULNERABLE, "WekaClassifier accepted out-of-root model %r" % path
+    return FIXED, "out-of-root weka model path refused by validate_tool_path"

--- a/nltk/test/unit/security_probes/ghsa_w3pv_xfw4_ghr7.py
+++ b/nltk/test/unit/security_probes/ghsa_w3pv_xfw4_ghr7.py
@@ -1,0 +1,25 @@
+"""GHSA-w3pv-xfw4-ghr7 [medium] -- Uncontrolled recursion in semantic-logic type parser causes denial of service via nested type strings (CWE-674)"""
+
+from ._base import FIXED, VULNERABLE, probe
+
+
+@probe("GHSA-w3pv-xfw4-ghr7")
+def _logic_read_type_recursion():
+    """Parse a deeply nested type string with ``read_type``.
+
+    ``read_type`` recursed once per ``<`` level with no bound, so a type like
+    ``<<<...,e>,e>,e>`` crashed with an uncaught ``RecursionError`` (a DoS). It
+    must now reject the input with a bounded ``LogicalExpressionException``.
+    """
+    from nltk.sem.logic import MAX_TYPE_DEPTH, LogicalExpressionException, read_type
+
+    payload = "e"
+    for _ in range(MAX_TYPE_DEPTH + 200):
+        payload = "<%s,e>" % payload
+    try:
+        read_type(payload)
+    except RecursionError:
+        return VULNERABLE, "read_type recursed to RecursionError (uncontrolled)"
+    except LogicalExpressionException as exc:
+        return FIXED, "deep type string rejected: %s" % str(exc)[:56]
+    return VULNERABLE, "read_type accepted an adversarially deep type string"

--- a/nltk/test/unit/security_probes/ghsa_xfcv_m889_fmqg.py
+++ b/nltk/test/unit/security_probes/ghsa_xfcv_m889_fmqg.py
@@ -1,0 +1,39 @@
+"""GHSA-xfcv-m889-fmqg [medium] -- Uncontrolled recursion in DependencyGraph traversal causes denial of service via deep dependency chains (CWE-674)"""
+
+import warnings
+
+from ._base import FIXED, VULNERABLE, probe
+
+
+def _deep_conll(n):
+    """A CoNLL-10 string that is one linear chain of ``n`` dependents."""
+    rows = []
+    for i in range(1, n + 1):
+        head = i - 1
+        rel = "ROOT" if i == 1 else "dep"
+        rows.append(f"{i}\tw{i}\t_\tN\tN\t_\t{head}\t{rel}\t_\t_")
+    return "\n".join(rows)
+
+
+@probe("GHSA-xfcv-m889-fmqg")
+def _dependencygraph_recursion():
+    """Build a graph with a long linear dependency chain and traverse it.
+
+    ``_tree`` / ``triples`` recursed once per dependent with no bound, so a
+    crafted chain crashed with an uncaught ``RecursionError`` (a DoS). Both must
+    now raise a bounded ``ValueError`` past ``MAX_GRAPH_DEPTH``.
+    """
+    from nltk.parse.dependencygraph import MAX_GRAPH_DEPTH, DependencyGraph
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        dg = DependencyGraph(_deep_conll(MAX_GRAPH_DEPTH + 200))
+    for label, run in (("triples", lambda: list(dg.triples())), ("_tree", dg.tree)):
+        try:
+            run()
+        except RecursionError:
+            return VULNERABLE, "%s recursed to RecursionError (uncontrolled)" % label
+        except ValueError:
+            continue
+        return VULNERABLE, "%s accepted an adversarially deep chain" % label
+    return FIXED, "deep dependency chain rejected by MAX_GRAPH_DEPTH in triples/_tree"

--- a/nltk/test/unit/security_probes/ghsa_xv54_447f_mj22.py
+++ b/nltk/test/unit/security_probes/ghsa_xv54_447f_mj22.py
@@ -1,0 +1,22 @@
+"""GHSA-xv54-447f-mj22 [low] -- Symlink-follow sandbox bypass in chat80.sql_query allows out-of-root SQLite file read (CWE-59, CWE-73)"""
+
+from ._base import guard_rejects, probe
+
+
+@probe("GHSA-xv54-447f-mj22")
+def _chat80_sql_query_symlink():
+    """Drive ``chat80.sql_query`` with a ``dbname`` that resolves outside the
+    data roots (a symlink, an absolute path, a traversal).
+
+    ``sql_query`` opened ``dbname`` with ``sqlite3`` without any containment
+    check, so a symlink or traversal could read a SQLite file outside the roots.
+    It now calls ``validate_path(dbname)`` first (like ``cities2table`` /
+    ``val_dump`` / ``val_load``), so each escape is security-rejected before the
+    connection is opened.
+    """
+    from nltk.sem.chat80 import sql_query
+
+    def guard(path, root):
+        sql_query(path, "SELECT 1")
+
+    return guard_rejects(guard)

--- a/nltk/test/unit/test_advisory_coverage_ci.py
+++ b/nltk/test/unit/test_advisory_coverage_ci.py
@@ -58,6 +58,22 @@ _CLOSED_WITH_PROBE = {
     "GHSA-8846-p9w9-5frf",
 }
 
+#: Draft advisories we have already fixed and probe ahead of publication. The
+#: public API lists only *published* advisories, so a probe for a still-draft id
+#: would otherwise trip the reverse check below. Once such an advisory is
+#: published it appears in the fetched list and its entry here becomes a
+#: harmless no-op.
+_DRAFT_WITH_PROBE = {
+    "GHSA-63wh-5r5m-wxr7",
+    "GHSA-w3pv-xfw4-ghr7",
+    "GHSA-3h95-x772-4765",
+    "GHSA-f2h2-f4fc-p978",
+    "GHSA-xfcv-m889-fmqg",
+    "GHSA-xv54-447f-mj22",
+    "GHSA-cc5r-64rf-75hg",
+    "GHSA-j456-xh4h-cpf2",
+}
+
 
 def _next_url(link_header):
     """The *on-origin* rel="next" URL from a GitHub ``Link`` header, else None.
@@ -120,6 +136,6 @@ def test_no_probe_targets_an_unknown_advisory():
     advisories = _fetch_advisories()
     if advisories is None:
         pytest.skip("could not fetch advisories from GitHub")
-    known = {a["ghsa_id"] for a in advisories} | _CLOSED_WITH_PROBE
+    known = {a["ghsa_id"] for a in advisories} | _CLOSED_WITH_PROBE | _DRAFT_WITH_PROBE
     unknown = sorted(set(probes.PROBES) - known)
     assert not unknown, "probes for ids GitHub does not list: %s" % unknown

--- a/nltk/test/unit/test_recursion_dos_hardening.py
+++ b/nltk/test/unit/test_recursion_dos_hardening.py
@@ -1,0 +1,247 @@
+# Natural Language Toolkit: uncontrolled-recursion (CWE-674) attack matrix
+#
+# Copyright (C) 2001-2026 NLTK Project
+# URL: <https://www.nltk.org/>
+# For license information, see LICENSE.TXT
+
+"""Attack matrix for uncontrolled recursion (CWE-674) across NLTK.
+
+Every raw-text parser / structure walker that recurses on untrusted input is
+driven with an adversarially deep payload and must raise a *bounded* exception
+(``ValueError`` or ``LogicalExpressionException``), never an uncaught
+``RecursionError`` and never silent acceptance. Benign inputs must still parse.
+
+Nothing is mocked: each case loads the real public API and runs it. Each guard
+fires at a fixed depth below the interpreter recursion limit, so the
+"even with a raised limit" case proves the module's own guard stops the walk
+rather than luck with the ambient limit.
+"""
+
+import warnings
+
+import pytest
+
+
+# --- deep-input attacks (each must raise a bounded exception) ----------------
+
+
+def _attack_tree_fromlist():
+    from nltk.tree import Tree
+    from nltk.tree.tree import MAX_TREE_DEPTH
+
+    payload = "leaf"
+    for _ in range(MAX_TREE_DEPTH + 500):
+        payload = ["N", payload]
+    Tree.fromlist(payload)
+
+
+def _attack_tree_fromstring():
+    from nltk.tree import Tree
+    from nltk.tree.tree import MAX_TREE_DEPTH
+
+    n = MAX_TREE_DEPTH + 500
+    Tree.fromstring("(S " * n + "x" + ")" * n)
+
+
+def _attack_read_type():
+    from nltk.sem.logic import MAX_TYPE_DEPTH, read_type
+
+    payload = "e"
+    for _ in range(MAX_TYPE_DEPTH + 500):
+        payload = "<%s,e>" % payload
+    read_type(payload)
+
+
+def _attack_ccg_matchbrackets():
+    from nltk.ccg.lexicon import MAX_CATEGORY_DEPTH, matchBrackets
+
+    n = MAX_CATEGORY_DEPTH + 500
+    matchBrackets("(" * n + ")" * n)
+
+
+def _attack_ccg_augparse():
+    from nltk.ccg.lexicon import MAX_CATEGORY_DEPTH, augParseCategory
+
+    n = MAX_CATEGORY_DEPTH + 500
+    augParseCategory("(" * n + "S" + ")" * n, ["S", "N"], {})
+
+
+def _attack_toolbox_settings():
+    from nltk.toolbox import MAX_TOOLBOX_DEPTH, ToolboxSettings
+
+    data = "".join("\\+f%d val\n" % i for i in range(MAX_TOOLBOX_DEPTH + 500))
+    ts = ToolboxSettings()
+    ts.open_string(data)
+    ts.parse()
+
+
+def _deep_conll(n):
+    rows = []
+    for i in range(1, n + 1):
+        head = i - 1
+        rel = "ROOT" if i == 1 else "dep"
+        rows.append(f"{i}\tw{i}\t_\tN\tN\t_\t{head}\t{rel}\t_\t_")
+    return "\n".join(rows)
+
+
+def _attack_depgraph_triples():
+    from nltk.parse.dependencygraph import MAX_GRAPH_DEPTH, DependencyGraph
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        dg = DependencyGraph(_deep_conll(MAX_GRAPH_DEPTH + 500))
+    list(dg.triples())
+
+
+def _attack_depgraph_tree():
+    from nltk.parse.dependencygraph import MAX_GRAPH_DEPTH, DependencyGraph
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        dg = DependencyGraph(_deep_conll(MAX_GRAPH_DEPTH + 500))
+    dg.tree()
+
+
+def _attack_depgraph_cycle_path():
+    from nltk.parse.dependencygraph import MAX_GRAPH_DEPTH, DependencyGraph
+
+    dg = DependencyGraph()
+    dg.nodes.clear()
+    n = MAX_GRAPH_DEPTH + 500
+    for i in range(n):
+        dg.nodes[i] = {
+            "address": i,
+            "word": "w%d" % i,
+            "deps": [i + 1] if i + 1 < n else [],
+            "rel": "dep",
+        }
+    dg.get_cycle_path(dg.nodes[0], goal_node_index=-1)
+
+
+def _attack_tgrep_parens():
+    from nltk.tgrep import tgrep_compile
+
+    n = 3000
+    tgrep_compile("(" * n + "A" + ")" * n)
+
+
+def _attack_tgrep_brackets():
+    from nltk.tgrep import tgrep_compile
+
+    n = 3000
+    tgrep_compile("A" + "[" * n + "]" * n)
+
+
+# id -> (attack callable, bounded exception types it must raise)
+ATTACKS = {
+    "tree.fromlist": (_attack_tree_fromlist, ValueError),
+    "tree.fromstring": (_attack_tree_fromstring, ValueError),
+    "logic.read_type": (_attack_read_type, Exception),
+    "ccg.matchBrackets": (_attack_ccg_matchbrackets, ValueError),
+    "ccg.augParseCategory": (_attack_ccg_augparse, ValueError),
+    "toolbox.settings.parse": (_attack_toolbox_settings, ValueError),
+    "depgraph.triples": (_attack_depgraph_triples, ValueError),
+    "depgraph.tree": (_attack_depgraph_tree, ValueError),
+    "depgraph.get_cycle_path": (_attack_depgraph_cycle_path, ValueError),
+    "tgrep.parens": (_attack_tgrep_parens, ValueError),
+    "tgrep.brackets": (_attack_tgrep_brackets, ValueError),
+}
+
+
+def _bounded_exc(key):
+    return ATTACKS[key][1]
+
+
+@pytest.mark.parametrize("key", sorted(ATTACKS))
+def test_deep_input_raises_bounded_error_not_recursionerror(key):
+    """A deep payload is rejected with a bounded exception, not RecursionError."""
+    attack, exc_type = ATTACKS[key]
+    with pytest.raises(exc_type) as caught:
+        attack()
+    assert not isinstance(caught.value, RecursionError), (
+        "%s leaked an uncaught RecursionError (uncontrolled recursion)" % key
+    )
+
+
+@pytest.mark.parametrize("key", sorted(ATTACKS))
+def test_guard_fires_even_with_a_raised_recursion_limit(key):
+    """Prove the module guard (not the ambient limit) stops the walk.
+
+    With the recursion limit raised well past each guard's fixed depth, the
+    attack must still be refused with the same bounded exception; a fix that
+    merely relied on the default limit would recurse further and crash here.
+    """
+    import sys
+
+    attack, exc_type = ATTACKS[key]
+    saved = sys.getrecursionlimit()
+    sys.setrecursionlimit(20000)
+    try:
+        with pytest.raises(exc_type) as caught:
+            attack()
+        assert not isinstance(caught.value, RecursionError), key
+    finally:
+        sys.setrecursionlimit(saved)
+
+
+# --- benign inputs must still work -------------------------------------------
+
+
+def test_benign_tree_fromlist():
+    from nltk.tree import Tree
+
+    # fromlist repr()s each label, so the label is "'S'"; assert structure.
+    tree = Tree.fromlist(["S", ["NP", "I"], ["VP", ["V", "saw"]]])
+    assert isinstance(tree, Tree) and len(tree) == 2
+
+
+def test_benign_tree_fromstring():
+    from nltk.tree import Tree
+
+    assert Tree.fromstring("(S (NP I) (VP (V saw) (NP him)))").label() == "S"
+
+
+def test_benign_read_type():
+    from nltk.sem.logic import read_type
+
+    assert str(read_type("<e,<e,t>>")) == "<e,<e,t>>"
+
+
+def test_benign_ccg_augparse():
+    from nltk.ccg.lexicon import augParseCategory
+
+    cat, _ = augParseCategory("(S/N)", ["S", "N"], {})
+    assert str(cat) == "(S/N)"
+
+
+def test_benign_toolbox_settings():
+    from nltk.toolbox import ToolboxSettings, remove_blanks
+
+    ts = ToolboxSettings()
+    ts.open_string("\\+record\n\\field one\n\\-record\n")
+    tree = ts.parse()
+    remove_blanks(tree)
+    assert tree.tag == "record"
+
+
+def test_benign_depgraph_triples_and_tree():
+    from nltk.parse.dependencygraph import DependencyGraph
+
+    conll = (
+        "1\tHi\t_\tUH\tUH\t_\t0\tROOT\t_\t_\n"
+        "2\tthere\t_\tRB\tRB\t_\t1\tdep\t_\t_"
+    )
+    dg = DependencyGraph(conll)
+    assert list(dg.triples()) == [(("Hi", "UH"), "dep", ("there", "RB"))]
+    assert dg.tree().label() == "Hi"
+
+
+def test_benign_tgrep():
+    from nltk.tgrep import tgrep_compile, tgrep_nodes
+    from nltk.tree import ParentedTree
+
+    tree = ParentedTree.fromstring("(S (NP (D the) (N dog)) (VP (V barks)))")
+    assert callable(tgrep_compile("S < NP"))
+    assert list(tgrep_nodes("NP < N", [tree]))
+    # a moderately nested but legitimate pattern parses fine
+    assert callable(tgrep_compile("(" * 6 + "S" + ")" * 6))

--- a/nltk/tgrep.py
+++ b/nltk/tgrep.py
@@ -955,6 +955,34 @@ def _build_tgrep_parser(set_parse_actions=True):
     return tgrep_exprs.ignore("#" + pyparsing.restOfLine)
 
 
+#: Maximum bracket/paren nesting depth accepted in a TGrep pattern. The
+#: pyparsing grammar parses ``(`` and ``[`` groups with recursive rules, so a
+#: deeply nested pattern makes pyparsing recurse until Python raises an uncaught
+#: RecursionError (CWE-674). Real patterns are shallow; a crafted deep pattern is
+#: rejected up front with a clear ValueError. Kept well below the depth at which
+#: pyparsing itself overflows the stack. Configurable.
+MAX_TGREP_DEPTH = 50
+
+
+def _check_tgrep_nesting(tgrep_string):
+    """Reject a pattern whose ``(``/``[`` nesting exceeds MAX_TGREP_DEPTH.
+
+    The scan is iterative, so it always runs before the recursive parser and is
+    unaffected by the ambient recursion limit.
+    """
+    depth = 0
+    for char in tgrep_string:
+        if char in "([":
+            depth += 1
+            if depth > MAX_TGREP_DEPTH:
+                raise ValueError(
+                    "TGrep pattern bracket nesting exceeds MAX_TGREP_DEPTH "
+                    "(%d); the pattern may be adversarially deep." % MAX_TGREP_DEPTH
+                )
+        elif char in ")]" and depth > 0:
+            depth -= 1
+
+
 def tgrep_tokenize(tgrep_string):
     """
     Tokenizes a TGrep search string into separate tokens.
@@ -962,6 +990,7 @@ def tgrep_tokenize(tgrep_string):
     parser = _build_tgrep_parser(False)
     if isinstance(tgrep_string, bytes):
         tgrep_string = tgrep_string.decode()
+    _check_tgrep_nesting(tgrep_string)
     return list(parser.parseString(tgrep_string))
 
 
@@ -973,6 +1002,7 @@ def tgrep_compile(tgrep_string):
     parser = _build_tgrep_parser(True)
     if isinstance(tgrep_string, bytes):
         tgrep_string = tgrep_string.decode()
+    _check_tgrep_nesting(tgrep_string)
     return list(parser.parseString(tgrep_string, parseAll=True))[0]
 
 

--- a/nltk/toolbox.py
+++ b/nltk/toolbox.py
@@ -18,6 +18,14 @@ from nltk import redos
 from nltk.data import PathPointer, find
 from nltk.pathsec import open as pathsec_open
 
+#: Maximum ``\+field`` / ``\-field`` nesting depth accepted when parsing a
+#: Toolbox settings file. Each ``\+`` opens a level that the resulting element
+#: tree is later walked by recursive helpers (remove_blanks, add_default_fields,
+#: _sort_fields, add_blank_lines, _to_settings_string), so unbounded nesting
+#: would raise an uncaught ``RecursionError`` (CWE-674); past this depth a clear
+#: ``ValueError`` is raised at parse time. Configurable.
+MAX_TOOLBOX_DEPTH = 500
+
 
 class StandardFormat:
     """
@@ -366,6 +374,7 @@ class ToolboxSettings(StandardFormat):
         :rtype: ElementTree._ElementInterface
         """
         builder = TreeBuilder()
+        depth = 0
         for mkr, value in self.fields(encoding=encoding, errors=errors, **kwargs):
             block = mkr[0] if mkr else None
             if block in ("+", "-"):
@@ -376,9 +385,16 @@ class ToolboxSettings(StandardFormat):
             safe_mkr = _sanitize_marker(mkr)
 
             if block == "+":
+                depth += 1
+                if depth > MAX_TOOLBOX_DEPTH:
+                    raise ValueError(
+                        "Toolbox settings nesting exceeds MAX_TOOLBOX_DEPTH "
+                        "(%d); the input may be adversarially deep." % MAX_TOOLBOX_DEPTH
+                    )
                 builder.start(safe_mkr, {})
                 builder.data(value)
             elif block == "-":
+                depth -= 1
                 builder.end(safe_mkr)
             else:
                 builder.start(safe_mkr, {})

--- a/nltk/tree/tree.py
+++ b/nltk/tree/tree.py
@@ -764,7 +764,7 @@ class Tree(list):
         raise ValueError(msg)
 
     @classmethod
-    def fromlist(cls, l):
+    def fromlist(cls, l, _depth=0):
         """
         :type l: list
         :param l: a tree represented as nested lists
@@ -774,10 +774,20 @@ class Tree(list):
 
         Convert nested lists to a NLTK Tree
         """
+        # Bound nesting depth: fromlist recurses once per level, so an arbitrarily
+        # deep nested list would raise RecursionError (CWE-674). fromstring guards
+        # its bracket parser the same way; a crafted deep list is rejected with a
+        # clear ValueError. ``_depth`` is internal (callers never pass it).
+        if _depth > MAX_TREE_DEPTH:
+            raise ValueError(
+                f"Nested-list nesting depth exceeds MAX_TREE_DEPTH "
+                f"({MAX_TREE_DEPTH}); the input may be adversarially deep. "
+                "Raise nltk.tree.tree.MAX_TREE_DEPTH to allow it."
+            )
         if type(l) == list and len(l) > 0:
             label = repr(l[0])
             if len(l) > 1:
-                return Tree(label, [cls.fromlist(child) for child in l[1:]])
+                return Tree(label, [cls.fromlist(child, _depth + 1) for child in l[1:]])
             else:
                 return label
 


### PR DESCRIPTION
## Summary

Hardening for eight draft security advisories spanning three vulnerability classes, found by a whole-tree audit. This combined branch is a reference snapshot: the recursion work overlaps with #3885, and the non-recursion work is being split into focused PRs (see below), so this PR is opened for provenance and closed immediately.

### Uncontrolled recursion (CWE-674)
Deeply nested untrusted input drove several parsers / traversal helpers into an uncaught `RecursionError` (DoS). Each is now bounded with a clear exception before that depth:

- `Tree.fromlist` (GHSA-63wh-5r5m-wxr7) via `MAX_TREE_DEPTH`
- `sem.logic.read_type` (GHSA-w3pv-xfw4-ghr7) via `MAX_TYPE_DEPTH`
- `ccg.lexicon.matchBrackets` / `augParseCategory` (GHSA-3h95-x772-4765) via `MAX_CATEGORY_DEPTH`
- `toolbox.ToolboxSettings.parse` (GHSA-f2h2-f4fc-p978) via `MAX_TOOLBOX_DEPTH`
- `parse.dependencygraph._tree` / `triples` / `get_cycle_path` (GHSA-xfcv-m889-fmqg) via `MAX_GRAPH_DEPTH`
- `tgrep.tgrep_compile` / `tgrep_tokenize` via `MAX_TGREP_DEPTH` (new finding, no advisory yet; pyparsing recurses on nested `(`/`[` and overflows at ~69 to 107 nesting)

### Untrusted search path (CWE-426 / CWE-427)
`config_prover9` (and Mace by inheritance), `config_megam`, `config_tadm` forwarded a caller path straight to `find_binary`, which honors an explicit relative path, so a planted CWD binary would be executed. They now resolve through a new `internals.find_binary_absolute` that accepts only an absolute location, matching Boxer/Malt/REPP (GHSA-cc5r-64rf-75hg).

### Symlink / path containment (CWE-59 / CWE-73)
`chat80.sql_query` opened `dbname` with sqlite3 with no containment check; it now calls `validate_path` first, like its siblings `cities2table` / `val_dump` / `val_load` (GHSA-xv54-447f-mj22).

`WekaClassifier` (GHSA-j456-xh4h-cpf2) was already validated through `validate_tool_path`; a regression probe was added.

## Tests
- 8 per-advisory probes under `security_probes/`, each running the real attack; all report FIXED.
- `test_recursion_dos_hardening.py`: an attack matrix plus benign checks, proving each guard fires even with the recursion limit raised.
- Coverage-CI allowlist updated for the draft advisory ids.
- Full-tree module import sweep and per-module security/functionality suites pass.
