### PR TITLE
Remove shadowed FeatStruct._walk stub and preserve its docstring

### DIFF
--- a/nltk/featstruct.py
+++ b/nltk/featstruct.py
@@ -463,9 +463,6 @@ class FeatStruct(SubstituteBindingsI):
         :param visited: A set containing the ids of all feature
             structures we've already visited while freezing.
         """
-        raise NotImplementedError()  # Implemented by subclasses.
-
-    def _walk(self, visited):
         if id(self) in visited:
             return
         visited.add(id(self))


### PR DESCRIPTION
### Problem

`FeatStruct._walk` is defined **twice** in the class body of `nltk/featstruct.py`:

```python
def _walk(self, visited):
    """
    Return an iterator that generates this feature structure, and
    each feature structure it contains.
    ...
    """
    raise NotImplementedError()  # Implemented by subclasses.

def _walk(self, visited):
    if id(self) in visited:
        return
    ...
```

In Python the second definition overrides the first, so:

- the abstract stub that `raise NotImplementedError()` **never runs** (no subclass overrides `_walk` either — `FeatDict`/`FeatList` rely on this base implementation), and
- the concrete generator that actually executes **has no docstring** — `help(FeatStruct._walk)` returns nothing and the parameter documentation is silently lost.

### Fix

Delete the dead stub and keep its docstring on the real implementation. Pure dead-code removal — no behavior change; `walk()` / `_walk()` behave exactly as before, and the docstring is now attached to the method that is actually called.

Verified: after the change `FeatStruct` has a single `_walk` (a generator function) whose `__doc__` is populated, and the module still parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
