### PR TITLE
Fix implicit Optional on the lepor tokenizer arguments

### DIFF
--- a/nltk/translate/lepor.py
+++ b/nltk/translate/lepor.py
@@ -237,7 +237,7 @@ def sentence_lepor(
     hypothesis: str,
     alpha: float = 1.0,
     beta: float = 1.0,
-    tokenizer: Callable[[str], list[str]] = None,
+    tokenizer: Callable[[str], list[str]] | None = None,
 ) -> list[float]:
     """
     Calculate LEPOR score a sentence from Han, A. L.-F. (2017).
@@ -304,7 +304,7 @@ def corpus_lepor(
     hypothesis: list[str],
     alpha: float = 1.0,
     beta: float = 1.0,
-    tokenizer: Callable[[str], list[str]] = None,
+    tokenizer: Callable[[str], list[str]] | None = None,
 ) -> list[list[float]]:
     """
     Calculate LEPOR score for list of sentences from Han, A. L.-F. (2017).


### PR DESCRIPTION
`sentence_lepor` and `corpus_lepor` annotate `tokenizer` as `Callable[[str], list[str]]` but default it to `None`, which PEP 484 prohibits:

```python
def sentence_lepor(
    references: list[str],
    hypothesis: str,
    alpha: float = 1.0,
    beta: float = 1.0,
    tokenizer: Callable[[str], list[str]] = None,
) -> list[float]:
```

`None` is clearly the intended sentinel — `sentence_lepor` branches on it, and the comment says so outright:

```python
    if tokenizer:
        hypothesis = tokenizer(hypothesis)
        ...
    else:  # If tokenizer is not provided, use the one in NLTK.
```

These are the only two occurrences in the package. `ruff`'s rule for this fires on `develop` and is clean afterwards:

```
$ ruff check --isolated --select RUF013 nltk/
nltk/translate/lepor.py:240:16: RUF013 PEP 484 prohibits implicit `Optional`
nltk/translate/lepor.py:307:16: RUF013 PEP 484 prohibits implicit `Optional`
Found 2 errors.
```

I used `| None` rather than `Optional[...]` to match the package, which uses `| None` throughout and has no `Optional[` anywhere, and `python_requires=">=3.10"` means it evaluates fine at runtime (these annotations aren't deferred — I checked `Callable[[str], list[str]] | None` builds and both functions still import and run).

No behaviour change:

```
sentence_lepor tokenizer: collections.abc.Callable[[str], list[str]] | None = None
default (tokenizer=None) works: 0.7824
explicit tokenizer works:       0.7603
```

Tests: `nltk/test/unit/translate/test_lepor.py` passes (4 tests) and the module's doctests pass. The wider `nltk/test/unit/translate/` suite has 5 failures (bleu/meteor/nist), but they're identical with and without this change — they need downloaded corpora in my environment.
