### PR TITLE
Reject a relative tool binary_location (untrusted search path, CWE-426/427)

### DIFF
--- a/nltk/classify/megam.py
+++ b/nltk/classify/megam.py
@@ -26,7 +26,7 @@ import math
 import numbers
 import subprocess
 
-from nltk.internals import find_binary
+from nltk.internals import find_binary_absolute
 from nltk.pathsec import TrustError, spawn_trusted
 
 try:
@@ -52,7 +52,9 @@ def config_megam(bin=None):
     :type bin: str
     """
     global _megam_bin
-    _megam_bin = find_binary(
+    # Accept only an absolute binary: a relative ``bin`` resolves against the CWD
+    # and would be executed from there (untrusted search path, CWE-426/CWE-427).
+    _megam_bin = find_binary_absolute(
         "megam",
         bin,
         env_vars=["MEGAM"],

--- a/nltk/classify/tadm.py
+++ b/nltk/classify/tadm.py
@@ -9,7 +9,7 @@ import math
 import numbers
 import sys
 
-from nltk.internals import find_binary
+from nltk.internals import find_binary_absolute
 from nltk.pathsec import TrustError, spawn_trusted
 
 try:
@@ -22,7 +22,9 @@ _tadm_bin = None
 
 def config_tadm(bin=None):
     global _tadm_bin
-    _tadm_bin = find_binary(
+    # Accept only an absolute binary: a relative ``bin`` resolves against the CWD
+    # and would be executed from there (untrusted search path, CWE-426/CWE-427).
+    _tadm_bin = find_binary_absolute(
         "tadm", bin, env_vars=["TADM"], binary_names=["tadm"], url="http://tadm.sf.net"
     )
 

--- a/nltk/inference/prover9.py
+++ b/nltk/inference/prover9.py
@@ -126,7 +126,11 @@ class Prover9Parent:
             self._prover9_bin = None
         else:
             name = "prover9"
-            self._prover9_bin = nltk.internals.find_binary(
+            # Accept only an absolute binary: a relative binary_location yields a
+            # CWD-relative path that _call()'s Popen would execute without
+            # consulting $PATH, so a planted "prover9" there would run (untrusted
+            # search path, CWE-426/CWE-427). Boxer/Malt/REPP refuse it the same way.
+            self._prover9_bin = nltk.internals.find_binary_absolute(
                 name,
                 path_to_bin=binary_location,
                 env_vars=["PROVER9"],

--- a/nltk/internals.py
+++ b/nltk/internals.py
@@ -1062,6 +1062,41 @@ def find_binary(
     )
 
 
+def find_binary_absolute(
+    name,
+    path_to_bin=None,
+    env_vars=(),
+    searchpath=(),
+    binary_names=None,
+    url=None,
+    verbose=False,
+):
+    """Like :func:`find_binary`, but return only an *absolute* match.
+
+    A relative match resolves against the current working directory, so a
+    wrapper that runs the result through ``subprocess.Popen`` would execute a
+    binary planted in an attacker-writable directory (an untrusted search path,
+    CWE-426 / CWE-427). ``find_binary_iter`` already refuses a bare name that
+    resolves only in the CWD, but an explicit *relative* ``path_to_bin`` (e.g.
+    ``"tools/prover9"``) is honored there as the caller's choice, which is unsafe
+    for something about to be executed. Tool wrappers (prover9/mace, megam, tadm;
+    cf. Boxer/Malt/REPP) therefore accept only an absolute location: an absolute
+    ``path_to_bin``, an env var, or a ``$PATH`` lookup, none of which resolve
+    against the CWD.
+    """
+    for path in find_binary_iter(
+        name, path_to_bin, env_vars, searchpath, binary_names, url, verbose
+    ):
+        if os.path.isabs(path):
+            return path
+    raise LookupError(
+        f"No absolute {name!r} binary found; a binary found relative to the "
+        "current working directory is refused (untrusted search path). Pass an "
+        "absolute path_to_bin, or set the tool's env var / searchpath to an "
+        "absolute location."
+    )
+
+
 def find_jar_iter(
     name_pattern,
     path_to_jar=None,

--- a/nltk/test/unit/security_probes/ghsa_cc5r_64rf_75hg.py
+++ b/nltk/test/unit/security_probes/ghsa_cc5r_64rf_75hg.py
@@ -1,0 +1,44 @@
+"""GHSA-cc5r-64rf-75hg [high] -- Untrusted search path in prover9/mace4 config allows local code execution via relative binary_location (CWE-426, CWE-427)"""
+
+import os
+import shutil
+import stat
+import tempfile
+
+from ._base import FIXED, VULNERABLE, probe
+
+
+@probe("GHSA-cc5r-64rf-75hg")
+def _prover9_relative_binary_location():
+    """Plant ``./prover9`` and ``./sub/prover9`` in the CWD, then configure the
+    prover with relative locations.
+
+    ``config_prover9`` forwarded ``binary_location`` straight to ``find_binary``,
+    which honors an explicit relative path, so a planted CWD binary would be run
+    by ``_call``'s ``Popen`` (an untrusted search path). It now resolves through
+    ``find_binary_absolute`` and accepts only an absolute location, like
+    Boxer/Malt/REPP; every relative form must be refused. Mace4 inherits the
+    same ``config_prover9``.
+    """
+    from nltk.inference.prover9 import Prover9
+
+    box = tempfile.mkdtemp()
+    for rel in ("prover9", "sub/prover9"):
+        target = os.path.join(box, rel)
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        with open(target, "w", encoding="utf-8") as fh:
+            fh.write("#!/bin/sh\necho PWNED\n")
+        os.chmod(target, os.stat(target).st_mode | stat.S_IEXEC)
+    old = os.getcwd()
+    try:
+        os.chdir(box)
+        for loc in (".", "./prover9", "sub/prover9"):
+            try:
+                Prover9().config_prover9(loc)
+            except LookupError:
+                continue
+            return VULNERABLE, "config_prover9(%r) took a CWD-relative binary" % loc
+        return FIXED, "every relative binary_location refused (absolute-only)"
+    finally:
+        os.chdir(old)
+        shutil.rmtree(box, ignore_errors=True)

--- a/nltk/test/unit/test_advisory_coverage_ci.py
+++ b/nltk/test/unit/test_advisory_coverage_ci.py
@@ -58,6 +58,14 @@ _CLOSED_WITH_PROBE = {
     "GHSA-8846-p9w9-5frf",
 }
 
+#: Draft advisories we have already fixed and probe ahead of publication. The
+#: public API lists only *published* advisories, so a probe for a still-draft id
+#: would otherwise trip the reverse check below. Once published it appears in the
+#: fetched list and its entry here becomes a harmless no-op.
+_DRAFT_WITH_PROBE = {
+    "GHSA-cc5r-64rf-75hg",
+}
+
 
 def _next_url(link_header):
     """The *on-origin* rel="next" URL from a GitHub ``Link`` header, else None.
@@ -120,6 +128,6 @@ def test_no_probe_targets_an_unknown_advisory():
     advisories = _fetch_advisories()
     if advisories is None:
         pytest.skip("could not fetch advisories from GitHub")
-    known = {a["ghsa_id"] for a in advisories} | _CLOSED_WITH_PROBE
+    known = {a["ghsa_id"] for a in advisories} | _CLOSED_WITH_PROBE | _DRAFT_WITH_PROBE
     unknown = sorted(set(probes.PROBES) - known)
     assert not unknown, "probes for ids GitHub does not list: %s" % unknown


### PR DESCRIPTION
## Summary

Fixes GHSA-cc5r-64rf-75hg (untrusted search path, CWE-426 / CWE-427).

`config_prover9` (inherited by Mace), `config_megam` and `config_tadm` forwarded a caller-supplied `binary_location` / `bin` straight to `find_binary`. `find_binary` already refuses a *bare* name that resolves only in the CWD, but it honors an explicit *relative* path (e.g. `"tools/prover9"`) as the caller's choice. For something about to be executed via `subprocess.Popen`, a relative path resolves against the current working directory, so an attacker who can plant a `prover9` / `megam` / `tadm` there gets code execution:

```python
# in an attacker-writable CWD containing ./prover9 or ./sub/prover9
Prover9().config_prover9("./prover9")     # before: runs the planted binary
```

## Fix

New `internals.find_binary_absolute` iterates `find_binary_iter` and returns only an **absolute** match (an absolute `path_to_bin`, an env var, or a `$PATH` lookup), refusing every CWD-relative candidate with a `LookupError`. This is exactly what Boxer / Malt / REPP already do inline. `config_prover9`, `config_megam` and `config_tadm` now resolve through it, so:

- `.`, `./prover9`, `sub/prover9`, `./`, `sub/` are all refused.
- an absolute `binary_location` is still honored.
- `find_binary`'s generic behavior (and its existing tests) is unchanged; only the tool-config entry points tighten to absolute-only.

## Tests

- `security_probes/ghsa_cc5r_64rf_75hg.py`: plants `./prover9` and `./sub/prover9` in a temp CWD and asserts every relative `binary_location` is refused (reports FIXED).
- Existing `test_internals.py`, `test_attack_tool_injection_candidates_expanded.py`, `test_megam_tadm_injection_security.py`, `test_tadm_security.py`, `test_prover9_security.py` all still pass.
